### PR TITLE
fix(pdb): Ignore terminating pods when checking for controllers to prevent race condition

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -872,7 +872,6 @@ func (dc *DisruptionController) getExpectedScale(ctx context.Context, pdb *polic
 	// With ControllerRef, a pod can only have 1 controller.
 	for _, pod := range pods {
 
-
 		controllerRef := metav1.GetControllerOf(pod)
 		if controllerRef == nil {
 			unmanagedPods = append(unmanagedPods, pod.Name)

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -871,7 +871,6 @@ func (dc *DisruptionController) getExpectedScale(ctx context.Context, pdb *polic
 	// preventing excessive and expensive writes to etcd.
 	// With ControllerRef, a pod can only have 1 controller.
 	for _, pod := range pods {
-
 		controllerRef := metav1.GetControllerOf(pod)
 		if controllerRef == nil {
 			unmanagedPods = append(unmanagedPods, pod.Name)

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -871,6 +871,8 @@ func (dc *DisruptionController) getExpectedScale(ctx context.Context, pdb *polic
 	// preventing excessive and expensive writes to etcd.
 	// With ControllerRef, a pod can only have 1 controller.
 	for _, pod := range pods {
+
+
 		controllerRef := metav1.GetControllerOf(pod)
 		if controllerRef == nil {
 			unmanagedPods = append(unmanagedPods, pod.Name)
@@ -896,7 +898,7 @@ func (dc *DisruptionController) getExpectedScale(ctx context.Context, pdb *polic
 				break
 			}
 		}
-		if !foundController {
+		if !foundController && pod.DeletionTimestamp == nil {
 			err = fmt.Errorf("found no controllers for pod %q", pod.Name)
 			return
 		}

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -1226,7 +1226,6 @@ func TestDeploymentFinderFunction(t *testing.T) {
 				UID:        dep.UID,
 				Controller: &trueVal,
 			})
-			t.Logf("ReplicaSet object: %+v", rs)
 			add(t, dc.rsStore, rs)
 
 			controllerRef := &metav1.OwnerReference{


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
This PR fixes a race condition in the PDB controller when determining the expected scale of pods.

**Problem:**  
Previously, if a pod was terminating (had a DeletionTimestamp) and its controller was already deleted (example scenario is during rolling restart if revisionHistoryLimit: 0), the PDB controller would return an error because it could not find a controller for the pod. This created a race condition between finding scale count in already deleted controller and, potentially resulting in unnecessary errors or incorrect PDB status.

**Solution:**  
- The PDB controller logic is updated to skip pods with a DeletionTimestamp when verifying controller presence for expected scale calculation.
- A unit test is added to ensure that terminating pods do not cause errors during expected scale calculation.

**Impact:**  
This change prevents the PDB controller from reporting errors or misbehaving in scenarios where pods are terminating and their controllers have already been deleted, thus making the disruption logic more robust.

Which issue(s) this PR is related to:
Closes #130723

Does this PR introduce a user-facing change?
No.