### PR TITLE
bugfix(hpa): introduce buildQuantity helper for consistent resource quantity

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -606,8 +606,9 @@ func (a *HorizontalController) computeStatusForResourceMetricGeneric(ctx context
 			return 0, nil, time.Time{}, "", condition, fmt.Errorf("failed to get %s usage: %v", resourceName, err)
 		}
 		metricNameProposal = fmt.Sprintf("%s resource", resourceName.String())
+		quantity := buildQuantity(resourceName, rawProposal)
 		status := autoscalingv2.MetricValueStatus{
-			AverageValue: resource.NewMilliQuantity(rawProposal, resource.DecimalSI),
+			AverageValue: &quantity,
 		}
 		return replicaCountProposal, &status, timestampProposal, metricNameProposal, autoscalingv2.HorizontalPodAutoscalerCondition{}, nil
 	}
@@ -627,11 +628,26 @@ func (a *HorizontalController) computeStatusForResourceMetricGeneric(ctx context
 	if sourceType == autoscalingv2.ContainerResourceMetricSourceType {
 		metricNameProposal = fmt.Sprintf("%s container resource utilization (percentage of request)", resourceName)
 	}
+	quantity := buildQuantity(resourceName, rawProposal)
 	status := autoscalingv2.MetricValueStatus{
 		AverageUtilization: &percentageProposal,
-		AverageValue:       resource.NewMilliQuantity(rawProposal, resource.DecimalSI),
+		AverageValue:       &quantity,
 	}
 	return replicaCountProposal, &status, timestampProposal, metricNameProposal, autoscalingv2.HorizontalPodAutoscalerCondition{}, nil
+}
+
+// buildQuantity creates a resource.Quantity for HPA metrics based on the resource type.
+//
+// For memory, rawProposal is expected in bytes and uses BinarySI formatting (Ki/Mi/Gi).
+// For CPU or other resources, rawProposal is expected in milli-units (e.g., 500 = 0.5 cores) and uses DecimalSI formatting (m).
+func buildQuantity(resourceName v1.ResourceName, rawProposal int64) resource.Quantity {
+	format := resource.DecimalSI
+	// to match what we return in the metrics server,
+	// see https://github.com/kubernetes-sigs/metrics-server/blob/55b4961bc1eceffd0a37809dc271e9ae38de9deb/pkg/storage/types.go#L63-L64
+	if resourceName == v1.ResourceMemory {
+		format = resource.BinarySI
+	}
+	return *resource.NewMilliQuantity(rawProposal, format)
 }
 
 // computeStatusForResourceMetric computes the desired number of replicas for the specified metric of type ResourceMetricSourceType.

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -5451,3 +5451,66 @@ func TestHPARescaleWithSuccessfulConflictRetry(t *testing.T) {
 
 	tc.runTest(t)
 }
+
+func TestBuildQuantity(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceName v1.ResourceName
+		rawProposal  int64
+		expected     resource.Quantity
+	}{
+		{
+			name:         "Memory - 1000 bytes → 1Ki",
+			resourceName: v1.ResourceMemory,
+			rawProposal:  1000,
+			expected:     *resource.NewQuantity(1, resource.BinarySI), // 1Ki
+		},
+		{
+			name:         "Memory - 1000000 bytes → 1000Ki",
+			resourceName: v1.ResourceMemory,
+			rawProposal:  1000000,
+			expected:     *resource.NewQuantity(1000, resource.BinarySI), // 1000Ki
+		},
+		{
+			name:         "CPU - 100 milli-cores",
+			resourceName: v1.ResourceCPU,
+			rawProposal:  100,
+			expected:     *resource.NewMilliQuantity(100, resource.DecimalSI),
+		},
+		{
+			name:         "CPU - 500 milli-cores",
+			resourceName: v1.ResourceCPU,
+			rawProposal:  500,
+			expected:     *resource.NewMilliQuantity(500, resource.DecimalSI),
+		},
+		{
+			name:         "CPU - 1 milli-core",
+			resourceName: v1.ResourceCPU,
+			rawProposal:  1,
+			expected:     *resource.NewMilliQuantity(1, resource.DecimalSI),
+		},
+		{
+			name:         "CustomResource - 200 milli-units",
+			resourceName: v1.ResourceName("custom-resource"),
+			rawProposal:  200,
+			expected:     *resource.NewMilliQuantity(200, resource.DecimalSI),
+		},
+		{
+			name:         "CustomResource - 300 milli-units",
+			resourceName: v1.ResourceName("custom-resource"),
+			rawProposal:  300,
+			expected:     *resource.NewMilliQuantity(300, resource.DecimalSI),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := buildQuantity(tt.resourceName, tt.rawProposal)
+			if !q.Equal(tt.expected) || (q.Format != tt.expected.Format) {
+				t.Errorf("expected quantity %v (Format: %v), got %v (Format: %v)",
+					tt.expected.String(), tt.expected.Format,
+					q.String(), q.Format)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces a new helper function, buildQuantity in the HPA controller.

Previously, quantities were created inline using NewMilliQuantity directly, which made it harder to:
- Ensure consistency between CPU and memory handling

Now, all resource quantity creation goes through buildQuantity:
- For memory: raw bytes are converted to KiB and use BinarySI
- For CPU or other resources: milli-units are used with DecimalSI

#### Which issue(s) this PR is related to: 

Fix: https://github.com/kubernetes/kubernetes/issues/130584
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
HPA status now displays memory metrics using Ki
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
