### PR TITLE
e2e: node: serial: fix cgroup path with crio

### DIFF
--- a/test/e2e_node/cpumanager_test.go
+++ b/test/e2e_node/cpumanager_test.go
@@ -1435,7 +1435,7 @@ func makeCgroupPathForContainer(pod *v1.Pod, ctnName string, isInit bool) (strin
 
 func containerCgroupPathPrefixFromDriver(runtimeName string) string {
 	if runtimeName == "cri-o" {
-		return "cri-o"
+		return "crio"
 	}
 	return "cri-containerd"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:
Fix cgroup cpu path construction in cri-o

#### Which issue(s) this PR is related to:
Fixes: #131769

#### Special notes for your reviewer:
Do we have the same set of pre-submit and periodic jobs? need to check.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```