### PR TITLE
conformance servicecidr read status endpoint

### DIFF
--- a/test/e2e/network/service_cidrs.go
+++ b/test/e2e/network/service_cidrs.go
@@ -162,9 +162,22 @@ var _ = common.SIGDescribe("ServiceCIDR and IPAddress API", func() {
 
 	framework.ConformanceIt("should support ServiceCIDR API operations", func(ctx context.Context) {
 		ginkgo.By("getting")
-		_, err := f.ClientSet.NetworkingV1().ServiceCIDRs().Get(ctx, defaultservicecidr.DefaultServiceCIDRName, metav1.GetOptions{})
+		defaultServiceCIDR, err := f.ClientSet.NetworkingV1().ServiceCIDRs().Get(ctx, defaultservicecidr.DefaultServiceCIDRName, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("unexpected error getting default ServiceCIDR: %v", err)
+		}
+
+		ginkgo.By("getting /status")
+		resource := networkingv1.SchemeGroupVersion.WithResource("servicecidrs")
+		gottenStatus, err := f.DynamicClient.Resource(resource).Get(ctx, defaultservicecidr.DefaultServiceCIDRName, metav1.GetOptions{}, "status")
+		if err != nil {
+			framework.Failf("unexpected error getting default ServiceCIDR status: %v", err)
+		}
+		if gottenStatus.GetObjectKind().GroupVersionKind() != networkingv1.SchemeGroupVersion.WithKind("ServiceCIDR") {
+			framework.Failf("unexpected GVK got %v expected: %v", gottenStatus.GetObjectKind().GroupVersionKind(), networkingv1.SchemeGroupVersion.WithKind("ServiceCIDR"))
+		}
+		if gottenStatus.GetUID() != defaultServiceCIDR.GetUID() {
+			framework.Failf("unexpected UID got %v expected: %v", gottenStatus.GetUID(), defaultServiceCIDR.GetUID())
 		}
 
 		ginkgo.By("patching")


### PR DESCRIPTION

/kind cleanup
/kind feature

```release-note
NONE
```

Add coverage for the missing conformance endpoint as reported in https://github.com/kubernetes/kubernetes/issues/131282#issuecomment-2971836261