### PR TITLE
feat(kubelet): migrate kuberuntime to contextual logging

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1239,7 +1239,8 @@ func RunKubelet(ctx context.Context, kubeServer *options.KubeletServer, kubeDeps
 		kubeDeps.OSInterface = kubecontainer.RealOS{}
 	}
 
-	k, err := createAndInitKubelet(kubeServer,
+	k, err := createAndInitKubelet(ctx,
+		kubeServer,
 		kubeDeps,
 		hostname,
 		nodeName,
@@ -1279,7 +1280,9 @@ func startKubelet(ctx context.Context, k kubelet.Bootstrap, podCfg *config.PodCo
 	go k.ListenAndServePodResources(ctx)
 }
 
-func createAndInitKubelet(kubeServer *options.KubeletServer,
+func createAndInitKubelet(
+	ctx context.Context,
+	kubeServer *options.KubeletServer,
 	kubeDeps *kubelet.Dependencies,
 	hostname string,
 	nodeName types.NodeName,
@@ -1287,7 +1290,9 @@ func createAndInitKubelet(kubeServer *options.KubeletServer,
 	// TODO: block until all sources have delivered at least one update to the channel, or break the sync loop
 	// up into "per source" synchronizations
 
-	k, err = kubelet.NewMainKubelet(&kubeServer.KubeletConfiguration,
+	k, err = kubelet.NewMainKubelet(
+		ctx,
+		&kubeServer.KubeletConfiguration,
 		kubeDeps,
 		&kubeServer.ContainerRuntimeOptions,
 		hostname,

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -213,6 +213,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/sysctl/.*
             contextual k8s.io/kubernetes/pkg/kubelet/apis/.*
             contextual k8s.io/kubernetes/pkg/kubelet/kubeletconfig/.*
+            contextual k8s.io/kubernetes/pkg/kubelet/kuberuntime/.*
             contextual k8s.io/kubernetes/pkg/kubelet/nodeshutdown/.*
             contextual k8s.io/kubernetes/pkg/kubelet/pod/.*
             contextual k8s.io/kubernetes/pkg/kubelet/preemption/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -227,6 +227,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/sysctl/.*
             contextual k8s.io/kubernetes/pkg/kubelet/apis/.*
             contextual k8s.io/kubernetes/pkg/kubelet/kubeletconfig/.*
+            contextual k8s.io/kubernetes/pkg/kubelet/kuberuntime/.*
             contextual k8s.io/kubernetes/pkg/kubelet/nodeshutdown/.*
             contextual k8s.io/kubernetes/pkg/kubelet/pod/.*
             contextual k8s.io/kubernetes/pkg/kubelet/preemption/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -59,6 +59,7 @@ contextual k8s.io/kubernetes/pkg/kubelet/status/.*
 contextual k8s.io/kubernetes/pkg/kubelet/sysctl/.*
 contextual k8s.io/kubernetes/pkg/kubelet/apis/.*
 contextual k8s.io/kubernetes/pkg/kubelet/kubeletconfig/.*
+contextual k8s.io/kubernetes/pkg/kubelet/kuberuntime/.*
 contextual k8s.io/kubernetes/pkg/kubelet/nodeshutdown/.*
 contextual k8s.io/kubernetes/pkg/kubelet/pod/.*
 contextual k8s.io/kubernetes/pkg/kubelet/preemption/.*

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -408,7 +408,8 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration, 
 
 // NewMainKubelet instantiates a new Kubelet object along with all the required internal modules.
 // No initialization of Kubelet and its modules should happen here.
-func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
+func NewMainKubelet(ctx context.Context,
+	kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	kubeDeps *Dependencies,
 	crOptions *config.ContainerRuntimeOptions,
 	hostname string,
@@ -434,7 +435,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeStatusMaxImages int32,
 	seccompDefault bool,
 ) (*Kubelet, error) {
-	ctx := context.Background()
 	logger := klog.FromContext(ctx)
 
 	if rootDirectory == "" {
@@ -753,6 +753,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	}
 
 	runtime, postImageGCHooks, err := kuberuntime.NewKubeGenericRuntimeManager(
+		ctx,
 		kubecontainer.FilterEventRecorder(kubeDeps.Recorder),
 		klet.livenessManager,
 		klet.readinessManager,

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3006,6 +3006,7 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 	crOptions := &config.ContainerRuntimeOptions{}
 
 	testMainKubelet, err := NewMainKubelet(
+		tCtx,
 		kubeCfg,
 		kubeDep,
 		crOptions,
@@ -3065,6 +3066,7 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 }
 
 func TestSyncPodSpans(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	testKubelet := newTestKubelet(t, false)
 	kubelet := testKubelet.kubelet
 
@@ -3105,6 +3107,7 @@ func TestSyncPodSpans(t *testing.T) {
 	assert.NoError(t, err)
 
 	kubelet.containerRuntime, _, err = kuberuntime.NewKubeGenericRuntimeManager(
+		tCtx,
 		kubelet.recorder,
 		kubelet.livenessManager,
 		kubelet.readinessManager,

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -95,8 +95,7 @@ func (f *fakePodPullingTimeRecorder) RecordImageStartedPulling(podUID types.UID)
 
 func (f *fakePodPullingTimeRecorder) RecordImageFinishedPulling(podUID types.UID) {}
 
-func newFakeKubeRuntimeManager(runtimeService internalapi.RuntimeService, imageService internalapi.ImageManagerService, machineInfo *cadvisorapi.MachineInfo, osInterface kubecontainer.OSInterface, runtimeHelper kubecontainer.RuntimeHelper, tracer trace.Tracer) (*kubeGenericRuntimeManager, error) {
-	ctx := context.Background()
+func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.RuntimeService, imageService internalapi.ImageManagerService, machineInfo *cadvisorapi.MachineInfo, osInterface kubecontainer.OSInterface, runtimeHelper kubecontainer.RuntimeHelper, tracer trace.Tracer) (*kubeGenericRuntimeManager, error) {
 	recorder := &record.FakeRecorder{}
 	logManager, err := logs.NewContainerLogManager(runtimeService, osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
 	if err != nil {
@@ -122,6 +121,9 @@ func newFakeKubeRuntimeManager(runtimeService internalapi.RuntimeService, imageS
 		podLogsDirectory:       fakePodLogsDirectory,
 		allocationManager:      allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
 	}
+
+	// Initialize swap controller availability check (always false for tests)
+	kubeRuntimeManager.getSwapControllerAvailable = func() bool { return false }
 
 	typedVersion, err := runtimeService.Version(ctx, kubeRuntimeAPIVersion)
 	if err != nil {

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -78,7 +78,7 @@ func toKubeContainerState(state runtimeapi.ContainerState) kubecontainer.State {
 }
 
 // toRuntimeProtocol converts v1.Protocol to runtimeapi.Protocol.
-func toRuntimeProtocol(protocol v1.Protocol) runtimeapi.Protocol {
+func toRuntimeProtocol(logger klog.Logger, protocol v1.Protocol) runtimeapi.Protocol {
 	switch protocol {
 	case v1.ProtocolTCP:
 		return runtimeapi.Protocol_TCP
@@ -88,12 +88,12 @@ func toRuntimeProtocol(protocol v1.Protocol) runtimeapi.Protocol {
 		return runtimeapi.Protocol_SCTP
 	}
 
-	klog.InfoS("Unknown protocol, defaulting to TCP", "protocol", protocol)
+	logger.Info("Unknown protocol, defaulting to TCP", "protocol", protocol)
 	return runtimeapi.Protocol_TCP
 }
 
 // toKubeContainer converts runtimeapi.Container to kubecontainer.Container.
-func (m *kubeGenericRuntimeManager) toKubeContainer(c *runtimeapi.Container) (*kubecontainer.Container, error) {
+func (m *kubeGenericRuntimeManager) toKubeContainer(ctx context.Context, c *runtimeapi.Container) (*kubecontainer.Container, error) {
 	if c == nil || c.Id == "" || c.Image == nil {
 		return nil, fmt.Errorf("unable to convert a nil pointer to a runtime container")
 	}
@@ -104,7 +104,7 @@ func (m *kubeGenericRuntimeManager) toKubeContainer(c *runtimeapi.Container) (*k
 		imageID = c.ImageId
 	}
 
-	annotatedInfo := getContainerInfoFromAnnotations(c.Annotations)
+	annotatedInfo := getContainerInfoFromAnnotations(ctx, c.Annotations)
 	return &kubecontainer.Container{
 		ID:                  kubecontainer.ContainerID{Type: m.runtimeName, ID: c.Id},
 		Name:                c.GetMetadata().GetName(),

--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -35,7 +36,8 @@ func seccompLocalhostRef(profileName string) string {
 }
 
 func TestGetSeccompProfile(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
 	unconfinedProfile := &runtimeapi.SecurityProfile{
@@ -135,7 +137,8 @@ func TestGetSeccompProfile(t *testing.T) {
 }
 
 func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
 	unconfinedProfile := &runtimeapi.SecurityProfile{

--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"context"
 	"net"
 	"net/http"
 	"testing"
@@ -28,6 +27,7 @@ import (
 	compbasemetrics "k8s.io/component-base/metrics"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestRecordOperation(t *testing.T) {
@@ -71,17 +71,17 @@ func TestRecordOperation(t *testing.T) {
 }
 
 func TestInstrumentedVersion(t *testing.T) {
-	ctx := context.Background()
-	fakeRuntime, _, _, _ := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, _, _ := createTestRuntimeManager(tCtx)
 	irs := newInstrumentedRuntimeService(fakeRuntime)
-	vr, err := irs.Version(ctx, "1")
+	vr, err := irs.Version(tCtx, "1")
 	assert.NoError(t, err)
 	assert.Equal(t, kubeRuntimeAPIVersion, vr.Version)
 }
 
 func TestStatus(t *testing.T) {
-	ctx := context.Background()
-	fakeRuntime, _, _, _ := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, _, _ := createTestRuntimeManager(tCtx)
 	fakeRuntime.FakeStatus = &runtimeapi.RuntimeStatus{
 		Conditions: []*runtimeapi.RuntimeCondition{
 			{Type: runtimeapi.RuntimeReady, Status: false},
@@ -89,7 +89,7 @@ func TestStatus(t *testing.T) {
 		},
 	}
 	irs := newInstrumentedRuntimeService(fakeRuntime)
-	actural, err := irs.Status(ctx, false)
+	actural, err := irs.Status(tCtx, false)
 	assert.NoError(t, err)
 	expected := &runtimeapi.RuntimeStatus{
 		Conditions: []*runtimeapi.RuntimeCondition{

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -81,10 +81,11 @@ var (
 // in particular, it ensures that a containerID never appears in an event message as that
 // is prone to causing a lot of distinct events that do not count well.
 // it replaces any reference to a containerID with the containerName which is stable, and is what users know.
-func (m *kubeGenericRuntimeManager) recordContainerEvent(pod *v1.Pod, container *v1.Container, containerID, eventType, reason, message string, args ...interface{}) {
+func (m *kubeGenericRuntimeManager) recordContainerEvent(ctx context.Context, pod *v1.Pod, container *v1.Container, containerID, eventType, reason, message string, args ...interface{}) {
+	logger := klog.FromContext(ctx)
 	ref, err := kubecontainer.GenerateContainerRef(pod, container)
 	if err != nil {
-		klog.ErrorS(err, "Can't make a container ref", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
+		logger.Error(err, "Can't make a container ref", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
 		return
 	}
 	eventMessage := message
@@ -196,6 +197,7 @@ func (m *kubeGenericRuntimeManager) getPodRuntimeHandler(pod *v1.Pod) (podRuntim
 // * start the container
 // * run the post start lifecycle hooks (if applicable)
 func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string, imageVolumes kubecontainer.ImageVolumes) (string, error) {
+	logger := klog.FromContext(ctx)
 	container := spec.container
 
 	// Step 1: pull the image.
@@ -206,13 +208,13 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 
 	ref, err := kubecontainer.GenerateContainerRef(pod, container)
 	if err != nil {
-		klog.ErrorS(err, "Couldn't make a ref to pod", "pod", klog.KObj(pod), "containerName", container.Name)
+		logger.Error(err, "Couldn't make a ref to pod", "pod", klog.KObj(pod), "containerName", container.Name)
 	}
 
 	imageRef, msg, err := m.imagePuller.EnsureImageExists(ctx, ref, pod, container.Image, pullSecrets, podSandboxConfig, podRuntimeHandler, container.ImagePullPolicy)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
-		m.recordContainerEvent(pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
+		m.recordContainerEvent(ctx, pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
 		return msg, err
 	}
 
@@ -236,7 +238,7 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 		logDir := BuildContainerLogsDirectory(m.podLogsDirectory, pod.Namespace, pod.Name, pod.UID, container.Name)
 		restartCount, err = calcRestartCountByLogDir(logDir)
 		if err != nil {
-			klog.InfoS("Cannot calculate restartCount from the log directory", "logDir", logDir, "err", err)
+			logger.Info("Cannot calculate restartCount from the log directory", "logDir", logDir, "err", err)
 			restartCount = 0
 		}
 	}
@@ -244,7 +246,7 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 	target, err := spec.getTargetID(podStatus)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
-		m.recordContainerEvent(pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
+		m.recordContainerEvent(ctx, pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
 		return s.Message(), ErrCreateContainerConfig
 	}
 
@@ -254,45 +256,45 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 	}
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
-		m.recordContainerEvent(pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
+		m.recordContainerEvent(ctx, pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
 		return s.Message(), ErrCreateContainerConfig
 	}
 
 	// When creating a container, mark the resources as actuated.
 	if err := m.allocationManager.SetActuatedResources(pod, container); err != nil {
-		m.recordContainerEvent(pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", err)
+		m.recordContainerEvent(ctx, pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", err)
 		return err.Error(), ErrCreateContainerConfig
 	}
 
 	err = m.internalLifecycle.PreCreateContainer(pod, container, containerConfig)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
-		m.recordContainerEvent(pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Internal PreCreateContainer hook failed: %v", s.Message())
+		m.recordContainerEvent(ctx, pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Internal PreCreateContainer hook failed: %v", s.Message())
 		return s.Message(), ErrPreCreateHook
 	}
 
 	containerID, err := m.runtimeService.CreateContainer(ctx, podSandboxID, containerConfig, podSandboxConfig)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
-		m.recordContainerEvent(pod, container, containerID, v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
+		m.recordContainerEvent(ctx, pod, container, containerID, v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", s.Message())
 		return s.Message(), ErrCreateContainer
 	}
 	err = m.internalLifecycle.PreStartContainer(pod, container, containerID)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
-		m.recordContainerEvent(pod, container, containerID, v1.EventTypeWarning, events.FailedToStartContainer, "Internal PreStartContainer hook failed: %v", s.Message())
+		m.recordContainerEvent(ctx, pod, container, containerID, v1.EventTypeWarning, events.FailedToStartContainer, "Internal PreStartContainer hook failed: %v", s.Message())
 		return s.Message(), ErrPreStartHook
 	}
-	m.recordContainerEvent(pod, container, containerID, v1.EventTypeNormal, events.CreatedContainer, "Created container: %v", container.Name)
+	m.recordContainerEvent(ctx, pod, container, containerID, v1.EventTypeNormal, events.CreatedContainer, "Created container: %v", container.Name)
 
 	// Step 3: start the container.
 	err = m.runtimeService.StartContainer(ctx, containerID)
 	if err != nil {
 		s, _ := grpcstatus.FromError(err)
-		m.recordContainerEvent(pod, container, containerID, v1.EventTypeWarning, events.FailedToStartContainer, "Error: %v", s.Message())
+		m.recordContainerEvent(ctx, pod, container, containerID, v1.EventTypeWarning, events.FailedToStartContainer, "Error: %v", s.Message())
 		return s.Message(), kubecontainer.ErrRunContainer
 	}
-	m.recordContainerEvent(pod, container, containerID, v1.EventTypeNormal, events.StartedContainer, "Started container %v", container.Name)
+	m.recordContainerEvent(ctx, pod, container, containerID, v1.EventTypeNormal, events.StartedContainer, "Started container %v", container.Name)
 
 	// Symlink container logs to the legacy container log location for cluster logging
 	// support.
@@ -308,7 +310,7 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 	// to create it in the first place. it happens when journald logging driver is used with docker.
 	if _, err := m.osInterface.Stat(containerLog); !os.IsNotExist(err) {
 		if err := m.osInterface.Symlink(containerLog, legacySymlink); err != nil {
-			klog.ErrorS(err, "Failed to create legacy symbolic link", "path", legacySymlink,
+			logger.Error(err, "Failed to create legacy symbolic link", "path", legacySymlink,
 				"containerID", containerID, "containerLogPath", containerLog)
 		}
 	}
@@ -321,12 +323,12 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 		}
 		msg, handlerErr := m.runner.Run(ctx, kubeContainerID, pod, container, container.Lifecycle.PostStart)
 		if handlerErr != nil {
-			klog.ErrorS(handlerErr, "Failed to execute PostStartHook", "pod", klog.KObj(pod),
+			logger.Error(handlerErr, "Failed to execute PostStartHook", "pod", klog.KObj(pod),
 				"podUID", pod.UID, "containerName", container.Name, "containerID", kubeContainerID.String())
 			// do not record the message in the event so that secrets won't leak from the server.
-			m.recordContainerEvent(pod, container, kubeContainerID.ID, v1.EventTypeWarning, events.FailedPostStartHook, "PostStartHook failed")
+			m.recordContainerEvent(ctx, pod, container, kubeContainerID.ID, v1.EventTypeWarning, events.FailedPostStartHook, "PostStartHook failed")
 			if err := m.killContainer(ctx, pod, kubeContainerID, container.Name, "FailedPostStartHook", reasonFailedPostStartHook, nil, nil); err != nil {
-				klog.ErrorS(err, "Failed to kill container", "pod", klog.KObj(pod),
+				logger.Error(err, "Failed to kill container", "pod", klog.KObj(pod),
 					"podUID", pod.UID, "containerName", container.Name, "containerID", kubeContainerID.String())
 			}
 			return msg, ErrPostStartHook
@@ -349,7 +351,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 	}
 
 	// Verify RunAsNonRoot. Non-root verification only supports numeric user.
-	if err := verifyRunAsNonRoot(pod, container, uid, username); err != nil {
+	if err := verifyRunAsNonRoot(ctx, pod, container, uid, username); err != nil {
 		return nil, cleanupAction, err
 	}
 
@@ -372,7 +374,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 		Args:        args,
 		WorkingDir:  container.WorkingDir,
 		Labels:      newContainerLabels(container, pod),
-		Annotations: newContainerAnnotations(container, pod, restartCount, opts),
+		Annotations: newContainerAnnotations(ctx, container, pod, restartCount, opts),
 		Devices:     makeDevices(opts),
 		CDIDevices:  makeCDIDevices(opts),
 		Mounts:      m.makeMounts(opts, container),
@@ -386,7 +388,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 		config.StopSignal = *stopsignal
 	}
 	// set platform specific configurations.
-	if err := m.applyPlatformSpecificContainerConfig(config, container, pod, uid, username, nsTarget); err != nil {
+	if err := m.applyPlatformSpecificContainerConfig(ctx, config, container, pod, uid, username, nsTarget); err != nil {
 		return nil, cleanupAction, err
 	}
 
@@ -404,31 +406,33 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 	return config, cleanupAction, nil
 }
 
-func (m *kubeGenericRuntimeManager) updateContainerResources(pod *v1.Pod, container *v1.Container, containerID kubecontainer.ContainerID) error {
-	containerResources := m.generateContainerResources(pod, container)
+func (m *kubeGenericRuntimeManager) updateContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container, containerID kubecontainer.ContainerID) error {
+	containerResources := m.generateContainerResources(ctx, pod, container)
 	if containerResources == nil {
 		return fmt.Errorf("container %q updateContainerResources failed: cannot generate resources config", containerID.String())
 	}
-	ctx := context.Background()
+	logger := klog.FromContext(ctx)
 	err := m.runtimeService.UpdateContainerResources(ctx, containerID.ID, containerResources)
 	if err == nil {
 		err = m.allocationManager.SetActuatedResources(pod, container)
+	} else {
+		logger.Error(err, "UpdateContainerResources failed", "container", containerID.String())
 	}
 	return err
 }
 
-func (m *kubeGenericRuntimeManager) updatePodSandboxResources(sandboxID string, pod *v1.Pod, podResources *cm.ResourceConfig) error {
+func (m *kubeGenericRuntimeManager) updatePodSandboxResources(ctx context.Context, sandboxID string, pod *v1.Pod, podResources *cm.ResourceConfig) error {
+	logger := klog.FromContext(ctx)
 	podResourcesRequest := m.generateUpdatePodSandboxResourcesRequest(sandboxID, pod, podResources)
 	if podResourcesRequest == nil {
 		return fmt.Errorf("sandboxID %q updatePodSandboxResources failed: cannot generate resources config", sandboxID)
 	}
 
-	ctx := context.Background()
 	_, err := m.runtimeService.UpdatePodSandboxResources(ctx, podResourcesRequest)
 	if err != nil {
 		stat, _ := grpcstatus.FromError(err)
 		if stat.Code() == codes.Unimplemented {
-			klog.V(3).InfoS("updatePodSandboxResources failed: unimplemented; this call is best-effort: proceeding with resize", "sandboxID", sandboxID)
+			logger.V(3).Info("updatePodSandboxResources failed: unimplemented; this call is best-effort: proceeding with resize", "sandboxID", sandboxID)
 			return nil
 		}
 		return fmt.Errorf("updatePodSandboxResources failed for sanboxID %q: %w", sandboxID, err)
@@ -528,6 +532,7 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 // The boolean parameter specifies whether returns all containers including
 // those already exited and dead containers (used for garbage collection).
 func (m *kubeGenericRuntimeManager) getKubeletContainers(ctx context.Context, allContainers bool) ([]*runtimeapi.Container, error) {
+	logger := klog.FromContext(ctx)
 	filter := &runtimeapi.ContainerFilter{}
 	if !allContainers {
 		filter.State = &runtimeapi.ContainerStateValue{
@@ -537,7 +542,7 @@ func (m *kubeGenericRuntimeManager) getKubeletContainers(ctx context.Context, al
 
 	containers, err := m.runtimeService.ListContainers(ctx, filter)
 	if err != nil {
-		klog.ErrorS(err, "ListContainers failed")
+		logger.Error(err, "ListContainers failed")
 		return nil, err
 	}
 
@@ -576,26 +581,26 @@ func getTerminationMessage(status *runtimeapi.ContainerStatus, terminationMessag
 
 // readLastStringFromContainerLogs attempts to read up to the max log length from the end of the CRI log represented
 // by path. It reads up to max log lines.
-func (m *kubeGenericRuntimeManager) readLastStringFromContainerLogs(path string) string {
+func (m *kubeGenericRuntimeManager) readLastStringFromContainerLogs(ctx context.Context, path string) string {
 	value := int64(kubecontainer.MaxContainerTerminationMessageLogLines)
 	buf, _ := circbuf.NewBuffer(kubecontainer.MaxContainerTerminationMessageLogLength)
-	if err := m.ReadLogs(context.Background(), path, "", &v1.PodLogOptions{TailLines: &value}, buf, buf); err != nil {
+	if err := m.ReadLogs(ctx, path, "", &v1.PodLogOptions{TailLines: &value}, buf, buf); err != nil {
 		return fmt.Sprintf("Error on reading termination message from logs: %v", err)
 	}
 	return buf.String()
 }
 
-func (m *kubeGenericRuntimeManager) convertToKubeContainerStatus(status *runtimeapi.ContainerStatus) (cStatus *kubecontainer.Status) {
-	cStatus = toKubeContainerStatus(status, m.runtimeName)
+func (m *kubeGenericRuntimeManager) convertToKubeContainerStatus(ctx context.Context, status *runtimeapi.ContainerStatus) (cStatus *kubecontainer.Status) {
+	cStatus = toKubeContainerStatus(ctx, status, m.runtimeName)
 	if status.State == runtimeapi.ContainerState_CONTAINER_EXITED {
 		// Populate the termination message if needed.
-		annotatedInfo := getContainerInfoFromAnnotations(status.Annotations)
+		annotatedInfo := getContainerInfoFromAnnotations(ctx, status.Annotations)
 		// If a container cannot even be started, it certainly does not have logs, so no need to fallbackToLogs.
 		fallbackToLogs := annotatedInfo.TerminationMessagePolicy == v1.TerminationMessageFallbackToLogsOnError &&
 			cStatus.ExitCode != 0 && cStatus.Reason != "ContainerCannotRun"
 		tMessage, checkLogs := getTerminationMessage(status, annotatedInfo.TerminationMessagePath, fallbackToLogs)
 		if checkLogs {
-			tMessage = m.readLastStringFromContainerLogs(status.GetLogPath())
+			tMessage = m.readLastStringFromContainerLogs(ctx, status.GetLogPath())
 		}
 		// Enrich the termination message written by the application is not empty
 		if len(tMessage) != 0 {
@@ -610,12 +615,13 @@ func (m *kubeGenericRuntimeManager) convertToKubeContainerStatus(status *runtime
 
 // getPodContainerStatuses gets all containers' statuses for the pod.
 func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context, uid kubetypes.UID, name, namespace, activePodSandboxID string) ([]*kubecontainer.Status, []*kubecontainer.Status, error) {
+	logger := klog.FromContext(ctx)
 	// Select all containers of the given pod.
 	containers, err := m.runtimeService.ListContainers(ctx, &runtimeapi.ContainerFilter{
 		LabelSelector: map[string]string{kubelettypes.KubernetesPodUIDLabel: string(uid)},
 	})
 	if err != nil {
-		klog.ErrorS(err, "ListContainers error")
+		logger.Error(err, "ListContainers error")
 		return nil, nil, err
 	}
 
@@ -633,14 +639,14 @@ func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context,
 		}
 		if err != nil {
 			// Merely log this here; GetPodStatus will actually report the error out.
-			klog.V(4).InfoS("ContainerStatus return error", "containerID", c.Id, "err", err)
+			logger.V(4).Info("ContainerStatus return error", "containerID", c.Id, "err", err)
 			return nil, nil, err
 		}
 		status := resp.GetStatus()
 		if status == nil {
 			return nil, nil, remote.ErrContainerStatusNil
 		}
-		cStatus := m.convertToKubeContainerStatus(status)
+		cStatus := m.convertToKubeContainerStatus(ctx, status)
 		statuses = append(statuses, cStatus)
 		if c.PodSandboxId == activePodSandboxID {
 			activeContainerStatuses = append(activeContainerStatuses, cStatus)
@@ -652,9 +658,9 @@ func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context,
 	return statuses, activeContainerStatuses, nil
 }
 
-func toKubeContainerStatus(status *runtimeapi.ContainerStatus, runtimeName string) *kubecontainer.Status {
-	annotatedInfo := getContainerInfoFromAnnotations(status.Annotations)
-	labeledInfo := getContainerInfoFromLabels(status.Labels)
+func toKubeContainerStatus(ctx context.Context, status *runtimeapi.ContainerStatus, runtimeName string) *kubecontainer.Status {
+	annotatedInfo := getContainerInfoFromAnnotations(ctx, status.Annotations)
+	labeledInfo := getContainerInfoFromLabels(ctx, status.Labels)
 	var cStatusResources *kubecontainer.ContainerResources
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// If runtime reports cpu & memory resources info, add it to container status
@@ -730,7 +736,8 @@ func toKubeContainerStatus(status *runtimeapi.ContainerStatus, runtimeName strin
 
 // executePreStopHook runs the pre-stop lifecycle hooks if applicable and returns the duration it takes.
 func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerSpec *v1.Container, gracePeriod int64) int64 {
-	klog.V(3).InfoS("Running preStop hook", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerSpec.Name, "containerID", containerID.String())
+	logger := klog.FromContext(ctx)
+	logger.V(3).Info("Running preStop hook", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerSpec.Name, "containerID", containerID.String())
 
 	start := metav1.Now()
 	done := make(chan struct{})
@@ -738,19 +745,19 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod 
 		defer close(done)
 		defer utilruntime.HandleCrash()
 		if _, err := m.runner.Run(ctx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop); err != nil {
-			klog.ErrorS(err, "PreStop hook failed", "pod", klog.KObj(pod), "podUID", pod.UID,
+			logger.Error(err, "PreStop hook failed", "pod", klog.KObj(pod), "podUID", pod.UID,
 				"containerName", containerSpec.Name, "containerID", containerID.String())
 			// do not record the message in the event so that secrets won't leak from the server.
-			m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeWarning, events.FailedPreStopHook, "PreStopHook failed")
+			m.recordContainerEvent(ctx, pod, containerSpec, containerID.ID, v1.EventTypeWarning, events.FailedPreStopHook, "PreStopHook failed")
 		}
 	}()
 
 	select {
 	case <-time.After(time.Duration(gracePeriod) * time.Second):
-		klog.V(2).InfoS("PreStop hook not completed in grace period", "pod", klog.KObj(pod), "podUID", pod.UID,
+		logger.V(2).Info("PreStop hook not completed in grace period", "pod", klog.KObj(pod), "podUID", pod.UID,
 			"containerName", containerSpec.Name, "containerID", containerID.String(), "gracePeriod", gracePeriod)
 	case <-done:
-		klog.V(3).InfoS("PreStop hook completed", "pod", klog.KObj(pod), "podUID", pod.UID,
+		logger.V(3).Info("PreStop hook completed", "pod", klog.KObj(pod), "podUID", pod.UID,
 			"containerName", containerSpec.Name, "containerID", containerID.String())
 	}
 
@@ -777,8 +784,8 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 		return nil, nil, remote.ErrContainerStatusNil
 	}
 
-	l := getContainerInfoFromLabels(s.Labels)
-	a := getContainerInfoFromAnnotations(s.Annotations)
+	l := getContainerInfoFromLabels(ctx, s.Labels)
+	a := getContainerInfoFromAnnotations(ctx, s.Annotations)
 	// Notice that the followings are not full spec. The container killing code should not use
 	// un-restored fields.
 	pod = &v1.Pod{
@@ -809,6 +816,7 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 // * Run the pre-stop lifecycle hooks (if applicable).
 // * Stop the container.
 func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, message string, reason containerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) error {
+	logger := klog.FromContext(ctx)
 	var containerSpec *v1.Container
 	if pod != nil {
 		if containerSpec = kubecontainer.GetContainerSpec(pod, containerName); containerSpec == nil {
@@ -825,16 +833,16 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 	}
 
 	// From this point, pod and container must be non-nil.
-	gracePeriod := setTerminationGracePeriod(pod, containerSpec, containerName, containerID, reason)
+	gracePeriod := setTerminationGracePeriod(ctx, pod, containerSpec, containerName, containerID, reason)
 
 	if len(message) == 0 {
 		message = fmt.Sprintf("Stopping container %s", containerSpec.Name)
 	}
-	m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeNormal, events.KillingContainer, "%v", message)
+	m.recordContainerEvent(ctx, pod, containerSpec, containerID.ID, v1.EventTypeNormal, events.KillingContainer, "%v", message)
 
 	if gracePeriodOverride != nil {
 		gracePeriod = *gracePeriodOverride
-		klog.V(3).InfoS("Killing container with a grace period override", "pod", klog.KObj(pod), "podUID", pod.UID,
+		logger.V(3).Info("Killing container with a grace period override", "pod", klog.KObj(pod), "podUID", pod.UID,
 			"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
 	}
 
@@ -855,16 +863,16 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 		gracePeriod = minimumGracePeriodInSeconds
 	}
 
-	klog.V(2).InfoS("Killing container with a grace period", "pod", klog.KObj(pod), "podUID", pod.UID,
+	logger.V(2).Info("Killing container with a grace period", "pod", klog.KObj(pod), "podUID", pod.UID,
 		"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
 
 	err := m.runtimeService.StopContainer(ctx, containerID.ID, gracePeriod)
 	if err != nil && !crierror.IsNotFound(err) {
-		klog.ErrorS(err, "Container termination failed with gracePeriod", "pod", klog.KObj(pod), "podUID", pod.UID,
+		logger.Error(err, "Container termination failed with gracePeriod", "pod", klog.KObj(pod), "podUID", pod.UID,
 			"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
 		return err
 	}
-	klog.V(3).InfoS("Container exited normally", "pod", klog.KObj(pod), "podUID", pod.UID,
+	logger.V(3).Info("Container exited normally", "pod", klog.KObj(pod), "podUID", pod.UID,
 		"containerName", containerName, "containerID", containerID.String())
 
 	if ordering != nil {
@@ -876,6 +884,7 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 
 // killContainersWithSyncResult kills all pod's containers with sync results.
 func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) (syncResults []*kubecontainer.SyncResult) {
+	logger := klog.FromContext(ctx)
 	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
 	wg := sync.WaitGroup{}
 
@@ -897,7 +906,7 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 			if err := m.killContainer(ctx, pod, container.ID, container.Name, "", reasonUnknown, gracePeriodOverride, termOrdering); err != nil {
 				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
 				// Use runningPod for logging as the pod passed in could be *nil*.
-				klog.ErrorS(err, "Kill container failed", "pod", klog.KRef(runningPod.Namespace, runningPod.Name), "podUID", runningPod.ID,
+				logger.Error(err, "Kill container failed", "pod", klog.KRef(runningPod.Namespace, runningPod.Name), "podUID", runningPod.ID,
 					"containerName", container.Name, "containerID", container.ID)
 			}
 			containerResults <- killContainerResult
@@ -917,6 +926,7 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 // present. This reduces load on the container garbage collector by only
 // preserving the most recent terminated init container.
 func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
+	logger := klog.FromContext(ctx)
 	// only the last execution of each init container should be preserved, and only preserve it if it is in the
 	// list of init containers to keep.
 	initContainerNames := sets.New[string]()
@@ -940,7 +950,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(ctx context.C
 				continue
 			}
 			// prune all other init containers that match this container name
-			klog.V(4).InfoS("Removing init container", "containerName", status.Name, "containerID", status.ID.ID, "count", count)
+			logger.V(4).Info("Removing init container", "containerName", status.Name, "containerID", status.ID.ID, "count", count)
 			if err := m.removeContainer(ctx, status.ID.ID); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
 				continue
@@ -953,6 +963,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(ctx context.C
 // of the container because it assumes all init containers have been stopped
 // before the call happens.
 func (m *kubeGenericRuntimeManager) purgeInitContainers(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
+	logger := klog.FromContext(ctx)
 	initContainerNames := sets.New[string]()
 	for _, container := range pod.Spec.InitContainers {
 		initContainerNames.Insert(container.Name)
@@ -965,7 +976,7 @@ func (m *kubeGenericRuntimeManager) purgeInitContainers(ctx context.Context, pod
 			}
 			count++
 			// Purge all init containers that match this container name
-			klog.V(4).InfoS("Removing init container", "containerName", status.Name, "containerID", status.ID.ID, "count", count)
+			logger.V(4).Info("Removing init container", "containerName", status.Name, "containerID", status.ID.ID, "count", count)
 			if err := m.removeContainer(ctx, status.ID.ID); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
 				continue
@@ -1003,7 +1014,8 @@ func hasAnyRegularContainerCreated(pod *v1.Pod, podStatus *kubecontainer.PodStat
 // - Start the first init container that has not been started.
 // - Restart all restartable init containers that have started but are not running.
 // - Kill the restartable init containers that are not alive or started.
-func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, podStatus *kubecontainer.PodStatus, changes *podActions) bool {
+func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, changes *podActions) bool {
+	logger := klog.FromContext(ctx)
 	if len(pod.Spec.InitContainers) == 0 {
 		return true
 	}
@@ -1053,7 +1065,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 	for i := len(pod.Spec.InitContainers) - 1; i >= 0; i-- {
 		container := &pod.Spec.InitContainers[i]
 		status := podStatus.FindContainerStatusByName(container.Name)
-		klog.V(4).InfoS("Computing init container action", "pod", klog.KObj(pod), "container", container.Name, "status", status)
+		logger.V(4).Info("Computing init container action", "pod", klog.KObj(pod), "container", container.Name, "status", status)
 		if status == nil {
 			// If the container is previously initialized but its status is not
 			// found, it means its last status is removed for some reason.
@@ -1107,7 +1119,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 					}
 				}
 
-				klog.V(4).InfoS("Init container has been initialized", "pod", klog.KObj(pod), "container", container.Name)
+				logger.V(4).Info("Init container has been initialized", "pod", klog.KObj(pod), "container", container.Name)
 				if i == (len(pod.Spec.InitContainers) - 1) {
 					podHasInitialized = true
 				} else if !isPreviouslyInitialized {
@@ -1150,7 +1162,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 					}
 				}
 
-				if !m.computePodResizeAction(pod, i, true, status, changes) {
+				if !m.computePodResizeAction(ctx, pod, i, true, status, changes) {
 					// computePodResizeAction updates 'changes' if resize policy requires restarting this container
 					break
 				}
@@ -1175,7 +1187,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 					break
 				}
 
-				klog.V(4).InfoS("Init container has been initialized", "pod", klog.KObj(pod), "container", container.Name)
+				logger.V(4).Info("Init container has been initialized", "pod", klog.KObj(pod), "container", container.Name)
 				if i == (len(pod.Spec.InitContainers) - 1) {
 					podHasInitialized = true
 				} else {
@@ -1197,7 +1209,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
 			} else { // init container
 				if !isInitContainerFailed(status) {
-					klog.V(4).InfoS("This should not happen, init container is in unknown state but not failed", "pod", klog.KObj(pod), "containerStatus", status)
+					logger.V(4).Info("This should not happen, init container is in unknown state but not failed", "pod", klog.KObj(pod), "containerStatus", status)
 				}
 
 				if !restartOnFailure {
@@ -1244,9 +1256,10 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 
 // GetContainerLogs returns logs of a specific container.
 func (m *kubeGenericRuntimeManager) GetContainerLogs(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) (err error) {
+	logger := klog.FromContext(ctx)
 	resp, err := m.runtimeService.ContainerStatus(ctx, containerID.ID, false)
 	if err != nil {
-		klog.V(4).InfoS("Failed to get container status", "containerID", containerID.String(), "err", err)
+		logger.V(4).Info("Failed to get container status", "containerID", containerID.String(), "err", err)
 		return fmt.Errorf("unable to retrieve container logs for %v", containerID.String())
 	}
 	status := resp.GetStatus()
@@ -1306,7 +1319,8 @@ func (m *kubeGenericRuntimeManager) RunInContainer(ctx context.Context, id kubec
 // Notice that we assume that the container should only be removed in non-running state, and
 // it will not write container logs anymore in that state.
 func (m *kubeGenericRuntimeManager) removeContainer(ctx context.Context, containerID string) error {
-	klog.V(4).InfoS("Removing container", "containerID", containerID)
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Removing container", "containerID", containerID)
 	// Call internal container post-stop lifecycle hook.
 	if err := m.internalLifecycle.PostStopContainer(containerID); err != nil {
 		return err
@@ -1339,7 +1353,7 @@ func (m *kubeGenericRuntimeManager) removeContainerLog(ctx context.Context, cont
 	}
 	// Remove the legacy container log symlink.
 	// TODO(random-liu): Remove this after cluster logging supports CRI container log path.
-	labeledInfo := getContainerInfoFromLabels(status.Labels)
+	labeledInfo := getContainerInfoFromLabels(ctx, status.Labels)
 	legacySymlink := legacyLogSymlink(containerID, labeledInfo.ContainerName, labeledInfo.PodName,
 		labeledInfo.PodNamespace)
 	if err := m.osInterface.Remove(legacySymlink); err != nil && !os.IsNotExist(err) {
@@ -1355,7 +1369,7 @@ func (m *kubeGenericRuntimeManager) DeleteContainer(ctx context.Context, contain
 }
 
 // setTerminationGracePeriod determines the grace period to use when killing a container
-func setTerminationGracePeriod(pod *v1.Pod, containerSpec *v1.Container, containerName string, containerID kubecontainer.ContainerID, reason containerKillReason) int64 {
+func setTerminationGracePeriod(ctx context.Context, pod *v1.Pod, containerSpec *v1.Container, containerName string, containerID kubecontainer.ContainerID, reason containerKillReason) int64 {
 	gracePeriod := int64(minimumGracePeriodInSeconds)
 	switch {
 	case pod.DeletionGracePeriodSeconds != nil:
@@ -1363,11 +1377,11 @@ func setTerminationGracePeriod(pod *v1.Pod, containerSpec *v1.Container, contain
 	case pod.Spec.TerminationGracePeriodSeconds != nil:
 		switch reason {
 		case reasonStartupProbe:
-			if isProbeTerminationGracePeriodSecondsSet(pod, containerSpec, containerSpec.StartupProbe, containerName, containerID, "StartupProbe") {
+			if isProbeTerminationGracePeriodSecondsSet(ctx, pod, containerSpec, containerSpec.StartupProbe, containerName, containerID, "StartupProbe") {
 				return *containerSpec.StartupProbe.TerminationGracePeriodSeconds
 			}
 		case reasonLivenessProbe:
-			if isProbeTerminationGracePeriodSecondsSet(pod, containerSpec, containerSpec.LivenessProbe, containerName, containerID, "LivenessProbe") {
+			if isProbeTerminationGracePeriodSecondsSet(ctx, pod, containerSpec, containerSpec.LivenessProbe, containerName, containerID, "LivenessProbe") {
 				return *containerSpec.LivenessProbe.TerminationGracePeriodSeconds
 			}
 		}
@@ -1376,10 +1390,11 @@ func setTerminationGracePeriod(pod *v1.Pod, containerSpec *v1.Container, contain
 	return gracePeriod
 }
 
-func isProbeTerminationGracePeriodSecondsSet(pod *v1.Pod, containerSpec *v1.Container, probe *v1.Probe, containerName string, containerID kubecontainer.ContainerID, probeType string) bool {
+func isProbeTerminationGracePeriodSecondsSet(ctx context.Context, pod *v1.Pod, containerSpec *v1.Container, probe *v1.Probe, containerName string, containerID kubecontainer.ContainerID, probeType string) bool {
+	logger := klog.FromContext(ctx)
 	if probe != nil && probe.TerminationGracePeriodSeconds != nil {
 		if *probe.TerminationGracePeriodSeconds > *pod.Spec.TerminationGracePeriodSeconds {
-			klog.V(4).InfoS("Using probe-level grace period that is greater than the pod-level grace period", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName, "containerID", containerID.String(), "probeType", probeType, "probeGracePeriod", *probe.TerminationGracePeriodSeconds, "podGracePeriod", *pod.Spec.TerminationGracePeriodSeconds)
+			logger.V(4).Info("Using probe-level grace period that is greater than the pod-level grace period", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName, "containerID", containerID.String(), "probeType", probeType, "probeGracePeriod", *probe.TerminationGracePeriodSeconds, "podGracePeriod", *pod.Spec.TerminationGracePeriodSeconds)
 		}
 		return true
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -20,6 +20,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -52,14 +53,14 @@ import (
 var defaultPageSize = int64(os.Getpagesize())
 
 // applyPlatformSpecificContainerConfig applies platform specific configurations to runtimeapi.ContainerConfig.
-func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(config *runtimeapi.ContainerConfig, container *v1.Container, pod *v1.Pod, uid *int64, username string, nsTarget *kubecontainer.ContainerID) error {
+func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(ctx context.Context, config *runtimeapi.ContainerConfig, container *v1.Container, pod *v1.Pod, uid *int64, username string, nsTarget *kubecontainer.ContainerID) error {
 	enforceMemoryQoS := false
 	// Set memory.min and memory.high if MemoryQoS enabled with cgroups v2
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
 		isCgroup2UnifiedMode() {
 		enforceMemoryQoS = true
 	}
-	cl, err := m.generateLinuxContainerConfig(container, pod, uid, username, nsTarget, enforceMemoryQoS)
+	cl, err := m.generateLinuxContainerConfig(ctx, container, pod, uid, username, nsTarget, enforceMemoryQoS)
 	if err != nil {
 		return err
 	}
@@ -77,13 +78,13 @@ func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(config 
 }
 
 // generateLinuxContainerConfig generates linux container config for kubelet runtime v1.
-func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.Container, pod *v1.Pod, uid *int64, username string, nsTarget *kubecontainer.ContainerID, enforceMemoryQoS bool) (*runtimeapi.LinuxContainerConfig, error) {
+func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(ctx context.Context, container *v1.Container, pod *v1.Pod, uid *int64, username string, nsTarget *kubecontainer.ContainerID, enforceMemoryQoS bool) (*runtimeapi.LinuxContainerConfig, error) {
 	sc, err := m.determineEffectiveSecurityContext(pod, container, uid, username)
 	if err != nil {
 		return nil, err
 	}
 	lc := &runtimeapi.LinuxContainerConfig{
-		Resources:       m.generateLinuxContainerResources(pod, container, enforceMemoryQoS),
+		Resources:       m.generateLinuxContainerResources(ctx, pod, container, enforceMemoryQoS),
 		SecurityContext: sc,
 	}
 
@@ -124,7 +125,8 @@ func getMemoryLimit(pod *v1.Pod, container *v1.Container) *resource.Quantity {
 }
 
 // generateLinuxContainerResources generates linux container resources config for runtime
-func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod, container *v1.Container, enforceMemoryQoS bool) *runtimeapi.LinuxContainerResources {
+func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container, enforceMemoryQoS bool) *runtimeapi.LinuxContainerResources {
+	logger := klog.FromContext(ctx)
 	// set linux container resources
 	var cpuRequest *resource.Quantity
 	if _, cpuRequestExists := container.Resources.Requests[v1.ResourceCPU]; cpuRequestExists {
@@ -137,16 +139,16 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 	// If pod has exclusive cpu and the container in question has integer cpu requests
 	// the cfs quota will not be enforced
 	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.ContainerHasExclusiveCPUs(pod, container)
-	klog.V(5).InfoS("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
+	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
 	lcr := m.calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit, disableCPUQuota)
 
 	lcr.OomScoreAdj = int64(qos.GetContainerOOMScoreAdjust(pod, container,
 		int64(m.machineInfo.MemoryCapacity)))
 
-	lcr.HugepageLimits = GetHugepageLimitsFromResources(container.Resources)
+	lcr.HugepageLimits = GetHugepageLimitsFromResources(ctx, container.Resources)
 
 	// Configure swap for the container
-	m.configureContainerSwapResources(lcr, pod, container)
+	m.configureContainerSwapResources(ctx, lcr, pod, container)
 
 	// Set memory.min and memory.high to enforce MemoryQoS
 	if enforceMemoryQoS {
@@ -191,7 +193,7 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 					lcr.Unified[k] = v
 				}
 			}
-			klog.V(4).InfoS("MemoryQoS config for container", "pod", klog.KObj(pod), "containerName", container.Name, "unified", unified)
+			logger.V(4).Info("MemoryQoS config for container", "pod", klog.KObj(pod), "containerName", container.Name, "unified", unified)
 		}
 	}
 
@@ -200,21 +202,21 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 
 // configureContainerSwapResources configures the swap resources for a specified (linux) container.
 // Swap is only configured if a swap cgroup controller is available and the NodeSwap feature gate is enabled.
-func (m *kubeGenericRuntimeManager) configureContainerSwapResources(lcr *runtimeapi.LinuxContainerResources, pod *v1.Pod, container *v1.Container) {
-	if !swapControllerAvailable() {
+func (m *kubeGenericRuntimeManager) configureContainerSwapResources(ctx context.Context, lcr *runtimeapi.LinuxContainerResources, pod *v1.Pod, container *v1.Container) {
+	if !m.getSwapControllerAvailable() {
 		return
 	}
 
-	swapConfigurationHelper := newSwapConfigurationHelper(*m.machineInfo)
+	swapConfigurationHelper := newSwapConfigurationHelper(*m.machineInfo, m.getSwapControllerAvailable)
 	// NOTE(ehashman): Behavior is defined in the opencontainers runtime spec:
 	// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
 	switch m.GetContainerSwapBehavior(pod, container) {
 	case types.NoSwap:
-		swapConfigurationHelper.ConfigureNoSwap(lcr)
+		swapConfigurationHelper.ConfigureNoSwap(ctx, lcr)
 	case types.LimitedSwap:
-		swapConfigurationHelper.ConfigureLimitedSwap(lcr, pod, container)
+		swapConfigurationHelper.ConfigureLimitedSwap(ctx, lcr, pod, container)
 	default:
-		swapConfigurationHelper.ConfigureNoSwap(lcr)
+		swapConfigurationHelper.ConfigureNoSwap(ctx, lcr)
 	}
 }
 
@@ -223,7 +225,7 @@ func (m *kubeGenericRuntimeManager) configureContainerSwapResources(lcr *runtime
 func (m *kubeGenericRuntimeManager) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Container) types.SwapBehavior {
 	c := types.SwapBehavior(m.memorySwapBehavior)
 	if c == types.LimitedSwap {
-		if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) || !swapControllerAvailable() {
+		if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) || !m.getSwapControllerAvailable() {
 			return types.NoSwap
 		}
 
@@ -246,7 +248,7 @@ func (m *kubeGenericRuntimeManager) GetContainerSwapBehavior(pod *v1.Pod, contai
 }
 
 // generateContainerResources generates platform specific (linux) container resources config for runtime
-func (m *kubeGenericRuntimeManager) generateContainerResources(pod *v1.Pod, container *v1.Container) *runtimeapi.ContainerResources {
+func (m *kubeGenericRuntimeManager) generateContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container) *runtimeapi.ContainerResources {
 	enforceMemoryQoS := false
 	// Set memory.min and memory.high if MemoryQoS enabled with cgroups v2
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
@@ -254,7 +256,7 @@ func (m *kubeGenericRuntimeManager) generateContainerResources(pod *v1.Pod, cont
 		enforceMemoryQoS = true
 	}
 	return &runtimeapi.ContainerResources{
-		Linux: m.generateLinuxContainerResources(pod, container, enforceMemoryQoS),
+		Linux: m.generateLinuxContainerResources(ctx, pod, container, enforceMemoryQoS),
 	}
 }
 
@@ -321,7 +323,8 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 }
 
 // GetHugepageLimitsFromResources returns limits of each hugepages from resources.
-func GetHugepageLimitsFromResources(resources v1.ResourceRequirements) []*runtimeapi.HugepageLimit {
+func GetHugepageLimitsFromResources(ctx context.Context, resources v1.ResourceRequirements) []*runtimeapi.HugepageLimit {
+	logger := klog.FromContext(ctx)
 	var hugepageLimits []*runtimeapi.HugepageLimit
 
 	// For each page size, limit to 0.
@@ -340,13 +343,13 @@ func GetHugepageLimitsFromResources(resources v1.ResourceRequirements) []*runtim
 
 		pageSize, err := v1helper.HugePageSizeFromResourceName(resourceObj)
 		if err != nil {
-			klog.InfoS("Failed to get hugepage size from resource", "object", resourceObj, "err", err)
+			logger.Info("Failed to get hugepage size from resource", "object", resourceObj, "err", err)
 			continue
 		}
 
 		sizeString, err := v1helper.HugePageUnitSizeFromByteSize(pageSize.Value())
 		if err != nil {
-			klog.InfoS("Size is invalid", "object", resourceObj, "err", err)
+			logger.Info("Size is invalid", "object", resourceObj, "err", err)
 			continue
 		}
 		requiredHugepageLimits[sizeString] = uint64(amountObj.Value())
@@ -399,21 +402,21 @@ var isCgroup2UnifiedMode = func() bool {
 	return libcontainercgroups.IsCgroup2UnifiedMode()
 }
 
-// Note: this function variable is being added here so it would be possible to mock
-// the swap controller availability for unit tests by assigning a new function to it. Without it,
-// the swap controller availability would solely depend on the environment running the test.
-var swapControllerAvailable = sync.OnceValue(func() bool {
+// checkSwapControllerAvailability checks if swap controller is available.
+// It returns true if the swap controller is available, false otherwise.
+func checkSwapControllerAvailability(ctx context.Context) bool {
 	// See https://github.com/containerd/containerd/pull/7838/
+	logger := klog.FromContext(ctx)
 	const warn = "Failed to detect the availability of the swap controller, assuming not available"
 	p := "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
 	if isCgroup2UnifiedMode() {
 		// memory.swap.max does not exist in the cgroup root, so we check /sys/fs/cgroup/<SELF>/memory.swap.max
 		cm, err := libcontainercgroups.ParseCgroupFile("/proc/self/cgroup")
 		if err != nil {
-			klog.V(5).ErrorS(fmt.Errorf("failed to parse /proc/self/cgroup: %w", err), warn)
+			logger.V(5).Error(fmt.Errorf("failed to parse /proc/self/cgroup: %w", err), warn)
 			return false
 		}
-		// Fr cgroup v2 unified hierarchy, there are no per-controller
+		// For cgroup v2 unified hierarchy, there are no per-controller
 		// cgroup paths, so the cm map returned by ParseCgroupFile above
 		// has a single element where the key is empty string ("") and
 		// the value is the cgroup path the <pid> is in.
@@ -421,37 +424,50 @@ var swapControllerAvailable = sync.OnceValue(func() bool {
 	}
 	if _, err := os.Stat(p); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			klog.V(5).ErrorS(err, warn)
+			logger.V(5).Error(err, warn)
 		}
 		return false
 	}
 
 	return true
-})
+}
+
+// initSwapControllerAvailabilityCheck returns a function that checks swap controller availability
+// with lazy initialization using sync.OnceValue
+func initSwapControllerAvailabilityCheck(ctx context.Context) func() bool {
+	return sync.OnceValue(func() bool {
+		return checkSwapControllerAvailability(ctx)
+	})
+}
 
 type swapConfigurationHelper struct {
-	machineInfo cadvisorv1.MachineInfo
+	machineInfo                cadvisorv1.MachineInfo
+	getSwapControllerAvailable func() bool
 }
 
-func newSwapConfigurationHelper(machineInfo cadvisorv1.MachineInfo) *swapConfigurationHelper {
-	return &swapConfigurationHelper{machineInfo: machineInfo}
+func newSwapConfigurationHelper(machineInfo cadvisorv1.MachineInfo, getSwapControllerAvailable func() bool) *swapConfigurationHelper {
+	return &swapConfigurationHelper{
+		machineInfo:                machineInfo,
+		getSwapControllerAvailable: getSwapControllerAvailable,
+	}
 }
 
-func (m swapConfigurationHelper) ConfigureLimitedSwap(lcr *runtimeapi.LinuxContainerResources, pod *v1.Pod, container *v1.Container) {
+func (m swapConfigurationHelper) ConfigureLimitedSwap(ctx context.Context, lcr *runtimeapi.LinuxContainerResources, pod *v1.Pod, container *v1.Container) {
+	logger := klog.FromContext(ctx)
 	containerMemoryRequest := container.Resources.Requests.Memory()
 	swapLimit, err := calcSwapForBurstablePods(containerMemoryRequest.Value(), int64(m.machineInfo.MemoryCapacity), int64(m.machineInfo.SwapCapacity))
 	if err != nil {
-		klog.ErrorS(err, "cannot calculate swap allocation amount; disallowing swap")
-		m.ConfigureNoSwap(lcr)
+		logger.Error(err, "Cannot calculate swap allocation amount; disallowing swap")
+		m.ConfigureNoSwap(ctx, lcr)
 		return
 	}
 
-	m.configureSwap(lcr, swapLimit)
+	m.configureSwap(ctx, lcr, swapLimit)
 }
 
-func (m swapConfigurationHelper) ConfigureNoSwap(lcr *runtimeapi.LinuxContainerResources) {
+func (m swapConfigurationHelper) ConfigureNoSwap(ctx context.Context, lcr *runtimeapi.LinuxContainerResources) {
 	if !isCgroup2UnifiedMode() {
-		if swapControllerAvailable() {
+		if m.getSwapControllerAvailable() {
 			// memorySwapLimit = total permitted memory+swap; if equal to memory limit, => 0 swap above memory limit
 			// Some swapping is still possible.
 			// Note that if memory limit is 0, memory swap limit is ignored.
@@ -460,12 +476,13 @@ func (m swapConfigurationHelper) ConfigureNoSwap(lcr *runtimeapi.LinuxContainerR
 		return
 	}
 
-	m.configureSwap(lcr, 0)
+	m.configureSwap(ctx, lcr, 0)
 }
 
-func (m swapConfigurationHelper) configureSwap(lcr *runtimeapi.LinuxContainerResources, swapMemory int64) {
+func (m swapConfigurationHelper) configureSwap(ctx context.Context, lcr *runtimeapi.LinuxContainerResources, swapMemory int64) {
+	logger := klog.FromContext(ctx)
 	if !isCgroup2UnifiedMode() {
-		klog.ErrorS(fmt.Errorf("swap configuration is not supported with cgroup v1"), "swap configuration under cgroup v1 is unexpected")
+		logger.Error(fmt.Errorf("swap configuration is not supported with cgroup v1"), "Swap configuration under cgroup v1 is unexpected")
 		return
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -46,21 +46,21 @@ import (
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
-func makeExpectedConfig(m *kubeGenericRuntimeManager, pod *v1.Pod, containerIndex int, enforceMemoryQoS bool) *runtimeapi.ContainerConfig {
-	ctx := context.Background()
+func makeExpectedConfig(t *testing.T, tCtx context.Context, m *kubeGenericRuntimeManager, pod *v1.Pod, containerIndex int, enforceMemoryQoS bool) *runtimeapi.ContainerConfig {
 	container := &pod.Spec.Containers[containerIndex]
 	podIP := ""
 	restartCount := 0
-	opts, _, _ := m.runtimeHelper.GenerateRunContainerOptions(ctx, pod, container, podIP, []string{podIP}, nil)
+	opts, _, _ := m.runtimeHelper.GenerateRunContainerOptions(tCtx, pod, container, podIP, []string{podIP}, nil)
 	containerLogsPath := buildContainerLogsPath(container.Name, restartCount)
 	stopsignal := getContainerConfigStopSignal(container)
 	restartCountUint32 := uint32(restartCount)
 	envs := make([]*runtimeapi.KeyValue, len(opts.Envs))
 
-	l, _ := m.generateLinuxContainerConfig(container, pod, new(int64), "", nil, enforceMemoryQoS)
+	l, _ := m.generateLinuxContainerConfig(tCtx, container, pod, new(int64), "", nil, enforceMemoryQoS)
 
 	expectedConfig := &runtimeapi.ContainerConfig{
 		Metadata: &runtimeapi.ContainerMetadata{
@@ -72,7 +72,7 @@ func makeExpectedConfig(m *kubeGenericRuntimeManager, pod *v1.Pod, containerInde
 		Args:        []string(nil),
 		WorkingDir:  container.WorkingDir,
 		Labels:      newContainerLabels(container, pod),
-		Annotations: newContainerAnnotations(container, pod, restartCount, opts),
+		Annotations: newContainerAnnotations(tCtx, container, pod, restartCount, opts),
 		Devices:     makeDevices(opts),
 		Mounts:      m.makeMounts(opts, container),
 		LogPath:     containerLogsPath,
@@ -90,8 +90,8 @@ func makeExpectedConfig(m *kubeGenericRuntimeManager, pod *v1.Pod, containerInde
 }
 
 func TestGenerateContainerConfig(t *testing.T) {
-	ctx := context.Background()
-	_, imageService, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, imageService, m, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	runAsUser := int64(1000)
@@ -119,8 +119,8 @@ func TestGenerateContainerConfig(t *testing.T) {
 		},
 	}
 
-	expectedConfig := makeExpectedConfig(m, pod, 0, false)
-	containerConfig, _, err := m.generateContainerConfig(ctx, &pod.Spec.Containers[0], pod, 0, "", pod.Spec.Containers[0].Image, []string{}, nil, nil)
+	expectedConfig := makeExpectedConfig(t, tCtx, m, pod, 0, false)
+	containerConfig, _, err := m.generateContainerConfig(tCtx, &pod.Spec.Containers[0], pod, 0, "", pod.Spec.Containers[0].Image, []string{}, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, containerConfig, "generate container config for kubelet runtime v1.")
 	assert.Equal(t, runAsUser, containerConfig.GetLinux().GetSecurityContext().GetRunAsUser().GetValue(), "RunAsUser should be set")
@@ -151,11 +151,11 @@ func TestGenerateContainerConfig(t *testing.T) {
 		},
 	}
 
-	_, _, err = m.generateContainerConfig(ctx, &podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image, []string{}, nil, nil)
+	_, _, err = m.generateContainerConfig(tCtx, &podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image, []string{}, nil, nil)
 	assert.Error(t, err)
 
-	imageID, _ := imageService.PullImage(ctx, &runtimeapi.ImageSpec{Image: "busybox"}, nil, nil)
-	resp, _ := imageService.ImageStatus(ctx, &runtimeapi.ImageSpec{Image: imageID}, false)
+	imageID, _ := imageService.PullImage(tCtx, &runtimeapi.ImageSpec{Image: "busybox"}, nil, nil)
+	resp, _ := imageService.ImageStatus(tCtx, &runtimeapi.ImageSpec{Image: imageID}, false)
 
 	resp.Image.Uid = nil
 	resp.Image.Username = "test"
@@ -163,12 +163,13 @@ func TestGenerateContainerConfig(t *testing.T) {
 	podWithContainerSecurityContext.Spec.Containers[0].SecurityContext.RunAsUser = nil
 	podWithContainerSecurityContext.Spec.Containers[0].SecurityContext.RunAsNonRoot = &runAsNonRootTrue
 
-	_, _, err = m.generateContainerConfig(ctx, &podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image, []string{}, nil, nil)
+	_, _, err = m.generateContainerConfig(tCtx, &podWithContainerSecurityContext.Spec.Containers[0], podWithContainerSecurityContext, 0, "", podWithContainerSecurityContext.Spec.Containers[0].Image, []string{}, nil, nil)
 	assert.Error(t, err, "RunAsNonRoot should fail for non-numeric username")
 }
 
 func TestGenerateLinuxContainerConfigResources(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	m.cpuCFSQuota = true
 
 	assert.NoError(t, err)
@@ -262,7 +263,7 @@ func TestGenerateLinuxContainerConfigResources(t *testing.T) {
 			pod.Spec.Resources = test.podResources
 		}
 
-		linuxConfig, err := m.generateLinuxContainerConfig(&pod.Spec.Containers[0], pod, new(int64), "", nil, false)
+		linuxConfig, err := m.generateLinuxContainerConfig(tCtx, &pod.Spec.Containers[0], pod, new(int64), "", nil, false)
 		assert.NoError(t, err)
 		assert.Equal(t, test.expected.CpuPeriod, linuxConfig.GetResources().CpuPeriod, test.name)
 		assert.Equal(t, test.expected.CpuQuota, linuxConfig.GetResources().CpuQuota, test.name)
@@ -272,7 +273,8 @@ func TestGenerateLinuxContainerConfigResources(t *testing.T) {
 }
 
 func TestCalculateLinuxResources(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	m.cpuCFSQuota = true
 
 	assert.NoError(t, err)
@@ -421,7 +423,8 @@ func TestCalculateLinuxResources(t *testing.T) {
 }
 
 func TestGenerateContainerConfigWithMemoryQoSEnforced(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	podRequestMemory := resource.MustParse("128Mi")
@@ -490,8 +493,8 @@ func TestGenerateContainerConfigWithMemoryQoSEnforced(t *testing.T) {
 		memoryLow       int64
 		memoryHigh      int64
 	}
-	l1, _ := m.generateLinuxContainerConfig(&pod1.Spec.Containers[0], pod1, new(int64), "", nil, true)
-	l2, _ := m.generateLinuxContainerConfig(&pod2.Spec.Containers[0], pod2, new(int64), "", nil, true)
+	l1, _ := m.generateLinuxContainerConfig(tCtx, &pod1.Spec.Containers[0], pod1, new(int64), "", nil, true)
+	l2, _ := m.generateLinuxContainerConfig(tCtx, &pod2.Spec.Containers[0], pod2, new(int64), "", nil, true)
 	tests := []struct {
 		name     string
 		pod      *v1.Pod
@@ -518,7 +521,7 @@ func TestGenerateContainerConfigWithMemoryQoSEnforced(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		linuxConfig, err := m.generateLinuxContainerConfig(&test.pod.Spec.Containers[0], test.pod, new(int64), "", nil, true)
+		linuxConfig, err := m.generateLinuxContainerConfig(tCtx, &test.pod.Spec.Containers[0], test.pod, new(int64), "", nil, true)
 		assert.NoError(t, err)
 		assert.Equal(t, test.expected.containerConfig, linuxConfig, test.name)
 		assert.Equal(t, linuxConfig.GetResources().GetUnified()["memory.min"], strconv.FormatInt(test.expected.memoryLow, 10), test.name)
@@ -527,6 +530,7 @@ func TestGenerateContainerConfigWithMemoryQoSEnforced(t *testing.T) {
 }
 
 func TestGetHugepageLimitsFromResources(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var baseHugepage []*runtimeapi.HugepageLimit
 
 	// For each page size, limit to 0.
@@ -672,7 +676,7 @@ func TestGetHugepageLimitsFromResources(t *testing.T) {
 			}
 		}
 
-		results := GetHugepageLimitsFromResources(test.resources)
+		results := GetHugepageLimitsFromResources(tCtx, test.resources)
 		if !reflect.DeepEqual(expectedHugepages, results) {
 			t.Errorf("%s test failed. Expected %v but got %v", test.name, expectedHugepages, results)
 		}
@@ -684,7 +688,8 @@ func TestGetHugepageLimitsFromResources(t *testing.T) {
 }
 
 func TestGenerateLinuxContainerConfigNamespaces(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	if err != nil {
 		t.Fatalf("error creating test RuntimeManager: %v", err)
 	}
@@ -741,7 +746,7 @@ func TestGenerateLinuxContainerConfigNamespaces(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := m.generateLinuxContainerConfig(&tc.pod.Spec.Containers[0], tc.pod, nil, "", tc.target, false)
+			got, err := m.generateLinuxContainerConfig(tCtx, &tc.pod.Spec.Containers[0], tc.pod, nil, "", tc.target, false)
 			assert.NoError(t, err)
 			if !proto.Equal(tc.want, got.SecurityContext.NamespaceOptions) {
 				t.Errorf("%v: want %q, got %q", t.Name(), tc.want, got.SecurityContext.NamespaceOptions)
@@ -757,7 +762,8 @@ var (
 )
 
 func TestGenerateLinuxConfigSupplementalGroupsPolicy(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	if err != nil {
 		t.Fatalf("error creating test RuntimeManager: %v", err)
 	}
@@ -823,7 +829,7 @@ func TestGenerateLinuxConfigSupplementalGroupsPolicy(t *testing.T) {
 	},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := m.generateLinuxContainerConfig(&tc.pod.Spec.Containers[0], tc.pod, nil, "", nil, false)
+			actual, err := m.generateLinuxContainerConfig(tCtx, &tc.pod.Spec.Containers[0], tc.pod, nil, "", nil, false)
 			if !tc.expectErr {
 				assert.Emptyf(t, err, "Unexpected error")
 				assert.EqualValuesf(t, tc.expected, actual.SecurityContext.SupplementalGroupsPolicy, "SupplementalGroupPolicy for %s", tc.name)
@@ -837,7 +843,8 @@ func TestGenerateLinuxConfigSupplementalGroupsPolicy(t *testing.T) {
 }
 
 func TestGenerateLinuxContainerResources(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
 
@@ -915,14 +922,14 @@ func TestGenerateLinuxContainerResources(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("cgroup%s:%s", tc.cgroupVersion, tc.name), func(t *testing.T) {
-			defer setSwapControllerAvailableDuringTest(false)()
 			setCgroupVersionDuringTest(tc.cgroupVersion)
+			m.getSwapControllerAvailable = func() bool { return false }
 
 			pod.Spec.Containers[0].Resources = v1.ResourceRequirements{Limits: tc.limits, Requests: tc.requests}
 
 			m.singleProcessOOMKill = ptr.To(tc.singleProcessOOMKill)
 
-			resources := m.generateLinuxContainerResources(pod, &pod.Spec.Containers[0], false)
+			resources := m.generateLinuxContainerResources(tCtx, pod, &pod.Spec.Containers[0], false)
 			tc.expected.HugepageLimits = resources.HugepageLimits
 			assert.Equal(t, tc.expected, resources)
 		})
@@ -930,7 +937,8 @@ func TestGenerateLinuxContainerResources(t *testing.T) {
 }
 
 func TestGetContainerSwapBehavior(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1041,7 +1049,7 @@ func TestGetContainerSwapBehavior(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m.memorySwapBehavior = string(tt.configuredMemorySwap)
 			setCgroupVersionDuringTest(tt.cgroupVersion)
-			defer setSwapControllerAvailableDuringTest(tt.isSwapControllerAvailable)()
+			m.getSwapControllerAvailable = func() bool { return tt.isSwapControllerAvailable }
 			testpod := pod.DeepCopy()
 			testpod.Status.QOSClass = tt.qosClass
 			if tt.containerResourceOverride != nil {
@@ -1053,7 +1061,8 @@ func TestGetContainerSwapBehavior(t *testing.T) {
 }
 
 func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 	m.machineInfo.MemoryCapacity = 42949672960 // 40Gb == 40 * 1024^3
 	m.machineInfo.SwapCapacity = 5368709120    // 5Gb == 5 * 1024^3
@@ -1283,7 +1292,7 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			setCgroupVersionDuringTest(tc.cgroupVersion)
-			defer setSwapControllerAvailableDuringTest(!tc.swapDisabledOnNode)()
+			m.getSwapControllerAvailable = func() bool { return !tc.swapDisabledOnNode }
 			m.memorySwapBehavior = string(tc.swapBehavior)
 
 			var resourceReqsC1, resourceReqsC2 v1.ResourceRequirements
@@ -1320,8 +1329,8 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 				assert.True(t, types.IsCriticalPod(pod), "pod is expected to be critical")
 			}
 
-			resourcesC1 := m.generateLinuxContainerResources(pod, &pod.Spec.Containers[0], false)
-			resourcesC2 := m.generateLinuxContainerResources(pod, &pod.Spec.Containers[1], false)
+			resourcesC1 := m.generateLinuxContainerResources(tCtx, pod, &pod.Spec.Containers[0], false)
+			resourcesC2 := m.generateLinuxContainerResources(tCtx, pod, &pod.Spec.Containers[1], false)
 
 			if tc.swapDisabledOnNode {
 				expectSwapDisabled(tc.cgroupVersion, resourcesC1, resourcesC2)
@@ -1351,7 +1360,8 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 }
 
 func TestGenerateUpdatePodSandboxResourcesRequest(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
 	podRequestCPU := resource.MustParse("400m")
@@ -1736,7 +1746,7 @@ func TestGenerateUpdatePodSandboxResourcesRequest(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			expectedLcr := m.calculateSandboxResources(tc.pod)
+			expectedLcr := m.calculateSandboxResources(tCtx, tc.pod)
 			expectedLcrOverhead := m.convertOverheadToLinuxResources(tc.pod)
 
 			podResourcesCfg := cm.ResourceConfigForPod(tc.pod, tc.enforceCPULimits, uint64((m.cpuCFSQuotaPeriod.Duration)/time.Microsecond), false)
@@ -1756,7 +1766,8 @@ func TestGenerateUpdatePodSandboxResourcesRequest(t *testing.T) {
 }
 
 func TestUpdatePodSandboxResources(t *testing.T) {
-	fakeRuntime, _, m, errCreate := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, m, errCreate := createTestRuntimeManager(tCtx)
 	require.NoError(t, errCreate)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1779,13 +1790,12 @@ func TestUpdatePodSandboxResources(t *testing.T) {
 	fakeSandbox, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
-	ctx := context.Background()
-	_, _, err := m.getPodContainerStatuses(ctx, pod.UID, pod.Name, pod.Namespace, "")
+	_, _, err := m.getPodContainerStatuses(tCtx, pod.UID, pod.Name, pod.Namespace, "")
 	require.NoError(t, err)
 
 	resourceConfig := &cm.ResourceConfig{}
 
-	err = m.updatePodSandboxResources(fakeSandbox.Id, pod, resourceConfig)
+	err = m.updatePodSandboxResources(tCtx, fakeSandbox.Id, pod, resourceConfig)
 	require.NoError(t, err)
 
 	// Verify sandbox is updated
@@ -1802,16 +1812,5 @@ const (
 func setCgroupVersionDuringTest(version CgroupVersion) {
 	isCgroup2UnifiedMode = func() bool {
 		return version == cgroupV2
-	}
-}
-
-func setSwapControllerAvailableDuringTest(available bool) func() {
-	original := swapControllerAvailable
-	swapControllerAvailable = func() bool {
-		return available
-	}
-
-	return func() {
-		swapControllerAvailable = original
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -38,6 +37,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -47,8 +47,8 @@ import (
 
 // TestRemoveContainer tests removing the container and its corresponding container logs.
 func TestRemoveContainer(t *testing.T) {
-	ctx := context.Background()
-	fakeRuntime, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -86,7 +86,7 @@ func TestRemoveContainer(t *testing.T) {
 	fakeOS.Create(expectedContainerLogPath)
 	fakeOS.Create(expectedContainerLogPathRotated)
 
-	err = m.removeContainer(ctx, containerID)
+	err = m.removeContainer(tCtx, containerID)
 	assert.NoError(t, err)
 
 	// Verify container log is removed.
@@ -96,14 +96,15 @@ func TestRemoveContainer(t *testing.T) {
 		fakeOS.Removes)
 	// Verify container is removed
 	assert.Contains(t, fakeRuntime.Called, "RemoveContainer")
-	containers, err := fakeRuntime.ListContainers(ctx, &runtimeapi.ContainerFilter{Id: containerID})
+	containers, err := fakeRuntime.ListContainers(tCtx, &runtimeapi.ContainerFilter{Id: containerID})
 	assert.NoError(t, err)
 	assert.Empty(t, containers)
 }
 
 // TestKillContainer tests killing the container in a Pod.
 func TestKillContainer(t *testing.T) {
-	_, _, m, _ := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, _ := createTestRuntimeManager(tCtx)
 
 	tests := []struct {
 		caseName            string
@@ -129,8 +130,8 @@ func TestKillContainer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ctx := context.Background()
-		err := m.killContainer(ctx, test.pod, test.containerID, test.containerName, test.reason, "", &test.gracePeriodOverride, nil)
+		tCtx := ktesting.Init(t)
+		err := m.killContainer(tCtx, test.pod, test.containerID, test.containerName, test.reason, "", &test.gracePeriodOverride, nil)
 		if test.succeed != (err == nil) {
 			t.Errorf("%s: expected %v, got %v (%v)", test.caseName, test.succeed, (err == nil), err)
 		}
@@ -141,6 +142,7 @@ func TestKillContainer(t *testing.T) {
 // the internal type (i.e., toKubeContainerStatus()) for containers in
 // different states.
 func TestToKubeContainerStatus(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	cid := &kubecontainer.ContainerID{Type: "testRuntime", ID: "dummyid"}
 	meta := &runtimeapi.ContainerMetadata{Name: "cname", Attempt: 3}
 	imageSpec := &runtimeapi.ImageSpec{Image: "fimage"}
@@ -229,7 +231,7 @@ func TestToKubeContainerStatus(t *testing.T) {
 			},
 		},
 	} {
-		actual := toKubeContainerStatus(test.input, cid.Type)
+		actual := toKubeContainerStatus(tCtx, test.input, cid.Type)
 		assert.Equal(t, test.expected, actual, desc)
 	}
 }
@@ -238,6 +240,7 @@ func TestToKubeContainerStatus(t *testing.T) {
 // the internal type (i.e., toKubeContainerStatus()) for containers that returns Resources.
 func TestToKubeContainerStatusWithResources(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	tCtx := ktesting.Init(t)
 	cid := &kubecontainer.ContainerID{Type: "testRuntime", ID: "dummyid"}
 	meta := &runtimeapi.ContainerMetadata{Name: "cname", Attempt: 3}
 	imageSpec := &runtimeapi.ImageSpec{Image: "fimage"}
@@ -363,7 +366,7 @@ func TestToKubeContainerStatusWithResources(t *testing.T) {
 				// TODO: remove skip once the failing test has been fixed.
 				t.Skip("Skip failing test on Windows.")
 			}
-			actual := toKubeContainerStatus(test.input, cid.Type)
+			actual := toKubeContainerStatus(tCtx, test.input, cid.Type)
 			assert.Equal(t, test.expected, actual, desc)
 		})
 	}
@@ -374,6 +377,7 @@ func TestToKubeContainerStatusWithUser(t *testing.T) {
 		t.Skip("Updating Pod Container User is not supported on Windows.")
 	}
 
+	tCtx := ktesting.Init(t)
 	cid := &kubecontainer.ContainerID{Type: "testRuntime", ID: "dummyid"}
 	meta := &runtimeapi.ContainerMetadata{Name: "cname", Attempt: 3}
 	imageSpec := &runtimeapi.ImageSpec{Image: "fimage"}
@@ -447,16 +451,16 @@ func TestToKubeContainerStatusWithUser(t *testing.T) {
 				StartedAt: startedAt,
 				User:      test.input,
 			}
-			actual := toKubeContainerStatus(cStatus, cid.Type)
+			actual := toKubeContainerStatus(tCtx, cStatus, cid.Type)
 			assert.EqualValues(t, test.expected, actual.User, desc)
 		})
 	}
 }
 
 func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Container) {
-
+	tCtx := ktesting.Init(t)
 	// Setup
-	fakeRuntime, _, m, _ := createTestRuntimeManager()
+	fakeRuntime, _, m, _ := createTestRuntimeManager(tCtx)
 
 	gracePeriod := int64(30)
 	cID := kubecontainer.ContainerID{
@@ -512,9 +516,9 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 
 	// Configured and works as expected
 	t.Run("PreStop-CMDExec", func(t *testing.T) {
-		ctx := context.Background()
+		tCtx := ktesting.Init(t)
 		testContainer.Lifecycle = cmdLifeCycle
-		_ = m.killContainer(ctx, testPod, cID, "foo", "testKill", "", &gracePeriod, nil)
+		_ = m.killContainer(tCtx, testPod, cID, "foo", "testKill", "", &gracePeriod, nil)
 		if fakeRunner.Cmd[0] != cmdLifeCycle.PreStop.Exec.Command[0] {
 			t.Errorf("CMD Prestop hook was not invoked")
 		}
@@ -523,11 +527,11 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 	// Configured and working HTTP hook
 	t.Run("PreStop-HTTPGet", func(t *testing.T) {
 		t.Run("consistent", func(t *testing.T) {
-			ctx := context.Background()
+			tCtx := ktesting.Init(t)
 			defer func() { fakeHTTP.req = nil }()
 			httpLifeCycle.PreStop.HTTPGet.Port = intstr.FromInt32(80)
 			testContainer.Lifecycle = httpLifeCycle
-			_ = m.killContainer(ctx, testPod, cID, "foo", "testKill", "", &gracePeriod, nil)
+			_ = m.killContainer(tCtx, testPod, cID, "foo", "testKill", "", &gracePeriod, nil)
 			if fakeHTTP.req == nil || !strings.Contains(fakeHTTP.req.URL.String(), httpLifeCycle.PreStop.HTTPGet.Host) {
 				t.Errorf("HTTP Prestop hook was not invoked")
 			}
@@ -536,13 +540,13 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 
 	// When there is no time to run PreStopHook
 	t.Run("PreStop-NoTimeToRun", func(t *testing.T) {
-		ctx := context.Background()
+		tCtx := ktesting.Init(t)
 		gracePeriodLocal := int64(0)
 
 		testPod.DeletionGracePeriodSeconds = &gracePeriodLocal
 		testPod.Spec.TerminationGracePeriodSeconds = &gracePeriodLocal
 
-		_ = m.killContainer(ctx, testPod, cID, "foo", "testKill", "", &gracePeriodLocal, nil)
+		_ = m.killContainer(tCtx, testPod, cID, "foo", "testKill", "", &gracePeriodLocal, nil)
 		if fakeHTTP.req != nil {
 			t.Errorf("HTTP Prestop hook Should not execute when gracePeriod is 0")
 		}
@@ -550,10 +554,10 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 
 	// Post Start script
 	t.Run("PostStart-CmdExe", func(t *testing.T) {
-		ctx := context.Background()
+		tCtx := ktesting.Init(t)
 		// Fake all the things you need before trying to create a container
 		fakeSandBox, _ := makeAndSetFakePod(t, m, fakeRuntime, testPod)
-		fakeSandBoxConfig, _ := m.generatePodSandboxConfig(testPod, 0)
+		fakeSandBoxConfig, _ := m.generatePodSandboxConfig(tCtx, testPod, 0)
 		testContainer.Lifecycle = cmdPostStart
 		fakePodStatus := &kubecontainer.PodStatus{
 			ContainerStatuses: []*kubecontainer.Status{
@@ -570,7 +574,7 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 		}
 
 		// Now try to create a container, which should in turn invoke PostStart Hook
-		_, err := m.startContainer(ctx, fakeSandBox.Id, fakeSandBoxConfig, containerStartSpec(testContainer), testPod, fakePodStatus, nil, "", []string{}, nil)
+		_, err := m.startContainer(tCtx, fakeSandBox.Id, fakeSandBoxConfig, containerStartSpec(testContainer), testPod, fakePodStatus, nil, "", []string{}, nil)
 		if err != nil {
 			t.Errorf("startContainer error =%v", err)
 		}
@@ -770,6 +774,7 @@ func TestRestartCountByLogDir(t *testing.T) {
 }
 
 func TestKillContainerGracePeriod(t *testing.T) {
+	tCtx := ktesting.Init(t)
 
 	shortGracePeriod := int64(10)
 	mediumGracePeriod := int64(30)
@@ -927,7 +932,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualGracePeriod := setTerminationGracePeriod(test.pod, &test.pod.Spec.Containers[0], "", kubecontainer.ContainerID{}, test.reason)
+			actualGracePeriod := setTerminationGracePeriod(tCtx, test.pod, &test.pod.Spec.Containers[0], "", kubecontainer.ContainerID{}, test.reason)
 			require.Equal(t, test.expectedGracePeriod, actualGracePeriod)
 		})
 	}
@@ -935,7 +940,8 @@ func TestKillContainerGracePeriod(t *testing.T) {
 
 // TestUpdateContainerResources tests updating a container in a Pod.
 func TestUpdateContainerResources(t *testing.T) {
-	fakeRuntime, _, m, errCreate := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, m, errCreate := createTestRuntimeManager(tCtx)
 	require.NoError(t, errCreate)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -958,12 +964,11 @@ func TestUpdateContainerResources(t *testing.T) {
 	_, fakeContainers := makeAndSetFakePod(t, m, fakeRuntime, pod)
 	assert.Len(t, fakeContainers, 1)
 
-	ctx := context.Background()
-	cStatus, _, err := m.getPodContainerStatuses(ctx, pod.UID, pod.Name, pod.Namespace, "")
+	cStatus, _, err := m.getPodContainerStatuses(tCtx, pod.UID, pod.Name, pod.Namespace, "")
 	assert.NoError(t, err)
 	containerID := cStatus[0].ID
 
-	err = m.updateContainerResources(pod, &pod.Spec.Containers[0], containerID)
+	err = m.updateContainerResources(tCtx, pod, &pod.Spec.Containers[0], containerID)
 	assert.NoError(t, err)
 
 	// Verify container is updated

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_unsupported.go
@@ -20,6 +20,8 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -28,12 +30,12 @@ import (
 )
 
 // applyPlatformSpecificContainerConfig applies platform specific configurations to runtimeapi.ContainerConfig.
-func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(config *runtimeapi.ContainerConfig, container *v1.Container, pod *v1.Pod, uid *int64, username string, nsTarget *kubecontainer.ContainerID) error {
+func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(ctx context.Context, config *runtimeapi.ContainerConfig, container *v1.Container, pod *v1.Pod, uid *int64, username string, nsTarget *kubecontainer.ContainerID) error {
 	return nil
 }
 
 // generateContainerResources generates platform specific container resources config for runtime
-func (m *kubeGenericRuntimeManager) generateContainerResources(pod *v1.Pod, container *v1.Container) *runtimeapi.ContainerResources {
+func (m *kubeGenericRuntimeManager) generateContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container) *runtimeapi.ContainerResources {
 	return nil
 }
 
@@ -52,4 +54,9 @@ func toKubeContainerUser(statusUser *runtimeapi.ContainerUser) *kubecontainer.Co
 
 func (m *kubeGenericRuntimeManager) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Container) types.SwapBehavior {
 	return types.NoSwap
+}
+
+// initSwapControllerAvailabilityCheck returns a function that always returns false on unsupported platforms
+func initSwapControllerAvailabilityCheck(ctx context.Context) func() bool {
+	return func() bool { return false }
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go
@@ -20,6 +20,8 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -32,8 +34,8 @@ import (
 )
 
 // applyPlatformSpecificContainerConfig applies platform specific configurations to runtimeapi.ContainerConfig.
-func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(config *runtimeapi.ContainerConfig, container *v1.Container, pod *v1.Pod, uid *int64, username string, _ *kubecontainer.ContainerID) error {
-	windowsConfig, err := m.generateWindowsContainerConfig(container, pod, uid, username)
+func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(ctx context.Context, config *runtimeapi.ContainerConfig, container *v1.Container, pod *v1.Pod, uid *int64, username string, _ *kubecontainer.ContainerID) error {
+	windowsConfig, err := m.generateWindowsContainerConfig(ctx, container, pod, uid, username)
 	if err != nil {
 		return err
 	}
@@ -43,9 +45,9 @@ func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(config 
 }
 
 // generateContainerResources generates platform specific (windows) container resources config for runtime
-func (m *kubeGenericRuntimeManager) generateContainerResources(pod *v1.Pod, container *v1.Container) *runtimeapi.ContainerResources {
+func (m *kubeGenericRuntimeManager) generateContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container) *runtimeapi.ContainerResources {
 	return &runtimeapi.ContainerResources{
-		Windows: m.generateWindowsContainerResources(pod, container),
+		Windows: m.generateWindowsContainerResources(ctx, pod, container),
 	}
 }
 
@@ -55,14 +57,14 @@ func (m *kubeGenericRuntimeManager) generateUpdatePodSandboxResourcesRequest(san
 }
 
 // generateWindowsContainerResources generates windows container resources config for runtime
-func (m *kubeGenericRuntimeManager) generateWindowsContainerResources(pod *v1.Pod, container *v1.Container) *runtimeapi.WindowsContainerResources {
-	wcr := m.calculateWindowsResources(container.Resources.Limits.Cpu(), container.Resources.Limits.Memory())
+func (m *kubeGenericRuntimeManager) generateWindowsContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container) *runtimeapi.WindowsContainerResources {
+	wcr := m.calculateWindowsResources(ctx, container.Resources.Limits.Cpu(), container.Resources.Limits.Memory())
 
 	return wcr
 }
 
 // calculateWindowsResources will create the windowsContainerResources type based on the provided CPU and memory resource requests, limits
-func (m *kubeGenericRuntimeManager) calculateWindowsResources(cpuLimit, memoryLimit *resource.Quantity) *runtimeapi.WindowsContainerResources {
+func (m *kubeGenericRuntimeManager) calculateWindowsResources(ctx context.Context, cpuLimit, memoryLimit *resource.Quantity) *runtimeapi.WindowsContainerResources {
 	resources := runtimeapi.WindowsContainerResources{}
 
 	memLimit := memoryLimit.Value()
@@ -100,7 +102,8 @@ func (m *kubeGenericRuntimeManager) calculateWindowsResources(cpuLimit, memoryLi
 	if resources.CpuCount > 0 {
 		if resources.CpuMaximum > 0 {
 			resources.CpuMaximum = 0
-			klog.InfoS("Mutually exclusive options: CPUCount priority > CPUMaximum priority on Windows Server Containers. CPUMaximum should be ignored")
+			logger := klog.FromContext(ctx)
+			logger.Info("Mutually exclusive options: CPUCount priority > CPUMaximum priority on Windows Server Containers. CPUMaximum should be ignored")
 		}
 	}
 
@@ -113,9 +116,9 @@ func (m *kubeGenericRuntimeManager) calculateWindowsResources(cpuLimit, memoryLi
 
 // generateWindowsContainerConfig generates windows container config for kubelet runtime v1.
 // Refer https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/cri-windows.md.
-func (m *kubeGenericRuntimeManager) generateWindowsContainerConfig(container *v1.Container, pod *v1.Pod, uid *int64, username string) (*runtimeapi.WindowsContainerConfig, error) {
+func (m *kubeGenericRuntimeManager) generateWindowsContainerConfig(ctx context.Context, container *v1.Container, pod *v1.Pod, uid *int64, username string) (*runtimeapi.WindowsContainerConfig, error) {
 	wc := &runtimeapi.WindowsContainerConfig{
-		Resources:       m.generateWindowsContainerResources(pod, container),
+		Resources:       m.generateWindowsContainerResources(ctx, pod, container),
 		SecurityContext: &runtimeapi.WindowsContainerSecurityContext{},
 	}
 
@@ -187,4 +190,9 @@ func toKubeContainerUser(statusUser *runtimeapi.ContainerUser) *kubecontainer.Co
 
 func (m *kubeGenericRuntimeManager) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Container) types.SwapBehavior {
 	return types.NoSwap
+}
+
+// initSwapControllerAvailabilityCheck returns a function that always returns false on Windows
+func initSwapControllerAvailabilityCheck(ctx context.Context) func() bool {
+	return func() bool { return false }
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
@@ -30,10 +30,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/winstats"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestApplyPlatformSpecificContainerConfig(t *testing.T) {
-	_, _, fakeRuntimeSvc, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, fakeRuntimeSvc, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
 	containerConfig := &runtimeapi.ContainerConfig{}
@@ -81,7 +83,7 @@ func TestApplyPlatformSpecificContainerConfig(t *testing.T) {
 		},
 	}
 
-	err = fakeRuntimeSvc.applyPlatformSpecificContainerConfig(containerConfig, &pod.Spec.Containers[0], pod, new(int64), "foo", nil)
+	err = fakeRuntimeSvc.applyPlatformSpecificContainerConfig(tCtx, containerConfig, &pod.Spec.Containers[0], pod, new(int64), "foo", nil)
 	require.NoError(t, err)
 
 	limit := int64(3000)
@@ -154,7 +156,8 @@ func TestCalculateWindowsResources(t *testing.T) {
 	// TODO: remove skip once the failing test has been fixed.
 	t.Skip("Skip failing test on Windows.")
 
-	_, _, fakeRuntimeSvc, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, fakeRuntimeSvc, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -192,7 +195,7 @@ func TestCalculateWindowsResources(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		windowsContainerResources := fakeRuntimeSvc.calculateWindowsResources(&test.cpuLim, &test.memLim)
+		windowsContainerResources := fakeRuntimeSvc.calculateWindowsResources(tCtx, &test.cpuLim, &test.memLim)
 		assert.Equal(t, test.expected, windowsContainerResources)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -31,15 +31,16 @@ import (
 // PullImage pulls an image from the network to local storage using the supplied
 // secrets if necessary.
 func (m *kubeGenericRuntimeManager) PullImage(ctx context.Context, image kubecontainer.ImageSpec, credentials []crededentialprovider.TrackedAuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, *crededentialprovider.TrackedAuthConfig, error) {
+	logger := klog.FromContext(ctx)
 	img := image.Image
 	imgSpec := toRuntimeAPIImageSpec(image)
 
 	if len(credentials) == 0 {
-		klog.V(3).InfoS("Pulling image without credentials", "image", img)
+		logger.V(3).Info("Pulling image without credentials", "image", img)
 
 		imageRef, err := m.imageService.PullImage(ctx, imgSpec, nil, podSandboxConfig)
 		if err != nil {
-			klog.ErrorS(err, "Failed to pull image", "image", img)
+			logger.Error(err, "Failed to pull image", "image", img)
 			return "", nil, err
 		}
 
@@ -72,9 +73,10 @@ func (m *kubeGenericRuntimeManager) PullImage(ctx context.Context, image kubecon
 // GetImageRef gets the ID of the image which has already been in
 // the local storage. It returns ("", nil) if the image isn't in the local storage.
 func (m *kubeGenericRuntimeManager) GetImageRef(ctx context.Context, image kubecontainer.ImageSpec) (string, error) {
+	logger := klog.FromContext(ctx)
 	resp, err := m.imageService.ImageStatus(ctx, toRuntimeAPIImageSpec(image), false)
 	if err != nil {
-		klog.ErrorS(err, "Failed to get image status", "image", image.Image)
+		logger.Error(err, "Failed to get image status", "image", image.Image)
 		return "", err
 	}
 	if resp.Image == nil {
@@ -84,9 +86,10 @@ func (m *kubeGenericRuntimeManager) GetImageRef(ctx context.Context, image kubec
 }
 
 func (m *kubeGenericRuntimeManager) GetImageSize(ctx context.Context, image kubecontainer.ImageSpec) (uint64, error) {
+	logger := klog.FromContext(ctx)
 	resp, err := m.imageService.ImageStatus(ctx, toRuntimeAPIImageSpec(image), false)
 	if err != nil {
-		klog.ErrorS(err, "Failed to get image status", "image", image.Image)
+		logger.Error(err, "Failed to get image status", "image", image.Image)
 		return 0, err
 	}
 	if resp.Image == nil {
@@ -97,11 +100,12 @@ func (m *kubeGenericRuntimeManager) GetImageSize(ctx context.Context, image kube
 
 // ListImages gets all images currently on the machine.
 func (m *kubeGenericRuntimeManager) ListImages(ctx context.Context) ([]kubecontainer.Image, error) {
+	logger := klog.FromContext(ctx)
 	var images []kubecontainer.Image
 
 	allImages, err := m.imageService.ListImages(ctx, nil)
 	if err != nil {
-		klog.ErrorS(err, "Failed to list images")
+		logger.Error(err, "Failed to list images")
 		return nil, err
 	}
 
@@ -113,7 +117,7 @@ func (m *kubeGenericRuntimeManager) ListImages(ctx context.Context) ([]kubeconta
 		// field is empty and log a warning message.
 		if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClassInImageCriAPI) {
 			if img.Spec == nil || (img.Spec != nil && img.Spec.RuntimeHandler == "") {
-				klog.V(2).InfoS("WARNING: RuntimeHandler is empty", "ImageID", img.Id)
+				logger.V(2).Info("WARNING: RuntimeHandler is empty", "ImageID", img.Id)
 			}
 		}
 
@@ -132,9 +136,10 @@ func (m *kubeGenericRuntimeManager) ListImages(ctx context.Context) ([]kubeconta
 
 // RemoveImage removes the specified image.
 func (m *kubeGenericRuntimeManager) RemoveImage(ctx context.Context, image kubecontainer.ImageSpec) error {
+	logger := klog.FromContext(ctx)
 	err := m.imageService.RemoveImage(ctx, &runtimeapi.ImageSpec{Image: image.Image})
 	if err != nil {
-		klog.ErrorS(err, "Failed to remove image", "image", image.Image)
+		logger.Error(err, "Failed to remove image", "image", image.Image)
 		return err
 	}
 
@@ -146,9 +151,10 @@ func (m *kubeGenericRuntimeManager) RemoveImage(ctx context.Context, image kubec
 // this is a known issue, and we'll address this by getting imagefs stats directly from CRI.
 // TODO: Get imagefs stats directly from CRI.
 func (m *kubeGenericRuntimeManager) ImageStats(ctx context.Context) (*kubecontainer.ImageStats, error) {
+	logger := klog.FromContext(ctx)
 	allImages, err := m.imageService.ListImages(ctx, nil)
 	if err != nil {
-		klog.ErrorS(err, "Failed to list images")
+		logger.Error(err, "Failed to list images")
 		return nil, err
 	}
 	stats := &kubecontainer.ImageStats{}
@@ -159,9 +165,10 @@ func (m *kubeGenericRuntimeManager) ImageStats(ctx context.Context) (*kubecontai
 }
 
 func (m *kubeGenericRuntimeManager) ImageFsInfo(ctx context.Context) (*runtimeapi.ImageFsInfoResponse, error) {
+	logger := klog.FromContext(ctx)
 	allImages, err := m.imageService.ImageFsInfo(ctx)
 	if err != nil {
-		klog.ErrorS(err, "Failed to get image filesystem")
+		logger.Error(err, "Failed to get image filesystem")
 		return nil, err
 	}
 	return allImages, nil

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -34,51 +33,52 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/images"
 	imagepullmanager "k8s.io/kubernetes/pkg/kubelet/images/pullmanager"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
 func TestPullImage(t *testing.T) {
-	ctx := context.Background()
-	_, _, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
-	imageRef, creds, err := fakeManager.PullImage(ctx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
+	imageRef, creds, err := fakeManager.PullImage(tCtx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "busybox", imageRef)
 	assert.Nil(t, creds) // as this was an anonymous pull
 
-	images, err := fakeManager.ListImages(ctx)
+	images, err := fakeManager.ListImages(tCtx)
 	assert.NoError(t, err)
 	assert.Len(t, images, 1)
 	assert.Equal(t, []string{"busybox"}, images[0].RepoTags)
 }
 
 func TestPullImageWithError(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	fakeImageService.InjectError("PullImage", fmt.Errorf("test-error"))
-	imageRef, creds, err := fakeManager.PullImage(ctx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
+	imageRef, creds, err := fakeManager.PullImage(tCtx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
 	assert.Error(t, err)
 	assert.Equal(t, "", imageRef)
 	assert.Nil(t, creds)
 
-	images, err := fakeManager.ListImages(ctx)
+	images, err := fakeManager.ListImages(tCtx)
 	assert.NoError(t, err)
 	assert.Empty(t, images)
 }
 
 func TestListImages(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	images := []string{"1111", "2222", "3333"}
 	expected := sets.New[string](images...)
 	fakeImageService.SetFakeImages(images)
 
-	actualImages, err := fakeManager.ListImages(ctx)
+	actualImages, err := fakeManager.ListImages(tCtx)
 	assert.NoError(t, err)
 	actual := sets.New[string]()
 	for _, i := range actualImages {
@@ -89,8 +89,8 @@ func TestListImages(t *testing.T) {
 }
 
 func TestListImagesPinnedField(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	imagesPinned := map[string]bool{
@@ -105,7 +105,7 @@ func TestListImagesPinnedField(t *testing.T) {
 	}
 	fakeImageService.SetFakeImages(imageList)
 
-	actualImages, err := fakeManager.ListImages(ctx)
+	actualImages, err := fakeManager.ListImages(tCtx)
 	assert.NoError(t, err)
 	for _, image := range actualImages {
 		assert.Equal(t, imagesPinned[image.ID], image.Pinned)
@@ -113,51 +113,51 @@ func TestListImagesPinnedField(t *testing.T) {
 }
 
 func TestListImagesWithError(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	fakeImageService.InjectError("ListImages", fmt.Errorf("test-failure"))
 
-	actualImages, err := fakeManager.ListImages(ctx)
+	actualImages, err := fakeManager.ListImages(tCtx)
 	assert.Error(t, err)
 	assert.Nil(t, actualImages)
 }
 
 func TestGetImageRef(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	image := "busybox"
 	fakeImageService.SetFakeImages([]string{image})
-	imageRef, err := fakeManager.GetImageRef(ctx, kubecontainer.ImageSpec{Image: image})
+	imageRef, err := fakeManager.GetImageRef(tCtx, kubecontainer.ImageSpec{Image: image})
 	assert.NoError(t, err)
 	assert.Equal(t, image, imageRef)
 }
 
 func TestImageSize(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	const imageSize = uint64(64)
 	fakeImageService.SetFakeImageSize(imageSize)
 	image := "busybox"
 	fakeImageService.SetFakeImages([]string{image})
-	actualSize, err := fakeManager.GetImageSize(ctx, kubecontainer.ImageSpec{Image: image})
+	actualSize, err := fakeManager.GetImageSize(tCtx, kubecontainer.ImageSpec{Image: image})
 	assert.NoError(t, err)
 	assert.Equal(t, imageSize, actualSize)
 }
 
 func TestGetImageRefImageNotAvailableLocally(t *testing.T) {
-	ctx := context.Background()
-	_, _, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	image := "busybox"
 
-	imageRef, err := fakeManager.GetImageRef(ctx, kubecontainer.ImageSpec{Image: image})
+	imageRef, err := fakeManager.GetImageRef(tCtx, kubecontainer.ImageSpec{Image: image})
 	assert.NoError(t, err)
 
 	imageNotAvailableLocallyRef := ""
@@ -165,61 +165,61 @@ func TestGetImageRefImageNotAvailableLocally(t *testing.T) {
 }
 
 func TestGetImageRefWithError(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	image := "busybox"
 
 	fakeImageService.InjectError("ImageStatus", fmt.Errorf("test-error"))
 
-	imageRef, err := fakeManager.GetImageRef(ctx, kubecontainer.ImageSpec{Image: image})
+	imageRef, err := fakeManager.GetImageRef(tCtx, kubecontainer.ImageSpec{Image: image})
 	assert.Error(t, err)
 	assert.Equal(t, "", imageRef)
 }
 
 func TestRemoveImage(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
-	_, _, err = fakeManager.PullImage(ctx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
+	_, _, err = fakeManager.PullImage(tCtx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
 	assert.NoError(t, err)
 	assert.Len(t, fakeImageService.Images, 1)
 
-	err = fakeManager.RemoveImage(ctx, kubecontainer.ImageSpec{Image: "busybox"})
+	err = fakeManager.RemoveImage(tCtx, kubecontainer.ImageSpec{Image: "busybox"})
 	assert.NoError(t, err)
 	assert.Empty(t, fakeImageService.Images)
 }
 
 func TestRemoveImageNoOpIfImageNotLocal(t *testing.T) {
-	ctx := context.Background()
-	_, _, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
-	err = fakeManager.RemoveImage(ctx, kubecontainer.ImageSpec{Image: "busybox"})
+	err = fakeManager.RemoveImage(tCtx, kubecontainer.ImageSpec{Image: "busybox"})
 	assert.NoError(t, err)
 }
 
 func TestRemoveImageWithError(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
-	_, _, err = fakeManager.PullImage(ctx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
+	_, _, err = fakeManager.PullImage(tCtx, kubecontainer.ImageSpec{Image: "busybox"}, nil, nil)
 	assert.NoError(t, err)
 	assert.Len(t, fakeImageService.Images, 1)
 
 	fakeImageService.InjectError("RemoveImage", fmt.Errorf("test-failure"))
 
-	err = fakeManager.RemoveImage(ctx, kubecontainer.ImageSpec{Image: "busybox"})
+	err = fakeManager.RemoveImage(tCtx, kubecontainer.ImageSpec{Image: "busybox"})
 	assert.Error(t, err)
 	assert.Len(t, fakeImageService.Images, 1)
 }
 
 func TestImageStats(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	const imageSize = 64
@@ -227,26 +227,26 @@ func TestImageStats(t *testing.T) {
 	images := []string{"1111", "2222", "3333"}
 	fakeImageService.SetFakeImages(images)
 
-	actualStats, err := fakeManager.ImageStats(ctx)
+	actualStats, err := fakeManager.ImageStats(tCtx)
 	assert.NoError(t, err)
 	expectedStats := &kubecontainer.ImageStats{TotalStorageBytes: imageSize * uint64(len(images))}
 	assert.Equal(t, expectedStats, actualStats)
 }
 
 func TestImageStatsWithError(t *testing.T) {
-	ctx := context.Background()
-	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	fakeImageService.InjectError("ListImages", fmt.Errorf("test-failure"))
 
-	actualImageStats, err := fakeManager.ImageStats(ctx)
+	actualImageStats, err := fakeManager.ImageStats(tCtx)
 	assert.Error(t, err)
 	assert.Nil(t, actualImageStats)
 }
 
 func TestPullWithSecrets(t *testing.T) {
-	ctx := context.Background()
+	tCtx := ktesting.Init(t)
 	// auth value is equivalent to: "username":"passed-user","password":"passed-password"
 	dockerCfg := map[string]map[string]string{"index.docker.io/v1/": {"email": "passed-email", "auth": "cGFzc2VkLXVzZXI6cGFzc2VkLXBhc3N3b3Jk"}}
 	dockercfgContent, err := json.Marshal(dockerCfg)
@@ -309,7 +309,7 @@ func TestPullWithSecrets(t *testing.T) {
 		builtInKeyRing := &credentialprovider.BasicDockerKeyring{}
 		builtInKeyRing.Add(nil, test.builtInDockerConfig)
 
-		_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+		_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 		require.NoError(t, err)
 
 		fsRecordAccessor, err := imagepullmanager.NewFSPullRecordsAccessor(t.TempDir())
@@ -317,7 +317,7 @@ func TestPullWithSecrets(t *testing.T) {
 			t.Fatal("failed to setup an file pull records accessor")
 		}
 
-		imagePullManager, err := imagepullmanager.NewImagePullManager(context.Background(), fsRecordAccessor, imagepullmanager.AlwaysVerifyImagePullPolicy(), fakeManager, 10)
+		imagePullManager, err := imagepullmanager.NewImagePullManager(tCtx, fsRecordAccessor, imagepullmanager.AlwaysVerifyImagePullPolicy(), fakeManager, 10)
 		if err != nil {
 			t.Fatal("failed to setup an image pull manager")
 		}
@@ -335,14 +335,14 @@ func TestPullWithSecrets(t *testing.T) {
 			&fakePodPullingTimeRecorder{},
 		)
 
-		_, _, err = fakeManager.imagePuller.EnsureImageExists(ctx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, nil, "", v1.PullAlways)
+		_, _, err = fakeManager.imagePuller.EnsureImageExists(tCtx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, nil, "", v1.PullAlways)
 		require.NoError(t, err)
 		fakeImageService.AssertImagePulledWithAuth(t, &runtimeapi.ImageSpec{Image: test.imageName, Annotations: make(map[string]string)}, test.expectedAuth, description)
 	}
 }
 
 func TestPullWithSecretsWithError(t *testing.T) {
-	ctx := context.Background()
+	tCtx := ktesting.Init(t)
 
 	dockerCfg := map[string]map[string]map[string]string{
 		"auths": {
@@ -379,7 +379,7 @@ func TestPullWithSecretsWithError(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+			_, fakeImageService, fakeManager, err := createTestRuntimeManager(tCtx)
 			assert.NoError(t, err)
 
 			if test.shouldInjectError {
@@ -391,7 +391,7 @@ func TestPullWithSecretsWithError(t *testing.T) {
 				t.Fatal("failed to setup an file pull records accessor")
 			}
 
-			imagePullManager, err := imagepullmanager.NewImagePullManager(context.Background(), fsRecordAccessor, imagepullmanager.AlwaysVerifyImagePullPolicy(), fakeManager, 10)
+			imagePullManager, err := imagepullmanager.NewImagePullManager(tCtx, fsRecordAccessor, imagepullmanager.AlwaysVerifyImagePullPolicy(), fakeManager, 10)
 			if err != nil {
 				t.Fatal("failed to setup an image pull manager")
 			}
@@ -409,11 +409,11 @@ func TestPullWithSecretsWithError(t *testing.T) {
 				&fakePodPullingTimeRecorder{},
 			)
 
-			imageRef, _, err := fakeManager.imagePuller.EnsureImageExists(ctx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, nil, "", v1.PullAlways)
+			imageRef, _, err := fakeManager.imagePuller.EnsureImageExists(tCtx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, nil, "", v1.PullAlways)
 			assert.Error(t, err)
 			assert.Equal(t, "", imageRef)
 
-			images, err := fakeManager.ListImages(ctx)
+			images, err := fakeManager.ListImages(tCtx)
 			assert.NoError(t, err)
 			assert.Empty(t, images)
 		})
@@ -421,8 +421,8 @@ func TestPullWithSecretsWithError(t *testing.T) {
 }
 
 func TestPullThenListWithAnnotations(t *testing.T) {
-	ctx := context.Background()
-	_, _, fakeManager, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, fakeManager, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
 
 	imageSpec := kubecontainer.ImageSpec{
@@ -432,10 +432,10 @@ func TestPullThenListWithAnnotations(t *testing.T) {
 		},
 	}
 
-	_, _, err = fakeManager.PullImage(ctx, imageSpec, nil, nil)
+	_, _, err = fakeManager.PullImage(tCtx, imageSpec, nil, nil)
 	assert.NoError(t, err)
 
-	images, err := fakeManager.ListImages(ctx)
+	images, err := fakeManager.ListImages(tCtx)
 	assert.NoError(t, err)
 	assert.Len(t, images, 1)
 	assert.Equal(t, images[0].Spec, imageSpec)

--- a/pkg/kubelet/kuberuntime/kuberuntime_logs.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_logs.go
@@ -32,6 +32,6 @@ import (
 func (m *kubeGenericRuntimeManager) ReadLogs(ctx context.Context, path, containerID string, apiOpts *v1.PodLogOptions, stdout, stderr io.Writer) error {
 	// Convert v1.PodLogOptions into internal log options.
 	opts := logs.NewLogOptions(apiOpts, time.Now())
-	logger := klog.Background()
+	logger := klog.FromContext(ctx)
 	return logs.ReadLogs(ctx, &logger, path, containerID, opts, m.runtimeService, stdout, stderr)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
@@ -28,11 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
 func TestApplySandboxResources(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	m.cpuCFSQuota = true
 	m.singleProcessOOMKill = ptr.To(false)
 
@@ -168,14 +170,16 @@ func TestApplySandboxResources(t *testing.T) {
 	for i, test := range tests {
 		setCgroupVersionDuringTest(test.cgroupVersion)
 
-		m.applySandboxResources(test.pod, config)
+		err = m.applySandboxResources(tCtx, test.pod, config)
+		require.NoError(t, err)
 		assert.Equal(t, test.expectedResource, config.Linux.Resources, "TestCase[%d]: %s", i, test.description)
 		assert.Equal(t, test.expectedOverhead, config.Linux.Overhead, "TestCase[%d]: %s", i, test.description)
 	}
 }
 
 func TestGeneratePodSandboxConfigWithLinuxSecurityContext(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 	pod := newTestPodWithLinuxSecurityContext()
 
@@ -189,7 +193,7 @@ func TestGeneratePodSandboxConfigWithLinuxSecurityContext(t *testing.T) {
 		},
 	}
 
-	podSandboxConfig, err := m.generatePodSandboxConfig(pod, 1)
+	podSandboxConfig, err := m.generatePodSandboxConfig(tCtx, pod, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.SelinuxOptions, podSandboxConfig.Linux.SecurityContext.SelinuxOptions)
 	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.RunAsUser, podSandboxConfig.Linux.SecurityContext.RunAsUser)
@@ -222,7 +226,8 @@ func newSupplementalGroupsPolicyPod(supplementalGroupsPolicy *v1.SupplementalGro
 }
 
 func TestGeneratePodSandboxLinuxConfigSupplementalGroupsPolicy(t *testing.T) {
-	_, _, m, err := createTestRuntimeManager()
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_unsupported.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_unsupported.go
@@ -20,10 +20,12 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (m *kubeGenericRuntimeManager) applySandboxResources(pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {
+func (m *kubeGenericRuntimeManager) applySandboxResources(ctx context.Context, pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {
 	return nil
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_windows.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_windows.go
@@ -20,10 +20,12 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func (m *kubeGenericRuntimeManager) applySandboxResources(pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {
+func (m *kubeGenericRuntimeManager) applySandboxResources(ctx context.Context, pod *v1.Pod, config *runtimeapi.PodSandboxConfig) error {
 	return nil
 }

--- a/pkg/kubelet/kuberuntime/labels_test.go
+++ b/pkg/kubelet/kuberuntime/labels_test.go
@@ -27,9 +27,11 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestContainerLabels(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	deletionGracePeriod := int64(10)
 	terminationGracePeriod := int64(10)
 	lifecycle := &v1.Lifecycle{
@@ -85,7 +87,7 @@ func TestContainerLabels(t *testing.T) {
 	// Test whether we can get right information from label
 	for _, test := range tests {
 		labels := newContainerLabels(container, pod)
-		containerInfo := getContainerInfoFromLabels(labels)
+		containerInfo := getContainerInfoFromLabels(tCtx, labels)
 		if !reflect.DeepEqual(containerInfo, test.expected) {
 			t.Errorf("%v: expected %v, got %v", test.description, test.expected, containerInfo)
 		}
@@ -93,6 +95,7 @@ func TestContainerLabels(t *testing.T) {
 }
 
 func TestContainerAnnotations(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	restartCount := 5
 	deletionGracePeriod := int64(10)
 	terminationGracePeriod := int64(10)
@@ -162,8 +165,8 @@ func TestContainerAnnotations(t *testing.T) {
 
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	// Test whether we can get right information from label
-	annotations := newContainerAnnotations(container, pod, restartCount, opts)
-	containerInfo := getContainerInfoFromAnnotations(annotations)
+	annotations := newContainerAnnotations(tCtx, container, pod, restartCount, opts)
+	containerInfo := getContainerInfoFromAnnotations(tCtx, annotations)
 	if !reflect.DeepEqual(containerInfo, expected) {
 		t.Errorf("expected %v, got %v", expected, containerInfo)
 	}
@@ -181,8 +184,8 @@ func TestContainerAnnotations(t *testing.T) {
 	expected.PreStopHandler = nil
 	// Because container is changed, the Hash should be updated
 	expected.Hash = kubecontainer.HashContainer(container)
-	annotations = newContainerAnnotations(container, pod, restartCount, opts)
-	containerInfo = getContainerInfoFromAnnotations(annotations)
+	annotations = newContainerAnnotations(tCtx, container, pod, restartCount, opts)
+	containerInfo = getContainerInfoFromAnnotations(tCtx, annotations)
 	if !reflect.DeepEqual(containerInfo, expected) {
 		t.Errorf("expected %v, got %v", expected, containerInfo)
 	}
@@ -192,6 +195,7 @@ func TestContainerAnnotations(t *testing.T) {
 }
 
 func TestPodLabels(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test_pod",
@@ -212,7 +216,7 @@ func TestPodLabels(t *testing.T) {
 
 	// Test whether we can get right information from label
 	labels := newPodLabels(pod)
-	podSandboxInfo := getPodSandboxInfoFromLabels(labels)
+	podSandboxInfo := getPodSandboxInfoFromLabels(tCtx, labels)
 	if !reflect.DeepEqual(podSandboxInfo, expected) {
 		t.Errorf("expected %v, got %v", expected, podSandboxInfo)
 	}

--- a/pkg/kubelet/kuberuntime/security_context_others.go
+++ b/pkg/kubelet/kuberuntime/security_context_others.go
@@ -20,6 +20,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -31,7 +32,7 @@ import (
 )
 
 // verifyRunAsNonRoot verifies RunAsNonRoot.
-func verifyRunAsNonRoot(pod *v1.Pod, container *v1.Container, uid *int64, username string) error {
+func verifyRunAsNonRoot(ctx context.Context, pod *v1.Pod, container *v1.Container, uid *int64, username string) error {
 	effectiveSc := securitycontext.DetermineEffectiveSecurityContext(pod, container)
 	// If the option is not set, or if running as root is allowed, return nil.
 	if effectiveSc == nil || effectiveSc.RunAsNonRoot == nil || !*effectiveSc.RunAsNonRoot {

--- a/pkg/kubelet/kuberuntime/security_context_others_test.go
+++ b/pkg/kubelet/kuberuntime/security_context_others_test.go
@@ -27,9 +27,11 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestVerifyRunAsNonRoot(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -168,7 +170,7 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 		},
 	} {
 		pod.Spec.Containers[0].SecurityContext = test.sc
-		err := verifyRunAsNonRoot(pod, &pod.Spec.Containers[0], test.uid, test.username)
+		err := verifyRunAsNonRoot(tCtx, pod, &pod.Spec.Containers[0], test.uid, test.username)
 		if test.fail {
 			assert.Error(t, err, test.desc)
 		} else {

--- a/pkg/kubelet/kuberuntime/security_context_windows_test.go
+++ b/pkg/kubelet/kuberuntime/security_context_windows_test.go
@@ -20,14 +20,16 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestVerifyRunAsNonRoot(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -173,7 +175,7 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 		},
 	} {
 		pod.Spec.Containers[0].SecurityContext = test.sc
-		err := verifyRunAsNonRoot(pod, &pod.Spec.Containers[0], test.uid, test.username)
+		err := verifyRunAsNonRoot(tCtx, pod, &pod.Spec.Containers[0], test.uid, test.username)
 		if test.fail {
 			assert.Error(t, err, test.desc)
 		} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR migrates the `pkg/kubelet/kuberuntime` package to use contextual logging as part of the ongoing effort to improve structured logging in Kubernetes.

The main changes include:
- Replace all `klog` calls with contextual logging using `logger` from `klog.FromContext(ctx)`
- Add context parameters to functions that need to pass context for logging
- Update golangci-lint configuration files to enable contextual logging checks for kuberuntime
- Update logcheck.conf to mark kuberuntime as using contextual logging
- Update all test files to use `ktesting.Init(t)` for consistent logger initialization
- Pass logger directly to short utility functions that only need logging functionality

**Notable refactoring:**
- **swapControllerAvailable**: Refactored from a global `sync.OnceValue` variable to a field in `kubeGenericRuntimeManager` to eliminate `context.TODO()` usage. The implementation maintains lazy initialization using `sync.OnceValue` and ensures consistent design pattern throughout the codebase:
  - Added `getSwapControllerAvailable func() bool` field to `kubeGenericRuntimeManager`
  - Modified `swapConfigurationHelper` to accept `getSwapControllerAvailable func() bool` instead of eagerly evaluating the boolean value
  - This ensures lazy evaluation is consistent between `kubeGenericRuntimeManager` and `swapConfigurationHelper`

Please check the following documents
- [KEP-3077: Contextual Logging](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging)
- [Contextual Logging Migration Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

#### Which issue(s) this PR is related to:

Part of #130069

#### Special notes for your reviewer:
There are still 2 `context.TODO()` remaining in the package:
- pkg/kubelet/kuberuntime/kuberuntime_manager.go:1612 (GeneratePodStatus)
- pkg/kubelet/kuberuntime/util/util.go:31 (PodSandboxChanged)

These cannot be addressed in this PR because they are called from outside the kuberuntime package.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
