### PR TITLE
Fix pod start duration observation

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1928,7 +1928,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Record the time it takes for the pod to become running
 	// since kubelet first saw the pod if firstSeenTime is set.
 	existingStatus, ok := kl.statusManager.GetPodStatus(pod.UID)
-	if !ok || existingStatus.Phase == v1.PodPending && apiPodStatus.Phase == v1.PodRunning &&
+	if (!ok || existingStatus.Phase == v1.PodPending) && apiPodStatus.Phase == v1.PodRunning &&
 		!firstSeenTime.IsZero() {
 		metrics.PodStartDuration.Observe(metrics.SinceInSeconds(firstSeenTime))
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1926,9 +1926,8 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	}
 
 	// Record the time it takes for the pod to become running
-	// since kubelet first saw the pod if firstSeenTime is set.
 	existingStatus, ok := kl.statusManager.GetPodStatus(pod.UID)
-	if (!ok || existingStatus.Phase == v1.PodPending) && apiPodStatus.Phase == v1.PodRunning &&
+	if ok && existingStatus.Phase == v1.PodPending && apiPodStatus.Phase == v1.PodRunning &&
 		!firstSeenTime.IsZero() {
 		metrics.PodStartDuration.Observe(metrics.SinceInSeconds(firstSeenTime))
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1449,7 +1449,7 @@ func TestPodStartDurationCountMetric(t *testing.T) {
 			podUID:                "uid2",
 			containerState:        kubecontainer.ContainerStateRunning,
 			populateStatusManager: false,
-			expectedHistogramBump: true,
+			expectedHistogramBump: false,
 		},
 		{
 			name:                  "statusManager is populated, existingStatus is pending, and apiPodStatus is pending",

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -226,13 +226,12 @@ var (
 		},
 		[]string{"operation_type"},
 	)
-	// PodStartDuration is a Histogram that tracks the duration (in seconds) it takes for a single pod to run since it's
-	// first time seen by kubelet.
+	// PodStartDuration is a Histogram that tracks the duration (in seconds) it takes for a single pod to go from pending to running.
 	PodStartDuration = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:      KubeletSubsystem,
 			Name:           PodStartDurationKey,
-			Help:           "Duration in seconds from kubelet seeing a pod for the first time to the pod starting to run",
+			Help:           "Duration in seconds for a single pod to go from pending to running.",
 			Buckets:        podStartupDurationBuckets,
 			StabilityLevel: metrics.ALPHA,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Try to fix issue #132268. It seems that the logic for observing pod startup duration is incorrect. When the pod status is not present in the status manager, kubelet records the duration (which doesn't seem right). Later, when the pod is actually running and it is in the status manager, it observes the pod startup again. I suppose it is the reason kubelet counts pod startups twice.

I added the log below for debugging, and it is the output before the fix.

```go
existingStatus, ok := kl.statusManager.GetPodStatus(pod.UID)
if !ok || existingStatus.Phase == v1.PodPending && apiPodStatus.Phase == v1.PodRunning &&
	!firstSeenTime.IsZero() {
        // Debug log
	klog.V(0).Infof("Observe pod start duration: pod.UID: %v, ok: %v, existingStatus.Phase: %v, apiPodStatus.Phase: %v, firstSeen: %v", pod.UID, ok, existingStatus.Phase, apiPodStatus.Phase, firstSeenTime)
	metrics.PodStartDuration.Observe(metrics.SinceInSeconds(firstSeenTime))
}
```

```bash
Observe pod start duration: pod.UID: 009e1a2b-4f75-4b4d-b30e-fd03ad52caad, ok: false, existingStatus.Phase: , apiPodStatus.Phase: Pending, firstSeen: 2025-06-13 03:57:50.571995801 +0000 UTC
Observe pod start duration: pod.UID: 009e1a2b-4f75-4b4d-b30e-fd03ad52caad, ok: true, existingStatus.Phase: Pending, apiPodStatus.Phase: Running, firstSeen: 2025-06-13 03:57:50.571995801 +0000 UTC
```

The pod in the first log is not running yet, but we observe its startup incorrectly. After the fix, the log happens only once - when the pod is actually running.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #132268

#### Special notes for your reviewer:

In addition to the above test, I verified that the `kubelet_pod_start_duration_seconds` metric increments its count by one with each pod creation after applying the fix.

My Kubelet is compiled using the master branch.  Also, my Containerd's version is as follows:

```bash
containerd github.com/containerd/containerd/v2 v2.1.1 cb1076646aa3740577fafbf3d914198b7fe8e3f7
```

Before the fix:

```bash
curl -k -H "Authorization: Bearer $METRICS_READER_TOKEN" https://localhost:10250/metrics | grep kubelet_pod_start_duration_seconds_count
kubelet_pod_start_duration_seconds_count 15

kubectl run nginx --image=nginx 

curl -k -H "Authorization: Bearer $METRICS_READER_TOKEN" https://localhost:10250/metrics | grep kubelet_pod_start_duration_seconds_count
kubelet_pod_start_duration_seconds_count 17
```

After the fix:

```bash
curl -k -H "Authorization: Bearer $METRICS_READER_TOKEN" https://localhost:10250/metrics | grep kubelet_pod_start_duration_seconds_count
kubelet_pod_start_duration_seconds_count 3

kubectl run nginx --image=nginx

curl -k -H "Authorization: Bearer $METRICS_READER_TOKEN" https://localhost:10250/metrics | grep kubelet_pod_start_duration_seconds_count
kubelet_pod_start_duration_seconds_count 4
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the issue with the `kubelet_pod_start_duration_seconds` metric being recorded twice per pod.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```