### PR TITLE
Remove typo in SelfSubjectAccessReview

### DIFF
--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -50,7 +50,7 @@ type SubjectAccessReview struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.19
 
-// SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
+// SelfSubjectAccessReview checks whether the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action
 type SelfSubjectAccessReview struct {


### PR DESCRIPTION
`whether or` -> `whether`

Fixes https://github.com/kubernetes/website/issues/45561

#### What type of PR is this?

/kind documentation

#### Does this PR introduce a user-facing change?

```release-note
NONE
```