### PR TITLE
Move ClusterEvent type to staging repo, leaving some functions (that contain logic internal to scheduler) in kubernetes/kubernetes

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/backend/heap"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -48,8 +49,8 @@ type activeQueuer interface {
 	listInFlightEvents() []interface{}
 	listInFlightPods() []*v1.Pod
 	clusterEventsForPod(logger klog.Logger, pInfo *framework.QueuedPodInfo) ([]*clusterEvent, error)
-	addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []framework.ClusterEvent) bool
-	addEventIfAnyInFlight(oldObj, newObj interface{}, event framework.ClusterEvent) bool
+	addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool
+	addEventIfAnyInFlight(oldObj, newObj interface{}, event fwk.ClusterEvent) bool
 
 	schedulingCycle() int64
 	done(pod types.UID)
@@ -383,7 +384,7 @@ func (aq *activeQueue) clusterEventsForPod(logger klog.Logger, pInfo *framework.
 
 // addEventsIfPodInFlight adds clusterEvent to inFlightEvents if the newPod is in inFlightPods.
 // It returns true if pushed the event to the inFlightEvents.
-func (aq *activeQueue) addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []framework.ClusterEvent) bool {
+func (aq *activeQueue) addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool {
 	aq.lock.Lock()
 	defer aq.lock.Unlock()
 
@@ -403,7 +404,7 @@ func (aq *activeQueue) addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []f
 
 // addEventIfAnyInFlight adds clusterEvent to inFlightEvents if any pod is in inFlightPods.
 // It returns true if pushed the event to the inFlightEvents.
-func (aq *activeQueue) addEventIfAnyInFlight(oldObj, newObj interface{}, event framework.ClusterEvent) bool {
+func (aq *activeQueue) addEventIfAnyInFlight(oldObj, newObj interface{}, event fwk.ClusterEvent) bool {
 	aq.lock.Lock()
 	defer aq.lock.Unlock()
 

--- a/pkg/scheduler/framework/events_test.go
+++ b/pkg/scheduler/framework/events_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/utils/ptr"
@@ -60,7 +61,7 @@ func TestNodeAllocatableChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{Status: v1.NodeStatus{Allocatable: test.oldAllocatable}}
 			newNode := &v1.Node{Status: v1.NodeStatus{Allocatable: test.newAllocatable}}
-			changed := extractNodeAllocatableChange(newNode, oldNode) != None
+			changed := extractNodeAllocatableChange(newNode, oldNode) != fwk.None
 			if changed != test.changed {
 				t.Errorf("nodeAllocatableChanged should be %t, got %t", test.changed, changed)
 			}
@@ -93,7 +94,7 @@ func TestNodeLabelsChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: test.oldLabels}}
 			newNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: test.newLabels}}
-			changed := extractNodeLabelsChange(newNode, oldNode) != None
+			changed := extractNodeLabelsChange(newNode, oldNode) != fwk.None
 			if changed != test.changed {
 				t.Errorf("Test case %q failed: should be %t, got %t", test.name, test.changed, changed)
 			}
@@ -125,7 +126,7 @@ func TestNodeTaintsChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{Spec: v1.NodeSpec{Taints: test.oldTaints}}
 			newNode := &v1.Node{Spec: v1.NodeSpec{Taints: test.newTaints}}
-			changed := extractNodeTaintsChange(newNode, oldNode) != None
+			changed := extractNodeTaintsChange(newNode, oldNode) != fwk.None
 			if changed != test.changed {
 				t.Errorf("Test case %q failed: should be %t, not %t", test.name, test.changed, changed)
 			}
@@ -180,7 +181,7 @@ func TestNodeConditionsChange(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			oldNode := &v1.Node{Status: v1.NodeStatus{Conditions: test.oldConditions}}
 			newNode := &v1.Node{Status: v1.NodeStatus{Conditions: test.newConditions}}
-			changed := extractNodeConditionsChange(newNode, oldNode) != None
+			changed := extractNodeConditionsChange(newNode, oldNode) != fwk.None
 			if changed != test.changed {
 				t.Errorf("Test case %q failed: should be %t, got %t", test.name, test.changed, changed)
 			}
@@ -193,7 +194,7 @@ func TestNodeSchedulingPropertiesChange(t *testing.T) {
 		name       string
 		newNode    *v1.Node
 		oldNode    *v1.Node
-		wantEvents []ClusterEvent
+		wantEvents []fwk.ClusterEvent
 	}{
 		{
 			name:       "no specific changed applied",
@@ -205,7 +206,7 @@ func TestNodeSchedulingPropertiesChange(t *testing.T) {
 			name:       "only node spec unavailable changed",
 			newNode:    st.MakeNode().Unschedulable(false).Obj(),
 			oldNode:    st.MakeNode().Unschedulable(true).Obj(),
-			wantEvents: []ClusterEvent{{Resource: Node, ActionType: UpdateNodeTaint}},
+			wantEvents: []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}},
 		},
 		{
 			name: "only node allocatable changed",
@@ -219,13 +220,13 @@ func TestNodeSchedulingPropertiesChange(t *testing.T) {
 				v1.ResourceMemory:                  "100m",
 				v1.ResourceName("example.com/foo"): "2"},
 			).Obj(),
-			wantEvents: []ClusterEvent{{Resource: Node, ActionType: UpdateNodeAllocatable}},
+			wantEvents: []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}},
 		},
 		{
 			name:       "only node label changed",
 			newNode:    st.MakeNode().Label("foo", "bar").Obj(),
 			oldNode:    st.MakeNode().Label("foo", "fuz").Obj(),
-			wantEvents: []ClusterEvent{{Resource: Node, ActionType: UpdateNodeLabel}},
+			wantEvents: []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}},
 		},
 		{
 			name: "only node taint changed",
@@ -235,13 +236,13 @@ func TestNodeSchedulingPropertiesChange(t *testing.T) {
 			oldNode: st.MakeNode().Taints([]v1.Taint{
 				{Key: v1.TaintNodeUnschedulable, Value: "foo", Effect: v1.TaintEffectNoSchedule},
 			}).Obj(),
-			wantEvents: []ClusterEvent{{Resource: Node, ActionType: UpdateNodeTaint}},
+			wantEvents: []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}},
 		},
 		{
 			name:       "only node annotation changed",
 			newNode:    st.MakeNode().Annotation("foo", "bar").Obj(),
 			oldNode:    st.MakeNode().Annotation("foo", "fuz").Obj(),
-			wantEvents: []ClusterEvent{{Resource: Node, ActionType: UpdateNodeAnnotation}},
+			wantEvents: []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAnnotation}},
 		},
 		{
 			name:    "only node condition changed",
@@ -252,7 +253,7 @@ func TestNodeSchedulingPropertiesChange(t *testing.T) {
 				"Ready",
 				"Ready",
 			).Obj(),
-			wantEvents: []ClusterEvent{{Resource: Node, ActionType: UpdateNodeCondition}},
+			wantEvents: []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeCondition}},
 		},
 		{
 			name: "both node label and node taint changed",
@@ -264,13 +265,13 @@ func TestNodeSchedulingPropertiesChange(t *testing.T) {
 			oldNode: st.MakeNode().Taints([]v1.Taint{
 				{Key: v1.TaintNodeUnschedulable, Value: "foo", Effect: v1.TaintEffectNoSchedule},
 			}).Obj(),
-			wantEvents: []ClusterEvent{{Resource: Node, ActionType: UpdateNodeLabel}, {Resource: Node, ActionType: UpdateNodeTaint}},
+			wantEvents: []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}, {Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}},
 		},
 	}
 
 	for _, tc := range testCases {
 		gotEvents := NodeSchedulingPropertiesChange(tc.newNode, tc.oldNode)
-		if diff := cmp.Diff(tc.wantEvents, gotEvents, cmpopts.EquateComparable(ClusterEvent{})); diff != "" {
+		if diff := cmp.Diff(tc.wantEvents, gotEvents, cmpopts.EquateComparable(fwk.ClusterEvent{})); diff != "" {
 			t.Errorf("unexpected event (-want, +got):\n%s", diff)
 		}
 	}
@@ -353,96 +354,96 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 		newPod      *v1.Pod
 		oldPod      *v1.Pod
 		draDisabled bool
-		want        []ClusterEvent
+		want        []fwk.ClusterEvent
 	}{
 		{
 			name:   "assigned pod is updated",
 			newPod: st.MakePod().Label("foo", "bar").Node("node").Obj(),
 			oldPod: st.MakePod().Label("foo", "bar2").Node("node").Obj(),
-			want:   []ClusterEvent{{Resource: assignedPod, ActionType: UpdatePodLabel}},
+			want:   []fwk.ClusterEvent{{Resource: assignedPod, ActionType: fwk.UpdatePodLabel}},
 		},
 		{
 			name:   "only label is updated",
 			newPod: st.MakePod().Label("foo", "bar").Obj(),
 			oldPod: st.MakePod().Label("foo", "bar2").Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: UpdatePodLabel}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodLabel}},
 		},
 		{
 			name:   "pod's resource request is scaled down",
 			oldPod: podWithBigRequest,
 			newPod: podWithSmallRequest,
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: UpdatePodScaleDown}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodScaleDown}},
 		},
 		{
 			name:   "pod's resource request is scaled up",
 			oldPod: podWithSmallRequest,
 			newPod: podWithBigRequest,
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
 		},
 		{
 			name:   "both pod's resource request and label are updated",
 			oldPod: podWithBigRequest,
 			newPod: podWithSmallRequestAndLabel,
-			want: []ClusterEvent{
-				{Resource: unschedulablePod, ActionType: UpdatePodLabel},
-				{Resource: unschedulablePod, ActionType: UpdatePodScaleDown},
+			want: []fwk.ClusterEvent{
+				{Resource: unschedulablePod, ActionType: fwk.UpdatePodLabel},
+				{Resource: unschedulablePod, ActionType: fwk.UpdatePodScaleDown},
 			},
 		},
 		{
 			name:   "untracked properties of pod is updated",
 			newPod: st.MakePod().Annotation("foo", "bar").Obj(),
 			oldPod: st.MakePod().Annotation("foo", "bar2").Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
 		},
 		{
 			name:   "scheduling gate is eliminated",
 			newPod: st.MakePod().SchedulingGates([]string{}).Obj(),
 			oldPod: st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: UpdatePodSchedulingGatesEliminated}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodSchedulingGatesEliminated}},
 		},
 		{
 			name:   "scheduling gate is removed, but not completely eliminated",
 			newPod: st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
 			oldPod: st.MakePod().SchedulingGates([]string{"foo", "bar"}).Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
 		},
 		{
 			name:   "pod's tolerations are updated",
 			newPod: st.MakePod().Toleration("key").Toleration("key2").Obj(),
 			oldPod: st.MakePod().Toleration("key").Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: UpdatePodToleration}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodToleration}},
 		},
 		{
 			name:        "pod claim statuses change, feature disabled",
 			draDisabled: true,
 			newPod:      st.MakePod().ResourceClaimStatuses(claimStatusA).Obj(),
 			oldPod:      st.MakePod().Obj(),
-			want:        []ClusterEvent{{Resource: unschedulablePod, ActionType: Update}},
+			want:        []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.Update}},
 		},
 		{
 			name:   "pod claim statuses change, feature enabled",
 			newPod: st.MakePod().ResourceClaimStatuses(claimStatusA).Obj(),
 			oldPod: st.MakePod().Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: UpdatePodGeneratedResourceClaim}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
 		},
 		{
 			name:   "pod claim statuses swapped",
 			newPod: st.MakePod().ResourceClaimStatuses(claimStatusA, claimStatusB).Obj(),
 			oldPod: st.MakePod().ResourceClaimStatuses(claimStatusB, claimStatusA).Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: UpdatePodGeneratedResourceClaim}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
 		},
 		{
 			name:   "pod claim statuses extended",
 			newPod: st.MakePod().ResourceClaimStatuses(claimStatusA, claimStatusB).Obj(),
 			oldPod: st.MakePod().ResourceClaimStatuses(claimStatusA).Obj(),
-			want:   []ClusterEvent{{Resource: unschedulablePod, ActionType: UpdatePodGeneratedResourceClaim}},
+			want:   []fwk.ClusterEvent{{Resource: unschedulablePod, ActionType: fwk.UpdatePodGeneratedResourceClaim}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DynamicResourceAllocation, !tt.draDisabled)
 			got := PodSchedulingPropertiesChange(tt.newPod, tt.oldPod)
-			if diff := cmp.Diff(tt.want, got, cmpopts.EquateComparable(ClusterEvent{})); diff != "" {
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateComparable(fwk.ClusterEvent{})); diff != "" {
 				t.Errorf("unexpected event is returned from podSchedulingPropertiesChange (-want, +got):\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -498,7 +498,7 @@ type EnqueueExtensions interface {
 	// Do not change the result during runtime, for example, based on the cluster's state etc.
 	//
 	// Appropriate implementation of this function will make Pod's re-scheduling accurate and performant.
-	EventsToRegister(context.Context) ([]ClusterEventWithHint, error)
+	EventsToRegister(context.Context) ([]fwk.ClusterEventWithHint, error)
 }
 
 // PreFilterExtensions is an interface that is included in plugins that allow specifying

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -22,8 +22,6 @@ import (
 	"math/rand"
 	"sort"
 
-	fwk "k8s.io/kube-scheduler/framework"
-
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +33,7 @@ import (
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -155,11 +154,11 @@ func (pl *DefaultPreemption) PreEnqueue(ctx context.Context, p *v1.Pod) *framewo
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (pl *DefaultPreemption) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *DefaultPreemption) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	if pl.fts.EnableAsyncPreemption {
-		return []framework.ClusterEventWithHint{
+		return []fwk.ClusterEventWithHint{
 			// We need to register the event to tell the scheduling queue that the pod could be un-gated after some Pods' deletion.
-			{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}, QueueingHintFn: pl.isPodSchedulableAfterPodDeletion},
+			{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isPodSchedulableAfterPodDeletion},
 		}, nil
 	}
 
@@ -175,8 +174,8 @@ func (pl *DefaultPreemption) EventsToRegister(_ context.Context) ([]framework.Cl
 // which failure will be resolved by the preemption.
 // The reason why we return Skip here is that the preemption plugin should not make the decision of when to requeueing Pods,
 // and rather, those plugins should be responsible for that.
-func (pl *DefaultPreemption) isPodSchedulableAfterPodDeletion(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
-	return framework.QueueSkip, nil
+func (pl *DefaultPreemption) isPodSchedulableAfterPodDeletion(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	return fwk.QueueSkip, nil
 }
 
 // calculateNumCandidates returns the number of candidates the FindCandidates

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1383,14 +1383,14 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 		pod            *v1.Pod
 		claims         []*resourceapi.ResourceClaim
 		oldObj, newObj interface{}
-		wantHint       framework.QueueingHint
+		wantHint       fwk.QueueingHint
 		wantErr        bool
 	}{
 		"skip-deletes": {
 			pod:      podWithClaimTemplate,
 			oldObj:   allocatedClaim,
 			newObj:   nil,
-			wantHint: framework.QueueSkip,
+			wantHint: fwk.QueueSkip,
 		},
 		"backoff-wrong-new-object": {
 			pod:     podWithClaimTemplate,
@@ -1404,7 +1404,7 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 				claim.OwnerReferences[0].UID += "123"
 				return claim
 			}(),
-			wantHint: framework.QueueSkip,
+			wantHint: fwk.QueueSkip,
 		},
 		"skip-unrelated-claim": {
 			pod:    podWithClaimTemplate,
@@ -1415,12 +1415,12 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 				claim.UID += "123"
 				return claim
 			}(),
-			wantHint: framework.QueueSkip,
+			wantHint: fwk.QueueSkip,
 		},
 		"queue-on-add": {
 			pod:      podWithClaimName,
 			newObj:   pendingClaim,
-			wantHint: framework.Queue,
+			wantHint: fwk.Queue,
 		},
 		"backoff-wrong-old-object": {
 			pod:     podWithClaimName,
@@ -1438,7 +1438,7 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 				claim.Finalizers = append(claim.Finalizers, "foo")
 				return claim
 			}(),
-			wantHint: framework.QueueSkip,
+			wantHint: fwk.QueueSkip,
 		},
 		"queue-on-status-change": {
 			pod:    podWithClaimName,
@@ -1449,7 +1449,7 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 				claim.Status.Allocation = &resourceapi.AllocationResult{}
 				return claim
 			}(),
-			wantHint: framework.Queue,
+			wantHint: fwk.Queue,
 		},
 		"claim-deallocate": {
 			pod:    podWithClaimName,
@@ -1460,7 +1460,7 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 				claim.Status.Allocation = nil
 				return claim
 			}(),
-			wantHint: framework.Queue,
+			wantHint: fwk.Queue,
 		},
 	}
 
@@ -1540,7 +1540,7 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 		pod      *v1.Pod
 		claims   []*resourceapi.ResourceClaim
 		obj      interface{}
-		wantHint framework.QueueingHint
+		wantHint fwk.QueueingHint
 		wantErr  bool
 	}{
 		"backoff-wrong-new-object": {
@@ -1552,7 +1552,7 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			objs:     []apiruntime.Object{pendingClaim},
 			pod:      podWithClaimTemplate,
 			obj:      podWithClaimTemplateInStatus,
-			wantHint: framework.Queue,
+			wantHint: fwk.Queue,
 		},
 		"wrong-pod": {
 			objs: []apiruntime.Object{pendingClaim},
@@ -1563,13 +1563,13 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 				return pod
 			}(),
 			obj:      podWithClaimTemplateInStatus,
-			wantHint: framework.QueueSkip,
+			wantHint: fwk.QueueSkip,
 		},
 		"missing-claim": {
 			objs:     nil,
 			pod:      podWithClaimTemplate,
 			obj:      podWithClaimTemplateInStatus,
-			wantHint: framework.QueueSkip,
+			wantHint: fwk.QueueSkip,
 		},
 		"incomplete": {
 			objs: []apiruntime.Object{pendingClaim},
@@ -1583,7 +1583,7 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 				}}
 				return pod
 			}(),
-			wantHint: framework.QueueSkip,
+			wantHint: fwk.QueueSkip,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -59,17 +60,17 @@ func (pl *InterPodAffinity) Name() string {
 
 // EventsToRegister returns the possible events that may make a failed Pod
 // schedulable
-func (pl *InterPodAffinity) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *InterPodAffinity) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	// A note about UpdateNodeTaint event:
 	// Ideally, it's supposed to register only Add | UpdateNodeLabel because UpdateNodeTaint will never change the result from this plugin.
 	// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
 	// See: https://github.com/kubernetes/kubernetes/issues/109437
-	nodeActionType := framework.Add | framework.UpdateNodeLabel | framework.UpdateNodeTaint
+	nodeActionType := fwk.Add | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint
 	if pl.enableSchedulingQueueHint {
 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeTaint event.
-		nodeActionType = framework.Add | framework.UpdateNodeLabel
+		nodeActionType = fwk.Add | fwk.UpdateNodeLabel
 	}
-	return []framework.ClusterEventWithHint{
+	return []fwk.ClusterEventWithHint{
 		// All ActionType includes the following events:
 		// - Delete. An unschedulable Pod may fail due to violating an existing Pod's anti-affinity constraints,
 		// deleting an existing Pod may make it schedulable.
@@ -77,8 +78,8 @@ func (pl *InterPodAffinity) EventsToRegister(_ context.Context) ([]framework.Clu
 		// an unschedulable Pod schedulable.
 		// - Add. An unschedulable Pod may fail due to violating pod-affinity constraints,
 		// adding an assigned Pod may make it schedulable.
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Add | framework.UpdatePodLabel | framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodChange},
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add | fwk.UpdatePodLabel | fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 	}, nil
 }
 
@@ -147,25 +148,25 @@ func GetNamespaceLabelsSnapshot(logger klog.Logger, ns string, nsLister listersv
 	return
 }
 
