### PR TITLE
 [FG:InPlacePodVerticalScaling] Add a feature gate for in-place resize with static memory manager policy support 

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -366,6 +366,12 @@ const (
 	// CPU Manager Static Policy option set.
 	InPlacePodVerticalScalingExclusiveCPUs featuregate.Feature = "InPlacePodVerticalScalingExclusiveCPUs"
 
+	// owner: @tallclair @pkrishn
+	//
+	// Allow memory resize for containers in Guaranteed pods (default false) when Memory Manager Policy is set to Static.
+	// Applies only in nodes with InPlacePodVerticalScaling and Memory Manager features enabled.
+	InPlacePodVerticalScalingExclusiveMemory featuregate.Feature = "InPlacePodVerticalScalingExclusiveMemory"
+
 	// owner: @trierra
 	//
 	// Disables the Portworx in-tree driver.
@@ -1262,6 +1268,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	InPlacePodVerticalScalingExclusiveCPUs: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	InPlacePodVerticalScalingExclusiveMemory: {
+		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	InTreePluginPortworxUnregister: {

--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"
@@ -702,20 +704,23 @@ func (m *manager) canAdmitPod(allocatedPods []*v1.Pod, pod *v1.Pod) (bool, strin
 func (m *manager) canResizePod(allocatedPods []*v1.Pod, pod *v1.Pod) (bool, string, string) {
 	// TODO: Move this logic into a PodAdmitHandler by introducing an operation field to
 	// lifecycle.PodAdmitAttributes, and combine canResizePod with canAdmitPod.
-	if v1qos.GetPodQOS(pod) == v1.PodQOSGuaranteed && !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) {
-		if m.containerManager.GetNodeConfig().CPUManagerPolicy == "static" {
-			msg := "Resize is infeasible for Guaranteed Pods alongside CPU Manager static policy"
+	if v1qos.GetPodQOS(pod) == v1.PodQOSGuaranteed {
+		if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) &&
+			m.containerManager.GetNodeConfig().CPUManagerPolicy == string(cpumanager.PolicyStatic) &&
+			m.guaranteedPodResourceResizeRequired(pod, v1.ResourceCPU) {
+			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods alongside CPU Manager policy \"%s\"", string(cpumanager.PolicyStatic))
 			klog.V(3).InfoS(msg, "pod", format.Pod(pod))
 			metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_cpu_manager_static_policy").Inc()
 			return false, v1.PodReasonInfeasible, msg
 		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.MemoryManager) {
-			if m.containerManager.GetNodeConfig().MemoryManagerPolicy == "Static" {
-				msg := "Resize is infeasible for Guaranteed Pods alongside Memory Manager static policy"
-				klog.V(3).InfoS(msg, "pod", format.Pod(pod))
-				metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_memory_manager_static_policy").Inc()
-				return false, v1.PodReasonInfeasible, msg
-			}
+		if utilfeature.DefaultFeatureGate.Enabled(features.MemoryManager) &&
+			!utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveMemory) &&
+			m.containerManager.GetNodeConfig().MemoryManagerPolicy == string(memorymanager.PolicyTypeStatic) &&
+			m.guaranteedPodResourceResizeRequired(pod, v1.ResourceMemory) {
+			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods alongside Memory Manager policy \"%s\"", string(memorymanager.PolicyTypeStatic))
+			klog.V(3).InfoS(msg, "pod", format.Pod(pod))
+			metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_memory_manager_static_policy").Inc()
+			return false, v1.PodReasonInfeasible, msg
 		}
 	}
 
@@ -801,6 +806,21 @@ func (m *manager) isPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecon
 				allocatedResources.Requests[v1.ResourceMemory].Equal(actuatedResources.Requests[v1.ResourceMemory]) &&
 				allocatedResources.Limits[v1.ResourceMemory].Equal(actuatedResources.Limits[v1.ResourceMemory])
 		})
+}
+
+func (m *manager) guaranteedPodResourceResizeRequired(pod *v1.Pod, resourceName v1.ResourceName) bool {
+	for container, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if !IsResizableContainer(container, containerType) {
+			continue
+		}
+		requestedResources := container.Resources
+		allocatedresources, _ := m.GetContainerResourceAllocation(pod.UID, container.Name)
+		// For Guaranteed pods, requests must equal limits, so checking requests is sufficient.
+		if !requestedResources.Requests[resourceName].Equal(allocatedresources.Requests[resourceName]) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *manager) getAllocatedPods(activePods []*v1.Pod) []*v1.Pod {

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -44,6 +44,7 @@ type FakeContainerManager struct {
 	CalledFunctions                     []string
 	PodContainerManager                 *FakePodContainerManager
 	shouldResetExtendedResourceCapacity bool
+	nodeConfig                          NodeConfig
 }
 
 var _ ContainerManager = &FakeContainerManager{}
@@ -51,6 +52,13 @@ var _ ContainerManager = &FakeContainerManager{}
 func NewFakeContainerManager() *FakeContainerManager {
 	return &FakeContainerManager{
 		PodContainerManager: NewFakePodContainerManager(),
+	}
+}
+
+func NewFakeContainerManagerWithNodeConfig(nodeConfig NodeConfig) *FakeContainerManager {
+	return &FakeContainerManager{
+		PodContainerManager: NewFakePodContainerManager(),
+		nodeConfig:          nodeConfig,
 	}
 }
 
@@ -72,7 +80,7 @@ func (cm *FakeContainerManager) GetNodeConfig() NodeConfig {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetNodeConfig")
-	return NodeConfig{}
+	return cm.nodeConfig
 }
 
 func (cm *FakeContainerManager) GetMountedSubsystems() *CgroupSubsystems {

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -140,9 +140,9 @@ func NewManager(policyName string, machineInfo *cadvisorapi.MachineInfo, nodeAll
 	case policyTypeNone:
 		policy = NewPolicyNone()
 
-	case policyTypeStatic:
+	case PolicyTypeStatic:
 		if runtime.GOOS == "windows" {
-			return nil, fmt.Errorf("policy %q is not available on Windows", policyTypeStatic)
+			return nil, fmt.Errorf("policy %q is not available on Windows", PolicyTypeStatic)
 		}
 
 		systemReserved, err := getSystemReservedMemory(machineInfo, nodeAllocatableReservation, reservedMemory)

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -78,7 +78,7 @@ func returnPolicyByName(testCase testMemoryManager) Policy {
 		return &mockPolicy{
 			err: fmt.Errorf("fake reg error"),
 		}
-	case policyTypeStatic:
+	case PolicyTypeStatic:
 		policy, _ := NewPolicyStatic(&testCase.machineInfo, testCase.reserved, topologymanager.NewFakeManager())
 		return policy
 	case policyTypeNone:
@@ -642,7 +642,7 @@ func TestRemoveStaleState(t *testing.T) {
 		},
 		{
 			description: "Stale state successfully removed, without multi NUMA assignments",
-			policyName:  policyTypeStatic,
+			policyName:  PolicyTypeStatic,
 			machineInfo: machineInfo,
 			reserved: systemReservedMemory{
 				0: map[v1.ResourceName]uint64{
@@ -768,7 +768,7 @@ func TestRemoveStaleState(t *testing.T) {
 		},
 		{
 			description: "Stale state successfully removed, with multi NUMA assignments",
-			policyName:  policyTypeStatic,
+			policyName:  PolicyTypeStatic,
 			machineInfo: machineInfo,
 			reserved: systemReservedMemory{
 				0: map[v1.ResourceName]uint64{
@@ -937,7 +937,7 @@ func TestAddContainer(t *testing.T) {
 	testCases := []testMemoryManager{
 		{
 			description: "Correct allocation and adding container on NUMA 0",
-			policyName:  policyTypeStatic,
+			policyName:  PolicyTypeStatic,
 			machineInfo: machineInfo,
 			reserved:    reserved,
 			machineState: state.NUMANodeMap{
@@ -1143,7 +1143,7 @@ func TestAddContainer(t *testing.T) {
 		},
 		{
 			description: "Correct allocation of container requiring amount of memory higher than capacity of one NUMA node",
-			policyName:  policyTypeStatic,
+			policyName:  PolicyTypeStatic,
 			machineInfo: machineInfo,
 			reserved:    reserved,
 			machineState: state.NUMANodeMap{
@@ -1249,7 +1249,7 @@ func TestAddContainer(t *testing.T) {
 		},
 		{
 			description: "Should fail if try to allocate container requiring amount of memory higher than capacity of one NUMA node but a small pod is already allocated",
-			policyName:  policyTypeStatic,
+			policyName:  PolicyTypeStatic,
 			machineInfo: machineInfo,
 			firstPod:    pod,
 			reserved:    reserved,
@@ -1440,7 +1440,7 @@ func TestRemoveContainer(t *testing.T) {
 		{
 			description:       "Correct removing of a container",
 			removeContainerID: "fakeID2",
-			policyName:        policyTypeStatic,
+			policyName:        PolicyTypeStatic,
 			machineInfo:       machineInfo,
 			reserved:          reserved,
 			assignments: state.ContainerMemoryAssignments{
@@ -1576,7 +1576,7 @@ func TestRemoveContainer(t *testing.T) {
 		{
 			description:       "Correct removing of a multi NUMA container",
 			removeContainerID: "fakeID2",
-			policyName:        policyTypeStatic,
+			policyName:        PolicyTypeStatic,
 			machineInfo:       machineInfo,
 			reserved:          reserved,
 			assignments: state.ContainerMemoryAssignments{
@@ -1712,7 +1712,7 @@ func TestRemoveContainer(t *testing.T) {
 		{
 			description:       "Should do nothing if container is not in containerMap",
 			removeContainerID: "fakeID3",
-			policyName:        policyTypeStatic,
+			policyName:        PolicyTypeStatic,
 			machineInfo:       machineInfo,
 			reserved:          reserved,
 			assignments: state.ContainerMemoryAssignments{
@@ -1901,7 +1901,7 @@ func getPolicyNameForOs() policyType {
 	if goruntime.GOOS == "windows" {
 		return policyTypeBestEffort
 	}
-	return policyTypeStatic
+	return PolicyTypeStatic
 }
 
 func TestNewManager(t *testing.T) {
@@ -2010,7 +2010,7 @@ func TestNewManager(t *testing.T) {
 						t.Errorf("Could not create the Memory Manager. Expected policy name: %v, but got: %v",
 							testCase.policyName, rawMgr.policy.Name())
 					}
-					if testCase.policyName == policyTypeStatic {
+					if testCase.policyName == PolicyTypeStatic {
 						if !reflect.DeepEqual(rawMgr.policy.(*staticPolicy).systemReserved, testCase.expectedReserved) {
 							t.Errorf("Could not create the Memory Manager. Expected system reserved: %+v, but got: %+v",
 								testCase.expectedReserved, rawMgr.policy.(*staticPolicy).systemReserved)
@@ -2029,7 +2029,7 @@ func TestGetTopologyHints(t *testing.T) {
 	testCases := []testMemoryManager{
 		{
 			description: "Successful hint generation",
-			policyName:  policyTypeStatic,
+			policyName:  PolicyTypeStatic,
 			machineInfo: returnMachineInfo(),
 			reserved: systemReservedMemory{
 				0: map[v1.ResourceName]uint64{
@@ -2174,7 +2174,7 @@ func TestAllocateAndAddPodWithInitContainers(t *testing.T) {
 	testCases := []testMemoryManager{
 		{
 			description: "should remove init containers from the state file, once app container started",
-			policyName:  policyTypeStatic,
+			policyName:  PolicyTypeStatic,
 			machineInfo: returnMachineInfo(),
 			assignments: state.ContainerMemoryAssignments{},
 			expectedAssignments: state.ContainerMemoryAssignments{

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 
-const policyTypeStatic policyType = "Static"
+const PolicyTypeStatic policyType = "Static"
 
 type systemReservedMemory map[int]map[v1.ResourceName]uint64
 type reusableMemory map[string]map[string]map[v1.ResourceName]uint64
@@ -82,7 +82,7 @@ func NewPolicyStatic(machineInfo *cadvisorapi.MachineInfo, reserved systemReserv
 }
 
 func (p *staticPolicy) Name() string {
-	return string(policyTypeStatic)
+	return string(PolicyTypeStatic)
 }
 
 func (p *staticPolicy) Start(s state.State) error {

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -205,8 +205,8 @@ func TestStaticPolicyName(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-			if p.Name() != string(policyTypeStatic) {
-				t.Errorf("policy name is different, expected: %q, actual: %q", p.Name(), policyTypeStatic)
+			if p.Name() != string(PolicyTypeStatic) {
+				t.Errorf("policy name is different, expected: %q, actual: %q", p.Name(), PolicyTypeStatic)
 			}
 		})
 	}

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -629,6 +629,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.32"
+- name: InPlacePodVerticalScalingExclusiveMemory
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.34"
 - name: InTreePluginPortworxUnregister
   versionedSpecs:
   - default: false


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR is to introduce a separate feature gate to enable/disable support for static memory policy. Along with introducing a new feature gate, a check is added to identify if CPU or Memory is being resized and check the appropriate feature gate.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/132466
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure memory resizing for Guaranteed QOS pods on static Memory policy configured is gated by `InPlacePodVerticalScalingExclusiveMemory` (defaults to `false`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
