### PR TITLE
Fix APIServerTracing test data race

### DIFF
--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -100,8 +100,8 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 	traceservice.RegisterTraceServiceServer(srv, fakeServer)
 
 	go func() {
-		if err := srv.Serve(listener); err != nil {
-			t.Error(err)
+		if serveErr := srv.Serve(listener); serveErr != nil {
+			t.Error(serveErr)
 			return
 		}
 	}()
@@ -354,8 +354,8 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 	traceservice.RegisterTraceServiceServer(srv, fakeServer)
 
 	go func() {
-		if err = srv.Serve(listener); err != nil {
-			t.Error(err)
+		if serveErr := srv.Serve(listener); serveErr != nil {
+			t.Error(serveErr)
 		}
 	}()
 	defer srv.Stop()


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Fixes a data race in an integration test for APIServerTracing. The spawned goroutine was sharing the `err` variable with the main goroutine, causing the data race.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/132050#issuecomment-2937098962

#### Special notes for your reviewer:

Verified:

```
~/go/src/k8s.io/kubernetes/test/integration/apiserver/tracing$ go test ./... -race
ok  	k8s.io/kubernetes/test/integration/apiserver/tracing	68.825s
```
