### PR TITLE
Add `last_config_info` metric for authn, authz and encryption config

### DIFF
--- a/pkg/kubeapiserver/authorizer/reload.go
+++ b/pkg/kubeapiserver/authorizer/reload.go
@@ -192,7 +192,7 @@ type kubeapiserverWebhookMetrics struct {
 // Blocks until ctx is complete.
 func (r *reloadableAuthorizerResolver) runReload(ctx context.Context) {
 	metrics.RegisterMetrics()
-	metrics.RecordAuthorizationConfigAutomaticReloadSuccess(r.apiServerID)
+	metrics.RecordAuthorizationConfigLastConfigInfo(r.apiServerID, string(r.lastReadData))
 
 	filesystem.WatchUntil(
 		ctx,
@@ -250,5 +250,5 @@ func (r *reloadableAuthorizerResolver) checkFile(ctx context.Context) {
 		ruleResolver: ruleResolver,
 	})
 	klog.InfoS("reloaded authz config")
-	metrics.RecordAuthorizationConfigAutomaticReloadSuccess(r.apiServerID)
+	metrics.RecordAuthorizationConfigAutomaticReloadSuccess(r.apiServerID, string(data))
 }

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -727,6 +727,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(
 
 	if len(o.AuthenticationConfigFile) > 0 {
 		authenticationconfigmetrics.RegisterMetrics()
+		authenticationconfigmetrics.RecordAuthenticationConfigLastConfigInfo(apiServerID, authenticatorConfig.AuthenticationConfigData)
 		trackedAuthenticationConfigData := authenticatorConfig.AuthenticationConfigData
 		var mu sync.Mutex
 
@@ -789,7 +790,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(
 
 				trackedAuthenticationConfigData = authConfigData
 				klog.InfoS("reloaded authentication config")
-				authenticationconfigmetrics.RecordAuthenticationConfigAutomaticReloadSuccess(apiServerID)
+				authenticationconfigmetrics.RecordAuthenticationConfigAutomaticReloadSuccess(apiServerID, authConfigData)
 			},
 			func(err error) { klog.ErrorS(err, "watching authentication config file") },
 		)

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -118,7 +118,7 @@ func (o *BuiltInAuthorizationOptions) Validate() []error {
 		}
 
 		// load/validate kube-apiserver authz config with no opinion about required modes
-		_, err := authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, authorizationcel.NewDefaultCompiler(), nil)
+		_, _, err := authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, authorizationcel.NewDefaultCompiler(), nil)
 		if err != nil {
 			return append(allErrors, err)
 		}
@@ -219,6 +219,7 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 
 	var authorizationConfiguration *authzconfig.AuthorizationConfiguration
 	var err error
+	var authorizationConfigData string
 
 	// if --authorization-config is set, check if
 	// 	- the feature flag is set
@@ -236,7 +237,7 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 			return nil, fmt.Errorf("--%s can not be specified when --%s or --authorization-webhook-* flags are defined", authorizationConfigFlag, authorizationModeFlag)
 		}
 		// load/validate kube-apiserver authz config with no opinion about required modes
-		authorizationConfiguration, err = authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, authorizationcel.NewDefaultCompiler(), nil)
+		authorizationConfiguration, authorizationConfigData, err = authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, authorizationcel.NewDefaultCompiler(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -252,8 +253,9 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 		VersionedInformerFactory: versionedInformerFactory,
 		WebhookRetryBackoff:      o.WebhookRetryBackoff,
 
-		ReloadFile:                 o.AuthorizationConfigurationFile,
-		AuthorizationConfiguration: authorizationConfiguration,
+		ReloadFile:                            o.AuthorizationConfigurationFile,
+		AuthorizationConfiguration:            authorizationConfiguration,
+		InitialAuthorizationConfigurationData: authorizationConfigData,
 	}, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authenticationconfig/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authenticationconfig/metrics/metrics_test.go
