### PR TITLE
Move UnsafeCorruptObjectDeletion outside of etcd3.New function

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -578,7 +578,7 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, *store, *kub
 	}
 	client := setupOpts.client(t)
 	versioner := storage.APIObjectVersioner{}
-	store := newStore(
+	store := New(
 		client,
 		setupOpts.codec,
 		setupOpts.newFunc,


### PR DESCRIPTION
By returning *store instead of storage.Interface we can expose Close() function so in the future we can register it to destroyFunc in newETCD3Storage.

/kind cleanup

```release-note
NONE
```
