### PR TITLE
Remove deprecated encryption config controller metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
@@ -44,17 +44,11 @@ func TestController(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KMSv1, true)
 
 	const expectedSuccessMetricValue = `
-# HELP apiserver_encryption_config_controller_automatic_reload_success_total [ALPHA] Total number of successful automatic reloads of encryption configuration split by apiserver identity.
-# TYPE apiserver_encryption_config_controller_automatic_reload_success_total counter
-apiserver_encryption_config_controller_automatic_reload_success_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027"} 1
 # HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
 # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
 apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",status="success"} 1
 `
 	const expectedFailureMetricValue = `
-# HELP apiserver_encryption_config_controller_automatic_reload_failures_total [ALPHA] Total number of failed automatic reloads of encryption configuration split by apiserver identity.
-# TYPE apiserver_encryption_config_controller_automatic_reload_failures_total counter
-apiserver_encryption_config_controller_automatic_reload_failures_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027"} 1
 # HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
 # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
 apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",status="failure"} 1
@@ -338,8 +332,6 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 			}
 
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.wantMetrics),
-				"apiserver_encryption_config_controller_automatic_reload_success_total",
-				"apiserver_encryption_config_controller_automatic_reload_failures_total",
 				"apiserver_encryption_config_controller_automatic_reloads_total",
 			); err != nil {
 				t.Errorf("failed to validate metrics: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics.go
@@ -43,34 +43,6 @@ var (
 		[]string{"status", "apiserver_id_hash"},
 	)
 
-	// deprecatedEncryptionConfigAutomaticReloadFailureTotal has been deprecated in 1.30.0
-	// use encryptionConfigAutomaticReloadsTotal instead
-	deprecatedEncryptionConfigAutomaticReloadFailureTotal = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Namespace:         namespace,
-			Subsystem:         subsystem,
-			Name:              "automatic_reload_failures_total",
-			Help:              "Total number of failed automatic reloads of encryption configuration split by apiserver identity.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.30.0",
-		},
-		[]string{"apiserver_id_hash"},
-	)
-
-	// deprecatedEncryptionConfigAutomaticReloadSuccessTotal has been deprecated in 1.30.0
-	// use encryptionConfigAutomaticReloadsTotal instead
-	deprecatedEncryptionConfigAutomaticReloadSuccessTotal = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Namespace:         namespace,
-			Subsystem:         subsystem,
-			Name:              "automatic_reload_success_total",
-			Help:              "Total number of successful automatic reloads of encryption configuration split by apiserver identity.",
-			StabilityLevel:    metrics.ALPHA,
-			DeprecatedVersion: "1.30.0",
-		},
-		[]string{"apiserver_id_hash"},
-	)
-
 	encryptionConfigAutomaticReloadLastTimestampSeconds = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Namespace:      namespace,
@@ -94,8 +66,6 @@ func RegisterMetrics() {
 			},
 		}
 		legacyregistry.MustRegister(encryptionConfigAutomaticReloadsTotal)
-		legacyregistry.MustRegister(deprecatedEncryptionConfigAutomaticReloadFailureTotal)
-		legacyregistry.MustRegister(deprecatedEncryptionConfigAutomaticReloadSuccessTotal)
 		legacyregistry.MustRegister(encryptionConfigAutomaticReloadLastTimestampSeconds)
 	})
 }
@@ -103,14 +73,12 @@ func RegisterMetrics() {
 func RecordEncryptionConfigAutomaticReloadFailure(apiServerID string) {
 	apiServerIDHash := getHash(apiServerID)
 	encryptionConfigAutomaticReloadsTotal.WithLabelValues("failure", apiServerIDHash).Inc()
-	deprecatedEncryptionConfigAutomaticReloadFailureTotal.WithLabelValues(apiServerIDHash).Inc()
 	recordEncryptionConfigAutomaticReloadTimestamp("failure", apiServerIDHash)
 }
 
 func RecordEncryptionConfigAutomaticReloadSuccess(apiServerID string) {
 	apiServerIDHash := getHash(apiServerID)
 	encryptionConfigAutomaticReloadsTotal.WithLabelValues("success", apiServerIDHash).Inc()
-	deprecatedEncryptionConfigAutomaticReloadSuccessTotal.WithLabelValues(apiServerIDHash).Inc()
 	recordEncryptionConfigAutomaticReloadTimestamp("success", apiServerIDHash)
 }
 

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -356,7 +356,6 @@ resources:
 	// NOTE: 2 successful automatic reload resulted from 2 config file updates
 	wantMetricStrings := []string{
 		`apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} FP`,
-		`apiserver_encryption_config_controller_automatic_reload_success_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795"} 2`,
 		`apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} 2`,
 	}
 

--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -83,7 +83,7 @@ const (
 	auditPolicyFileName      = "audit-policy.yaml"
 	auditLogFileName         = "audit.log"
 	encryptionConfigFileName = "encryption.conf"
-	metricPrefix             = "apiserver_encryption_config_controller_automatic_reload_success_total"
+	metricPrefix             = "apiserver_encryption_config_controller_automatic_reloads_total"
 	defaultNamespace         = "default"
 	crdName                  = "testcrd"
 	crdGroup                 = "stable.example.com"
@@ -540,7 +540,7 @@ func (svm *svmTest) getAutomaticReloadSuccessTotal(ctx context.Context, t *testi
 		t.Fatal(err)
 	}
 
-	metricRegex := regexp.MustCompile(fmt.Sprintf(`%s{.*} (\d+)`, metricPrefix))
+	metricRegex := regexp.MustCompile(fmt.Sprintf(`%s\s*{apiserver_id_hash="[^"]*",status="success"} (\d+)`, metricPrefix))
 	for _, line := range strings.Split(string(body), "\n") {
 		if strings.HasPrefix(line, metricPrefix) {
 			matches := metricRegex.FindStringSubmatch(line)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Remove deprecated encryption config controller alpha metrics.

follow-up to https://github.com/kubernetes/kubernetes/pull/123179.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: removed the deprecated `apiserver_encryption_config_controller_automatic_reload_success_total` and `apiserver_encryption_config_controller_automatic_reload_failure_total` metrics in favor of `apiserver_encryption_config_controller_automatic_reloads_total`.
```

/triage accepted
/sig auth
/priority important-longterm
/assign @enj