### PR TITLE
Refactor(hpa): extract common metric target validation logic

### DIFF
--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -327,10 +327,7 @@ func validateObjectSource(src *autoscaling.ObjectMetricSource, fldPath *field.Pa
 	allErrs = append(allErrs, ValidateCrossVersionObjectReference(src.DescribedObject, fldPath.Child("describedObject"))...)
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
-
-	if src.Target.Value == nil && src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must set either a target value or averageValue"))
-	}
+	allErrs = append(allErrs, validateValueOrAverageValue(src.Target, fldPath.Child("target"))...)
 
 	return allErrs
 }
@@ -340,14 +337,7 @@ func validateExternalSource(src *autoscaling.ExternalMetricSource, fldPath *fiel
 
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
-
-	if src.Target.Value == nil && src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must set either a target value for metric or a per-pod target"))
-	}
-
-	if src.Target.Value != nil && src.Target.AverageValue != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("target").Child("value"), "may not set both a target value for metric and a per-pod target"))
-	}
+	allErrs = append(allErrs, validateValueOrAverageValue(src.Target, fldPath.Child("target"))...)
 
 	return allErrs
 }
@@ -381,14 +371,7 @@ func validateContainerResourceSource(src *autoscaling.ContainerResourceMetricSou
 	}
 
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
-
-	if src.Target.AverageUtilization == nil && src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageUtilization"), "must set either a target raw value or a target utilization"))
-	}
-
-	if src.Target.AverageUtilization != nil && src.Target.AverageValue != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("target").Child("averageValue"), "may not set both a target raw value and a target utilization"))
-	}
+	allErrs = append(allErrs, validateUtilizationOrAverageValue(src.Target, fldPath.Child("target"))...)
 
 	return allErrs
 }
@@ -401,14 +384,7 @@ func validateResourceSource(src *autoscaling.ResourceMetricSource, fldPath *fiel
 	}
 
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
-
-	if src.Target.AverageUtilization == nil && src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageUtilization"), "must set either a target raw value or a target utilization"))
-	}
-
-	if src.Target.AverageUtilization != nil && src.Target.AverageValue != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("target").Child("averageValue"), "may not set both a target raw value and a target utilization"))
-	}
+	allErrs = append(allErrs, validateUtilizationOrAverageValue(src.Target, fldPath.Child("target"))...)
 
 	return allErrs
 }
@@ -450,6 +426,41 @@ func validateMetricIdentifier(id autoscaling.MetricIdentifier, fldPath *field.Pa
 		for _, msg := range pathvalidation.IsValidPathSegmentName(id.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), id.Name, msg))
 		}
+	}
+	return allErrs
+}
+
+func validateValueOrAverageValue(target autoscaling.MetricTarget, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if target.Value == nil && target.AverageValue == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("averageValue"),
+			"must set either a target value or averageValue"))
+	}
+
+	if target.Value != nil && target.AverageValue != nil {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("value"),
+			"must not set both a target value or averageValue"))
+	}
+
+	return allErrs
+}
+
+func validateUtilizationOrAverageValue(target autoscaling.MetricTarget, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if target.AverageUtilization == nil && target.AverageValue == nil {
+		allErrs = append(allErrs, field.Required(
+			fldPath.Child("averageUtilization"),
+			"must set either a target raw value or a target utilization",
+		))
+	}
+
+	if target.AverageUtilization != nil && target.AverageValue != nil {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath.Child("averageValue"),
+			"must not set both a target raw value and a target utilization",
+		))
 	}
 	return allErrs
 }

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -842,7 +842,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				}},
 			},
 		},
-		msg: "may not set both a target raw value and a target utilization",
+		msg: "must not set both a target raw value and a target utilization",
 	}, {
 		horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
@@ -867,7 +867,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				}},
 			},
 		},
-		msg: "may not set both a target raw value and a target utilization",
+		msg: "must not set both a target raw value and a target utilization",
 	}, {
 		horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
@@ -1231,7 +1231,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					}},
 				},
 			},
-			msg: "must set either a target value for metric or a per-pod target",
+			msg: "must set either a target value or averageValue",
 		}, {
 			horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
@@ -1301,7 +1301,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					}},
 				},
 			},
-			msg: "may not set both a target value for metric and a per-pod target",
+			msg: "must not set both a target value or averageValue",
 		}, {
 			horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- This PR refactors the validation logic for various metric sources in the Horizontal Pod Autoscaler (HPA), extracting common validation patterns into reusable functions.

Previously, similar checks for mutually exclusive fields such as `Value`/`AverageValue` and `AverageUtilization`/`AverageValue` were duplicated across multiple validation functions like `validateExternalSource`, `validateResourceSource`, etc. This change consolidates that logic into shared validators to improve code maintainability and readability.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
