### PR TITLE
KEP-5311 Relaxed validation for Services names

### DIFF
--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -27,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/networking"
+	"k8s.io/kubernetes/pkg/features"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 )
@@ -283,6 +285,9 @@ type IngressValidationOptions struct {
 
 	// AllowInvalidWildcardHostRule indicates whether invalid rule values are allowed in rules with wildcard hostnames
 	AllowInvalidWildcardHostRule bool
+
+	// AllowRelaxedServiceNameValidation indicates if the backend service name can be validated with apimachineryvalidation.NameIsDNSLabel
+	AllowRelaxedServiceNameValidation bool
 }
 
 // ValidateIngress validates Ingresses on create and update.
@@ -296,8 +301,9 @@ func validateIngress(ingress *networking.Ingress, opts IngressValidationOptions)
 func ValidateIngressCreate(ingress *networking.Ingress) field.ErrorList {
 	allErrs := field.ErrorList{}
 	opts := IngressValidationOptions{
-		AllowInvalidSecretName:       false,
-		AllowInvalidWildcardHostRule: false,
+		AllowInvalidSecretName:            false,
+		AllowInvalidWildcardHostRule:      false,
+		AllowRelaxedServiceNameValidation: allowRelaxedServiceNameValidation(nil),
 	}
 	allErrs = append(allErrs, validateIngress(ingress, opts)...)
 	annotationVal, annotationIsSet := ingress.Annotations[annotationIngressClass]
@@ -312,8 +318,9 @@ func ValidateIngressCreate(ingress *networking.Ingress) field.ErrorList {
 func ValidateIngressUpdate(ingress, oldIngress *networking.Ingress) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&ingress.ObjectMeta, &oldIngress.ObjectMeta, field.NewPath("metadata"))
 	opts := IngressValidationOptions{
-		AllowInvalidSecretName:       allowInvalidSecretName(oldIngress),
-		AllowInvalidWildcardHostRule: allowInvalidWildcardHostRule(oldIngress),
+		AllowInvalidSecretName:            allowInvalidSecretName(oldIngress),
+		AllowInvalidWildcardHostRule:      allowInvalidWildcardHostRule(oldIngress),
+		AllowRelaxedServiceNameValidation: allowRelaxedServiceNameValidation(oldIngress),
 	}
 
 	allErrs = append(allErrs, validateIngress(ingress, opts)...)
@@ -513,7 +520,13 @@ func validateIngressBackend(backend *networking.IngressBackend, fldPath *field.P
 		if len(backend.Service.Name) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("service", "name"), ""))
 		} else {
-			for _, msg := range apivalidation.ValidateServiceName(backend.Service.Name, false) {
+
+			validationFunc := apivalidation.ValidateServiceName
+			if opts.AllowRelaxedServiceNameValidation {
+				validationFunc = apimachineryvalidation.NameIsDNSLabel
+			}
+
+			for _, msg := range validationFunc(backend.Service.Name, false) {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("service", "name"), backend.Service.Name, msg))
 			}
 		}
