### PR TITLE
Test requests send to etcd for all LIST requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -643,13 +643,11 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 	if err := store.GetList(ctx, "/pods/second", storageOpts, list); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	continueRV, _ := strconv.Atoi(list.ResourceVersion)
+	continueRV := mustParseResourceVersion(t, list.ResourceVersion)
 	secondContinuation, err := storage.EncodeContinue("/pods/second/foo", "/pods/second/", int64(continueRV))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	initialRV2, _ := strconv.Atoi(initialRV)
 
 	getAttrs := func(obj runtime.Object) (labels.Set, fields.Set, error) {
 		pod := obj.(*example.Pod)
@@ -677,7 +675,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		expectContinueTooOld       bool
 		expectRV                   string
 		expectRVFunc               func(string) error
-		expectEtcdRequest          func() []RecordedList
+		expectCacherRequestsToEtcd func() []RecordedList
 	}{
 		{
 			name:        "rejects invalid resource version",
@@ -710,6 +708,16 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			prefix:      "/pods/first/",
 			pred:        storage.Everything,
 			expectedOut: []example.Pod{*updatedPod},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key: "/registry/pods/first/",
+					},
+				}
+			},
 		},
 		{
 			name:                 "test List on existing key with resource version set to 0",
@@ -726,6 +734,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[0].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[0].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/first/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[0].ResourceVersion)},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List on existing key with resource version set before creation, match=Exact",
@@ -735,6 +754,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[0].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[0].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[0].ResourceVersion)},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List on existing key with resource version set after creation, match=Exact",
@@ -744,6 +774,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[1].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[1].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[1].ResourceVersion)},
+					},
+				}
+			},
 		},
 		{
 			name:           "test List on existing key with resource version set before first write, match=Exact",
@@ -752,6 +793,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:             initialRV,
 			rvMatch:        metav1.ResourceVersionMatchExact,
 			expectRVTooOld: true,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/first/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, initialRV)},
+					},
+				}
+			},
 		},
 		{
 			name:                 "test List on existing key with resource version set to 0, match=NotOlderThan",
@@ -800,6 +852,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          list.ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    list.ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/first/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV)},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List on existing key with resource version set to current resource version, match=NotOlderThan",
@@ -814,6 +877,16 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			prefix:      "/pods/non-existing/",
 			pred:        storage.Everything,
 			expectedOut: []example.Pod{},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key: "/registry/pods/non-existing/",
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with pod name matching",
@@ -823,6 +896,16 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Field: fields.ParseSelectorOrDie("metadata.name!=bar"),
 			},
 			expectedOut: []example.Pod{},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key: "/registry/pods/first/",
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with pod name matching with resource version set to current resource version, match=NotOlderThan",
@@ -848,7 +931,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(createdPods[1].Name+"\x00", int64(mustAtoi(currentRV))),
 			expectedRemainingItemCount: ptr.To[int64](1),
-			expectEtcdRequest: func() []RecordedList {
+			expectCacherRequestsToEtcd: func() []RecordedList {
 				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
 					return nil
 				}
@@ -874,6 +957,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectedRemainingItemCount: ptr.To[int64](1),
 			rv:                         list.ResourceVersion,
 			expectRV:                   list.ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit at current resource version and match=Exact",
@@ -890,6 +984,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:                         list.ResourceVersion,
 			rvMatch:                    metav1.ResourceVersionMatchExact,
 			expectRV:                   list.ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit at current resource version and match=NotOlderThan",
@@ -958,6 +1063,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:             createdPods[0].ResourceVersion,
 			rvMatch:        metav1.ResourceVersionMatchExact,
 			expectRV:       createdPods[0].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[0].ResourceVersion), Limit: 1},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit at resource version after created and match=Exact",
@@ -972,6 +1088,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:             createdPods[1].ResourceVersion,
 			rvMatch:        metav1.ResourceVersionMatchExact,
 			expectRV:       createdPods[1].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[1].ResourceVersion), Limit: 1},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with pregenerated continue token",
@@ -983,6 +1110,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Continue: secondContinuation,
 			},
 			expectedOut: []example.Pod{*createdPods[2]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1, Continue: "/registry/pods/second/foo"},
