### PR TITLE
Estimate average size of objects in etcd and plug it into request cost estimator

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1277,6 +1277,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 
+	genericfeatures.SizeBasedListCostEstimate: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	genericfeatures.StorageVersionAPI: {
 		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -176,6 +176,11 @@ const (
 	// if the generated name conflicts with an existing resource name, up to a maximum number of 7 retries.
 	RetryGenerateName featuregate.Feature = "RetryGenerateName"
 
+	// owner: @serathius
+	//
+	// Enables APF to use size of objects for estimating request cost.
+	SizeBasedListCostEstimate featuregate.Feature = "SizeBasedListCostEstimate"
+
 	// owner: @cici37
 	//
 	// StrictCostEnforcementForVAP is used to apply strict CEL cost validation for ValidatingAdmissionPolicy.
@@ -360,6 +365,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	SeparateCacheWatchRPC: {
 		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
+	},
+
+	SizeBasedListCostEstimate: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	StorageVersionAPI: {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
@@ -107,8 +107,8 @@ func (s *DryRunnableStorage) GuaranteedUpdate(
 	return s.Storage.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, tryUpdate, cachedExistingObject)
 }
 
-func (s *DryRunnableStorage) Count(ctx context.Context, key string) (int64, error) {
-	return s.Storage.Count(ctx, key)
+func (s *DryRunnableStorage) Stats(ctx context.Context) (storage.Stats, error) {
+	return s.Storage.Stats(ctx)
 }
 
 func (s *DryRunnableStorage) copyInto(in, out runtime.Object) error {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1667,15 +1667,15 @@ func (e *Store) startObservingCount(period time.Duration, objectCountTracker flo
 	klog.V(2).InfoS("Monitoring resource count at path", "resource", resourceName, "path", "<storage-prefix>/"+prefix)
 	stopCh := make(chan struct{})
 	go wait.JitterUntil(func() {
-		count, err := e.Storage.Count(ctx, prefix)
+		stats, err := e.Storage.Stats(ctx)
 		if err != nil {
 			klog.V(5).InfoS("Failed to update storage count metric", "err", err)
-			count = -1
+			stats.ObjectCount = -1
 		}
 
-		metrics.UpdateObjectCount(e.DefaultQualifiedResource, count)
+		metrics.UpdateObjectCount(e.DefaultQualifiedResource, stats.ObjectCount)
 		if objectCountTracker != nil {
-			objectCountTracker.Set(resourceName, count)
+			objectCountTracker.Set(resourceName, stats)
 		}
 	}, period, resourceCountPollPeriodJitter, true, stopCh)
 	return func() { close(stopCh) }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -459,7 +459,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 			}, time.Second, stopCh,
 		)
 	}()
-
+	config.Storage.SetKeysFunc(cacher.getKeys)
 	return cacher, nil
 }
 
@@ -1287,6 +1287,14 @@ func (c *Cacher) setInitialEventsEndBookmarkIfRequested(cacheInterval *watchCach
 
 		cacheInterval.initialEventsEndBookmark = initialEventsEndBookmark
 	}
+}
+
+func (c *Cacher) getKeys(ctx context.Context) ([]string, error) {
+	rev, err := c.storage.GetCurrentResourceVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return c.watchCache.WaitUntilFreshAndGetKeys(ctx, rev)
 }
 
 func (c *Cacher) Ready() bool {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -646,3 +646,18 @@ func BenchmarkStoreList(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkStoreStats(b *testing.B) {
+	klog.SetLogger(logr.Discard())
+	data := storagetesting.PrepareBenchchmarkData(50, 3_000, 5_000)
+	ctx, cacher, _, terminate := testSetupWithEtcdServer(b)
+	b.Cleanup(terminate)
+	var out example.Pod
+	for _, pod := range data.Pods {
+		err := cacher.Create(ctx, computePodKey(pod), pod, &out, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	storagetesting.RunBenchmarkStoreStats(ctx, b, cacher)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -71,6 +71,7 @@ func newEtcdTestStorage(t testing.TB, prefix string) (*etcd3testing.EtcdTestServ
 		etcd3.NewDefaultLeaseManagerConfig(),
 		etcd3.NewDefaultDecoder(codec, versioner),
 		versioner)
+	t.Cleanup(storage.Close)
 	return server, storage
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -189,8 +189,8 @@ func (d *dummyStorage) GetList(ctx context.Context, resPrefix string, opts stora
 func (d *dummyStorage) GuaranteedUpdate(_ context.Context, _ string, _ runtime.Object, _ bool, _ *storage.Preconditions, _ storage.UpdateFunc, _ runtime.Object) error {
 	return fmt.Errorf("unimplemented")
 }
-func (d *dummyStorage) Count(_ context.Context, _ string) (int64, error) {
-	return 0, fmt.Errorf("unimplemented")
+func (d *dummyStorage) Stats(_ context.Context) (storage.Stats, error) {
+	return storage.Stats{}, fmt.Errorf("unimplemented")
 }
 func (d *dummyStorage) ReadinessCheck() error {
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -192,6 +192,8 @@ func (d *dummyStorage) GuaranteedUpdate(_ context.Context, _ string, _ runtime.O
 func (d *dummyStorage) Stats(_ context.Context) (storage.Stats, error) {
 	return storage.Stats{}, fmt.Errorf("unimplemented")
 }
+func (d *dummyStorage) SetKeysFunc(storage.KeysFunc) {
+}
 func (d *dummyStorage) ReadinessCheck() error {
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -274,8 +274,8 @@ func (c *CacheDelegator) GuaranteedUpdate(ctx context.Context, key string, desti
 	return c.storage.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, tryUpdate, nil)
 }
 
-func (c *CacheDelegator) Count(ctx context.Context, pathPrefix string) (int64, error) {
-	return c.storage.Count(ctx, pathPrefix)
+func (c *CacheDelegator) Stats(ctx context.Context) (storage.Stats, error) {
+	return c.storage.Stats(ctx)
 }
 
 func (c *CacheDelegator) ReadinessCheck() error {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -99,6 +99,10 @@ func (c *CacheDelegator) GetCurrentResourceVersion(ctx context.Context) (uint64,
 	return c.storage.GetCurrentResourceVersion(ctx)
 }
 
+func (c *CacheDelegator) SetKeysFunc(keys storage.KeysFunc) {
+	c.storage.SetKeysFunc(keys)
+}
+
 func (c *CacheDelegator) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
 	// Ignore the suggestion and try to pass down the current version of the object
 	// read from cache.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd3
+
+import (
+	"context"
+	"sync"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+type keysFunc func(context.Context) ([]string, error)
+
+func newStatsCache(getKeys keysFunc) *statsCache {
+	sc := &statsCache{
+		getKeys: getKeys,
+		keys:    make(map[string]sizeRevision),
+	}
+	return sc
+}
+
+// statsCache efficiently estimates the average object size
+// based on the last observed state of individual keys.
+// By plugging statsCache into GetList and Watch functions,
+// a fairly accurate estimate of object sizes can be maintained
+// without additional requests to the underlying storage.
+// To handle potential out-of-order or incomplete data,
+// it uses a per-key revision to identify the newer state.
+// This approach may leak keys if delete events are not observed,
+// thus we run a background goroutine to periodically cleanup keys if needed.
+type statsCache struct {
+	getKeys keysFunc
+
+	lock sync.Mutex
+	keys map[string]sizeRevision
+}
+
+type sizeRevision struct {
+	sizeBytes int64
+	revision  int64
+}
+
+func (sc *statsCache) Stats(ctx context.Context) (storage.Stats, error) {
+	keys, err := sc.getKeys(ctx)
+	if err != nil {
+		return storage.Stats{}, err
+	}
+	stats := storage.Stats{
+		ObjectCount: int64(len(keys)),
+	}
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	sc.cleanKeys(keys)
+	if len(sc.keys) != 0 {
+		stats.EstimatedAverageObjectSizeBytes = sc.keySizes() / int64(len(sc.keys))
+	}
+	return stats, nil
+}
+
+func (sc *statsCache) cleanKeys(keepKeys []string) {
+	newKeys := make(map[string]sizeRevision, len(keepKeys))
+	for _, key := range keepKeys {
+		keySizeRevision, ok := sc.keys[key]
+		if !ok {
+			continue
+		}
+		newKeys[key] = keySizeRevision
+	}
+	sc.keys = newKeys
+}
+
+func (sc *statsCache) keySizes() (totalSize int64) {
+	for _, sizeRevision := range sc.keys {
+		totalSize += sizeRevision.sizeBytes
+	}
+	return totalSize
+}
+
+func (sc *statsCache) Update(kvs []*mvccpb.KeyValue) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	for _, kv := range kvs {
+		sc.updateKey(kv)
+	}
+}
+
+func (sc *statsCache) UpdateKey(kv *mvccpb.KeyValue) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	sc.updateKey(kv)
+}
+
+func (sc *statsCache) updateKey(kv *mvccpb.KeyValue) {
+	key := string(kv.Key)
+	keySizeRevision := sc.keys[key]
+	if keySizeRevision.revision >= kv.ModRevision {
+		return
+	}
+
+	sc.keys[key] = sizeRevision{
+		sizeBytes: int64(len(kv.Value)),
+		revision:  kv.ModRevision,
+	}
+}
+
+func (sc *statsCache) DeleteKey(kv *mvccpb.KeyValue) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	key := string(kv.Key)
+	keySizeRevision := sc.keys[key]
+	if keySizeRevision.revision >= kv.ModRevision {
+		return
+	}
+
+	delete(sc.keys, key)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+)
+
+func TestStatsCache(t *testing.T) {
+	ctx := t.Context()
+	store := newStatsCache(func(ctx context.Context) ([]string, error) { return []string{}, nil })
+
+	stats, err := store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.EstimatedAverageObjectSizeBytes)
+
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2})
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo1"}, nil }
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3})
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo1", "foo2"}, nil }
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(15), stats.EstimatedAverageObjectSizeBytes)
+
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("012345678901234567890123456789"), ModRevision: 4})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(25), stats.EstimatedAverageObjectSizeBytes)
+
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("0123456789"), ModRevision: 5})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), stats.EstimatedAverageObjectSizeBytes)
+
+	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("foo1"), ModRevision: 6})
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo2"}, nil }
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	// Snapshot revision from revision 3
+	store.Update([]*mvccpb.KeyValue{
+		{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2},
+		{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3},
+	})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	// Replay from revision 2
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("012345678901234567890123456789"), ModRevision: 4})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("0123456789"), ModRevision: 5})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("foo1"), ModRevision: 6})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
+
+	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("foo1"), ModRevision: 7})
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{}, nil }
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.EstimatedAverageObjectSizeBytes)
+
+	// Old snapshot might restore old revision if keys were recreated
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo1", "foo2"}, nil }
+	store.Update([]*mvccpb.KeyValue{
+		{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2},
+		{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3},
+	})
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(15), stats.EstimatedAverageObjectSizeBytes)
+
+	// Cleanup if keys were deleted
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{}, nil }
+	stats, err = store.Stats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.EstimatedAverageObjectSizeBytes)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats_test.go
@@ -28,6 +28,7 @@ import (
 func TestStatsCache(t *testing.T) {
 	ctx := t.Context()
 	store := newStatsCache(func(ctx context.Context) ([]string, error) { return []string{}, nil })
+	defer store.Close()
 
 	stats, err := store.Stats(ctx)
 	require.NoError(t, err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/stats_test.go
@@ -27,77 +27,77 @@ import (
 
 func TestStatsCache(t *testing.T) {
 	ctx := t.Context()
-	store := newStatsCache(func(ctx context.Context) ([]string, error) { return []string{}, nil })
+	store := newStatsCache("/prefix", func(ctx context.Context) ([]string, error) { return []string{}, nil })
 	defer store.Close()
 
 	stats, err := store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), stats.EstimatedAverageObjectSizeBytes)
 
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2})
-	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo1"}, nil }
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo1"), Value: []byte("0123456789"), ModRevision: 2})
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"/prefix/foo1"}, nil }
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3})
-	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo1", "foo2"}, nil }
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo2"), Value: []byte("01234567890123456789"), ModRevision: 3})
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"/prefix/foo1", "/prefix/foo2"}, nil }
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(15), stats.EstimatedAverageObjectSizeBytes)
 
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("012345678901234567890123456789"), ModRevision: 4})
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo1"), Value: []byte("012345678901234567890123456789"), ModRevision: 4})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(25), stats.EstimatedAverageObjectSizeBytes)
 
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("0123456789"), ModRevision: 5})
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo2"), Value: []byte("0123456789"), ModRevision: 5})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(20), stats.EstimatedAverageObjectSizeBytes)
 
