### PR TITLE
imageMaximumGCAge download /remove loop with CreateContainerConfigError state

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -37,6 +37,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"
@@ -68,6 +69,14 @@ type PostImageGCHook func(ctx context.Context, remainingImages []string, gcStart
 type StatsProvider interface {
 	// ImageFsStats returns the stats of the image filesystem.
 	ImageFsStats(ctx context.Context) (*statsapi.FsStats, *statsapi.FsStats, error)
+}
+
+// PodGetter returns the list of pods. When provided to ImageGCManager, images
+// referenced by non-terminal pods (including those in CreateContainerConfigError
+// where no container exists in the runtime) are considered in use to prevent
+// the imageMaximumGCAge download/remove loop.
+type PodGetter interface {
+	GetPods() []*v1.Pod
 }
 
 // ImageGCManager is an interface for managing lifecycle of all images.
@@ -109,6 +118,11 @@ type ImageGCPolicy struct {
 type realImageGCManager struct {
 	// Container runtime
 	runtime container.Runtime
+
+	// Optional: when set, images referenced by non-terminal pods are considered
+	// in use. This fixes the CreateContainerConfigError case where the image
+	// was pulled but no container exists in the runtime.
+	podGetter PodGetter
 
 	// Records of images and their use. Indexed by ImageId.
 	// If RuntimeClassInImageCriAPI feature gate is enabled, imageRecords
@@ -192,7 +206,9 @@ type imageRecord struct {
 }
 
 // NewImageGCManager instantiates a new ImageGCManager object.
-func NewImageGCManager(runtime container.Runtime, statsProvider StatsProvider, postGCHooks []PostImageGCHook, recorder record.EventRecorder, nodeRef *v1.ObjectReference, policy ImageGCPolicy, tracerProvider trace.TracerProvider) (ImageGCManager, error) {
+// podGetter is optional; when provided, images referenced by non-terminal pods
+// (e.g. CreateContainerConfigError) are considered in use to prevent GC loops.
+func NewImageGCManager(runtime container.Runtime, statsProvider StatsProvider, postGCHooks []PostImageGCHook, recorder record.EventRecorder, nodeRef *v1.ObjectReference, policy ImageGCPolicy, tracerProvider trace.TracerProvider, podGetter PodGetter) (ImageGCManager, error) {
 	// Validate policy.
 	if policy.HighThresholdPercent < 0 || policy.HighThresholdPercent > 100 {
 		return nil, fmt.Errorf("invalid HighThresholdPercent %d, must be in range [0-100]", policy.HighThresholdPercent)
@@ -206,6 +222,7 @@ func NewImageGCManager(runtime container.Runtime, statsProvider StatsProvider, p
 	tracer := tracerProvider.Tracer(instrumentationScope)
 	im := &realImageGCManager{
 		runtime:       runtime,
+		podGetter:     podGetter,
 		policy:        policy,
 		imageRecords:  make(map[string]*imageRecord),
 		statsProvider: statsProvider,
@@ -373,6 +390,36 @@ func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.
 					"containerName", container.Name,
 					"containerState", container.State)
 			}
+		}
+	}
+
+	// Consider images referenced by non-terminal pods (desired state). This fixes
+	// the CreateContainerConfigError case: the image was pulled but container
+	// creation failed, so no container exists in the runtime. Without this, the
+	// image would be GC'd and re-pulled repeatedly.
+	if im.podGetter != nil {
+		for _, pod := range im.podGetter.GetPods() {
+			if podutil.IsPodTerminal(pod) {
+				continue
+			}
+			podutil.VisitContainers(&pod.Spec, podutil.AllFeatureEnabledContainers(), func(c *v1.Container, _ podutil.ContainerType) bool {
+				imageRef, err := im.runtime.GetImageRef(ctx, container.ImageSpec{Image: c.Image})
+				if err != nil || imageRef == "" {
+					return true
+				}
+				if !isRuntimeClassInImageCriAPIEnabled {
+					imagesInUse.Insert(imageRef)
+				} else {
+					// Match all images with this ID (any runtime handler) since we don't have container-level runtime info.
+					for _, img := range images {
+						if img.ID == imageRef {
+							imagesInUse.Insert(getImageTuple(img.ID, img.Spec.RuntimeHandler))
+						}
+					}
+				}
+				logger.V(5).Info("Pod spec references image (e.g. CreateContainerConfigError)", "pod", klog.KRef(pod.Namespace, pod.Name), "containerName", c.Name, "imageID", imageRef)
+				return true
+			})
 		}
 	}
 

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -241,6 +241,30 @@ func (im *realImageGCManager) GetImageList() ([]container.Image, error) {
 	return im.imageCache.get(), nil
 }
 
+// isContainerActuallyUsingImage determines if a container is actually using its image.
+// Containers in error states or not running are not considered to be using their image
+// for garbage collection purposes.
+func isContainerActuallyUsingImage(container *container.Container) bool {
+	// Only consider containers that are actually running or in a valid state
+	// that indicates they are using the image
+	switch container.State {
+	case "running":
+		return true
+	case "created":
+		// Created containers may be using the image but haven't started yet
+		return true
+	case "exited":
+		// Exited containers are not currently using the image
+		return false
+	case "unknown":
+		// Unknown state containers are not considered to be using the image
+		return false
+	default:
+		// For any other state, be conservative and assume they're not using the image
+		return false
+	}
+}
+
 func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.Time) (sets.Set[string], error) {
 	logger := klog.FromContext(ctx)
 	isRuntimeClassInImageCriAPIEnabled := utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClassInImageCriAPI)
@@ -258,6 +282,16 @@ func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.
 	// Make a set of images in use by containers.
 	for _, pod := range pods {
 		for _, container := range pod.Containers {
+			// Skip containers that are not actually using the image
+			// This includes containers in error states like CreateContainerConfigError
+			if !isContainerActuallyUsingImage(container) {
+				klog.V(5).InfoS("Skipping container for image usage, container not actually using image",
+					"pod", klog.KRef(pod.Namespace, pod.Name),
+					"containerName", container.Name,
+					"containerState", container.State)
+				continue
+			}
+
 			if err := im.handleImageVolumes(ctx, imagesInUse, container, pod, images); err != nil {
 				return imagesInUse, err
 			}

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -186,6 +186,9 @@ type imageRecord struct {
 
 	// Pinned status of the image
 	pinned bool
+
+	// Reserved for restart indicates if this image is reserved for containers that will be restarted
+	reservedForRestart bool
 }
 
 // NewImageGCManager instantiates a new ImageGCManager object.
@@ -262,6 +265,60 @@ func isContainerActuallyUsingImage(c *container.Container) bool {
 	}
 }
 
+// willContainerRestart determines if a container in its current state will be restarted.
+// This is used to decide whether to reserve the container's image from garbage collection.
+func willContainerRestart(c *container.Container) bool {
+	switch c.State {
+	case container.ContainerStateUnknown:
+		// Unknown state containers are always restarted according to ShouldContainerBeRestarted logic
+		return true
+	case container.ContainerStateCreated:
+		// Created containers are always restarted according to ShouldContainerBeRestarted logic
+		return true
+	case container.ContainerStateExited:
+		// Exited containers may be restarted depending on restart policy
+		// We use a conservative approach and assume they will be restarted
+		// This prevents GC of images for containers that might restart
+		return true
+	case container.ContainerStateRunning:
+		// Running containers don't need restart
+		return false
+	default:
+		// For any other state, be conservative and assume they will be restarted
+		return true
+	}
+}
+
+// reserveImageForRestart marks an image as reserved for container restart to prevent garbage collection.
+func (im *realImageGCManager) reserveImageForRestart(imageID, runtimeHandler string, isRuntimeClassInImageCriAPIEnabled bool) {
+	im.imageRecordsLock.Lock()
+	defer im.imageRecordsLock.Unlock()
+
+	imageKey := imageID
+	if isRuntimeClassInImageCriAPIEnabled {
+		imageKey = getImageTuple(imageID, runtimeHandler)
+	}
+
+	if record, exists := im.imageRecords[imageKey]; exists {
+		record.reservedForRestart = true
+		record.lastUsed = time.Now() // Update last used time to prevent immediate GC
+	}
+}
+
+// clearReservationsForImagesInUse clears reservations for images that are now actively in use.
+func (im *realImageGCManager) clearReservationsForImagesInUse(imagesInUse sets.Set[string]) {
+	im.imageRecordsLock.Lock()
+	defer im.imageRecordsLock.Unlock()
+
+	for imageKey := range im.imageRecords {
+		if isImageUsed(imageKey, imagesInUse) {
+			if record, exists := im.imageRecords[imageKey]; exists && record.reservedForRestart {
+				record.reservedForRestart = false
+			}
+		}
+	}
+}
+
 func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.Time) (sets.Set[string], error) {
 	logger := klog.FromContext(ctx)
 	isRuntimeClassInImageCriAPIEnabled := utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClassInImageCriAPI)
@@ -276,33 +333,51 @@ func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.
 		return imagesInUse, err
 	}
 
-	// Make a set of images in use by containers.
+	// Make a set of images in use by containers and track reservations for restarting containers.
 	for _, pod := range pods {
 		for _, container := range pod.Containers {
-			// Skip containers that are not actually using the image
-			// This includes containers in error states like CreateContainerConfigError
-			if !isContainerActuallyUsingImage(container) {
-				klog.V(5).InfoS("Skipping container for image usage, container not actually using image",
+			// Check if container is actually using the image
+			containerUsingImage := isContainerActuallyUsingImage(container)
+
+			// Check if container will be restarted (needs image reservation)
+			containerWillRestart := willContainerRestart(container)
+
+			if containerUsingImage {
+				// Container is actively using the image - mark as in use
+				if err := im.handleImageVolumes(ctx, imagesInUse, container, pod, images); err != nil {
+					return imagesInUse, err
+				}
+
+				if !isRuntimeClassInImageCriAPIEnabled {
+					logger.V(5).Info("Container uses image", "pod", klog.KRef(pod.Namespace, pod.Name), "containerName", container.Name, "containerImage", container.Image, "imageID", container.ImageID, "imageRef", container.ImageRef)
+					imagesInUse.Insert(container.ImageID)
+				} else {
+					imageKey := getImageTuple(container.ImageID, container.ImageRuntimeHandler)
+					logger.V(5).Info("Container uses image", "pod", klog.KRef(pod.Namespace, pod.Name), "containerName", container.Name, "containerImage", container.Image, "imageID", container.ImageID, "imageRef", container.ImageRef, "imageKey", imageKey)
+					imagesInUse.Insert(imageKey)
+				}
+			} else if containerWillRestart {
+				// Container is not using the image but will be restarted - reserve the image
+				logger.V(5).Info("Reserving image for container restart",
+					"pod", klog.KRef(pod.Namespace, pod.Name),
+					"containerName", container.Name,
+					"containerState", container.State,
+					"imageID", container.ImageID)
+
+				// Mark image as reserved for restart
+				im.reserveImageForRestart(container.ImageID, container.ImageRuntimeHandler, isRuntimeClassInImageCriAPIEnabled)
+			} else {
+				// Container is not using the image and won't be restarted - safe to skip
+				logger.V(5).Info("Skipping container for image usage, container not using image and won't restart",
 					"pod", klog.KRef(pod.Namespace, pod.Name),
 					"containerName", container.Name,
 					"containerState", container.State)
-				continue
-			}
-
-			if err := im.handleImageVolumes(ctx, imagesInUse, container, pod, images); err != nil {
-				return imagesInUse, err
-			}
-
-			if !isRuntimeClassInImageCriAPIEnabled {
-				logger.V(5).Info("Container uses image", "pod", klog.KRef(pod.Namespace, pod.Name), "containerName", container.Name, "containerImage", container.Image, "imageID", container.ImageID, "imageRef", container.ImageRef)
-				imagesInUse.Insert(container.ImageID)
-			} else {
-				imageKey := getImageTuple(container.ImageID, container.ImageRuntimeHandler)
-				logger.V(5).Info("Container uses image", "pod", klog.KRef(pod.Namespace, pod.Name), "containerName", container.Name, "containerImage", container.Image, "imageID", container.ImageID, "imageRef", container.ImageRef, "imageKey", imageKey)
-				imagesInUse.Insert(imageKey)
 			}
 		}
 	}
+
+	// Clear reservations for images that are now actively in use
+	im.clearReservationsForImagesInUse(imagesInUse)
 
 	// Add new images and record those being used.
 	now := time.Now()
@@ -599,7 +674,11 @@ func (im *realImageGCManager) imagesInEvictionOrder(ctx context.Context, freeTim
 		if record.pinned {
 			logger.V(5).Info("Image is pinned, skipping garbage collection", "imageID", image)
 			continue
-
+		}
+		// Check if image is reserved for container restart, prevent garbage collection
+		if record.reservedForRestart {
+			logger.V(5).Info("Image is reserved for container restart, skipping garbage collection", "imageID", image)
+			continue
 		}
 		if !isRuntimeClassInImageCriAPIEnabled {
 			images = append(images, evictionInfo{

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -244,20 +244,17 @@ func (im *realImageGCManager) GetImageList() ([]container.Image, error) {
 // isContainerActuallyUsingImage determines if a container is actually using its image.
 // Containers in error states or not running are not considered to be using their image
 // for garbage collection purposes.
-func isContainerActuallyUsingImage(container *container.Container) bool {
+func isContainerActuallyUsingImage(c *container.Container) bool {
 	// Only consider containers that are actually running or in a valid state
 	// that indicates they are using the image
-	switch container.State {
-	case "running":
+	switch c.State {
+	case container.ContainerStateRunning:
 		return true
-	case "created":
-		// Created containers may be using the image but haven't started yet
+	case container.ContainerStateCreated:
 		return true
-	case "exited":
-		// Exited containers are not currently using the image
+	case container.ContainerStateExited:
 		return false
-	case "unknown":
-		// Unknown state containers are not considered to be using the image
+	case container.ContainerStateUnknown:
 		return false
 	default:
 		// For any other state, be conservative and assume they're not using the image

--- a/pkg/kubelet/images/image_gc_manager_test.go
+++ b/pkg/kubelet/images/image_gc_manager_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	noopoteltrace "go.opentelemetry.io/otel/trace/noop"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -55,6 +57,14 @@ func newRealImageGCManager(policy ImageGCPolicy, mockStatsProvider stats.Provide
 		recorder:      &record.FakeRecorder{},
 		tracer:        noopoteltrace.NewTracerProvider().Tracer(""),
 	}, fakeRuntime
+}
+
+type fakePodGetter struct {
+	pods []*v1.Pod
+}
+
+func (f *fakePodGetter) GetPods() []*v1.Pod {
+	return f.pods
 }
 
 // Accessors used for thread-safe testing.
@@ -427,6 +437,46 @@ func TestDetectImagesContainerStopped(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(zero, container2.firstDetected)
 	assert.True(container2.lastUsed.Equal(withContainer.lastUsed))
+}
+
+func TestDetectImagesWithPodSpecReferencingImageCreateContainerConfigError(t *testing.T) {
+	// Simulates CreateContainerConfigError: image was pulled but no container exists
+	// in the runtime. The pod spec references the image. Without PodGetter, the image
+	// would be GC'd and re-pulled repeatedly.
+	ctx := ktesting.Init(t)
+	mockStatsProvider := statstest.NewMockProvider(t)
+
+	manager, fakeRuntime := newRealImageGCManager(ImageGCPolicy{}, mockStatsProvider)
+	fakeRuntime.ImageList = []container.Image{
+		makeImage(0, 1024),
+		makeImage(1, 2048),
+	}
+	// No containers in runtime - simulating CreateContainerConfigError
+	fakeRuntime.AllPodList = []*containertest.FakePod{}
+
+	// PodGetter returns a non-terminal pod that references image-1
+	manager.podGetter = &fakePodGetter{
+		pods: []*v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Status:     v1.PodStatus{Phase: v1.PodPending},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "test", Image: imageID(1)},
+					},
+				},
+			},
+		},
+	}
+
+	imagesInUse, err := manager.detectImages(ctx, zero)
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.True(imagesInUse.Has(imageID(1)), "image referenced by pod spec should be in use")
+	// lastUsed should be updated for the image
+	record, ok := manager.getImageRecord(imageID(1))
+	require.True(t, ok)
+	assert.False(record.lastUsed.Equal(zero), "lastUsed should be set for pod-spec-referenced image")
 }
 
 func TestDetectImagesWithRemovedImages(t *testing.T) {
@@ -942,7 +992,7 @@ func TestValidateImageGCPolicy(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if _, err := NewImageGCManager(nil, nil, nil, nil, nil, tc.imageGCPolicy, noopoteltrace.NewTracerProvider()); err != nil {
+		if _, err := NewImageGCManager(nil, nil, nil, nil, nil, tc.imageGCPolicy, noopoteltrace.NewTracerProvider(), nil); err != nil {
 			if err.Error() != tc.expectErr {
 				t.Errorf("[%s:]Expected err:%v, but got:%v", tc.name, tc.expectErr, err.Error())
 			}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -891,7 +891,7 @@ func NewMainKubelet(ctx context.Context,
 	klet.containerDeletor = newPodContainerDeletor(klet.containerRuntime, max(containerGCPolicy.MaxPerPodContainer, minDeadContainerInPod))
 
 	// setup imageManager
-	imageManager, err := images.NewImageGCManager(klet.containerRuntime, klet.StatsProvider, postImageGCHooks, kubeDeps.Recorder, nodeRef, imageGCPolicy, kubeDeps.TracerProvider)
+	imageManager, err := images.NewImageGCManager(klet.containerRuntime, klet.StatsProvider, postImageGCHooks, kubeDeps.Recorder, nodeRef, imageGCPolicy, kubeDeps.TracerProvider, klet)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize image manager: %v", err)
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -359,7 +359,7 @@ func newTestKubeletWithImageList(
 		HighThresholdPercent: 90,
 		LowThresholdPercent:  80,
 	}
-	imageGCManager, err := images.NewImageGCManager(fakeRuntime, kubelet.StatsProvider, nil, fakeRecorder, fakeNodeRef, fakeImageGCPolicy, noopoteltrace.NewTracerProvider())
+	imageGCManager, err := images.NewImageGCManager(fakeRuntime, kubelet.StatsProvider, nil, fakeRecorder, fakeNodeRef, fakeImageGCPolicy, noopoteltrace.NewTracerProvider(), nil)
 	assert.NoError(t, err)
 	kubelet.imageManager = &fakeImageGCManager{
 		fakeImageService: fakeRuntime,


### PR DESCRIPTION
<!--  
Thanks for sending a pull request! Please read the guidelines:
https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution  
https://git.k8s.io/community/contributors/devel/development.md#development-guide  
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes an issue where images used by containers in error states (such as `CreateContainerConfigError`) were repeatedly garbage collected and re-downloaded, causing unnecessary network traffic and resource usage.  
The image garbage collection logic now excludes containers that are not actually using their images (i.e., not in "running" or "created" state), preventing images referenced by error-state containers from being considered "in use."  
This avoids the download/remove loop and reduces unnecessary image pulls.

#### Which issue(s) this PR is related to:

Fixes #132403

#### Special notes for your reviewer:

- The fix introduces a helper function to determine if a container is actually using its image.
- Unit tests and image GC tests have been updated to reflect the new logic.
- Please review the test changes to ensure they align with the intended behavior.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet: Fixes an issue where images used by containers in error states (e.g., CreateContainerConfigError) were repeatedly garbage collected and re-downloaded, causing high network traffic. Images are now only considered "in use" if the container is actually running or created.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```