### PR TITLE
Fixed large resourceversion and limit for storages

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -19,6 +19,7 @@ package etcd3
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"reflect"
@@ -31,6 +32,7 @@ import (
 	"go.etcd.io/etcd/client/v3/kubernetes"
 	"go.opentelemetry.io/otel/attribute"
 
+	etcdrpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -744,6 +746,14 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 		})
 		metrics.RecordEtcdRequest(metricsOp, s.groupResource, err, startTime)
 		if err != nil {
+			if errors.Is(err, etcdrpc.ErrFutureRev) {
+				currentRV, getRVErr := s.GetCurrentResourceVersion(ctx)
+				if getRVErr != nil {
+					// If we can't get the current RV, use 0 as a fallback.
+					currentRV = 0
+				}
+				return storage.NewTooLargeResourceVersionError(uint64(withRev), currentRV, 0)
+			}
 			return interpretListError(err, len(opts.Predicate.Continue) > 0, continueKey, keyPrefix)
 		}
 		numFetched += len(getResp.Kvs)

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -1608,9 +1608,8 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, inc
 			listCtx := context.WithValue(ctx, recorderContextKey, recorderKey)
 			err := store.GetList(listCtx, tt.prefix, storageOpts, out)
 			if tt.expectRVTooLarge {
-				// TODO: Clasify etcd future revision error as TooLargeResourceVersion
-				if err == nil || !(storage.IsTooLargeResourceVersion(err) || strings.Contains(err.Error(), "etcdserver: mvcc: required revision is a future revision")) {
-					t.Fatalf("expecting resource version too high error, but get: %q", err)
+				if !storage.IsTooLargeResourceVersion(err) {
+					t.Fatalf("expecting resource version too high error, but get: %v", err)
 				}
 				return
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Currently, when you do try to query the StorageClassList with a very high resourceVersion and a high limit value, you'll get a response, like this:
NOTE: Youll not only get a error message from etcdserver, you will also get a 500 error code.
```
curl -v -X GET "https://localhost:6443/apis/storage.k8s.io/v1/storageclasses?resourceVersion=276&timeoutSeconds=1&gracePeriodSeconds=103" -H "Authorization: Bearer $TOKEN" --insecure

{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "etcdserver: mvcc: required revision is a future revision",
  "code": 500
```

The issues #132358 suggested, that we might want to return a more graceful error message and a error code of 504, like this:
```
    "causes": [
      {
        "reason": "ResourceVersionTooLarge",
        "message": "Too large resource version"
      }
    ],
    "retryAfterSeconds": 1
  },
  "code": 504
```

After making some slight adjustments on the error handling, we are able to query the StorageClassList with a very high resourceVersion and a high limit value, and we will receive the desired message:

```
curl -v -X GET "https://localhost:6443/apis/storage.k8s.io/v1/storageclasses?resourceVersion=44232320&limit=38&timeoutSeconds=1&gracePeriodSeconds=103" -H "Authorization: Bearer $TOKEN" --insecure

{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "Timeout: Too large resource version: 2902323232, current: 300",
  "reason": "Timeout",
  "details": {
    "causes": [
      {
        "reason": "ResourceVersionTooLarge",
        "message": "Too large resource version"
      }
    ],
    "retryAfterSeconds": 1
  },
  "code": 504

```

#### Which issue(s) this PR is related to:

Fixes #132358 

#### Special notes for your reviewer:
I am quite not sure, if the current change is what we really want.
This was a challenge for me 😄 

We will check for the error message from etcd:
`if err == etcdrpc.ErrFutureRev`, which is infact this 
```
ErrGRPCFutureRev               = status.Error(codes.OutOfRange, "etcdserver: mvcc: required revision is a future revision")
```
As I am not sure, if this is a good practice, I looked at the `interpretListError` function, which will be called within the `GetList` function. 

And yes, we already doing it this way:
```
func interpretListError(err error, paging bool, continueKey, keyPrefix string) error {
	switch {
	case err == etcdrpc.ErrCompacted:
		if paging {
			return handleCompactedErrorForPaging(continueKey, keyPrefix)
		}
		return errors.NewResourceExpired(expired)
	}
	return err
}
```

But I'd be more than happy for some suggestions, if this is not the right approach 👍 

#### Does this PR introduce a user-facing change?
```release-note
Fixed API response for StorageClassList queries and returns a graceful error message, if the provided ResourceVersion is too large.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