@@ -27,6 +27,18 @@ import (
 const (
 	testAPIServerID     = "testAPIServerID"
 	testAPIServerIDHash = "sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37"
+	testConfigData      = `
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://test-issuer
+    audiences: [ "aud" ]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: ""
+`
 )
 
 func TestRecordAuthenticationConfigAutomaticReloadFailure(t *testing.T) {
@@ -53,15 +65,19 @@ func TestRecordAuthenticationConfigAutomaticReloadSuccess(t *testing.T) {
 	# HELP apiserver_authentication_config_controller_automatic_reloads_total [BETA] Total number of automatic reloads of authentication configuration split by status and apiserver identity.
     # TYPE apiserver_authentication_config_controller_automatic_reloads_total counter
     apiserver_authentication_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 1
+	# HELP apiserver_authentication_config_controller_last_config_info [ALPHA] Information about the last applied authentication configuration with hash as label, split by apiserver identity.
+	# TYPE apiserver_authentication_config_controller_last_config_info gauge
+	apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",hash="sha256:ccbcaf98557c273dfc779222d54a5bd3e785ea5330048f3bf4278cf3997b669c"} 1
 	`
 	metrics := []string{
 		namespace + "_" + subsystem + "_automatic_reloads_total",
+		namespace + "_" + subsystem + "_last_config_info",
 	}
 
-	authenticationConfigAutomaticReloadsTotal.Reset()
+	ResetMetricsForTest()
 	RegisterMetrics()
 
-	RecordAuthenticationConfigAutomaticReloadSuccess(testAPIServerID)
+	RecordAuthenticationConfigAutomaticReloadSuccess(testAPIServerID, testConfigData)
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
 		t.Fatal(err)
 	}
@@ -105,5 +121,36 @@ func TestAuthenticationConfigAutomaticReloadLastTimestampSeconds(t *testing.T) {
 		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedValue), metrics...); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestRecordAuthenticationConfigAutomaticReloadSuccess_StaleMetricCleanup(t *testing.T) {
+	ResetMetricsForTest()
+	RegisterMetrics()
+
+	// Record initial success with first config
+	firstConfig := "config1"
+	RecordAuthenticationConfigAutomaticReloadSuccess(testAPIServerID, firstConfig)
+
+	// Record success with different config - should clean up old metric
+	secondConfig := "config2"
+	RecordAuthenticationConfigAutomaticReloadSuccess(testAPIServerID, secondConfig)
+
+	// Verify only the latest hash is present
+	expectedValue := `
+	# HELP apiserver_authentication_config_controller_automatic_reloads_total [BETA] Total number of automatic reloads of authentication configuration split by status and apiserver identity.
+    # TYPE apiserver_authentication_config_controller_automatic_reloads_total counter
+    apiserver_authentication_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 2
+	# HELP apiserver_authentication_config_controller_last_config_info [ALPHA] Information about the last applied authentication configuration with hash as label, split by apiserver identity.
+	# TYPE apiserver_authentication_config_controller_last_config_info gauge
+	apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",hash="sha256:f309dd9c31fe24b3e594d2f9420419c48dfe954523245d5f35dc37739970d881"} 1
+	`
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reloads_total",
+		namespace + "_" + subsystem + "_last_config_info",
+	}
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics.go
@@ -22,6 +22,7 @@ import (
 	"hash"
 	"sync"
 
+	"k8s.io/apiserver/pkg/util/configmetrics"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -53,10 +54,20 @@ var (
 		},
 		[]string{"status", "apiserver_id_hash"},
 	)
+
+	authorizationConfigLastConfigInfo = metrics.NewDesc(
+		metrics.BuildFQName(namespace, subsystem, "last_config_info"),
+		"Information about the last applied authorization configuration with hash as label, split by apiserver identity.",
+		[]string{"apiserver_id_hash", "hash"},
+		nil,
+		metrics.ALPHA,
+		"",
+	)
 )
 
 var registerMetrics sync.Once
 var hashPool *sync.Pool
+var configHashProvider = configmetrics.NewAtomicHashProvider()
 
 func RegisterMetrics() {
 	registerMetrics.Do(func() {
@@ -67,6 +78,7 @@ func RegisterMetrics() {
 		}
 		legacyregistry.MustRegister(authorizationConfigAutomaticReloadsTotal)
 		legacyregistry.MustRegister(authorizationConfigAutomaticReloadLastTimestampSeconds)
+		legacyregistry.CustomMustRegister(configmetrics.NewConfigInfoCustomCollector(authorizationConfigLastConfigInfo, configHashProvider))
 	})
 }
 
@@ -81,10 +93,16 @@ func RecordAuthorizationConfigAutomaticReloadFailure(apiServerID string) {
 	authorizationConfigAutomaticReloadLastTimestampSeconds.WithLabelValues("failure", apiServerIDHash).SetToCurrentTime()
 }
 
-func RecordAuthorizationConfigAutomaticReloadSuccess(apiServerID string) {
+func RecordAuthorizationConfigAutomaticReloadSuccess(apiServerID, authzConfigData string) {
 	apiServerIDHash := getHash(apiServerID)
 	authorizationConfigAutomaticReloadsTotal.WithLabelValues("success", apiServerIDHash).Inc()
 	authorizationConfigAutomaticReloadLastTimestampSeconds.WithLabelValues("success", apiServerIDHash).SetToCurrentTime()
+
+	RecordAuthorizationConfigLastConfigInfo(apiServerID, authzConfigData)
+}
+
+func RecordAuthorizationConfigLastConfigInfo(apiServerID, authzConfigData string) {
+	configHashProvider.SetHashes(getHash(apiServerID), getHash(authzConfigData))
 }
 
 func getHash(data string) string {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics_test.go
@@ -27,6 +27,27 @@ import (
 const (
 	testAPIServerID     = "testAPIServerID"
 	testAPIServerIDHash = "sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37"
+	testConfigData      = `
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthorizationConfiguration
+authorizers:
+- type: Webhook
+  name: error.example.com
+  webhook:
+    timeout: 5s
+    failurePolicy: Deny
+    subjectAccessReviewVersion: v1
+    matchConditionSubjectAccessReviewVersion: v1
+    authorizedTTL: 1ms
+    unauthorizedTTL: 1ms
+    connectionInfo:
+      type: KubeConfigFile
+      kubeConfigFile: /path/to/kubeconfig
+    matchConditions:
+    - expression: has(request.resourceAttributes)
+    - expression: 'request.resourceAttributes.namespace == "fail"'
+    - expression: 'request.resourceAttributes.name == "error"'
+`
 )
 
 func TestRecordAuthorizationConfigAutomaticReloadFailure(t *testing.T) {
@@ -53,15 +74,19 @@ func TestRecordAuthorizationConfigAutomaticReloadSuccess(t *testing.T) {
 	# HELP apiserver_authorization_config_controller_automatic_reloads_total [BETA] Total number of automatic reloads of authorization configuration split by status and apiserver identity.
     # TYPE apiserver_authorization_config_controller_automatic_reloads_total counter
     apiserver_authorization_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 1
+	# HELP apiserver_authorization_config_controller_last_config_info [ALPHA] Information about the last applied authorization configuration with hash as label, split by apiserver identity.
+	# TYPE apiserver_authorization_config_controller_last_config_info gauge
+	apiserver_authorization_config_controller_last_config_info{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",hash="sha256:2a66c95e5593fc74e6c3dbbb708741361f0690ed45d17e4d4ac0b9c282b6538f"} 1
 	`
 	metrics := []string{
 		namespace + "_" + subsystem + "_automatic_reloads_total",
+		namespace + "_" + subsystem + "_last_config_info",
 	}
 
-	authorizationConfigAutomaticReloadsTotal.Reset()
+	ResetMetricsForTest()
 	RegisterMetrics()
 
-	RecordAuthorizationConfigAutomaticReloadSuccess(testAPIServerID)
+	RecordAuthorizationConfigAutomaticReloadSuccess(testAPIServerID, testConfigData)
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
 		t.Fatal(err)
 	}
@@ -105,5 +130,36 @@ func TestAuthorizationConfigAutomaticReloadLastTimestampSeconds(t *testing.T) {
 		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedValue), metrics...); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestRecordAuthorizationConfigAutomaticReloadSuccess_StaleMetricCleanup(t *testing.T) {
+	ResetMetricsForTest()
+	RegisterMetrics()
+
+	// Record initial success with first config
+	firstConfig := "config1"
+	RecordAuthorizationConfigAutomaticReloadSuccess(testAPIServerID, firstConfig)
+
+	// Record success with different config - should clean up old metric
+	secondConfig := "config2"
+	RecordAuthorizationConfigAutomaticReloadSuccess(testAPIServerID, secondConfig)
+
+	// Verify only the latest hash is present
+	expectedValue := `
+	# HELP apiserver_authorization_config_controller_automatic_reloads_total [BETA] Total number of automatic reloads of authorization configuration split by status and apiserver identity.
+    # TYPE apiserver_authorization_config_controller_automatic_reloads_total counter
+    apiserver_authorization_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 2
+	# HELP apiserver_authorization_config_controller_last_config_info [ALPHA] Information about the last applied authorization configuration with hash as label, split by apiserver identity.
+	# TYPE apiserver_authorization_config_controller_last_config_info gauge
+	apiserver_authorization_config_controller_last_config_info{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",hash="sha256:f309dd9c31fe24b3e594d2f9420419c48dfe954523245d5f35dc37739970d881"} 1
+	`
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reloads_total",
+		namespace + "_" + subsystem + "_last_config_info",
+	}
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -907,9 +907,8 @@ func (u unionTransformers) TransformToStorage(ctx context.Context, data []byte, 
 
 // computeEncryptionConfigHash returns the expected hash for an encryption config file that has been loaded as bytes.
 // We use a hash instead of the raw file contents when tracking changes to avoid holding any encryption keys in memory outside of their associated transformers.
-// This hash must be used in-memory and not externalized to the process because it has no cross-release stability guarantees.
 func computeEncryptionConfigHash(data []byte) string {
-	return fmt.Sprintf("k8s:enc:unstable:1:%x", sha256.Sum256(data))
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 }
 
 var _ storagevalue.ResourceTransformers = &DynamicTransformers{}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -1843,7 +1843,7 @@ func errString(err error) string {
 
 func TestComputeEncryptionConfigHash(t *testing.T) {
 	// hash the empty string to be sure that sha256 is being used
-	expect := "k8s:enc:unstable:1:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	expect := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	sum := computeEncryptionConfigHash([]byte(""))
 	if expect != sum {
 		t.Errorf("expected hash %q but got %q", expect, sum)
@@ -2220,7 +2220,7 @@ func TestGetEncryptionConfigHash(t *testing.T) {
 		{
 			name:     "valid file",
 			filepath: "testdata/valid-configs/secret-box-first.yaml",
-			wantHash: "k8s:enc:unstable:1:c638c0327dbc3276dd1fcf3e67895d19ebca16b91ae0d19af24ef0759b8e0f66",
+			wantHash: "sha256:c638c0327dbc3276dd1fcf3e67895d19ebca16b91ae0d19af24ef0759b8e0f66",
 			wantErr:  ``,
 		},
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
@@ -174,7 +174,7 @@ func (d *DynamicEncryptionConfigContent) processWorkItem(serverCtx context.Conte
 		}
 
 		if updatedEffectiveConfig && err == nil {
-			metrics.RecordEncryptionConfigAutomaticReloadSuccess(d.apiServerID)
+			metrics.RecordEncryptionConfigAutomaticReloadSuccess(d.apiServerID, encryptionConfiguration.EncryptionFileContentHash)
 		}
 
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
@@ -47,6 +47,9 @@ func TestController(t *testing.T) {
 # HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
 # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
 apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",status="success"} 1
+# HELP apiserver_encryption_config_controller_last_config_info [ALPHA] Information about the last applied encryption configuration with hash as label, split by apiserver identity.
+# TYPE apiserver_encryption_config_controller_last_config_info gauge
+apiserver_encryption_config_controller_last_config_info{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",hash="sha256:6f6af143a5aec5c4056d759f2bdf8b6ffe218a2bf3846c4fd42b6baef037c5ef"} 1
 `
 	const expectedFailureMetricValue = `
 # HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
@@ -67,7 +70,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 	}{
 		{
 			name:                    "when invalid config is provided previous config shouldn't be changed",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           1,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -82,7 +85,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 		},
 		{
 			name:                    "when new valid config is provided it should be updated",
-			wantECFileHash:          "some new config hash",
+			wantECFileHash:          "sha256:6f6af143a5aec5c4056d759f2bdf8b6ffe218a2bf3846c4fd42b6baef037c5ef", // some new config hash
 			wantLoadCalls:           1,
 			wantHashCalls:           1,
 			wantMetrics:             expectedSuccessMetricValue,
@@ -98,13 +101,13 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 							err:        nil,
 						},
 					},
-					EncryptionFileContentHash: "some new config hash",
+					EncryptionFileContentHash: "sha256:6f6af143a5aec5c4056d759f2bdf8b6ffe218a2bf3846c4fd42b6baef037c5ef", // some new config hash
 				}, nil
 			},
 		},
 		{
 			name:                    "when same valid config is provided previous config shouldn't be changed",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           1,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -122,13 +125,13 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 						},
 					},
 					// hash of initial "testdata/ec_config.yaml" config file before reloading
-					EncryptionFileContentHash: "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+					EncryptionFileContentHash: "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 				}, nil
 			},
 		},
 		{
 			name:                    "when transformer's health check fails previous config shouldn't be changed",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           1,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -152,7 +155,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 		},
 		{
 			name:                    "when multiple health checks are present previous config shouldn't be changed",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           1,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -179,7 +182,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 		},
 		{
 			name:                    "when invalid health check URL is provided previous config shouldn't be changed",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           1,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -202,7 +205,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 		},
 		{
 			name:                    "when config is not updated transformers are closed correctly",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           1,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -220,13 +223,13 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 						},
 					},
 					// hash of initial "testdata/ec_config.yaml" config file before reloading
