### PR TITLE
Cleanup: Remove redundant detail messages in field.Required

### DIFF
--- a/pkg/apis/apiserverinternal/validation/validation.go
+++ b/pkg/apis/apiserverinternal/validation/validation.go
@@ -168,10 +168,10 @@ func validateStorageVersionCondition(conditions []apiserverinternal.StorageVersi
 		allErrs = append(allErrs, apivalidation.ValidateQualifiedName(string(condition.Type), fldPath.Index(i).Child("type"))...)
 		allErrs = append(allErrs, apivalidation.ValidateQualifiedName(string(condition.Status), fldPath.Index(i).Child("status"))...)
 		if condition.Reason == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("reason"), "reason cannot be empty"))
+			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("reason"), ""))
 		}
 		if condition.Message == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("message"), "message cannot be empty"))
+			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("message"), ""))
 		}
 	}
 	return allErrs

--- a/pkg/apis/apiserverinternal/validation/validation_test.go
+++ b/pkg/apis/apiserverinternal/validation/validation_test.go
@@ -360,14 +360,14 @@ func TestValidateStorageVersionCondition(t *testing.T) {
 			Status:  "True",
 			Message: "unknown",
 		}},
-		expectedErr: "Required value: reason cannot be empty",
+		expectedErr: "Required value",
 	}, {
 		conditions: []apiserverinternal.StorageVersionCondition{{
 			Type:   "fea",
 			Status: "True",
 			Reason: "unknown",
 		}},
-		expectedErr: "Required value: message cannot be empty",
+		expectedErr: "Required value",
 	}, {
 		conditions: []apiserverinternal.StorageVersionCondition{{
 			Type:    "fea",

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -682,7 +682,7 @@ func ValidateDeployment(obj *apps.Deployment, opts apivalidation.PodValidationOp
 func ValidateDeploymentRollback(obj *apps.DeploymentRollback) field.ErrorList {
 	allErrs := apivalidation.ValidateAnnotations(obj.UpdatedAnnotations, field.NewPath("updatedAnnotations"))
 	if len(obj.Name) == 0 {
-		allErrs = append(allErrs, field.Required(field.NewPath("name"), "name is required"))
+		allErrs = append(allErrs, field.Required(field.NewPath("name"), ""))
 	}
 	allErrs = append(allErrs, ValidateRollback(&obj.RollbackTo, field.NewPath("rollback"))...)
 	return allErrs

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6682,10 +6682,10 @@ func validateConfigMapNodeConfigSourceStatus(source *core.ConfigMapNodeConfigSou
 	allErrs := field.ErrorList{}
 	// uid and resourceVersion must be set in status
 	if string(source.UID) == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("uid"), "uid must be set in status"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("uid"), ""))
 	}
 	if source.ResourceVersion == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("resourceVersion"), "resourceVersion must be set in status"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceVersion"), ""))
 	}
 	return append(allErrs, validateConfigMapNodeConfigSource(source, fldPath)...)
 }
@@ -6695,7 +6695,7 @@ func validateConfigMapNodeConfigSource(source *core.ConfigMapNodeConfigSource, f
 	allErrs := field.ErrorList{}
 	// validate target configmap namespace
 	if source.Namespace == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), "namespace must be set"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), ""))
 	} else {
 		for _, msg := range ValidateNameFunc(ValidateNamespaceName)(source.Namespace, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), source.Namespace, msg))
@@ -6703,7 +6703,7 @@ func validateConfigMapNodeConfigSource(source *core.ConfigMapNodeConfigSource, f
 	}
 	// validate target configmap name
 	if source.Name == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "name must be set"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
 	} else {
 		for _, msg := range ValidateNameFunc(ValidateConfigMapName)(source.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), source.Name, msg))
