### PR TITLE
Fix [Failing test] [sig-node] [Feature:GPUDevicePlugin] [Serial]-related tests

### DIFF
--- a/test/e2e/node/gpu.go
+++ b/test/e2e/node/gpu.go
@@ -293,6 +293,23 @@ func SetupEnvironmentAndSkipIfNeeded(ctx context.Context, f *framework.Framework
 	}
 }
 
+func isControlPlaneNode(node v1.Node) bool {
+	_, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
+	if isControlPlane {
+		framework.Logf("Node: %q is a control-plane node (label)", node.Name)
+		return true
+	}
+
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "node-role.kubernetes.io/control-plane" {
+			framework.Logf("Node: %q is a control-plane node (taint)", node.Name)
+			return true
+		}
+	}
+	framework.Logf("Node: %q is NOT a control-plane node", node.Name)
+	return false
+}
+
 func areGPUsAvailableOnAllSchedulableNodes(ctx context.Context, clientSet clientset.Interface) error {
 	framework.Logf("Getting list of Nodes from API server")
 	nodeList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
@@ -300,10 +317,7 @@ func areGPUsAvailableOnAllSchedulableNodes(ctx context.Context, clientSet client
 		return fmt.Errorf("unexpected error getting node list: %w", err)
 	}
 	for _, node := range nodeList.Items {
-		if node.Spec.Unschedulable {
-			continue
-		}
-		if _, ok := node.Labels[framework.ControlPlaneLabel]; ok {
+		if node.Spec.Unschedulable || isControlPlaneNode(node) {
 			continue
 		}
 		framework.Logf("gpuResourceName %s", e2egpu.NVIDIAGPUResourceName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

After https://github.com/kubernetes/kubernetes/pull/122384 is merged, these tests re-added by https://github.com/kubernetes/kubernetes/pull/127456 is failing.

error message:

```
{ failed [FAILED] Timed out after 600.001s.
Expected success, but got an error:
    <*errors.errorString | 0xc001481e00>: 
    nvidia GPUs not available on Node: "bootstrap-e2e-master"
    {
        s: "nvidia GPUs not available on Node: \"bootstrap-e2e-master\"",
    }
In [It] at: k8s.io/kubernetes/test/e2e/node/gpu.go:393 @ 06/18/25 13:46:30.284
}
```

According to [the source of resurrected code](https://github.com/kubernetes/kubernetes/blob/release-1.30/test/e2e/scheduling/nvidia-gpus.go), the master node shouldn't consider as a gpu node but re-added code doesn't meet this requirement.

```
- apiVersion: v1
  kind: Node
  metadata:
    annotations:
      node.alpha.kubernetes.io/ttl: "0"
      volumes.kubernetes.io/controller-managed-attach-detach: "true"
    creationTimestamp: "2025-06-18T11:36:09Z"
    labels:
      beta.kubernetes.io/arch: amd64
      beta.kubernetes.io/instance-type: e2-standard-2
      beta.kubernetes.io/os: linux
      cloud.google.com/metadata-proxy-ready: "true"
      failure-domain.beta.kubernetes.io/region: us-central1
      failure-domain.beta.kubernetes.io/zone: us-central1-b
      kubernetes.io/arch: amd64
      kubernetes.io/hostname: bootstrap-e2e-master
      kubernetes.io/os: linux
      node.kubernetes.io/instance-type: e2-standard-2
      topology.kubernetes.io/region: us-central1
      topology.kubernetes.io/zone: us-central1-b
    name: bootstrap-e2e-master
    resourceVersion: "726"
    uid: 36054c32-3c5c-462f-a8e6-880068c673f4
  spec:
    podCIDR: 10.64.0.0/24
    podCIDRs:
    - 10.64.0.0/24
    providerID: gce://k8s-infra-e2e-boskos-gpu-03/us-central1-b/bootstrap-e2e-master
    taints:
    - effect: NoSchedule
      key: node-role.kubernetes.io/control-plane
    - effect: NoSchedule
      key: node.kubernetes.io/unschedulable
    unschedulable: true
```

The master node doesn't have `node-role.kubernetes.io/control-plane` label.

After https://github.com/kubernetes/kubernetes/pull/122384 is merged and [flags+=" --register-schedulable=false](https://github.com/kubernetes/kubernetes/pull/122384/files#diff-09816a4dd2fd3cf28f97bf9f34330a66336c631830b103d0c96d71eb632dab0dL797) is removed. This is the reason why the test is failing. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #132397


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
