### PR TITLE
e2e: node: fix podresources API feature label

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -352,8 +352,10 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	PodReadyToStartContainersCondition = framework.WithFeature(framework.ValidFeatures.Add("PodReadyToStartContainersCondition"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	PodResources = framework.WithFeature(framework.ValidFeatures.Add("PodResources"))
+	// Owner: sig-node
+	// Marks tests which exercise or consume the kubelet-local Pod Resources API
+	// see: KEPs 606, 2043; see: pkg/kubelet/apis/podresources/
+	PodResourcesAPI = framework.WithFeature(framework.ValidFeatures.Add("PodResourcesAPI"))
 
 	// Owner: sig-node
 	// Verify ProcMount feature.

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -947,7 +947,7 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 }
 
 // Serial because the test updates kubelet configuration.
-var _ = SIGDescribe("POD Resources", framework.WithSerial(), feature.PodResources, func() {
+var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodResourcesAPI, func() {
 	f := framework.NewDefaultFramework("podresources-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We want to fix and enhance lanes which exercise the podresources API tests. The first step is to clarify the label and made it specific to podresources API, minimzing the clash and the ambiguity with the "PodLevelResources"  feature.


#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Emerged during the review of KEP-3965
See: https://github.com/kubernetes/enhancements/pull/5346#discussion_r2150961273 and following

#### Does this PR introduce a user-facing change?
```release-note
NONE
```