### PR TITLE
DRA E2E: label tests which need a certain minimum kubelet, II

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -2185,7 +2185,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodDelete))
 	})
 
-	f.It("sequential update with pods replacing each other", framework.WithSlow(), func(ctx context.Context) {
+	f.It("sequential update with pods replacing each other", f.WithLabel("KubeletMinVersion:1.33"), framework.WithSlow(), func(ctx context.Context) {
 		nodes := NewNodesNow(ctx, f, 1, 1)
 
 		// Same driver name, same socket path.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Commit 71b2f32d70fdd7143849476c00ff84b82555f42b missed one test which needs the "kubelet >= 1.33" label because that test didn't run in the canary presubmit. It's now failing in the ci-kind-dra-n-2 job.

https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-kind-dra-n-2

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/128965

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