+					},
+				}
+			},
 		},
 		{
 			name:   "ignores resource version 0 for List with pregenerated continue token",
@@ -995,12 +1133,33 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			rv:          "0",
 			expectedOut: []example.Pod{*createdPods[2]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/second/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1, Continue: "/registry/pods/second/foo"},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with multiple levels of directories and expect flattened result",
 			prefix:      "/pods/second/",
 			pred:        storage.Everything,
 			expectedOut: []example.Pod{*createdPods[1], *createdPods[2]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key: "/registry/pods/second/",
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with multiple levels of directories and expect flattened result with current resource version and match=NotOlderThan",
@@ -1020,6 +1179,25 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut:    []example.Pod{*createdPods[3]},
 			expectContinue: true,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Limit: 1},
+					},
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 2, Continue: "/registry/pods/first/bar\x00"},
+					},
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 4, Continue: "/registry/pods/second/foo\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with filter returning only one item, ensure only a single page returned with current resource version and match=NotOlderThan",
@@ -1045,6 +1223,21 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut:    []example.Pod{*createdPods[3]},
 			expectContinue: false,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 0, Limit: 2},
+					},
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 4, Continue: "/registry/pods/second/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with filter returning only one item, covers the entire list with current resource version and match=NotOlderThan",
@@ -1082,6 +1275,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectContinue: true,
 			expectedOut:    []example.Pod{*updatedPod, *createdPods[1]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 0, Limit: 2},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with filter returning two items, more pages possible with current resource version and match=NotOlderThan",
@@ -1105,6 +1309,21 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Limit: 2,
 			},
 			expectedOut: []example.Pod{*createdPods[2], *createdPods[4]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 0, Limit: 2},
+					},
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 4, Continue: "/registry/pods/second/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "filter returns two items split across multiple pages with current resource version and match=NotOlderThan",
@@ -1128,6 +1347,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Continue: encodeContinueOrDie("third/barfoo", int64(continueRV)),
 			},
 			expectedOut: []example.Pod{*createdPods[4]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 2, Continue: "/registry/pods/third/barfoo"},
+					},
+				}
+			},
 		},
 		{
 			name:   "filter returns one item for last page, starts on last item, full",
@@ -1139,6 +1369,21 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Continue: encodeContinueOrDie("third/barfoo", int64(continueRV)),
 			},
 			expectedOut: []example.Pod{*createdPods[4]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 1, Continue: "/registry/pods/third/barfoo"},
+					},
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 2, Continue: "/registry/pods/third/barfoo\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "filter returns one item for last page, starts on last item, partial page",
@@ -1150,6 +1395,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Continue: encodeContinueOrDie("third/barfoo", int64(continueRV)),
 			},
 			expectedOut: []example.Pod{*createdPods[4]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 2, Continue: "/registry/pods/third/barfoo"},
+					},
+				}
+			},
 		},
 		{
 			name:   "filter returns two items, page size equal to total list size",
@@ -1160,6 +1416,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Limit: 5,
 			},
 			expectedOut: []example.Pod{*createdPods[2], *createdPods[4]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 0, Limit: 5},
+					},
+				}
+			},
 		},
 		{
 			name:   "filter returns two items, page size equal to total list size with current resource version and match=NotOlderThan",
@@ -1182,6 +1449,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Limit: 5,
 			},
 			expectedOut: []example.Pod{*createdPods[3]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 0, Limit: 5},
+					},
+				}
+			},
 		},
 		{
 			name:   "filter returns one item, page size equal to total list size with current resource version and match=NotOlderThan",
@@ -1200,6 +1478,16 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			prefix:      "/pods/",
 			pred:        storage.Everything,
 			expectedOut: []example.Pod{*updatedPod, *createdPods[1], *createdPods[2], *createdPods[3], *createdPods[4]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key: "/registry/pods/",
+					},
+				}
+			},
 		},
 		{
 			name:        "list all items with current resource version and match=NotOlderThan",
@@ -1240,6 +1528,16 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          "",
 			expectRV:    currentRV,
 			expectedOut: []example.Pod{},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key: "/registry/pods/empty/",
+					},
+				}
+			},
 		},
 		{
 			name:         "test non-consistent List",
@@ -1266,6 +1564,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[0].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[0].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 2},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version of second write, match=Exact",
@@ -1275,6 +1584,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[1].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[1].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 3},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version of third write, match=Exact",
@@ -1284,6 +1604,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[2].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[2].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 4},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version of fourth write, match=Exact",
@@ -1293,6 +1624,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[3].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[3].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 5},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version of fifth write, match=Exact",
@@ -1302,6 +1644,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[4].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[4].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 6},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version of six write, match=Exact",
@@ -1311,6 +1664,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          createdPods[5].ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    createdPods[5].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 7},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version of seventh write, match=Exact",
@@ -1320,6 +1684,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          updatedPod.ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    updatedPod.ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: 8},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version of eight write, match=Exact",
@@ -1329,6 +1704,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          fmt.Sprint(continueRV),
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    fmt.Sprint(continueRV),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV)},
+					},
+				}
+			},
 		},
 		{
 			name:        "test List with resource version after writes, match=Exact",
@@ -1338,6 +1724,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          fmt.Sprint(continueRV + 1),
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    fmt.Sprint(continueRV + 1),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) && utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1},
+					},
+				}
+			},
 		},
 		{
 			name:             "test List with future resource version, match=Exact",
@@ -1346,6 +1743,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:               fmt.Sprint(continueRV + 2),
 			rvMatch:          metav1.ResourceVersionMatchExact,
 			expectRVTooLarge: true,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 2},