-					EncryptionFileContentHash: "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+					EncryptionFileContentHash: "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 				}, nil
 			},
 		},
 		{
 			name:                    "when config hash is not updated transformers are closed correctly",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           0,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -234,7 +237,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 			wantAddRateLimitedCount: 0,
 			mockGetEncryptionConfigHash: func(ctx context.Context, filepath string) (string, error) {
 				// hash of initial "testdata/ec_config.yaml" config file before reloading
-				return "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3", nil
+				return "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3", nil
 			},
 			mockLoadEncryptionConfig: func(ctx context.Context, filepath string, reload bool, apiServerID string) (*encryptionconfig.EncryptionConfiguration, error) {
 				return nil, fmt.Errorf("should not be called")
@@ -242,7 +245,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 		},
 		{
 			name:                    "when config hash errors transformers are closed correctly",
-			wantECFileHash:          "k8s:enc:unstable:1:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
+			wantECFileHash:          "sha256:6bc9f4aa2e5587afbb96074e1809550cbc4de3cc3a35717dac8ff2800a147fd3",
 			wantLoadCalls:           0,
 			wantHashCalls:           1,
 			wantTransformerClosed:   true,
@@ -332,7 +335,7 @@ apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash
 			}
 
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.wantMetrics),
-				"apiserver_encryption_config_controller_automatic_reloads_total",
+				"apiserver_encryption_config_controller_automatic_reloads_total", "apiserver_encryption_config_controller_automatic_reload_last_config_info",
 			); err != nil {
 				t.Errorf("failed to validate metrics: %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
 	encryptionconfigcontroller "k8s.io/apiserver/pkg/server/options/encryptionconfig/controller"
+	encryptionconfigmetrics "k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -298,6 +299,7 @@ func (s *EtcdOptions) maybeApplyResourceTransformers(c *server.Config) (err erro
 	if err != nil {
 		return err
 	}
+	encryptionconfigmetrics.RecordEncryptionConfigLastConfigInfo(c.APIServerID, encryptionConfiguration.EncryptionFileContentHash)
 
 	if s.EncryptionProviderConfigAutomaticReload {
 		// with reload=true we will always have 1 health check

--- a/staging/src/k8s.io/apiserver/pkg/util/configmetrics/info_collector.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/configmetrics/info_collector.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmetrics
+
+import (
+	"slices"
+	"sync/atomic"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/utils/ptr"
+)
+
+// HashProvider is an interface for getting the current config hash values
+type HashProvider interface {
+	GetCurrentHashes() []string
+	SetHashes(hashes ...string)
+}
+
+// AtomicHashProvider implements HashProvider using a single atomic pointer to a slice
+type AtomicHashProvider struct {
+	hashes *atomic.Pointer[[]string]
+}
+
+// NewAtomicHashProvider creates a new atomic hash provider
+func NewAtomicHashProvider() *AtomicHashProvider {
+	p := &AtomicHashProvider{
+		hashes: &atomic.Pointer[[]string]{},
+	}
+	// Initialize with empty slice
+	p.hashes.Store(ptr.To([]string{}))
+	return p
+}
+
+func (h *AtomicHashProvider) GetCurrentHashes() []string {
+	hashesPtr := h.hashes.Load()
+	if hashesPtr == nil {
+		// should never happen, but just in case
+		return []string{}
+	}
+	// Return a copy to prevent external modification
+	hashes := *hashesPtr
+	return slices.Clone(hashes)
+}
+
+func (h *AtomicHashProvider) SetHashes(hashes ...string) {
+	hashCopy := slices.Clone(hashes)
+	h.hashes.Store(&hashCopy)
+}
+
+// NewConfigInfoCustomCollector creates a custom collector for config hash info metrics.
+// This eliminates the need for state management and locks by collecting metrics on demand.
+func NewConfigInfoCustomCollector(desc *metrics.Desc, hashProvider HashProvider) metrics.StableCollector {
+	return &configInfoCustomCollector{
+		desc:         desc,
+		hashProvider: hashProvider,
+	}
+}
+
+type configInfoCustomCollector struct {
+	metrics.BaseStableCollector
+	desc         *metrics.Desc
+	hashProvider HashProvider
+}
+
+var _ metrics.StableCollector = &configInfoCustomCollector{}
+
+func (c *configInfoCustomCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- c.desc
+}
+
+func (c *configInfoCustomCollector) CollectWithStability(ch chan<- metrics.Metric) {
+	hashes := c.hashProvider.GetCurrentHashes()
+	if len(hashes) == 0 {
+		return
+	}
+
+	ch <- metrics.NewLazyConstMetric(c.desc, metrics.GaugeValue, 1, hashes...)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/configmetrics/info_collector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/configmetrics/info_collector_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmetrics
+
+import (
+	"testing"
+)
+
+// assertHashesEqual is a test helper that compares expected and actual hash slices
+func assertHashesEqual(t *testing.T, expected, actual []string) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Errorf("expected %d hashes, got %d", len(expected), len(actual))
+		return
+	}
+	for i, hash := range actual {
+		if hash != expected[i] {
+			t.Errorf("expected hash %q at index %d, got %q", expected[i], i, hash)
+		}
+	}
+}
+
+func TestAtomicHashProvider(t *testing.T) {
+	provider := NewAtomicHashProvider()
+
+	apiServerIDHash := "sha256:abc123"
+	configHash := "sha256:hash1"
+
+	// Test initial state
+	hashes := provider.GetCurrentHashes()
+	assertHashesEqual(t, []string{}, hashes)
+
+	// Test setting hashes
+	provider.SetHashes(apiServerIDHash, configHash)
+	hashes = provider.GetCurrentHashes()
+	assertHashesEqual(t, []string{apiServerIDHash, configHash}, hashes)
+
+	// Test updating hashes
+	newConfigHash := "sha256:hash2"
+	provider.SetHashes(apiServerIDHash, newConfigHash)
+	hashes = provider.GetCurrentHashes()
+	assertHashesEqual(t, []string{apiServerIDHash, newConfigHash}, hashes)
+
+	// Test empty hashes
+	provider.SetHashes()
+	hashes = provider.GetCurrentHashes()
+	assertHashesEqual(t, []string{}, hashes)
+}

--- a/test/integration/apiserver/oidc/oidc_test.go
+++ b/test/integration/apiserver/oidc/oidc_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -1146,6 +1147,7 @@ jwt:
 			wantMetricStrings: []string{
 				`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} FP`,
 				`apiserver_authentication_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} 1`,
+				`apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="replace_with_new_config_hash"} 1`,
 			},
 		},
 		{
@@ -1229,6 +1231,7 @@ jwt:
 			wantMetricStrings: []string{
 				`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} FP`,
 				`apiserver_authentication_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} 1`,
+				`apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="replace_with_new_config_hash"} 1`,
 			},
 		},
 		{
@@ -1277,6 +1280,7 @@ jwt:
 			wantMetricStrings: []string{
 				`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} FP`,
 				`apiserver_authentication_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} 1`,
+				`apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="replace_with_new_config_hash"} 1`,
 			},
 		},
 		{
@@ -1332,6 +1336,7 @@ jwt:
 			wantMetricStrings: []string{
 				`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} FP`,
 				`apiserver_authentication_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} 1`,
+				`apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="replace_with_new_config_hash"} 1`,
 			},
 		},
 		{
@@ -1390,6 +1395,7 @@ jwt:
 			wantMetricStrings: []string{
 				`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="failure"} FP`,
 				`apiserver_authentication_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="failure"} 1`,
+				`apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="replace_with_old_config_hash"} 1`,
 			},
 		},
 		{
@@ -1433,6 +1439,7 @@ kind: AuthenticationConfiguration
 			wantMetricStrings: []string{
 				`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} FP`,
 				`apiserver_authentication_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} 1`,
+				`apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="replace_with_new_config_hash"} 1`,
 			},
 		},
 		{
@@ -1490,6 +1497,7 @@ jwt:
 			wantMetricStrings: []string{
 				`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="failure"} FP`,
 				`apiserver_authentication_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="failure"} 1`,
+				`apiserver_authentication_config_controller_last_config_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="replace_with_old_config_hash"} 1`,
 			},
 		},
 	}
