### PR TITLE
Automated cherry pick of #130782: Kubeadm issue #3152 ControlPlane node setup failing with "etcdserver: can only promote a learner member"

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -576,6 +576,15 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 			ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 			defer cancel()
 
+			isLearner, err := c.isLearner(learnerID)
+			if err != nil {
+				return false, err
+			}
+			if !isLearner {
+				klog.V(1).Infof("[etcd] Member %s was already promoted.", strconv.FormatUint(learnerID, 16))
+				return true, nil
+			}
+
 			_, err = cli.MemberPromote(ctx, learnerID)
 			if err == nil {
 				klog.V(1).Infof("[etcd] The learner was promoted as a voting member: %s", strconv.FormatUint(learnerID, 16))


### PR DESCRIPTION
Cherry pick of #130782 on release-1.30.

#130782: Kubeadm issue #3152 ControlPlane node setup failing with "etcdserver: can only promote a learner member"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fixed issue where etcd member promotion fails with an error saying the member was already promoted
```