### PR TITLE
Adding the missing step in the Documentation for Building Kubernetes in Docker

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -2,6 +2,8 @@
 
 Building Kubernetes is easy if you take advantage of the containerized build environment. This document will help guide you through understanding this build process.
 
+If you're starting fresh, please take a look at the [Contributing Documentation](https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md) and learn how to set up [local development environment](https://github.com/kubernetes/community/tree/master/contributors/guide#setting-up-your-development-environment).
+
 ## Requirements
 
 1. Docker, using one of the following configurations:


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

This Pull Requests add some additional informations, on how to set up the local development environment.
Its pointing to the contribution guide, and also the the guide for learning to set up the local dev environment.

#### Which issue(s) this PR is related to:
Fixes #125511

#### Special notes for your reviewer:
None. I believe having the links to the documentations outside of the requirements list is a good (first) approach.

#### Does this PR introduce a user-facing change?

```release-note
Added additional links for the documentation 'Building Kubernetes'
```