### PR TITLE
nftables short-circuit local traffic to external addresses

### DIFF
--- a/pkg/proxy/nftables/README.md
+++ b/pkg/proxy/nftables/README.md
@@ -131,7 +131,7 @@ by setting appropriate `priority` values for your base chains. In particular:
     will will see masqueraded source IPs for some traffic.)
 
   - Traffic to services with no endpoints will be dropped or rejected from a chain with
-    `type filter`, `priority dstnat-10`, and any of `hook input`, `hook output`, or `hook
+    `type filter`, `priority filter`, and any of `hook input`, `hook output`, or `hook
     forward`.
 
 Note that the use of `mark` to indicate what traffic needs to be masqueraded is *not*

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -68,7 +68,6 @@ const (
 	filterInputChain             = "filter-input"
 	filterForwardChain           = "filter-forward"
 	filterOutputChain            = "filter-output"
-	filterOutputPostDNATChain    = "filter-output-post-dnat"
 	natPreroutingChain           = "nat-prerouting"
 	natOutputChain               = "nat-output"
 	natPostroutingChain          = "nat-postrouting"
@@ -401,9 +400,6 @@ var nftablesBaseChains = []nftablesBaseChain{
 	{filterForwardChain, knftables.FilterType, knftables.ForwardHook, knftables.FilterPriority},
 	{filterOutputChain, knftables.FilterType, knftables.OutputHook, knftables.FilterPriority},
 
-	// filter base chain (post-dnat priority)
-	{filterOutputPostDNATChain, knftables.FilterType, knftables.OutputHook, knftables.DNATPriority + "+10"},
-
 	// nat base chains (dnat priority)
 	{natPreroutingChain, knftables.NATType, knftables.PreroutingHook, knftables.DNATPriority},
 	{natOutputChain, knftables.NATType, knftables.OutputHook, knftables.DNATPriority},
@@ -436,7 +432,7 @@ var nftablesJumpChains = []nftablesJumpChain{
 	{masqueradingChain, natPostroutingChain, ""},
 
 	{clusterIPsCheckChain, filterForwardChain, "ct state new"},
-	{clusterIPsCheckChain, filterOutputPostDNATChain, "ct state new"},
+	{clusterIPsCheckChain, filterOutputChain, "ct state new"},
 }
 
 // ensureChain adds commands to tx to ensure that chain exists and doesn't contain

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -165,7 +165,6 @@ var baseRules = dedent.Dedent(`
 	add chain ip kube-proxy filter-forward { type filter hook forward priority 0 ; }
 	add chain ip kube-proxy filter-input { type filter hook input priority 0 ; }
 	add chain ip kube-proxy filter-output { type filter hook output priority 0 ; }
-	add chain ip kube-proxy filter-output-post-dnat { type filter hook output priority -90 ; }
 	add chain ip kube-proxy firewall-check
 	add chain ip kube-proxy mark-for-masquerade
 	add chain ip kube-proxy masquerading
@@ -186,7 +185,7 @@ var baseRules = dedent.Dedent(`
 	add rule ip kube-proxy filter-input ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-output ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-output-pre-dnat ct state new jump firewall-check
-	add rule ip kube-proxy filter-output-post-dnat ct state new jump cluster-ips-check
+	add rule ip kube-proxy filter-output ct state new jump cluster-ips-check
 	add rule ip kube-proxy firewall-check ip daddr . meta l4proto . th dport vmap @firewall-ips
 	add rule ip kube-proxy mark-for-masquerade mark set mark or 0x4000
 	add rule ip kube-proxy masquerading mark and 0x4000 == 0 return

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -160,10 +160,11 @@ var baseRules = dedent.Dedent(`
 	add map ip kube-proxy service-nodeports { type inet_proto . inet_service : verdict ; comment "NodePort traffic" ; }
 
 	add chain ip kube-proxy cluster-ips-check
-	add chain ip kube-proxy filter-prerouting { type filter hook prerouting priority -110 ; }
-	add chain ip kube-proxy filter-forward { type filter hook forward priority -110 ; }
-	add chain ip kube-proxy filter-input { type filter hook input priority -110 ; }
-	add chain ip kube-proxy filter-output { type filter hook output priority -110 ; }
+	add chain ip kube-proxy filter-prerouting-pre-dnat { type filter hook prerouting priority -110 ; }
+	add chain ip kube-proxy filter-output-pre-dnat { type filter hook output priority -110 ; }
+	add chain ip kube-proxy filter-forward { type filter hook forward priority 0 ; }
+	add chain ip kube-proxy filter-input { type filter hook input priority 0 ; }
+	add chain ip kube-proxy filter-output { type filter hook output priority 0 ; }
 	add chain ip kube-proxy filter-output-post-dnat { type filter hook output priority -90 ; }
 	add chain ip kube-proxy firewall-check
 	add chain ip kube-proxy mark-for-masquerade
@@ -178,13 +179,13 @@ var baseRules = dedent.Dedent(`
 
 	add rule ip kube-proxy cluster-ips-check ip daddr @cluster-ips reject comment "Reject traffic to invalid ports of ClusterIPs"
 	add rule ip kube-proxy cluster-ips-check ip daddr { 172.30.0.0/16 } drop comment "Drop traffic to unallocated ClusterIPs"
-	add rule ip kube-proxy filter-prerouting ct state new jump firewall-check
+	add rule ip kube-proxy filter-prerouting-pre-dnat ct state new jump firewall-check
 	add rule ip kube-proxy filter-forward ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-forward ct state new jump cluster-ips-check
 	add rule ip kube-proxy filter-input ct state new jump nodeport-endpoints-check
 	add rule ip kube-proxy filter-input ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-output ct state new jump service-endpoints-check
-	add rule ip kube-proxy filter-output ct state new jump firewall-check
+	add rule ip kube-proxy filter-output-pre-dnat ct state new jump firewall-check
 	add rule ip kube-proxy filter-output-post-dnat ct state new jump cluster-ips-check
 	add rule ip kube-proxy firewall-check ip daddr . meta l4proto . th dport vmap @firewall-ips
 	add rule ip kube-proxy mark-for-masquerade mark set mark or 0x4000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes priorities of nftables filter chains which kube-proxy installs. We currently have 5 filter chains
1. filter-prerouting (-110)
2. filter-forward (-110)
3. filter-input (-110)
4. filter-output (-110)
5. filter-output-post-dnat (-90)

The first 4 chains operates at a priority lower than DNAT to allow filtering on pre-dnated destination IP and port. This filtering is only used in `filter-prerouting` and `filter-output` chain. But with this the locally originated traffic which should not be subjected external traffic policies is subjected to external traffic policies. 

With this PR we are adding a new chain ` filter-output-pre-dnat` that will operate on pre-dnat priority, and we are merging `filter-output-post-dnat ` into `filter-output`. We are also setting priorities of ` filter-forward`, ` filter-input` and `filter-output` to 0 to short circuit local traffic to external addresses of the service.

1. filter-prerouting-pre-dnat (-110)
2. filter-output-pre-dnat (-110)
3. filter-forward (0)
4. filter-input (0)
5. filter-output (0)

#### Which issue(s) this PR is related to:
Fixes #131765

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:

<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-proxy nftables now reject/drop traffic to service with no endpoints from filter chains at priority 0 (NF_IP_PRI_FILTER)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
