### PR TITLE
Kubectl run fix container

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -458,7 +458,6 @@ func waitForPod(podClient corev1client.PodsGetter, ns, name string, timeout time
 }
 
 func handleAttachPod(f cmdutil.Factory, podClient corev1client.PodsGetter, ns, name string, opts *attach.AttachOptions) error {
-	// pod, err := waitForPod(podClient, ns, name, opts.GetPodTimeout, podRunningAndReady)
 	pod, err := waitForPod(podClient, ns, name, opts.GetPodTimeout, mainContainerRunning)
 	if err != nil && err != ErrPodCompleted {
 		return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -54,7 +54,6 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/interrupt"
 	"k8s.io/kubectl/pkg/util/templates"
-	uexec "k8s.io/utils/exec"
 )
 
 var (
@@ -367,9 +366,9 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 			// we need different exit condition depending on restart policy
 			// for Never it can either fail or succeed, for OnFailure only
 			// success matters
-			exitCondition := podCompleted
+			exitCondition := mainContainerTerminated
 			if restartPolicy == corev1.RestartPolicyOnFailure {
-				exitCondition = podSucceeded
+				exitCondition = mainContainerSucceeded
 			}
 			pod, err = waitForPod(clientset.CoreV1(), attachablePod.Namespace, attachablePod.Name, opts.GetPodTimeout, exitCondition)
 			if err != nil {
@@ -380,25 +379,16 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 			return nil
 		}
 
-		switch pod.Status.Phase {
-		case corev1.PodSucceeded:
-			return nil
-		case corev1.PodFailed:
-			unknownRcErr := fmt.Errorf("pod %s/%s failed with unknown exit code", pod.Namespace, pod.Name)
-			if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {
-				return unknownRcErr
+		for _, container := range pod.Status.ContainerStatuses {
+			if container.Name == pod.Name {
+				if container.State.Terminated != nil {
+					if container.State.Terminated.ExitCode == 0 {
+						return nil
+					} else {
+						return fmt.Errorf("pod %s/%s terminated (%s)\n%s", pod.Namespace, pod.Name, container.State.Terminated.Reason, container.State.Terminated.Message)
+					}
+				}
 			}
-			// assume here that we have at most one status because kubectl-run only creates one container per pod
-			rc := pod.Status.ContainerStatuses[0].State.Terminated.ExitCode
-			if rc == 0 {
-				return unknownRcErr
-			}
-			return uexec.CodeExitError{
-				Err:  fmt.Errorf("pod %s/%s terminated (%s)\n%s", pod.Namespace, pod.Name, pod.Status.ContainerStatuses[0].State.Terminated.Reason, pod.Status.ContainerStatuses[0].State.Terminated.Message),
-				Code: int(rc),
-			}
-		default:
-			return fmt.Errorf("pod %s/%s left in phase %s", pod.Namespace, pod.Name, pod.Status.Phase)
 		}
 
 	}
@@ -468,7 +458,8 @@ func waitForPod(podClient corev1client.PodsGetter, ns, name string, timeout time
 }
 
 func handleAttachPod(f cmdutil.Factory, podClient corev1client.PodsGetter, ns, name string, opts *attach.AttachOptions) error {
-	pod, err := waitForPod(podClient, ns, name, opts.GetPodTimeout, podRunningAndReady)
+	// pod, err := waitForPod(podClient, ns, name, opts.GetPodTimeout, podRunningAndReady)
+	pod, err := waitForPod(podClient, ns, name, opts.GetPodTimeout, mainContainerRunning)
 	if err != nil && err != ErrPodCompleted {
 		return err
 	}
@@ -712,6 +703,63 @@ func podRunningAndReady(event watch.Event) (bool, error) {
 					conditions[i].Status == corev1.ConditionTrue {
 					return true, nil
 				}
+			}
+		}
+	}
+	return false, nil
+}
+
+// mainContainerRunning returns true if the main container is running
+func mainContainerRunning(event watch.Event) (bool, error) {
+	switch event.Type {
+	case watch.Deleted:
+		return false, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "")
+	}
+	switch t := event.Object.(type) {
+	case *corev1.Pod:
+		// in kubectl run, the container name is the same as the pod name
+		containerName := event.Object.(*corev1.Pod).Name
+		for _, container := range t.Status.ContainerStatuses {
+			if container.Name == containerName && container.State.Running != nil {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// mainContainerSucceeded returns true if the main container has run to completion and exited successfully
+func mainContainerSucceeded(event watch.Event) (bool, error) {
+	switch event.Type {
+	case watch.Deleted:
+		return false, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "")
+	}
+	switch t := event.Object.(type) {
+	case *corev1.Pod:
+		containerName := event.Object.(*corev1.Pod).Name
+		for _, container := range t.Status.ContainerStatuses {
+			if container.Name == containerName && container.State.Terminated != nil {
+				if container.State.Terminated.ExitCode == 0 {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+// mainContainerTerminated returns true if the main container has run to completion, no matter exited successfully or not
+func mainContainerTerminated(event watch.Event) (bool, error) {
+	switch event.Type {
+	case watch.Deleted:
+		return false, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "")
+	}
+	switch t := event.Object.(type) {
+	case *corev1.Pod:
+		containerName := event.Object.(*corev1.Pod).Name
+		for _, container := range t.Status.ContainerStatuses {
+			if container.Name == containerName && container.State.Terminated != nil {
+				return true, nil
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
When we use kubectl run to run a pod, if we use the --attach, --rm, and --restart=Never parameters, we expect to print the execution output of the pod during its execution and automatically delete the pod after completion. Typically, the pod created this way has a container with the same name as the pod, which works fine. However, when our namespace has Istio sidecar injection enabled by default, and we also want the pod created by kubectl run to inject the Istio sidecar, the timing for determining when to attach and when to determine if execution is complete should not be based on the pod's status, but rather should be based on the status of the container that has the same name as the pod。

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
