### PR TITLE
kubectl delete: update interactive delete to break on new line

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -524,7 +524,7 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 }
 
 func (o *DeleteOptions) confirmation(infos []*resource.Info) bool {
-	fmt.Fprintf(o.Out, i18n.T("You are about to delete the following %d resource(s):\n"), len(infos))
+	fmt.Fprintf(o.Out, i18n.T("You are about to delete the following %d resource(s):\n"), len(infos)) //nolint:errcheck
 	for _, info := range infos {
 		groupKind := info.Mapping.GroupVersionKind
 		kindString := fmt.Sprintf("%s.%s", strings.ToLower(groupKind.Kind), groupKind.Group)
@@ -532,11 +532,11 @@ func (o *DeleteOptions) confirmation(infos []*resource.Info) bool {
 			kindString = strings.ToLower(groupKind.Kind)
 		}
 
-		fmt.Fprintf(o.Out, "%s/%s\n", kindString, info.Name)
+		fmt.Fprintf(o.Out, "%s/%s\n", kindString, info.Name) //nolint:errcheck
 	}
-	fmt.Fprint(o.Out, i18n.T("Do you want to continue?")+" (y/n): ")
+	fmt.Fprint(o.Out, i18n.T("Do you want to continue?")+" (y/N): ") //nolint:errcheck
 	var input string
-	_, err := fmt.Fscan(o.In, &input)
+	_, err := fmt.Fscanln(o.In, &input)
 	if err != nil {
 		return false
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -375,7 +375,7 @@ func TestDeleteObjectWithInteractive(t *testing.T) {
 	}
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/n): replicationcontroller/redis-master\n" {
+	if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/N): replicationcontroller/redis-master\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
@@ -396,7 +396,7 @@ func TestDeleteObjectWithInteractive(t *testing.T) {
 	}
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/n): deletion is cancelled\n" {
+	if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/N): deletion is cancelled\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 	if buf.String() == ": replicationcontroller/redis-master\n" {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR fixes the test failures in https://github.com/kubernetes/kubernetes/pull/131119. This PR supersedes https://github.com/kubernetes/kubernetes/pull/131119

#### Which issue(s) this PR is related to:

ref: https://github.com/kubernetes/kubernetes/pull/114530/files#r1259635470

#### Does this PR introduce a user-facing change?
```release-note
kubectl interactive delete: treat empty newline input as N
```
