### PR TITLE
flag: fix nil-ptr panic & typo messages

### DIFF
--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -171,7 +171,7 @@ type ReservedMemoryVar struct {
 // Set sets the flag value
 func (v *ReservedMemoryVar) Set(s string) error {
 	if v.Value == nil {
-		return fmt.Errorf("no target (nil pointer to *[]MemoryReservation")
+		return fmt.Errorf("no target (nil pointer to *[]MemoryReservation)")
 	}
 
 	if s == "" {
@@ -200,7 +200,7 @@ func (v *ReservedMemoryVar) Set(s string) error {
 		}
 		numaNodeID, err := strconv.Atoi(numaNodeReservation[0])
 		if err != nil {
-			return fmt.Errorf("failed to convert the NUMA node ID, exptected integer, got %s", numaNodeReservation[0])
+			return fmt.Errorf("failed to convert the NUMA node ID, expected integer, got %s", numaNodeReservation[0])
 		}
 
 		memoryReservation := kubeletconfig.MemoryReservation{
@@ -211,7 +211,7 @@ func (v *ReservedMemoryVar) Set(s string) error {
 		for _, memoryTypeReservation := range memoryTypeReservations {
 			limit := strings.Split(memoryTypeReservation, "=")
 			if len(limit) != 2 {
-				return fmt.Errorf("the reserved limit has incorrect value, expected type=quantatity, got %s", memoryTypeReservation)
+				return fmt.Errorf("the reserved limit has incorrect value, expected type=quantity, got %s", memoryTypeReservation)
 			}
 
 			resourceName := v1.ResourceName(limit[0])
@@ -221,7 +221,7 @@ func (v *ReservedMemoryVar) Set(s string) error {
 
 			q, err := resource.ParseQuantity(limit[1])
 			if err != nil {
-				return fmt.Errorf("failed to parse the quantatity, expected quantatity, got %s", limit[1])
+				return fmt.Errorf("failed to parse the quantity: %s", limit[1])
 			}
 
 			memoryReservation.Limits[v1.ResourceName(limit[0])] = q
@@ -264,6 +264,10 @@ type RegisterWithTaintsVar struct {
 
 // Set sets the flag value
 func (t RegisterWithTaintsVar) Set(s string) error {
+	if t.Value == nil {
+		return fmt.Errorf("no target (nil pointer to []v1.Taint)")
+	}
+
 	if len(s) == 0 {
 		*t.Value = nil
 		return nil
@@ -283,7 +287,7 @@ func (t RegisterWithTaintsVar) Set(s string) error {
 
 // String returns the flag value
 func (t RegisterWithTaintsVar) String() string {
-	if len(*t.Value) == 0 {
+	if t.Value == nil || len(*t.Value) == 0 {
 		return ""
 	}
 	var taints []string


### PR DESCRIPTION
### What changed
* [RegisterWithTaintsVar](cci:2://file:///d:/Github/kubernetes/pkg/util/flag/flags.go:260:0-262:1)
  * Added nil-target checks in [Set](cci:1://file:///d:/Github/kubernetes/pkg/util/flag/flags.go:170:0-231:1) and [String](cci:1://file:///d:/Github/kubernetes/pkg/util/flag/flags.go:151:0-157:1); avoids panic when slice pointer isn’t pre-initialised.
* [ReservedMemoryVar](cci:2://file:///d:/Github/kubernetes/pkg/util/flag/flags.go:165:0-168:1)
  * Closed missing parenthesis in error string.
  * Corrected spelling in three user-visible error messages.

### Why it matters
* Prevents kubelet (and any consumer) from crashing during flag parsing if the `--register-with-taints` target slice wasn’t set up.
* Clear, correctly-spelled errors make mis-configured `--reserved-memory` flags easier to diagnose.

_No functional behaviour altered; only robustness and usability improved._