@@ -1529,8 +1537,9 @@ jwt:
 				_ = tempFile.Close()
 			}()
 
+			newAuthConfig := tt.newAuthConfigFn(t, oidcServer.URL(), string(caCert))
 			// Write the new content to the temporary file
-			_, err = tempFile.Write([]byte(tt.newAuthConfigFn(t, oidcServer.URL(), string(caCert))))
+			_, err = tempFile.Write([]byte(newAuthConfig))
 			require.NoError(t, err)
 
 			// Atomically replace the original file with the temporary file
@@ -1564,6 +1573,16 @@ jwt:
 
 			_, err = client.CoreV1().Pods(defaultNamespace).List(ctx, metav1.ListOptions{})
 			tt.newAssertErrFn(t, err)
+
+			oldAuthConfigHash := getHash(tt.authConfigFn(t, oidcServer.URL(), string(caCert)))
+			newAuthConfigHash := getHash(newAuthConfig)
+			for i := range tt.wantMetricStrings {
+				if strings.Contains(tt.wantMetricStrings[i], "replace_with_new_config_hash") {
+					tt.wantMetricStrings[i] = strings.ReplaceAll(tt.wantMetricStrings[i], "replace_with_new_config_hash", newAuthConfigHash)
+				} else if strings.Contains(tt.wantMetricStrings[i], "replace_with_old_config_hash") {
+					tt.wantMetricStrings[i] = strings.ReplaceAll(tt.wantMetricStrings[i], "replace_with_old_config_hash", oldAuthConfigHash)
+				}
+			}
 
 			adminClient := kubernetes.NewForConfigOrDie(apiServer.ClientConfig)
 			body, err := adminClient.RESTClient().Get().AbsPath("/metrics").DoRaw(ctx)
