### PR TITLE
apimachinery/pkg/util/errors: deprecated MessageCountMap

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
@@ -24,6 +24,7 @@ import (
 )
 
 // MessageCountMap contains occurrence for each error message.
+// Deprecated: Not used anymore in the k8s.io codebase, use `errors.Join` instead.
 type MessageCountMap map[string]int
 
 // Aggregate represents an object that contains multiple errors, but does not
@@ -199,6 +200,7 @@ func Flatten(agg Aggregate) Aggregate {
 }
 
 // CreateAggregateFromMessageCountMap converts MessageCountMap Aggregate
+// Deprecated: Not used anymore in the k8s.io codebase, use `errors.Join` instead.
 func CreateAggregateFromMessageCountMap(m MessageCountMap) Aggregate {
 	if m == nil {
 		return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- xref #131726
  - Not used anymore in the k8s.io codebase.
  - Nobody should use the [k8s.io/apimachinery/pkg/util/errors](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/errors) package anymore as [errors.Join](https://pkg.go.dev/errors#Join) exists since Go 1.20

#### Which issue(s) this PR is related to:

Fixes #131726

#### Special notes for your reviewer:

This is my first time submitting a pull request in the Kubernetes core project. If anything needs to change, please let me know.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apimachinery: deprecated MessageCountMap and CreateAggregateFromMessageCountMap
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