+					},
+				}
+			},
 		},
 		// limit, match=Exact
 		{
@@ -1363,6 +1771,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rvMatch:                    metav1.ResourceVersionMatchExact,
 			expectRV:                   createdPods[1].ResourceVersion,
 			expectedRemainingItemCount: ptr.To[int64](1),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[1].ResourceVersion), Limit: 1},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit, resource version of third write, match=Exact",
@@ -1379,6 +1798,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinueExact:        encodeContinueOrDie(createdPods[1].Namespace+"/"+createdPods[1].Name+"\x00", int64(mustAtoi(createdPods[2].ResourceVersion))),
 			expectRV:                   createdPods[2].ResourceVersion,
 			expectedRemainingItemCount: ptr.To[int64](1),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[2].ResourceVersion), Limit: 2},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit, resource version of fourth write, match=Exact",
@@ -1392,6 +1822,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectedOut: []example.Pod{*createdPods[0], *createdPods[1], *createdPods[2], *createdPods[3]},
 			expectRV:    createdPods[3].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[3].ResourceVersion), Limit: 4},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit, resource version of fifth write, match=Exact",
@@ -1408,6 +1849,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(createdPods[0].Namespace+"/"+createdPods[0].Name+"\x00", int64(mustAtoi(createdPods[4].ResourceVersion))),
 			expectedRemainingItemCount: ptr.To[int64](4),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[4].ResourceVersion), Limit: 1},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit, resource version of six write, match=Exact",
@@ -1424,6 +1876,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(createdPods[1].Namespace+"/"+createdPods[1].Name+"\x00", int64(mustAtoi(createdPods[5].ResourceVersion))),
 			expectedRemainingItemCount: ptr.To[int64](4),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[5].ResourceVersion), Limit: 2},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit, resource version of seventh write, match=Exact",
@@ -1440,6 +1903,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(createdPods[2].Namespace+"/"+createdPods[2].Name+"\x00", int64(mustAtoi(updatedPod.ResourceVersion))),
 			expectedRemainingItemCount: ptr.To[int64](2),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, updatedPod.ResourceVersion), Limit: 4},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit, resource version of eight write, match=Exact",
@@ -1453,6 +1927,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          fmt.Sprint(continueRV),
 			rvMatch:     metav1.ResourceVersionMatchExact,
 			expectRV:    fmt.Sprint(continueRV),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV), Limit: 8},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with limit, resource version after writes, match=Exact",
@@ -1469,6 +1954,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(updatedPod.Namespace+"/"+updatedPod.Name+"\x00", int64(continueRV+1)),
 			expectedRemainingItemCount: ptr.To[int64](4),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) && utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 1},
+					},
+				}
+			},
 		},
 		// Continue
 		{
@@ -1478,9 +1974,20 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Label:    labels.Everything(),
 				Field:    fields.Everything(),
 				Limit:    1,
-				Continue: encodeContinueOrDie(createdPods[0].Namespace+"/"+createdPods[0].Name+"\x00", int64(initialRV2)),
+				Continue: encodeContinueOrDie(createdPods[0].Namespace+"/"+createdPods[0].Name+"\x00", mustParseResourceVersion(t, initialRV)),
 			},
 			expectContinueTooOld: true,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, initialRV), Limit: 4},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue, resource version of first write",
@@ -1493,6 +2000,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut: []example.Pod{},
 			expectRV:    createdPods[0].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[0].ResourceVersion), Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue, resource version of second write",
@@ -1505,6 +2023,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut: []example.Pod{*createdPods[1]},
 			expectRV:    createdPods[1].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[1].ResourceVersion), Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue, resource version of third write",
@@ -1517,6 +2046,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut: []example.Pod{*createdPods[2]},
 			expectRV:    createdPods[2].ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[2].ResourceVersion), Limit: 2, Continue: "/registry/pods/second/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue, resource version of fifth write",
@@ -1532,6 +2072,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(createdPods[1].Namespace+"/"+createdPods[1].Name+"\x00", int64(mustAtoi(createdPods[4].ResourceVersion))),
 			expectedRemainingItemCount: ptr.To[int64](3),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[4].ResourceVersion), Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue, resource version of six write",