@@ -2113,4 +2132,11 @@ func testContext(t *testing.T) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+func getHash(data string) string {
+	if len(data) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(data)))
 }

--- a/test/integration/auth/authz_config_test.go
+++ b/test/integration/auth/authz_config_test.go
@@ -735,8 +735,8 @@ authorizers:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if initialMetrics.reloadSuccess == nil {
-		t.Fatal("expected success timestamp, got none")
+	if initialMetrics.reloadSuccess != nil {
+		t.Fatal("expected no success timestamp, got one")
 	}
 	if initialMetrics.reloadFailure != nil {
 		t.Fatal("expected no failure timestamp, got one")
@@ -754,18 +754,12 @@ authorizers:
 		if err != nil {
 			t.Fatal(err)
 		}
-		if reload1Metrics.reloadSuccess == nil {
-			t.Fatal("expected success timestamp, got none")
-		}
-		if !reload1Metrics.reloadSuccess.Equal(*initialMetrics.reloadSuccess) {
-			t.Fatalf("success timestamp changed from initial success %s to %s unexpectedly", initialMetrics.reloadSuccess.String(), reload1Metrics.reloadSuccess.String())
+		if reload1Metrics.reloadSuccess != nil {
+			t.Fatal("expected no success timestamp, got one")
 		}
 		if reload1Metrics.reloadFailure == nil {
 			t.Log("expected failure timestamp, got nil, retrying")
 			return false, nil
-		}
-		if !reload1Metrics.reloadFailure.After(*reload1Metrics.reloadSuccess) {
-			t.Fatalf("expected failure timestamp to be more recent than success timestamp, got %s <= %s", reload1Metrics.reloadFailure.String(), reload1Metrics.reloadSuccess.String())
 		}
 		return true, nil
 	})
@@ -829,14 +823,18 @@ authorizers:
 			t.Fatalf("failure timestamp changed from reload1Metrics.reloadFailure %s to %s unexpectedly", reload1Metrics.reloadFailure.String(), reload2Metrics.reloadFailure.String())
 		}
 		if reload2Metrics.reloadSuccess == nil {
-			t.Fatal("expected success timestamp, got none")
-		}
-		if reload2Metrics.reloadSuccess.Equal(*initialMetrics.reloadSuccess) {
-			t.Log("success timestamp hasn't updated from initial success, retrying")
+			t.Log("expected success timestamp, got nil, retrying")
 			return false, nil
 		}
 		if !reload2Metrics.reloadSuccess.After(*reload2Metrics.reloadFailure) {
 			t.Fatalf("expected success timestamp to be more recent than failure, got %s <= %s", reload2Metrics.reloadSuccess.String(), reload2Metrics.reloadFailure.String())
+		}
+		if len(reload2Metrics.configHash) == 0 {
+			t.Fatal("expected config hash, got none")
+		}
+		if reload2Metrics.configHash == initialMetrics.configHash {
+			t.Logf("config hash %s is the same as initial %s, retrying", reload2Metrics.configHash, initialMetrics.configHash)
+			return false, nil
 		}
 		return true, nil
 	})
