### PR TITLE
podtopologylabels: update topology.k8s.io->topology.kubernetes.io

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -638,7 +638,7 @@ const (
 	// alpha: v1.33
 	//
 	// Enables the PodTopologyLabelsAdmission admission plugin that mutates `pod/binding`
-	// requests by copying the `topology.k8s.io/{zone,region}` labels from the assigned
+	// requests by copying the `topology.kubernetes.io/{zone,region}` labels from the assigned
 	// Node object (in the Binding being admitted) onto the Binding
 	// so that it can be persisted onto the Pod object when the Pod is being scheduled.
 	// This allows workloads running in pods to understand the topology information of their assigned node.

--- a/plugin/pkg/admission/podtopologylabels/admission.go
+++ b/plugin/pkg/admission/podtopologylabels/admission.go
@@ -41,7 +41,7 @@ const PluginName = "PodTopologyLabels"
 // This configuration is used by kube-apiserver.
 // It is not exported to avoid any chance of accidentally mutating the variable.
 var defaultConfig = Config{
-	Labels: []string{"topology.k8s.io/zone", "topology.k8s.io/region"},
+	Labels: []string{"topology.kubernetes.io/zone", "topology.kubernetes.io/region"},
 }
 
 // Register registers a plugin

--- a/plugin/pkg/admission/podtopologylabels/admission_test.go
+++ b/plugin/pkg/admission/podtopologylabels/admission_test.go
@@ -49,62 +49,62 @@ func TestPodTopology(t *testing.T) {
 		featureDisabled       bool                 // configure whether the SetPodTopologyLabels feature gate should be disabled.
 	}{
 		{
-			name: "copies topology.k8s.io/zone and region labels to binding labels",
+			name: "copies topology.kubernetes.io/zone and region labels to binding labels",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone":      "zone1",
-				"topology.k8s.io/region":    "region1",
-				"topology.k8s.io/arbitrary": "something",
-				"non-topology.k8s.io/label": "something", // verify we don't unexpectedly copy non topology.k8s.io labels.
+				"topology.kubernetes.io/zone":      "zone1",
+				"topology.kubernetes.io/region":    "region1",
+				"topology.kubernetes.io/arbitrary": "something",
+				"non-topology.kubernetes.io/label": "something", // verify we don't unexpectedly copy non topology.kubernetes.io labels.
 			},
 			expectedBindingLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone1",
-				"topology.k8s.io/region": "region1",
+				"topology.kubernetes.io/zone":   "zone1",
+				"topology.kubernetes.io/region": "region1",
 			},
 		},
 		{
 			name: "does not copy arbitrary topology labels",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone":      "zone1",
-				"topology.k8s.io/arbitrary": "something",
+				"topology.kubernetes.io/zone":      "zone1",
+				"topology.kubernetes.io/arbitrary": "something",
 			},
 			expectedBindingLabels: map[string]string{
-				"topology.k8s.io/zone": "zone1",
+				"topology.kubernetes.io/zone": "zone1",
 			},
 		},
 		{
 			name: "does not copy topology labels that use a subdomain",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/region":   "region1",
-				"sub.topology.k8s.io/zone": "value",
+				"topology.kubernetes.io/region":   "region1",
+				"sub.topology.kubernetes.io/zone": "value",
 			},
 			expectedBindingLabels: map[string]string{
-				"topology.k8s.io/region": "region1",
+				"topology.kubernetes.io/region": "region1",
 			},
 		},
 		{
 			name: "does not copy label keys that don't contain a / character",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io": "value",
+				"topology.kubernetes.io": "value",
 			},
 			existingBindingLabels: map[string]string{},
 		},
 		{
 			name: "overwrites existing topology labels",
 			existingBindingLabels: map[string]string{
-				"topology.k8s.io/zone": "oldValue",
+				"topology.kubernetes.io/zone": "oldValue",
 			},
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone": "newValue",
+				"topology.kubernetes.io/zone": "newValue",
 			},
 			expectedBindingLabels: map[string]string{
-				"topology.k8s.io/zone": "newValue",
+				"topology.kubernetes.io/zone": "newValue",
 			},
 		},
 		{
 			name: "does nothing if the SetPodTopologyLabels feature gate is disabled",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone1",
-				"topology.k8s.io/region": "region1",
+				"topology.kubernetes.io/zone":   "zone1",
+				"topology.kubernetes.io/region": "region1",
 			},
 			expectedBindingLabels: map[string]string{},
 			featureDisabled:       true,

