### PR TITLE
Removed the variable WaitIntervalString from iptables.go

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -177,9 +177,6 @@ var RandomFullyMinVersion = utilversion.MustParseGeneric("1.6.2")
 // WaitMinVersion a minimum iptables versions supporting the -w and -w<seconds> flags
 var WaitMinVersion = utilversion.MustParseGeneric("1.4.20")
 
-// WaitIntervalMinVersion a minimum iptables versions supporting the wait interval useconds
-var WaitIntervalMinVersion = utilversion.MustParseGeneric("1.6.1")
-
 // WaitSecondsMinVersion a minimum iptables versions supporting the wait seconds
 var WaitSecondsMinVersion = utilversion.MustParseGeneric("1.4.22")
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR removes
```
// WaitIntervalMinVersion a minimum iptables versions supporting the wait interval useconds
var WaitIntervalMinVersion = utilversion.MustParseGeneric("1.6.1")
```
from the iptables.go file.

#### Which issue(s) this PR is related to:

Fixes #132006 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Removed the deprecated flag '--wait-interval' for the ip6tables-legacy-restore binary.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
