### PR TITLE
Use `jq` docker image for pause windows build

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -35,12 +35,14 @@ BASE.linux := scratch
 BASE.windows := mcr.microsoft.com/oss/kubernetes/windows-pause-image-base:v0.4.1@sha256:37cc10768383b55611d724a05eb18564cb5184c89b0c2faa7d4eff63475092df
 BASE := ${BASE.${OS}}
 
+JQ_IMAGE := ghcr.io/jqlang/jq@sha256:a186dcd84a1e28bb48cdf3d7768b890d08621a87bb651fadb7db6815a6bf5ad5
+
 ALL_OS = linux windows
 ALL_ARCH.linux = amd64 arm arm64 ppc64le s390x
 ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 ALL_ARCH.windows = amd64
 # ALL_OSVERSIONS lists all os.versions in BASE.windows.
-ALL_OSVERSIONS.windows := $(shell docker manifest inspect ${BASE.windows} | jq '.manifests' | jq -c '.[]' | jq '.platform."os.version"' | tr -d '"')
+ALL_OSVERSIONS.windows := $(shell docker manifest inspect ${BASE.windows} | docker run --rm -i ${JQ_IMAGE} '.manifests | .[] | .platform."os.version"' | tr -d '"')
 ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-$(arch)-${osversion}))
 ALL_OS_ARCH = $(foreach os, $(ALL_OS), ${ALL_OS_ARCH.${os}})
 
@@ -130,9 +132,9 @@ container: .container-${OS}-$(ARCH)
 .container-windows-$(ARCH): $(foreach binary, ${BIN}, bin/${binary}-${OS}-${ARCH})
 	# For Windows images, each "os.version" maps to a specific image "digest" that serves as a base to build corresponding windows-pause image variant.
 	set -x; \
-	image_manifests=$$(docker manifest inspect "${BASE.windows}" | jq '.manifests'); \
+	image_manifests=$$(docker manifest inspect "${BASE.windows}" | docker run --rm -i ${JQ_IMAGE} '.manifests'); \
 	for osversion in $(ALL_OSVERSIONS.windows); do \
-			digest=$$(echo "$${image_manifests}" | jq -r '.[]|select(.platform."os.version" | contains("'$${osversion}'"))' | jq '.digest' | awk -F\" '{print $$2}'); \
+			digest=$$(echo "$${image_manifests}" | docker run --rm -i ${JQ_IMAGE} '.[]|select(.platform."os.version" | contains("'$${osversion}'")) | .digest' | awk -F\" '{print $$2}'); \
 			base_image=$$(echo "${BASE.windows}" | awk -F: '{print $$1}')@$${digest}; \
 			docker buildx build --provenance=false --sbom=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
 							-t $(IMAGE):$(TAG)-${OS}-$(ARCH)-$${osversion} --build-arg BASE=$${base_image} --build-arg ARCH=$(ARCH) -f Dockerfile_windows .; \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will use `jq` docker image to parse `windows-pause-image-base` manifest for windows pause build.
Fixes error: `/bin/sh: jq: not found`

Ref Discussion: 
- https://github.com/kubernetes/kubernetes/pull/131258#discussion_r2129567249
- https://github.com/kubernetes/test-infra/pull/34963#pullrequestreview-2917905517


#### Which issue(s) this PR is related to:
Fixes #https://github.com/kubernetes/kubernetes/issues/131257
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Blocks dependency bump for pause: https://github.com/kubernetes/kubernetes/pull/130713

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