-	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("foo1"), ModRevision: 6})
-	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo2"}, nil }
+	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo1"), ModRevision: 6})
+	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"/prefix/foo2"}, nil }
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
 	// Snapshot revision from revision 3
 	store.Update([]*mvccpb.KeyValue{
-		{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2},
-		{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3},
+		{Key: []byte("/prefix/foo1"), Value: []byte("0123456789"), ModRevision: 2},
+		{Key: []byte("/prefix/foo2"), Value: []byte("01234567890123456789"), ModRevision: 3},
 	})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
 	// Replay from revision 2
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2})
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo1"), Value: []byte("0123456789"), ModRevision: 2})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3})
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo2"), Value: []byte("01234567890123456789"), ModRevision: 3})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo1"), Value: []byte("012345678901234567890123456789"), ModRevision: 4})
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo1"), Value: []byte("012345678901234567890123456789"), ModRevision: 4})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
-	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("foo2"), Value: []byte("0123456789"), ModRevision: 5})
+	store.UpdateKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo2"), Value: []byte("0123456789"), ModRevision: 5})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
-	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("foo1"), ModRevision: 6})
+	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo1"), ModRevision: 6})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(10), stats.EstimatedAverageObjectSizeBytes)
 
-	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("foo1"), ModRevision: 7})
+	store.DeleteKey(&mvccpb.KeyValue{Key: []byte("/prefix/foo1"), ModRevision: 7})
 	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{}, nil }
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)
@@ -106,8 +106,8 @@ func TestStatsCache(t *testing.T) {
 	// Old snapshot might restore old revision if keys were recreated
 	store.getKeys = func(ctx context.Context) ([]string, error) { return []string{"foo1", "foo2"}, nil }
 	store.Update([]*mvccpb.KeyValue{
-		{Key: []byte("foo1"), Value: []byte("0123456789"), ModRevision: 2},
-		{Key: []byte("foo2"), Value: []byte("01234567890123456789"), ModRevision: 3},
+		{Key: []byte("/prefix/foo1"), Value: []byte("0123456789"), ModRevision: 2},
+		{Key: []byte("/prefix/foo2"), Value: []byte("01234567890123456789"), ModRevision: 3},
 	})
 	stats, err = store.Stats(ctx)
 	require.NoError(t, err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -202,6 +202,12 @@ func (s *store) Versioner() storage.Versioner {
 	return s.versioner
 }
 
+func (s *store) Close() {
+	if s.stats != nil {
+		s.stats.Close()
+	}
+}
+
 // Get implements storage.Interface.Get.
 func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, out runtime.Object) error {
 	preparedKey, err := s.prepareKey(key)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -183,7 +183,7 @@ func New(c *kubernetes.Client, codec runtime.Codec, newFunc, newListFunc func() 
 		newListFunc:    newListFunc,
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
-		stats := newStatsCache(s.getKeys)
+		stats := newStatsCache(pathPrefix, s.getKeys)
 		s.stats = stats
 		w.stats = stats
 	}
@@ -631,6 +631,12 @@ func (s *store) Stats(ctx context.Context) (stats storage.Stats, err error) {
 	return storage.Stats{
 		ObjectCount: count,
 	}, nil
+}
+
+func (s *store) SetKeysFunc(keys storage.KeysFunc) {
+	if s.stats != nil {
+		s.stats.SetKeysFunc(keys)
+	}
 }
 
 func (s *store) getKeys(ctx context.Context) ([]string, error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -600,6 +600,7 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, *store, *kub
 		NewDefaultDecoder(setupOpts.codec, versioner),
 		versioner,
 	)
+	t.Cleanup(store.Close)
 	ctx := context.Background()
 	return ctx, store, client
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -43,10 +43,13 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	"k8s.io/apiserver/pkg/storage/value"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 )
 
@@ -343,9 +346,15 @@ func TestListResourceVersionMatch(t *testing.T) {
 	storagetesting.RunTestListResourceVersionMatch(ctx, t, &storeWithPrefixTransformer{store})
 }
 
-func TestCount(t *testing.T) {
-	ctx, store, _ := testSetup(t)
-	storagetesting.RunTestCount(ctx, t, store)
+func TestStats(t *testing.T) {
+	for _, sizeBasedListCostEstimate := range []bool{true, false} {
+		t.Run(fmt.Sprintf("SizeBasedListCostEstimate=%v", sizeBasedListCostEstimate), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SizeBasedListCostEstimate, sizeBasedListCostEstimate)
+			// Match transformer with cacher tests.
+			ctx, store, _ := testSetup(t)
+			storagetesting.RunTestStats(ctx, t, store, store.codec, store.transformer, sizeBasedListCostEstimate)
+		})
+	}
 }
 
 // =======================================================================
