### PR TITLE
deps: bump cadvisor to 0.49.2 in release 1.31

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/protobuf v1.5.4
-	github.com/google/cadvisor v0.49.0
+	github.com/google/cadvisor v0.49.2
 	github.com/google/cel-go v0.20.1
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/golangplus/testing v1.0.0/go.mod h1:ZDreixUV3YzhoVraIDyOzHrr76p6NUh6k
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
-github.com/google/cadvisor v0.49.0 h1:1PYeiORXmcFYi609M4Qvq5IzcvcVaWgYxDt78uH8jYA=
-github.com/google/cadvisor v0.49.0/go.mod h1:s6Fqwb2KiWG6leCegVhw4KW40tf9f7m+SF1aXiE8Wsk=
+github.com/google/cadvisor v0.49.2 h1:6RGbLCA9sBq9EMqce+M1gefBibz4pQpwX/kODwC+FqM=
+github.com/google/cadvisor v0.49.2/go.mod h1:s6Fqwb2KiWG6leCegVhw4KW40tf9f7m+SF1aXiE8Wsk=
 github.com/google/cel-go v0.20.1 h1:nDx9r8S3L4pE61eDdt8igGj8rf5kjYR3ILxWIpWNi84=
 github.com/google/cel-go v0.20.1/go.mod h1:kWcIzTsPX0zmQ+H3TirHstLLf9ep5QTsZBN9u4dOYLg=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=

--- a/vendor/github.com/google/cadvisor/container/crio/factory.go
+++ b/vendor/github.com/google/cadvisor/container/crio/factory.go
@@ -32,9 +32,6 @@ import (
 // The namespace under which crio aliases are unique.
 const CrioNamespace = "crio"
 
-// The namespace suffix under which crio aliases are unique.
-const CrioNamespaceSuffix = ".scope"
-
 // The namespace systemd runs components under.
 const SystemdNamespace = "system-systemd"
 
@@ -117,20 +114,15 @@ func (f *crioFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 		// TODO(runcom): should we include crio-conmon cgroups?
 		return false, false, nil
 	}
-	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
-		return true, false, nil
-	}
 	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
 		return false, false, nil
+	}
+	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
+		return true, false, nil
 	}
 	// if the container is not associated with CRI-O, we can't handle it or accept it.
 	if !isContainerName(name) {
 		return false, false, nil
-	}
-
-	if !strings.HasSuffix(path.Base(name), CrioNamespaceSuffix) {
-		// this mean it's a sandbox container
-		return true, false, nil
 	}
 	return true, true, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -246,7 +246,7 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v1.0.1
 ## explicit; go 1.12
 github.com/google/btree
-# github.com/google/cadvisor v0.49.0
+# github.com/google/cadvisor v0.49.2
 ## explicit; go 1.19
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

```shell
go get github.com/google/cadvisor@v0.49.2
hack/update-vendor.sh
```

Bump cAdvisor to v0.49.2 in 1.31 release.

releated:
- https://github.com/google/cadvisor/issues/3577

fixes #131889

/cc @dims @cwangVT @haircommander
/sig node


The bump cadvisor for the master branch is bump to v0.51.0 and included in  kubernetes 1.32,see https://github.com/kubernetes/kubernetes/pull/128346, with many changes. cherrypick is not a good choice. Therefore, I choose a more streamlined small version of the patch

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bump cAdvisor to v0.49.2
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