@@ -883,6 +881,12 @@ authorizers:
 		if !reload3Metrics.reloadSuccess.Equal(*reload2Metrics.reloadSuccess) {
 			t.Fatalf("success timestamp changed from %s to %s unexpectedly", reload2Metrics.reloadSuccess.String(), reload3Metrics.reloadSuccess.String())
 		}
+		if len(reload3Metrics.configHash) == 0 {
+			t.Fatal("expected config hash, got none")
+		}
+		if reload3Metrics.configHash != reload2Metrics.configHash {
+			t.Fatalf("expected config hash to be the same as reload2Metrics %s, got %s", reload2Metrics.configHash, reload3Metrics.configHash)
+		}
 		if reload3Metrics.reloadFailure == nil {
 			t.Log("expected failure timestamp, got nil, retrying")
 			return false, nil
@@ -925,6 +929,7 @@ authorizers:
 type metrics struct {
 	reloadSuccess *time.Time
 	reloadFailure *time.Time
+	configHash    string
 	decisions     map[authorizerKey]map[string]int
 	exclusions    int
 	evalErrors    int
@@ -945,12 +950,14 @@ var webhookMatchConditionEvalErrorMetric = regexp.MustCompile(`apiserver_authori
 var whTotalMetric = regexp.MustCompile(`apiserver_authorization_webhook_evaluations_total{name="(.*?)",result="(.*?)"} (\d+)`)
 var webhookDurationMetric = regexp.MustCompile(`apiserver_authorization_webhook_duration_seconds_count{name="(.*?)",result="(.*?)"} (\d+)`)
 var webhookFailOpenMetric = regexp.MustCompile(`apiserver_authorization_webhook_evaluations_fail_open_total{name="(.*?)",result="(.*?)"} (\d+)`)
+var configInfoMetric = regexp.MustCompile(`apiserver_authorization_config_controller_last_config_info\{apiserver_id_hash="sha256:[^"]*",hash="([^"]*)"\} (\d+)`)
 
 func getMetrics(t *testing.T, client *clientset.Clientset) (*metrics, error) {
 	data, err := client.RESTClient().Get().AbsPath("/metrics").DoRaw(context.TODO())
 
 	//  apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:4b86cfa719a83dd63a4dc6a9831edb2b59240d0f59cf215b2d51aacb3f5c395e",status="success"} 1.7002567356895502e+09
 	//  apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:4b86cfa719a83dd63a4dc6a9831edb2b59240d0f59cf215b2d51aacb3f5c395e",status="failure"} 1.7002567356895502e+09
+	//  apiserver_authorization_config_controller_automatic_reload_last_config_info{apiserver_id_hash="sha256:4b86cfa719a83dd63a4dc6a9831edb2b59240d0f59cf215b2d51aacb3f5c395e",hash="sha256:f309dd9c31fe24b3e594d2f9420419c48dfe954523245d5f35dc37739970d881"} 1
 	//  apiserver_authorization_decisions_total{decision="allowed",name="allow.example.com",type="Webhook"} 2
 	//  apiserver_authorization_decisions_total{decision="allowed",name="allowreloaded.example.com",type="Webhook"} 1
 	//  apiserver_authorization_decisions_total{decision="denied",name="deny.example.com",type="Webhook"} 1
@@ -1051,6 +1058,12 @@ func getMetrics(t *testing.T, client *clientset.Clientset) (*metrics, error) {
 				m.reloadFailure = &tm
 				t.Log("failure", m.reloadFailure.String())
 			}
+		}
+		if matches := configInfoMetric.FindStringSubmatch(line); matches != nil {
+			t.Logf("line: %s\n", line)
+			t.Log(matches)
+			m.configHash = matches[1]
+			t.Logf("config hash: %s", m.configHash)
 		}
 	}
 	return &m, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
Add `apiserver_authentication_config_controller_last_config_info`, `apiserver_authorization_config_controller_last_config_info` and `apiserver_encryption_config_controller_last_config_info` metrics to track the last config hash that's loaded successfully for auth config files (authn, authz and encryption)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)

If there is no associated issue, then write "N/A".
-->

KEP: https://github.com/kubernetes/enhancements/issues/3331

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver now reports the last configuration hash as a label in

- `apiserver_authentication_config_controller_last_config_info` metric after successfully loading the authentication configuration file.
- `apiserver_authorization_config_controller_last_config_info` metric after successfully loading the authorization configuration file.
- `apiserver_encryption_config_controller_last_config_info` metric after successfully loading the encryption configuration file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3331-structured-authentication-configuration
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3221-structured-authorization-configuration
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements
```

/sig auth
/triage accepted
/milestone v1.34
/priority important-soon
/assign enj