@@ -666,8 +675,6 @@ func TestInvalidKeys(t *testing.T) {
 	expectInvalidKey("Get", store.Get(ctx, invalidKey, storage.GetOptions{}, nil))
 	expectInvalidKey("GetList", store.GetList(ctx, invalidKey, storage.ListOptions{}, nil))
 	expectInvalidKey("GuaranteedUpdate", store.GuaranteedUpdate(ctx, invalidKey, nil, true, nil, nil, nil))
-	_, countErr := store.Count(t.Context(), invalidKey)
-	expectInvalidKey("Count", countErr)
 }
 
 func BenchmarkStore_GetList(b *testing.B) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -267,7 +267,14 @@ type Interface interface {
 	// GetCurrentResourceVersion gets the current resource version from etcd.
 	// This method issues an empty list request and reads only the ResourceVersion from the object metadata
 	GetCurrentResourceVersion(ctx context.Context) (uint64, error)
+
+	// SetKeysFunc allows to override the function used to get keys from storage.
+	// This allows to replace default function that fetches keys from storage with one using cache.
+	SetKeysFunc(KeysFunc)
 }
+
+// KeysFunc is a function prototype to fetch keys from storage.
+type KeysFunc func(context.Context) ([]string, error)
 
 // GetOptions provides the options that may be provided for storage get operations.
 type GetOptions struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -243,8 +243,8 @@ type Interface interface {
 		ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool,
 		preconditions *Preconditions, tryUpdate UpdateFunc, cachedExistingObject runtime.Object) error
 
