### PR TITLE
Moving Scheduler interfaces to staging: Move PodInfo and NodeInfo interfaces (together with related types) to staging repo, leaving internal implementation in kubernetes/kubernetes/pkg/scheduler

### DIFF
--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -515,7 +515,7 @@ func newFoo(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.
 	return &foo{}, nil
 }
 
-func (*foo) PreFilter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (*foo) PreFilter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return nil, nil
 }
 
@@ -523,6 +523,6 @@ func (*foo) PreFilterExtensions() framework.PreFilterExtensions {
 	return nil
 }
 
-func (*foo) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (*foo) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	return nil
 }

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -87,8 +88,8 @@ func (b *hostPortInfoBuilder) add(protocol, ip string, port int32) *hostPortInfo
 	return b
 }
 
-func (b *hostPortInfoBuilder) build() framework.HostPortInfo {
-	res := make(framework.HostPortInfo)
+func (b *hostPortInfoBuilder) build() fwk.HostPortInfo {
+	res := make(fwk.HostPortInfo)
 	for _, param := range b.inputs {
 		res.Add(param.ip, param.protocol, param.port)
 	}
@@ -98,8 +99,8 @@ func (b *hostPortInfoBuilder) build() framework.HostPortInfo {
 func newNodeInfo(requestedResource *framework.Resource,
 	nonzeroRequest *framework.Resource,
 	pods []*v1.Pod,
-	usedPorts framework.HostPortInfo,
-	imageStates map[string]*framework.ImageStateSummary,
+	usedPorts fwk.HostPortInfo,
+	imageStates map[string]*fwk.ImageStateSummary,
 ) *framework.NodeInfo {
 	nodeInfo := framework.NewNodeInfo(pods...)
 	nodeInfo.Requested = requestedResource
@@ -142,7 +143,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}, {
 		name: "node requested resource are equal to the sum of the assumed pods requested resource, node contains host ports defined by pods",
@@ -158,7 +159,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[1], testPods[2]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}, { // test non-zero request
 		name: "assumed pod without resource request",
@@ -174,7 +175,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[3]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}, {
 		name: "assumed one pod with extended resource",
@@ -191,7 +192,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[4]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}, {
 		name: "assumed two pods with extended resources",
@@ -208,7 +209,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[4], testPods[5]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}, {
 		name: "assumed pod with random invalid extended resource key",
@@ -224,7 +225,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[6]},
 			newHostPortInfoBuilder().build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	},
 	}
@@ -321,7 +322,7 @@ func TestExpirePod(t *testing.T) {
 				// Order gets altered when removing pods.
 				[]*v1.Pod{testPods[2], testPods[1]},
 				newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
-				make(map[string]*framework.ImageStateSummary),
+				make(map[string]*fwk.ImageStateSummary),
 			),
 			ttl: defaultTTL,
 		},
@@ -342,7 +343,7 @@ func TestExpirePod(t *testing.T) {
 				},
 				[]*v1.Pod{testPods[0]},
 				newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-				make(map[string]*framework.ImageStateSummary),
+				make(map[string]*fwk.ImageStateSummary),
 			),
 			ttl: time.Duration(0),
 		},
@@ -407,7 +408,7 @@ func TestAddPodWillConfirm(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}
 
@@ -520,7 +521,7 @@ func TestAddPodAlwaysUpdatesPodInfoInNodeInfo(t *testing.T) {
 				},
 				[]*v1.Pod{p2},
 				newHostPortInfoBuilder().add("TCP", "0.0.0.0", 80).build(),
-				make(map[string]*framework.ImageStateSummary),
+				make(map[string]*fwk.ImageStateSummary),
 			),
 		},
 	}
@@ -576,7 +577,7 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 				},
 				[]*v1.Pod{updatedPod.DeepCopy()},
 				newHostPortInfoBuilder().add("TCP", "0.0.0.0", 90).build(),
-				make(map[string]*framework.ImageStateSummary),
+				make(map[string]*fwk.ImageStateSummary),
 			),
 		},
 	}
@@ -629,7 +630,7 @@ func TestAddPodAfterExpiration(t *testing.T) {
 			},
 			[]*v1.Pod{basePod},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}
 
@@ -683,7 +684,7 @@ func TestUpdatePod(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[1]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		), newNodeInfo(
 			&framework.Resource{
 				MilliCPU: 100,
@@ -695,7 +696,7 @@ func TestUpdatePod(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		)},
 	}
 
@@ -827,7 +828,7 @@ func TestExpireAddUpdatePod(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[1]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		), newNodeInfo(
 			&framework.Resource{
 				MilliCPU: 100,
@@ -839,7 +840,7 @@ func TestExpireAddUpdatePod(t *testing.T) {
 			},
 			[]*v1.Pod{testPods[0]},
 			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
+			make(map[string]*fwk.ImageStateSummary),
 		)},
 	}
 
@@ -901,8 +902,8 @@ func TestEphemeralStorageResource(t *testing.T) {
 				Memory:   schedutil.DefaultMemoryRequest,
 			},
 			[]*v1.Pod{podE},
-			framework.HostPortInfo{},
-			make(map[string]*framework.ImageStateSummary),
+			fwk.HostPortInfo{},
+			make(map[string]*fwk.ImageStateSummary),
 		),
 	}
 	logger, ctx := ktesting.NewTestContext(t)
@@ -947,7 +948,7 @@ func TestRemovePod(t *testing.T) {
 		},
 		[]*v1.Pod{pod},
 		newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-		make(map[string]*framework.ImageStateSummary),
