### PR TITLE
fix(typo): incorrectly spelled 'registration'

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
@@ -70,7 +70,7 @@ service DevicePlugin {
 	// of the steps to make the Device available in the container
 	rpc Allocate(AllocateRequest) returns (AllocateResponse) {}
 
-	// PreStartContainer is called, if indicated by Device Plugin during registeration phase,
+	// PreStartContainer is called, if indicated by Device Plugin during registration phase,
 	// before each container start. Device plugin can run device specific operations
 	// such as resetting the device before making devices available to the container
 	rpc PreStartContainer(PreStartContainerRequest) returns (PreStartContainerResponse) {}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Typo: Incorrectly spelled the word registration as 'registeration'.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
