### PR TITLE
Correct error message to print `ResetConfigurationKind`

### DIFF
--- a/cmd/kubeadm/app/util/config/resetconfiguration.go
+++ b/cmd/kubeadm/app/util/config/resetconfiguration.go
@@ -135,7 +135,7 @@ func documentMapToResetConfiguration(gvkmap kubeadmapi.DocumentMap, allowDepreca
 	}
 
 	if len(resetBytes) == 0 {
-		return nil, errors.Errorf("no %s found in the supplied config", constants.JoinConfigurationKind)
+		return nil, errors.Errorf("no %s found in the supplied config", constants.ResetConfigurationKind)
 	}
 
 	internalcfg := &kubeadmapi.ResetConfiguration{}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The previous message incorrectly used `JoinConfigurationKind`, which is unrelated, as `documentMapToResetConfiguration` function only processes ResetConfiguration. Thus, correct the error message to print `ResetConfigurationKind`.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubeadm/issues/3210

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Fixed an incorrect reference to `JoinConfigurationKind` in the error message when no ResetConfiguration is found during `kubeadm reset` with the `--config` flag.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