-func (pl *InterPodAffinity) isSchedulableAfterPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *InterPodAffinity) isSchedulableAfterPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalPod, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 	if (modifiedPod != nil && modifiedPod.Spec.NodeName == "") || (originalPod != nil && originalPod.Spec.NodeName == "") {
 		logger.V(5).Info("the added/updated/deleted pod is unscheduled, so it doesn't make the target pod schedulable",
 			"pod", klog.KObj(pod), "originalPod", klog.KObj(originalPod), "modifiedPod", klog.KObj(modifiedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	terms, err := framework.GetAffinityTerms(pod, framework.GetPodAffinityTerms(pod.Spec.Affinity))
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	antiTerms, err := framework.GetAffinityTerms(pod, framework.GetPodAntiAffinityTerms(pod.Spec.Affinity))
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	// Pod is updated. Return Queue when the updated pod matching the target pod's affinity or not matching anti-affinity.
@@ -175,16 +176,16 @@ func (pl *InterPodAffinity) isSchedulableAfterPodChange(logger klog.Logger, pod 
 		if !podMatchesAllAffinityTerms(terms, originalPod) && podMatchesAllAffinityTerms(terms, modifiedPod) {
 			logger.V(5).Info("a scheduled pod was updated to match the target pod's affinity, and the pod may be schedulable now",
 				"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 		if podMatchesAllAffinityTerms(antiTerms, originalPod) && !podMatchesAllAffinityTerms(antiTerms, modifiedPod) {
 			logger.V(5).Info("a scheduled pod was updated not to match the target pod's anti affinity, and the pod may be schedulable now",
 				"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 		logger.V(5).Info("a scheduled pod was updated but it doesn't match the target pod's affinity or does match the target pod's anti-affinity",
 			"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	// Pod is added. Return Queue when the added pod matching the target pod's affinity.
@@ -192,33 +193,33 @@ func (pl *InterPodAffinity) isSchedulableAfterPodChange(logger klog.Logger, pod 
 		if podMatchesAllAffinityTerms(terms, modifiedPod) {
 			logger.V(5).Info("a scheduled pod was added and it matches the target pod's affinity",
 				"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 		logger.V(5).Info("a scheduled pod was added and it doesn't match the target pod's affinity",
 			"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	// Pod is deleted. Return Queue when the deleted pod matching the target pod's anti-affinity.
 	if !podMatchesAllAffinityTerms(antiTerms, originalPod) {
 		logger.V(5).Info("a scheduled pod was deleted but it doesn't match the target pod's anti-affinity",
 			"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 	logger.V(5).Info("a scheduled pod was deleted and it matches the target pod's anti-affinity. The pod may be schedulable now",
 		"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-	return framework.Queue, nil
+	return fwk.Queue, nil
 }
 
-func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalNode, modifiedNode, err := util.As[*v1.Node](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	terms, err := framework.GetAffinityTerms(pod, framework.GetPodAffinityTerms(pod.Spec.Affinity))
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	// When queuing this Pod:
@@ -231,7 +232,7 @@ func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod
 				// Case 1: A new node is added with the pod affinity topologyKey.
 				logger.V(5).Info("A node with a matched pod affinity topologyKey was added and it may make the pod schedulable",
 					"pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-				return framework.Queue, nil
+				return fwk.Queue, nil
 			}
 			continue
 		}
@@ -242,20 +243,20 @@ func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod
 			// Case 2: Original node does not have the pod affinity topologyKey, but the modified node does.
 			logger.V(5).Info("A node got updated to have the topology key of pod affinity, which may make the pod schedulable",
 				"pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 
 		if originalHasKey && modifiedHasKey && (originalTopologyValue != modifiedTopologyValue) {
 			// Case 3: Both nodes have the pod affinity topologyKey, but the values differ.
 			logger.V(5).Info("A node is moved to a different domain of pod affinity, which may make the pod schedulable",
 				"pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 
 	antiTerms, err := framework.GetAffinityTerms(pod, framework.GetPodAntiAffinityTerms(pod.Spec.Affinity))
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	// When queuing this Pod:
@@ -271,7 +272,7 @@ func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod
 			//   But, it's out-of-scope of this QHint to check which Pods are in the topology this Node is in.
 			logger.V(5).Info("A node was added and it may make the pod schedulable",
 				"pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 
 		originalTopologyValue, originalHasKey := originalNode.Labels[term.TopologyKey]
@@ -283,17 +284,17 @@ func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod
 			// because the node without the topology label can always accept pods with pod anti-affinity.
 			logger.V(5).Info("A node got updated to not have the topology key of pod anti-affinity, which may make the pod schedulable",
 				"pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 
 		if originalHasKey && modifiedHasKey && (originalTopologyValue != modifiedTopologyValue) {
 			// Case 3: Both nodes have the pod anti-affinity topologyKey, but the values differ.
 			logger.V(5).Info("A node is moved to a different domain of pod anti-affinity, which may make the pod schedulable",
 				"pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 	logger.V(5).Info("a node is added/updated but doesn't have any topologyKey which matches pod affinity/anti-affinity",
 		"pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
@@ -25,9 +25,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	plugintesting "k8s.io/kubernetes/pkg/scheduler/framework/plugins/testing"
 	schedruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
@@ -39,53 +39,53 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 		name           string
 		pod            *v1.Pod
 		oldPod, newPod *v1.Pod
-		expectedHint   framework.QueueingHint
+		expectedHint   fwk.QueueingHint
 	}{
 		{
 			name:         "add a pod which matches the pod affinity",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "add an un-scheduled pod",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Label("service", "securityscan").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "add a pod which doesn't match the pod affinity",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("aaa", "a").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update a pod from non-match to match pod affinity",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("aaa", "a").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "the updating pod matches target pod's affinity both before and after label changes",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("service", "value2").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update an un-scheduled pod",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Label("service", "securityscan").Obj(),
 			oldPod:       st.MakePod().Label("service", "securityscan").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update a pod from match to non-match the pod affinity",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("aaa", "a").Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name: "update a pod from match to non-match pod's affinity - multiple terms case",
@@ -93,7 +93,7 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 				PodAffinityExists("bbb", "hostname", st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("aaa", "a").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name: "update a pod from non-match to match pod's affinity - multiple terms case",
@@ -101,33 +101,33 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 				PodAffinityExists("bbb", "hostname", st.PodAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("aaa", "").Label("bbb", "").Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("aaa", "a").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "modify pod label to change it from satisfying pod anti-affinity to not satisfying anti-affinity",
 			pod:          st.MakePod().Name("p").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("service", "aaaa").Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "modify pod label to change it from not satisfying pod anti-affinity to satisfying anti-affinity",
 			pod:          st.MakePod().Name("p").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			newPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("service", "bbb").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "delete a pod which doesn't match pod's anti-affinity",
 			pod:          st.MakePod().Name("p").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("aaa", "a").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "delete a pod which matches pod's anti-affinity",
 			pod:          st.MakePod().Name("p").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			oldPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 	}
 	for _, tc := range tests {
@@ -155,89 +155,89 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 		name             string
 		pod              *v1.Pod
 		oldNode, newNode *v1.Node
-		expectedHint     framework.QueueingHint
+		expectedHint     fwk.QueueingHint
 	}{
 		// affinity
 		{
 			name:         "add a new node with matched pod affinity topologyKey",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "add a new node without matched topologyKey",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update node label but not topologyKey",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("aaa", "a").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("aaa", "b").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update node label that isn't related to the pod affinity",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Label("unrelated-label", "unrelated").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update node with different affinity topologyKey value",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone2").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "update node to have the affinity topology label",
 			pod:          st.MakePod().Name("p").PodAffinityIn("service", "zone", []string{"securityscan", "value2"}, st.PodAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("aaa", "a").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		// anti-affinity
 		{
 			name:         "add a new node with matched pod anti-affinity topologyKey",
 			pod:          st.MakePod().Name("p").PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"another": "label"}}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "add a new node without matched pod anti-affinity topologyKey",
 			pod:          st.MakePod().Name("p").PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"another": "label"}}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			newNode:      st.MakeNode().Name("node-a").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "update node label that isn't related to the pod anti-affinity",
 			pod:          st.MakePod().Name("p").PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"another": "label"}}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Label("unrelated-label", "unrelated").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update node with different anti-affinity topologyKey value",
 			pod:          st.MakePod().Name("p").PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"another": "label"}}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone2").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "update node to have the anti-affinity topology label",
 			pod:          st.MakePod().Name("p").PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"another": "label"}}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("aaa", "a").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "update node label not to have anti-affinity topology label",
 			pod:          st.MakePod().Name("p").PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"another": "label"}}, st.PodAntiAffinityWithRequiredReq).Obj(),
 			oldNode:      st.MakeNode().Name("node-a").Label("zone", "zone1").Obj(),
 			newNode:      st.MakeNode().Name("node-a").Label("aaa", "a").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -1239,14 +1240,14 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 		args           *config.NodeAffinityArgs
 		pod            *v1.Pod
 		oldObj, newObj interface{}
-		expectedHint   framework.QueueingHint
+		expectedHint   fwk.QueueingHint
 		expectedErr    bool
 	}{
 		"backoff-wrong-new-object": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       "not-a-node",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		"backoff-wrong-old-object": {
@@ -1254,55 +1255,55 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			pod:          podWithNodeAffinity.Obj(),
 			oldObj:       "not-a-node",
 			newObj:       st.MakeNode().Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		"skip-queue-on-add": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       st.MakeNode().Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"queue-on-add": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       st.MakeNode().Label("foo", "bar").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		"skip-unrelated-changes": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			oldObj:       st.MakeNode().Obj(),
 			newObj:       st.MakeNode().Capacity(nil).Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"skip-unrelated-changes-on-labels": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.DeepCopy(),
 			oldObj:       st.MakeNode().Obj(),
 			newObj:       st.MakeNode().Label("k", "v").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"skip-labels-changes-on-node-from-suitable-to-unsuitable": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.DeepCopy(),
 			oldObj:       st.MakeNode().Label("foo", "bar").Obj(),
 			newObj:       st.MakeNode().Label("k", "v").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"queue-on-labels-change-makes-pod-schedulable": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			oldObj:       st.MakeNode().Obj(),
 			newObj:       st.MakeNode().Label("foo", "bar").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		"skip-unrelated-change-that-keeps-pod-schedulable": {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			oldObj:       st.MakeNode().Label("foo", "bar").Obj(),
 			newObj:       st.MakeNode().Capacity(nil).Label("foo", "bar").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"skip-queue-on-add-scheduler-enforced-node-affinity": {
 			args: &config.NodeAffinityArgs{
@@ -1324,7 +1325,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       st.MakeNode().Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"queue-on-add-scheduler-enforced-node-affinity": {
 			args: &config.NodeAffinityArgs{
@@ -1346,7 +1347,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       st.MakeNode().Label("foo", "bar").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -45,21 +45,21 @@ const (
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (pl *NodeName) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *NodeName) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	// A note about UpdateNodeTaint/UpdateNodeLabel event:
 	// Ideally, it's supposed to register only Add because any Node update event will never change the result from this plugin.
 	// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
 	// See: https://github.com/kubernetes/kubernetes/issues/109437
-	nodeActionType := framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeLabel
+	nodeActionType := fwk.Add | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel
 	if pl.enableSchedulingQueueHint {
 		// preCheck is not used when QHint is enabled, and hence Update event isn't necessary.
-		nodeActionType = framework.Add
+		nodeActionType = fwk.Add
 	}
 
-	return []framework.ClusterEventWithHint{
+	return []fwk.ClusterEventWithHint{
 		// We don't need the QueueingHintFn here because the scheduling of Pods will be always retried with backoff when this Event happens.
 		// (the same as Queue)
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}},
 	}, nil
 }
 

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -96,44 +96,44 @@ func getPreFilterState(cycleState fwk.CycleState) (preFilterState, error) {
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (pl *NodePorts) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *NodePorts) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	// A note about UpdateNodeTaint/UpdateNodeLabel event:
 	// Ideally, it's supposed to register only Add because NodeUpdated event never means to have any free ports for the Pod.
 	// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
 	// See: https://github.com/kubernetes/kubernetes/issues/109437
-	nodeActionType := framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeLabel
+	nodeActionType := fwk.Add | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel
 	if pl.enableSchedulingQueueHint {
 		// preCheck is not used when QHint is enabled, and hence Update event isn't necessary.
-		nodeActionType = framework.Add
+		nodeActionType = fwk.Add
 	}
 
-	return []framework.ClusterEventWithHint{
+	return []fwk.ClusterEventWithHint{
 		// Due to immutable fields `spec.containers[*].ports`, pod update events are ignored.
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
 		// We don't need the QueueingHintFn here because the scheduling of Pods will be always retried with backoff when this Event happens.
 		// (the same as Queue)
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}},
 	}, nil
 }
 
 // isSchedulableAfterPodDeleted is invoked whenever a pod deleted. It checks whether
 // that change made a previously unschedulable pod schedulable.
-func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, nil)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	// If the deleted pod is unscheduled, it doesn't make the target pod schedulable.
 	if deletedPod.Spec.NodeName == "" && deletedPod.Status.NominatedNodeName == "" {
 		logger.V(4).Info("the deleted pod is unscheduled and it doesn't make the target pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	// If the deleted pod doesn't use any host ports, it doesn't make the target pod schedulable.
 	ports := util.GetHostPorts(deletedPod)
 	if len(ports) == 0 {
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	// Construct a fake NodeInfo that only has the deleted Pod.
@@ -146,11 +146,11 @@ func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 	nodeInfo := framework.NodeInfo{UsedPorts: usedPorts}
 	if Fits(pod, &nodeInfo) {
 		logger.V(4).Info("the deleted pod and the target pod don't have any common port(s), returning QueueSkip as deleting this Pod won't make the Pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	logger.V(4).Info("the deleted pod and the target pod have any common port(s), returning Queue as deleting this Pod may make the Pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-	return framework.Queue, nil
+	return fwk.Queue, nil
 }
 
 // Filter invoked at the filter extension point.

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -222,34 +222,34 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 	testcases := map[string]struct {
 		pod          *v1.Pod
 		oldObj       interface{}
-		expectedHint framework.QueueingHint
+		expectedHint fwk.QueueingHint
 		expectedErr  bool
 	}{
 		"backoff-wrong-old-object": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       "not-a-pod",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		"skip-queue-on-unscheduled": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"skip-queue-on-non-hostport": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Node("fake-node").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"skip-queue-on-unrelated-hostport": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Node("fake-node").HostPort(8081).Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"queue-on-released-hostport": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Node("fake-node").HostPort(8080).Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -261,53 +261,53 @@ func getPreFilterState(cycleState fwk.CycleState) (*preFilterState, error) {
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (f *Fit) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	podActionType := framework.Delete
+func (f *Fit) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	podActionType := fwk.Delete
 	if f.enableInPlacePodVerticalScaling {
 		// If InPlacePodVerticalScaling (KEP 1287) is enabled, then UpdatePodScaleDown event should be registered
 		// for this plugin since a Pod update may free up resources that make other Pods schedulable.
-		podActionType |= framework.UpdatePodScaleDown
+		podActionType |= fwk.UpdatePodScaleDown
 	}
 
 	// A note about UpdateNodeTaint/UpdateNodeLabel event:
 	// Ideally, it's supposed to register only Add | UpdateNodeAllocatable because the only resource update could change the node resource fit plugin's result.
 	// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
 	// See: https://github.com/kubernetes/kubernetes/issues/109437
-	nodeActionType := framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeTaint | framework.UpdateNodeLabel
+	nodeActionType := fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel
 	if f.enableSchedulingQueueHint {
 		// preCheck is not used when QHint is enabled, and hence Update event isn't necessary.
-		nodeActionType = framework.Add | framework.UpdateNodeAllocatable
+		nodeActionType = fwk.Add | fwk.UpdateNodeAllocatable
 	}
 
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: podActionType}, QueueingHintFn: f.isSchedulableAfterPodEvent},
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}, QueueingHintFn: f.isSchedulableAfterNodeChange},
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: podActionType}, QueueingHintFn: f.isSchedulableAfterPodEvent},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}, QueueingHintFn: f.isSchedulableAfterNodeChange},
 	}, nil
 }
 
 // isSchedulableAfterPodEvent is invoked whenever a pod deleted or scaled down. It checks whether
 // that change made a previously unschedulable pod schedulable.
-func (f *Fit) isSchedulableAfterPodEvent(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (f *Fit) isSchedulableAfterPodEvent(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalPod, modifiedPod, err := schedutil.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	if modifiedPod == nil {
 		if originalPod.Spec.NodeName == "" && originalPod.Status.NominatedNodeName == "" {
 			logger.V(5).Info("the deleted pod was unscheduled and it wouldn't make the unscheduled pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
-			return framework.QueueSkip, nil
+			return fwk.QueueSkip, nil
 		}
 
 		// any deletion event to a scheduled pod could make the unscheduled pod schedulable.
 		logger.V(5).Info("another scheduled pod was deleted, and it may make the unscheduled pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
-		return framework.Queue, nil
+		return fwk.Queue, nil
 	}
 
 	if !f.enableInPlacePodVerticalScaling {
 		// If InPlacePodVerticalScaling (KEP 1287) is disabled, the pod scale down event cannot free up any resources.
 		logger.V(5).Info("another pod was modified, but InPlacePodVerticalScaling is disabled, so it doesn't make the unscheduled pod schedulable", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	if !f.isSchedulableAfterPodScaleDown(pod, originalPod, modifiedPod) {
@@ -317,11 +317,11 @@ func (f *Fit) isSchedulableAfterPodEvent(logger klog.Logger, pod *v1.Pod, oldObj
 		} else {
 			logger.V(5).Info("pod got scaled down, but the modification isn't related to the resource requests of the target pod", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
 		}
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	logger.V(5).Info("another scheduled pod or the target pod itself got scaled down, and it may make the unscheduled pod schedulable", "pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-	return framework.Queue, nil
+	return fwk.Queue, nil
 }
 
 // isSchedulableAfterPodScaleDown checks whether the scale down event may make the target pod schedulable. Specifically:
@@ -375,29 +375,29 @@ func (f *Fit) isSchedulableAfterPodScaleDown(targetPod, originalPod, modifiedPod
 
 // isSchedulableAfterNodeChange is invoked whenever a node added or changed. It checks whether
 // that change could make a previously unschedulable pod schedulable.
-func (f *Fit) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (f *Fit) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalNode, modifiedNode, err := schedutil.As[*v1.Node](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 	// Leaving in the queue, since the pod won't fit into the modified node anyway.
 	if !isFit(pod, modifiedNode, ResourceRequestsOptions{EnablePodLevelResources: f.enablePodLevelResources}) {
 		logger.V(5).Info("node was created or updated, but it doesn't have enough resource(s) to accommodate this pod", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 	// The pod will fit, so since it's add, unblock scheduling.
 	if originalNode == nil {
 		logger.V(5).Info("node was added and it might fit the pod's resource requests", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-		return framework.Queue, nil
+		return fwk.Queue, nil
 	}
 	// The pod will fit, but since there was no increase in available resources, the change won't make the pod schedulable.
 	if !haveAnyRequestedResourcesIncreased(pod, originalNode, modifiedNode, ResourceRequestsOptions{EnablePodLevelResources: f.enablePodLevelResources}) {
 		logger.V(5).Info("node was updated, but haven't changed the pod's resource requestments fit assessment", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	logger.V(5).Info("node was updated, and may now fit the pod's resource requests", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-	return framework.Queue, nil
+	return fwk.Queue, nil
 }
 
 // haveAnyRequestedResourcesIncreased returns true if any of the resources requested by the pod have increased or if allowed pod number increased.

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -51,33 +51,33 @@ const (
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	if !pl.enableSchedulingQueueHint {
-		return []framework.ClusterEventWithHint{
+		return []fwk.ClusterEventWithHint{
 			// A note about UpdateNodeLabel event:
 			// Ideally, it's supposed to register only Add | UpdateNodeTaint because UpdateNodeLabel will never change the result from this plugin.
 			// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
 			// See: https://github.com/kubernetes/kubernetes/issues/109437
-			{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeLabel}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+			{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 		}, nil
 	}
 
-	return []framework.ClusterEventWithHint{
+	return []fwk.ClusterEventWithHint{
 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeLabel event.
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 		// When the QueueingHint feature is enabled,
 		// the scheduling queue uses Pod/Update Queueing Hint
 		// to determine whether a Pod's update makes the Pod schedulable or not.
 		// https://github.com/kubernetes/kubernetes/pull/122234
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.UpdatePodToleration}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodToleration}, QueueingHintFn: pl.isSchedulableAfterPodTolerationChange},
 	}, nil
 }
 
 // isSchedulableAfterPodTolerationChange is invoked whenever a pod's toleration changed.
-func (pl *NodeUnschedulable) isSchedulableAfterPodTolerationChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *NodeUnschedulable) isSchedulableAfterPodTolerationChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	_, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	if pod.UID == modifiedPod.UID {
@@ -91,24 +91,24 @@ func (pl *NodeUnschedulable) isSchedulableAfterPodTolerationChange(logger klog.L
 		}) {
 			// This update makes the pod tolerate the unschedulable taint.
 			logger.V(5).Info("a new toleration is added for the unschedulable Pod, and it may make it schedulable", "pod", klog.KObj(modifiedPod))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 		logger.V(5).Info("a new toleration is added for the unschedulable Pod, but it's an unrelated toleration", "pod", klog.KObj(modifiedPod))
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	logger.V(5).Info("a new toleration is added for a Pod, but it's an unrelated Pod and wouldn't change the TaintToleration plugin's decision", "pod", klog.KObj(modifiedPod))
 
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
 // isSchedulableAfterNodeChange is invoked for all node events reported by
 // an informer. It checks whether that change made a previously unschedulable
 // pod schedulable.
-func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalNode, modifiedNode, err := util.As[*v1.Node](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	// We queue this Pod when -
@@ -117,11 +117,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
 	if (originalNode != nil && originalNode.Spec.Unschedulable && !modifiedNode.Spec.Unschedulable) ||
 		(originalNode == nil && !modifiedNode.Spec.Unschedulable) {
 		logger.V(5).Info("node was created or updated, pod may be schedulable now", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-		return framework.Queue, nil
+		return fwk.Queue, nil
 	}
 
 	logger.V(5).Info("node was created or updated, but it doesn't make this pod schedulable", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
 // Name returns name of the plugin. It is used in logs, etc.

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -94,14 +95,14 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 		name           string
 		pod            *v1.Pod
 		oldObj, newObj interface{}
-		expectedHint   framework.QueueingHint
+		expectedHint   fwk.QueueingHint
 		expectedErr    bool
 	}{
 		{
 			name:         "error-wrong-new-object",
 			pod:          &v1.Pod{},
 			newObj:       "not-a-node",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		{
@@ -113,7 +114,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 				},
 			},
 			oldObj:       "not-a-node",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		{
@@ -124,7 +125,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 					Unschedulable: true,
 				},
 			},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name: "queue-on-schedulable-node-added",
@@ -134,7 +135,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 					Unschedulable: false,
 				},
 			},
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name: "skip-unrelated-change-unschedulable-true",
@@ -155,7 +156,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 					Unschedulable: true,
 				},
 			},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name: "skip-unrelated-change-unschedulable-false",
@@ -176,7 +177,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 					Unschedulable: false,
 				},
 			},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name: "queue-on-unschedulable-field-change",
@@ -191,7 +192,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 					Unschedulable: true,
 				},
 			},
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 	}
 
@@ -215,14 +216,14 @@ func TestIsSchedulableAfterPodTolerationChange(t *testing.T) {
 		name           string
 		pod            *v1.Pod
 		oldObj, newObj interface{}
-		expectedHint   framework.QueueingHint
+		expectedHint   fwk.QueueingHint
 		expectedErr    bool
 	}{
 		{
 			name:         "error-wrong-new-object",
 			pod:          &v1.Pod{},
 			newObj:       "not-a-pod",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		{
@@ -230,7 +231,7 @@ func TestIsSchedulableAfterPodTolerationChange(t *testing.T) {
 			pod:          &v1.Pod{},
 			newObj:       &v1.Pod{},
 			oldObj:       "not-a-pod",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		{
@@ -238,21 +239,21 @@ func TestIsSchedulableAfterPodTolerationChange(t *testing.T) {
 			pod:          st.MakePod().UID("uid").Obj(),
 			newObj:       st.MakePod().UID("different-uid").Toleration(v1.TaintNodeUnschedulable).Obj(),
 			oldObj:       st.MakePod().UID("different-uid").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name:         "queue-when-the-unsched-pod-gets-toleration",
 			pod:          st.MakePod().UID("uid").Obj(),
 			newObj:       st.MakePod().UID("uid").Toleration(v1.TaintNodeUnschedulable).Obj(),
 			oldObj:       st.MakePod().UID("uid").Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 		{
 			name:         "skip-when-the-unsched-pod-gets-unrelated-toleration",
 			pod:          st.MakePod().UID("uid").Obj(),
 			newObj:       st.MakePod().UID("uid").Toleration("unrelated-key").Obj(),
 			oldObj:       st.MakePod().UID("uid").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -84,50 +84,50 @@ func (pl *CSILimits) Name() string {
 
 // EventsToRegister returns the possible events that may make a Pod.
 // failed by this plugin schedulable.
-func (pl *CSILimits) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
+func (pl *CSILimits) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
 		// We don't register any `QueueingHintFn` intentionally
 		// because any new CSINode could make pods that were rejected by CSI volumes schedulable.
-		{Event: framework.ClusterEvent{Resource: framework.CSINode, ActionType: framework.Add}},
-		{Event: framework.ClusterEvent{Resource: framework.CSINode, ActionType: framework.Update}, QueueingHintFn: pl.isSchedulableAfterCSINodeUpdated},
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
-		{Event: framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add}, QueueingHintFn: pl.isSchedulableAfterPVCAdded},
-		{Event: framework.ClusterEvent{Resource: framework.VolumeAttachment, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterVolumeAttachmentDeleted},
+		{Event: fwk.ClusterEvent{Resource: fwk.CSINode, ActionType: fwk.Add}},
+		{Event: fwk.ClusterEvent{Resource: fwk.CSINode, ActionType: fwk.Update}, QueueingHintFn: pl.isSchedulableAfterCSINodeUpdated},
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPVCAdded},
+		{Event: fwk.ClusterEvent{Resource: fwk.VolumeAttachment, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterVolumeAttachmentDeleted},
 	}, nil
 }
 
-func (pl *CSILimits) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *CSILimits) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPodDeleted: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPodDeleted: %w", err)
 	}
 
 	if len(deletedPod.Spec.Volumes) == 0 {
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	if deletedPod.Spec.NodeName == "" && deletedPod.Status.NominatedNodeName == "" {
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	for _, vol := range deletedPod.Spec.Volumes {
 		if vol.PersistentVolumeClaim != nil || vol.Ephemeral != nil || pl.translator.IsInlineMigratable(&vol) {
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 
 	logger.V(5).Info("The deleted pod does not impact the scheduling of the unscheduled pod", "deletedPod", klog.KObj(pod), "pod", klog.KObj(deletedPod))
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
-func (pl *CSILimits) isSchedulableAfterPVCAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *CSILimits) isSchedulableAfterPVCAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	_, addedPvc, err := util.As[*v1.PersistentVolumeClaim](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPVCAdded: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPVCAdded: %w", err)
 	}
 
 	if addedPvc.Namespace != pod.Namespace {
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	for _, volumes := range pod.Spec.Volumes {
@@ -144,18 +144,18 @@ func (pl *CSILimits) isSchedulableAfterPVCAdded(logger klog.Logger, pod *v1.Pod,
 
 		if pvcName == addedPvc.Name {
 			logger.V(5).Info("PVC that is referred from the pod was created, which might make this pod schedulable", "pod", klog.KObj(pod), "PVC", klog.KObj(addedPvc))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 
 	logger.V(5).Info("PVC irrelevant to the Pod was created, which doesn't make this pod schedulable", "pod", klog.KObj(pod), "PVC", klog.KObj(addedPvc))
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
-func (pl *CSILimits) isSchedulableAfterVolumeAttachmentDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *CSILimits) isSchedulableAfterVolumeAttachmentDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	deletedVolumeAttachment, _, err := util.As[*storagev1.VolumeAttachment](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterVolumeAttachmentDeleted: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterVolumeAttachmentDeleted: %w", err)
 	}
 
 	for _, vol := range pod.Spec.Volumes {
@@ -163,7 +163,7 @@ func (pl *CSILimits) isSchedulableAfterVolumeAttachmentDeleted(logger klog.Logge
 		// If it does, return Queue
 		if vol.PersistentVolumeClaim != nil {
 			logger.V(5).Info("Pod volume uses PersistentVolumeClaim, which might make this pod schedulable due to VolumeAttachment deletion", "pod", klog.KObj(pod), "volumeAttachment", klog.KObj(deletedVolumeAttachment), "volume", vol.Name)
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 
 		if !pl.translator.IsInlineMigratable(&vol) {
@@ -172,7 +172,7 @@ func (pl *CSILimits) isSchedulableAfterVolumeAttachmentDeleted(logger klog.Logge
 
 		translatedPV, err := pl.translator.TranslateInTreeInlineVolumeToCSI(logger, &vol, pod.Namespace)
 		if err != nil || translatedPV == nil {
-			return framework.Queue, fmt.Errorf("converting volume(%s) from inline to csi: %w", vol.Name, err)
+			return fwk.Queue, fmt.Errorf("converting volume(%s) from inline to csi: %w", vol.Name, err)
 		}
 
 		if translatedPV.Spec.CSI != nil && deletedVolumeAttachment.Spec.Attacher == translatedPV.Spec.CSI.Driver {
@@ -181,19 +181,19 @@ func (pl *CSILimits) isSchedulableAfterVolumeAttachmentDeleted(logger klog.Logge
 				"pod", klog.KObj(pod), "volumeAttachment", klog.KObj(deletedVolumeAttachment),
 				"volume", vol.Name, "csiDriver", translatedPV.Spec.CSI.Driver,
 			)
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 
 	logger.V(5).Info("the VolumeAttachment deletion wouldn't make this pod schedulable because the pod has no volume related to a deleted VolumeAttachment",
 		"pod", klog.KObj(pod), "volumeAttachment", klog.KObj(deletedVolumeAttachment))
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
-func (pl *CSILimits) isSchedulableAfterCSINodeUpdated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *CSILimits) isSchedulableAfterCSINodeUpdated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	oldCSINode, newCSINode, err := util.As[*storagev1.CSINode](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterCSINodeUpdated: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterCSINodeUpdated: %w", err)
 	}
 
 	oldLimits := make(map[string]int32)
@@ -223,12 +223,12 @@ func (pl *CSILimits) isSchedulableAfterCSINodeUpdated(logger klog.Logger, pod *v
 				"oldLimit", oldLimit,
 				"newLimit", newLimit,
 			)
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 
 	// If no driver limit was increased, skip queueing.
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
 // PreFilter invoked at the prefilter extension point

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	csitrans "k8s.io/csi-translation-lib"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
@@ -669,32 +670,32 @@ func TestCSILimitsQHint(t *testing.T) {
 		deletedPod             *v1.Pod
 		deletedPodNotScheduled bool
 		test                   string
-		wantQHint              framework.QueueingHint
+		wantQHint              fwk.QueueingHint
 	}{
 		{
 			newPod:     podEbs.Obj(),
 			deletedPod: st.MakePod().PVC("placeholder").Obj(),
 			test:       "return a Queue when a deleted pod has a PVC",
-			wantQHint:  framework.Queue,
+			wantQHint:  fwk.Queue,
 		},
 		{
 			newPod:     podEbs.Obj(),
 			deletedPod: st.MakePod().Volume(v1.Volume{VolumeSource: v1.VolumeSource{AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{}}}).Obj(),
 			test:       "return a Queue when a deleted pod has a inline migratable volume",
-			wantQHint:  framework.Queue,
+			wantQHint:  fwk.Queue,
 		},
 		{
 			newPod:     podEbs.Obj(),
 			deletedPod: st.MakePod().Obj(),
 			test:       "return a QueueSkip when a deleted pod doesn't have any volume",
-			wantQHint:  framework.QueueSkip,
+			wantQHint:  fwk.QueueSkip,
 		},
 		{
 			newPod:                 podEbs.Obj(),
 			deletedPod:             st.MakePod().PVC("csi-ebs.csi.aws.com-0").Obj(),
 			deletedPodNotScheduled: true,
 			test:                   "return a QueueSkip when a deleted pod is not scheduled.",
-			wantQHint:              framework.QueueSkip,
+			wantQHint:              fwk.QueueSkip,
 		},
 	}
 
@@ -731,13 +732,13 @@ func TestCSILimitsAddedPVCQHint(t *testing.T) {
 		test      string
 		newPod    *v1.Pod
 		addedPvc  *v1.PersistentVolumeClaim
-		wantQHint framework.QueueingHint
+		wantQHint fwk.QueueingHint
 	}{
 		{
 			test:      "a pod isn't in the same namespace as an added PVC",
 			newPod:    st.MakePod().Namespace("ns1").Obj(),
 			addedPvc:  st.MakePersistentVolumeClaim().Namespace("ns2").Obj(),
-			wantQHint: framework.QueueSkip,
+			wantQHint: fwk.QueueSkip,
 		},
 		{
 			test: "a pod is in the same namespace as an added PVC",
@@ -750,7 +751,7 @@ func TestCSILimitsAddedPVCQHint(t *testing.T) {
 					},
 				}).Obj(),
 			addedPvc:  st.MakePersistentVolumeClaim().Name("pvc1").Namespace("ns1").Obj(),
-			wantQHint: framework.Queue,
+			wantQHint: fwk.Queue,
 		},
 		{
 			test: "a pod has an ephemeral volume related to an added PVC",
@@ -763,7 +764,7 @@ func TestCSILimitsAddedPVCQHint(t *testing.T) {
 				},
 			).Obj(),
 			addedPvc:  st.MakePersistentVolumeClaim().Name("pod1-ephemeral").Namespace("ns1").Obj(),
-			wantQHint: framework.Queue,
+			wantQHint: fwk.Queue,
 		},
 		{
 			test: "a pod doesn't have the same PVC as an added PVC",
@@ -777,13 +778,13 @@ func TestCSILimitsAddedPVCQHint(t *testing.T) {
 				},
 			).Obj(),
 			addedPvc:  st.MakePersistentVolumeClaim().Name("pvc2").Namespace("ns1").Obj(),
-			wantQHint: framework.QueueSkip,
+			wantQHint: fwk.QueueSkip,
 		},
 		{
 			test:      "a pod doesn't have any PVC attached",
 			newPod:    st.MakePod().Namespace("ns1").Obj(),
 			addedPvc:  st.MakePersistentVolumeClaim().Name("pvc2").Namespace("ns1").Obj(),
-			wantQHint: framework.QueueSkip,
+			wantQHint: fwk.QueueSkip,
 		},
 	}
 
@@ -809,7 +810,7 @@ func TestCSILimitsDeletedVolumeAttachmentQHint(t *testing.T) {
 		newPod      *v1.Pod
 		existingPVC *v1.PersistentVolumeClaim
 		deletedVA   *storagev1.VolumeAttachment
-		wantQHint   framework.QueueingHint
+		wantQHint   fwk.QueueingHint
 	}{
 		{
 			test: "a pod has PVC when VolumeAttachment is deleting",
@@ -828,7 +829,7 @@ func TestCSILimitsDeletedVolumeAttachmentQHint(t *testing.T) {
 				NodeName("fake-node").
 				Attacher("test.storage.gke.io").
 				Source(storagev1.VolumeAttachmentSource{PersistentVolumeName: ptr.To("pv1")}).Obj(),
-			wantQHint: framework.Queue,
+			wantQHint: fwk.Queue,
 		},
 		{
 			test: "a pod has an Inline Migratable volume (AWSEBSDriver) when VolumeAttachment (AWSEBSDriver) is deleting (match)",
@@ -853,7 +854,7 @@ func TestCSILimitsDeletedVolumeAttachmentQHint(t *testing.T) {
 						},
 					},
 				}).Obj(),
-			wantQHint: framework.Queue,
+			wantQHint: fwk.Queue,
 		},
 		{
 			test: "a pod has an Inline Migratable volume (GCEPDDriver) when VolumeAttachment (AWSEBSDriver) is deleting (no match)",
@@ -878,7 +879,7 @@ func TestCSILimitsDeletedVolumeAttachmentQHint(t *testing.T) {
 						},
 					},
 				}).Obj(),
-			wantQHint: framework.QueueSkip,
+			wantQHint: fwk.QueueSkip,
 		},
 		{
 			test: "a pod has an Inline Migratable volume (AWSEBSDriver) and PVC when VolumeAttachment (AWSEBSDriver) is deleting",
@@ -913,7 +914,7 @@ func TestCSILimitsDeletedVolumeAttachmentQHint(t *testing.T) {
 						},
 					},
 				}).Obj(),
-			wantQHint: framework.Queue,
+			wantQHint: fwk.Queue,
 		},
 		{
 			test: "a pod has an Inline Migratable volume (AWSEBSDriver) and PVC when VolumeAttachment (AWSEBSDriver)  is deleting",
@@ -940,7 +941,7 @@ func TestCSILimitsDeletedVolumeAttachmentQHint(t *testing.T) {
 				NodeName("fake-node").
 				Attacher("test.storage.gke.io").
 				Source(storagev1.VolumeAttachmentSource{PersistentVolumeName: ptr.To("pv1")}).Obj(),
-			wantQHint: framework.Queue,
+			wantQHint: fwk.Queue,
 		},
 		{
 			test:   "a pod has no PVC when VolumeAttachment is deleting",
@@ -949,7 +950,7 @@ func TestCSILimitsDeletedVolumeAttachmentQHint(t *testing.T) {
 				NodeName("fake-node").
 				Attacher("test.storage.gke.io").
 				Source(storagev1.VolumeAttachmentSource{PersistentVolumeName: ptr.To("pv1")}).Obj(),
-			wantQHint: framework.QueueSkip,
+			wantQHint: fwk.QueueSkip,
 		},
 	}
 
@@ -987,7 +988,7 @@ func TestCSILimitsAfterCSINodeUpdatedQHint(t *testing.T) {
 		name       string
 		oldDrivers []storagev1.CSINodeDriver
 		newDrivers []storagev1.CSINodeDriver
-		wantQHint  framework.QueueingHint
+		wantQHint  fwk.QueueingHint
 	}{
 		{
 			name: "limit raised, queue",
@@ -1005,7 +1006,7 @@ func TestCSILimitsAfterCSINodeUpdatedQHint(t *testing.T) {
 					Count: ptr.To(int32(2)),
 				},
 			}},
-			wantQHint: framework.Queue,
+			wantQHint: fwk.Queue,
 		},
 		{
 			name: "limit decreased, skip queueing",
@@ -1023,7 +1024,7 @@ func TestCSILimitsAfterCSINodeUpdatedQHint(t *testing.T) {
 					Count: ptr.To(int32(1)),
 				},
 			}},
-			wantQHint: framework.QueueSkip,
+			wantQHint: fwk.QueueSkip,
 		},
 		{
 			name: "limit unchanged, skip queueing",
@@ -1041,7 +1042,7 @@ func TestCSILimitsAfterCSINodeUpdatedQHint(t *testing.T) {
 					Count: ptr.To(int32(1)),
 				},
 			}},
-			wantQHint: framework.QueueSkip,
+			wantQHint: fwk.QueueSkip,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -58,7 +59,7 @@ func (pl *SchedulingGates) PreEnqueue(ctx context.Context, p *v1.Pod) *framework
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (pl *SchedulingGates) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *SchedulingGates) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	if !pl.enableSchedulingQueueHint {
 		return nil, nil
 	}
@@ -66,9 +67,9 @@ func (pl *SchedulingGates) EventsToRegister(_ context.Context) ([]framework.Clus
 	// the scheduling queue uses Pod/Update Queueing Hint
 	// to determine whether a Pod's update makes the Pod schedulable or not.
 	// https://github.com/kubernetes/kubernetes/pull/122234
-	return []framework.ClusterEventWithHint{
+	return []fwk.ClusterEventWithHint{
 		// Pods can be more schedulable once it's gates are removed
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.UpdatePodSchedulingGatesEliminated}, QueueingHintFn: pl.isSchedulableAfterUpdatePodSchedulingGatesEliminated},
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodSchedulingGatesEliminated}, QueueingHintFn: pl.isSchedulableAfterUpdatePodSchedulingGatesEliminated},
 	}, nil
 }
 
@@ -79,16 +80,16 @@ func New(_ context.Context, _ runtime.Object, _ framework.Handle, fts feature.Fe
 	}, nil
 }
 
-func (pl *SchedulingGates) isSchedulableAfterUpdatePodSchedulingGatesEliminated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *SchedulingGates) isSchedulableAfterUpdatePodSchedulingGatesEliminated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	_, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, err
+		return fwk.Queue, err
 	}
 
 	if modifiedPod.UID != pod.UID {
 		// If the update event is not for targetPod, it wouldn't make targetPod schedulable.
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
-	return framework.Queue, nil
+	return fwk.Queue, nil
 }

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -67,32 +68,32 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 	testcases := map[string]struct {
 		pod            *v1.Pod
 		oldObj, newObj interface{}
-		expectedHint   framework.QueueingHint
+		expectedHint   fwk.QueueingHint
 		expectedErr    bool
 	}{
 		"backoff-wrong-old-object": {
 			pod:          &v1.Pod{},
 			oldObj:       "not-a-pod",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		"backoff-wrong-new-object": {
 			pod:          &v1.Pod{},
 			newObj:       "not-a-pod",
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  true,
 		},
 		"skip-queue-on-other-pod-updated": {
 			pod:          st.MakePod().Name("p").SchedulingGates([]string{"foo", "bar"}).UID("uid0").Obj(),
 			oldObj:       st.MakePod().Name("p1").SchedulingGates([]string{"foo", "bar"}).UID("uid1").Obj(),
 			newObj:       st.MakePod().Name("p1").SchedulingGates([]string{"foo"}).UID("uid1").Obj(),
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 		},
 		"queue-on-the-unsched-pod-updated": {
 			pod:          st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj(),
 			oldObj:       st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj(),
 			newObj:       st.MakePod().Name("p").SchedulingGates([]string{}).Obj(),
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -1136,14 +1137,14 @@ func TestIsSchedulableAfterCSINodeChange(t *testing.T) {
 		oldObj interface{}
 		newObj interface{}
 		err    bool
-		expect framework.QueueingHint
+		expect fwk.QueueingHint
 	}{
 		{
 			name:   "unexpected objects are passed",
 			oldObj: new(struct{}),
 			newObj: new(struct{}),
 			err:    true,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "CSINode is newly created",
@@ -1154,7 +1155,7 @@ func TestIsSchedulableAfterCSINodeChange(t *testing.T) {
 			},
 			oldObj: nil,
 			err:    false,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "CSINode's migrated-plugins annotations is added",
@@ -1175,7 +1176,7 @@ func TestIsSchedulableAfterCSINodeChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "CSINode's migrated-plugins annotation is updated",
@@ -1196,7 +1197,7 @@ func TestIsSchedulableAfterCSINodeChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "CSINode is updated but migrated-plugins annotation gets unchanged",
@@ -1217,7 +1218,7 @@ func TestIsSchedulableAfterCSINodeChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.QueueSkip,
+			expect: fwk.QueueSkip,
 		},
 	}
 	for _, item := range table {
@@ -1243,7 +1244,7 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 		oldPVC  interface{}
 		newPVC  interface{}
 		wantErr bool
-		expect  framework.QueueingHint
+		expect  fwk.QueueingHint
 	}{
 		{
 			name:    "pod has no pvc or ephemeral volumes",
@@ -1251,7 +1252,7 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 			oldPVC:  makePVC("pvc-b", "sc-a").PersistentVolumeClaim,
 			newPVC:  makePVC("pvc-b", "sc-a").PersistentVolumeClaim,
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "pvc with the same name as the one used by the pod in a different namespace is modified",
@@ -1263,7 +1264,7 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 			oldPVC:  nil,
 			newPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "pod has no pvc that is being modified",
@@ -1274,7 +1275,7 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 			oldPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
 			newPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "pod has no generic ephemeral volume that is being modified",
@@ -1285,7 +1286,7 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 			oldPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
 			newPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "pod has the pvc that is being modified",
@@ -1296,7 +1297,7 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 			oldPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
 			newPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name: "pod has the generic ephemeral volume that is being modified",
@@ -1307,14 +1308,14 @@ func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 			oldPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
 			newPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name:    "type conversion error",
 			oldPVC:  new(struct{}),
 			newPVC:  new(struct{}),
 			wantErr: true,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 	}
 
@@ -1341,7 +1342,7 @@ func TestIsSchedulableAfterStorageClassChange(t *testing.T) {
 		newSC     interface{}
 		pvcLister tf.PersistentVolumeClaimLister
 		err       bool
-		expect    framework.QueueingHint
+		expect    fwk.QueueingHint
 	}{
 		{
 			name:  "When a new StorageClass is created, it returns Queue",
@@ -1353,7 +1354,7 @@ func TestIsSchedulableAfterStorageClassChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "When the AllowedTopologies are changed, it returns Queue",
@@ -1379,7 +1380,7 @@ func TestIsSchedulableAfterStorageClassChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "When there are no changes to the StorageClass, it returns QueueSkip",
@@ -1395,14 +1396,14 @@ func TestIsSchedulableAfterStorageClassChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.QueueSkip,
+			expect: fwk.QueueSkip,
 		},
 		{
 			name:   "type conversion error",
 			oldSC:  new(struct{}),
 			newSC:  new(struct{}),
 			err:    true,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 	}
 
@@ -1428,7 +1429,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 		oldCap  interface{}
 		newCap  interface{}
 		wantErr bool
-		expect  framework.QueueingHint
+		expect  fwk.QueueingHint
 	}{
 		{
 			name:   "When a new CSIStorageCapacity is created, it returns Queue",
@@ -1440,7 +1441,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name: "When the volume limit is increase(Capacity set), it returns Queue",
@@ -1457,7 +1458,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				Capacity: resource.NewQuantity(100, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name: "When the volume limit is increase(MaximumVolumeSize set), it returns Queue",
@@ -1474,7 +1475,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				MaximumVolumeSize: resource.NewQuantity(100, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name: "When the volume limit is increase(Capacity increase), it returns Queue",
@@ -1492,7 +1493,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				Capacity: resource.NewQuantity(100, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name: "When the volume limit is increase(MaximumVolumeSize unset), it returns Queue",
@@ -1511,7 +1512,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				Capacity: resource.NewQuantity(100, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name: "When the volume limit is increase(MaximumVolumeSize increase), it returns Queue",
@@ -1531,7 +1532,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				MaximumVolumeSize: resource.NewQuantity(60, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 		{
 			name: "When there are no changes to the CSIStorageCapacity, it returns QueueSkip",
@@ -1551,7 +1552,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "When the volume limit is equal(Capacity), it returns QueueSkip",
@@ -1569,7 +1570,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				Capacity: resource.NewQuantity(100, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "When the volume limit is equal(MaximumVolumeSize unset), it returns QueueSkip",
@@ -1588,7 +1589,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				Capacity: resource.NewQuantity(50, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "When the volume limit is decrease(Capacity), it returns QueueSkip",
@@ -1606,7 +1607,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				Capacity: resource.NewQuantity(90, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name: "When the volume limit is decrease(MaximumVolumeSize), it returns QueueSkip",
@@ -1624,14 +1625,14 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				MaximumVolumeSize: resource.NewQuantity(90, resource.DecimalSI),
 			},
 			wantErr: false,
-			expect:  framework.QueueSkip,
+			expect:  fwk.QueueSkip,
 		},
 		{
 			name:    "type conversion error",
 			oldCap:  new(struct{}),
 			newCap:  new(struct{}),
 			wantErr: true,
-			expect:  framework.Queue,
+			expect:  fwk.Queue,
 		},
 	}
 
@@ -1657,7 +1658,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 		newObj interface{}
 		oldObj interface{}
 		err    bool
-		expect framework.QueueingHint
+		expect fwk.QueueingHint
 	}{
 		{
 			name: "pod has no CSIDriver",
@@ -1676,7 +1677,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.QueueSkip,
+			expect: fwk.QueueSkip,
 		},
 		{
 			name:   "unexpected objects are passed",
@@ -1684,7 +1685,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 			newObj: new(struct{}),
 			oldObj: new(struct{}),
 			err:    true,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "driver name in pod and csidriver name are different",
@@ -1706,7 +1707,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.QueueSkip,
+			expect: fwk.QueueSkip,
 		},
 		{
 			name: "original StorageCapacity is nil",
@@ -1728,7 +1729,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.QueueSkip,
+			expect: fwk.QueueSkip,
 		},
 		{
 			name: "original StorageCapacity is false",
@@ -1750,7 +1751,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.QueueSkip,
+			expect: fwk.QueueSkip,
 		},
 		{
 			name: "modified StorageCapacity is nil",
@@ -1772,7 +1773,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 		{
 			name: "modified StorageCapacity is true",
@@ -1794,7 +1795,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.QueueSkip,
+			expect: fwk.QueueSkip,
 		},
 
 		{
@@ -1817,7 +1818,7 @@ func TestIsSchedulableAfterCSIDriverChange(t *testing.T) {
 				},
 			},
 			err:    false,
-			expect: framework.Queue,
+			expect: fwk.Queue,
 		},
 	}
 	for _, item := range table {

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -320,42 +320,42 @@ func (pl *VolumeRestrictions) Filter(ctx context.Context, cycleState fwk.CycleSt
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (pl *VolumeRestrictions) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *VolumeRestrictions) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	// A note about UpdateNodeTaint/UpdateNodeLabel event:
 	// Ideally, it's supposed to register only Add because any Node update event will never change the result from this plugin.
 	// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
 	// See: https://github.com/kubernetes/kubernetes/issues/109437
-	nodeActionType := framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeLabel
+	nodeActionType := fwk.Add | fwk.UpdateNodeTaint | fwk.UpdateNodeLabel
 	if pl.enableSchedulingQueueHint {
 		// preCheck is not used when QHint is enabled, and hence Update event isn't necessary.
-		nodeActionType = framework.Add
+		nodeActionType = fwk.Add
 	}
 
-	return []framework.ClusterEventWithHint{
+	return []fwk.ClusterEventWithHint{
 		// Pods may fail to schedule because of volumes conflicting with other pods on same node.
 		// Once running pods are deleted and volumes have been released, the unschedulable pod will be schedulable.
 		// Due to immutable fields `spec.volumes`, pod update events are ignored.
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}, QueueingHintFn: pl.isSchedulableAfterPodDeleted},
 		// A new Node may make a pod schedulable.
 		// We intentionally don't set QueueingHint since all Node/Add events could make Pods schedulable.
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: nodeActionType}},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: nodeActionType}},
 		// Pods may fail to schedule because the PVC it uses has not yet been created.
 		// This PVC is required to exist to check its access modes.
-		{Event: framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add},
+		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add},
 			QueueingHintFn: pl.isSchedulableAfterPersistentVolumeClaimAdded},
 	}, nil
 }
 
 // isSchedulableAfterPersistentVolumeClaimAdded is invoked whenever a PersistentVolumeClaim added or changed, It checks whether
 // that change made a previously unschedulable pod schedulable.
-func (pl *VolumeRestrictions) isSchedulableAfterPersistentVolumeClaimAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *VolumeRestrictions) isSchedulableAfterPersistentVolumeClaimAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	_, newPersistentVolumeClaim, err := util.As[*v1.PersistentVolumeClaim](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPersistentVolumeClaimChange: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPersistentVolumeClaimChange: %w", err)
 	}
 
 	if newPersistentVolumeClaim.Namespace != pod.Namespace {
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	for _, volume := range pod.Spec.Volumes {
@@ -365,29 +365,29 @@ func (pl *VolumeRestrictions) isSchedulableAfterPersistentVolumeClaimAdded(logge
 
 		if volume.PersistentVolumeClaim.ClaimName == newPersistentVolumeClaim.Name {
 			logger.V(5).Info("PVC that is referred from the pod was created, which might make this pod schedulable", "pod", klog.KObj(pod), "PVC", klog.KObj(newPersistentVolumeClaim))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 	logger.V(5).Info("PVC irrelevant to the Pod was created, which doesn't make this pod schedulable", "pod", klog.KObj(pod), "PVC", klog.KObj(newPersistentVolumeClaim))
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
 // isSchedulableAfterPodDeleted is invoked whenever a pod deleted,
 // It checks whether the deleted pod will conflict with volumes of other pods on the same node
-func (pl *VolumeRestrictions) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *VolumeRestrictions) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
-		return framework.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPodDeleted: %w", err)
+		return fwk.Queue, fmt.Errorf("unexpected objects in isSchedulableAfterPodDeleted: %w", err)
 	}
 
 	if deletedPod.Namespace != pod.Namespace {
-		return framework.QueueSkip, nil
+		return fwk.QueueSkip, nil
 	}
 
 	nodeInfo := framework.NewNodeInfo(deletedPod)
 	if !satisfyVolumeConflicts(pod, nodeInfo) {
 		logger.V(5).Info("Pod with the volume that the target pod requires was deleted, which might make this pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-		return framework.Queue, nil
+		return fwk.Queue, nil
 	}
 
 	// Return Queue if a deleted pod uses the same PVC since the pod may be unschedulable due to the ReadWriteOncePod access mode of the PVC.
@@ -405,12 +405,12 @@ func (pl *VolumeRestrictions) isSchedulableAfterPodDeleted(logger klog.Logger, p
 	for _, volume := range deletedPod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil && claims.Has(volume.PersistentVolumeClaim.ClaimName) {
 			logger.V(5).Info("Pod with the same PVC that the target pod requires was deleted, which might make this pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-			return framework.Queue, nil
+			return fwk.Queue, nil
 		}
 	}
 
 	logger.V(5).Info("An irrelevant Pod was deleted, which doesn't make this pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-	return framework.QueueSkip, nil
+	return fwk.QueueSkip, nil
 }
 
 // New initializes a new plugin and returns it.

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -579,7 +580,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 		oldObj, newObj interface{}
 		existingPods   []*v1.Pod
 		existingPVC    *v1.PersistentVolumeClaim
-		expectedHint   framework.QueueingHint
+		expectedHint   fwk.QueueingHint
 		expectedErr    bool
 	}{
 		"queue-new-object-gcedisk-conflict": {
@@ -587,7 +588,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podGCEDiskConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  false,
 		},
 		"skip-new-object-gcedisk-no-conflict": {
@@ -595,7 +596,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podGCEDiskNoConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 		"queue-new-object-awsdisk-conflict": {
@@ -603,7 +604,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podAWSDiskConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  false,
 		},
 		"skip-new-object-awsdisk-no-conflict": {
@@ -611,7 +612,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podAWSDiskNoConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 		"queue-new-object-rbddisk-conflict": {
@@ -619,7 +620,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podRBDDiskDiskConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  false,
 		},
 		"skip-new-object-rbddisk-no-conflict": {
@@ -627,7 +628,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podRBDDiskNoConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 		"queue-new-object-iscsidisk-conflict": {
@@ -635,7 +636,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podISCSIDiskConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  false,
 		},
 		"skip-new-object-iscsidisk-no-conflict": {
@@ -643,7 +644,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       podISCSIDiskNoConflicts,
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 		"queue-has-same-claim": {
@@ -651,7 +652,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       st.MakePod().Name("pod2").PVC("claim-rwop").Obj(),
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  false,
 		},
 		"skip-no-same-claim": {
@@ -659,7 +660,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			oldObj:       st.MakePod().Name("pod2").PVC("claim-2-rwop").Obj(),
 			existingPods: []*v1.Pod{},
 			existingPVC:  &v1.PersistentVolumeClaim{},
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 	}
@@ -718,42 +719,42 @@ func Test_isSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 		existingPods   []*v1.Pod
 		pod            *v1.Pod
 		oldObj, newObj interface{}
-		expectedHint   framework.QueueingHint
+		expectedHint   fwk.QueueingHint
 		expectedErr    bool
 	}{
 		"queue-new-object-pvc-belong-pod": {
 			existingPods: []*v1.Pod{},
 			pod:          podWithTwoPVCs,
 			newObj:       PVC1,
-			expectedHint: framework.Queue,
+			expectedHint: fwk.Queue,
 			expectedErr:  false,
 		},
 		"skip-new-object-unused": {
 			existingPods: []*v1.Pod{},
 			pod:          podWithOnePVC,
 			newObj:       PVC2,
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 		"skip-nil-old-object": {
 			existingPods: []*v1.Pod{},
 			pod:          podWithOnePVC,
 			newObj:       PVC2,
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 		"skip-new-object-not-belong-pod": {
 			existingPods: []*v1.Pod{},
 			pod:          podWithOnePVC,
 			newObj:       PVC2,
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 		"skip-new-object-namespace-not-equal-pod": {
 			existingPods: []*v1.Pod{},
 			pod:          podWithNotEqualNamespace,
 			newObj:       PVC1,
-			expectedHint: framework.QueueSkip,
+			expectedHint: fwk.QueueSkip,
 			expectedErr:  false,
 		},
 	}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -641,7 +641,7 @@ type defaultEnqueueExtension struct {
 }
 
 func (p *defaultEnqueueExtension) Name() string { return p.pluginName }
-func (p *defaultEnqueueExtension) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (p *defaultEnqueueExtension) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	// need to return all specific cluster events with framework.All action instead of wildcard event
 	// because the returning values are used to register event handlers.
 	// If we return the wildcard here, it won't affect the event handlers registered by the plugin

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -35,284 +35,70 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	resourcehelper "k8s.io/component-helpers/resource"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 var generation int64
 
-// ActionType is an integer to represent one type of resource change.
-// Different ActionTypes can be bit-wised to compose new semantics.
-type ActionType int64
-
-// Constants for ActionTypes.
-// CAUTION for contributors: When you add a new ActionType, you must update the following:
-// - The list of basic, podOnly, and nodeOnly.
-// - String() method.
-const (
-	Add ActionType = 1 << iota
-	Delete
-
-	// UpdateNodeXYZ is only applicable for Node events.
-	// If you use UpdateNodeXYZ,
-	// your plugin's QueueingHint is only executed for the specific sub-Update event.
-	// It's better to narrow down the scope of the event by using them instead of just using Update event
-	// for better performance in requeueing.
-	UpdateNodeAllocatable
-	UpdateNodeLabel
-	// UpdateNodeTaint is an update for node's taints or node.Spec.Unschedulable.
-	UpdateNodeTaint
-	UpdateNodeCondition
-	UpdateNodeAnnotation
-
-	// UpdatePodXYZ is only applicable for Pod events.
-	// If you use UpdatePodXYZ,
-	// your plugin's QueueingHint is only executed for the specific sub-Update event.
-	// It's better to narrow down the scope of the event by using them instead of Update event
-	// for better performance in requeueing.
-	UpdatePodLabel
-	// UpdatePodScaleDown is an update for pod's scale down (i.e., any resource request is reduced).
-	UpdatePodScaleDown
-	// UpdatePodToleration is an addition for pod's tolerations.
-	// (Due to API validation, we can add, but cannot modify or remove tolerations.)
-	UpdatePodToleration
-	// UpdatePodSchedulingGatesEliminated is an update for pod's scheduling gates, which eliminates all scheduling gates in the Pod.
-	UpdatePodSchedulingGatesEliminated
-	// UpdatePodGeneratedResourceClaim is an update of the list of ResourceClaims generated for the pod.
-	// Depends on the DynamicResourceAllocation feature gate.
-	UpdatePodGeneratedResourceClaim
-
-	All ActionType = 1<<iota - 1
-
-	// Use the general Update type if you don't either know or care the specific sub-Update type to use.
-	Update = UpdateNodeAllocatable | UpdateNodeLabel | UpdateNodeTaint | UpdateNodeCondition | UpdateNodeAnnotation | UpdatePodLabel | UpdatePodScaleDown | UpdatePodToleration | UpdatePodSchedulingGatesEliminated | UpdatePodGeneratedResourceClaim
-
-	// None is a special ActionType that is only used internally.
-	None ActionType = 0
-)
-
 var (
 	// basicActionTypes is a list of basicActionTypes ActionTypes.
-	basicActionTypes = []ActionType{Add, Delete, Update}
+	basicActionTypes = []fwk.ActionType{fwk.Add, fwk.Delete, fwk.Update}
 	// podActionTypes is a list of ActionTypes that are only applicable for Pod events.
-	podActionTypes = []ActionType{UpdatePodLabel, UpdatePodScaleDown, UpdatePodToleration, UpdatePodSchedulingGatesEliminated, UpdatePodGeneratedResourceClaim}
+	podActionTypes = []fwk.ActionType{fwk.UpdatePodLabel, fwk.UpdatePodScaleDown, fwk.UpdatePodToleration, fwk.UpdatePodSchedulingGatesEliminated, fwk.UpdatePodGeneratedResourceClaim}
 	// nodeActionTypes is a list of ActionTypes that are only applicable for Node events.
-	nodeActionTypes = []ActionType{UpdateNodeAllocatable, UpdateNodeLabel, UpdateNodeTaint, UpdateNodeCondition, UpdateNodeAnnotation}
+	nodeActionTypes = []fwk.ActionType{fwk.UpdateNodeAllocatable, fwk.UpdateNodeLabel, fwk.UpdateNodeTaint, fwk.UpdateNodeCondition, fwk.UpdateNodeAnnotation}
 )
 
-func (a ActionType) String() string {
-	switch a {
-	case Add:
-		return "Add"
-	case Delete:
-		return "Delete"
-	case UpdateNodeAllocatable:
-		return "UpdateNodeAllocatable"
-	case UpdateNodeLabel:
-		return "UpdateNodeLabel"
-	case UpdateNodeTaint:
-		return "UpdateNodeTaint"
-	case UpdateNodeCondition:
-		return "UpdateNodeCondition"
-	case UpdateNodeAnnotation:
-		return "UpdateNodeAnnotation"
-	case UpdatePodLabel:
-		return "UpdatePodLabel"
-	case UpdatePodScaleDown:
-		return "UpdatePodScaleDown"
-	case UpdatePodToleration:
-		return "UpdatePodToleration"
-	case UpdatePodSchedulingGatesEliminated:
-		return "UpdatePodSchedulingGatesEliminated"
-	case UpdatePodGeneratedResourceClaim:
-		return "UpdatePodGeneratedResourceClaim"
-	case All:
-		return "All"
-	case Update:
-		return "Update"
-	}
-
-	// Shouldn't reach here.
-	return ""
-}
-
-// EventResource is basically short for group/version/kind, which can uniquely represent a particular API resource.
-type EventResource string
-
 // Constants for GVKs.
-//
-// CAUTION for contributors: When you add a new EventResource, you must register a new one to allResources.
-//
-// Note:
-// - UpdatePodXYZ or UpdateNodeXYZ: triggered by updating particular parts of a Pod or a Node, e.g. updatePodLabel.
-// Use specific events rather than general ones (updatePodLabel vs update) can make the requeueing process more efficient
-// and consume less memory as less events will be cached at scheduler.
 const (
-	// There are a couple of notes about how the scheduler notifies the events of Pods:
-	// - Add: add events could be triggered by either a newly created Pod or an existing Pod that is scheduled to a Node.
-	// - Delete: delete events could be triggered by:
-	//           - a Pod that is deleted
-	//           - a Pod that was assumed, but gets un-assumed due to some errors in the binding cycle.
-	//           - an existing Pod that was unscheduled but gets scheduled to a Node.
-	//
-	// Note that the Pod event type includes the events for the unscheduled Pod itself.
-	// i.e., when unscheduled Pods are updated, the scheduling queue checks with Pod/Update QueueingHint(s) whether the update may make the pods schedulable,
-	// and requeues them to activeQ/backoffQ when at least one QueueingHint(s) return Queue.
-	// Plugins **have to** implement a QueueingHint for Pod/Update event
-	// if the rejection from them could be resolved by updating unscheduled Pods themselves.
-	// Example: Pods that require excessive resources may be rejected by the noderesources plugin,
-	// if this unscheduled pod is updated to require fewer resources,
-	// the previous rejection from noderesources plugin can be resolved.
-	// this plugin would implement QueueingHint for Pod/Update event
-	// that returns Queue when such label changes are made in unscheduled Pods.
-	Pod EventResource = "Pod"
-
 	// These assignedPod and unschedulablePod are internal resources that are used to represent the type of Pod.
 	// We don't expose them to the plugins deliberately because we don't publish Pod events with unschedulable Pods in the first place.
-	assignedPod      EventResource = "AssignedPod"
-	unschedulablePod EventResource = "UnschedulablePod"
-
-	// A note about NodeAdd event and UpdateNodeTaint event:
-	// When QHint is disabled, NodeAdd often isn't worked expectedly because of the internal feature called preCheck.
-	// It's definitely not something expected for plugin developers,
-	// and registering UpdateNodeTaint event is the only mitigation for now.
-	// So, kube-scheduler registers UpdateNodeTaint event for plugins that has NodeAdded event, but don't have UpdateNodeTaint event.
-	// It has a bad impact for the requeuing efficiency though, a lot better than some Pods being stuck in the
-	// unschedulable pod pool.
-	// This problematic preCheck feature is disabled when QHint is enabled,
-	// and eventually will be removed along with QHint graduation.
-	// See: https://github.com/kubernetes/kubernetes/issues/110175
-	Node                  EventResource = "Node"
-	PersistentVolume      EventResource = "PersistentVolume"
-	PersistentVolumeClaim EventResource = "PersistentVolumeClaim"
-	CSINode               EventResource = "storage.k8s.io/CSINode"
-	CSIDriver             EventResource = "storage.k8s.io/CSIDriver"
-	VolumeAttachment      EventResource = "storage.k8s.io/VolumeAttachment"
-	CSIStorageCapacity    EventResource = "storage.k8s.io/CSIStorageCapacity"
-	StorageClass          EventResource = "storage.k8s.io/StorageClass"
-	ResourceClaim         EventResource = "resource.k8s.io/ResourceClaim"
-	ResourceSlice         EventResource = "resource.k8s.io/ResourceSlice"
-	DeviceClass           EventResource = "resource.k8s.io/DeviceClass"
-
-	// WildCard is a special EventResource to match all resources.
-	// e.g., If you register `{Resource: "*", ActionType: All}` in EventsToRegister,
-	// all coming clusterEvents will be admitted. Be careful to register it, it will
-	// increase the computing pressure in requeueing unless you really need it.
-	//
-	// Meanwhile, if the coming clusterEvent is a wildcard one, all pods
-	// will be moved from unschedulablePod pool to activeQ/backoffQ forcibly.
-	WildCard EventResource = "*"
+	assignedPod      fwk.EventResource = "AssignedPod"
+	unschedulablePod fwk.EventResource = "UnschedulablePod"
 )
 
 var (
 	// allResources is a list of all resources.
-	allResources = []EventResource{
-		Pod,
+	allResources = []fwk.EventResource{
+		fwk.Pod,
 		assignedPod,
 		unschedulablePod,
-		Node,
-		PersistentVolume,
-		PersistentVolumeClaim,
-		CSINode,
-		CSIDriver,
-		CSIStorageCapacity,
-		StorageClass,
-		VolumeAttachment,
-		ResourceClaim,
-		ResourceSlice,
-		DeviceClass,
+		fwk.Node,
+		fwk.PersistentVolume,
+		fwk.PersistentVolumeClaim,
+		fwk.CSINode,
+		fwk.CSIDriver,
+		fwk.CSIStorageCapacity,
+		fwk.StorageClass,
+		fwk.VolumeAttachment,
+		fwk.ResourceClaim,
+		fwk.ResourceSlice,
+		fwk.DeviceClass,
 	}
 )
-
-type ClusterEventWithHint struct {
-	Event ClusterEvent
-	// QueueingHintFn is executed for the Pod rejected by this plugin when the above Event happens,
-	// and filters out events to reduce useless retry of Pod's scheduling.
-	// It's an optional field. If not set,
-	// the scheduling of Pods will be always retried with backoff when this Event happens.
-	// (the same as Queue)
-	QueueingHintFn QueueingHintFn
-}
-
-// QueueingHintFn returns a hint that signals whether the event can make a Pod,
-// which was rejected by this plugin in the past scheduling cycle, schedulable or not.
-// It's called before a Pod gets moved from unschedulableQ to backoffQ or activeQ.
-// If it returns an error, we'll take the returned QueueingHint as `Queue` at the caller whatever we returned here so that
-// we can prevent the Pod from being stuck in the unschedulable pod pool.
-//
-// - `pod`: the Pod to be enqueued, which is rejected by this plugin in the past.
-// - `oldObj` `newObj`: the object involved in that event.
-//   - For example, the given event is "Node deleted", the `oldObj` will be that deleted Node.
-//   - `oldObj` is nil if the event is add event.
-//   - `newObj` is nil if the event is delete event.
-type QueueingHintFn func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (QueueingHint, error)
-
-type QueueingHint int
-
-const (
-	// QueueSkip implies that the cluster event has no impact on
-	// scheduling of the pod.
-	QueueSkip QueueingHint = iota
-
-	// Queue implies that the Pod may be schedulable by the event.
-	Queue
-)
-
-func (s QueueingHint) String() string {
-	switch s {
-	case QueueSkip:
-		return "QueueSkip"
-	case Queue:
-		return "Queue"
-	}
-	return ""
-}
-
-// ClusterEvent abstracts how a system resource's state gets changed.
-// Resource represents the standard API resources such as Pod, Node, etc.
-// ActionType denotes the specific change such as Add, Update or Delete.
-type ClusterEvent struct {
-	Resource   EventResource
-	ActionType ActionType
-
-	// label describes this cluster event.
-	// It's an optional field to control String(), which is used in logging and metrics.
-	// Normally, it's not necessary to set this field; only used for special events like UnschedulableTimeout.
-	label string
-}
-
-// Label is used for logging and metrics.
-func (ce ClusterEvent) Label() string {
-	if ce.label != "" {
-		return ce.label
-	}
-
-	return fmt.Sprintf("%v%v", ce.Resource, ce.ActionType)
-}
 
 // AllClusterEventLabels returns all possible cluster event labels given to the metrics.
 func AllClusterEventLabels() []string {
 	labels := []string{UnschedulableTimeout, ForceActivate}
 	for _, r := range allResources {
 		for _, a := range basicActionTypes {
-			labels = append(labels, ClusterEvent{Resource: r, ActionType: a}.Label())
+			labels = append(labels, fwk.ClusterEvent{Resource: r, ActionType: a}.Label())
 		}
-		if r == Pod {
-			for _, a := range podActionTypes {
-				labels = append(labels, ClusterEvent{Resource: r, ActionType: a}.Label())
-			}
-		} else if r == Node {
-			for _, a := range nodeActionTypes {
-				labels = append(labels, ClusterEvent{Resource: r, ActionType: a}.Label())
-			}
-		}
+	}
+	for _, a := range podActionTypes {
+		labels = append(labels, fwk.ClusterEvent{Resource: fwk.Pod, ActionType: a}.Label())
+	}
+	for _, a := range nodeActionTypes {
+		labels = append(labels, fwk.ClusterEvent{Resource: fwk.Node, ActionType: a}.Label())
 	}
 	return labels
 }
 
 // IsWildCard returns true if ClusterEvent follows WildCard semantics
-func (ce ClusterEvent) IsWildCard() bool {
-	return ce.Resource == WildCard && ce.ActionType == All
+func ClusterEventIsWildCard(ce fwk.ClusterEvent) bool {
+	return ce.Resource == fwk.WildCard && ce.ActionType == fwk.All
 }
 
 // Match returns true if ClusterEvent is matched with the coming event.
@@ -331,43 +117,43 @@ func (ce ClusterEvent) IsWildCard() bool {
 // Note: we have a special case here when the coming event is a wildcard event,
 // it will force all Pods to move to activeQ/backoffQ,
 // but we take it as an unmatched event unless the ce is also a wildcard one.
-func (ce ClusterEvent) Match(incomingEvent ClusterEvent) bool {
-	return ce.IsWildCard() ||
-		ce.Resource.match(incomingEvent.Resource) && ce.ActionType&incomingEvent.ActionType != 0 && incomingEvent.ActionType <= ce.ActionType
+func MatchClusterEvents(ce, incomingEvent fwk.ClusterEvent) bool {
+	return ClusterEventIsWildCard(ce) ||
+		matchEventResources(ce.Resource, incomingEvent.Resource) && ce.ActionType&incomingEvent.ActionType != 0 && incomingEvent.ActionType <= ce.ActionType
 }
 
 // match returns true if the resource is matched with the coming resource.
-func (r EventResource) match(resource EventResource) bool {
+func matchEventResources(r, resource fwk.EventResource) bool {
 	// WildCard matches all resources
-	return r == WildCard ||
+	return r == fwk.WildCard ||
 		// Exact match
 		r == resource ||
 		// Pod matches assignedPod and unscheduledPod.
 		// (assignedPod and unscheduledPod aren't exposed and hence only used for incoming events and never used in EventsToRegister)
-		r == Pod && (resource == assignedPod || resource == unschedulablePod)
+		r == fwk.Pod && (resource == assignedPod || resource == unschedulablePod)
 }
 
-func (ce ClusterEvent) MatchAny(events []ClusterEvent) bool {
-	for _, e := range events {
-		if e.Match(ce) {
+func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent) bool {
+	for _, e := range incomingEvents {
+		if MatchClusterEvents(e, ce) {
 			return true
 		}
 	}
 	return false
 }
 
-func UnrollWildCardResource() []ClusterEventWithHint {
-	return []ClusterEventWithHint{
-		{Event: ClusterEvent{Resource: Pod, ActionType: All}},
-		{Event: ClusterEvent{Resource: Node, ActionType: All}},
-		{Event: ClusterEvent{Resource: PersistentVolume, ActionType: All}},
-		{Event: ClusterEvent{Resource: PersistentVolumeClaim, ActionType: All}},
-		{Event: ClusterEvent{Resource: CSINode, ActionType: All}},
-		{Event: ClusterEvent{Resource: CSIDriver, ActionType: All}},
-		{Event: ClusterEvent{Resource: CSIStorageCapacity, ActionType: All}},
-		{Event: ClusterEvent{Resource: StorageClass, ActionType: All}},
-		{Event: ClusterEvent{Resource: ResourceClaim, ActionType: All}},
-		{Event: ClusterEvent{Resource: DeviceClass, ActionType: All}},
+func UnrollWildCardResource() []fwk.ClusterEventWithHint {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolume, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.CSINode, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.CSIDriver, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.CSIStorageCapacity, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.StorageClass, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.ResourceClaim, ActionType: fwk.All}},
+		{Event: fwk.ClusterEvent{Resource: fwk.DeviceClass, ActionType: fwk.All}},
 	}
 }
 
@@ -420,7 +206,7 @@ type QueuedPodInfo struct {
 	GatingPlugin string
 	// GatingPluginEvents records the events registered by the plugin that gated the Pod at PreEnqueue.
 	// We have it as a cache purpose to avoid re-computing which event(s) might ungate the Pod.
-	GatingPluginEvents []ClusterEvent
+	GatingPluginEvents []fwk.ClusterEvent
 }
 
 // Gated returns true if the pod is gated by any plugin.

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -31,6 +31,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
@@ -2095,63 +2096,63 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 func TestCloudEvent_Match(t *testing.T) {
 	testCases := []struct {
 		name        string
-		event       ClusterEvent
-		comingEvent ClusterEvent
+		event       fwk.ClusterEvent
+		comingEvent fwk.ClusterEvent
 		wantResult  bool
 	}{
 		{
 			name:        "wildcard event matches with all kinds of coming events",
-			event:       ClusterEvent{Resource: WildCard, ActionType: All},
-			comingEvent: ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel},
+			event:       fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.All},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
 		{
 			name:        "event with resource = 'Pod' matching with coming events carries same actionType",
-			event:       ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel | UpdateNodeTaint},
-			comingEvent: ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel},
+			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel | fwk.UpdateNodeTaint},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
 		{
 			name:        "event with resource = 'Pod' matching with coming events carries unschedulablePod",
-			event:       ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel | UpdateNodeTaint},
-			comingEvent: ClusterEvent{Resource: unschedulablePod, ActionType: UpdateNodeLabel},
+			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel | fwk.UpdateNodeTaint},
+			comingEvent: fwk.ClusterEvent{Resource: unschedulablePod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
 		{
 			name:        "event with resource = '*' matching with coming events carries same actionType",
-			event:       ClusterEvent{Resource: WildCard, ActionType: UpdateNodeLabel},
-			comingEvent: ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel},
+			event:       fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.UpdateNodeLabel},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
 		{
 			name:        "event with resource = '*' matching with coming events carries different actionType",
-			event:       ClusterEvent{Resource: WildCard, ActionType: UpdateNodeLabel},
-			comingEvent: ClusterEvent{Resource: Pod, ActionType: UpdateNodeAllocatable},
+			event:       fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.UpdateNodeLabel},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeAllocatable},
 			wantResult:  false,
 		},
 		{
 			name:        "event matching with coming events carries '*' resources",
-			event:       ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel},
-			comingEvent: ClusterEvent{Resource: WildCard, ActionType: UpdateNodeLabel},
+			event:       fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  false,
 		},
 		{
 			name:        "event with resource = '*' matching with coming events carrying a too broad actionType",
-			event:       ClusterEvent{Resource: WildCard, ActionType: UpdateNodeLabel},
-			comingEvent: ClusterEvent{Resource: Pod, ActionType: Update},
+			event:       fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.UpdateNodeLabel},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Update},
 			wantResult:  false,
 		},
 		{
 			name:        "event with resource = '*' matching with coming events carrying a more specific actionType",
-			event:       ClusterEvent{Resource: WildCard, ActionType: Update},
-			comingEvent: ClusterEvent{Resource: Pod, ActionType: UpdateNodeLabel},
+			event:       fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.Update},
+			comingEvent: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdateNodeLabel},
 			wantResult:  true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.event.Match(tc.comingEvent)
+			got := MatchClusterEvents(tc.event, tc.comingEvent)
 			if got != tc.wantResult {
 				t.Fatalf("unexpected result")
 			}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -421,8 +421,8 @@ func New(ctx context.Context,
 
 // defaultQueueingHintFn is the default queueing hint function.
 // It always returns Queue as the queueing hint.
-var defaultQueueingHintFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (framework.QueueingHint, error) {
-	return framework.Queue, nil
+var defaultQueueingHintFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (fwk.QueueingHint, error) {
+	return fwk.Queue, nil
 }
 
 func buildQueueingHintMap(ctx context.Context, es []framework.EnqueueExtensions) (internalqueue.QueueingHintMap, error) {
@@ -454,11 +454,11 @@ func buildQueueingHintMap(ctx context.Context, es []framework.EnqueueExtensions)
 				fn = defaultQueueingHintFn
 			}
 
-			if event.Event.Resource == framework.Node {
-				if event.Event.ActionType&framework.Add != 0 {
+			if event.Event.Resource == fwk.Node {
+				if event.Event.ActionType&fwk.Add != 0 {
 					registerNodeAdded = true
 				}
-				if event.Event.ActionType&framework.UpdateNodeTaint != 0 {
+				if event.Event.ActionType&fwk.UpdateNodeTaint != 0 {
 					registerNodeTaintUpdated = true
 				}
 			}
@@ -479,8 +479,8 @@ func buildQueueingHintMap(ctx context.Context, es []framework.EnqueueExtensions)
 			// unschedulable pod pool.
 			// This behavior will be removed when we remove the preCheck feature.
 			// See: https://github.com/kubernetes/kubernetes/issues/110175
-			queueingHintMap[framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}] =
-				append(queueingHintMap[framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}],
+			queueingHintMap[fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}] =
+				append(queueingHintMap[fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}],
 					&internalqueue.QueueingHintFunction{
 						PluginName:     e.Name(),
 						QueueingHintFn: defaultQueueingHintFn,
@@ -585,8 +585,8 @@ func buildExtenders(logger klog.Logger, extenders []schedulerapi.Extender, profi
 
 type FailureHandlerFn func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *framework.Status, nominatingInfo *framework.NominatingInfo, start time.Time)
 
-func unionedGVKs(queueingHintsPerProfile internalqueue.QueueingHintMapPerProfile) map[framework.EventResource]framework.ActionType {
-	gvkMap := make(map[framework.EventResource]framework.ActionType)
+func unionedGVKs(queueingHintsPerProfile internalqueue.QueueingHintMapPerProfile) map[fwk.EventResource]fwk.ActionType {
+	gvkMap := make(map[fwk.EventResource]fwk.ActionType)
 	for _, queueingHints := range queueingHintsPerProfile {
 		for evt := range queueingHints {
 			if _, ok := gvkMap[evt.Resource]; ok {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -616,42 +616,42 @@ func Test_buildQueueingHintMap(t *testing.T) {
 	tests := []struct {
 		name                string
 		plugins             []framework.Plugin
-		want                map[framework.ClusterEvent][]*internalqueue.QueueingHintFunction
+		want                map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction
 		featuregateDisabled bool
 		wantErr             error
 	}{
 		{
 			name:    "filter without EnqueueExtensions plugin",
 			plugins: []framework.Plugin{&filterWithoutEnqueueExtensionsPlugin{}},
-			want: map[framework.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: framework.Pod, ActionType: framework.All}: {
+			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
+				{Resource: fwk.Pod, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.Node, ActionType: framework.All}: {
+				{Resource: fwk.Node, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.CSINode, ActionType: framework.All}: {
+				{Resource: fwk.CSINode, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.CSIDriver, ActionType: framework.All}: {
+				{Resource: fwk.CSIDriver, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.CSIStorageCapacity, ActionType: framework.All}: {
+				{Resource: fwk.CSIStorageCapacity, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.PersistentVolume, ActionType: framework.All}: {
+				{Resource: fwk.PersistentVolume, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.StorageClass, ActionType: framework.All}: {
+				{Resource: fwk.StorageClass, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.PersistentVolumeClaim, ActionType: framework.All}: {
+				{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.ResourceClaim, ActionType: framework.All}: {
+				{Resource: fwk.ResourceClaim, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
-				{Resource: framework.DeviceClass, ActionType: framework.All}: {
+				{Resource: fwk.DeviceClass, ActionType: fwk.All}: {
 					{PluginName: filterWithoutEnqueueExtensions, QueueingHintFn: defaultQueueingHintFn},
 				},
 			},
@@ -659,14 +659,14 @@ func Test_buildQueueingHintMap(t *testing.T) {
 		{
 			name:    "node and pod plugin",
 			plugins: []framework.Plugin{&fakeNodePlugin{}, &fakePodPlugin{}},
-			want: map[framework.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: framework.Pod, ActionType: framework.Add}: {
+			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
+				{Resource: fwk.Pod, ActionType: fwk.Add}: {
 					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
 				},
-				{Resource: framework.Node, ActionType: framework.Add}: {
+				{Resource: fwk.Node, ActionType: fwk.Add}: {
 					{PluginName: fakeNode, QueueingHintFn: fakeNodePluginQueueingFn},
 				},
-				{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: {
+				{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}: {
 					{PluginName: fakeNode, QueueingHintFn: defaultQueueingHintFn}, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
 				},
 			},
@@ -675,14 +675,14 @@ func Test_buildQueueingHintMap(t *testing.T) {
 			name:                "node and pod plugin (featuregate is disabled)",
 			plugins:             []framework.Plugin{&fakeNodePlugin{}, &fakePodPlugin{}},
 			featuregateDisabled: true,
-			want: map[framework.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: framework.Pod, ActionType: framework.Add}: {
+			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
+				{Resource: fwk.Pod, ActionType: fwk.Add}: {
 					{PluginName: fakePod, QueueingHintFn: defaultQueueingHintFn}, // default queueing hint due to disabled feature gate.
 				},
-				{Resource: framework.Node, ActionType: framework.Add}: {
+				{Resource: fwk.Node, ActionType: fwk.Add}: {
 					{PluginName: fakeNode, QueueingHintFn: defaultQueueingHintFn}, // default queueing hint due to disabled feature gate.
 				},
-				{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: {
+				{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}: {
 					{PluginName: fakeNode, QueueingHintFn: defaultQueueingHintFn}, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
 				},
 			},
@@ -690,19 +690,19 @@ func Test_buildQueueingHintMap(t *testing.T) {
 		{
 			name:    "register plugin with empty event",
 			plugins: []framework.Plugin{&emptyEventPlugin{}},
-			want:    map[framework.ClusterEvent][]*internalqueue.QueueingHintFunction{},
+			want:    map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{},
 		},
 		{
 			name:    "register plugins including emptyEventPlugin",
 			plugins: []framework.Plugin{&emptyEventPlugin{}, &fakeNodePlugin{}},
-			want: map[framework.ClusterEvent][]*internalqueue.QueueingHintFunction{
-				{Resource: framework.Pod, ActionType: framework.Add}: {
+			want: map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{
+				{Resource: fwk.Pod, ActionType: fwk.Add}: {
 					{PluginName: fakePod, QueueingHintFn: fakePodPluginQueueingFn},
 				},
-				{Resource: framework.Node, ActionType: framework.Add}: {
+				{Resource: fwk.Node, ActionType: fwk.Add}: {
 					{PluginName: fakeNode, QueueingHintFn: fakeNodePluginQueueingFn},
 				},
-				{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: {
+				{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}: {
 					{PluginName: fakeNode, QueueingHintFn: defaultQueueingHintFn}, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
 				},
 			},
@@ -710,7 +710,7 @@ func Test_buildQueueingHintMap(t *testing.T) {
 		{
 			name:    "one EventsToRegister returns an error",
 			plugins: []framework.Plugin{&errorEventsToRegisterPlugin{}},
-			want:    map[framework.ClusterEvent][]*internalqueue.QueueingHintFunction{},
+			want:    map[fwk.ClusterEvent][]*internalqueue.QueueingHintFunction{},
 			wantErr: errors.New("mock error"),
 		},
 	}
@@ -793,7 +793,7 @@ func Test_UnionedGVKs(t *testing.T) {
 	tests := []struct {
 		name                            string
 		plugins                         schedulerapi.PluginSet
-		want                            map[framework.EventResource]framework.ActionType
+		want                            map[fwk.EventResource]fwk.ActionType
 		enableInPlacePodVerticalScaling bool
 		enableSchedulerQueueingHints    bool
 	}{
@@ -807,17 +807,17 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.EventResource]framework.ActionType{
-				framework.Pod:                   framework.All,
-				framework.Node:                  framework.All,
-				framework.CSINode:               framework.All,
-				framework.CSIDriver:             framework.All,
-				framework.CSIStorageCapacity:    framework.All,
-				framework.PersistentVolume:      framework.All,
-				framework.PersistentVolumeClaim: framework.All,
-				framework.StorageClass:          framework.All,
-				framework.ResourceClaim:         framework.All,
-				framework.DeviceClass:           framework.All,
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.Pod:                   fwk.All,
+				fwk.Node:                  fwk.All,
+				fwk.CSINode:               fwk.All,
+				fwk.CSIDriver:             fwk.All,
+				fwk.CSIStorageCapacity:    fwk.All,
+				fwk.PersistentVolume:      fwk.All,
+				fwk.PersistentVolumeClaim: fwk.All,
+				fwk.StorageClass:          fwk.All,
+				fwk.ResourceClaim:         fwk.All,
+				fwk.DeviceClass:           fwk.All,
 			},
 		},
 		{
@@ -830,8 +830,8 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.EventResource]framework.ActionType{
-				framework.Node: framework.Add | framework.UpdateNodeTaint, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.Node: fwk.Add | fwk.UpdateNodeTaint, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
 			},
 		},
 		{
@@ -844,8 +844,8 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.EventResource]framework.ActionType{
-				framework.Pod: framework.Add,
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.Pod: fwk.Add,
 			},
 		},
 		{
@@ -859,9 +859,9 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.EventResource]framework.ActionType{
-				framework.Pod:  framework.Add,
-				framework.Node: framework.Add | framework.UpdateNodeTaint, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.Pod:  fwk.Add,
+				fwk.Node: fwk.Add | fwk.UpdateNodeTaint, // When Node/Add is registered, Node/UpdateNodeTaint is automatically registered.
 			},
 		},
 		{
@@ -874,52 +874,52 @@ func Test_UnionedGVKs(t *testing.T) {
 				},
 				Disabled: []schedulerapi.Plugin{{Name: "*"}}, // disable default plugins
 			},
-			want: map[framework.EventResource]framework.ActionType{},
+			want: map[fwk.EventResource]fwk.ActionType{},
 		},
 		{
 			name:    "plugins with default profile (No feature gate enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
-			want: map[framework.EventResource]framework.ActionType{
-				framework.Pod:                   framework.Add | framework.UpdatePodLabel | framework.Delete,
-				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
-				framework.CSINode:               framework.All - framework.Delete,
-				framework.CSIDriver:             framework.Update,
-				framework.CSIStorageCapacity:    framework.All - framework.Delete,
-				framework.PersistentVolume:      framework.All - framework.Delete,
-				framework.PersistentVolumeClaim: framework.All - framework.Delete,
-				framework.StorageClass:          framework.All - framework.Delete,
-				framework.VolumeAttachment:      framework.Delete,
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.Delete,
+				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
+				fwk.CSINode:               fwk.All - fwk.Delete,
+				fwk.CSIDriver:             fwk.Update,
+				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+				fwk.PersistentVolume:      fwk.All - fwk.Delete,
+				fwk.PersistentVolumeClaim: fwk.All - fwk.Delete,
+				fwk.StorageClass:          fwk.All - fwk.Delete,
+				fwk.VolumeAttachment:      fwk.Delete,
 			},
 		},
 		{
 			name:    "plugins with default profile (InPlacePodVerticalScaling: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
-			want: map[framework.EventResource]framework.ActionType{
-				framework.Pod:                   framework.Add | framework.UpdatePodLabel | framework.UpdatePodScaleDown | framework.Delete,
-				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
-				framework.CSINode:               framework.All - framework.Delete,
-				framework.CSIDriver:             framework.Update,
-				framework.CSIStorageCapacity:    framework.All - framework.Delete,
-				framework.PersistentVolume:      framework.All - framework.Delete,
-				framework.PersistentVolumeClaim: framework.All - framework.Delete,
-				framework.StorageClass:          framework.All - framework.Delete,
-				framework.VolumeAttachment:      framework.Delete,
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
+				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
+				fwk.CSINode:               fwk.All - fwk.Delete,
+				fwk.CSIDriver:             fwk.Update,
+				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+				fwk.PersistentVolume:      fwk.All - fwk.Delete,
+				fwk.PersistentVolumeClaim: fwk.All - fwk.Delete,
+				fwk.StorageClass:          fwk.All - fwk.Delete,
+				fwk.VolumeAttachment:      fwk.Delete,
 			},
 			enableInPlacePodVerticalScaling: true,
 		},
 		{
 			name:    "plugins with default profile (queueingHint/InPlacePodVerticalScaling: enabled)",
 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
-			want: map[framework.EventResource]framework.ActionType{
-				framework.Pod:                   framework.Add | framework.UpdatePodLabel | framework.UpdatePodScaleDown | framework.UpdatePodToleration | framework.UpdatePodSchedulingGatesEliminated | framework.Delete,
-				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
-				framework.CSINode:               framework.All - framework.Delete,
-				framework.CSIDriver:             framework.Update,
-				framework.CSIStorageCapacity:    framework.All - framework.Delete,
-				framework.PersistentVolume:      framework.All - framework.Delete,
-				framework.PersistentVolumeClaim: framework.All - framework.Delete,
-				framework.StorageClass:          framework.All - framework.Delete,
-				framework.VolumeAttachment:      framework.Delete,
+			want: map[fwk.EventResource]fwk.ActionType{
+				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
+				fwk.CSINode:               fwk.All - fwk.Delete,
+				fwk.CSIDriver:             fwk.Update,
+				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+				fwk.PersistentVolume:      fwk.All - fwk.Delete,
+				fwk.PersistentVolumeClaim: fwk.All - fwk.Delete,
+				fwk.StorageClass:          fwk.All - fwk.Delete,
+				fwk.VolumeAttachment:      fwk.Delete,
 			},
 			enableInPlacePodVerticalScaling: true,
 			enableSchedulerQueueingHints:    true,
@@ -1164,11 +1164,11 @@ func (*filterWithoutEnqueueExtensionsPlugin) Filter(_ context.Context, _ fwk.Cyc
 	return nil
 }
 
-var hintFromFakeNode = framework.QueueingHint(100)
+var hintFromFakeNode = fwk.QueueingHint(100)
 
 type fakeNodePlugin struct{}
 
-var fakeNodePluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (framework.QueueingHint, error) {
+var fakeNodePluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (fwk.QueueingHint, error) {
 	return hintFromFakeNode, nil
 }
 
@@ -1178,17 +1178,17 @@ func (*fakeNodePlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ 
 	return nil
 }
 
-func (pl *fakeNodePlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add}, QueueingHintFn: fakeNodePluginQueueingFn},
+func (pl *fakeNodePlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add}, QueueingHintFn: fakeNodePluginQueueingFn},
 	}, nil
 }
 
-var hintFromFakePod = framework.QueueingHint(101)
+var hintFromFakePod = fwk.QueueingHint(101)
 
 type fakePodPlugin struct{}
 
-var fakePodPluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (framework.QueueingHint, error) {
+var fakePodPluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (fwk.QueueingHint, error) {
 	return hintFromFakePod, nil
 }
 
@@ -1198,9 +1198,9 @@ func (*fakePodPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *
 	return nil
 }
 
-func (pl *fakePodPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Add}, QueueingHintFn: fakePodPluginQueueingFn},
+func (pl *fakePodPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add}, QueueingHintFn: fakePodPluginQueueingFn},
 	}, nil
 }
 
@@ -1212,7 +1212,7 @@ func (*emptyEventPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, 
 	return nil
 }
 
-func (pl *emptyEventPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *emptyEventPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return nil, nil
 }
 
@@ -1225,7 +1225,7 @@ func (*errorEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, 
 	return nil
 }
 
-func (*errorEventsToRegisterPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (*errorEventsToRegisterPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return nil, errors.New("mock error")
 }
 
@@ -1240,7 +1240,7 @@ func (*emptyEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, 
 	return nil
 }
 
-func (*emptyEventsToRegisterPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (*emptyEventsToRegisterPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return nil, nil
 }
 

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/klog/v2"
+)
+
+// ActionType is an integer to represent one type of resource change.
+// Different ActionTypes can be bit-wised to compose new semantics.
+type ActionType int64
+
+// Constants for ActionTypes.
+// CAUTION for contributors: When you add a new ActionType, you must update the following:
+// - The list of basic, podOnly, and nodeOnly.
+// - String() method.
+const (
+	Add ActionType = 1 << iota
+	Delete
+
+	// UpdateNodeXYZ is only applicable for Node events.
+	// If you use UpdateNodeXYZ,
+	// your plugin's QueueingHint is only executed for the specific sub-Update event.
+	// It's better to narrow down the scope of the event by using them instead of just using Update event
+	// for better performance in requeueing.
+	UpdateNodeAllocatable
+	UpdateNodeLabel
+	// UpdateNodeTaint is an update for node's taints or node.Spec.Unschedulable.
+	UpdateNodeTaint
+	UpdateNodeCondition
+	UpdateNodeAnnotation
+
+	// UpdatePodXYZ is only applicable for Pod events.
+	// If you use UpdatePodXYZ,
+	// your plugin's QueueingHint is only executed for the specific sub-Update event.
+	// It's better to narrow down the scope of the event by using them instead of Update event
+	// for better performance in requeueing.
+	UpdatePodLabel
+	// UpdatePodScaleDown is an update for pod's scale down (i.e., any resource request is reduced).
+	UpdatePodScaleDown
+	// UpdatePodToleration is an addition for pod's tolerations.
+	// (Due to API validation, we can add, but cannot modify or remove tolerations.)
+	UpdatePodToleration
+	// UpdatePodSchedulingGatesEliminated is an update for pod's scheduling gates, which eliminates all scheduling gates in the Pod.
+	UpdatePodSchedulingGatesEliminated
+	// UpdatePodGeneratedResourceClaim is an update of the list of ResourceClaims generated for the pod.
+	// Depends on the DynamicResourceAllocation feature gate.
+	UpdatePodGeneratedResourceClaim
+
+	All ActionType = 1<<iota - 1
+
+	// Use the general Update type if you don't either know or care the specific sub-Update type to use.
+	Update = UpdateNodeAllocatable | UpdateNodeLabel | UpdateNodeTaint | UpdateNodeCondition | UpdateNodeAnnotation | UpdatePodLabel | UpdatePodScaleDown | UpdatePodToleration | UpdatePodSchedulingGatesEliminated | UpdatePodGeneratedResourceClaim
+
+	// None is a special ActionType that is only used internally.
+	None ActionType = 0
+)
+
+func (a ActionType) String() string {
+	switch a {
+	case Add:
+		return "Add"
+	case Delete:
+		return "Delete"
+	case UpdateNodeAllocatable:
+		return "UpdateNodeAllocatable"
+	case UpdateNodeLabel:
+		return "UpdateNodeLabel"
+	case UpdateNodeTaint:
+		return "UpdateNodeTaint"
+	case UpdateNodeCondition:
+		return "UpdateNodeCondition"
+	case UpdateNodeAnnotation:
+		return "UpdateNodeAnnotation"
+	case UpdatePodLabel:
+		return "UpdatePodLabel"
+	case UpdatePodScaleDown:
+		return "UpdatePodScaleDown"
+	case UpdatePodToleration:
+		return "UpdatePodToleration"
+	case UpdatePodSchedulingGatesEliminated:
+		return "UpdatePodSchedulingGatesEliminated"
+	case UpdatePodGeneratedResourceClaim:
+		return "UpdatePodGeneratedResourceClaim"
+	case All:
+		return "All"
+	case Update:
+		return "Update"
+	}
+
+	// Shouldn't reach here.
+	return ""
+}
+
+// EventResource is basically short for group/version/kind, which can uniquely represent a particular API resource.
+type EventResource string
+
+// Constants for GVKs.
+//
+// CAUTION for contributors: When you add a new EventResource, you must register a new one to allResources.
+//
+// Note:
+// - UpdatePodXYZ or UpdateNodeXYZ: triggered by updating particular parts of a Pod or a Node, e.g. updatePodLabel.
+// Use specific events rather than general ones (updatePodLabel vs update) can make the requeueing process more efficient
+// and consume less memory as less events will be cached at scheduler.
+const (
+	// There are a couple of notes about how the scheduler notifies the events of Pods:
+	// - Add: add events could be triggered by either a newly created Pod or an existing Pod that is scheduled to a Node.
+	// - Delete: delete events could be triggered by:
+	//           - a Pod that is deleted
+	//           - a Pod that was assumed, but gets un-assumed due to some errors in the binding cycle.
+	//           - an existing Pod that was unscheduled but gets scheduled to a Node.
+	//
+	// Note that the Pod event type includes the events for the unscheduled Pod itself.
+	// i.e., when unscheduled Pods are updated, the scheduling queue checks with Pod/Update QueueingHint(s) whether the update may make the pods schedulable,
+	// and requeues them to activeQ/backoffQ when at least one QueueingHint(s) return Queue.
+	// Plugins **have to** implement a QueueingHint for Pod/Update event
+	// if the rejection from them could be resolved by updating unscheduled Pods themselves.
+	// Example: Pods that require excessive resources may be rejected by the noderesources plugin,
+	// if this unscheduled pod is updated to require fewer resources,
+	// the previous rejection from noderesources plugin can be resolved.
+	// this plugin would implement QueueingHint for Pod/Update event
+	// that returns Queue when such label changes are made in unscheduled Pods.
+	Pod EventResource = "Pod"
+
+	// A note about NodeAdd event and UpdateNodeTaint event:
+	// When QHint is disabled, NodeAdd often isn't worked expectedly because of the internal feature called preCheck.
+	// It's definitely not something expected for plugin developers,
+	// and registering UpdateNodeTaint event is the only mitigation for now.
+	// So, kube-scheduler registers UpdateNodeTaint event for plugins that has NodeAdded event, but don't have UpdateNodeTaint event.
+	// It has a bad impact for the requeuing efficiency though, a lot better than some Pods being stuck in the
+	// unschedulable pod pool.
+	// This problematic preCheck feature is disabled when QHint is enabled,
+	// and eventually will be removed along with QHint graduation.
+	// See: https://github.com/kubernetes/kubernetes/issues/110175
+	Node                  EventResource = "Node"
+	PersistentVolume      EventResource = "PersistentVolume"
+	PersistentVolumeClaim EventResource = "PersistentVolumeClaim"
+	CSINode               EventResource = "storage.k8s.io/CSINode"
+	CSIDriver             EventResource = "storage.k8s.io/CSIDriver"
+	VolumeAttachment      EventResource = "storage.k8s.io/VolumeAttachment"
+	CSIStorageCapacity    EventResource = "storage.k8s.io/CSIStorageCapacity"
+	StorageClass          EventResource = "storage.k8s.io/StorageClass"
+	ResourceClaim         EventResource = "resource.k8s.io/ResourceClaim"
+	ResourceSlice         EventResource = "resource.k8s.io/ResourceSlice"
+	DeviceClass           EventResource = "resource.k8s.io/DeviceClass"
+
+	// WildCard is a special EventResource to match all resources.
+	// e.g., If you register `{Resource: "*", ActionType: All}` in EventsToRegister,
+	// all coming clusterEvents will be admitted. Be careful to register it, it will
+	// increase the computing pressure in requeueing unless you really need it.
+	//
+	// Meanwhile, if the coming clusterEvent is a wildcard one, all pods
+	// will be moved from unschedulablePod pool to activeQ/backoffQ forcibly.
+	WildCard EventResource = "*"
+)
+
+type ClusterEventWithHint struct {
+	Event ClusterEvent
+	// QueueingHintFn is executed for the Pod rejected by this plugin when the above Event happens,
+	// and filters out events to reduce useless retry of Pod's scheduling.
+	// It's an optional field. If not set,
+	// the scheduling of Pods will be always retried with backoff when this Event happens.
+	// (the same as Queue)
+	QueueingHintFn QueueingHintFn
+}
+
+// QueueingHintFn returns a hint that signals whether the event can make a Pod,
+// which was rejected by this plugin in the past scheduling cycle, schedulable or not.
+// It's called before a Pod gets moved from unschedulableQ to backoffQ or activeQ.
+// If it returns an error, we'll take the returned QueueingHint as `Queue` at the caller whatever we returned here so that
+// we can prevent the Pod from being stuck in the unschedulable pod pool.
+//
+// - `pod`: the Pod to be enqueued, which is rejected by this plugin in the past.
+// - `oldObj` `newObj`: the object involved in that event.
+//   - For example, the given event is "Node deleted", the `oldObj` will be that deleted Node.
+//   - `oldObj` is nil if the event is add event.
+//   - `newObj` is nil if the event is delete event.
+type QueueingHintFn func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (QueueingHint, error)
+
+type QueueingHint int
+
+const (
+	// QueueSkip implies that the cluster event has no impact on
+	// scheduling of the pod.
+	QueueSkip QueueingHint = iota
+
+	// Queue implies that the Pod may be schedulable by the event.
+	Queue
+)
+
+func (s QueueingHint) String() string {
+	switch s {
+	case QueueSkip:
+		return "QueueSkip"
+	case Queue:
+		return "Queue"
+	}
+	return ""
+}
+
+// ClusterEvent abstracts how a system resource's state gets changed.
+// Resource represents the standard API resources such as Pod, Node, etc.
+// ActionType denotes the specific change such as Add, Update or Delete.
+type ClusterEvent struct {
+	Resource   EventResource
+	ActionType ActionType
+
+	// CustomLabel describes this cluster event.
+	// It's an optional field to control Label(), which is used in logging and metrics.
+	// Normally, it's not necessary to set this field; only used for special events like UnschedulableTimeout.
+	CustomLabel string
+}
+
+// Label is used for logging and metrics.
+func (ce ClusterEvent) Label() string {
+	if ce.CustomLabel != "" {
+		return ce.CustomLabel
+	}
+
+	return fmt.Sprintf("%v%v", ce.Resource, ce.ActionType)
+}

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -30,7 +30,7 @@ type ActionType int64
 
 // Constants for ActionTypes.
 // CAUTION for contributors: When you add a new ActionType, you must update the following:
-// - The list of basic, podOnly, and nodeOnly.
+// - The list of basicActionTypes, podActionTypes, and nodeActionTypes at k/k/pkg/scheduler/framework/types.go
 // - String() method.
 const (
 	Add ActionType = 1 << iota
@@ -115,7 +115,7 @@ type EventResource string
 
 // Constants for GVKs.
 //
-// CAUTION for contributors: When you add a new EventResource, you must register a new one to allResources.
+// CAUTION for contributors: When you add a new EventResource, you must register a new one to allResources at k/k/pkg/scheduler/framework/types.go
 //
 // Note:
 // - UpdatePodXYZ or UpdateNodeXYZ: triggered by updating particular parts of a Pod or a Node, e.g. updatePodLabel.

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -11,7 +11,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
-	k8s.io/klog/v2 v2.130.1	
+	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/yaml v1.5.0
 )
 

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/klog/v2 v2.130.1	
 	sigs.k8s.io/yaml v1.5.0
 )
 
@@ -27,7 +28,6 @@ require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/test/integration/scheduler/eventhandler/eventhandler_test.go
+++ b/test/integration/scheduler/eventhandler/eventhandler_test.go
@@ -67,9 +67,9 @@ func (pl *fooPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.P
 	return framework.NewStatus(framework.Unschedulable)
 }
 
-func (pl *fooPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}},
+func (pl *fooPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}},
 	}, nil
 }
 

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -384,7 +384,7 @@ func (sp *ScorePlugin) ScoreExtensions() framework.ScoreExtensions {
 	return nil
 }
 
-func (sp *ScorePlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (sp *ScorePlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return nil, nil
 }
 
@@ -438,9 +438,9 @@ func (fp *FilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v
 	return nil
 }
 
-func (fp *FilterPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Delete}},
+func (fp *FilterPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete}},
 	}, nil
 }
 
@@ -511,7 +511,7 @@ func (pp *PreBindPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod 
 	return nil
 }
 
-func (pp *PreBindPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pp *PreBindPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return nil, nil
 }
 
@@ -681,7 +681,7 @@ func (pp *PermitPlugin) rejectAllPods() {
 	pp.fh.IterateOverWaitingPods(func(wp framework.WaitingPod) { wp.Reject(pp.name, "rejectAllPods") })
 }
 
-func (pp *PermitPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pp *PermitPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return nil, nil
 }
 
@@ -2769,9 +2769,9 @@ func (pl *SchedulingGatesPluginWithEvents) PreEnqueue(ctx context.Context, p *v1
 	return pl.SchedulingGates.PreEnqueue(ctx, p)
 }
 
-func (pl *SchedulingGatesPluginWithEvents) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Update}},
+func (pl *SchedulingGatesPluginWithEvents) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Update}},
 	}, nil
 }
 
@@ -2790,7 +2790,7 @@ func (pl *SchedulingGatesPluginWOEvents) PreEnqueue(ctx context.Context, p *v1.P
 	return pl.SchedulingGates.PreEnqueue(ctx, p)
 }
 
-func (pl *SchedulingGatesPluginWOEvents) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
+func (pl *SchedulingGatesPluginWOEvents) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return nil, nil
 }
 

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/component-helpers/storage/volume"
 	configv1 "k8s.io/kube-scheduler/config/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
@@ -75,7 +76,7 @@ type CoreResourceEnqueueTestCase struct {
 	// TriggerFn is the function that triggers the event to move Pods.
 	// It returns the map keyed with ClusterEvents to be triggered by this function,
 	// and valued with the number of triggering of the event.
-	TriggerFn func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error)
+	TriggerFn func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error)
 	// WantRequeuedPods is the map of Pods that are expected to be requeued after triggerFn.
 	WantRequeuedPods sets.Set[string]
 	// EnableSchedulingQueueHint indicates which feature gate value(s) the test case should run with.
@@ -92,8 +93,8 @@ var (
 	// because they're only used internally for the metric labels/logging.
 	// We need to declare them here to use them in the test
 	// because this test is using the metric labels.
-	assignedPod      framework.EventResource = "AssignedPod"
-	unschedulablePod framework.EventResource = "UnschedulablePod"
+	assignedPod      fwk.EventResource = "AssignedPod"
+	unschedulablePod fwk.EventResource = "UnschedulablePod"
 )
 
 // We define all the test cases here in the one place,
@@ -111,14 +112,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Obj(),
 			st.MakePod().Name("pod2").Toleration(v1.TaintNodeNotReady).Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeChange event by increasing CPU capacity.
 			// It makes Pod2 schedulable.
 			// Pod1 is not requeued because the Node is still unready and it doesn't have the required toleration.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().UpdateStatus(testCtx.Ctx, st.MakeNode().Name("fake-node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Taints([]v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoSchedule}}).Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeAllocatable}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod2"),
 	},
@@ -133,7 +134,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod2 will be rejected by the PodAffinity plugin.
 			st.MakePod().Label("anti", "anti").Name("pod2").PodAntiAffinityExists("anti", "node", st.PodAntiAffinityWithRequiredReq).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeCreated event.
 			// Note that this Node has a un-ready taint and pod2 should be requeued ideally because unschedulable plugins registered for pod2 is PodAffinity.
 			// However, due to preCheck, it's not requeueing pod2 to activeQ.
@@ -150,9 +151,9 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, node, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to remove taints off the node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{
-				{Resource: framework.Node, ActionType: framework.Add}:             1,
-				{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{
+				{Resource: fwk.Node, ActionType: fwk.Add}:             1,
+				{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod2"),
 	},
@@ -166,14 +167,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod2 will be rejected by the NodeAffinity plugin.
 			st.MakePod().Name("pod2").NodeAffinityIn("group", []string{"c"}, st.NodeSelectorTypeMatchExpressions).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event to change label.
 			// It causes pod1 to be requeued.
 			// It causes pod2 not to be requeued.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, st.MakeNode().Name("fake-node1").Label("group", "b").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -188,13 +189,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - The pod will be blocked by the NodeAffinity plugin for node2, therefore we know NodeAffinity will be queried for qhint for both testing nodes.
 			st.MakePod().Name("pod1").NodeAffinityIn("group", []string{"a"}, st.NodeSelectorTypeMatchExpressions).Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event to add new label.
 			// It won't cause pod to be requeued, because there was a match already before the update, meaning this plugin wasn't blocking the scheduling.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, st.MakeNode().Name("node1").Label("group", "a").Label("node", "fake-node").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.Set[string]{},
 		EnableSchedulingQueueHint: sets.New(true),
@@ -209,14 +210,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod2 will be rejected by the NodeAffinity plugin.
 			st.MakePod().Name("pod2").NodeAffinityIn("group", []string{"c"}, st.NodeSelectorTypeMatchExpressions).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeAdd event with the awaited label.
 			// It causes pod1 to be requeued.
 			// It causes pod2 not to be requeued.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, st.MakeNode().Name("fake-node2").Label("group", "b").Obj(), metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -229,13 +230,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod1").Container("image").Obj(),
 			st.MakePod().Name("pod2").Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a PodUpdate event by adding a toleration to Pod1.
 			// It makes Pod1 schedulable. Pod2 is not requeued because of not having toleration.
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Container("image").Toleration("taint-key").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the pod: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: framework.UpdatePodToleration}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.UpdatePodToleration}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -249,13 +250,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod2").Toleration("taint-key2").Container("image").Obj(),
 			st.MakePod().Name("pod3").Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event that changes the existing taint to a taint that matches the toleration that pod1 has.
 			// It makes Pod1 schedulable. Pod2 and pod3 are not requeued because of not having the corresponding toleration.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, st.MakeNode().Name("fake-node").Taints([]v1.Taint{{Key: "taint-key", Effect: v1.TaintEffectNoSchedule}}).Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the Node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -269,13 +270,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod1").Toleration("taint-key").Container("image").Obj(),
 			st.MakePod().Name("pod2").Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeCreated event with the taint.
 			// It makes Pod1 schedulable. Pod2 is not requeued because of not having toleration.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, st.MakeNode().Name("fake-node2").Taints([]v1.Taint{{Key: "taint-key", Effect: v1.TaintEffectNoSchedule}}).Obj(), metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create the Node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -287,13 +288,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod1 requests a large amount of CPU and will be rejected by the NodeResourcesFit plugin.
 			st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a PodUpdate event by reducing cpu requested by pod1.
 			// It makes Pod1 schedulable.
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).UpdateResize(testCtx.Ctx, "pod1", st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to resize the pod: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: framework.UpdatePodScaleDown}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.UpdatePodScaleDown}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -308,13 +309,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod2 request will be rejected because there are not enough free resources on the Node
 			st.MakePod().Name("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an assigned Pod1 delete event.
 			// It makes Pod2 schedulable.
 			if err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 				return nil, fmt.Errorf("failed to delete pod1: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
+			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod2"),
 	},
@@ -328,14 +329,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod2 requests a large amount of CPU and will be rejected by the NodeResourcesFit plugin.
 			st.MakePod().Name("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "5"}).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeCreated event.
 			// It makes Pod1 schedulable. Pod2 is not requeued because of having too high requests.
 			node := st.MakeNode().Name("fake-node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create a new node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -349,13 +350,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod2 requests a large amount of CPU and will be rejected by the NodeResourcesFit plugin.
 			st.MakePod().Name("pod2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "5"}).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event that increases the CPU capacity of fake-node.
 			// It makes Pod1 schedulable. Pod2 is not requeued because of having too high requests.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().UpdateStatus(testCtx.Ctx, st.MakeNode().Name("fake-node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update fake-node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeAllocatable}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -370,12 +371,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod1 requests available amount of CPU (in fake-node1), but will be rejected by NodeAffinity plugin. Note that the NodeResourceFit plugin will register for QHints because it rejected fake-node2.
 			st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).NodeAffinityIn("group", []string{"b"}, st.NodeSelectorTypeMatchExpressions).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event that increases unrealted (not requested) memory capacity of fake-node1, which should not requeue Pod1.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().UpdateStatus(testCtx.Ctx, st.MakeNode().Name("fake-node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4", v1.ResourceMemory: "4000"}).Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update fake-node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeAllocatable}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}: 1}, nil
 		},
 		WantRequeuedPods:          sets.Set[string]{},
 		EnableSchedulingQueueHint: sets.New(true),
@@ -391,12 +392,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod1 requests available amount of CPU (in fake-node1), but will be rejected by NodeAffinity plugin. Note that the NodeResourceFit plugin will register for QHints because it rejected fake-node2.
 			st.MakePod().Name("pod1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).NodeAffinityIn("group", []string{"b"}, st.NodeSelectorTypeMatchExpressions).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event that increases the requested CPU capacity of fake-node1, which should requeue Pod1.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().UpdateStatus(testCtx.Ctx, st.MakeNode().Name("fake-node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "5"}).Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update fake-node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeAllocatable}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -416,12 +417,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod2 is unschedulable because Pod1 saturated ResourcePods limit in fake-node2. Note that the NodeResourceFit plugin will register for QHints because it rejected fake-node2.
 			st.MakePod().Name("pod2").NodeAffinityIn("group", []string{"b"}, st.NodeSelectorTypeMatchExpressions).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event that increases the allowed Pods number of fake-node1, which should requeue Pod2.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().UpdateStatus(testCtx.Ctx, st.MakeNode().Name("fake-node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "3"}).Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update fake-node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeAllocatable}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -434,11 +435,11 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod1 doesn't have the required toleration and will be rejected by the TaintToleration plugin.
 			st.MakePod().Name("pod1").Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Label("key", "val").Container("image").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the pod: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: framework.UpdatePodLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: unschedulablePod, ActionType: fwk.UpdatePodLabel}: 1}, nil
 		},
 		WantRequeuedPods: sets.Set[string]{},
 		// This behaviour is only true when enabling QHint
@@ -459,7 +460,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// - Pod1 will be rejected by the NodeAffinity plugin and NodeResourcesFit plugin.
 			st.MakePod().Label("unscheduled", "plugins").Name("pod1").NodeAffinityIn("metadata.name", []string{"fake-node"}, st.NodeSelectorTypeMatchFields).Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Because of preCheck, we cannot determine which unschedulable plugins are registered for pod1.
 			// So, not the ideal way as the integration test though,
 			// here we check the unschedulable plugins by directly using the SchedulingQueue function for now.
@@ -494,12 +495,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("anti2", "anti2").PodAntiAffinityExists("anti2", "node", st.PodAntiAffinityWithRequiredReq).Container("image").Obj(),
 		},
 
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Delete the pod's label 'anti1' which will make it match pod2's antiAffinity.
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Label("anti2", "anti2").Container("image").Node("fake-node").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pod1: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: assignedPod, ActionType: framework.UpdatePodLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: assignedPod, ActionType: fwk.UpdatePodLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -517,12 +518,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").PodAffinityExists("bbb", "node", st.PodAffinityWithRequiredReq).Container("image").Obj(),
 		},
 
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Add label to the pod which will make it match pod2's podAffinity.
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Label("aaa", "bbb").Container("image").Node("fake-node").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pod1: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: assignedPod, ActionType: framework.UpdatePodLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: assignedPod, ActionType: fwk.UpdatePodLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -538,12 +539,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod2").PodAffinityExists("ccc", "region", st.PodAffinityWithRequiredReq).Container("image").Obj(),
 		},
 
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Create the node which will make it match pod1's podAffinity.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, st.MakeNode().Name("fake-node2").Label("zone", "zone1").Obj(), metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create fake-node2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -565,13 +566,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			// This Pod doesn't have any label so that this PodAffinity doesn't match this Pod itself.
 			st.MakePod().Name("pod4").PodAffinityExists("affinity1", "region", st.PodAffinityWithRequiredReq).NodeAffinityIn("group", []string{"b"}, st.NodeSelectorTypeMatchExpressions).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Add "node" label to the node which may make pod2 schedulable.
 			// Update "region" label to the node which may make pod4 schedulable.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, st.MakeNode().Name("fake-node").Label("node", "fake-node").Label("region", "region-2").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update fake-node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2", "pod4"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -589,13 +590,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("anti1", "anti1").PodAntiAffinityExists("anti1", "service", st.PodAntiAffinityWithRequiredReq).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("anti1", "anti1").PodAntiAffinityExists("anti1", "other", st.PodAntiAffinityWithRequiredReq).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Remove "node" label from the node which will make it not match pod2's podAntiAffinity.
 			// Change "service" label from service-a to service-b which may pod3 schedulable.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, st.MakeNode().Name("fake-node").Label("service", "service-b").Label("region", "fake-node").Label("other", "fake-node").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update fake-node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2", "pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -612,12 +613,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod2").PodAntiAffinityExists("anti1", "zone", st.PodAntiAffinityWithRequiredReq).Container("image").Obj(),
 			st.MakePod().Name("pod3").PodAntiAffinityExists("anti1", "node", st.PodAntiAffinityWithRequiredReq).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Create the node which will make pod2, pod3 be schedulable.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, st.MakeNode().Name("fake-node2").Label("zone", "fake-node").Obj(), metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create fake-node2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2", "pod3"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -634,14 +635,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Container("image").ContainerPort([]v1.ContainerPort{{ContainerPort: 8080, HostPort: 8080}}).Obj(),
 			st.MakePod().Name("pod4").Container("image").ContainerPort([]v1.ContainerPort{{ContainerPort: 8080, HostPort: 8081}}).Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an assigned Pod delete event.
 			// Because Pod1 and Pod3 have common port, deleting Pod1 makes Pod3 schedulable.
 			// By setting GracePeriodSeconds to 0, allowing Pod3 to be requeued immediately after Pod1 is deleted.
 			if err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 				return nil, fmt.Errorf("failed to delete Pod: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
+			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -656,14 +657,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod2").Container("image").ContainerPort([]v1.ContainerPort{{ContainerPort: 8080, HostPort: 8080}}).Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeCreated event.
 			// It makes Pod2 schedulable.
 			node := st.MakeNode().Name("fake-node2").Label("node", "fake-node2").Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create a new node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -675,13 +676,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeUpdate event to change the Node to ready.
 			// It makes Pod1 schedulable.
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, st.MakeNode().Name("fake-node").Unschedulable(false).Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -692,14 +693,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeCreated event.
 			// It makes Pod1 schedulable.
 			node := st.MakeNode().Name("fake-node2").Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create a new node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod1"),
 	},
@@ -710,13 +711,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger a NodeCreated event, but with unschedulable node, which wouldn't make Pod1 schedulable.
 			node := st.MakeNode().Name("fake-node2").Unschedulable(true).Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create a new node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods: sets.Set[string]{},
 		// This test case is valid only when QHint is enabled
@@ -736,7 +737,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("key2", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key2").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an assigned Pod add event.
 			// It should requeue pod3 only because this pod only has key1 label that pod3's topologyspread checks, and doesn't have key2 label that pod4's one does.
 			pod := st.MakePod().Name("pod5").Label("key1", "val").Node("fake-node").Container("image").Obj()
@@ -744,7 +745,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 				return nil, fmt.Errorf("failed to create Pod %q: %w", pod.Name, err)
 			}
 
-			return map[framework.ClusterEvent]uint64{framework.EventAssignedPodAdd: 1}, nil
+			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodAdd: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -762,14 +763,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("key2", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key2").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an assigned Pod update event.
 			// It should requeue pod3 only because this updated pod had key1 label,
 			// and it's related only to the label selector that pod3's topologyspread has.
 			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Update(testCtx.Ctx, st.MakePod().Name("pod1").Label("key3", "val").Container("image").Node("fake-node").Obj(), metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update the pod: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{framework.EventAssignedPodUpdate: 1}, nil
+			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodUpdate: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -787,13 +788,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(2)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("key2", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key2").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an assigned Pod delete event.
 			// It should requeue pod3 only because this pod only has key1 label that pod3's topologyspread checks, and doesn't have key2 label that pod4's one does.
 			if err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 				return nil, fmt.Errorf("failed to delete Pod: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
+			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -814,14 +815,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(2)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("key1", "val").SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(2)), nil, nil, nil).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an Node add event.
 			// It should requeue pod3 only because this node only has node label, and doesn't have zone label that pod4's topologyspread requires.
 			node := st.MakeNode().Name("fake-node3").Label("node", "fake-node").Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create a new node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -847,7 +848,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod8").Label("key1", "val").SpreadConstraint(1, "other", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod9").Label("key1", "val").SpreadConstraint(1, "service", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an Node update event.
 			// It should requeue pod5 because it deletes the "node" label from fake-node2.
 			// It should requeue pod6 because the update adds the "zone" label to fake-node2.
@@ -858,7 +859,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, node, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod5", "pod6", "pod9"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -879,13 +880,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("key1", "val").SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an NodeTaint delete event.
 			// It should requeue pod4 only because this node only has zone label, and doesn't have node label that pod3 requires.
 			if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, "fake-node2", metav1.DeleteOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Delete}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Delete}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod4"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -906,13 +907,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("key1", "val").SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an NodeTaint delete event.
 			// It should requeue both pod3 and pod4 only because PodTopologySpread subscribes to Node/delete events.
 			if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, "fake-node2", metav1.DeleteOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Delete}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Delete}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod3", "pod4"),
 		EnableSchedulingQueueHint: sets.New(false),
@@ -934,14 +935,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod3").Label("key1", "val").SpreadConstraint(1, "node", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Obj(),
 			st.MakePod().Name("pod4").Label("key1", "val").SpreadConstraint(1, "zone", v1.DoNotSchedule, st.MakeLabelSelector().Exists("key1").Obj(), ptr.To(int32(3)), nil, nil, nil).Container("image").Toleration("aaa").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// Trigger an NodeTaint update event.
 			// It should requeue pod4 only because this node only has zone label, and doesn't have node label that pod3 requires.
 			node := st.MakeNode().Name("fake-node3").Label("zone", "fake-node").Taints([]v1.Taint{{Key: "aaa", Value: "bbb", Effect: v1.TaintEffectNoSchedule}}).Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, node, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeTaint}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint}: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod4"),
 	},
@@ -980,7 +981,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pv2 := st.MakePersistentVolume().Name("pv2").Label(v1.LabelTopologyZone, "us-west1-a").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 				Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
@@ -989,7 +990,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Create(testCtx.Ctx, pv2, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create pv2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolume, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolume, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1036,7 +1037,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pv2 := st.MakePersistentVolume().Name("pv2").Label(v1.LabelTopologyZone, "us-west1-a").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 				Capacity(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}).
@@ -1045,7 +1046,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Update(testCtx.Ctx, pv2, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pv2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolume, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolume, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1086,7 +1087,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 			st.MakePod().Name("pod3").Container("image").PVC("pvc3").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc2 := st.MakePersistentVolumeClaim().
 				Name("pvc2").
 				Annotation(volume.AnnBindCompleted, "true").
@@ -1097,7 +1098,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Create(testCtx.Ctx, pvc2, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to add pvc2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1144,7 +1145,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 			st.MakePod().Name("pod3").Container("image").PVC("pvc3").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc2 := st.MakePersistentVolumeClaim().
 				Name("pvc2").
 				Annotation(volume.AnnBindCompleted, "true").
@@ -1155,7 +1156,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Update(testCtx.Ctx, pvc2, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pvc2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolumeClaim, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1195,7 +1196,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			sc1 := st.MakeStorageClass().
 				Name("sc1").
 				VolumeBindingMode(storagev1.VolumeBindingWaitForFirstConsumer).
@@ -1204,7 +1205,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().StorageClasses().Create(testCtx.Ctx, sc1, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create sc1: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.StorageClass, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.StorageClass, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1251,7 +1252,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pv2 := st.MakePersistentVolume().Name("pv2").
 				Labels(map[string]string{v1.LabelTopologyZone: "us-east1", "unrelated": "unrelated"}).
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
@@ -1261,7 +1262,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Update(testCtx.Ctx, pv2, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pv2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolume, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolume, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.Set[string]{},
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1282,7 +1283,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc2 := st.MakePersistentVolumeClaim().
 				Name("pvc1").
 				Annotation(volume.AnnBindCompleted, "true").
@@ -1293,7 +1294,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Create(testCtx.Ctx, pvc2, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to add pvc1: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1326,11 +1327,11 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc1").Obj(),
 			st.MakePod().Name("pod3").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			if err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 				return nil, fmt.Errorf("failed to delete pod1: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
+			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1362,12 +1363,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			node := st.MakeNode().Name("fake-node2").Label(v1.LabelTopologyZone, "us-east-1a").Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1403,12 +1404,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			node := st.MakeNode().Name("fake-node").Label("node", "fake-node").Label("aaa", "ccc").Obj()
 			if _, err := testCtx.ClientSet.CoreV1().Nodes().Update(testCtx.Ctx, node, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update node: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.Node, ActionType: framework.UpdateNodeLabel}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1438,7 +1439,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			if err := testCtx.ClientSet.CoreV1().PersistentVolumes().Delete(testCtx.Ctx, "pv1", metav1.DeleteOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to delete pv1: %w", err)
 			}
@@ -1452,7 +1453,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Create(testCtx.Ctx, pv1, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create pv: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolume, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolume, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1481,7 +1482,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pv1 := st.MakePersistentVolume().
 				Name("pv1").
 				NodeAffinityIn(v1.LabelTopologyZone, []string{"us-east-1a"}).
@@ -1492,7 +1493,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumes().Update(testCtx.Ctx, pv1, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pv: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolume, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolume, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1523,7 +1524,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			if err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Delete(testCtx.Ctx, "pvc1", metav1.DeleteOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to delete pvc1: %w", err)
 			}
@@ -1537,7 +1538,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Create(testCtx.Ctx, pvc1, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create pvc: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1568,7 +1569,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc1 := st.MakePersistentVolumeClaim().
 				Name("pvc1").
 				VolumeName("pv1").
@@ -1580,7 +1581,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Update(testCtx.Ctx, pvc1, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update pvc: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolumeClaim, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1607,7 +1608,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			sc1 := st.MakeStorageClass().
 				Name("sc1").
 				VolumeBindingMode(storagev1.VolumeBindingWaitForFirstConsumer).
@@ -1616,7 +1617,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().StorageClasses().Create(testCtx.Ctx, sc1, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create storageclass: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.StorageClass, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.StorageClass, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1657,7 +1658,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			sc1 := st.MakeStorageClass().
 				Name("sc1").
 				VolumeBindingMode(storagev1.VolumeBindingWaitForFirstConsumer).
@@ -1673,7 +1674,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().StorageClasses().Update(testCtx.Ctx, sc1, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update storageclass: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.StorageClass, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.StorageClass, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1715,7 +1716,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			sc1 := st.MakeStorageClass().
 				Name("sc1").
 				Label("key", "updated").
@@ -1732,7 +1733,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().StorageClasses().Update(testCtx.Ctx, sc1, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update storageclass: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.StorageClass, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.StorageClass, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.Set[string]{},
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1758,13 +1759,13 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			csinode1 := st.MakeCSINode().Name("fake-node").Obj()
 
 			if _, err := testCtx.ClientSet.StorageV1().CSINodes().Create(testCtx.Ctx, csinode1, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create CSINode: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSINode, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSINode, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1794,7 +1795,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// When updating CSINodes by using MakeCSINode, an error occurs because the resourceVersion is not specified. Therefore, the actual CSINode is retrieved.
 			csinode, err := testCtx.ClientSet.StorageV1().CSINodes().Get(testCtx.Ctx, "fake-node", metav1.GetOptions{})
 			if err != nil {
@@ -1805,7 +1806,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().CSINodes().Update(testCtx.Ctx, csinode, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update CSINode: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSINode, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSINode, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1842,7 +1843,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 				},
 			).Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// When updating CSIDrivers by using MakeCSIDriver, an error occurs because the resourceVersion is not specified. Therefore, the actual CSIDrivers is retrieved.
 			csidriver, err := testCtx.ClientSet.StorageV1().CSIDrivers().Get(testCtx.Ctx, "csidriver", metav1.GetOptions{})
 			if err != nil {
@@ -1853,7 +1854,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().CSIDrivers().Update(testCtx.Ctx, csidriver, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update CSIDriver: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSIDriver, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSIDriver, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1890,7 +1891,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 				},
 			).Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// When updating CSIDrivers by using MakeCSIDriver, an error occurs because the resourceVersion is not specified. Therefore, the actual CSIDrivers is retrieved.
 			csidriver, err := testCtx.ClientSet.StorageV1().CSIDrivers().Get(testCtx.Ctx, "csidriver", metav1.GetOptions{})
 			if err != nil {
@@ -1901,7 +1902,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().CSIDrivers().Update(testCtx.Ctx, csidriver, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update CSIDriver: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSIDriver, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSIDriver, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.Set[string]{},
 		EnableSchedulingQueueHint: sets.New(true),
@@ -1935,12 +1936,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			csc := st.MakeCSIStorageCapacity().Name("csc").StorageClassName("sc1").Capacity(resource.NewQuantity(10, resource.BinarySI)).Obj()
 			if _, err := testCtx.ClientSet.StorageV1().CSIStorageCapacities(testCtx.NS.Name).Create(testCtx.Ctx, csc, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create CSIStorageCapacity: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSIStorageCapacity, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSIStorageCapacity, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -1977,7 +1978,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// When updating CSIStorageCapacities by using MakeCSIStorageCapacity, an error occurs because the resourceVersion is not specified. Therefore, the actual CSIStorageCapacities is retrieved.
 			csc, err := testCtx.ClientSet.StorageV1().CSIStorageCapacities(testCtx.NS.Name).Get(testCtx.Ctx, "csc", metav1.GetOptions{})
 			if err != nil {
@@ -1988,7 +1989,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().CSIStorageCapacities(testCtx.NS.Name).Update(testCtx.Ctx, csc, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update CSIStorageCapacity: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSIStorageCapacity, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSIStorageCapacity, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true, false),
@@ -2023,7 +2024,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			// When updating CSIStorageCapacities by using MakeCSIStorageCapacity, an error occurs because the resourceVersion is not specified. Therefore, the actual CSIStorageCapacities is retrieved.
 			csc, err := testCtx.ClientSet.StorageV1().CSIStorageCapacities(testCtx.NS.Name).Get(testCtx.Ctx, "csc", metav1.GetOptions{})
 			if err != nil {
@@ -2034,7 +2035,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.StorageV1().CSIStorageCapacities(testCtx.NS.Name).Update(testCtx.Ctx, csc, metav1.UpdateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to update CSIStorageCapacity: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSIStorageCapacity, ActionType: framework.Update}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSIStorageCapacity, ActionType: fwk.Update}: 1}, nil
 		},
 		WantRequeuedPods:          sets.Set[string]{},
 		EnableSchedulingQueueHint: sets.New(true),
@@ -2069,12 +2070,12 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			csinode1 := st.MakeCSINode().Name("csinode").Obj()
 			if _, err := testCtx.ClientSet.StorageV1().CSINodes().Create(testCtx.Ctx, csinode1, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to create CSINode: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.CSINode, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.CSINode, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -2125,11 +2126,11 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			if err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 				return nil, fmt.Errorf("failed to delete Pod: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
+			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
 		},
 		WantRequeuedPods: sets.New("pod2"),
 	},
@@ -2172,7 +2173,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod2").Container("image").PVC("pvc2").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc := st.MakePersistentVolumeClaim().
 				Name("pvc2").
 				Annotation(volume.AnnBindCompleted, "true").
@@ -2183,7 +2184,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			if _, err := testCtx.ClientSet.CoreV1().PersistentVolumeClaims(testCtx.NS.Name).Create(testCtx.Ctx, pvc, metav1.CreateOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to add pvc2: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod2"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -2225,11 +2226,11 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		Pods: []*v1.Pod{
 			st.MakePod().Name("pod1").Container("image").PVC("pvc1").Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			if err := testCtx.ClientSet.StorageV1().VolumeAttachments().Delete(testCtx.Ctx, "volumeattachment1", metav1.DeleteOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to delete VolumeAttachment: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.VolumeAttachment, ActionType: framework.Delete}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.VolumeAttachment, ActionType: fwk.Delete}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),
@@ -2311,11 +2312,11 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 				},
 			).Obj(),
 		},
-		TriggerFn: func(testCtx *testutils.TestContext) (map[framework.ClusterEvent]uint64, error) {
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			if err := testCtx.ClientSet.StorageV1().VolumeAttachments().Delete(testCtx.Ctx, "volumeattachment1", metav1.DeleteOptions{}); err != nil {
 				return nil, fmt.Errorf("failed to delete VolumeAttachment: %w", err)
 			}
-			return map[framework.ClusterEvent]uint64{{Resource: framework.VolumeAttachment, ActionType: framework.Delete}: 1}, nil
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.VolumeAttachment, ActionType: fwk.Delete}: 1}, nil
 		},
 		WantRequeuedPods:          sets.New("pod1"),
 		EnableSchedulingQueueHint: sets.New(true),

--- a/test/integration/scheduler/queueing/queue_test.go
+++ b/test/integration/scheduler/queueing/queue_test.go
@@ -194,9 +194,9 @@ func (f *fakeCRPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ 
 
 // EventsToRegister returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (f *fakeCRPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: "foos.v1.example.com", ActionType: framework.All}},
+func (f *fakeCRPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: "foos.v1.example.com", ActionType: fwk.All}},
 	}, nil
 }
 
@@ -458,9 +458,9 @@ func TestRequeueByPermitRejection(t *testing.T) {
 		fakePermitPluginName: func(ctx context.Context, o runtime.Object, fh framework.Handle) (framework.Plugin, error) {
 			fakePermit = &fakePermitPlugin{
 				frameworkHandler: fh,
-				schedulingHint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+				schedulingHint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 					queueingHintCalledCounter++
-					return framework.Queue, nil
+					return fwk.Queue, nil
 				},
 			}
 			return fakePermit, nil
@@ -560,7 +560,7 @@ func TestRequeueByPermitRejection(t *testing.T) {
 
 type fakePermitPlugin struct {
 	frameworkHandler framework.Handle
-	schedulingHint   framework.QueueingHintFn
+	schedulingHint   fwk.QueueingHintFn
 }
 
 const fakePermitPluginName = "fakePermitPlugin"
@@ -573,9 +573,9 @@ func (p *fakePermitPlugin) Permit(ctx context.Context, state fwk.CycleState, _ *
 	return framework.NewStatus(framework.Wait), wait.ForeverTestTimeout
 }
 
-func (p *fakePermitPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.UpdateNodeLabel}, QueueingHintFn: p.schedulingHint},
+func (p *fakePermitPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}, QueueingHintFn: p.schedulingHint},
 	}, nil
 }
 

--- a/test/integration/scheduler/rescheduling_test.go
+++ b/test/integration/scheduler/rescheduling_test.go
@@ -67,12 +67,12 @@ func (rp *ReservePlugin) Unreserve(ctx context.Context, state fwk.CycleState, p 
 	rp.numUnreserveCalled += 1
 }
 
-func (rp *ReservePlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
+func (rp *ReservePlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
 		{
-			Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add},
-			QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
-				return framework.Queue, nil
+			Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add},
+			QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+				return fwk.Queue, nil
 			},
 		},
 	}, nil
@@ -104,12 +104,12 @@ func (pp *PermitPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.
 	return nil, 0
 }
 
-func (pp *PermitPlugin) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
-	return []framework.ClusterEventWithHint{
+func (pp *PermitPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
 		{
-			Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add},
-			QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
-				return framework.Queue, nil
+			Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add},
+			QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+				return fwk.Queue, nil
 			},
 		},
 	}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This is part of a larger change that moves interfaces and type and func defiinitions to the staging repo "k8s.io/kube-scheduler", to allow users for importing scheduler framework interfaces without importing k/k repo.
This PR moves structs ClusterEvent, ActionType, EventResource, ClusterEventWithHint, types QueueingHint and QueueingHintFn from k/k to the staging repo. Functions handling matching events remain in k/k, since they contain logic internal to kube-scheduler and are not required by scheduling framework plugins.

#### Which issue(s) this PR is related to:
Part of #89930

#### Special notes for your reviewer:
Moving this in a separate PR, since the PR moving everything is just too big to be reviewed

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Types: ClusterEvent, ActionType, EventResource, ClusterEventWithHint, QueueingHint and QueueingHintFn moved from pkg/scheduler/framework to k8s.io/kube-scheduler/framework.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
