### PR TITLE
[KEP-2400] Add a container_swap_limit_bytes metric

### DIFF
--- a/pkg/kubelet/metrics/collectors/resource_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics_test.go
@@ -43,6 +43,7 @@ func TestCollectResourceMetrics(t *testing.T) {
 		"container_cpu_usage_seconds_total",
 		"container_memory_working_set_bytes",
 		"container_swap_usage_bytes",
+		"container_swap_limit_bytes",
 		"container_start_time_seconds",
 		"pod_cpu_usage_seconds_total",
 		"pod_memory_working_set_bytes",
@@ -151,8 +152,9 @@ func TestCollectResourceMetrics(t *testing.T) {
 									WorkingSetBytes: ptr.To[uint64](1000),
 								},
 								Swap: &statsapi.SwapStats{
-									Time:           testTime,
-									SwapUsageBytes: ptr.To[uint64](1000),
+									Time:               testTime,
+									SwapUsageBytes:     ptr.To[uint64](1000),
+									SwapAvailableBytes: ptr.To[uint64](9000),
 								},
 							},
 							{
@@ -214,6 +216,9 @@ func TestCollectResourceMetrics(t *testing.T) {
 				container_start_time_seconds{container="container_a",namespace="namespace_a",pod="pod_a"} 1.6243962483020916e+09
 				container_start_time_seconds{container="container_a",namespace="namespace_b",pod="pod_b"} 1.6243956783020916e+09
 				container_start_time_seconds{container="container_b",namespace="namespace_a",pod="pod_a"} 1.6243961583020916e+09
+				# HELP container_swap_limit_bytes [ALPHA] Current amount of the container swap limit in bytes. Reported only on non-windows systems
+				# TYPE container_swap_limit_bytes gauge
+				container_swap_limit_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 10000 1624396278302
         		# HELP container_swap_usage_bytes [ALPHA] Current amount of the container swap usage in bytes. Reported only on non-windows systems
         		# TYPE container_swap_usage_bytes gauge
         		container_swap_usage_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 1000 1624396278302

--- a/test/e2e_node/resource_metrics_test.go
+++ b/test/e2e_node/resource_metrics_test.go
@@ -106,6 +106,11 @@ var _ = SIGDescribe("ResourceMetricsAPI", feature.ResourceMetrics, func() {
 					fmt.Sprintf("%s::%s::%s", f.Namespace.Name, pod1, "busybox-container"): zeroSampe,
 				}),
 
+				"container_swap_limit_bytes": gstruct.MatchElements(containerID, gstruct.IgnoreExtras, gstruct.Elements{
+					fmt.Sprintf("%s::%s::%s", f.Namespace.Name, pod0, "busybox-container"): boundedSample(0*e2evolume.Kb, 80*e2evolume.Mb),
+					fmt.Sprintf("%s::%s::%s", f.Namespace.Name, pod1, "busybox-container"): boundedSample(0*e2evolume.Kb, 80*e2evolume.Mb),
+				}),
+
 				"pod_cpu_usage_seconds_total": gstruct.MatchElements(podID, gstruct.IgnoreExtras, gstruct.Elements{
 					fmt.Sprintf("%s::%s", f.Namespace.Name, pod0): boundedSample(0, 100),
 					fmt.Sprintf("%s::%s", f.Namespace.Name, pod1): boundedSample(0, 100),


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig node

#### What this PR does / why we need it:
Swap metrics were originally added as part of https://github.com/kubernetes/kubernetes/pull/118865.

This PR adds a `container_swap_limit_bytes` to report the calculated swap limit for each container and be available at the `/metrics/resource` endpoint.

After this is merged, we can consider adding this as part of `kubectl top pod/node --show-swap`, as a follow-up to https://github.com/kubernetes/kubernetes/pull/129458.

This is **NOT** a blocker for KEP-2400 GA, but rather a nice-to-have addition.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/132228

#### Does this PR introduce a user-facing change?
```release-note
Adds a `container_swap_limit_bytes` metric to expose the swap limit assigned to containers under the `LimitedSwap` swap behavior.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