@@ -678,6 +691,37 @@ func allowInvalidWildcardHostRule(oldIngress *networking.Ingress) bool {
 		for _, rule := range oldIngress.Spec.Rules {
 			if strings.Contains(rule.Host, "*") && len(validateIngressRuleValue(&rule.IngressRuleValue, nil, IngressValidationOptions{})) > 0 {
 				// backwards compatibility with existing invalid data
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func allowRelaxedServiceNameValidation(oldIngress *networking.Ingress) bool {
+	// Early exit if the feature gate is enabled, as it allows relaxed validation
+	if utilfeature.DefaultFeatureGate.Enabled(features.RelaxedServiceNameValidation) {
+		return true
+	}
+	// Early exit if no old Ingress is provided
+	if oldIngress == nil {
+		return false
+	}
+	// If feature gate is disabled, check if any service names in the old Ingresss
+	for _, rule := range oldIngress.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if path.Backend.Service == nil {
+				continue
+			}
+			serviceName := path.Backend.Service.Name
+			// If a name doesn't validate with apimachineryvalidation.NameIsDNS1035Label, but does validate with apimachineryvalidation.NameIsDNSLabel,
+			// then we allow it to be used as a Service name in an Ingress.
+			dnsLabelValidationErrors := apimachineryvalidation.NameIsDNSLabel(serviceName, false)
+			dns1035LabelValidationErrors := apimachineryvalidation.NameIsDNS1035Label(serviceName, false)
+			if len(dnsLabelValidationErrors) == 0 && len(dns1035LabelValidationErrors) > 0 {
 				return true
 			}
 		}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -636,6 +636,12 @@ const (
 	// Allow almost all printable ASCII characters in environment variables
 	RelaxedEnvironmentVariableValidation featuregate.Feature = "RelaxedEnvironmentVariableValidation"
 
+	// owner: @adrianmoisey
+	// kep: https://kep.k8s.io/5311
+	//
+	// Relaxed DNS search string validation.
+	RelaxedServiceNameValidation featuregate.Feature = "RelaxedServiceNameValidation"
+
 	// owner: @zhangweikop
 	//
 	// Enable kubelet tls server to update certificate if the specified certificate files are changed.
@@ -1639,6 +1645,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
+	},
+
+	RelaxedServiceNameValidation: {
+		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	ReloadKubeletServerCertificateFile: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1185,6 +1185,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.34"
+- name: RelaxedServiceNameValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.34"
 - name: ReloadKubeletServerCertificateFile
   versionedSpecs:
   - default: true

--- a/test/integration/service/service_test.go
+++ b/test/integration/service/service_test.go
@@ -1215,3 +1215,95 @@ func Test_ServiceWatchUntil(t *testing.T) {
 	}
 	t.Logf("Service %s deleted", testSvcName)
 }
+
+func Test_ServiceValidation_FeatureGateEnableDisable(t *testing.T) {
+
+	////////////////////////////////////////////////////////////////////////////
+	// Start kube-apiserver with RelaxedServiceNameValidation feature-gate
+	// enabled.
+	////////////////////////////////////////////////////////////////////////////
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RelaxedServiceNameValidation, true)
+
+	sharedEtcd := framework.SharedEtcd()
+	server1 := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), sharedEtcd)
+
+	client1, err := clientset.NewForConfig(server1.ClientConfig)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	// Create services with names that start with a digit and a letter.
+	//
+	// Assert that the services are created successfully with the feature gate enabled
+	////////////////////////////////////////////////////////////////////////////
+
+	ns := framework.CreateNamespaceOrDie(client1, "test-service-traffic-distribution", t)
+	makeService := func(serviceName string) *corev1.Service {
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: ns.GetName(),
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 443}},
+			},
+		}
+	}
+
+	// Expected to pass, as the feature gate is enabled
+	_, err = client1.CoreV1().Services(ns.Name).Create(t.Context(), makeService("test-service-1"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test service: %v", err)
+	}
+
+	// Expected to pass, as the feature gate is enabled
+	_, err = client1.CoreV1().Services(ns.Name).Create(t.Context(), makeService("9-test-service-1"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Successfully created service, but shouldn't have: %v", err)
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	// Restart the kube-apiserver with RelaxedServiceNameValidation feature-gate
+	// disabled.
+	//
+	// Assert that the services are created using previous validation only
+	////////////////////////////////////////////////////////////////////////////
+
+	server1.TearDownFn()
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.34"))
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RelaxedServiceNameValidation, false)
+
+	server2 := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), sharedEtcd)
+	client2, err := clientset.NewForConfig(server2.ClientConfig)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	// Expected to pass, as the feature gate is disabled
+	_, err = client2.CoreV1().Services(ns.Name).Create(t.Context(), makeService("test-service-2"), metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test service: %v", err)
+	}
+
+	// Expected to fail, as the feature gate is disabled and this name requires relaxed validation
+	_, err = client2.CoreV1().Services(ns.Name).Create(t.Context(), makeService("9-test-service-2"), metav1.CreateOptions{})
+	if err == nil {
+		t.Fatalf("Successfully created service, but shouldn't have: %v", err)
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	// Assert that the services created prior to the feature gate being disabled
+	// can still be patched successfully even though it requires relaxed validation.
+	////////////////////////////////////////////////////////////////////////////
+
+	// Expected to pass as the service was created before the feature gate was disabled
+	patch := []byte(`{"spec":{"selector":{"foo":"baz"}}}`)
+	_, err = client2.CoreV1().Services(ns.Name).Patch(t.Context(), "9-test-service-1", types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		t.Fatalf("Failed to patch selector of service '9-test-service-1': %v", err)
+	}
+
+	server2.TearDownFn()
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Implements the new relaxed variation for Service names

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When `RelaxedServiceNameValidation` feature gate is enabled, the 
names of new Services names are validation with `NameIsDNSLabel()`,
relaxing the  pre-existing validation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
- [KEP]: https://github.com/kubernetes/enhancements/issues/5311
```

/kind feature
/sig network
/assign @thockin @aojea @danwinship 
/priority important-soon
/triage accepted