@@ -6711,7 +6711,7 @@ func validateConfigMapNodeConfigSource(source *core.ConfigMapNodeConfigSource, f
 	}
 	// validate kubeletConfigKey against rules for configMap key names
 	if source.KubeletConfigKey == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("kubeletConfigKey"), "kubeletConfigKey must be set"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("kubeletConfigKey"), ""))
 	} else {
 		for _, msg := range validation.IsConfigMapKey(source.KubeletConfigKey) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("kubeletConfigKey"), source.KubeletConfigKey, msg))
@@ -7904,7 +7904,7 @@ func validateOS(podSpec *core.PodSpec, fldPath *field.Path, opts PodValidationOp
 		return allErrs
 	}
 	if len(os.Name) == 0 {
-		return append(allErrs, field.Required(fldPath.Child("name"), "cannot be empty"))
+		return append(allErrs, field.Required(fldPath.Child("name"), ""))
 	}
 	if !validOS.Has(os.Name) {
 		allErrs = append(allErrs, field.NotSupported(fldPath, os.Name, sets.List(validOS)))

--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -338,7 +338,7 @@ func ValidateFlowSchemaStatusUpdate(old, fs *flowcontrol.FlowSchema) field.Error
 func ValidateFlowSchemaCondition(condition *flowcontrol.FlowSchemaCondition, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if len(condition.Type) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), ""))
 	}
 	return allErrs
 }
@@ -530,7 +530,7 @@ func ValidatePriorityLevelConfigurationStatusUpdate(old, pl *flowcontrol.Priorit
 func ValidatePriorityLevelConfigurationCondition(condition *flowcontrol.PriorityLevelConfigurationCondition, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if len(condition.Type) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), ""))
 	}
 	return allErrs
 }

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -1171,7 +1171,7 @@ func TestValidateFlowSchemaStatus(t *testing.T) {
 			}},
 		},
 		expectedErrors: field.ErrorList{
-			field.Required(field.NewPath("status").Child("conditions").Index(0).Child("type"), "must not be empty"),
+			field.Required(field.NewPath("status").Child("conditions").Index(0).Child("type"), ""),
 		},
 	}}
 	for _, testCase := range testCases {
@@ -1213,7 +1213,7 @@ func TestValidatePriorityLevelConfigurationStatus(t *testing.T) {
 			}},
 		},
 		expectedErrors: field.ErrorList{
-			field.Required(field.NewPath("status").Child("conditions").Index(0).Child("type"), "must not be empty"),
+			field.Required(field.NewPath("status").Child("conditions").Index(0).Child("type"), ""),
 		},
 	}}
 	for _, testCase := range testCases {

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -590,7 +590,7 @@ func validateIngressTypedLocalObjectReference(params *api.TypedLocalObjectRefere
 	}
 
 	if params.Kind == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), "kind is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), ""))
 	} else {
 		for _, msg := range pathvalidation.IsValidPathSegmentName(params.Kind) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), params.Kind, msg))
@@ -598,7 +598,7 @@ func validateIngressTypedLocalObjectReference(params *api.TypedLocalObjectRefere
 	}
 
 	if params.Name == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "name is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
 	} else {
 		for _, msg := range pathvalidation.IsValidPathSegmentName(params.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), params.Name, msg))

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -1648,13 +1648,13 @@ func TestValidateIngressClass(t *testing.T) {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
 				setParams(makeIngressClassParams(utilpointer.String("example.com"), "", "bar", utilpointer.String("Cluster"), nil)),
 			),
-			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.kind"), "kind is required")},
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.kind"), "")},
 		},
 		"valid name, valid controller, invalid params (no name)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
 				setParams(makeIngressClassParams(utilpointer.String("example.com"), "foo", "", utilpointer.String("Cluster"), nil)),
 			),
-			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.name"), "name is required")},
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.name"), "")},
 		},
 		"valid name, valid controller, invalid params (bad kind)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",

