### PR TITLE
add warnings when creating headless service with specified load balan…

### DIFF
--- a/pkg/api/service/warnings.go
+++ b/pkg/api/service/warnings.go
@@ -41,6 +41,18 @@ func GetWarningsForService(service, oldService *api.Service) []string {
 		}
 	}
 
+	if isHeadlessService(service) {
+		if service.Spec.LoadBalancerIP != "" {
+			warnings = append(warnings, "spec.loadBalancerIP is ignored for headless services")
+		}
+		if len(service.Spec.ExternalIPs) > 0 {
+			warnings = append(warnings, "spec.externalIPs is ignored for headless services")
+		}
+		if service.Spec.SessionAffinity != "" {
+			warnings = append(warnings, "spec.SessionAffinity is ignored for headless services")
+		}
+	}
+
 	for i, externalIP := range service.Spec.ExternalIPs {
 		warnings = append(warnings, utilvalidation.GetWarningsForIP(field.NewPath("spec").Child("externalIPs").Index(i), externalIP)...)
 	}
@@ -61,4 +73,8 @@ func GetWarningsForService(service, oldService *api.Service) []string {
 	}
 
 	return warnings
+}
+
+func isHeadlessService(service *api.Service) bool {
+	return service != nil && service.Spec.Type == api.ServiceTypeClusterIP && service.Spec.ClusterIP == api.ClusterIPNone
 }

--- a/pkg/api/service/warnings_test.go
+++ b/pkg/api/service/warnings_test.go
@@ -56,6 +56,40 @@ func TestGetWarningsForService(t *testing.T) {
 			s.Spec.ExternalName = "example.com"
 		},
 		numWarnings: 1,
+	}, {
+		name: "LoadBalancerIP set when headless service",
+		tweakSvc: func(s *api.Service) {
+			s.Spec.Type = api.ServiceTypeClusterIP
+			s.Spec.ClusterIP = api.ClusterIPNone
+			s.Spec.LoadBalancerIP = "1.2.3.4"
+		},
+		numWarnings: 1,
+	}, {
+		name: "ExternalIPs set when headless service",
+		tweakSvc: func(s *api.Service) {
+			s.Spec.Type = api.ServiceTypeClusterIP
+			s.Spec.ClusterIP = api.ClusterIPNone
+			s.Spec.ExternalIPs = []string{"1.2.3.4"}
+		},
+		numWarnings: 1,
+	}, {
+		name: "SessionAffinity set when headless service",
+		tweakSvc: func(s *api.Service) {
+			s.Spec.Type = api.ServiceTypeClusterIP
+			s.Spec.ClusterIP = api.ClusterIPNone
+			s.Spec.SessionAffinity = api.ServiceAffinityClientIP
+		},
+		numWarnings: 1,
+	}, {
+		name: "ExternalIPs, LoadBalancerIP and SessionAffinity set when headless service",
+		tweakSvc: func(s *api.Service) {
+			s.Spec.Type = api.ServiceTypeClusterIP
+			s.Spec.ClusterIP = api.ClusterIPNone
+			s.Spec.ExternalIPs = []string{"1.2.3.4"}
+			s.Spec.LoadBalancerIP = "1.2.3.4"
+			s.Spec.SessionAffinity = api.ServiceAffinityClientIP
+		},
+		numWarnings: 3,
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixed https://github.com/kubernetes/kubernetes/issues/131497


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Adds warnings when creating headless service with set loadBalancerIP,externalIPs and/or SessionAffinity
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
