### PR TITLE
Replaced deprecated pointer pkg with new ptr pkg on src/apimachinery

### DIFF
--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"k8s.io/klog/v2"
@@ -73,8 +72,8 @@ func TestNewNodeLease(t *testing.T) {
 					Namespace: corev1.NamespaceNodeLease,
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr(node.Name),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To(node.Name),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now()},
 				},
 			},
@@ -103,8 +102,8 @@ func TestNewNodeLease(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr(node.Name),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To(node.Name),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now()},
 				},
 			},
@@ -123,8 +122,8 @@ func TestNewNodeLease(t *testing.T) {
 					Namespace: corev1.NamespaceNodeLease,
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr(node.Name),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To(node.Name),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-10 * time.Second)},
 				},
 			},
@@ -142,8 +141,8 @@ func TestNewNodeLease(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr(node.Name),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To(node.Name),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now()},
 				},
 			},
@@ -170,8 +169,8 @@ func TestNewNodeLease(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr(node.Name),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To(node.Name),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-10 * time.Second)},
 				},
 			},
@@ -189,8 +188,8 @@ func TestNewNodeLease(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr(node.Name),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To(node.Name),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now()},
 				},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This Pull Request replaces the deprecated package `k8s.io/utils/pointer` with the new `k8s.io/utils/ptr` on the components-helper for the apimachinery.

#### Which issue(s) this PR is related to:
As this is a long on-going effort, this PR does not closes a specific issue.
But it's related to #132086

Fixes #<issue number>

#### Special notes for your reviewer:
In actually modified file there has already been migration happening from the old to the new package.
`LeaseDurationSeconds: ptr.To[int32](10),`

I choosed to follow this convention, as instead using the other option as 
`LeaseDurationSeconds: ptr.To(int32(10)),`

We should think about using the variation : `ptr.To(int32(10))`.

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the components-helper of the apimachinery. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
