### PR TITLE
fix: objectSelector for pod exec admission webhooks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -1055,7 +1055,9 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				if isSubresource {
 					doc = "connect " + method + " requests to " + subresource + " of " + kind
 				}
-				handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, deprecated, removedRelease, restfulConnectResource(connecter, reqScope, admit, path, isSubresource))
+				// Get the getter from the storage
+				getter, _ := storage.(rest.Getter)
+				handler := metrics.InstrumentRouteFunc(action.Verb, group, version, resource, subresource, requestScope, metrics.APIServerComponent, deprecated, removedRelease, restfulConnectResource(connecter, getter, reqScope, admit, path, isSubresource))
 				handler = utilwarning.AddWarningsHandler(handler, warnings)
 				route := ws.Method(method).Path(action.Path).
 					To(handler).
@@ -1343,8 +1345,8 @@ func restfulGetResourceWithOptions(r rest.GetterWithOptions, scope handlers.Requ
 	}
 }
 
-func restfulConnectResource(connecter rest.Connecter, scope handlers.RequestScope, admit admission.Interface, restPath string, isSubresource bool) restful.RouteFunction {
+func restfulConnectResource(connecter rest.Connecter, getter rest.Getter, scope handlers.RequestScope, admit admission.Interface, restPath string, isSubresource bool) restful.RouteFunction {
 	return func(req *restful.Request, res *restful.Response) {
-		handlers.ConnectResource(connecter, &scope, admit, restPath, isSubresource)(res.ResponseWriter, req.Request)
+		handlers.ConnectResource(connecter, getter, &scope, admit, restPath, isSubresource)(res.ResponseWriter, req.Request)
 	}
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
This PR fixes an issue where `objectSelector` in ValidatingWebhookConfiguration doesn't work properly for pod exec operations. Previously, when using `objectSelector` with pod exec webhooks, the webhook would stop being triggered entirely, regardless of whether the pod had matching labels or not.

#### Which issue(s) this PR is related to:
Fixes #[132287]

#### Special notes for your reviewer:
The root cause was that the admission webhook wasn't receiving the pod object during CONNECT operations, which meant it couldn't evaluate the `objectSelector` criteria. The fix ensures that:

1. The pod object is properly fetched during CONNECT operations
2. The pod object is passed to the admission webhook
3. The webhook can properly evaluate the `objectSelector` against the pod's labels

#### Does this PR introduce a user-facing change?

Fix objectSelector for pod exec admission webhooks to properly evaluate pod labels during exec operations


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A