### PR TITLE
kubectl: avoid logging during init

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/i18n/i18n.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/i18n/i18n.go
@@ -154,7 +154,6 @@ func LoadTranslations(root string, getLanguageFn func() string) error {
 		fmt.Sprintf("%s/%s/LC_MESSAGES/k8s.mo", root, langStr),
 	}
 
-	klog.V(3).Infof("Setting language to %s", langStr)
 	// TODO: list the directory and load all files.
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

LoadTranslations gets called during the init phase:

     0  0x0000000005926c56 in k8s.io/kubectl/pkg/util/i18n.LoadTranslations
        at ./staging/src/k8s.io/kubectl/pkg/util/i18n/i18n.go:146
     1  0x0000000005926727 in k8s.io/kubectl/pkg/util/i18n.init.func1
        at ./staging/src/k8s.io/kubectl/pkg/util/i18n/i18n.go:60
     2  0x000000000592780f in k8s.io/kubectl/pkg/util/i18n.lazyLoadTranslations.func1
        at ./staging/src/k8s.io/kubectl/pkg/util/i18n/i18n.go:191
     3  0x0000000001b876e8 in sync.(*Once).doSlow
        at /nvme/gopath/go-1.24.0/src/sync/once.go:78
     4  0x0000000001b8753e in sync.(*Once).Do
        at /nvme/gopath/go-1.24.0/src/sync/once.go:69
     5  0x0000000005927565 in k8s.io/kubectl/pkg/util/i18n.lazyLoadTranslations
        at ./staging/src/k8s.io/kubectl/pkg/util/i18n/i18n.go:187
     6  0x00000000059275cd in k8s.io/kubectl/pkg/util/i18n.T
        at ./staging/src/k8s.io/kubectl/pkg/util/i18n/i18n.go:201
     7  0x000000000599fb6d in k8s.io/kubectl/pkg/cmd/apiresources.init
        at <autogenerated>:1
     8  0x0000000001b41bf4 in runtime.doInit1
        at /nvme/gopath/go-1.24.0/src/runtime/proc.go:7350
     9  0x0000000001b6bf8a in runtime.doInit
        at /nvme/gopath/go-1.24.0/src/runtime/proc.go:7317
    10  0x0000000001b33910 in runtime.main
        at /nvme/gopath/go-1.24.0/src/runtime/proc.go:254
    11  0x0000000001b72881 in runtime.goexit
        at /nvme/gopath/go-1.24.0/src/runtime/asm_amd64.s:1700

During init, klog verbosity is either zero (making the log call redundant because it doesn't print anything) or some other init function reconfigures logging, in which case the output is potentially confusing because it is not guaranteed that logging is reconfigured before the log call is invoked.

In other scenarios, flag parsing might switch from klog text format to something else entirely, which then leads to a mixture of text and e.g. JSON output. In general, code running during init should not log.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

I ran into this when experimenting with early logging configuration in test/e2e. I bet in practice no-one has ever seen this log output when invoking kubectl, so removing it shouldn't make a difference.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
