### PR TITLE
Plug size of objects stored into APF estimator

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -743,6 +743,11 @@ const (
 	// pod's lifecycle and will not block pod termination.
 	SidecarContainers featuregate.Feature = "SidecarContainers"
 
+	// owner: @serathius
+	//
+	// Enables APF to use size of objects for estimating request cost.
+	SizeBasedListCostEstimate featuregate.Feature = "SizeBasedListCostEstimate"
+
 	// owner: @derekwaynecarr
 	//
 	// Enables kubelet support to size memory backed volumes
@@ -1737,6 +1742,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.33"), Default: true, LockToDefault: true, PreRelease: featuregate.GA}, // GA in 1.33 remove in 1.36
+	},
+
+	SizeBasedListCostEstimate: {
+		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Beta},
 	},
 
 	SizeMemoryBackedVolumes: {

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -176,6 +176,11 @@ const (
 	// if the generated name conflicts with an existing resource name, up to a maximum number of 7 retries.
 	RetryGenerateName featuregate.Feature = "RetryGenerateName"
 
+	// owner: @serathius
+	//
+	// Enables APF to use size of objects for estimating request cost.
+	SizeBasedListCostEstimate featuregate.Feature = "SizeBasedListCostEstimate"
+
 	// owner: @cici37
 	//
 	// StrictCostEnforcementForVAP is used to apply strict CEL cost validation for ValidatingAdmissionPolicy.
@@ -360,6 +365,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	SeparateCacheWatchRPC: {
 		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
+	},
+
+	SizeBasedListCostEstimate: {
+		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Beta},
 	},
 
 	StorageVersionAPI: {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
@@ -107,8 +107,8 @@ func (s *DryRunnableStorage) GuaranteedUpdate(
 	return s.Storage.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, tryUpdate, cachedExistingObject)
 }
 
-func (s *DryRunnableStorage) Count(ctx context.Context, key string) (int64, error) {
-	return s.Storage.Count(ctx, key)
+func (s *DryRunnableStorage) Stats(ctx context.Context) (storage.Stats, error) {
+	return s.Storage.Stats(ctx)
 }
 
 func (s *DryRunnableStorage) copyInto(in, out runtime.Object) error {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1664,15 +1664,15 @@ func (e *Store) startObservingCount(period time.Duration, objectCountTracker flo
 	klog.V(2).InfoS("Monitoring resource count at path", "resource", resourceName, "path", "<storage-prefix>/"+prefix)
 	stopCh := make(chan struct{})
 	go wait.JitterUntil(func() {
-		count, err := e.Storage.Count(ctx, prefix)
+		stats, err := e.Storage.Stats(ctx)
 		if err != nil {
 			klog.V(5).InfoS("Failed to update storage count metric", "err", err)
-			count = -1
+			stats.ObjectCount = -1
 		}
 
-		metrics.UpdateObjectCount(e.DefaultQualifiedResource, count)
+		metrics.UpdateObjectCount(e.DefaultQualifiedResource, stats.ObjectCount)
 		if objectCountTracker != nil {
-			objectCountTracker.Set(resourceName, count)
+			objectCountTracker.Set(resourceName, stats)
 		}
 	}, period, resourceCountPollPeriodJitter, true, stopCh)
 	return func() { close(stopCh) }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -279,10 +279,15 @@ func TestTransformationFailure(t *testing.T) {
 	// TODO(#109831): Enable use of this test and run it.
 }
 
-func TestCount(t *testing.T) {
-	ctx, cacher, terminate := testSetup(t)
-	t.Cleanup(terminate)
-	storagetesting.RunTestCount(ctx, t, cacher)
+func TestStats(t *testing.T) {
+	for _, sizeBasedListCostEstimate := range []bool{true, false} {
+		t.Run(fmt.Sprintf("SizeBasedListCostEstimate=%v", sizeBasedListCostEstimate), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SizeBasedListCostEstimate, sizeBasedListCostEstimate)
+			ctx, cacher, terminate := testSetup(t)
+			t.Cleanup(terminate)
+			storagetesting.RunTestStats(ctx, t, cacher, sizeBasedListCostEstimate)
+		})
+	}
 }
 
 func TestWatch(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -189,8 +189,8 @@ func (d *dummyStorage) GetList(ctx context.Context, resPrefix string, opts stora
 func (d *dummyStorage) GuaranteedUpdate(_ context.Context, _ string, _ runtime.Object, _ bool, _ *storage.Preconditions, _ storage.UpdateFunc, _ runtime.Object) error {
 	return fmt.Errorf("unimplemented")
 }
-func (d *dummyStorage) Count(_ context.Context, _ string) (int64, error) {
-	return 0, fmt.Errorf("unimplemented")
+func (d *dummyStorage) Stats(_ context.Context) (storage.Stats, error) {
+	return storage.Stats{}, fmt.Errorf("unimplemented")
 }
 func (d *dummyStorage) ReadinessCheck() error {
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 )
@@ -72,6 +73,10 @@ type storeIndexer interface {
 	ByIndex(indexName, indexedValue string) ([]interface{}, error)
 }
 
+type statser interface {
+	Stats() storage.Stats
+}
+
 type orderedLister interface {
 	ListPrefix(prefix, continueKey string) []interface{}
 	Count(prefix, continueKey string) (count int)
@@ -95,6 +100,7 @@ type storeElement struct {
 	Object runtime.Object
 	Labels labels.Set
 	Fields fields.Set
+	Size   int64
 }
 
 func storeElementKey(obj interface{}) (string, error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -311,9 +311,7 @@ func TestWatchChanSync(t *testing.T) {
 				origCtx,
 				testCase.watchKey,
 				0,
-				true,
-				false,
-				storage.Everything)
+				storage.ListOptions{Recursive: true, Predicate: storage.Everything})
 
 			err = w.sync()
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -243,8 +243,8 @@ type Interface interface {
 		ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool,
 		preconditions *Preconditions, tryUpdate UpdateFunc, cachedExistingObject runtime.Object) error
 
-	// Count returns number of different entries under the key (generally being path prefix).
-	Count(ctx context.Context, key string) (int64, error)
+	// Stats returns storage stats.
+	Stats(ctx context.Context) (Stats, error)
 
 	// ReadinessCheck checks if the storage is ready for accepting requests.
 	ReadinessCheck() error
@@ -318,6 +318,10 @@ type ListOptions struct {
 	// event containing a ResourceVersion after which the server
 	// continues streaming events.
 	SendInitialEvents *bool
+	// WithObjectSize requests storage to provide information about sizes of objects in storage.
+	// When enabled the objects will gain additional internal label.
+	// This option should not be exposed in API, should be only supported by etcd3.store and cacher should remove the label before returning it.
+	WithObjectSize bool
 }
 
 // DeleteOptions provides the options that may be provided for storage delete operations.
@@ -369,4 +373,12 @@ func ValidateListOptions(keyPrefix string, versioner Versioner, opts ListOptions
 		return withRev, "", fmt.Errorf("unknown ResourceVersionMatch value: %v", opts.ResourceVersionMatch)
 	}
 	return withRev, "", nil
+}
+
+// Stats provides statistics information about storage.
+type Stats struct {
+	// ObjectCount informs about number of objects stored in the storage.
+	ObjectCount int64
+	// ObjectSize informs about size of objects stored in the storage, based on size of serialized values.
+	ObjectSize int64
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/size.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/size.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// objectSizeLabel is an internal label that is used to pass information about object size between etcd3.store and cacher.
+// This label should not be exposed externally.
+const objectSizeLabel = "k8s.io/object-size"
+
+func SetObjectSizeLabel(accessor meta.MetadataAccessor, obj runtime.Object, size int64) error {
+	labels, err := accessor.Labels(obj)
+	if err != nil {
+		return err
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[objectSizeLabel] = strconv.FormatInt(size, 10)
+	return accessor.SetLabels(obj, labels)
+}
+
+func ReadAndRemoveObjectSizeLabel(accessor meta.MetadataAccessor, obj runtime.Object) (int64, error) {
+	labels, err := accessor.Labels(obj)
+	if err != nil {
+		return 0, err
+	}
+	if labels == nil {
+		return 0, fmt.Errorf("expected object to have %q label", objectSizeLabel)
+	}
+	sizeStr, ok := labels[objectSizeLabel]
+	if !ok {
+		return 0, fmt.Errorf("expected object to have %q label", objectSizeLabel)
+	}
+	delete(labels, objectSizeLabel)
+	if len(labels) == 0 {
+		labels = nil
+	}
+	err = accessor.SetLabels(obj, labels)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(sizeStr, 10, 64)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/size_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/size_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/testresource"
+)
+
+func TestObjectSizeWithoutLabels(t *testing.T) {
+	obj := &testresource.TestResource{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5"}}
+	accessor := meta.NewAccessor()
+	err := SetObjectSizeLabel(accessor, obj, 42)
+	require.NoError(t, err)
+	assert.Equal(t, &testresource.TestResource{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5", Labels: map[string]string{objectSizeLabel: "42"}}}, obj)
+	size, err := ReadAndRemoveObjectSizeLabel(accessor, obj)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), size)
+	assert.Equal(t, &testresource.TestResource{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5"}}, obj)
+}
+
+func TestObjectSize(t *testing.T) {
+	obj := &testresource.TestResource{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5", Labels: map[string]string{"env": "prod"}}}
+	accessor := meta.NewAccessor()
+	err := SetObjectSizeLabel(accessor, obj, 42)
+	require.NoError(t, err)
+	assert.Equal(t, &testresource.TestResource{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5", Labels: map[string]string{objectSizeLabel: "42", "env": "prod"}}}, obj)
+	size, err := ReadAndRemoveObjectSizeLabel(accessor, obj)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), size)
+	assert.Equal(t, &testresource.TestResource{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5", Labels: map[string]string{"env": "prod"}}}, obj)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
@@ -55,7 +56,7 @@ var (
 type StorageObjectCountTracker interface {
 	// Set is invoked to update the current number of total
 	// objects for the given resource
-	Set(string, int64)
+	Set(string, storage.Stats)
 
 	// Get returns the total number of objects for the given resource.
 	// The following errors are returned:
@@ -63,7 +64,7 @@ type StorageObjectCountTracker interface {
 	//    failures ObjectCountStaleErr is returned.
 	//  - if the given resource is not being tracked then
 	//    ObjectCountNotFoundErr is returned.
-	Get(string) (int64, error)
+	Get(string) (storage.Stats, error)
 
 	// RunUntil starts all the necessary maintenance.
 	RunUntil(stopCh <-chan struct{})
@@ -75,14 +76,14 @@ type StorageObjectCountTracker interface {
 func NewStorageObjectCountTracker() StorageObjectCountTracker {
 	return &objectCountTracker{
 		clock:  &clock.RealClock{},
-		counts: map[string]*timestampedCount{},
+		counts: map[string]*timestampedStats{},
 	}
 }
 
-// timestampedCount stores the count of a given resource with a last updated
+// timestampedStats stores the count of a given resource with a last updated
 // timestamp so we can prune it after it goes stale for certain threshold.
-type timestampedCount struct {
-	count         int64
+type timestampedStats struct {
+	storage.Stats
 	lastUpdatedAt time.Time
 }
 
@@ -92,11 +93,11 @@ type objectCountTracker struct {
 	clock clock.PassiveClock
 
 	lock   sync.RWMutex
-	counts map[string]*timestampedCount
+	counts map[string]*timestampedStats
 }
 
-func (t *objectCountTracker) Set(groupResource string, count int64) {
-	if count <= -1 {
+func (t *objectCountTracker) Set(groupResource string, stats storage.Stats) {
+	if stats.ObjectCount <= -1 {
 		// a value of -1 indicates that the 'Count' call failed to contact
 		// the storage layer, in most cases this error can be transient.
 		// we will continue to work with the count that is in the cache
@@ -114,18 +115,18 @@ func (t *objectCountTracker) Set(groupResource string, count int64) {
 	defer t.lock.Unlock()
 
 	if item, ok := t.counts[groupResource]; ok {
-		item.count = count
+		item.Stats = stats
 		item.lastUpdatedAt = now
 		return
 	}
 
-	t.counts[groupResource] = &timestampedCount{
-		count:         count,
+	t.counts[groupResource] = &timestampedStats{
+		Stats:         stats,
 		lastUpdatedAt: now,
 	}
 }
 
-func (t *objectCountTracker) Get(groupResource string) (int64, error) {
+func (t *objectCountTracker) Get(groupResource string) (storage.Stats, error) {
 	staleThreshold := t.clock.Now().Add(-staleTolerationThreshold)
 
 	t.lock.RLock()
@@ -133,11 +134,11 @@ func (t *objectCountTracker) Get(groupResource string) (int64, error) {
 
 	if item, ok := t.counts[groupResource]; ok {
 		if item.lastUpdatedAt.Before(staleThreshold) {
-			return item.count, ObjectCountStaleErr
+			return item.Stats, ObjectCountStaleErr
 		}
-		return item.count, nil
+		return item.Stats, nil
 	}
-	return 0, ObjectCountNotFoundErr
+	return storage.Stats{}, ObjectCountNotFoundErr
 }
 
 // RunUntil runs all the necessary maintenance.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apiserver/pkg/storage"
 	testclock "k8s.io/utils/clock/testing"
 )
 
@@ -69,21 +70,21 @@ func TestStorageObjectCountTracker(t *testing.T) {
 			fakeClock := &testclock.FakePassiveClock{}
 			tracker := &objectCountTracker{
 				clock:  fakeClock,
-				counts: map[string]*timestampedCount{},
+				counts: map[string]*timestampedStats{},
 			}
 
 			key := "foo.bar.resource"
 			now := time.Now()
 			fakeClock.SetTime(now.Add(-test.lastUpdated))
-			tracker.Set(key, test.count)
+			tracker.Set(key, storage.Stats{ObjectCount: test.count})
 
 			fakeClock.SetTime(now)
-			countGot, err := tracker.Get(key)
+			stats, err := tracker.Get(key)
 			if test.errExpected != err {
 				t.Errorf("Expected error: %v, but got: %v", test.errExpected, err)
 			}
-			if test.countExpected != countGot {
-				t.Errorf("Expected count: %d, but got: %d", test.countExpected, countGot)
+			if test.countExpected != stats.ObjectCount {
+				t.Errorf("Expected count: %d, but got: %d", test.countExpected, stats.ObjectCount)
 			}
 			if test.count <= -1 && len(tracker.counts) > 0 {
 				t.Errorf("Expected the cache to be empty, but got: %d", len(tracker.counts))
@@ -96,23 +97,23 @@ func TestStorageObjectCountTrackerWithPrune(t *testing.T) {
 	fakeClock := &testclock.FakePassiveClock{}
 	tracker := &objectCountTracker{
 		clock:  fakeClock,
-		counts: map[string]*timestampedCount{},
+		counts: map[string]*timestampedStats{},
 	}
 
 	now := time.Now()
 	fakeClock.SetTime(now.Add(-61 * time.Minute))
-	tracker.Set("k1", 61)
+	tracker.Set("k1", storage.Stats{ObjectCount: 61})
 	fakeClock.SetTime(now.Add(-60 * time.Minute))
-	tracker.Set("k2", 60)
+	tracker.Set("k2", storage.Stats{ObjectCount: 60})
 	// we are going to prune keys that are stale for >= 1h
 	// so the above keys are expected to be pruned and the
 	// key below should not be pruned.
 	mostRecent := now.Add(-59 * time.Minute)
 	fakeClock.SetTime(mostRecent)
-	tracker.Set("k3", 59)
-	expected := map[string]*timestampedCount{
+	tracker.Set("k3", storage.Stats{ObjectCount: 59})
+	expected := map[string]*timestampedStats{
 		"k3": {
-			count:         59,
+			Stats:         storage.Stats{ObjectCount: 59},
 			lastUpdatedAt: mostRecent,
 		},
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -23,6 +23,7 @@ import (
 
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"k8s.io/klog/v2"
@@ -56,9 +57,9 @@ func (we *WorkEstimate) MaxSeats() int {
 	return int(we.FinalSeats)
 }
 
-// objectCountGetterFunc represents a function that gets the total
+// statsGetterFunc represents a function that gets the total
 // number of objects for a given resource.
-type objectCountGetterFunc func(string) (int64, error)
+type statsGetterFunc func(string) (storage.Stats, error)
 
 // watchCountGetterFunc represents a function that gets the total
 // number of watchers potentially interested in a given request.
@@ -71,7 +72,7 @@ type maxSeatsFunc func(priorityLevelName string) uint64
 // NewWorkEstimator estimates the work that will be done by a given request,
 // if no WorkEstimatorFunc matches the given request then the default
 // work estimate of 1 seat is allocated to the request.
-func NewWorkEstimator(objectCountFn objectCountGetterFunc, watchCountFn watchCountGetterFunc, config *WorkEstimatorConfig, maxSeatsFn maxSeatsFunc) WorkEstimatorFunc {
+func NewWorkEstimator(objectCountFn statsGetterFunc, watchCountFn watchCountGetterFunc, config *WorkEstimatorConfig, maxSeatsFn maxSeatsFunc) WorkEstimatorFunc {
 	estimator := &workEstimator{
 		minimumSeats:          config.MinimumSeats,
 		maximumSeatsLimit:     config.MaximumSeatsLimit,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -24,6 +24,7 @@ import (
 
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
@@ -547,8 +548,8 @@ func TestWorkEstimator(t *testing.T) {
 			if len(counts) == 0 {
 				counts = map[string]int64{}
 			}
-			countsFn := func(key string) (int64, error) {
-				return counts[key], test.countErr
+			countsFn := func(key string) (storage.Stats, error) {
+				return storage.Stats{ObjectCount: counts[key]}, test.countErr
 			}
 			watchCountsFn := func(_ *apirequest.RequestInfo) int {
 				return test.watchCount

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1421,6 +1421,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.33"
+- name: SizeBasedListCostEstimate
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: SizeMemoryBackedVolumes
   versionedSpecs:
   - default: false


### PR DESCRIPTION
/kind feature

```release-note
Added SizeBasedListCostEstimate feature gate that allows apiserver to use sizes of objects to estimate cost of LIST requests
```

Ref https://github.com/kubernetes/kubernetes/issues/132233
Alternative to https://github.com/kubernetes/kubernetes/pull/132355

To get size of objects stored we need to change the periodic Count request to etcd to fetch also object content. As for large clusters fetching all data every 1 minute would be to costly, I propose to calculate it using watch cache. We can use the existing List and Watch requests used to fill cache, to get the current size and keep it up to date.

The only challenge here is passing the object size information from Storage to Cache. We need size of each object individually in LIST and Watch and the current interfaces don't have a place to store it. The solution should work for both builtin and Custom Resources. 

In this PR I have implemented storing object size within dedicated a object label `k8s.io/object-size`, based on idea of [K8s well-known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/). In the current implementation the label is kept internal, getting it requires passing a new option to `ListOptions` that is not exposed publicly, set only by watch cache and cleaned up before returned. However, there is no validation preventing user from setting it on object, which will cause the label to be stored, but not returned. 

I don't have strong opinions about those decisions and I'm looking for feedback on whether:
* We should use label or annotation
* Label should be public 
* We should prevent user from setting it.
* We should any other mechanism to pass object size information

Alternatives

* Estimate average object size based on last X objects observed in store - Loose accuracy, could diverge over time. However lists size is already an estimate.
* Have Storage calculate and cache 