### PR TITLE
etcd build script moved to ./scripts/build.sh

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -34,7 +34,7 @@ LATEST_ETCD_VERSION?=3.6.1
 # REVISION provides a version number for this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
 # for each revision of this image at that etcd version.
-REVISION?=0
+REVISION?=1
 
 # IMAGE_TAG Uniquely identifies registry.k8s.io/etcd docker image with a tag of the form "<etcd-version>-<revision>".
 IMAGE_TAG=$(LATEST_ETCD_VERSION)-$(REVISION)
@@ -171,7 +171,7 @@ else
 			"git clone https://github.com/etcd-io/etcd $$etcd_build_dir \
 			&& cd $$etcd_build_dir \
 			&& git checkout v$${version} \
-			&& $(arch_prefix) GOARCH=$(ARCH) ./build.sh \
+			&& $(arch_prefix) GOARCH=$(ARCH) ./scripts/build.sh \
 			&& cp -f bin/$(ARCH)/etcd* bin/etcd* /etcdbin; echo 'done'"; \
 		$(BIN_INSTALL) $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
 		$(BIN_INSTALL) $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig etcd 

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #132368

#### Special notes for your reviewer:
I checked an example https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-arm64/1935312615039307776. 

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-arm64/1935312615039307776/artifacts/kind-control-plane/images.log 
```
registry.k8s.io/etcd                            3.6.0-0                             7df6e80961e80       99.2MB
```

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-arm64/1935312615039307776/artifacts/kind-control-plane/pods/kube-system_etcd-kind-control-plane_836cc930e79643c72f7678b5dde61b2a/etcd/0.log
- etcd binary of arm64 etcd image 3.6.0-0 is etcd 3.5.21.

```
2025-06-18T12:28:55.923067Z stderr F {"level":"info","ts":"2025-06-18T12:28:55.923030Z","caller":"etcdserver/server.go:875","msg":"starting etcd server","local-member-id":"5320353a7d98bdee","local-server-version":"3.5.21","cluster-version":"to_be_decided"}
```


#### Does this PR introduce a user-facing change?

```release-note
None
```
