### PR TITLE
DRA E2E: label tests which need a certain minimum kubelet

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -272,7 +272,9 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			testContainerEnv(ctx, f, pod, pod.Spec.Containers[1].Name, true, container1Env...)
 		})
 
-		ginkgo.It("blocks new pod after force-delete", func(ctx context.Context) {
+		// https://github.com/kubernetes/kubernetes/issues/131513 was fixed in master for 1.34 and not backported,
+		// so this test only passes for kubelet >= 1.34.
+		f.It("blocks new pod after force-delete", f.WithLabel("KubeletMinVersion:1.34"), func(ctx context.Context) {
 			// The problem with a force-deleted pod is that kubelet
 			// is not necessarily done yet with tearing down the
 			// pod at the time when the pod and its claim are
@@ -2096,7 +2098,8 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodDelete))
 	})
 
-	ginkgo.It("rolling update", func(ctx context.Context) {
+	// Seamless upgrade support was added in Kubernetes 1.33.
+	f.It("rolling update", f.WithLabel("KubeletMinVersion:1.33"), func(ctx context.Context) {
 		nodes := NewNodesNow(ctx, f, 1, 1)
 
 		oldDriver := NewDriverInstance(f)
@@ -2138,7 +2141,8 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodDelete))
 	})
 
-	ginkgo.It("failed update", func(ctx context.Context) {
+	// Seamless upgrade support was added in Kubernetes 1.33.
+	f.It("failed update", f.WithLabel("KubeletMinVersion:1.33"), func(ctx context.Context) {
 		nodes := NewNodesNow(ctx, f, 1, 1)
 
 		oldDriver := NewDriverInstance(f)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is used by n-1 and n-2 version skew jobs to exclude current tests which cannot run with a certain older kubelet release because the tested functionality wasn't present yet.


#### Which issue(s) this PR is related to:

Related-to: https://github.com/kubernetes/test-infra/pull/34981

#### Special notes for your reviewer:

/hold

That job update must be merged first before this PR can be tested with the canary version skew presubmits,

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 