--- a/pkg/apis/storagemigration/validation/validation.go
+++ b/pkg/apis/storagemigration/validation/validation.go
@@ -171,11 +171,11 @@ func validateCondition(condition storagemigration.MigrationCondition, fldPath *f
 	}
 
 	if condition.LastUpdateTime.IsZero() {
-		allErrs = append(allErrs, field.Required(fldPath.Child("lastTransitionTime"), "must be set"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("lastTransitionTime"), ""))
 	}
 
 	if len(condition.Reason) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("reason"), "must be set"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("reason"), ""))
 	} else {
 		for _, currErr := range isValidConditionReason(condition.Reason) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("reason"), condition.Reason, currErr))

--- a/pkg/credentialprovider/plugin/config.go
+++ b/pkg/credentialprovider/plugin/config.go
@@ -154,7 +154,7 @@ func validateCredentialProviderConfig(config *kubeletconfig.CredentialProviderCo
 		seenProviderNames.Insert(provider.Name)
 
 		if provider.APIVersion == "" {
-			allErrs = append(allErrs, field.Required(fieldPath.Child("apiVersion"), "apiVersion is required"))
+			allErrs = append(allErrs, field.Required(fieldPath.Child("apiVersion"), ""))
 		} else if _, ok := apiVersions[provider.APIVersion]; !ok {
 			validAPIVersions := sets.StringKeySet(apiVersions).List()
 			allErrs = append(allErrs, field.NotSupported(fieldPath.Child("apiVersion"), provider.APIVersion, validAPIVersions))
@@ -171,7 +171,7 @@ func validateCredentialProviderConfig(config *kubeletconfig.CredentialProviderCo
 		}
 
 		if provider.DefaultCacheDuration == nil {
-			allErrs = append(allErrs, field.Required(fieldPath.Child("defaultCacheDuration"), "defaultCacheDuration is required"))
+			allErrs = append(allErrs, field.Required(fieldPath.Child("defaultCacheDuration"), ""))
 		}
 
 		if provider.DefaultCacheDuration != nil && provider.DefaultCacheDuration.Duration < 0 {
@@ -184,10 +184,10 @@ func validateCredentialProviderConfig(config *kubeletconfig.CredentialProviderCo
 				allErrs = append(allErrs, field.Forbidden(fldPath, "tokenAttributes is not supported when KubeletServiceAccountTokenForCredentialProviders feature gate is disabled"))
 			}
 			if len(provider.TokenAttributes.ServiceAccountTokenAudience) == 0 {
-				allErrs = append(allErrs, field.Required(fldPath.Child("serviceAccountTokenAudience"), "serviceAccountTokenAudience is required"))
+				allErrs = append(allErrs, field.Required(fldPath.Child("serviceAccountTokenAudience"), ""))
 			}
 			if provider.TokenAttributes.RequireServiceAccount == nil {
-				allErrs = append(allErrs, field.Required(fldPath.Child("requireServiceAccount"), "requireServiceAccount is required"))
+				allErrs = append(allErrs, field.Required(fldPath.Child("requireServiceAccount"), ""))
 			}
 			if provider.APIVersion != credentialproviderv1.SchemeGroupVersion.String() {
 				allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("tokenAttributes is only supported for %s API version", credentialproviderv1.SchemeGroupVersion.String())))

--- a/pkg/credentialprovider/plugin/config_test.go
+++ b/pkg/credentialprovider/plugin/config_test.go
@@ -771,7 +771,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 					},
 				},
 			},
-			expectErr: `providers.defaultCacheDuration: Required value: defaultCacheDuration is required`,
+			expectErr: `providers.defaultCacheDuration: Required value`,
 		},
 		{
 			name: "name contains '/'",
@@ -861,7 +861,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 					},
 				},
 			},
-			expectErr: "providers.apiVersion: Required value: apiVersion is required",
+			expectErr: "providers.apiVersion: Required value",
 		},
 		{
 			name: "invalid apiVersion",
@@ -953,7 +953,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 				},
 			},
 			saTokenForCredentialProviders: true,
