### PR TITLE
[WIP] Switch from cmp diff to reflect deep equal to ensure dead code elimination ( staging/src/k8s.io/component-base/logs/api/v1/options.go )

### DIFF
--- a/staging/src/k8s.io/component-base/logs/api/v1/options.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options.go
@@ -23,11 +23,11 @@ import (
 	"io"
 	"math"
 	"os"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"time"
 
-	"github.com/google/go-cmp/cmp" //nolint:depguard
 	"github.com/spf13/pflag"
 
 	"k8s.io/klog/v2"
@@ -240,8 +240,8 @@ func apply(c *LoggingConfiguration, options *LoggingOptions, featureGate feature
 		case ReapplyHandlingError:
 			return errors.New("logging configuration was already applied earlier, changing it is not allowed")
 		case ReapplyHandlingIgnoreUnchanged:
-			if diff := cmp.Diff(oldP, p); diff != "" {
-				return fmt.Errorf("the logging configuration should not be changed after setting it once (- old setting, + new setting):\n%s", diff)
+			if !reflect.DeepEqual(oldP, p) {
+				return fmt.Errorf("the logging configuration should not be changed after setting it once (- old setting, + new setting):\n-: %#v\n+: %#v\n", oldP, p)
 			}
 			return nil
 		default:


### PR DESCRIPTION
Running `KUBE_VERBOSE=4 GOLDFLAGS=-dumpdep make kube-apiserver > deadcode.log` and processing the log using whydeadcode shows the following:

```
github.com/google/go-cmp/cmp/internal/value.appendTypeName reachable from:
         github.com/google/go-cmp/cmp.formatOptions.FormatType
         github.com/google/go-cmp/cmp.formatOptions.FormatDiff
         github.com/google/go-cmp/cmp.(*defaultReporter).String
         github.com/google/go-cmp/cmp.Diff
         k8s.io/component-base/logs/api/v1.apply
         k8s.io/component-base/logs/api/v1.validateAndApply
         k8s.io/kubernetes/cmd/kube-apiserver/app.NewAPIServerCommand.func2
         k8s.io/kubernetes/cmd/kube-apiserver/app.NewAPIServerCommand
         main.main
         runtime.main_main·f
         runtime.main
         runtime.mainPC
         runtime.rt0_go
         _rt0_arm64_darwin
         _
```

This was reported in:
https://github.com/kubernetes/kubernetes/pull/132177#issuecomment-2954136355

and the umbrella issue is:
https://github.com/kubernetes/kubernetes/issues/132216

Solution: For this specific use of `cmp.Diff` switch to `reflect.DeepEqual`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