@@ -1547,6 +2098,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(createdPods[2].Namespace+"/"+createdPods[2].Name+"\x00", int64(mustAtoi(createdPods[5].ResourceVersion))),
 			expectedRemainingItemCount: ptr.To[int64](2),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, createdPods[5].ResourceVersion), Limit: 2, Continue: "/registry/pods/second/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue, resource version of seventh write",
@@ -1559,6 +2121,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut: []example.Pod{*createdPods[3], *createdPods[4]},
 			expectRV:    updatedPod.ResourceVersion,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: mustParseResourceVersion(t, updatedPod.ResourceVersion), Limit: 4, Continue: "/registry/pods/second/foo\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue, resource version after writes",
@@ -1574,6 +2147,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinue:             true,
 			expectContinueExact:        encodeContinueOrDie(createdPods[1].Namespace+"/"+createdPods[1].Name+"\x00", int64(continueRV+1)),
 			expectedRemainingItemCount: ptr.To[int64](3),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) && utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Revision: int64(continueRV) + 1, Limit: 1, Continue: "/registry/pods/first/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue from second pod, negative resource version gives consistent read",
@@ -1585,6 +2169,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut: []example.Pod{*createdPods[1], *createdPods[2], *createdPods[3], *createdPods[4]},
 			expectRV:    currentRV,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) && utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Continue: "/registry/pods/first/bar\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue from second pod and limit, negative resource version gives consistent read",
@@ -1600,6 +2195,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			expectContinueExact:        encodeContinueOrDie(createdPods[2].Namespace+"/"+createdPods[2].Name+"\x00", int64(continueRV+1)),
 			expectRV:                   currentRV,
 			expectedRemainingItemCount: ptr.To[int64](2),
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) && utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Continue: "/registry/pods/first/bar\x00", Limit: 2},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue from third pod, negative resource version gives consistent read",
@@ -1611,6 +2217,17 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			},
 			expectedOut: []example.Pod{*createdPods[3], *createdPods[4]},
 			expectRV:    currentRV,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				if utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache) && utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+					return nil
+				}
+				return []RecordedList{
+					{
+						Key:         "/registry/pods/",
+						ListOptions: kubernetes.ListOptions{Continue: "/registry/pods/second/foo\x00"},
+					},
+				}
+			},
 		},
 		{
 			name:   "test List with continue from empty fails",
@@ -1731,11 +2348,14 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			if !cmp.Equal(tt.expectedRemainingItemCount, out.RemainingItemCount) {
 				t.Fatalf("unexpected remainingItemCount, diff: %s", cmp.Diff(tt.expectedRemainingItemCount, out.RemainingItemCount))
 			}
-			if watchCacheEnabled && tt.expectEtcdRequest != nil {
-				expectEtcdLists := tt.expectEtcdRequest()
-				etcdLists := recorder.ListRequestForKey(recorderKey)
-				if !cmp.Equal(expectEtcdLists, etcdLists) {
-					t.Fatalf("unexpected etcd requests, diff: %s", cmp.Diff(expectEtcdLists, etcdLists))
+			if watchCacheEnabled {
+				var expectedListRequests []RecordedList
+				if tt.expectCacherRequestsToEtcd != nil {
+					expectedListRequests = tt.expectCacherRequestsToEtcd()
+				}
+				gotListRequests := recorder.ListRequestForKey(recorderKey)
+				if !cmp.Equal(expectedListRequests, gotListRequests) {
+					t.Fatalf("unexpected etcd list requests, diff: %s", cmp.Diff(expectedListRequests, gotListRequests))
 				}
 			}
 		})
@@ -3854,4 +4474,14 @@ func RunTestKeySchema(ctx context.Context, t *testing.T, store storage.Interface
 	require.NoError(t, store.Delete(ctx, "/pods/", deleteOut, nil, deleteFunc, nil, deleteOpts))
 	require.NoError(t, store.Delete(ctx, "/pods/namespace", deleteOut, nil, deleteFunc, nil, deleteOpts))
 	require.NoError(t, store.Delete(ctx, "/pods/namespace/name", deleteOut, nil, deleteFunc, nil, deleteOpts))
+}
+
+func mustParseResourceVersion(t *testing.T, resourceVersion string) int64 {
+	t.Helper()
+	versioner := storage.APIObjectVersioner{}
+	rv, err := versioner.ParseResourceVersion(resourceVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return int64(rv)
 }


### PR DESCRIPTION
/kind feature

This PR build upon https://github.com/kubernetes/kubernetes/pull/132253 to cover all LIST request. This gives us confidence that there is no other fallback issues like https://github.com/kubernetes/kubernetes/issues/132132
```release-note
NONE
```

/assign @wojtek-t @liggitt
/cc @hakuna-matatah