### PR TITLE
Promote RelaxedEnvironmentVariableValidation test to Conformance #132219

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2066,6 +2066,16 @@
     watch event.
   release: v1.19
   file: test/e2e/network/service.go
+- testname: ConfigMap, from environment field with various prefixes
+  codename: '[sig-node] ConfigMap should be consumable as environment variable names
+    with various prefixes [Conformance]'
+  description: Create a Pod with environment variable values set using values from
+    ConfigMap. Allows users to use envFrom to set prefixes with various printable
+    ASCII characters excluding '=' as environment variable names. This test verifies
+    that different prefixes including digits, special characters, and letters can
+    be correctly used.
+  release: v1.34
+  file: test/e2e/common/node/configmap.go
 - testname: ConfigMap, from environment field
   codename: '[sig-node] ConfigMap should be consumable via environment variable [NodeConformance]
     [Conformance]'
@@ -2638,6 +2648,16 @@
     patch, delete, and deletecollection.'
   release: v1.20
   file: test/e2e/common/node/runtimeclass.go
+- testname: Secrets, pod environment from source
+  codename: '[sig-node] Secrets should be consumable as environment variable names
+    variable names with various prefixes [Conformance]'
+  description: Create a Pod with environment variable values set using values from
+    Secret. Allows users to use envFrom to set prefixes with various printable ASCII
+    characters excluding '=' as environment variable names. This test verifies that
+    different prefixes including digits, special characters, and letters can be correctly
+    used.
+  release: v1.34
+  file: test/e2e/common/node/secrets.go
 - testname: Secrets, pod environment field
   codename: '[sig-node] Secrets should be consumable from pods in env vars [NodeConformance]
     [Conformance]'

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -250,7 +250,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		Allows users to use envFrom to set prefixes with various printable ASCII characters excluding '=' as environment variable names.
 		This test verifies that different prefixes including digits, special characters, and letters can be correctly used.
 	*/
-	framework.It("should be consumable as environment variable names with various prefixes", func(ctx context.Context) {
+	framework.ConformanceIt("should be consumable as environment variable names with various prefixes", func(ctx context.Context) {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))

--- a/test/e2e/common/node/secrets.go
+++ b/test/e2e/common/node/secrets.go
@@ -246,7 +246,7 @@ var _ = SIGDescribe("Secrets", func() {
 		Allows users to use envFrom to set prefixes with various printable ASCII characters excluding '=' as environment variable names.
 		This test verifies that different prefixes including digits, special characters, and letters can be correctly used.
 	*/
-	framework.It("should be consumable as environment variable names when secret keys start with a digit", func(ctx context.Context) {
+	framework.ConformanceIt("should be consumable as environment variable names variable names with various prefixes", func(ctx context.Context) {
 		name := "secret-test-" + string(uuid.NewUUID())
 		secret := secretForTest(f.Namespace.Name, name)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The RelaxedEnvironmentVariableValidation feature gate has now reached GA stage. We are promoting its related tests to the Conformance test, This is follow up to https://github.com/kubernetes/kubernetes/pull/132054 .

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Tests are reliably green here: 
- https://testgrid.k8s.io/sig-release-master-blocking#gce-ubuntu-master-containerd&include-filter-by-regex=ConfigMap%20should%20be%20consumable%20as%20environment%20variable%20names%20with%20various%20prefixes
- https://testgrid.k8s.io/sig-release-master-blocking#gce-ubuntu-master-containerd&include-filter-by-regex=Secrets%20should%20be%20consumable%20as%20environment%20variable%20names%20when%20secret%20keys%20start%20with%20a%20digit

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4369-allow-special-characters-environment-variable
```