+		make(map[string]*fwk.ImageStateSummary),
 	)
 	tests := map[string]struct {
 		assume bool
@@ -1050,7 +1051,7 @@ func TestForgetPod(t *testing.T) {
 }
 
 // buildNodeInfo creates a NodeInfo by simulating node operations in cache.
-func buildNodeInfo(node *v1.Node, pods []*v1.Pod, imageStates map[string]*framework.ImageStateSummary) *framework.NodeInfo {
+func buildNodeInfo(node *v1.Node, pods []*v1.Pod, imageStates map[string]*fwk.ImageStateSummary) *framework.NodeInfo {
 	expected := framework.NewNodeInfo()
 	expected.SetNode(node)
 	expected.Allocatable = framework.NewResource(node.Status.Allocatable)
@@ -1069,13 +1070,13 @@ func buildNodeInfo(node *v1.Node, pods []*v1.Pod, imageStates map[string]*framew
 }
 
 // buildImageStates creates ImageStateSummary of image from nodes that will be added in cache.
-func buildImageStates(nodes []*v1.Node) map[string]*framework.ImageStateSummary {
-	imageStates := make(map[string]*framework.ImageStateSummary)
+func buildImageStates(nodes []*v1.Node) map[string]*fwk.ImageStateSummary {
+	imageStates := make(map[string]*fwk.ImageStateSummary)
 	for _, item := range nodes {
 		for _, image := range item.Status.Images {
 			for _, name := range image.Names {
 				if state, ok := imageStates[name]; !ok {
-					state = &framework.ImageStateSummary{
+					state = &fwk.ImageStateSummary{
 						Size:  image.SizeBytes,
 						Nodes: sets.New[string](item.Name),
 					}
@@ -1777,14 +1778,13 @@ func compareCacheWithNodeInfoSnapshot(t *testing.T, cache *cacheImpl, snapshot *
 			return fmt.Errorf("Unexpected node info for node (-want, +got):\n%s", diff)
 		}
 	}
-
 	// Compare the lists.
 	if len(snapshot.nodeInfoList) != cache.nodeTree.numNodes {
 		return fmt.Errorf("unexpected number of nodes in NodeInfoList. Expected: %v, got: %v", cache.nodeTree.numNodes, len(snapshot.nodeInfoList))
 	}
 
-	expectedNodeInfoList := make([]*framework.NodeInfo, 0, cache.nodeTree.numNodes)
-	expectedHavePodsWithAffinityNodeInfoList := make([]*framework.NodeInfo, 0, cache.nodeTree.numNodes)
+	expectedNodeInfoList := make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
+	expectedHavePodsWithAffinityNodeInfoList := make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
 	expectedUsedPVCSet := sets.New[string]()
 	nodesList, err := cache.nodeTree.list()
 	if err != nil {
@@ -2038,7 +2038,7 @@ func makeBasePod(t testingMode, nodeName, objName, cpu, mem, extended string, po
 // the collected ImageStateSummary should be equal
 func checkImageStateSummary(nodes map[string]*framework.NodeInfo, imageNames ...string) bool {
 	for _, imageName := range imageNames {
-		var imageState *framework.ImageStateSummary
+		var imageState *fwk.ImageStateSummary
 		for _, node := range nodes {
 			state, ok := node.ImageStates[imageName]
 			if !ok {

--- a/pkg/scheduler/backend/cache/debugger/comparer.go
+++ b/pkg/scheduler/backend/cache/debugger/comparer.go
@@ -92,7 +92,7 @@ func (c *CacheComparer) ComparePods(pods, waitingPods []*v1.Pod, nodeinfos map[s
 	cached := []string{}
 	for _, nodeinfo := range nodeinfos {
 		for _, p := range nodeinfo.Pods {
-			cached = append(cached, string(p.Pod.UID))
+			cached = append(cached, string(p.GetPod().UID))
 		}
 	}
 	for _, pod := range waitingPods {

--- a/pkg/scheduler/backend/cache/debugger/dumper.go
+++ b/pkg/scheduler/backend/cache/debugger/dumper.go
@@ -69,14 +69,14 @@ func (d *CacheDumper) printNodeInfo(name string, n *framework.NodeInfo) string {
 		name, n.Node() == nil, n.Requested, n.Allocatable, len(n.Pods)))
 	// Dumping Pod Info
 	for _, p := range n.Pods {
-		nodeData.WriteString(printPod(p.Pod))
+		nodeData.WriteString(printPod(p.GetPod()))
 	}
 	// Dumping nominated pods info on the node
 	nominatedPodInfos := d.podQueue.NominatedPodsForNode(name)
 	if len(nominatedPodInfos) != 0 {
 		nodeData.WriteString(fmt.Sprintf("Nominated Pods(number: %v):\n", len(nominatedPodInfos)))
 		for _, pi := range nominatedPodInfos {
-			nodeData.WriteString(printPod(pi.Pod))
+			nodeData.WriteString(printPod(pi.GetPod()))
 		}
 	}
 	return nodeData.String()

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -318,7 +318,7 @@ func (aq *activeQueue) list() []*v1.Pod {
 	defer aq.lock.RUnlock()
 	var result []*v1.Pod
 	for _, pInfo := range aq.queue.List() {
-		result = append(result, pInfo.Pod)
+		result = append(result, pInfo.GetPod())
 	}
 	return result
 }

--- a/pkg/scheduler/backend/queue/active_queue_test.go
+++ b/pkg/scheduler/backend/queue/active_queue_test.go
@@ -30,7 +30,7 @@ import (
 func TestClose(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	rr := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
-	aq := newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](newDefaultQueueSort()), metrics.NewActivePodsRecorder()), true, *rr, nil)
+	aq := newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](convertLessFn(newDefaultQueueSort())), metrics.NewActivePodsRecorder()), true, *rr, nil)
 
 	aq.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
 		unlockedActiveQ.add(&framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: st.MakePod().Namespace("foo").Name("p1").UID("p1").Obj()}}, framework.EventUnscheduledPodAdd.Label())

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -2506,12 +2506,12 @@ func TestPriorityQueue_NominatedPodsForNode(t *testing.T) {
 	if p, err := q.Pop(logger); err != nil || p.Pod != highPriorityPodInfo.Pod {
 		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
 	}
-	expectedList := []*framework.PodInfo{medPriorityPodInfo, unschedulablePodInfo}
+	expectedList := []fwk.PodInfo{medPriorityPodInfo, unschedulablePodInfo}
 	podInfos := q.NominatedPodsForNode("node1")
 	if diff := cmp.Diff(expectedList, podInfos, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
 		t.Errorf("Unexpected list of nominated Pods for node: (-want, +got):\n%s", diff)
 	}
-	podInfos[0].Pod.Name = "not mpp"
+	podInfos[0].GetPod().Name = "not mpp"
 	if diff := cmp.Diff(podInfos, q.NominatedPodsForNode("node1"), cmpopts.IgnoreUnexported(framework.PodInfo{})); diff == "" {
 		t.Error("Expected list of nominated Pods for node2 is different from podInfos")
 	}

--- a/pkg/scheduler/extender.go
+++ b/pkg/scheduler/extender.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	restclient "k8s.io/client-go/rest"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -209,10 +210,10 @@ func (h *HTTPExtender) convertToVictims(
 // and extender, i.e. when the pod is not found in nodeInfo.Pods.
 func (h *HTTPExtender) convertPodUIDToPod(
 	metaPod *extenderv1.MetaPod,
-	nodeInfo *framework.NodeInfo) (*v1.Pod, error) {
-	for _, p := range nodeInfo.Pods {
-		if string(p.Pod.UID) == metaPod.UID {
-			return p.Pod, nil
+	nodeInfo fwk.NodeInfo) (*v1.Pod, error) {
+	for _, p := range nodeInfo.GetPods() {
+		if string(p.GetPod().UID) == metaPod.UID {
+			return p.GetPod(), nil
 		}
 	}
 	return nil, fmt.Errorf("extender: %v claims to preempt pod (UID: %v) on node: %v, but the pod is not found on that node",
@@ -247,16 +248,16 @@ func convertToMetaVictims(
 // unresolvable.
 func (h *HTTPExtender) Filter(
 	pod *v1.Pod,
-	nodes []*framework.NodeInfo,
-) (filteredList []*framework.NodeInfo, failedNodes, failedAndUnresolvableNodes extenderv1.FailedNodesMap, err error) {
+	nodes []fwk.NodeInfo,
+) (filteredList []fwk.NodeInfo, failedNodes, failedAndUnresolvableNodes extenderv1.FailedNodesMap, err error) {
 	var (
 		result     extenderv1.ExtenderFilterResult
 		nodeList   *v1.NodeList
 		nodeNames  *[]string
-		nodeResult []*framework.NodeInfo
+		nodeResult []fwk.NodeInfo
 		args       *extenderv1.ExtenderArgs
 	)
-	fromNodeName := make(map[string]*framework.NodeInfo)
+	fromNodeName := make(map[string]fwk.NodeInfo)
 	for _, n := range nodes {
 		fromNodeName[n.Node().Name] = n
 	}
@@ -292,7 +293,7 @@ func (h *HTTPExtender) Filter(
 	}
 
 	if h.nodeCacheCapable && result.NodeNames != nil {
-		nodeResult = make([]*framework.NodeInfo, len(*result.NodeNames))
+		nodeResult = make([]fwk.NodeInfo, len(*result.NodeNames))
 		for i, nodeName := range *result.NodeNames {
 			if n, ok := fromNodeName[nodeName]; ok {
 				nodeResult[i] = n
@@ -303,7 +304,7 @@ func (h *HTTPExtender) Filter(
 			}
 		}
 	} else if result.Nodes != nil {
-		nodeResult = make([]*framework.NodeInfo, len(result.Nodes.Items))
+		nodeResult = make([]fwk.NodeInfo, len(result.Nodes.Items))
 		for i := range result.Nodes.Items {
 			nodeResult[i] = framework.NewNodeInfo()
 			nodeResult[i].SetNode(&result.Nodes.Items[i])
@@ -316,7 +317,7 @@ func (h *HTTPExtender) Filter(
 // Prioritize based on extender implemented priority functions. Weight*priority is added
 // up for each such priority function. The returned score is added to the score computed
 // by Kubernetes scheduler. The total score is used to do the host selection.
-func (h *HTTPExtender) Prioritize(pod *v1.Pod, nodes []*framework.NodeInfo) (*extenderv1.HostPriorityList, int64, error) {
+func (h *HTTPExtender) Prioritize(pod *v1.Pod, nodes []fwk.NodeInfo) (*extenderv1.HostPriorityList, int64, error) {
 	var (
 		result    extenderv1.HostPriorityList
 		nodeList  *v1.NodeList

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -29,6 +29,7 @@ import (
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
@@ -552,7 +553,7 @@ func TestConvertToVictims(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// nodeInfos instantiations
-			nodeInfoList := make([]*framework.NodeInfo, 0, len(tt.nodeNames))
+			nodeInfoList := make([]fwk.NodeInfo, 0, len(tt.nodeNames))
 			for i, nm := range tt.nodeNames {
 				nodeInfo := framework.NewNodeInfo()
 				node := createNode(nm)

--- a/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
@@ -36,7 +36,7 @@ import (
 
 type frameworkContract interface {
 	RunPreFilterPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *fwk.Status, sets.Set[string])
-	RunFilterPlugins(context.Context, fwk.CycleState, *v1.Pod, *framework.NodeInfo) *fwk.Status
+	RunFilterPlugins(context.Context, fwk.CycleState, *v1.Pod, fwk.NodeInfo) *fwk.Status
 	RunReservePluginsReserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status
 }
 

--- a/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -38,19 +39,19 @@ var _ framework.SharedDRAManager = &sharedDRAManagerContract{}
 
 type nodeInfoListerContract struct{}
 
-func (c *nodeInfoListerContract) List() ([]*framework.NodeInfo, error) {
+func (c *nodeInfoListerContract) List() ([]fwk.NodeInfo, error) {
 	return nil, nil
 }
 
-func (c *nodeInfoListerContract) HavePodsWithAffinityList() ([]*framework.NodeInfo, error) {
+func (c *nodeInfoListerContract) HavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
 	return nil, nil
 }
 
-func (c *nodeInfoListerContract) HavePodsWithRequiredAntiAffinityList() ([]*framework.NodeInfo, error) {
+func (c *nodeInfoListerContract) HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
 	return nil, nil
 }
 
-func (c *nodeInfoListerContract) Get(_ string) (*framework.NodeInfo, error) {
+func (c *nodeInfoListerContract) Get(_ string) (fwk.NodeInfo, error) {
 	return nil, nil
 }
 

--- a/pkg/scheduler/framework/extender.go
+++ b/pkg/scheduler/framework/extender.go
@@ -19,6 +19,7 @@ package framework
 import (
 	v1 "k8s.io/api/core/v1"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 )
 
 // Extender is an interface for external processes to influence scheduling
@@ -33,12 +34,12 @@ type Extender interface {
 	// The failedNodes and failedAndUnresolvableNodes optionally contains the list
 	// of failed nodes and failure reasons, except nodes in the latter are
 	// unresolvable.
-	Filter(pod *v1.Pod, nodes []*NodeInfo) (filteredNodes []*NodeInfo, failedNodesMap extenderv1.FailedNodesMap, failedAndUnresolvable extenderv1.FailedNodesMap, err error)
+	Filter(pod *v1.Pod, nodes []fwk.NodeInfo) (filteredNodes []fwk.NodeInfo, failedNodesMap extenderv1.FailedNodesMap, failedAndUnresolvable extenderv1.FailedNodesMap, err error)
 
 	// Prioritize based on extender-implemented priority functions. The returned scores & weight
 	// are used to compute the weighted score for an extender. The weighted scores are added to
 	// the scores computed by Kubernetes scheduler. The total scores are used to do the host selection.
-	Prioritize(pod *v1.Pod, nodes []*NodeInfo) (hostPriorities *extenderv1.HostPriorityList, weight int64, err error)
+	Prioritize(pod *v1.Pod, nodes []fwk.NodeInfo) (hostPriorities *extenderv1.HostPriorityList, weight int64, err error)
 
 	// Bind delegates the action of binding a pod to a node to the extender.
 	Bind(binding *v1.Binding) error

--- a/pkg/scheduler/framework/interface_test.go
+++ b/pkg/scheduler/framework/interface_test.go
@@ -263,9 +263,9 @@ func TestIsStatusEqual(t *testing.T) {
 	}
 }
 
-type nodeInfoLister []*NodeInfo
+type nodeInfoLister []fwk.NodeInfo
 
-func (nodes nodeInfoLister) Get(nodeName string) (*NodeInfo, error) {
+func (nodes nodeInfoLister) Get(nodeName string) (fwk.NodeInfo, error) {
 	for _, node := range nodes {
 		if node != nil && node.Node().Name == nodeName {
 			return node, nil
@@ -274,15 +274,15 @@ func (nodes nodeInfoLister) Get(nodeName string) (*NodeInfo, error) {
 	return nil, fmt.Errorf("unable to find node: %s", nodeName)
 }
 
-func (nodes nodeInfoLister) List() ([]*NodeInfo, error) {
+func (nodes nodeInfoLister) List() ([]fwk.NodeInfo, error) {
 	return nodes, nil
 }
 
-func (nodes nodeInfoLister) HavePodsWithAffinityList() ([]*NodeInfo, error) {
+func (nodes nodeInfoLister) HavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
 	return nodes, nil
 }
 
-func (nodes nodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]*NodeInfo, error) {
+func (nodes nodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
 	return nodes, nil
 }
 

--- a/pkg/scheduler/framework/listers.go
+++ b/pkg/scheduler/framework/listers.go
@@ -21,18 +21,19 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured"
+	fwk "k8s.io/kube-scheduler/framework"
 )
 
 // NodeInfoLister interface represents anything that can list/get NodeInfo objects from node name.
 type NodeInfoLister interface {
 	// List returns the list of NodeInfos.
-	List() ([]*NodeInfo, error)
+	List() ([]fwk.NodeInfo, error)
 	// HavePodsWithAffinityList returns the list of NodeInfos of nodes with pods with affinity terms.
-	HavePodsWithAffinityList() ([]*NodeInfo, error)
+	HavePodsWithAffinityList() ([]fwk.NodeInfo, error)
 	// HavePodsWithRequiredAntiAffinityList returns the list of NodeInfos of nodes with pods with required anti-affinity terms.
-	HavePodsWithRequiredAntiAffinityList() ([]*NodeInfo, error)
+	HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error)
 	// Get returns the NodeInfo of the given node name.
-	Get(nodeName string) (*NodeInfo, error)
+	Get(nodeName string) (fwk.NodeInfo, error)
 }
 
 // StorageInfoLister interface represents anything that handles storage-related operations and resources.

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -365,7 +365,7 @@ func (pl *DynamicResources) foreachPodResourceClaim(pod *v1.Pod, cb func(podReso
 // PreFilter invoked at the prefilter extension point to check if pod has all
 // immediate claims bound. UnschedulableAndUnresolvable is returned if
 // the pod cannot be scheduled at the moment on any node.
-func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	if !pl.enabled {
 		return nil, fwk.NewStatus(fwk.Skip)
 	}
@@ -535,7 +535,7 @@ func getStateData(cs fwk.CycleState) (*stateData, error) {
 //
 // For claims that are unbound, it checks whether the claim might get allocated
 // for the node.
-func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	if !pl.enabled {
 		return nil
 	}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1141,7 +1141,7 @@ func TestPlugin(t *testing.T) {
 			})
 			unschedulable := status.IsRejected()
 
-			var potentialNodes []*framework.NodeInfo
+			var potentialNodes []fwk.NodeInfo
 
 			initialObjects = testCtx.listAll(t)
 			testCtx.updateAPIServer(t, initialObjects, tc.prepare.filter)
@@ -1177,7 +1177,7 @@ func TestPlugin(t *testing.T) {
 				initialObjects = testCtx.updateAPIServer(t, initialObjects, tc.prepare.prescore)
 			}
 
-			var selectedNode *framework.NodeInfo
+			var selectedNode fwk.NodeInfo
 			if !unschedulable && len(potentialNodes) > 0 {
 				selectedNode = potentialNodes[0]
 
@@ -1250,7 +1250,7 @@ type testContext struct {
 	informerFactory informers.SharedInformerFactory
 	draManager      *DefaultDRAManager
 	p               *DynamicResources
-	nodeInfos       []*framework.NodeInfo
+	nodeInfos       []fwk.NodeInfo
 	state           fwk.CycleState
 }
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -50,7 +50,7 @@ type preFilterState struct {
 	// A map of topology pairs to the number of existing pods that match the anti-affinity terms of the "pod".
 	antiAffinityCounts topologyToMatchedTermCount
 	// podInfo of the incoming pod.
-	podInfo *framework.PodInfo
+	podInfo fwk.PodInfo
 	// A copy of the incoming pod's namespace labels.
 	namespaceLabels labels.Set
 }
@@ -72,16 +72,16 @@ func (s *preFilterState) Clone() fwk.StateData {
 }
 
 // updateWithPod updates the preFilterState counters with the (anti)affinity matches for the given podInfo.
-func (s *preFilterState) updateWithPod(pInfo *framework.PodInfo, node *v1.Node, multiplier int64) {
+func (s *preFilterState) updateWithPod(pInfo fwk.PodInfo, node *v1.Node, multiplier int64) {
 	if s == nil {
 		return
 	}
 
-	s.existingAntiAffinityCounts.updateWithAntiAffinityTerms(pInfo.RequiredAntiAffinityTerms, s.podInfo.Pod, s.namespaceLabels, node, multiplier)
-	s.affinityCounts.updateWithAffinityTerms(s.podInfo.RequiredAffinityTerms, pInfo.Pod, node, multiplier)
+	s.existingAntiAffinityCounts.updateWithAntiAffinityTerms(pInfo.GetRequiredAntiAffinityTerms(), s.podInfo.GetPod(), s.namespaceLabels, node, multiplier)
+	s.affinityCounts.updateWithAffinityTerms(s.podInfo.GetRequiredAffinityTerms(), pInfo.GetPod(), node, multiplier)
 	// The incoming pod's terms have the namespaceSelector merged into the namespaces, and so
 	// here we don't lookup the updated pod's namespace labels, hence passing nil for nsLabels.
-	s.antiAffinityCounts.updateWithAntiAffinityTerms(s.podInfo.RequiredAntiAffinityTerms, pInfo.Pod, nil, node, multiplier)
+	s.antiAffinityCounts.updateWithAntiAffinityTerms(s.podInfo.GetRequiredAntiAffinityTerms(), pInfo.GetPod(), nil, node, multiplier)
 }
 
 type topologyPair struct {
@@ -122,7 +122,7 @@ func (m topologyToMatchedTermCount) update(node *v1.Node, tk string, value int64
 // updates the topologyToMatchedTermCount map with the specified value
 // for each affinity term if "targetPod" matches ALL terms.
 func (m topologyToMatchedTermCount) updateWithAffinityTerms(
-	terms []framework.AffinityTerm, pod *v1.Pod, node *v1.Node, value int64) {
+	terms []fwk.AffinityTerm, pod *v1.Pod, node *v1.Node, value int64) {
 	if podMatchesAllAffinityTerms(terms, pod) {
 		for _, t := range terms {
 			m.update(node, t.TopologyKey, value)
@@ -132,7 +132,7 @@ func (m topologyToMatchedTermCount) updateWithAffinityTerms(
 
 // updates the topologyToMatchedTermCount map with the specified value
 // for each anti-affinity term matched the target pod.
-func (m topologyToMatchedTermCount) updateWithAntiAffinityTerms(terms []framework.AffinityTerm, pod *v1.Pod, nsLabels labels.Set, node *v1.Node, value int64) {
+func (m topologyToMatchedTermCount) updateWithAntiAffinityTerms(terms []fwk.AffinityTerm, pod *v1.Pod, nsLabels labels.Set, node *v1.Node, value int64) {
 	// Check anti-affinity terms.
 	for _, t := range terms {
 		if t.Matches(pod, nsLabels) {
@@ -164,7 +164,7 @@ func (m *topologyToMatchedTermCountList) append(node *v1.Node, tk string, value 
 // appends the specified value to the topologyToMatchedTermCountList
 // for each affinity term if "targetPod" matches ALL terms.
 func (m *topologyToMatchedTermCountList) appendWithAffinityTerms(
-	terms []framework.AffinityTerm, pod *v1.Pod, node *v1.Node, value int64) {
+	terms []fwk.AffinityTerm, pod *v1.Pod, node *v1.Node, value int64) {
 	if podMatchesAllAffinityTerms(terms, pod) {
 		for _, t := range terms {
 			m.append(node, t.TopologyKey, value)
@@ -174,7 +174,7 @@ func (m *topologyToMatchedTermCountList) appendWithAffinityTerms(
 
 // appends the specified value to the topologyToMatchedTermCountList
 // for each anti-affinity term matched the target pod.
-func (m *topologyToMatchedTermCountList) appendWithAntiAffinityTerms(terms []framework.AffinityTerm, pod *v1.Pod, nsLabels labels.Set, node *v1.Node, value int64) {
+func (m *topologyToMatchedTermCountList) appendWithAntiAffinityTerms(terms []fwk.AffinityTerm, pod *v1.Pod, nsLabels labels.Set, node *v1.Node, value int64) {
 	// Check anti-affinity terms.
 	for _, t := range terms {
 		if t.Matches(pod, nsLabels) {
@@ -184,7 +184,7 @@ func (m *topologyToMatchedTermCountList) appendWithAntiAffinityTerms(terms []fra
 }
 
 // returns true IFF the given pod matches all the given terms.
-func podMatchesAllAffinityTerms(terms []framework.AffinityTerm, pod *v1.Pod) bool {
+func podMatchesAllAffinityTerms(terms []fwk.AffinityTerm, pod *v1.Pod) bool {
 	if len(terms) == 0 {
 		return false
 	}
@@ -201,7 +201,7 @@ func podMatchesAllAffinityTerms(terms []framework.AffinityTerm, pod *v1.Pod) boo
 // calculates the following for each existing pod on each node:
 //  1. Whether it has PodAntiAffinity
 //  2. Whether any AntiAffinityTerm matches the incoming pod
-func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, pod *v1.Pod, nsLabels labels.Set, nodes []*framework.NodeInfo) topologyToMatchedTermCount {
+func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, pod *v1.Pod, nsLabels labels.Set, nodes []fwk.NodeInfo) topologyToMatchedTermCount {
 	antiAffinityCountsList := make([]topologyToMatchedTermCountList, len(nodes))
 	index := int32(-1)
 	processNode := func(i int) {
@@ -209,8 +209,8 @@ func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, p
 		node := nodeInfo.Node()
 
 		antiAffinityCounts := make(topologyToMatchedTermCountList, 0)
-		for _, existingPod := range nodeInfo.PodsWithRequiredAntiAffinity {
-			antiAffinityCounts.appendWithAntiAffinityTerms(existingPod.RequiredAntiAffinityTerms, pod, nsLabels, node, 1)
+		for _, existingPod := range nodeInfo.GetPodsWithRequiredAntiAffinity() {
+			antiAffinityCounts.appendWithAntiAffinityTerms(existingPod.GetRequiredAntiAffinityTerms(), pod, nsLabels, node, 1)
 		}
 		if len(antiAffinityCounts) != 0 {
 			antiAffinityCountsList[atomic.AddInt32(&index, 1)] = antiAffinityCounts
@@ -231,10 +231,10 @@ func (pl *InterPodAffinity) getExistingAntiAffinityCounts(ctx context.Context, p
 // It returns a topologyToMatchedTermCount that are checked later by the affinity
 // predicate. With this topologyToMatchedTermCount available, the affinity predicate does not
 // need to check all the pods in the cluster.
-func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Context, podInfo *framework.PodInfo, allNodes []*framework.NodeInfo) (topologyToMatchedTermCount, topologyToMatchedTermCount) {
+func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Context, podInfo fwk.PodInfo, allNodes []fwk.NodeInfo) (topologyToMatchedTermCount, topologyToMatchedTermCount) {
 	affinityCounts := make(topologyToMatchedTermCount)
 	antiAffinityCounts := make(topologyToMatchedTermCount)
-	if len(podInfo.RequiredAffinityTerms) == 0 && len(podInfo.RequiredAntiAffinityTerms) == 0 {
+	if len(podInfo.GetRequiredAffinityTerms()) == 0 && len(podInfo.GetRequiredAntiAffinityTerms()) == 0 {
 		return affinityCounts, antiAffinityCounts
 	}
 
@@ -247,11 +247,11 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 
 		affinity := make(topologyToMatchedTermCountList, 0)
 		antiAffinity := make(topologyToMatchedTermCountList, 0)
-		for _, existingPod := range nodeInfo.Pods {
-			affinity.appendWithAffinityTerms(podInfo.RequiredAffinityTerms, existingPod.Pod, node, 1)
+		for _, existingPod := range nodeInfo.GetPods() {
+			affinity.appendWithAffinityTerms(podInfo.GetRequiredAffinityTerms(), existingPod.GetPod(), node, 1)
 			// The incoming pod's terms have the namespaceSelector merged into the namespaces, and so
 			// here we don't lookup the existing pod's namespace labels, hence passing nil for nsLabels.
-			antiAffinity.appendWithAntiAffinityTerms(podInfo.RequiredAntiAffinityTerms, existingPod.Pod, nil, node, 1)
+			antiAffinity.appendWithAntiAffinityTerms(podInfo.GetRequiredAntiAffinityTerms(), existingPod.GetPod(), nil, node, 1)
 		}
 
 		if len(affinity) > 0 || len(antiAffinity) > 0 {
@@ -271,8 +271,8 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 }
 
 // PreFilter invoked at the prefilter extension point.
-func (pl *InterPodAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, allNodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
-	var nodesWithRequiredAntiAffinityPods []*framework.NodeInfo
+func (pl *InterPodAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, allNodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+	var nodesWithRequiredAntiAffinityPods []fwk.NodeInfo
 	var err error
 	if nodesWithRequiredAntiAffinityPods, err = pl.sharedLister.NodeInfos().HavePodsWithRequiredAntiAffinityList(); err != nil {
 		return nil, fwk.AsStatus(fmt.Errorf("failed to list NodeInfos with pods with affinity: %w", err))
@@ -284,13 +284,13 @@ func (pl *InterPodAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleS
 		return nil, fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("parsing pod: %+v", err))
 	}
 
-	for i := range s.podInfo.RequiredAffinityTerms {
-		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(&s.podInfo.RequiredAffinityTerms[i]); err != nil {
+	for i := range s.podInfo.GetRequiredAffinityTerms() {
+		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(s.podInfo.GetRequiredAffinityTerms()[i]); err != nil {
 			return nil, fwk.AsStatus(err)
 		}
 	}
-	for i := range s.podInfo.RequiredAntiAffinityTerms {
-		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(&s.podInfo.RequiredAntiAffinityTerms[i]); err != nil {
+	for i := range s.podInfo.GetRequiredAntiAffinityTerms() {
+		if err := pl.mergeAffinityTermNamespacesIfNotEmpty(s.podInfo.GetRequiredAntiAffinityTerms()[i]); err != nil {
 			return nil, fwk.AsStatus(err)
 		}
 	}
@@ -300,7 +300,7 @@ func (pl *InterPodAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleS
 	s.existingAntiAffinityCounts = pl.getExistingAntiAffinityCounts(ctx, pod, s.namespaceLabels, nodesWithRequiredAntiAffinityPods)
 	s.affinityCounts, s.antiAffinityCounts = pl.getIncomingAffinityAntiAffinityCounts(ctx, s.podInfo, allNodes)
 
-	if len(s.existingAntiAffinityCounts) == 0 && len(s.podInfo.RequiredAffinityTerms) == 0 && len(s.podInfo.RequiredAntiAffinityTerms) == 0 {
+	if len(s.existingAntiAffinityCounts) == 0 && len(s.podInfo.GetRequiredAffinityTerms()) == 0 && len(s.podInfo.GetRequiredAntiAffinityTerms()) == 0 {
 		return nil, fwk.NewStatus(fwk.Skip)
 	}
 
@@ -314,7 +314,7 @@ func (pl *InterPodAffinity) PreFilterExtensions() framework.PreFilterExtensions 
 }
 
 // AddPod from pre-computed data in cycleState.
-func (pl *InterPodAffinity) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *InterPodAffinity) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	state, err := getPreFilterState(cycleState)
 	if err != nil {
 		return fwk.AsStatus(err)
@@ -324,7 +324,7 @@ func (pl *InterPodAffinity) AddPod(ctx context.Context, cycleState fwk.CycleStat
 }
 
 // RemovePod from pre-computed data in cycleState.
-func (pl *InterPodAffinity) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *InterPodAffinity) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	state, err := getPreFilterState(cycleState)
 	if err != nil {
 		return fwk.AsStatus(err)
@@ -349,7 +349,7 @@ func getPreFilterState(cycleState fwk.CycleState) (*preFilterState, error) {
 
 // Checks if scheduling the pod onto this node would break any anti-affinity
 // terms indicated by the existing pods.
-func satisfyExistingPodsAntiAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) bool {
+func satisfyExistingPodsAntiAffinity(state *preFilterState, nodeInfo fwk.NodeInfo) bool {
 	if len(state.existingAntiAffinityCounts) > 0 {
 		// Iterate over topology pairs to get any of the pods being affected by
 		// the scheduled pod anti-affinity terms
@@ -364,9 +364,9 @@ func satisfyExistingPodsAntiAffinity(state *preFilterState, nodeInfo *framework.
 }
 
 // Checks if the node satisfies the incoming pod's anti-affinity rules.
-func satisfyPodAntiAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) bool {
+func satisfyPodAntiAffinity(state *preFilterState, nodeInfo fwk.NodeInfo) bool {
 	if len(state.antiAffinityCounts) > 0 {
-		for _, term := range state.podInfo.RequiredAntiAffinityTerms {
+		for _, term := range state.podInfo.GetRequiredAntiAffinityTerms() {
 			if topologyValue, ok := nodeInfo.Node().Labels[term.TopologyKey]; ok {
 				tp := topologyPair{key: term.TopologyKey, value: topologyValue}
 				if state.antiAffinityCounts[tp] > 0 {
@@ -379,9 +379,9 @@ func satisfyPodAntiAffinity(state *preFilterState, nodeInfo *framework.NodeInfo)
 }
 
 // Checks if the node satisfies the incoming pod's affinity rules.
-func satisfyPodAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) bool {
+func satisfyPodAffinity(state *preFilterState, nodeInfo fwk.NodeInfo) bool {
 	podsExist := true
-	for _, term := range state.podInfo.RequiredAffinityTerms {
+	for _, term := range state.podInfo.GetRequiredAffinityTerms() {
 		if topologyValue, ok := nodeInfo.Node().Labels[term.TopologyKey]; ok {
 			tp := topologyPair{key: term.TopologyKey, value: topologyValue}
 			if state.affinityCounts[tp] <= 0 {
@@ -399,7 +399,7 @@ func satisfyPodAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) boo
 		// in the cluster matches the namespace and selector of this pod, the pod matches
 		// its own terms, and the node has all the requested topologies, then we allow the pod
 		// to pass the affinity check.
-		if len(state.affinityCounts) == 0 && podMatchesAllAffinityTerms(state.podInfo.RequiredAffinityTerms, state.podInfo.Pod) {
+		if len(state.affinityCounts) == 0 && podMatchesAllAffinityTerms(state.podInfo.GetRequiredAffinityTerms(), state.podInfo.GetPod()) {
 			return true
 		}
 		return false
@@ -409,7 +409,7 @@ func satisfyPodAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) boo
 
 // Filter invoked at the filter extension point.
 // It checks if a pod can be scheduled on the specified node with pod affinity/anti-affinity configuration.
-func (pl *InterPodAffinity) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *InterPodAffinity) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 
 	state, err := getPreFilterState(cycleState)
 	if err != nil {

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
@@ -1467,7 +1467,7 @@ func TestGetTPMapMatchingIncomingAffinityAntiAffinity(t *testing.T) {
 	}
 }
 
-func mustGetNodeInfo(t *testing.T, snapshot *cache.Snapshot, name string) *framework.NodeInfo {
+func mustGetNodeInfo(t *testing.T, snapshot *cache.Snapshot, name string) fwk.NodeInfo {
 	t.Helper()
 	nodeInfo, err := snapshot.NodeInfos().Get(name)
 	if err != nil {

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -121,7 +121,7 @@ func getArgs(obj runtime.Object) (config.InterPodAffinityArgs, error) {
 // is set to Nothing()) or is Empty(), which means match everything. Therefore,
 // there when matching against this term, there is no need to lookup the existing
 // pod's namespace labels to match them against term's namespaceSelector explicitly.
-func (pl *InterPodAffinity) mergeAffinityTermNamespacesIfNotEmpty(at *framework.AffinityTerm) error {
+func (pl *InterPodAffinity) mergeAffinityTermNamespacesIfNotEmpty(at fwk.AffinityTerm) error {
 	if at.NamespaceSelector.Empty() {
 		return nil
 	}

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
@@ -144,7 +144,7 @@ func (pl *NodeAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1
 }
 
 // PreFilter builds and writes cycle state used by Filter.
-func (pl *NodeAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *NodeAffinity) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	affinity := pod.Spec.Affinity
 	noNodeAffinity := (affinity == nil ||
 		affinity.NodeAffinity == nil ||
@@ -203,7 +203,7 @@ func (pl *NodeAffinity) PreFilterExtensions() framework.PreFilterExtensions {
 
 // Filter checks if the Node matches the Pod .spec.affinity.nodeAffinity and
 // the plugin's added affinity.
-func (pl *NodeAffinity) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *NodeAffinity) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 
 	if pl.addedNodeSelector != nil && !pl.addedNodeSelector.Match(node) {
@@ -238,7 +238,7 @@ func (s *preScoreState) Clone() fwk.StateData {
 }
 
 // PreScore builds and writes cycle state used by Score and NormalizeScore.
-func (pl *NodeAffinity) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (pl *NodeAffinity) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	preferredNodeAffinity, err := getPodPreferredNodeAffinity(pod)
 	if err != nil {
 		return fwk.AsStatus(err)
@@ -257,7 +257,7 @@ func (pl *NodeAffinity) PreScore(ctx context.Context, cycleState fwk.CycleState,
 // Score returns the sum of the weights of the terms that match the Node.
 // Terms came from the Pod .spec.affinity.nodeAffinity and from the plugin's
 // default affinity.
-func (pl *NodeAffinity) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *NodeAffinity) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	node := nodeInfo.Node()
 
 	var count int64

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -69,7 +69,7 @@ func (pl *NodeName) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *NodeName) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *NodeName) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 
 	if !Fits(pod, nodeInfo) {
 		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReason)
@@ -78,7 +78,7 @@ func (pl *NodeName) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, n
 }
 
 // Fits actually checks if the pod fits the node.
-func Fits(pod *v1.Pod, nodeInfo *framework.NodeInfo) bool {
+func Fits(pod *v1.Pod, nodeInfo fwk.NodeInfo) bool {
 	return len(pod.Spec.NodeName) == 0 || pod.Spec.NodeName == nodeInfo.Node().Name
 }
 

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -51,7 +51,7 @@ func newPod(host string, hostPortInfos ...string) *v1.Pod {
 func TestNodePorts(t *testing.T) {
 	tests := []struct {
 		pod                 *v1.Pod
-		nodeInfo            *framework.NodeInfo
+		nodeInfo            fwk.NodeInfo
 		name                string
 		wantPreFilterStatus *fwk.Status
 		wantFilterStatus    *fwk.Status

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -63,7 +63,7 @@ func (s *balancedAllocationPreScoreState) Clone() fwk.StateData {
 }
 
 // PreScore calculates incoming pod's resource requests and writes them to the cycle state used.
-func (ba *BalancedAllocation) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (ba *BalancedAllocation) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	podRequests := ba.calculatePodResourceRequestList(pod, ba.resources)
 	if ba.isBestEffortPod(podRequests) {
 		// Skip BalancedAllocation scoring for best-effort pods to
@@ -97,7 +97,7 @@ func (ba *BalancedAllocation) Name() string {
 }
 
 // Score invoked at the score extension point.
-func (ba *BalancedAllocation) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (ba *BalancedAllocation) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	s, err := getBalancedAllocationPreScoreState(state)
 	if err != nil {
 		s = &balancedAllocationPreScoreState{podRequests: ba.calculatePodResourceRequestList(pod, ba.resources)}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -26,7 +26,6 @@ import (
 	resourcehelper "k8s.io/component-helpers/resource"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
@@ -49,7 +48,7 @@ type resourceAllocationScorer struct {
 func (r *resourceAllocationScorer) score(
 	ctx context.Context,
 	pod *v1.Pod,
-	nodeInfo *framework.NodeInfo,
+	nodeInfo fwk.NodeInfo,
 	podRequests []int64) (int64, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
@@ -87,10 +86,10 @@ func (r *resourceAllocationScorer) score(
 // - 1st param: quantity of allocatable resource on the node.
 // - 2nd param: aggregated quantity of requested resource on the node.
 // Note: if it's an extended resource, and the pod doesn't request it, (0, 0) is returned.
-func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(logger klog.Logger, nodeInfo *framework.NodeInfo, resource v1.ResourceName, podRequest int64) (int64, int64) {
-	requested := nodeInfo.NonZeroRequested
+func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(logger klog.Logger, nodeInfo fwk.NodeInfo, resource v1.ResourceName, podRequest int64) (int64, int64) {
+	requested := nodeInfo.GetNonZeroRequested()
 	if r.useRequested {
-		requested = nodeInfo.Requested
+		requested = nodeInfo.GetRequested()
 	}
 
 	// If it's an extended resource, and the pod doesn't request it. We return (0, 0)
@@ -100,14 +99,14 @@ func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(logger kl
 	}
 	switch resource {
 	case v1.ResourceCPU:
-		return nodeInfo.Allocatable.MilliCPU, (requested.MilliCPU + podRequest)
+		return nodeInfo.GetAllocatable().GetMilliCPU(), (requested.GetMilliCPU() + podRequest)
 	case v1.ResourceMemory:
-		return nodeInfo.Allocatable.Memory, (requested.Memory + podRequest)
+		return nodeInfo.GetAllocatable().GetMemory(), (requested.GetMemory() + podRequest)
 	case v1.ResourceEphemeralStorage:
-		return nodeInfo.Allocatable.EphemeralStorage, (nodeInfo.Requested.EphemeralStorage + podRequest)
+		return nodeInfo.GetAllocatable().GetEphemeralStorage(), (nodeInfo.GetRequested().GetEphemeralStorage() + podRequest)
 	default:
-		if _, exists := nodeInfo.Allocatable.ScalarResources[resource]; exists {
-			return nodeInfo.Allocatable.ScalarResources[resource], (nodeInfo.Requested.ScalarResources[resource] + podRequest)
+		if _, exists := nodeInfo.GetAllocatable().GetScalarResources()[resource]; exists {
+			return nodeInfo.GetAllocatable().GetScalarResources()[resource], (nodeInfo.GetRequested().GetScalarResources()[resource] + podRequest)
 		}
 	}
 	logger.V(10).Info("Requested resource is omitted for node score calculation", "resourceName", resource)

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -130,7 +130,7 @@ func (pl *NodeUnschedulable) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 
 	if !node.Spec.Unschedulable {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -234,7 +234,7 @@ func (pl *CSILimits) isSchedulableAfterCSINodeUpdated(logger klog.Logger, pod *v
 // PreFilter invoked at the prefilter extension point
 //
 // If the pod haven't those types of volumes, we'll skip the Filter phase
-func (pl *CSILimits) PreFilter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, _ []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *CSILimits) PreFilter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, _ []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	volumes := pod.Spec.Volumes
 	for i := range volumes {
 		vol := &volumes[i]
@@ -252,7 +252,7 @@ func (pl *CSILimits) PreFilterExtensions() framework.PreFilterExtensions {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *CSILimits) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *CSILimits) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	// If the new pod doesn't have any volume attached to it, the predicate will always be true
 	if len(pod.Spec.Volumes) == 0 {
 		return nil
@@ -291,8 +291,8 @@ func (pl *CSILimits) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, 
 
 	// Count CSI volumes from existing pods
 	attachedVolumes := make(map[string]string)
-	for _, existingPod := range nodeInfo.Pods {
-		if err := pl.filterAttachableVolumes(logger, existingPod.Pod, csiNode, false /* existing pod */, attachedVolumes); err != nil {
+	for _, existingPod := range nodeInfo.GetPods() {
+		if err := pl.filterAttachableVolumes(logger, existingPod.GetPod(), csiNode, false /* existing pod */, attachedVolumes); err != nil {
 			return fwk.AsStatus(err)
 		}
 	}

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -1198,7 +1198,7 @@ func getFakeCSINodeLister(csiNode *storagev1.CSINode) tf.CSINodeLister {
 	return csiNodeLister
 }
 
-func getNodeWithPodAndVolumeLimits(limitSource string, pods []*v1.Pod, limit int32, driverNames ...string) (*framework.NodeInfo, *storagev1.CSINode) {
+func getNodeWithPodAndVolumeLimits(limitSource string, pods []*v1.Pod, limit int32, driverNames ...string) (fwk.NodeInfo, *storagev1.CSINode) {
 	nodeInfo := framework.NewNodeInfo(pods...)
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "node-for-max-pd-test-1"},

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	"k8s.io/utils/ptr"
 )
@@ -141,17 +141,17 @@ func mergeLabelSetWithSelector(matchLabels labels.Set, s labels.Selector) labels
 	return mergedSelector
 }
 
-func countPodsMatchSelector(podInfos []*framework.PodInfo, selector labels.Selector, ns string) int {
+func countPodsMatchSelector(podInfos []fwk.PodInfo, selector labels.Selector, ns string) int {
 	if selector.Empty() {
 		return 0
 	}
 	count := 0
 	for _, p := range podInfos {
 		// Bypass terminating Pod (see #87621).
-		if p.Pod.DeletionTimestamp != nil || p.Pod.Namespace != ns {
+		if p.GetPod().DeletionTimestamp != nil || p.GetPod().Namespace != ns {
 			continue
 		}
-		if selector.Matches(labels.Set(p.Pod.Labels)) {
+		if selector.Matches(labels.Set(p.GetPod().Labels)) {
 			count++
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -137,7 +137,7 @@ func (p *criticalPaths) update(tpVal string, num int) {
 }
 
 // PreFilter invoked at the prefilter extension point.
-func (pl *PodTopologySpread) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *PodTopologySpread) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	s, err := pl.calPreFilterState(ctx, pod, nodes)
 	if err != nil {
 		return nil, fwk.AsStatus(err)
@@ -155,24 +155,24 @@ func (pl *PodTopologySpread) PreFilterExtensions() framework.PreFilterExtensions
 }
 
 // AddPod from pre-computed data in cycleState.
-func (pl *PodTopologySpread) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *PodTopologySpread) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	s, err := getPreFilterState(cycleState)
 	if err != nil {
 		return fwk.AsStatus(err)
 	}
 
-	pl.updateWithPod(s, podInfoToAdd.Pod, podToSchedule, nodeInfo.Node(), 1)
+	pl.updateWithPod(s, podInfoToAdd.GetPod(), podToSchedule, nodeInfo.Node(), 1)
 	return nil
 }
 
 // RemovePod from pre-computed data in cycleState.
-func (pl *PodTopologySpread) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *PodTopologySpread) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	s, err := getPreFilterState(cycleState)
 	if err != nil {
 		return fwk.AsStatus(err)
 	}
 
-	pl.updateWithPod(s, podInfoToRemove.Pod, podToSchedule, nodeInfo.Node(), -1)
+	pl.updateWithPod(s, podInfoToRemove.GetPod(), podToSchedule, nodeInfo.Node(), -1)
 	return nil
 }
 
@@ -232,7 +232,7 @@ type topologyCount struct {
 }
 
 // calPreFilterState computes preFilterState describing how pods are spread on topologies.
-func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod, allNodes []*framework.NodeInfo) (*preFilterState, error) {
+func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod, allNodes []fwk.NodeInfo) (*preFilterState, error) {
 	constraints, err := pl.getConstraints(pod)
 	if err != nil {
 		return nil, fmt.Errorf("get constraints from pod: %w", err)
@@ -277,7 +277,7 @@ func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod,
 			}
 
 			value := node.Labels[c.TopologyKey]
-			count := countPodsMatchSelector(nodeInfo.Pods, c.Selector, pod.Namespace)
+			count := countPodsMatchSelector(nodeInfo.GetPods(), c.Selector, pod.Namespace)
 			tpCounts = append(tpCounts, topologyCount{
 				topologyValue: value,
 				constraintID:  i,
@@ -308,7 +308,7 @@ func (pl *PodTopologySpread) calPreFilterState(ctx context.Context, pod *v1.Pod,
 }
 
 // Filter invoked at the filter extension point.
-func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 
 	s, err := getPreFilterState(cycleState)

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -1467,7 +1468,7 @@ func BenchmarkTestPodTopologySpreadScore(b *testing.B) {
 			if !status.IsSuccess() {
 				b.Fatalf("unexpected error: %v", status)
 			}
-			nodeInfos := make([]*framework.NodeInfo, len(filteredNodes))
+			nodeInfos := make([]fwk.NodeInfo, len(filteredNodes))
 			for i, n := range filteredNodes {
 				nodeInfo, err := p.sharedLister.NodeInfos().Get(n.Name)
 				if err != nil {

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
@@ -41,10 +42,10 @@ func (pl *PrioritySort) Name() string {
 // Less is the function used by the activeQ heap algorithm to sort pods.
 // It sorts pods based on their priority. When priorities are equal, it uses
 // PodQueueInfo.timestamp.
-func (pl *PrioritySort) Less(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
-	p1 := corev1helpers.PodPriority(pInfo1.Pod)
-	p2 := corev1helpers.PodPriority(pInfo2.Pod)
-	return (p1 > p2) || (p1 == p2 && pInfo1.Timestamp.Before(pInfo2.Timestamp))
+func (pl *PrioritySort) Less(pInfo1, pInfo2 fwk.QueuedPodInfo) bool {
+	p1 := corev1helpers.PodPriority(pInfo1.GetPodInfo().GetPod())
+	p2 := corev1helpers.PodPriority(pInfo2.GetPodInfo().GetPod())
+	return (p1 > p2) || (p1 == p2 && pInfo1.GetTimestamp().Before(pInfo2.GetTimestamp()))
 }
 
 // New initializes a new plugin and returns it.

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -108,7 +108,7 @@ func (pl *TaintToleration) isSchedulableAfterNodeChange(logger klog.Logger, pod 
 }
 
 // Filter invoked at the filter extension point.
-func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 
 	taint, isUntolerated := v1helper.FindMatchingUntoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations, helper.DoNotScheduleTaintsFilterFunc())
@@ -143,7 +143,7 @@ func getAllTolerationPreferNoSchedule(tolerations []v1.Toleration) (tolerationLi
 }
 
 // PreScore builds and writes cycle state used by Score and NormalizeScore.
-func (pl *TaintToleration) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (pl *TaintToleration) PreScore(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	tolerationsPreferNoSchedule := getAllTolerationPreferNoSchedule(pod.Spec.Tolerations)
 	state := &preScoreState{
 		tolerationsPreferNoSchedule: tolerationsPreferNoSchedule,
@@ -181,7 +181,7 @@ func countIntolerableTaintsPreferNoSchedule(taints []v1.Taint, tolerations []v1.
 }
 
 // Score invoked at the Score extension point.
-func (pl *TaintToleration) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *TaintToleration) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	node := nodeInfo.Node()
 
 	s, err := getPreScoreState(state)

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -350,7 +350,7 @@ func (pl *VolumeBinding) podHasPVCs(pod *v1.Pod) (bool, error) {
 // PreFilter invoked at the prefilter extension point to check if pod has all
 // immediate PVCs bound. If not all immediate PVCs are bound, an
 // UnschedulableAndUnresolvable is returned.
-func (pl *VolumeBinding) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *VolumeBinding) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	// If pod does not reference any PVC, we don't need to do anything.
 	if hasPVC, err := pl.podHasPVCs(pod); err != nil {
@@ -414,7 +414,7 @@ func getStateData(cs fwk.CycleState) (*stateData, error) {
 //
 // The predicate returns true if all bound PVCs have compatible PVs with the node, and if all unbound
 // PVCs can be matched with an available and node-compatible PV.
-func (pl *VolumeBinding) Filter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *VolumeBinding) Filter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 
@@ -446,7 +446,7 @@ func (pl *VolumeBinding) Filter(ctx context.Context, cs fwk.CycleState, pod *v1.
 }
 
 // PreScore invoked at the preScore extension point. It checks whether volumeBinding can skip Score
-func (pl *VolumeBinding) PreScore(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (pl *VolumeBinding) PreScore(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	if pl.scorer == nil {
 		return fwk.NewStatus(fwk.Skip)
 	}
@@ -461,7 +461,7 @@ func (pl *VolumeBinding) PreScore(ctx context.Context, cs fwk.CycleState, pod *v
 }
 
 // Score invoked at the score extension point.
-func (pl *VolumeBinding) Score(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *VolumeBinding) Score(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	if pl.scorer == nil {
 		return 0, nil
 	}

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -67,13 +67,13 @@ type preFilterState struct {
 	conflictingPVCRefCount int
 }
 
-func (s *preFilterState) updateWithPod(podInfo *framework.PodInfo, multiplier int) {
+func (s *preFilterState) updateWithPod(podInfo fwk.PodInfo, multiplier int) {
 	s.conflictingPVCRefCount += multiplier * s.conflictingPVCRefCountForPod(podInfo)
 }
 
-func (s *preFilterState) conflictingPVCRefCountForPod(podInfo *framework.PodInfo) int {
+func (s *preFilterState) conflictingPVCRefCountForPod(podInfo fwk.PodInfo) int {
 	conflicts := 0
-	for _, volume := range podInfo.Pod.Spec.Volumes {
+	for _, volume := range podInfo.GetPod().Spec.Volumes {
 		if volume.PersistentVolumeClaim == nil {
 			continue
 		}
@@ -163,7 +163,7 @@ func needsRestrictionsCheck(v v1.Volume) bool {
 }
 
 // PreFilter computes and stores cycleState containing details for enforcing ReadWriteOncePod.
-func (pl *VolumeRestrictions) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *VolumeRestrictions) PreFilter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	needsCheck := false
 	for i := range pod.Spec.Volumes {
 		if needsRestrictionsCheck(pod.Spec.Volumes[i]) {
@@ -193,7 +193,7 @@ func (pl *VolumeRestrictions) PreFilter(ctx context.Context, cycleState fwk.Cycl
 }
 
 // AddPod from pre-computed data in cycleState.
-func (pl *VolumeRestrictions) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *VolumeRestrictions) AddPod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	state, err := getPreFilterState(cycleState)
 	if err != nil {
 		return fwk.AsStatus(err)
@@ -203,7 +203,7 @@ func (pl *VolumeRestrictions) AddPod(ctx context.Context, cycleState fwk.CycleSt
 }
 
 // RemovePod from pre-computed data in cycleState.
-func (pl *VolumeRestrictions) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *VolumeRestrictions) RemovePod(ctx context.Context, cycleState fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	state, err := getPreFilterState(cycleState)
 	if err != nil {
 		return fwk.AsStatus(err)
@@ -265,14 +265,14 @@ func (pl *VolumeRestrictions) readWriteOncePodPVCsForPod(ctx context.Context, po
 
 // Checks if scheduling the pod onto this node would cause any conflicts with
 // existing volumes.
-func satisfyVolumeConflicts(pod *v1.Pod, nodeInfo *framework.NodeInfo) bool {
+func satisfyVolumeConflicts(pod *v1.Pod, nodeInfo fwk.NodeInfo) bool {
 	for i := range pod.Spec.Volumes {
 		v := pod.Spec.Volumes[i]
 		if !needsRestrictionsCheck(v) {
 			continue
 		}
-		for _, ev := range nodeInfo.Pods {
-			if isVolumeConflict(&v, ev.Pod) {
+		for _, ev := range nodeInfo.GetPods() {
+			if isVolumeConflict(&v, ev.GetPod()) {
 				return false
 			}
 		}
@@ -307,7 +307,7 @@ func (pl *VolumeRestrictions) PreFilterExtensions() framework.PreFilterExtension
 // - ISCSI forbids if any two pods share at least same IQN and ISCSI volume is read-only
 // If the pod uses PVCs with the ReadWriteOncePod access mode, it evaluates if
 // these PVCs are already in-use and if preemption will help.
-func (pl *VolumeRestrictions) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *VolumeRestrictions) Filter(ctx context.Context, cycleState fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	if !satisfyVolumeConflicts(pod, nodeInfo) {
 		return fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	}

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -57,7 +57,7 @@ func TestGCEDiskConflicts(t *testing.T) {
 	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
-		nodeInfo            *framework.NodeInfo
+		nodeInfo            fwk.NodeInfo
 		name                string
 		preFilterWantStatus *fwk.Status
 		wantStatus          *fwk.Status
@@ -139,7 +139,7 @@ func TestAWSDiskConflicts(t *testing.T) {
 	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
-		nodeInfo            *framework.NodeInfo
+		nodeInfo            fwk.NodeInfo
 		name                string
 		wantStatus          *fwk.Status
 		preFilterWantStatus *fwk.Status
@@ -220,7 +220,7 @@ func TestRBDDiskConflicts(t *testing.T) {
 	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
-		nodeInfo            *framework.NodeInfo
+		nodeInfo            fwk.NodeInfo
 		name                string
 		wantStatus          *fwk.Status
 		preFilterWantStatus *fwk.Status
@@ -301,7 +301,7 @@ func TestISCSIDiskConflicts(t *testing.T) {
 	errStatus := fwk.NewStatus(fwk.Unschedulable, ErrReasonDiskConflict)
 	tests := []struct {
 		pod                 *v1.Pod
-		nodeInfo            *framework.NodeInfo
+		nodeInfo            fwk.NodeInfo
 		name                string
 		wantStatus          *fwk.Status
 		preFilterWantStatus *fwk.Status
@@ -405,7 +405,7 @@ func TestAccessModeConflicts(t *testing.T) {
 	tests := []struct {
 		name                string
 		pod                 *v1.Pod
-		nodeInfo            *framework.NodeInfo
+		nodeInfo            fwk.NodeInfo
 		existingPods        []*v1.Pod
 		existingNodes       []*v1.Node
 		existingPVCs        []*v1.PersistentVolumeClaim

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -109,7 +109,7 @@ func (pl *VolumeZone) Name() string {
 //
 // Currently, this is only supported with PersistentVolumeClaims,
 // and only looks for the bound PersistentVolume.
-func (pl *VolumeZone) PreFilter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *VolumeZone) PreFilter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	podPVTopologies, status := pl.getPVbyPod(logger, pod)
 	if !status.IsSuccess() {
@@ -188,7 +188,7 @@ func (pl *VolumeZone) PreFilterExtensions() framework.PreFilterExtensions {
 // determining the zone of a volume during scheduling, and that is likely to
 // require calling out to the cloud provider.  It seems that we are moving away
 // from inline volume declarations anyway.
-func (pl *VolumeZone) Filter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *VolumeZone) Filter(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	logger := klog.FromContext(ctx)
 	// If a pod doesn't have any volume attached to it, the predicate will always be true.
 	// Thus we make a fast path for it, to avoid unnecessary computations in this case.

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -814,7 +814,7 @@ func BenchmarkVolumeZone(b *testing.B) {
 			defer cancel()
 			nodes := makeNodesWithTopologyZone(tt.NumNodes)
 			pl := newPluginWithListers(ctx, b, []*v1.Pod{tt.Pod}, nodes, makePVCsWithPV(tt.NumPVC), makePVsWithZoneLabel(tt.NumPV))
-			nodeInfos := make([]*framework.NodeInfo, len(nodes))
+			nodeInfos := make([]fwk.NodeInfo, len(nodes))
 			for i := 0; i < len(nodes); i++ {
 				nodeInfo := &framework.NodeInfo{}
 				nodeInfo.SetNode(nodes[i])

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -119,7 +119,7 @@ type Interface interface {
 	// for "pod" to be scheduled.
 	// Note that both `state` and `nodeInfo` are deep copied.
 	SelectVictimsOnNode(ctx context.Context, state fwk.CycleState,
-		pod *v1.Pod, nodeInfo *framework.NodeInfo, pdbs []*policy.PodDisruptionBudget) ([]*v1.Pod, int, *fwk.Status)
+		pod *v1.Pod, nodeInfo fwk.NodeInfo, pdbs []*policy.PodDisruptionBudget) ([]*v1.Pod, int, *fwk.Status)
 	// OrderedScoreFuncs returns a list of ordered score functions to select preferable node where victims will be preempted.
 	// The ordered score functions will be processed one by one iff we find more than one node with the highest score.
 	// Default score functions will be processed if nil returned here for backwards-compatibility.
@@ -305,7 +305,7 @@ func (ev *Evaluator) Preempt(ctx context.Context, state fwk.CycleState, pod *v1.
 
 // FindCandidates calculates a slice of preemption candidates.
 // Each candidate is executable to make the given <pod> schedulable.
-func (ev *Evaluator) findCandidates(ctx context.Context, state fwk.CycleState, allNodes []*framework.NodeInfo, pod *v1.Pod, m framework.NodeToStatusReader) ([]Candidate, *framework.NodeToStatus, error) {
+func (ev *Evaluator) findCandidates(ctx context.Context, state fwk.CycleState, allNodes []fwk.NodeInfo, pod *v1.Pod, m framework.NodeToStatusReader) ([]Candidate, *framework.NodeToStatus, error) {
 	if len(allNodes) == 0 {
 		return nil, nil, errors.New("no nodes available")
 	}
@@ -668,8 +668,8 @@ func getLowerPriorityNominatedPods(logger klog.Logger, pn framework.PodNominator
 	var lowerPriorityPods []*v1.Pod
 	podPriority := corev1helpers.PodPriority(pod)
 	for _, pi := range podInfos {
-		if corev1helpers.PodPriority(pi.Pod) < podPriority {
-			lowerPriorityPods = append(lowerPriorityPods, pi.Pod)
+		if corev1helpers.PodPriority(pi.GetPod()) < podPriority {
+			lowerPriorityPods = append(lowerPriorityPods, pi.GetPod())
 		}
 	}
 	return lowerPriorityPods
@@ -680,7 +680,7 @@ func getLowerPriorityNominatedPods(logger klog.Logger, pn framework.PodNominator
 // The number of candidates depends on the constraints defined in the plugin's args. In the returned list of
 // candidates, ones that do not violate PDB are preferred over ones that do.
 // NOTE: This method is exported for easier testing in default preemption.
-func (ev *Evaluator) DryRunPreemption(ctx context.Context, state fwk.CycleState, pod *v1.Pod, potentialNodes []*framework.NodeInfo,
+func (ev *Evaluator) DryRunPreemption(ctx context.Context, state fwk.CycleState, pod *v1.Pod, potentialNodes []fwk.NodeInfo,
 	pdbs []*policy.PodDisruptionBudget, offset int32, candidatesNum int32) ([]Candidate, *framework.NodeToStatus, error) {
 
 	fh := ev.Handler

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -74,8 +74,8 @@ type FakePostFilterPlugin struct {
 
 func (pl *FakePostFilterPlugin) SelectVictimsOnNode(
 	ctx context.Context, state fwk.CycleState, pod *v1.Pod,
-	nodeInfo *framework.NodeInfo, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
-	return append(victims, nodeInfo.Pods[0].Pod), pl.numViolatingVictim, nil
+	nodeInfo fwk.NodeInfo, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
+	return append(victims, nodeInfo.GetPods()[0].GetPod()), pl.numViolatingVictim, nil
 }
 
 func (pl *FakePostFilterPlugin) GetOffsetAndNumCandidates(nodes int32) (int32, int32) {
@@ -111,8 +111,8 @@ type FakePreemptionScorePostFilterPlugin struct{}
 
 func (pl *FakePreemptionScorePostFilterPlugin) SelectVictimsOnNode(
 	ctx context.Context, state fwk.CycleState, pod *v1.Pod,
-	nodeInfo *framework.NodeInfo, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
-	return append(victims, nodeInfo.Pods[0].Pod), 1, nil
+	nodeInfo fwk.NodeInfo, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *fwk.Status) {
+	return append(victims, nodeInfo.GetPods()[0].GetPod()), 1, nil
 }
 
 func (pl *FakePreemptionScorePostFilterPlugin) GetOffsetAndNumCandidates(nodes int32) (int32, int32) {
@@ -812,7 +812,7 @@ type fakePodNominator struct {
 	requestStopper chan struct{}
 }
 
-func (f *fakePodNominator) NominatedPodsForNode(nodeName string) []*framework.PodInfo {
+func (f *fakePodNominator) NominatedPodsForNode(nodeName string) []fwk.PodInfo {
 	<-f.requestStopper
 	return nil
 }
@@ -881,13 +881,13 @@ func (f *fakeExtender) IsInterested(pod *v1.Pod) bool {
 	return pod != nil
 }
 
-func (f *fakeExtender) Filter(_ *v1.Pod, _ []*framework.NodeInfo) ([]*framework.NodeInfo, extenderv1.FailedNodesMap, extenderv1.FailedNodesMap, error) {
+func (f *fakeExtender) Filter(_ *v1.Pod, _ []fwk.NodeInfo) ([]fwk.NodeInfo, extenderv1.FailedNodesMap, extenderv1.FailedNodesMap, error) {
 	return nil, nil, nil, nil
 }
 
 func (f *fakeExtender) Prioritize(
 	_ *v1.Pod,
-	_ []*framework.NodeInfo,
+	_ []fwk.NodeInfo,
 ) (hostPriorities *extenderv1.HostPriorityList, weight int64, err error) {
 	return nil, 0, nil
 }

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -138,7 +138,7 @@ func (pl *TestScoreWithNormalizePlugin) NormalizeScore(ctx context.Context, stat
 	return injectNormalizeRes(pl.inj, scores)
 }
 
-func (pl *TestScoreWithNormalizePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *TestScoreWithNormalizePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	return setScoreRes(pl.inj)
 }
 
@@ -156,11 +156,11 @@ func (pl *TestScorePlugin) Name() string {
 	return pl.name
 }
 
-func (pl *TestScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (pl *TestScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Code(pl.inj.PreScoreStatus), injectReason)
 }
 
-func (pl *TestScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *TestScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	return setScoreRes(pl.inj)
 }
 
@@ -185,10 +185,10 @@ type TestPlugin struct {
 	inj  injectedResult
 }
 
-func (pl *TestPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *TestPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToAdd fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Code(pl.inj.PreFilterAddPodStatus), injectReason)
 }
-func (pl *TestPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *TestPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod, podInfoToRemove fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Code(pl.inj.PreFilterRemovePodStatus), injectReason)
 }
 
@@ -196,11 +196,11 @@ func (pl *TestPlugin) Name() string {
 	return pl.name
 }
 
-func (pl *TestPlugin) Less(*framework.QueuedPodInfo, *framework.QueuedPodInfo) bool {
+func (pl *TestPlugin) Less(fwk.QueuedPodInfo, fwk.QueuedPodInfo) bool {
 	return false
 }
 
-func (pl *TestPlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *TestPlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	return 0, fwk.NewStatus(fwk.Code(pl.inj.ScoreStatus), injectReason)
 }
 
@@ -208,7 +208,7 @@ func (pl *TestPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return nil
 }
 
-func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return pl.inj.PreFilterResult, fwk.NewStatus(fwk.Code(pl.inj.PreFilterStatus), injectReason)
 }
 
@@ -216,7 +216,7 @@ func (pl *TestPlugin) PreFilterExtensions() framework.PreFilterExtensions {
 	return pl
 }
 
-func (pl *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *TestPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Code(pl.inj.FilterStatus), injectFilterReason)
 }
 
@@ -224,7 +224,7 @@ func (pl *TestPlugin) PostFilter(_ context.Context, _ fwk.CycleState, _ *v1.Pod,
 	return nil, fwk.NewStatus(fwk.Code(pl.inj.PostFilterStatus), injectReason)
 }
 
-func (pl *TestPlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (pl *TestPlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Code(pl.inj.PreScoreStatus), injectReason)
 }
 
@@ -282,7 +282,7 @@ func (pl *TestPreFilterPlugin) Name() string {
 	return preFilterPluginName
 }
 
-func (pl *TestPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *TestPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	pl.PreFilterCalled++
 	return nil, nil
 }
@@ -302,19 +302,19 @@ func (pl *TestPreFilterWithExtensionsPlugin) Name() string {
 	return preFilterWithExtensionsPluginName
 }
 
-func (pl *TestPreFilterWithExtensionsPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *TestPreFilterWithExtensionsPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	pl.PreFilterCalled++
 	return nil, nil
 }
 
 func (pl *TestPreFilterWithExtensionsPlugin) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+	podInfoToAdd fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	pl.AddCalled++
 	return nil
 }
 
 func (pl *TestPreFilterWithExtensionsPlugin) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+	podInfoToRemove fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	pl.RemoveCalled++
 	return nil
 }
@@ -330,7 +330,7 @@ func (dp *TestDuplicatePlugin) Name() string {
 	return duplicatePluginName
 }
 
-func (dp *TestDuplicatePlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (dp *TestDuplicatePlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return nil, nil
 }
 
@@ -381,7 +381,7 @@ func (pl *TestQueueSortPlugin) Name() string {
 	return queueSortPlugin
 }
 
-func (pl *TestQueueSortPlugin) Less(_, _ *framework.QueuedPodInfo) bool {
+func (pl *TestQueueSortPlugin) Less(_, _ fwk.QueuedPodInfo) bool {
 	return false
 }
 
@@ -1941,7 +1941,8 @@ func TestRunPreFilterExtensionAddPod(t *testing.T) {
 
 			state := framework.NewCycleState()
 			state.SetSkipFilterPlugins(tt.skippedPluginNames)
-			status := f.RunPreFilterExtensionAddPod(ctx, state, nil, nil, nil)
+			ni := framework.NewNodeInfo()
+			status := f.RunPreFilterExtensionAddPod(ctx, state, nil, nil, ni)
 			if status.Code() != tt.wantStatusCode {
 				t.Errorf("wrong status code. got: %v, want: %v", status, tt.wantStatusCode)
 			}
@@ -3546,8 +3547,8 @@ func mustNewPodInfo(t *testing.T, pod *v1.Pod) *framework.PodInfo {
 }
 
 // BuildNodeInfos build NodeInfo slice from a v1.Node slice
-func BuildNodeInfos(nodes []*v1.Node) []*framework.NodeInfo {
-	res := make([]*framework.NodeInfo, len(nodes))
+func BuildNodeInfos(nodes []*v1.Node) []fwk.NodeInfo {
+	res := make([]fwk.NodeInfo, len(nodes))
 	for i := 0; i < len(nodes); i++ {
 		res[i] = framework.NewNodeInfo()
 		res[i].SetNode(nodes[i])

--- a/pkg/scheduler/framework/runtime/instrumented_plugins.go
+++ b/pkg/scheduler/framework/runtime/instrumented_plugins.go
@@ -33,7 +33,7 @@ type instrumentedFilterPlugin struct {
 
 var _ framework.FilterPlugin = &instrumentedFilterPlugin{}
 
-func (p *instrumentedFilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (p *instrumentedFilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	p.metric.Inc()
 	return p.FilterPlugin.Filter(ctx, state, pod, nodeInfo)
 }
@@ -46,7 +46,7 @@ type instrumentedPreFilterPlugin struct {
 
 var _ framework.PreFilterPlugin = &instrumentedPreFilterPlugin{}
 
-func (p *instrumentedPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (p *instrumentedPreFilterPlugin) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	result, status := p.PreFilterPlugin.PreFilter(ctx, state, pod, nodes)
 	if !status.IsSkip() {
 		p.metric.Inc()
@@ -62,7 +62,7 @@ type instrumentedPreScorePlugin struct {
 
 var _ framework.PreScorePlugin = &instrumentedPreScorePlugin{}
 
-func (p *instrumentedPreScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (p *instrumentedPreScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	status := p.PreScorePlugin.PreScore(ctx, state, pod, nodes)
 	if !status.IsSkip() {
 		p.metric.Inc()
@@ -78,7 +78,7 @@ type instrumentedScorePlugin struct {
 
 var _ framework.ScorePlugin = &instrumentedScorePlugin{}
 
-func (p *instrumentedScorePlugin) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (p *instrumentedScorePlugin) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	p.metric.Inc()
 	return p.ScorePlugin.Score(ctx, state, pod, nodeInfo)
 }

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 var nodeInfoCmpOpts = []cmp.Option{
-	cmp.AllowUnexported(NodeInfo{}, PodInfo{}, podResource{}),
+	cmp.AllowUnexported(NodeInfo{}, PodInfo{}, fwk.PodResource{}),
 }
 
 func TestNewResource(t *testing.T) {
@@ -263,16 +263,16 @@ func TestNewNodeInfo(t *testing.T) {
 		},
 		Allocatable: &Resource{},
 		Generation:  2,
-		UsedPorts: HostPortInfo{
-			"127.0.0.1": map[ProtocolPort]struct{}{
+		UsedPorts: fwk.HostPortInfo{
+			"127.0.0.1": map[fwk.ProtocolPort]struct{}{
 				{Protocol: "TCP", Port: 80}:   {},
 				{Protocol: "TCP", Port: 8080}: {},
 			},
 		},
-		ImageStates:  map[string]*ImageStateSummary{},
+		ImageStates:  map[string]*fwk.ImageStateSummary{},
 		PVCRefCounts: map[string]int{},
-		Pods: []*PodInfo{
-			{
+		Pods: []fwk.PodInfo{
+			&PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "node_info_cache_test",
@@ -300,16 +300,16 @@ func TestNewNodeInfo(t *testing.T) {
 						NodeName: nodeName,
 					},
 				},
-				cachedResource: &podResource{
-					resource: Resource{
+				cachedResource: &fwk.PodResource{
+					Resource: &Resource{
 						MilliCPU: 100,
 						Memory:   500,
 					},
-					non0CPU: 100,
-					non0Mem: 500,
+					Non0CPU: 100,
+					Non0Mem: 500,
 				},
 			},
-			{
+			&PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "node_info_cache_test",
@@ -337,13 +337,13 @@ func TestNewNodeInfo(t *testing.T) {
 						NodeName: nodeName,
 					},
 				},
-				cachedResource: &podResource{
-					resource: Resource{
+				cachedResource: &fwk.PodResource{
+					Resource: &Resource{
 						MilliCPU: 200,
 						Memory:   1024,
 					},
-					non0CPU: 200,
-					non0Mem: 1024,
+					Non0CPU: 200,
+					Non0Mem: 1024,
 				},
 			},
 		},
@@ -372,16 +372,16 @@ func TestNodeInfoClone(t *testing.T) {
 				NonZeroRequested: &Resource{},
 				Allocatable:      &Resource{},
 				Generation:       2,
-				UsedPorts: HostPortInfo{
-					"127.0.0.1": map[ProtocolPort]struct{}{
+				UsedPorts: fwk.HostPortInfo{
+					"127.0.0.1": map[fwk.ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 80}:   {},
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				ImageStates:  map[string]*ImageStateSummary{},
+				ImageStates:  map[string]*fwk.ImageStateSummary{},
 				PVCRefCounts: map[string]int{},
-				Pods: []*PodInfo{
-					{
+				Pods: []fwk.PodInfo{
+					&PodInfo{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "node_info_cache_test",
@@ -409,16 +409,16 @@ func TestNodeInfoClone(t *testing.T) {
 								NodeName: nodeName,
 							},
 						},
-						cachedResource: &podResource{
-							resource: Resource{
+						cachedResource: &fwk.PodResource{
+							Resource: &Resource{
 								MilliCPU: 100,
 								Memory:   500,
 							},
-							non0CPU: 100,
-							non0Mem: 500,
+							Non0CPU: 100,
+							Non0Mem: 500,
 						},
 					},
-					{
+					&PodInfo{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "node_info_cache_test",
@@ -446,13 +446,13 @@ func TestNodeInfoClone(t *testing.T) {
 								NodeName: nodeName,
 							},
 						},
-						cachedResource: &podResource{
-							resource: Resource{
+						cachedResource: &fwk.PodResource{
+							Resource: &Resource{
 								MilliCPU: 200,
 								Memory:   1024,
 							},
-							non0CPU: 200,
-							non0Mem: 1024,
+							Non0CPU: 200,
+							Non0Mem: 1024,
 						},
 					},
 				},
@@ -462,16 +462,16 @@ func TestNodeInfoClone(t *testing.T) {
 				NonZeroRequested: &Resource{},
 				Allocatable:      &Resource{},
 				Generation:       2,
-				UsedPorts: HostPortInfo{
-					"127.0.0.1": map[ProtocolPort]struct{}{
+				UsedPorts: fwk.HostPortInfo{
+					"127.0.0.1": map[fwk.ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 80}:   {},
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				ImageStates:  map[string]*ImageStateSummary{},
+				ImageStates:  map[string]*fwk.ImageStateSummary{},
 				PVCRefCounts: map[string]int{},
-				Pods: []*PodInfo{
-					{
+				Pods: []fwk.PodInfo{
+					&PodInfo{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "node_info_cache_test",
@@ -499,16 +499,16 @@ func TestNodeInfoClone(t *testing.T) {
 								NodeName: nodeName,
 							},
 						},
-						cachedResource: &podResource{
-							resource: Resource{
+						cachedResource: &fwk.PodResource{
+							Resource: &Resource{
 								MilliCPU: 100,
 								Memory:   500,
 							},
-							non0CPU: 100,
-							non0Mem: 500,
+							Non0CPU: 100,
+							Non0Mem: 500,
 						},
 					},
-					{
+					&PodInfo{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "node_info_cache_test",
@@ -536,13 +536,13 @@ func TestNodeInfoClone(t *testing.T) {
 								NodeName: nodeName,
 							},
 						},
-						cachedResource: &podResource{
-							resource: Resource{
+						cachedResource: &fwk.PodResource{
+							Resource: &Resource{
 								MilliCPU: 200,
 								Memory:   1024,
 							},
-							non0CPU: 200,
-							non0Mem: 1024,
+							Non0CPU: 200,
+							Non0Mem: 1024,
 						},
 					},
 				},
@@ -716,16 +716,16 @@ func TestNodeInfoAddPod(t *testing.T) {
 		},
 		Allocatable: &Resource{},
 		Generation:  2,
-		UsedPorts: HostPortInfo{
-			"127.0.0.1": map[ProtocolPort]struct{}{
+		UsedPorts: fwk.HostPortInfo{
+			"127.0.0.1": map[fwk.ProtocolPort]struct{}{
 				{Protocol: "TCP", Port: 80}:   {},
 				{Protocol: "TCP", Port: 8080}: {},
 			},
 		},
-		ImageStates:  map[string]*ImageStateSummary{},
+		ImageStates:  map[string]*fwk.ImageStateSummary{},
 		PVCRefCounts: map[string]int{"node_info_cache_test/pvc-1": 2, "node_info_cache_test/pvc-2": 1},
-		Pods: []*PodInfo{
-			{
+		Pods: []fwk.PodInfo{
+			&PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "node_info_cache_test",
@@ -765,16 +765,16 @@ func TestNodeInfoAddPod(t *testing.T) {
 						},
 					},
 				},
-				cachedResource: &podResource{
-					resource: Resource{
+				cachedResource: &fwk.PodResource{
+					Resource: &Resource{
 						MilliCPU: 600,
 						Memory:   500,
 					},
-					non0CPU: 600,
-					non0Mem: 500,
+					Non0CPU: 600,
+					Non0Mem: 500,
 				},
 			},
-			{
+			&PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "node_info_cache_test",
@@ -814,16 +814,16 @@ func TestNodeInfoAddPod(t *testing.T) {
 						},
 					},
 				},
-				cachedResource: &podResource{
-					resource: Resource{
+				cachedResource: &fwk.PodResource{
+					Resource: &Resource{
 						MilliCPU: 700,
 						Memory:   500,
 					},
-					non0CPU: 700,
-					non0Mem: schedutil.DefaultMemoryRequest + 500,
+					Non0CPU: 700,
+					Non0Mem: schedutil.DefaultMemoryRequest + 500,
 				},
 			},
-			{
+			&PodInfo{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "node_info_cache_test",
@@ -873,13 +873,13 @@ func TestNodeInfoAddPod(t *testing.T) {
 						},
 					},
 				},
-				cachedResource: &podResource{
-					resource: Resource{
+				cachedResource: &fwk.PodResource{
+					Resource: &Resource{
 						MilliCPU: 1000,
 						Memory:   schedutil.DefaultMemoryRequest + 500,
 					},
-					non0CPU: 1000,
-					non0Mem: schedutil.DefaultMemoryRequest + 500,
+					Non0CPU: 1000,
+					Non0Mem: schedutil.DefaultMemoryRequest + 500,
 				},
 			},
 		},
@@ -966,16 +966,16 @@ func TestNodeInfoRemovePod(t *testing.T) {
 				},
 				Allocatable: &Resource{},
 				Generation:  2,
-				UsedPorts: HostPortInfo{
-					"127.0.0.1": map[ProtocolPort]struct{}{
+				UsedPorts: fwk.HostPortInfo{
+					"127.0.0.1": map[fwk.ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 80}:   {},
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				ImageStates:  map[string]*ImageStateSummary{},
+				ImageStates:  map[string]*fwk.ImageStateSummary{},
 				PVCRefCounts: map[string]int{"node_info_cache_test/pvc-1": 1},
-				Pods: []*PodInfo{
-					{
+				Pods: []fwk.PodInfo{
+					&PodInfo{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "node_info_cache_test",
@@ -1016,16 +1016,16 @@ func TestNodeInfoRemovePod(t *testing.T) {
 								},
 							},
 						},
-						cachedResource: &podResource{
-							resource: Resource{
+						cachedResource: &fwk.PodResource{
+							Resource: &Resource{
 								MilliCPU: 600,
 								Memory:   1000,
 							},
-							non0CPU: 600,
-							non0Mem: 1000,
+							Non0CPU: 600,
+							Non0Mem: 1000,
 						},
 					},
-					{
+					&PodInfo{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "node_info_cache_test",
@@ -1057,13 +1057,13 @@ func TestNodeInfoRemovePod(t *testing.T) {
 								},
 							},
 						},
-						cachedResource: &podResource{
-							resource: Resource{
+						cachedResource: &fwk.PodResource{
+							Resource: &Resource{
 								MilliCPU: 700,
 								Memory:   1524,
 							},
-							non0CPU: 700,
-							non0Mem: 1524,
+							Non0CPU: 700,
+							Non0Mem: 1524,
 						},
 					},
 				},
@@ -1133,15 +1133,15 @@ func TestNodeInfoRemovePod(t *testing.T) {
 				},
 				Allocatable: &Resource{},
 				Generation:  3,
-				UsedPorts: HostPortInfo{
-					"127.0.0.1": map[ProtocolPort]struct{}{
+				UsedPorts: fwk.HostPortInfo{
+					"127.0.0.1": map[fwk.ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				ImageStates:  map[string]*ImageStateSummary{},
+				ImageStates:  map[string]*fwk.ImageStateSummary{},
 				PVCRefCounts: map[string]int{},
-				Pods: []*PodInfo{
-					{
+				Pods: []fwk.PodInfo{
+					&PodInfo{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "node_info_cache_test",
@@ -1173,13 +1173,13 @@ func TestNodeInfoRemovePod(t *testing.T) {
 								},
 							},
 						},
-						cachedResource: &podResource{
-							resource: Resource{
+						cachedResource: &fwk.PodResource{
+							Resource: &Resource{
 								MilliCPU: 700,
 								Memory:   1524,
 							},
-							non0CPU: 700,
-							non0Mem: 1524,
+							Non0CPU: 700,
+							Non0Mem: 1524,
 						},
 					},
 				},
@@ -1225,220 +1225,6 @@ func fakeNodeInfo(pods ...*v1.Pod) *NodeInfo {
 		},
 	})
 	return ni
-}
-
-type hostPortInfoParam struct {
-	protocol, ip string
-	port         int32
-}
-
-func TestHostPortInfo_AddRemove(t *testing.T) {
-	tests := []struct {
-		desc    string
-		added   []hostPortInfoParam
-		removed []hostPortInfoParam
-		length  int
-	}{
-		{
-			desc: "normal add case",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 79},
-				{"UDP", "127.0.0.1", 80},
-				{"TCP", "127.0.0.1", 81},
-				{"TCP", "127.0.0.1", 82},
-				// this might not make sense in real case, but the struct doesn't forbid it.
-				{"TCP", "0.0.0.0", 79},
-				{"UDP", "0.0.0.0", 80},
-				{"TCP", "0.0.0.0", 81},
-				{"TCP", "0.0.0.0", 82},
-				{"TCP", "0.0.0.0", 0},
-				{"TCP", "0.0.0.0", -1},
-			},
-			length: 8,
-		},
-		{
-			desc: "empty ip and protocol add should work",
-			added: []hostPortInfoParam{
-				{"", "127.0.0.1", 79},
-				{"UDP", "127.0.0.1", 80},
-				{"", "127.0.0.1", 81},
-				{"", "127.0.0.1", 82},
-				{"", "", 79},
-				{"UDP", "", 80},
-				{"", "", 81},
-				{"", "", 82},
-				{"", "", 0},
-				{"", "", -1},
-			},
-			length: 8,
-		},
-		{
-			desc: "normal remove case",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 79},
-				{"UDP", "127.0.0.1", 80},
-				{"TCP", "127.0.0.1", 81},
-				{"TCP", "127.0.0.1", 82},
-				{"TCP", "0.0.0.0", 79},
-				{"UDP", "0.0.0.0", 80},
-				{"TCP", "0.0.0.0", 81},
-				{"TCP", "0.0.0.0", 82},
-			},
-			removed: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 79},
-				{"UDP", "127.0.0.1", 80},
-				{"TCP", "127.0.0.1", 81},
-				{"TCP", "127.0.0.1", 82},
-				{"TCP", "0.0.0.0", 79},
-				{"UDP", "0.0.0.0", 80},
-				{"TCP", "0.0.0.0", 81},
-				{"TCP", "0.0.0.0", 82},
-			},
-			length: 0,
-		},
-		{
-			desc: "empty ip and protocol remove should work",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 79},
-				{"UDP", "127.0.0.1", 80},
-				{"TCP", "127.0.0.1", 81},
-				{"TCP", "127.0.0.1", 82},
-				{"TCP", "0.0.0.0", 79},
-				{"UDP", "0.0.0.0", 80},
-				{"TCP", "0.0.0.0", 81},
-				{"TCP", "0.0.0.0", 82},
-			},
-			removed: []hostPortInfoParam{
-				{"", "127.0.0.1", 79},
-				{"", "127.0.0.1", 81},
-				{"", "127.0.0.1", 82},
-				{"UDP", "127.0.0.1", 80},
-				{"", "", 79},
-				{"", "", 81},
-				{"", "", 82},
-				{"UDP", "", 80},
-			},
-			length: 0,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			hp := make(HostPortInfo)
-			for _, param := range test.added {
-				hp.Add(param.ip, param.protocol, param.port)
-			}
-			for _, param := range test.removed {
-				hp.Remove(param.ip, param.protocol, param.port)
-			}
-			if hp.Len() != test.length {
-				t.Errorf("%v failed: expect length %d; got %d", test.desc, test.length, hp.Len())
-				t.Error(hp)
-			}
-		})
-	}
-}
-
-func TestHostPortInfo_Check(t *testing.T) {
-	tests := []struct {
-		desc   string
-		added  []hostPortInfoParam
-		check  hostPortInfoParam
-		expect bool
-	}{
-		{
-			desc: "empty check should check 0.0.0.0 and TCP",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 80},
-			},
-			check:  hostPortInfoParam{"", "", 81},
-			expect: false,
-		},
-		{
-			desc: "empty check should check 0.0.0.0 and TCP (conflicted)",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 80},
-			},
-			check:  hostPortInfoParam{"", "", 80},
-			expect: true,
-		},
-		{
-			desc: "empty port check should pass",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 80},
-			},
-			check:  hostPortInfoParam{"", "", 0},
-			expect: false,
-		},
-		{
-			desc: "0.0.0.0 should check all registered IPs",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 80},
-			},
-			check:  hostPortInfoParam{"TCP", "0.0.0.0", 80},
-			expect: true,
-		},
-		{
-			desc: "0.0.0.0 with different protocol should be allowed",
-			added: []hostPortInfoParam{
-				{"UDP", "127.0.0.1", 80},
-			},
-			check:  hostPortInfoParam{"TCP", "0.0.0.0", 80},
-			expect: false,
-		},
-		{
-			desc: "0.0.0.0 with different port should be allowed",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 79},
-				{"TCP", "127.0.0.1", 81},
-				{"TCP", "127.0.0.1", 82},
-			},
-			check:  hostPortInfoParam{"TCP", "0.0.0.0", 80},
-			expect: false,
-		},
-		{
-			desc: "normal ip should check all registered 0.0.0.0",
-			added: []hostPortInfoParam{
-				{"TCP", "0.0.0.0", 80},
-			},
-			check:  hostPortInfoParam{"TCP", "127.0.0.1", 80},
-			expect: true,
-		},
-		{
-			desc: "normal ip with different port/protocol should be allowed (0.0.0.0)",
-			added: []hostPortInfoParam{
-				{"TCP", "0.0.0.0", 79},
-				{"UDP", "0.0.0.0", 80},
-				{"TCP", "0.0.0.0", 81},
-				{"TCP", "0.0.0.0", 82},
-			},
-			check:  hostPortInfoParam{"TCP", "127.0.0.1", 80},
-			expect: false,
-		},
-		{
-			desc: "normal ip with different port/protocol should be allowed",
-			added: []hostPortInfoParam{
-				{"TCP", "127.0.0.1", 79},
-				{"UDP", "127.0.0.1", 80},
-				{"TCP", "127.0.0.1", 81},
-				{"TCP", "127.0.0.1", 82},
-			},
-			check:  hostPortInfoParam{"TCP", "127.0.0.1", 80},
-			expect: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			hp := make(HostPortInfo)
-			for _, param := range test.added {
-				hp.Add(param.ip, param.protocol, param.port)
-			}
-			if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
-				t.Errorf("expected %t; got %t", test.expect, !test.expect)
-			}
-		})
-	}
 }
 
 func TestGetNamespacesFromPodAffinityTerm(t *testing.T) {
@@ -1630,16 +1416,16 @@ func TestPodInfoCalculateResources(t *testing.T) {
 		containers               []v1.Container
 		podResources             *v1.ResourceRequirements
 		podLevelResourcesEnabled bool
-		expectedResource         podResource
+		expectedResource         fwk.PodResource
 		initContainers           []v1.Container
 	}{
 		{
 			name:       "requestless container",
 			containers: []v1.Container{{}},
-			expectedResource: podResource{
-				resource: Resource{},
-				non0CPU:  schedutil.DefaultMilliCPURequest,
-				non0Mem:  schedutil.DefaultMemoryRequest,
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{},
+				Non0CPU:  schedutil.DefaultMilliCPURequest,
+				Non0Mem:  schedutil.DefaultMemoryRequest,
 			},
 		},
 		{
@@ -1654,13 +1440,13 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					},
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu500m.MilliValue(),
 					Memory:   mem500M.Value(),
 				},
-				non0CPU: cpu500m.MilliValue(),
-				non0Mem: mem500M.Value(),
+				Non0CPU: cpu500m.MilliValue(),
+				Non0Mem: mem500M.Value(),
 			},
 		},
 		{
@@ -1683,13 +1469,13 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					},
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu500m.MilliValue() + cpu700m.MilliValue(),
 					Memory:   mem500M.Value() + mem800M.Value(),
 				},
-				non0CPU: cpu500m.MilliValue() + cpu700m.MilliValue(),
-				non0Mem: mem500M.Value() + mem800M.Value(),
+				Non0CPU: cpu500m.MilliValue() + cpu700m.MilliValue(),
+				Non0Mem: mem500M.Value() + mem800M.Value(),
 			},
 		},
 		{
@@ -1721,13 +1507,13 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					v1.ResourceMemory: mem1200M,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu1200m.MilliValue(),
 					Memory:   mem1200M.Value(),
 				},
-				non0CPU: cpu1200m.MilliValue(),
-				non0Mem: mem1200M.Value(),
+				Non0CPU: cpu1200m.MilliValue(),
+				Non0Mem: mem1200M.Value(),
 			},
 		},
 		{
@@ -1760,13 +1546,13 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					v1.ResourceMemory: mem1200M,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu1200m.MilliValue(),
 					Memory:   mem1200M.Value(),
 				},
-				non0CPU: cpu1200m.MilliValue(),
-				non0Mem: mem1200M.Value(),
+				Non0CPU: cpu1200m.MilliValue(),
+				Non0Mem: mem1200M.Value(),
 			},
 		},
 		{
@@ -1787,12 +1573,12 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					v1.ResourceMemory: mem1200M,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					Memory: mem1200M.Value(),
 				},
-				non0CPU: schedutil.DefaultMilliCPURequest,
-				non0Mem: mem1200M.Value(),
+				Non0CPU: schedutil.DefaultMilliCPURequest,
+				Non0Mem: mem1200M.Value(),
 			},
 		},
 		{
@@ -1813,12 +1599,12 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					v1.ResourceCPU: cpu500m,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu500m.MilliValue(),
 				},
-				non0CPU: cpu500m.MilliValue(),
-				non0Mem: schedutil.DefaultMemoryRequest,
+				Non0CPU: cpu500m.MilliValue(),
+				Non0Mem: schedutil.DefaultMemoryRequest,
 			},
 		},
 		{
@@ -1847,13 +1633,13 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					v1.ResourceCPU: cpu500m,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU:         cpu500m.MilliValue(),
 					EphemeralStorage: mem800M.Value(),
 				},
-				non0CPU: cpu500m.MilliValue(),
-				non0Mem: schedutil.DefaultMemoryRequest,
+				Non0CPU: cpu500m.MilliValue(),
+				Non0Mem: schedutil.DefaultMemoryRequest,
 			},
 		},
 	}
@@ -1870,7 +1656,7 @@ func TestPodInfoCalculateResources(t *testing.T) {
 					},
 				},
 			}
-			res := podInfo.calculateResource()
+			res := podInfo.CalculateResource()
 			if diff := cmp.Diff(tc.expectedResource, res, nodeInfoCmpOpts...); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 			}
@@ -1969,19 +1755,19 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 		resizeStatus           []*v1.PodCondition
 		sidecarRequests        *v1.ResourceList
 		sidecarStatusResources *v1.ResourceList
-		expectedResource       podResource
+		expectedResource       fwk.PodResource
 	}{
 		{
 			name:            "Pod with no pending resize",
 			requests:        v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			statusResources: v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu500m.MilliValue(),
 					Memory:   mem500M.Value(),
 				},
-				non0CPU: cpu500m.MilliValue(),
-				non0Mem: mem500M.Value(),
+				Non0CPU: cpu500m.MilliValue(),
+				Non0Mem: mem500M.Value(),
 			},
 		},
 		{
@@ -1994,13 +1780,13 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 					Status: v1.ConditionTrue,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu500m.MilliValue(),
 					Memory:   mem500M.Value(),
 				},
-				non0CPU: cpu500m.MilliValue(),
-				non0Mem: mem500M.Value(),
+				Non0CPU: cpu500m.MilliValue(),
+				Non0Mem: mem500M.Value(),
 			},
 		},
 		{
@@ -2014,13 +1800,13 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 					Reason: v1.PodReasonDeferred,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu700m.MilliValue(),
 					Memory:   mem800M.Value(),
 				},
-				non0CPU: cpu700m.MilliValue(),
-				non0Mem: mem800M.Value(),
+				Non0CPU: cpu700m.MilliValue(),
+				Non0Mem: mem800M.Value(),
 			},
 		},
 		{
@@ -2034,13 +1820,13 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 					Reason: v1.PodReasonInfeasible,
 				},
 			},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu500m.MilliValue(),
 					Memory:   mem500M.Value(),
 				},
-				non0CPU: cpu500m.MilliValue(),
-				non0Mem: mem500M.Value(),
+				Non0CPU: cpu500m.MilliValue(),
+				Non0Mem: mem500M.Value(),
 			},
 		},
 		{
@@ -2049,13 +1835,13 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			statusResources:     v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M},
 			initRequests:        &v1.ResourceList{v1.ResourceCPU: cpu700m, v1.ResourceMemory: mem800M},
 			initStatusResources: &v1.ResourceList{v1.ResourceCPU: cpu700m, v1.ResourceMemory: mem800M},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu700m.MilliValue(),
 					Memory:   mem800M.Value(),
 				},
-				non0CPU: cpu700m.MilliValue(),
-				non0Mem: mem800M.Value(),
+				Non0CPU: cpu700m.MilliValue(),
+				Non0Mem: mem800M.Value(),
 			},
 		},
 		{
@@ -2066,13 +1852,13 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			initStatusResources:    &v1.ResourceList{v1.ResourceCPU: cpu700m, v1.ResourceMemory: mem800M},
 			sidecarRequests:        &v1.ResourceList{v1.ResourceCPU: cpu700m, v1.ResourceMemory: mem800M},
 			sidecarStatusResources: &v1.ResourceList{v1.ResourceCPU: cpu700m, v1.ResourceMemory: mem800M},
-			expectedResource: podResource{
-				resource: Resource{
+			expectedResource: fwk.PodResource{
+				Resource: &Resource{
 					MilliCPU: cpu500m.MilliValue() + cpu700m.MilliValue(),
 					Memory:   mem500M.Value() + mem800M.Value(),
 				},
-				non0CPU: cpu500m.MilliValue() + cpu700m.MilliValue(),
-				non0Mem: mem500M.Value() + mem800M.Value(),
+				Non0CPU: cpu500m.MilliValue() + cpu700m.MilliValue(),
+				Non0Mem: mem500M.Value() + mem800M.Value(),
 			},
 		},
 	}
@@ -2085,7 +1871,7 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 				tt.sidecarRequests, tt.sidecarStatusResources,
 				tt.resizeStatus)
 
-			res := podInfo.calculateResource()
+			res := podInfo.CalculateResource()
 			if diff := cmp.Diff(tt.expectedResource, res, nodeInfoCmpOpts...); diff != "" {
 				t.Errorf("Unexpected podResource (-want, +got):\n%s", diff)
 			}
@@ -2176,30 +1962,30 @@ func TestNodeInfoKMetadata(t *testing.T) {
 
 func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 	testCases := []struct {
-		ports HostPortInfo
+		ports fwk.HostPortInfo
 		pod   *v1.Pod
-		want  HostPortInfo
+		want  fwk.HostPortInfo
 	}{
 		{
-			ports: HostPortInfo{},
+			ports: fwk.HostPortInfo{},
 			pod:   nil,
-			want:  HostPortInfo{},
+			want:  fwk.HostPortInfo{},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: nil,
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{},
+			ports: fwk.HostPortInfo{},
 			pod: st.MakePod().
 				ContainerPort([]v1.ContainerPort{
 					{
@@ -2207,10 +1993,10 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{},
+			want: fwk.HostPortInfo{},
 		},
 		{
-			ports: HostPortInfo{},
+			ports: fwk.HostPortInfo{},
 			pod: st.MakePod().
 				ContainerPort([]v1.ContainerPort{
 					{
@@ -2219,16 +2005,16 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2239,15 +2025,15 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
-					ProtocolPort{"TCP", 8002}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8002}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{},
+			ports: fwk.HostPortInfo{},
 			pod: st.MakePod().
 				InitContainerPort(false /* sidecar */, []v1.ContainerPort{
 					{
@@ -2256,12 +2042,12 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{},
+			want: fwk.HostPortInfo{},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2272,14 +2058,14 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{},
+			ports: fwk.HostPortInfo{},
 			pod: st.MakePod().
 				InitContainerPort(true /* sidecar */, []v1.ContainerPort{
 					{
@@ -2288,16 +2074,16 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2308,16 +2094,16 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2328,10 +2114,10 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
-					ProtocolPort{"TCP", 8002}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8002}: struct{}{},
 				},
 			},
 		},
@@ -2347,30 +2133,30 @@ func TestUpdateUsedPorts_PodAdd(t *testing.T) {
 
 func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 	testCases := []struct {
-		ports HostPortInfo
+		ports fwk.HostPortInfo
 		pod   *v1.Pod
-		want  HostPortInfo
+		want  fwk.HostPortInfo
 	}{
 		{
-			ports: HostPortInfo{},
+			ports: fwk.HostPortInfo{},
 			pod:   nil,
-			want:  HostPortInfo{},
+			want:  fwk.HostPortInfo{},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: nil,
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{},
+			ports: fwk.HostPortInfo{},
 			pod: st.MakePod().
 				ContainerPort([]v1.ContainerPort{
 					{
@@ -2378,12 +2164,12 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{},
+			want: fwk.HostPortInfo{},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2394,12 +2180,12 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{},
+			want: fwk.HostPortInfo{},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2410,17 +2196,17 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
-					ProtocolPort{"TCP", 8002}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8002}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2431,16 +2217,16 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2451,16 +2237,16 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2471,12 +2257,12 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{},
+			want: fwk.HostPortInfo{},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2487,17 +2273,17 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},
 		{
-			ports: HostPortInfo{
+			ports: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
-					ProtocolPort{"TCP", 8002}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8002}: struct{}{},
 				},
 			},
 			pod: st.MakePod().
@@ -2508,9 +2294,9 @@ func TestUpdateUsedPorts_PodRemove(t *testing.T) {
 						Protocol:      v1.ProtocolTCP,
 					}}).
 				Obj(),
-			want: HostPortInfo{
+			want: fwk.HostPortInfo{
 				"0.0.0.0": {
-					ProtocolPort{"TCP", 8001}: struct{}{},
+					fwk.ProtocolPort{Protocol: "TCP", Port: 8001}: struct{}{},
 				},
 			},
 		},

--- a/pkg/scheduler/profile/profile_test.go
+++ b/pkg/scheduler/profile/profile_test.go
@@ -283,7 +283,7 @@ func (p *fakePlugin) Name() string {
 	return p.name
 }
 
-func (p *fakePlugin) Less(*framework.QueuedPodInfo, *framework.QueuedPodInfo) bool {
+func (p *fakePlugin) Less(fwk.QueuedPodInfo, fwk.QueuedPodInfo) bool {
 	return false
 }
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -452,7 +452,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 
 // Filters the nodes to find the ones that fit the pod based on the framework
 // filter plugins and filter extenders.
-func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, pod *v1.Pod) ([]*framework.NodeInfo, framework.Diagnosis, error) {
+func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, pod *v1.Pod) ([]fwk.NodeInfo, framework.Diagnosis, error) {
 	logger := klog.FromContext(ctx)
 	diagnosis := framework.Diagnosis{
 		NodeToStatus: framework.NewDefaultNodeToStatus(),
@@ -495,7 +495,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 
 	nodes := allNodes
 	if !preRes.AllNodes() {
-		nodes = make([]*framework.NodeInfo, 0, len(preRes.NodeNames))
+		nodes = make([]fwk.NodeInfo, 0, len(preRes.NodeNames))
 		for nodeName := range preRes.NodeNames {
 			// PreRes may return nodeName(s) which do not exist; we verify
 			// node exists in the Snapshot.
@@ -536,14 +536,14 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	return feasibleNodesAfterExtender, diagnosis, nil
 }
 
-func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, fwk framework.Framework, state fwk.CycleState, diagnosis framework.Diagnosis) ([]*framework.NodeInfo, error) {
+func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
 	nnn := pod.Status.NominatedNodeName
 	nodeInfo, err := sched.nodeInfoSnapshot.Get(nnn)
 	if err != nil {
 		return nil, err
 	}
-	node := []*framework.NodeInfo{nodeInfo}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, fwk, state, pod, &diagnosis, node)
+	node := []fwk.NodeInfo{nodeInfo}
+	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	state fwk.CycleState,
 	pod *v1.Pod,
 	diagnosis *framework.Diagnosis,
-	nodes []*framework.NodeInfo) ([]*framework.NodeInfo, error) {
+	nodes []fwk.NodeInfo) ([]fwk.NodeInfo, error) {
 	numAllNodes := len(nodes)
 	numNodesToFind := sched.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), int32(numAllNodes))
 	if !sched.hasExtenderFilters() && !sched.hasScoring(schedFramework) {
@@ -595,7 +595,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 
 	// Create feasible list with enough space to avoid growing it
 	// and allow assigning.
-	feasibleNodes := make([]*framework.NodeInfo, numNodesToFind)
+	feasibleNodes := make([]fwk.NodeInfo, numNodesToFind)
 
 	if !schedFramework.HasFilterPlugins() {
 		for i := range feasibleNodes {
@@ -695,7 +695,7 @@ func (sched *Scheduler) numFeasibleNodesToFind(percentageOfNodesToScore *int32, 
 	return numNodes
 }
 
-func findNodesThatPassExtenders(ctx context.Context, extenders []framework.Extender, pod *v1.Pod, feasibleNodes []*framework.NodeInfo, statuses *framework.NodeToStatus) ([]*framework.NodeInfo, error) {
+func findNodesThatPassExtenders(ctx context.Context, extenders []framework.Extender, pod *v1.Pod, feasibleNodes []fwk.NodeInfo, statuses *framework.NodeToStatus) ([]fwk.NodeInfo, error) {
 	logger := klog.FromContext(ctx)
 
 	// Extenders are called sequentially.
@@ -749,15 +749,15 @@ func findNodesThatPassExtenders(ctx context.Context, extenders []framework.Exten
 func prioritizeNodes(
 	ctx context.Context,
 	extenders []framework.Extender,
-	fwk framework.Framework,
+	schedFramework framework.Framework,
 	state fwk.CycleState,
 	pod *v1.Pod,
-	nodes []*framework.NodeInfo,
+	nodes []fwk.NodeInfo,
 ) ([]framework.NodePluginScores, error) {
 	logger := klog.FromContext(ctx)
 	// If no priority configs are provided, then all nodes will have a score of one.
 	// This is required to generate the priority list in the required format
-	if len(extenders) == 0 && !fwk.HasScorePlugins() {
+	if len(extenders) == 0 && !schedFramework.HasScorePlugins() {
 		result := make([]framework.NodePluginScores, 0, len(nodes))
 		for i := range nodes {
 			result = append(result, framework.NodePluginScores{
@@ -769,13 +769,13 @@ func prioritizeNodes(
 	}
 
 	// Run PreScore plugins.
-	preScoreStatus := fwk.RunPreScorePlugins(ctx, state, pod, nodes)
+	preScoreStatus := schedFramework.RunPreScorePlugins(ctx, state, pod, nodes)
 	if !preScoreStatus.IsSuccess() {
 		return nil, preScoreStatus.AsError()
 	}
 
 	// Run the Score plugins.
-	nodesScores, scoreStatus := fwk.RunScorePlugins(ctx, state, pod, nodes)
+	nodesScores, scoreStatus := schedFramework.RunScorePlugins(ctx, state, pod, nodes)
 	if !scoreStatus.IsSuccess() {
 		return nil, scoreStatus.AsError()
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1138,7 +1138,7 @@ func (pl *fakeQueueSortPlugin) Name() string {
 	return queueSort
 }
 
-func (pl *fakeQueueSortPlugin) Less(_, _ *framework.QueuedPodInfo) bool {
+func (pl *fakeQueueSortPlugin) Less(_, _ fwk.QueuedPodInfo) bool {
 	return false
 }
 
@@ -1160,7 +1160,7 @@ type filterWithoutEnqueueExtensionsPlugin struct{}
 
 func (*filterWithoutEnqueueExtensionsPlugin) Name() string { return filterWithoutEnqueueExtensions }
 
-func (*filterWithoutEnqueueExtensionsPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+func (*filterWithoutEnqueueExtensionsPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1174,7 +1174,7 @@ var fakeNodePluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) 
 
 func (*fakeNodePlugin) Name() string { return fakeNode }
 
-func (*fakeNodePlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+func (*fakeNodePlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1194,7 +1194,7 @@ var fakePodPluginQueueingFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (
 
 func (*fakePodPlugin) Name() string { return fakePod }
 
-func (*fakePodPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+func (*fakePodPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1208,7 +1208,7 @@ type emptyEventPlugin struct{}
 
 func (*emptyEventPlugin) Name() string { return emptyEventExtensions }
 
-func (*emptyEventPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+func (*emptyEventPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1221,7 +1221,7 @@ type errorEventsToRegisterPlugin struct{}
 
 func (*errorEventsToRegisterPlugin) Name() string { return errorEventsToRegister }
 
-func (*errorEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+func (*errorEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -1236,7 +1236,7 @@ type emptyEventsToRegisterPlugin struct{}
 
 func (*emptyEventsToRegisterPlugin) Name() string { return emptyEventsToRegister }
 
-func (*emptyEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+func (*emptyEventsToRegisterPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
 	return nil
 }
 

--- a/pkg/scheduler/testing/framework/fake_extender.go
+++ b/pkg/scheduler/testing/framework/fake_extender.go
@@ -33,10 +33,10 @@ import (
 )
 
 // FitPredicate is a function type which is used in fake extender.
-type FitPredicate func(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status
+type FitPredicate func(pod *v1.Pod, node fwk.NodeInfo) *fwk.Status
 
 // PriorityFunc is a function type which is used in fake extender.
-type PriorityFunc func(pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.NodeScoreList, error)
+type PriorityFunc func(pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.NodeScoreList, error)
 
 // PriorityConfig is used in fake extender to perform Prioritize function.
 type PriorityConfig struct {
@@ -45,23 +45,23 @@ type PriorityConfig struct {
 }
 
 // ErrorPredicateExtender implements FitPredicate function to always return error status.
-func ErrorPredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+func ErrorPredicateExtender(pod *v1.Pod, node fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Error, "some error")
 }
 
 // FalsePredicateExtender implements FitPredicate function to always return unschedulable status.
-func FalsePredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+func FalsePredicateExtender(pod *v1.Pod, node fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("pod is unschedulable on the node %q", node.Node().Name))
 }
 
 // TruePredicateExtender implements FitPredicate function to always return success status.
-func TruePredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+func TruePredicateExtender(pod *v1.Pod, node fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Success)
 }
 
 // Node1PredicateExtender implements FitPredicate function to return true
 // when the given node's name is "node1"; otherwise return false.
-func Node1PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+func Node1PredicateExtender(pod *v1.Pod, node fwk.NodeInfo) *fwk.Status {
 	if node.Node().Name == "node1" {
 		return fwk.NewStatus(fwk.Success)
 	}
@@ -70,7 +70,7 @@ func Node1PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 
 // Node2PredicateExtender implements FitPredicate function to return true
 // when the given node's name is "node2"; otherwise return false.
-func Node2PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+func Node2PredicateExtender(pod *v1.Pod, node fwk.NodeInfo) *fwk.Status {
 	if node.Node().Name == "node2" {
 		return fwk.NewStatus(fwk.Success)
 	}
@@ -78,13 +78,13 @@ func Node2PredicateExtender(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
 }
 
 // ErrorPrioritizerExtender implements PriorityFunc function to always return error.
-func ErrorPrioritizerExtender(pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.NodeScoreList, error) {
+func ErrorPrioritizerExtender(pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.NodeScoreList, error) {
 	return &framework.NodeScoreList{}, fmt.Errorf("some error")
 }
 
 // Node1PrioritizerExtender implements PriorityFunc function to give score 10
 // if the given node's name is "node1"; otherwise score 1.
-func Node1PrioritizerExtender(pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.NodeScoreList, error) {
+func Node1PrioritizerExtender(pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.NodeScoreList, error) {
 	result := framework.NodeScoreList{}
 	for _, node := range nodes {
 		score := 1
@@ -98,7 +98,7 @@ func Node1PrioritizerExtender(pod *v1.Pod, nodes []*framework.NodeInfo) (*framew
 
 // Node2PrioritizerExtender implements PriorityFunc function to give score 10
 // if the given node's name is "node2"; otherwise score 1.
-func Node2PrioritizerExtender(pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.NodeScoreList, error) {
+func Node2PrioritizerExtender(pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.NodeScoreList, error) {
 	result := framework.NodeScoreList{}
 	for _, node := range nodes {
 		score := 1
@@ -125,7 +125,7 @@ func (pl *node2PrioritizerPlugin) Name() string {
 }
 
 // Score return score 100 if the given nodeName is "node2"; otherwise return score 10.
-func (pl *node2PrioritizerPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *node2PrioritizerPlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	score := 10
 	if nodeInfo.Node().Name == "node2" {
 		score = 100
@@ -147,7 +147,7 @@ type FakeExtender struct {
 	Prioritizers     []PriorityConfig
 	Weight           int64
 	NodeCacheCapable bool
-	FilteredNodes    []*framework.NodeInfo
+	FilteredNodes    []fwk.NodeInfo
 	UnInterested     bool
 	Ignorable        bool
 	Binder           func() error
@@ -222,7 +222,7 @@ func (f *FakeExtender) ProcessPreemption(
 // 1. More victim pods (if any) amended by preemption phase of extender.
 // 2. Number of violating victim (used to calculate PDB).
 // 3. Fits or not after preemption phase on extender's side.
-func (f *FakeExtender) selectVictimsOnNodeByExtender(logger klog.Logger, pod *v1.Pod, node *framework.NodeInfo) ([]*v1.Pod, int, bool, error) {
+func (f *FakeExtender) selectVictimsOnNodeByExtender(logger klog.Logger, pod *v1.Pod, node fwk.NodeInfo) ([]*v1.Pod, int, bool, error) {
 	// If a extender support preemption but have no cached node info, let's run filter to make sure
 	// default scheduler's decision still stand with given pod and node.
 	if !f.NodeCacheCapable {
@@ -238,7 +238,7 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(logger klog.Logger, pod *v1
 
 	// Otherwise, as a extender support preemption and have cached node info, we will assume cachedNodeNameToInfo is available
 	// and get cached node info by given node name.
-	nodeInfoCopy := f.CachedNodeNameToInfo[node.Node().Name].Snapshot()
+	nodeInfoCopy := f.CachedNodeNameToInfo[node.Node().Name].SnapshotConcrete()
 
 	var potentialVictims []*v1.Pod
 
@@ -251,10 +251,10 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(logger klog.Logger, pod *v1
 	// As the first step, remove all the lower priority pods from the node and
 	// check if the given pod can be scheduled.
 	podPriority := corev1helpers.PodPriority(pod)
-	for _, p := range nodeInfoCopy.Pods {
-		if corev1helpers.PodPriority(p.Pod) < podPriority {
-			potentialVictims = append(potentialVictims, p.Pod)
-			if err := removePod(p.Pod); err != nil {
+	for _, p := range nodeInfoCopy.GetPods() {
+		if corev1helpers.PodPriority(p.GetPod()) < podPriority {
+			potentialVictims = append(potentialVictims, p.GetPod())
+			if err := removePod(p.GetPod()); err != nil {
 				return nil, 0, false, err
 			}
 		}
@@ -302,7 +302,7 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(logger klog.Logger, pod *v1
 
 // runPredicate run predicates of extender one by one for given pod and node.
 // Returns: fits or not.
-func (f *FakeExtender) runPredicate(pod *v1.Pod, node *framework.NodeInfo) *fwk.Status {
+func (f *FakeExtender) runPredicate(pod *v1.Pod, node fwk.NodeInfo) *fwk.Status {
 	for _, predicate := range f.Predicates {
 		status := predicate(pod, node)
 		if !status.IsSuccess() {
@@ -313,8 +313,8 @@ func (f *FakeExtender) runPredicate(pod *v1.Pod, node *framework.NodeInfo) *fwk.
 }
 
 // Filter implements the extender Filter function.
-func (f *FakeExtender) Filter(pod *v1.Pod, nodes []*framework.NodeInfo) ([]*framework.NodeInfo, extenderv1.FailedNodesMap, extenderv1.FailedNodesMap, error) {
-	var filtered []*framework.NodeInfo
+func (f *FakeExtender) Filter(pod *v1.Pod, nodes []fwk.NodeInfo) ([]fwk.NodeInfo, extenderv1.FailedNodesMap, extenderv1.FailedNodesMap, error) {
+	var filtered []fwk.NodeInfo
 	failedNodesMap := extenderv1.FailedNodesMap{}
 	failedAndUnresolvableMap := extenderv1.FailedNodesMap{}
 	for _, node := range nodes {
@@ -338,7 +338,7 @@ func (f *FakeExtender) Filter(pod *v1.Pod, nodes []*framework.NodeInfo) ([]*fram
 }
 
 // Prioritize implements the extender Prioritize function.
-func (f *FakeExtender) Prioritize(pod *v1.Pod, nodes []*framework.NodeInfo) (*extenderv1.HostPriorityList, int64, error) {
+func (f *FakeExtender) Prioritize(pod *v1.Pod, nodes []fwk.NodeInfo) (*extenderv1.HostPriorityList, int64, error) {
 	result := extenderv1.HostPriorityList{}
 	combinedScores := map[string]int64{}
 	for _, prioritizer := range f.Prioritizers {

--- a/pkg/scheduler/testing/framework/fake_listers.go
+++ b/pkg/scheduler/testing/framework/fake_listers.go
@@ -28,7 +28,7 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fwk "k8s.io/kube-scheduler/framework"
 )
 
 var _ corelisters.ServiceLister = &ServiceLister{}
@@ -224,11 +224,11 @@ func (pvcs PersistentVolumeClaimLister) PersistentVolumeClaims(namespace string)
 	}
 }
 
-// NodeInfoLister declares a framework.NodeInfo type for testing.
-type NodeInfoLister []*framework.NodeInfo
+// NodeInfoLister declares a fwk.NodeInfo type for testing.
+type NodeInfoLister []fwk.NodeInfo
 
 // Get returns a fake node object in the fake nodes.
-func (nodes NodeInfoLister) Get(nodeName string) (*framework.NodeInfo, error) {
+func (nodes NodeInfoLister) Get(nodeName string) (fwk.NodeInfo, error) {
 	for _, node := range nodes {
 		if node != nil && node.Node().Name == nodeName {
 			return node, nil
@@ -238,19 +238,19 @@ func (nodes NodeInfoLister) Get(nodeName string) (*framework.NodeInfo, error) {
 }
 
 // List lists all nodes.
-func (nodes NodeInfoLister) List() ([]*framework.NodeInfo, error) {
+func (nodes NodeInfoLister) List() ([]fwk.NodeInfo, error) {
 	return nodes, nil
 }
 
 // HavePodsWithAffinityList is supposed to list nodes with at least one pod with affinity. For the fake lister
 // we just return everything.
-func (nodes NodeInfoLister) HavePodsWithAffinityList() ([]*framework.NodeInfo, error) {
+func (nodes NodeInfoLister) HavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
 	return nodes, nil
 }
 
 // HavePodsWithRequiredAntiAffinityList is supposed to list nodes with at least one pod with
 // required anti-affinity. For the fake lister we just return everything.
-func (nodes NodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]*framework.NodeInfo, error) {
+func (nodes NodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
 	return nodes, nil
 }
 

--- a/pkg/scheduler/testing/framework/fake_plugins.go
+++ b/pkg/scheduler/testing/framework/fake_plugins.go
@@ -41,7 +41,7 @@ func (pl *FalseFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *FalseFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *FalseFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Unschedulable, ErrReasonFake)
 }
 
@@ -59,7 +59,7 @@ func (pl *TrueFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *TrueFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *TrueFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	return nil
 }
 
@@ -91,7 +91,7 @@ func (pl *FakeFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *FakeFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *FakeFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	atomic.AddInt32(&pl.NumFilterCalled, 1)
 
 	if returnCode, ok := pl.FailedNodeReturnCodeMap[nodeInfo.Node().Name]; ok {
@@ -120,7 +120,7 @@ func (pl *MatchFilterPlugin) Name() string {
 }
 
 // Filter invoked at the filter extension point.
-func (pl *MatchFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *MatchFilterPlugin) Filter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
 	if node == nil {
 		return fwk.NewStatus(fwk.Error, "node not found")
@@ -149,7 +149,7 @@ func (pl *FakePreFilterPlugin) Name() string {
 }
 
 // PreFilter invoked at the PreFilter extension point.
-func (pl *FakePreFilterPlugin) PreFilter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (pl *FakePreFilterPlugin) PreFilter(_ context.Context, _ fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	return pl.Result, pl.Status
 }
 
@@ -264,7 +264,7 @@ func (pl *FakePreScoreAndScorePlugin) Name() string {
 	return pl.name
 }
 
-func (pl *FakePreScoreAndScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo *framework.NodeInfo) (int64, *fwk.Status) {
+func (pl *FakePreScoreAndScorePlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	return pl.score, pl.scoreStatus
 }
 
@@ -272,7 +272,7 @@ func (pl *FakePreScoreAndScorePlugin) ScoreExtensions() framework.ScoreExtension
 	return nil
 }
 
-func (pl *FakePreScoreAndScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) *fwk.Status {
+func (pl *FakePreScoreAndScorePlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
 	return pl.preScoreStatus
 }
 

--- a/pkg/scheduler/testing/framework/framework_helpers.go
+++ b/pkg/scheduler/testing/framework/framework_helpers.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeschedulerconfigv1 "k8s.io/kube-scheduler/config/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -148,8 +149,8 @@ func getPluginSetByExtension(plugins *schedulerapi.Plugins, extension string) *s
 }
 
 // BuildNodeInfos build NodeInfo slice from a v1.Node slice
-func BuildNodeInfos(nodes []*v1.Node) []*framework.NodeInfo {
-	res := make([]*framework.NodeInfo, len(nodes))
+func BuildNodeInfos(nodes []*v1.Node) []fwk.NodeInfo {
+	res := make([]fwk.NodeInfo, len(nodes))
 	for i := 0; i < len(nodes); i++ {
 		res[i] = framework.NewNodeInfo()
 		res[i].SetNode(nodes[i])

--- a/staging/src/k8s.io/kube-scheduler/framework/types_test.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "testing"
+
+type hostPortInfoParam struct {
+	protocol, ip string
+	port         int32
+}
+
+func TestHostPortInfo_AddRemove(t *testing.T) {
+	tests := []struct {
+		desc    string
+		added   []hostPortInfoParam
+		removed []hostPortInfoParam
+		length  int
+	}{
+		{
+			desc: "normal add case",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 79},
+				{"UDP", "127.0.0.1", 80},
+				{"TCP", "127.0.0.1", 81},
+				{"TCP", "127.0.0.1", 82},
+				// this might not make sense in real case, but the struct doesn't forbid it.
+				{"TCP", "0.0.0.0", 79},
+				{"UDP", "0.0.0.0", 80},
+				{"TCP", "0.0.0.0", 81},
+				{"TCP", "0.0.0.0", 82},
+				{"TCP", "0.0.0.0", 0},
+				{"TCP", "0.0.0.0", -1},
+			},
+			length: 8,
+		},
+		{
+			desc: "empty ip and protocol add should work",
+			added: []hostPortInfoParam{
+				{"", "127.0.0.1", 79},
+				{"UDP", "127.0.0.1", 80},
+				{"", "127.0.0.1", 81},
+				{"", "127.0.0.1", 82},
+				{"", "", 79},
+				{"UDP", "", 80},
+				{"", "", 81},
+				{"", "", 82},
+				{"", "", 0},
+				{"", "", -1},
+			},
+			length: 8,
+		},
+		{
+			desc: "normal remove case",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 79},
+				{"UDP", "127.0.0.1", 80},
+				{"TCP", "127.0.0.1", 81},
+				{"TCP", "127.0.0.1", 82},
+				{"TCP", "0.0.0.0", 79},
+				{"UDP", "0.0.0.0", 80},
+				{"TCP", "0.0.0.0", 81},
+				{"TCP", "0.0.0.0", 82},
+			},
+			removed: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 79},
+				{"UDP", "127.0.0.1", 80},
+				{"TCP", "127.0.0.1", 81},
+				{"TCP", "127.0.0.1", 82},
+				{"TCP", "0.0.0.0", 79},
+				{"UDP", "0.0.0.0", 80},
+				{"TCP", "0.0.0.0", 81},
+				{"TCP", "0.0.0.0", 82},
+			},
+			length: 0,
+		},
+		{
+			desc: "empty ip and protocol remove should work",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 79},
+				{"UDP", "127.0.0.1", 80},
+				{"TCP", "127.0.0.1", 81},
+				{"TCP", "127.0.0.1", 82},
+				{"TCP", "0.0.0.0", 79},
+				{"UDP", "0.0.0.0", 80},
+				{"TCP", "0.0.0.0", 81},
+				{"TCP", "0.0.0.0", 82},
+			},
+			removed: []hostPortInfoParam{
+				{"", "127.0.0.1", 79},
+				{"", "127.0.0.1", 81},
+				{"", "127.0.0.1", 82},
+				{"UDP", "127.0.0.1", 80},
+				{"", "", 79},
+				{"", "", 81},
+				{"", "", 82},
+				{"UDP", "", 80},
+			},
+			length: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			for _, param := range test.removed {
+				hp.Remove(param.ip, param.protocol, param.port)
+			}
+			if hp.Len() != test.length {
+				t.Errorf("%v failed: expect length %d; got %d", test.desc, test.length, hp.Len())
+				t.Error(hp)
+			}
+		})
+	}
+}
+
+func TestHostPortInfo_Check(t *testing.T) {
+	tests := []struct {
+		desc   string
+		added  []hostPortInfoParam
+		check  hostPortInfoParam
+		expect bool
+	}{
+		{
+			desc: "empty check should check 0.0.0.0 and TCP",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 80},
+			},
+			check:  hostPortInfoParam{"", "", 81},
+			expect: false,
+		},
+		{
+			desc: "empty check should check 0.0.0.0 and TCP (conflicted)",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 80},
+			},
+			check:  hostPortInfoParam{"", "", 80},
+			expect: true,
+		},
+		{
+			desc: "empty port check should pass",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 80},
+			},
+			check:  hostPortInfoParam{"", "", 0},
+			expect: false,
+		},
+		{
+			desc: "0.0.0.0 should check all registered IPs",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 80},
+			},
+			check:  hostPortInfoParam{"TCP", "0.0.0.0", 80},
+			expect: true,
+		},
+		{
+			desc: "0.0.0.0 with different protocol should be allowed",
+			added: []hostPortInfoParam{
+				{"UDP", "127.0.0.1", 80},
+			},
+			check:  hostPortInfoParam{"TCP", "0.0.0.0", 80},
+			expect: false,
+		},
+		{
+			desc: "0.0.0.0 with different port should be allowed",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 79},
+				{"TCP", "127.0.0.1", 81},
+				{"TCP", "127.0.0.1", 82},
+			},
+			check:  hostPortInfoParam{"TCP", "0.0.0.0", 80},
+			expect: false,
+		},
+		{
+			desc: "normal ip should check all registered 0.0.0.0",
+			added: []hostPortInfoParam{
+				{"TCP", "0.0.0.0", 80},
+			},
+			check:  hostPortInfoParam{"TCP", "127.0.0.1", 80},
+			expect: true,
+		},
+		{
+			desc: "normal ip with different port/protocol should be allowed (0.0.0.0)",
+			added: []hostPortInfoParam{
+				{"TCP", "0.0.0.0", 79},
+				{"UDP", "0.0.0.0", 80},
+				{"TCP", "0.0.0.0", 81},
+				{"TCP", "0.0.0.0", 82},
+			},
+			check:  hostPortInfoParam{"TCP", "127.0.0.1", 80},
+			expect: false,
+		},
+		{
+			desc: "normal ip with different port/protocol should be allowed",
+			added: []hostPortInfoParam{
+				{"TCP", "127.0.0.1", 79},
+				{"UDP", "127.0.0.1", 80},
+				{"TCP", "127.0.0.1", 81},
+				{"TCP", "127.0.0.1", 82},
+			},
+			check:  hostPortInfoParam{"TCP", "127.0.0.1", 80},
+			expect: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
+				t.Errorf("expected %t; got %t", test.expect, !test.expect)
+			}
+		})
+	}
+}

--- a/test/integration/scheduler/eventhandler/eventhandler_test.go
+++ b/test/integration/scheduler/eventhandler/eventhandler_test.go
@@ -55,7 +55,7 @@ func (pl *fooPlugin) Name() string {
 	return "foo"
 }
 
-func (pl *fooPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *fwk.Status {
+func (pl *fooPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	taints := nodeInfo.Node().Spec.Taints
 	if len(taints) == 0 {
 		return nil

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -105,7 +105,7 @@ func (fp *tokenFilter) Name() string {
 }
 
 func (fp *tokenFilter) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod,
-	nodeInfo *framework.NodeInfo) *fwk.Status {
+	nodeInfo fwk.NodeInfo) *fwk.Status {
 	if fp.Tokens > 0 {
 		fp.Tokens--
 		return nil
@@ -117,7 +117,7 @@ func (fp *tokenFilter) Filter(ctx context.Context, state fwk.CycleState, pod *v1
 	return fwk.NewStatus(status, fmt.Sprintf("can't fit %v", pod.Name))
 }
 
-func (fp *tokenFilter) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []*framework.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
+func (fp *tokenFilter) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (*framework.PreFilterResult, *fwk.Status) {
 	if !fp.EnablePreFilter || fp.Tokens > 0 {
 		return nil, nil
 	}
@@ -125,13 +125,13 @@ func (fp *tokenFilter) PreFilter(ctx context.Context, state fwk.CycleState, pod 
 }
 
 func (fp *tokenFilter) AddPod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToAdd *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+	podInfoToAdd fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	fp.Tokens--
 	return nil
 }
 
 func (fp *tokenFilter) RemovePod(ctx context.Context, state fwk.CycleState, podToSchedule *v1.Pod,
-	podInfoToRemove *framework.PodInfo, nodeInfo *framework.NodeInfo) *fwk.Status {
+	podInfoToRemove fwk.PodInfo, nodeInfo fwk.NodeInfo) *fwk.Status {
 	fp.Tokens++
 	return nil
 }

--- a/test/integration/scheduler/queueing/queue_test.go
+++ b/test/integration/scheduler/queueing/queue_test.go
@@ -188,7 +188,7 @@ func (f *fakeCRPlugin) Name() string {
 	return "fakeCRPlugin"
 }
 
-func (f *fakeCRPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ *framework.NodeInfo) *fwk.Status {
+func (f *fakeCRPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
 	return fwk.NewStatus(fwk.Unschedulable, "always fail")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is part of a larger change that moves interfaces and type and func defiinitions to the staging repo "k8s.io/kube-scheduler", to allow users for importing scheduler framework interfaces without importing k/k repo.
This PR moves types NodeInfo, PodInfo, QueuedPodInfo, PodResource, AffinityTerm, WeightedAffinityTerm, Resource, ImageStateSummary, ProtocolPort and HostPortInfo from k/k to the staging repo. Some types are moved as interfaces instead of concrete implementation, to keep internal implementation in k/k.


#### Which issue(s) this PR is related to:
Part of #89930
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Types: NodeInfo, PodInfo, QueuedPodInfo, PodResource, AffinityTerm, WeightedAffinityTerm, Resource, ImageStateSummary, ProtocolPort and HostPortInfo moved from pkg/scheduler/framework to staging repo.
Users should update import path for these types from "k8s.io/kubernetes/pkg/scheduler/framework" to "k8s.io/kube-scheduler/framework" and update use of fields (to use getter/setter functions instead) where needed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
