### PR TITLE
feat: optimize label selector match performance

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
@@ -31,6 +31,9 @@ type Labels interface {
 
 	// Get returns the value for the provided label.
 	Get(label string) (value string)
+
+	// Lookup returns the value for the provided label if it exists and whether the provided label exist
+	Lookup(label string) (value string, exists bool)
 }
 
 // Set is a map of label:value. It implements Labels.
@@ -57,6 +60,12 @@ func (ls Set) Has(label string) bool {
 // Get returns the value in the map for the provided label.
 func (ls Set) Get(label string) string {
 	return ls[label]
+}
+
+// Lookup returns the value for the provided label if it exists and whether the provided label exist
+func (ls Set) Lookup(label string) (string, bool) {
+	val, exists := ls[label]
+	return val, exists
 }
 
 // AsSelector converts labels into a selectors. It does not

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -236,26 +236,29 @@ func (r *Requirement) hasValue(value string) bool {
 func (r *Requirement) Matches(ls Labels) bool {
 	switch r.operator {
 	case selection.In, selection.Equals, selection.DoubleEquals:
-		if !ls.Has(r.key) {
+		val, exists := ls.Lookup(r.key)
+		if !exists {
 			return false
 		}
-		return r.hasValue(ls.Get(r.key))
+		return r.hasValue(val)
 	case selection.NotIn, selection.NotEquals:
-		if !ls.Has(r.key) {
+		val, exists := ls.Lookup(r.key)
+		if !exists {
 			return true
 		}
-		return !r.hasValue(ls.Get(r.key))
+		return !r.hasValue(val)
 	case selection.Exists:
 		return ls.Has(r.key)
 	case selection.DoesNotExist:
 		return !ls.Has(r.key)
 	case selection.GreaterThan, selection.LessThan:
-		if !ls.Has(r.key) {
+		val, exists := ls.Lookup(r.key)
+		if !exists {
 			return false
 		}
-		lsValue, err := strconv.ParseInt(ls.Get(r.key), 10, 64)
+		lsValue, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			klog.V(10).Infof("ParseInt failed for value %+v in label %+v, %+v", ls.Get(r.key), ls, err)
+			klog.V(10).Infof("ParseInt failed for value %+v in label %+v, %+v", val, ls, err)
 			return false
 		}
 
@@ -996,7 +999,8 @@ type ValidatedSetSelector Set
 
 func (s ValidatedSetSelector) Matches(labels Labels) bool {
 	for k, v := range s {
-		if !labels.Has(k) || v != labels.Get(k) {
+		val, exists := labels.Lookup(k)
+		if !exists || v != val {
 			return false
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -1008,6 +1008,26 @@ func BenchmarkRequirementString(b *testing.B) {
 	}
 }
 
+func BenchmarkRequirementMatches(b *testing.B) {
+	r := Requirement{
+		key:      "environment",
+		operator: selection.NotIn,
+		strValues: []string{
+			"dev",
+		},
+	}
+	labels := Set(map[string]string{
+		"key":         "value",
+		"environment": "dev",
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.Matches(labels)
+	}
+}
+
 func TestRequirementEqual(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
we found that the InterPodAffinity plugin has relatively high latency, with part of the overhead coming from `mapaccess2_faststr`. After reviewing the code implementation, we noticed that each key is being accessed from the map twice, whereas the same effect could have been achieved with just a single access. The impact becomes more significant in large-scale clusters with a high number of pods using PodAffinity.  
![image](https://github.com/user-attachments/assets/e7d6028f-e916-4158-b215-784501ebe538)  


I also added benchmark test for Matches fucntion to compare the result:
Begore:
BenchmarkRequirementMatches-10    	69176058	        17.23 ns/op	       0 B/op	       0 allocs/op
After:
BenchmarkRequirementMatches-10    	100000000	        10.35 ns/op	       0 B/op	       0 allocs/op
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