-			expectErr:                     `providers.tokenAttributes.serviceAccountTokenAudience: Required value: serviceAccountTokenAudience is required`,
+			expectErr:                     `providers.tokenAttributes.serviceAccountTokenAudience: Required value`,
 		},
 		{
 			name: "token attributes not nil but empty ServiceAccountTokenRequired",
@@ -972,7 +972,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 				},
 			},
 			saTokenForCredentialProviders: true,
-			expectErr:                     `providers.tokenAttributes.requireServiceAccount: Required value: requireServiceAccount is required`,
+			expectErr:                     `providers.tokenAttributes.requireServiceAccount: Required value`,
 		},
 		{
 			name: "required service account annotation keys not qualified name (same validation as metav1.ObjectMeta)",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -370,7 +370,7 @@ func validateCustomResourceDefinitionSpec(ctx context.Context, spec *apiextensio
 		if spec.Validation == nil || spec.Validation.OpenAPIV3Schema == nil {
 			for i, v := range spec.Versions {
 				if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
-					allErrs = append(allErrs, field.Required(fldPath.Child("versions").Index(i).Child("schema").Child("openAPIV3Schema"), "schemas are required"))
+					allErrs = append(allErrs, field.Required(fldPath.Child("versions").Index(i).Child("schema").Child("openAPIV3Schema"), ""))
 				}
 			}
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation.go
@@ -80,10 +80,10 @@ func validateEmbeddedResource(pth *field.Path, x map[string]interface{}, s *stru
 
 	// require apiVersion and kind, but not metadata
 	if _, found := x["apiVersion"]; !found {
-		allErrs = append(allErrs, field.Required(pth.Child("apiVersion"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(pth.Child("apiVersion"), ""))
 	}
 	if _, found := x["kind"]; !found {
-		allErrs = append(allErrs, field.Required(pth.Child("kind"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(pth.Child("kind"), ""))
 	}
 
 	for k, v := range x {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -328,11 +328,11 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 	}
 
 	if condition.LastTransitionTime.IsZero() {
-		allErrs = append(allErrs, field.Required(fldPath.Child("lastTransitionTime"), "must be set"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("lastTransitionTime"), ""))
 	}
 
 	if len(condition.Reason) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("reason"), "must be set"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("reason"), ""))
 	} else {
 		for _, currErr := range isValidConditionReason(condition.Reason) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("reason"), condition.Reason, currErr))

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
@@ -442,7 +442,7 @@ func TestValidateConditions(t *testing.T) {
 			if !hasError(errs, needle) {
 				t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
 			}
-			needle = `status.conditions[0].lastTransitionTime: Required value: must be set`
+			needle = `status.conditions[0].lastTransitionTime: Required value`
 			if !hasError(errs, needle) {
 				t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
 			}

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -128,7 +128,7 @@ func validateIssuer(issuer api.Issuer, disallowedIssuers sets.Set[string], fldPa
 
 func validateIssuerURL(issuerURL string, disallowedIssuers sets.Set[string], fldPath *field.Path) field.ErrorList {
 	if len(issuerURL) == 0 {
-		return field.ErrorList{field.Required(fldPath, "URL is required")}
+		return field.ErrorList{field.Required(fldPath, "")}
 	}
 
 	return validateURL(issuerURL, disallowedIssuers, fldPath)
@@ -198,7 +198,7 @@ func validateAudiences(audiences []string, audienceMatchPolicy api.AudienceMatch
 	for i, audience := range audiences {
 		fldPath := fldPath.Index(i)
 		if len(audience) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath, "audience can't be empty"))
+			allErrs = append(allErrs, field.Required(fldPath, ""))
 		}
 		if seenAudiences.Has(audience) {
 			allErrs = append(allErrs, field.Duplicate(fldPath, audience))
@@ -364,7 +364,7 @@ func validateClaimMappings(compiler authenticationcel.Compiler, state *validatio
 		seenExtraKeys.Insert(mapping.Key)
 
 		if len(mapping.ValueExpression) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("valueExpression"), "valueExpression is required"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("valueExpression"), ""))
 			continue
 		}
 
@@ -564,7 +564,7 @@ func validateUserValidationRules(compiler authenticationcel.Compiler, state *val
 		fldPath := fldPath.Index(i)
 
 		if len(rule.Expression) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("expression"), "expression is required"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("expression"), ""))
 			continue
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -685,7 +685,7 @@ func TestValidateIssuerURL(t *testing.T) {
 		{
 			name: "url is empty",
 			in:   "",
-			want: "issuer.url: Required value: URL is required",
+			want: "issuer.url: Required value",
 		},
 		{
 			name: "url parse error",
@@ -857,7 +857,7 @@ func TestValidateAudiences(t *testing.T) {
 		{
 			name: "audience is empty",
 			in:   []string{""},
-			want: "issuer.audiences[0]: Required value: audience can't be empty",
+			want: "issuer.audiences[0]: Required value",
 		},
 		{
 			name:        "invalid match policy with single audience",
@@ -1282,7 +1282,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimMappings.extra[0].valueExpression: Required value: valueExpression is required`,
+			want:                          `issuer.claimMappings.extra[0].valueExpression: Required value`,
 		},
 		{
 			name: "extra mapping value expression is invalid",
@@ -1655,7 +1655,7 @@ func TestValidateUserValidationRules(t *testing.T) {
 			name:                          "user info validation rule, expression is empty",
 			in:                            []api.UserValidationRule{{}},
 			structuredAuthnFeatureEnabled: true,
-			want:                          "issuer.userValidationRules[0].expression: Required value: expression is required",
+			want:                          "issuer.userValidationRules[0].expression: Required value",
 		},
 		{
 			name: "duplicate expression",

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/validation.go
@@ -65,11 +65,11 @@ func ValidateWebhookService(fldPath *field.Path, namespace, name string, path *s
 	var allErrors field.ErrorList
 
 	if len(name) == 0 {
-		allErrors = append(allErrors, field.Required(fldPath.Child("name"), "service name is required"))
+		allErrors = append(allErrors, field.Required(fldPath.Child("name"), ""))
 	}
 
 	if len(namespace) == 0 {
-		allErrors = append(allErrors, field.Required(fldPath.Child("namespace"), "service namespace is required"))
+		allErrors = append(allErrors, field.Required(fldPath.Child("namespace"), ""))
 	}
 
 	if errs := validation.IsValidPortNum(int(port)); errs != nil {

--- a/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config.go
+++ b/staging/src/k8s.io/controller-manager/pkg/leadermigration/config/config.go
@@ -100,10 +100,10 @@ func validateControllerLeaderConfiguration(path *field.Path, config *internal.Co
 		return
 	}
 	if config.Component == "" {
-		allErrs = append(allErrs, field.Required(path.Child("component"), "component must be set"))
+		allErrs = append(allErrs, field.Required(path.Child("component"), ""))
 	}
 	if config.Name == "" {
-		allErrs = append(allErrs, field.Required(path.Child("name"), "name must be set"))
+		allErrs = append(allErrs, field.Required(path.Child("name"), ""))
 	}
 	return
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture


#### What this PR does / why we need it:
This pull request addresses issue [#111698](https://github.com/kubernetes/kubernetes/issues/111698) by removing redundant detail messages from field.Required calls throughout the repository.

Many validation checks used messages that simply stated a field was "required" or "must be set". This is unnecessary, as the error type field.Required already conveys that information.

#### Which issue(s) this PR is related to:

xref [111698](https://github.com/kubernetes/kubernetes/issues/111698)


#### Special notes for your reviewer:
Here is the list of all the instances of `field.Required`: https://gist.github.com/xiaoweim/cf96a57089939ebed8d9dfcffcd0b991

#### Does this PR introduce a user-facing change?
<!--
Yes

Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Simplied validation error message for required fields by removing redundant messages.
```