--- a/plugin/pkg/admission/podtopologylabels/doc.go
+++ b/plugin/pkg/admission/podtopologylabels/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package podtopologylabels is a plugin that mutates `pod/binding` requests
-// by copying the `topology.k8s.io/{zone,region}` labels from the assigned Node
+// by copying the `topology.kubernetes.io/{zone,region}` labels from the assigned Node
 // object (in the Binding being admitted) onto the Binding so that it can be
 // persisted onto the Pod object when the Pod is being scheduled.
 // Requests for the regular `pods` resource that set the `spec.nodeName` will

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -49,52 +49,52 @@ func TestPodTopologyLabels(t *testing.T) {
 		{
 			name: "zone and region topology labels copied from assigned Node",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone",
-				"topology.k8s.io/region": "region",
+				"topology.kubernetes.io/zone":   "zone",
+				"topology.kubernetes.io/region": "region",
 			},
 			expectedPodLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone",
-				"topology.k8s.io/region": "region",
+				"topology.kubernetes.io/zone":   "zone",
+				"topology.kubernetes.io/region": "region",
 			},
 		},
 		{
-			name: "subdomains of topology.k8s.io are not copied",
+			name: "subdomains of topology.kubernetes.io are not copied",
 			targetNodeLabels: map[string]string{
-				"sub.topology.k8s.io/zone": "zone",
-				"topology.k8s.io/region":   "region",
+				"sub.topology.kubernetes.io/zone": "zone",
+				"topology.kubernetes.io/region":   "region",
 			},
 			expectedPodLabels: map[string]string{
-				"topology.k8s.io/region": "region",
+				"topology.kubernetes.io/region": "region",
 			},
 		},
 		{
-			name: "custom topology.k8s.io labels are not copied",
+			name: "custom topology.kubernetes.io labels are not copied",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/custom": "thing",
-				"topology.k8s.io/zone":   "zone",
-				"topology.k8s.io/region": "region",
+				"topology.kubernetes.io/custom": "thing",
+				"topology.kubernetes.io/zone":   "zone",
+				"topology.kubernetes.io/region": "region",
 			},
 			expectedPodLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone",
-				"topology.k8s.io/region": "region",
+				"topology.kubernetes.io/zone":   "zone",
+				"topology.kubernetes.io/region": "region",
 			},
 		},
 		{
 			name: "labels from Bindings overwriting existing labels on Pod",
 			existingPodLabels: map[string]string{
-				"topology.k8s.io/zone":   "bad-zone",
-				"topology.k8s.io/region": "bad-region",
-				"topology.k8s.io/abc":    "123",
+				"topology.kubernetes.io/zone":   "bad-zone",
+				"topology.kubernetes.io/region": "bad-region",
+				"topology.kubernetes.io/abc":    "123",
 			},
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone",
-				"topology.k8s.io/region": "region",
-				"topology.k8s.io/abc":    "456", // this label isn't in (zone, region) so isn't copied
+				"topology.kubernetes.io/zone":   "zone",
+				"topology.kubernetes.io/region": "region",
+				"topology.kubernetes.io/abc":    "456", // this label isn't in (zone, region) so isn't copied
 			},
 			expectedPodLabels: map[string]string{
-				"topology.k8s.io/zone":   "zone",
-				"topology.k8s.io/region": "region",
-				"topology.k8s.io/abc":    "123",
+				"topology.kubernetes.io/zone":   "zone",
+				"topology.kubernetes.io/region": "region",
+				"topology.kubernetes.io/abc":    "123",
 			},
 		},
 	}
@@ -110,10 +110,10 @@ func TestPodTopologyLabels_FeatureDisabled(t *testing.T) {
 		{
 			name: "does nothing when the feature is not enabled",
 			targetNodeLabels: map[string]string{
-				"topology.k8s.io/zone":     "zone",
-				"topology.k8s.io/region":   "region",
-				"topology.k8s.io/custom":   "thing",
-				"sub.topology.k8s.io/zone": "zone",
+				"topology.kubernetes.io/zone":     "zone",
+				"topology.kubernetes.io/region":   "region",
+				"topology.kubernetes.io/custom":   "thing",
+				"sub.topology.kubernetes.io/zone": "zone",
 			},
 			expectedPodLabels: map[string]string{},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As noted in https://github.com/kubernetes/enhancements/issues/4742#issuecomment-2898592444, the labels to be copied across from Node->Pod had the incorrect domain key `topology.k8s.io`.

A corresponding KEP update has been opened https://github.com/kubernetes/enhancements/pull/5428 to reflect the correct domain there too.

This likely means we need to extend the alpha period for this feature by a release to allow time for meaningful feedback from the community/soak time.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/4742
KEP update: https://github.com/kubernetes/enhancements/pull/5428

#### Special notes for your reviewer:

This has prevented users providing feedback on this feature.

#### Does this PR introduce a user-facing change?
```release-note
Fix bug that prevents the alpha feature PodTopologyLabelAdmission to not work due to checking for the incorrect label key when copying topology labels. This bug delays the graduation of the feature to beta by an additional release to allow time for meaningful feedback. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
KEP: https://github.com/kubernetes/enhancements/issues/4742
KEP update: https://github.com/kubernetes/enhancements/pull/5428
```

/cc @andrewsykim @SergeyKanzhelev 
