### PR TITLE
Adding batch handling for popping items from RealFIFO

### DIFF
--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -58,6 +58,12 @@ const (
 	// Refactor informers to deliver watch stream events in order instead of out of order.
 	InOrderInformers Feature = "InOrderInformers"
 
+	// owner: @yue9944882
+	// beta: v1.35
+	//
+	// Allow InOrderInformer to process incoming events in batches to expedite the process rate.
+	InOrderInformersBatchProcess Feature = "InOrderInformersBatchProcess"
+
 	// owner: @enj, @michaelasp
 	// alpha: v1.30
 	// GA: v1.35
@@ -88,6 +94,9 @@ var defaultVersionedKubernetesFeatureGates = map[Feature]VersionedSpecs{
 	},
 	InOrderInformers: {
 		{Version: version.MustParse("1.33"), Default: true, PreRelease: Beta},
+	},
+	InOrderInformersBatchProcess: {
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: Beta},
 	},
 	InformerResourceVersion: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: Alpha},

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -48,8 +49,19 @@ type Config struct {
 	// Something that can list and watch your objects.
 	ListerWatcher
 
-	// Something that can process a popped Deltas.
+	// Process can process a popped Deltas.
 	Process ProcessFunc
+
+	// ProcessBatch can process a batch of popped Deltas, which should return `TransactionError` if not all items
+	// in the batch were successfully processed.
+	//
+	// For batch processing to be used:
+	// * ProcessBatch must be non-nil
+	// * Queue must implement QueueWithBatch
+	// * The client InOrderInformersBatchProcess feature gate must be enabled
+	//
+	// If any of those are false, Process is used and no batch processing is done.
+	ProcessBatch ProcessBatchFunc
 
 	// ObjectType is an example object of the type this controller is
 	// expected to handle.
@@ -93,6 +105,10 @@ type ShouldResyncFunc func() bool
 
 // ProcessFunc processes a single object.
 type ProcessFunc func(obj interface{}, isInInitialList bool) error
+
+// ProcessBatchFunc processes multiple objects in batch.
+// The deltas must not contain multiple entries for the same object.
+type ProcessBatchFunc func(deltas []Delta, isInInitialList bool) error
 
 // `*controller` implements Controller
 type controller struct {
@@ -203,12 +219,23 @@ func (c *controller) LastSyncResourceVersion() string {
 // to make sure that we don't end up processing the same object multiple times
 // concurrently.
 func (c *controller) processLoop(ctx context.Context) {
+	useBatchProcess := false
+	batchQueue, ok := c.config.Queue.(QueueWithBatch)
+	if ok && c.config.ProcessBatch != nil && clientgofeaturegate.FeatureGates().Enabled(clientgofeaturegate.InOrderInformersBatchProcess) {
+		useBatchProcess = true
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			_, err := c.config.Pop(PopProcessFunc(c.config.Process))
+			var err error
+			if useBatchProcess {
+				err = batchQueue.PopBatch(c.config.ProcessBatch)
+			} else {
+				// otherwise fallback to non-batch process behavior
+				_, err = c.config.Pop(PopProcessFunc(c.config.Process))
+			}
 			if err != nil {
 				if errors.Is(err, ErrFIFOClosed) {
 					return
@@ -585,6 +612,91 @@ func processDeltas(
 	return nil
 }
 
+// processDeltasInBatch applies a batch of Delta objects to the given Store and
+// notifies the ResourceEventHandler of add, update, or delete events.
+//
+// If the Store supports transactions (TransactionStore), all Deltas are applied
+// atomically in a single transaction and corresponding handler callbacks are
+// executed afterward. Otherwise, each Delta is processed individually.
+//
+// Returns an error if any Delta or transaction fails. For TransactionError,
+// only successful operations trigger callbacks.
+func processDeltasInBatch(
+	handler ResourceEventHandler,
+	clientState Store,
+	deltas []Delta,
+	isInInitialList bool,
+) error {
+	// from oldest to newest
+	txns := make([]Transaction, 0)
+	callbacks := make([]func(), 0)
+	txnStore, txnSupported := clientState.(TransactionStore)
+	if !txnSupported {
+		var errs []error
+		for _, delta := range deltas {
+			if err := processDeltas(handler, clientState, Deltas{delta}, isInInitialList); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("unexpected error when handling deltas: %v", errs)
+		}
+		return nil
+	}
+	// deltasList is a list of unique objects
+	for _, d := range deltas {
+		obj := d.Object
+		switch d.Type {
+		case Sync, Replaced, Added, Updated:
+			// it will only return one old object for each because items are unique
+			if old, exists, err := clientState.Get(obj); err == nil && exists {
+				txn := Transaction{
+					Type:   TransactionTypeUpdate,
+					Object: obj,
+				}
+				txns = append(txns, txn)
+				callbacks = append(callbacks, func() {
+					handler.OnUpdate(old, obj)
+				})
+			} else {
+				txn := Transaction{
+					Type:   TransactionTypeAdd,
+					Object: obj,
+				}
+				txns = append(txns, txn)
+				callbacks = append(callbacks, func() {
+					handler.OnAdd(obj, isInInitialList)
+				})
+			}
+		case Deleted:
+			txn := Transaction{
+				Type:   TransactionTypeDelete,
+				Object: obj,
+			}
+			txns = append(txns, txn)
+			callbacks = append(callbacks, func() {
+				handler.OnDelete(obj)
+			})
+		}
+	}
+
+	err := txnStore.Transaction(txns...)
+	if err != nil {
+		// if txn had error, only execute the callbacks for the successful ones
+		for _, i := range err.SuccessfulIndices {
+			if i < len(callbacks) {
+				callbacks[i]()
+			}
+		}
+		// formatting the error so txns doesn't escape and keeps allocated in the stack.
+		return fmt.Errorf("not all items in the batch successfully processed: %s", err.Error())
+	}
+	for _, callback := range callbacks {
+		callback()
+	}
+	return nil
+}
+
 // newInformer returns a controller for populating the store while also
 // providing event notifications.
 //
@@ -623,6 +735,9 @@ func newInformer(clientState Store, options InformerOptions) Controller {
 				return processDeltas(options.Handler, clientState, deltas, isInInitialList)
 			}
 			return errors.New("object given as Process argument is not Deltas")
+		},
+		ProcessBatch: func(deltaList []Delta, isInInitialList bool) error {
+			return processDeltasInBatch(options.Handler, clientState, deltaList, isInInitialList)
 		},
 	}
 	return New(cfg)

--- a/staging/src/k8s.io/client-go/tools/cache/fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo.go
@@ -60,6 +60,23 @@ type Queue interface {
 	Close()
 }
 
+// QueueWithBatch extends the Queue interface with support for batch processing.
+//
+// In addition to the standard single-item Pop method, QueueWithBatch provides
+// PopBatch, which allows multiple items to be popped and processed together as
+// a batch. This can be used to improve processing efficiency when it is
+// beneficial to handle multiple queued keys or accumulators in a single
+// operation.
+// TODO: Consider merging this interface into Queue after feature gate GA
+type QueueWithBatch interface {
+	Queue
+
+	// PopBatch behaves similarly to Queue#Pop, but processes multiple keys
+	// as a batch. The implementation determines the batching strategy,
+	// such as the number of keys to include per batch.
+	PopBatch(ProcessBatchFunc) error
+}
+
 // Pop is helper function for popping from Queue.
 // WARNING: Do NOT use this function in non-test code to avoid races
 // unless you really really really really know what you are doing.

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -563,6 +563,7 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 			ShouldResync:      s.processor.shouldResync,
 
 			Process:                      s.HandleDeltas,
+			ProcessBatch:                 s.HandleBatchDeltas,
 			WatchErrorHandlerWithContext: s.watchErrorHandler,
 		}
 
@@ -733,6 +734,12 @@ func (s *sharedIndexInformer) HandleDeltas(obj interface{}, isInInitialList bool
 		return processDeltas(s, s.indexer, deltas, isInInitialList)
 	}
 	return errors.New("object given as Process argument is not Deltas")
+}
+
+func (s *sharedIndexInformer) HandleBatchDeltas(deltas []Delta, isInInitialList bool) error {
+	s.blockDeltas.Lock()
+	defer s.blockDeltas.Unlock()
+	return processDeltasInBatch(s, s.indexer, deltas, isInInitialList)
 }
 
 // Conforms to ResourceEventHandler


### PR DESCRIPTION
/kind feature
/sig api-machinery

### Summary

Ref: https://github.com/kubernetes/kubernetes/issues/130767

The above issue noted a problem that the write lock acquisition from DeltaFIFO's `processDeltas` can have much lower throughput due to read lock contention:

- Read lock attempts were multi-threaded in a classic controller model so it has higher chance to acquire the lock.
- Write lock works in a single-threaded context so at least one read lock will be able to acquire the lock in-between.

This leads to an problem that the distribution between read lock and write lock are almost 1:1 in a large scale busy cluster. 

This PR enables DeltaFIFO to process items in a batch fashion while preserving the in-queue orders, so it can batch multiple item writes (add/update/delete) within a single write lock acquisition.

```release-note
Improved throughput in the real-FIFO queue used by informer/controllers by adding batch handling for processing watch events.
```

### Performance Test

By running the following unit test which simulates heavy watch event stream. It constructs a simple controller with an informer built from in-memory fake watch, then we use 100 concurrent routines to flood watch events to the watch channel:

> https://gist.github.com/yue9944882/f9ee6bbc81373545253b95abc9a65269


<img width="1001" alt="Screenshot 2025-06-11 at 6 55 48 PM" src="https://github.com/user-attachments/assets/f8dc798b-933f-4b41-95a4-041f3b6f8f12" />


- Achieve ~10x write throughput than reads
- Increasing overall controller throughput by ~6x