-	// Count returns number of different entries under the key (generally being path prefix).
-	Count(ctx context.Context, key string) (int64, error)
+	// Stats returns storage stats.
+	Stats(ctx context.Context) (Stats, error)
 
 	// ReadinessCheck checks if the storage is ready for accepting requests.
 	ReadinessCheck() error
@@ -369,4 +369,13 @@ func ValidateListOptions(keyPrefix string, versioner Versioner, opts ListOptions
 		return withRev, "", fmt.Errorf("unknown ResourceVersionMatch value: %v", opts.ResourceVersionMatch)
 	}
 	return withRev, "", nil
+}
+
+// Stats provides statistics information about storage.
+type Stats struct {
+	// ObjectCount informs about number of objects stored in the storage.
+	ObjectCount int64
+	// EstimatedAverageObjectSizeBytes informs about size of objects stored in the storage, based on size of serialized values.
+	// Value is an estimate, meaning it doesn't need to provide accurate nor consistent.
+	EstimatedAverageObjectSizeBytes int64
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
@@ -220,3 +220,13 @@ type BenchmarkData struct {
 	NamespaceNames []string
 	NodeNames      []string
 }
+
+func RunBenchmarkStoreStats(ctx context.Context, b *testing.B, store storage.Interface) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := store.Stats(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
@@ -55,7 +56,7 @@ var (
 type StorageObjectCountTracker interface {
 	// Set is invoked to update the current number of total
 	// objects for the given resource
-	Set(string, int64)
+	Set(string, storage.Stats)
 
 	// Get returns the total number of objects for the given resource.
 	// The following errors are returned:
@@ -63,7 +64,7 @@ type StorageObjectCountTracker interface {
 	//    failures ObjectCountStaleErr is returned.
 	//  - if the given resource is not being tracked then
 	//    ObjectCountNotFoundErr is returned.
-	Get(string) (int64, error)
+	Get(string) (storage.Stats, error)
 
 	// RunUntil starts all the necessary maintenance.
 	RunUntil(stopCh <-chan struct{})
@@ -75,14 +76,14 @@ type StorageObjectCountTracker interface {
 func NewStorageObjectCountTracker() StorageObjectCountTracker {
 	return &objectCountTracker{
 		clock:  &clock.RealClock{},
-		counts: map[string]*timestampedCount{},
+		counts: map[string]*timestampedStats{},
 	}
 }
 
-// timestampedCount stores the count of a given resource with a last updated
+// timestampedStats stores the count of a given resource with a last updated
 // timestamp so we can prune it after it goes stale for certain threshold.
-type timestampedCount struct {
-	count         int64
+type timestampedStats struct {
+	storage.Stats
 	lastUpdatedAt time.Time
 }
 
@@ -92,11 +93,11 @@ type objectCountTracker struct {
 	clock clock.PassiveClock
 
 	lock   sync.RWMutex
-	counts map[string]*timestampedCount
+	counts map[string]*timestampedStats
 }
 
-func (t *objectCountTracker) Set(groupResource string, count int64) {
-	if count <= -1 {
+func (t *objectCountTracker) Set(groupResource string, stats storage.Stats) {
+	if stats.ObjectCount <= -1 {
 		// a value of -1 indicates that the 'Count' call failed to contact
 		// the storage layer, in most cases this error can be transient.
 		// we will continue to work with the count that is in the cache
@@ -114,18 +115,18 @@ func (t *objectCountTracker) Set(groupResource string, count int64) {
 	defer t.lock.Unlock()
 
 	if item, ok := t.counts[groupResource]; ok {
-		item.count = count
+		item.Stats = stats
 		item.lastUpdatedAt = now
 		return
 	}
 
-	t.counts[groupResource] = &timestampedCount{
-		count:         count,
+	t.counts[groupResource] = &timestampedStats{
+		Stats:         stats,
 		lastUpdatedAt: now,
 	}
 }
 
-func (t *objectCountTracker) Get(groupResource string) (int64, error) {
+func (t *objectCountTracker) Get(groupResource string) (storage.Stats, error) {
 	staleThreshold := t.clock.Now().Add(-staleTolerationThreshold)
 
 	t.lock.RLock()
@@ -133,11 +134,11 @@ func (t *objectCountTracker) Get(groupResource string) (int64, error) {
 
 	if item, ok := t.counts[groupResource]; ok {
 		if item.lastUpdatedAt.Before(staleThreshold) {
-			return item.count, ObjectCountStaleErr
+			return item.Stats, ObjectCountStaleErr
 		}
-		return item.count, nil
+		return item.Stats, nil
 	}
-	return 0, ObjectCountNotFoundErr
+	return storage.Stats{}, ObjectCountNotFoundErr
 }
 
 // RunUntil runs all the necessary maintenance.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apiserver/pkg/storage"
 	testclock "k8s.io/utils/clock/testing"
 )
 
@@ -69,21 +70,21 @@ func TestStorageObjectCountTracker(t *testing.T) {
 			fakeClock := &testclock.FakePassiveClock{}
 			tracker := &objectCountTracker{
 				clock:  fakeClock,
-				counts: map[string]*timestampedCount{},
+				counts: map[string]*timestampedStats{},
 			}
 
 			key := "foo.bar.resource"
 			now := time.Now()
 			fakeClock.SetTime(now.Add(-test.lastUpdated))
-			tracker.Set(key, test.count)
+			tracker.Set(key, storage.Stats{ObjectCount: test.count})
 
 			fakeClock.SetTime(now)
-			countGot, err := tracker.Get(key)
+			stats, err := tracker.Get(key)
 			if test.errExpected != err {
 				t.Errorf("Expected error: %v, but got: %v", test.errExpected, err)
 			}
-			if test.countExpected != countGot {
-				t.Errorf("Expected count: %d, but got: %d", test.countExpected, countGot)
+			if test.countExpected != stats.ObjectCount {
+				t.Errorf("Expected count: %d, but got: %d", test.countExpected, stats.ObjectCount)
 			}
 			if test.count <= -1 && len(tracker.counts) > 0 {
 				t.Errorf("Expected the cache to be empty, but got: %d", len(tracker.counts))
@@ -96,23 +97,23 @@ func TestStorageObjectCountTrackerWithPrune(t *testing.T) {
 	fakeClock := &testclock.FakePassiveClock{}
 	tracker := &objectCountTracker{
 		clock:  fakeClock,
-		counts: map[string]*timestampedCount{},
+		counts: map[string]*timestampedStats{},
 	}
 
 	now := time.Now()
 	fakeClock.SetTime(now.Add(-61 * time.Minute))
-	tracker.Set("k1", 61)
+	tracker.Set("k1", storage.Stats{ObjectCount: 61})
 	fakeClock.SetTime(now.Add(-60 * time.Minute))
-	tracker.Set("k2", 60)
+	tracker.Set("k2", storage.Stats{ObjectCount: 60})
 	// we are going to prune keys that are stale for >= 1h
 	// so the above keys are expected to be pruned and the
 	// key below should not be pruned.
 	mostRecent := now.Add(-59 * time.Minute)
 	fakeClock.SetTime(mostRecent)
-	tracker.Set("k3", 59)
-	expected := map[string]*timestampedCount{
+	tracker.Set("k3", storage.Stats{ObjectCount: 59})
+	expected := map[string]*timestampedStats{
 		"k3": {
-			count:         59,
+			Stats:         storage.Stats{ObjectCount: 59},
 			lastUpdatedAt: mostRecent,
 		},
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -23,6 +23,7 @@ import (
 
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"k8s.io/klog/v2"
@@ -56,9 +57,9 @@ func (we *WorkEstimate) MaxSeats() int {
 	return int(we.FinalSeats)
 }
 
-// objectCountGetterFunc represents a function that gets the total
+// statsGetterFunc represents a function that gets the total
 // number of objects for a given resource.
-type objectCountGetterFunc func(string) (int64, error)
+type statsGetterFunc func(string) (storage.Stats, error)
 
 // watchCountGetterFunc represents a function that gets the total
 // number of watchers potentially interested in a given request.
@@ -71,7 +72,7 @@ type maxSeatsFunc func(priorityLevelName string) uint64
 // NewWorkEstimator estimates the work that will be done by a given request,
 // if no WorkEstimatorFunc matches the given request then the default
 // work estimate of 1 seat is allocated to the request.
-func NewWorkEstimator(objectCountFn objectCountGetterFunc, watchCountFn watchCountGetterFunc, config *WorkEstimatorConfig, maxSeatsFn maxSeatsFunc) WorkEstimatorFunc {
+func NewWorkEstimator(objectCountFn statsGetterFunc, watchCountFn watchCountGetterFunc, config *WorkEstimatorConfig, maxSeatsFn maxSeatsFunc) WorkEstimatorFunc {
 	estimator := &workEstimator{
 		minimumSeats:          config.MinimumSeats,
 		maximumSeatsLimit:     config.MaximumSeatsLimit,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -24,6 +24,7 @@ import (
 
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
@@ -547,8 +548,8 @@ func TestWorkEstimator(t *testing.T) {
 			if len(counts) == 0 {
 				counts = map[string]int64{}
 			}
-			countsFn := func(key string) (int64, error) {
-				return counts[key], test.countErr
+			countsFn := func(key string) (storage.Stats, error) {
+				return storage.Stats{ObjectCount: counts[key]}, test.countErr
 			}
 			watchCountsFn := func(_ *apirequest.RequestInfo) int {
 				return test.watchCount

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1429,6 +1429,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.33"
+- name: SizeBasedListCostEstimate
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: SizeMemoryBackedVolumes
   versionedSpecs:
   - default: false


### PR DESCRIPTION
/kind feature

Ref https://github.com/kubernetes/kubernetes/issues/132233
Alternative to https://github.com/kubernetes/kubernetes/pull/132292

```release-note
Added SizeBasedListCostEstimate feature gate that allows apiserver to estimate sizes of objects to calculate cost of LIST requests
```

This PR proposes to track object size in resource by caching last observed state for each key and then calculating average size of keys available in etcd. Fetching the list of keys from etcd is required to make sure we remove stale keys that were not deleted due skipped watch events. We could take list of keys from cacher to avoid `WithKeysOnly` request. 

/assign @deads2k @wojtek-t 
