### PR TITLE
Added omitempty tag and opt tag to the API v1beta2 and v1beta1 AdminAccess type

### DIFF
--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1274,7 +1274,7 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess" protobuf:"bytes,5,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
 
 	// A copy of all tolerations specified in the request at the time
 	// when the device got allocated.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1266,7 +1266,7 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess" protobuf:"bytes,5,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
 
 	// A copy of all tolerations specified in the request at the time
 	// when the device got allocated.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This Pull Request adds the missing `omitempty` and `opt` tag to the AdminAccess API Type for API Version v1beta1 and v1beta2.

#### Which issue(s) this PR is related to:
Fixes #132274 

#### Special notes for your reviewer:
In the issue it was mentioned, that the tag `omitempty` is missing for the AdminAccess type. I revisited the types.go file for the v1beta2, and all the other Types, that have the `+optional` documentation, also provided the tag `opt`. So I choosed to introduce this one, too.

Here is also a snippet of the AdminAccess type in the ExactDeviceRequest struct:
```
	// +optional
	// +featureGate=DRAAdminAccess
	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
```

#### Does this PR introduce a user-facing change?

```release-note
Added omitempty and opt tag to the API v1beta2 AdminAccess type in the DeviceRequestAllocationResult struct.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
