### PR TITLE
[WIP] pkg/kubelet: Fix concurrent map write crash during image gc

### DIFF
--- a/test/e2e_node/image_gc_test.go
+++ b/test/e2e_node/image_gc_test.go
@@ -18,6 +18,8 @@ package e2enode
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -29,6 +31,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
@@ -114,4 +117,123 @@ var _ = SIGDescribe("ImageGarbageCollect", framework.WithSerial(), feature.Garba
 			}, checkGCUntil, checkGCFreq).Should(gomega.BeNumerically("<", len(allImages)))
 		})
 	})
+	ginkgo.Context("Concurrent garbage collection stability", func() {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.EvictionHard = map[string]string{
+				"imagefs.available": "15%",
+			}
+			initialConfig.EvictionMinimumReclaim = map[string]string{
+				"imagefs.available": "1GB",
+			}
+			// Configure aggressive GC thresholds
+			initialConfig.ImageGCHighThresholdPercent = 50
+			initialConfig.ImageGCLowThresholdPercent = 40
+			initialConfig.ImageMinimumGCAge = metav1.Duration{Duration: 0}
+		})
+
+		ginkgo.It("should handle concurrent image deletions without crashing under DiskPressure", func(ctx context.Context) {
+			resp, err := is.ImageFsInfo(ctx)
+			framework.ExpectNoError(err)
+			gomega.Expect(resp.ImageFilesystems).NotTo(gomega.BeEmpty())
+			gomega.Expect(resp.ImageFilesystems[0].FsId).NotTo(gomega.BeNil())
+			diskToPressure := filepath.Dir(resp.ImageFilesystems[0].FsId.Mountpoint)
+			ginkgo.By(fmt.Sprintf("Got imageFs directory: %s", diskToPressure))
+
+			var imagesLenBeforeGC int
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				images, err := is.ListImages(ctx, &runtimeapi.ImageFilter{})
+				if err != nil {
+					return err
+				}
+				imagesLenBeforeGC = len(images)
+				return nil
+			}, 1*time.Minute, 5*time.Second).Should(gomega.Succeed())
+			ginkgo.By(fmt.Sprintf("Number of images found before GC: %d", imagesLenBeforeGC))
+
+			const numPods = 15
+			image := imageutils.GetE2EImage(imageutils.Agnhost)
+			var pods []*v1.Pod
+
+			for i := 0; i < numPods; i++ {
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("gc-stress-pod-%d", i),
+						Namespace: f.Namespace.Name,
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{{
+							Name:    fmt.Sprintf("container-%d", i),
+							Image:   image,
+							Command: []string{"/bin/sh", "-c", "sleep 3600"},
+						}},
+					},
+				}
+				pods = append(pods, pod)
+			}
+
+			e2epod.NewPodClient(f).CreateBatch(ctx, pods)
+			for _, pod := range pods {
+				e2epod.NewPodClient(f).DeleteSync(ctx, pod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+			}
+
+			kubeletHealthy := true
+			watchdogCtx, watchdogCancel := context.WithCancel(ctx)
+			defer watchdogCancel()
+			startHealthMonitor(watchdogCtx, &kubeletHealthy)
+
+			sizeOfPressure := "8000" // 8GB - proven effective size
+			ginkgo.By(fmt.Sprintf("Inducing disk pressure on %s with size %s MB", diskToPressure, sizeOfPressure))
+			gomega.Expect(runDDOnFilesystem(diskToPressure, sizeOfPressure)).Should(gomega.Succeed())
+
+			ginkgo.By("Waiting for NodeDiskPressure condition")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				if hasNodeCondition(ctx, f, v1.NodeDiskPressure) {
+					return nil
+				}
+				return fmt.Errorf("NodeDiskPressure condition not active")
+			}, 5*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+			ginkgo.By("Waiting for garbage collection to complete")
+			gomega.Eventually(ctx, func() bool {
+				currentResp, err := is.ListImages(ctx, &runtimeapi.ImageFilter{})
+				if err != nil {
+					return false
+				}
+				return len(currentResp) < imagesLenBeforeGC
+			}, 5*time.Minute, 30*time.Second).Should(gomega.BeTrueBecause("GC should reduce image count"))
+
+			gomega.Expect(kubeletHealthy).To(gomega.BeTrueBecause("Kubelet should remain healthy"))
+
+			// 9. Cleanup (from split_disk_test)
+			ginkgo.By("Removing disk pressure")
+			gomega.Expect(removeDiskPressure(diskToPressure)).Should(gomega.Succeed())
+
+			// 10. Verify pressure cleared (from split_disk_test)
+			ginkgo.By("Waiting for DiskPressure to clear")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				if hasNodeCondition(ctx, f, v1.NodeDiskPressure) {
+					return fmt.Errorf("DiskPressure still active")
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
+		})
+	})
 })
+
+func startHealthMonitor(ctx context.Context, healthy *bool) {
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if !kubeletHealthCheck(kubeletHealthCheckURL) {
+					*healthy = false
+					return
+				}
+			}
+		}
+	}()
+}


### PR DESCRIPTION
This fixes the issue where nodes experienced fatal crashes due to concurrent map writes in the image gc process when under DiskPressure. The crash occurred when multiple gc goroutines attempted to delete the same image record. The freeImage() implementation had insufficient locking scope, no handling for concurrent operations on same image, and no backoff mechanism for failed deletions.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/132435
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
