### PR TITLE
feat: optimize ListAll and ListAllByNamespace to return directly when nothing to select

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -23,11 +23,12 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/klog/v2"
+
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -113,6 +114,15 @@ var sharedNothingSelector Selector = nothingSelector{}
 // Nothing returns a selector that matches no labels
 func Nothing() Selector {
 	return sharedNothingSelector
+}
+
+// MatchesNothing only returns true for selectors which are definitively determined to match no objects.
+// This currently only detects the `labels.Nothing()` selector, but may change over time to detect more selectors that match no objects.
+//
+// Note: The current implementation does not check for selector conflict scenarios (e.g., a=a,a!=a).
+// Support for detecting such cases can be added in the future.
+func MatchesNothing(selector Selector) bool {
+	return selector == sharedNothingSelector
 }
 
 // NewSelector returns a nil selector

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -1099,3 +1099,114 @@ func TestRequirementEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesNothing(t *testing.T) {
+	tests := []struct {
+		name          string
+		selector      string
+		set           map[string]string
+		labelSelector Selector
+		want          bool
+	}{
+		{
+			name:          "MatchNothing should match Nothing()",
+			labelSelector: Nothing(),
+			want:          true,
+		},
+		{
+			name:          "MatchNothing should match sharedNothingSelector",
+			labelSelector: sharedNothingSelector,
+			want:          true,
+		},
+		{
+			name:          "MatchNothing should not match Everything()",
+			labelSelector: Everything(),
+			want:          false,
+		},
+		{
+			name:          "MatchNothing should not match sharedEverythingSelector",
+			labelSelector: sharedEverythingSelector,
+			want:          false,
+		},
+		{
+			name: "MatchNothing should not match empty set",
+			set:  map[string]string{},
+			want: false,
+		},
+		{
+			name: "MatchNothing should not match non-empty set",
+			set:  map[string]string{"key": "value"},
+			want: false,
+		},
+		{
+			name:     "MatchNothing should not match empty selector",
+			selector: "",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - exists",
+			selector: "a",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - not exists",
+			selector: "!a",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - equals",
+			selector: "a=b",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - not equals",
+			selector: "a!=b",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - in",
+			selector: "a in (b)",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - notin",
+			selector: "a notin (b)",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - conflict exists and not exists",
+			selector: "a,!a",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - conflict equals and not equals",
+			selector: "a=b,a!=b",
+			want:     false,
+		},
+		{
+			name:     "MatchNothing should not match non-empty selector - conflict in and notin",
+			selector: "a in (b),a notin (b)",
+			want:     false,
+		},
+	}
+
+	for i := 0; i < len(tests); i++ {
+		if tests[i].labelSelector != nil {
+			expectMatchNothing(t, tests[i].labelSelector, tests[i].want)
+		} else if tests[i].set != nil {
+			expectMatchNothing(t, SelectorFromSet(tests[i].set), tests[i].want)
+		} else {
+			selector, err := Parse(tests[i].selector)
+			if err != nil {
+				t.Errorf("Unable to parse %v as a selector.\n", selector)
+			}
+			expectMatchNothing(t, selector, tests[i].want)
+		}
+	}
+}
+
+func expectMatchNothing(t *testing.T, selector Selector, want bool) {
+	if MatchesNothing(selector) != want {
+		t.Errorf("Wanted %s to MatchNothing '%t', but it did not.\n", selector, want)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/listers.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers.go
@@ -32,6 +32,10 @@ type AppendFunc func(interface{})
 
 // ListAll lists items in the store matching the given selector, calling appendFn on each one.
 func ListAll(store Store, selector labels.Selector, appendFn AppendFunc) error {
+	if labels.MatchesNothing(selector) {
+		return nil
+	}
+
 	selectAll := selector.Empty()
 	for _, m := range store.List() {
 		if selectAll {
@@ -55,6 +59,10 @@ func ListAll(store Store, selector labels.Selector, appendFn AppendFunc) error {
 // calling appendFn on each one.
 // If a blank namespace (NamespaceAll) is specified, this delegates to ListAll().
 func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selector, appendFn AppendFunc) error {
+	if labels.MatchesNothing(selector) {
+		return nil
+	}
+
 	if namespace == metav1.NamespaceAll {
 		return ListAll(indexer, selector, appendFn)
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/listers_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers_test.go
@@ -138,3 +138,23 @@ func BenchmarkLister_Match_100k_100(b *testing.B) {
 func BenchmarkLister_Match_1M_100(b *testing.B) {
 	benchmarkLister(b, 1000000, 100, map[string]string{"match": "true"})
 }
+
+func benchmarkNothingLister(b *testing.B, numObjects int, numMatching int, labelSelector *metav1.LabelSelector) {
+	store := mustCreateStore(numObjects, numMatching, nil)
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		b.Fatalf("LabelSelectorAsSelector returned an error: %v", err)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err := ListAll(store, selector, func(m interface{}) {
+		})
+		if err != nil {
+			b.Fatalf("ListAll returned an error: %v", err)
+		}
+	}
+}
+
+func BenchmarkLister_Match_1M_0(b *testing.B) {
+	benchmarkNothingLister(b, 1000000, 0, nil)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The `ListAll` and `ListAllByNamespace` methods of the lister still perform a full (but ineffective) iteration even when the passed-in selector is labels.Nothing(). While it's possible to add a check at the call site to skip the operation when the selector is labels.Nothing(), this relies on developers to remember to do so, making it easy to miss such checks.
e.g.
https://github.com/kubernetes/kubernetes/blob/990e5ded4f51b08f9dda499ef184edda7250a966/pkg/scheduler/framework/types.go#L662-L675
`nsSelector` will be `labels.Nothing()` if `term.NamespaceSelector` is nil. 
https://github.com/kubernetes/kubernetes/blob/990e5ded4f51b08f9dda499ef184edda7250a966/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go#L123-L136
`at.NamespaceSelector` is the `nsSelector` mentioned above. So when it is `labels.Nothing()`, it results in an unnecessary iteration over all namespaces when to call `List` function.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
