### PR TITLE
Automated cherry pick of #132308: Kubeadm: fix failing e2e tests  

### DIFF
--- a/test/e2e_kubeadm/nodes_test.go
+++ b/test/e2e_kubeadm/nodes_test.go
@@ -52,7 +52,7 @@ var _ = Describe("nodes", func() {
 			List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "error reading nodes")
 
-		var nodeLocalCRISocketEnabled bool
+		nodeLocalCRISocketEnabled := true
 		cc := getClusterConfiguration(f.ClientSet)
 		if _, ok := cc["featureGates"]; ok {
 			fgCC := cc["featureGates"].(map[interface{}]interface{})


### PR DESCRIPTION
Cherry pick of #132308 on release-1.33.

#132308: Kubeadm: fix failing e2e tests  

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Fixes https://github.com/kubernetes/kubernetes/issues/132304 

```release-note
NONE
```