### PR TITLE
sheduler_perf: Add test cases for createPodsOp

### DIFF
--- a/test/integration/scheduler_perf/executor_test.go
+++ b/test/integration/scheduler_perf/executor_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -37,12 +38,13 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-type verifyFunc func(t *testing.T, tCtx ktesting.TContext, op realOp) error
+type verifyFunc func(t *testing.T, tCtx ktesting.TContext, op realOp, opIndex int) error
 
 func TestRunOp(t *testing.T) {
 	tests := []struct {
 		name            string
 		op              realOp
+		workload        *Workload
 		expectedFailure bool
 		verifyFuncs     []verifyFunc
 	}{
@@ -240,6 +242,160 @@ func TestRunOp(t *testing.T) {
 				verifyLabelValuesAllowed("test-param", sets.New("substituted-value")),
 			},
 		},
+		{
+			name: "Create Two Pods",
+			op: &createPodsOp{
+				Opcode:               createPodsOpcode,
+				Count:                2,
+				SkipWaitToCompletion: true,
+			},
+			verifyFuncs: []verifyFunc{
+				verifyCount(2),
+				verifyNamespaceCreated("namespace-0"),
+				verifyObj(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace-0",
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "pause",
+									Image: "registry.k8s.io/pause:latest",
+								},
+							},
+						},
+					}),
+			},
+		},
+		{
+			name: "Create Pods with Custom Namespace",
+			op: &createPodsOp{
+				Opcode:               createPodsOpcode,
+				Count:                1,
+				Namespace:            ptr.To("test-namespace"),
+				PodTemplatePath:      newPodTemplateFile(t, "test-namespace"),
+				SkipWaitToCompletion: true,
+			},
+			verifyFuncs: []verifyFunc{
+				verifyNamespaceCreated("test-namespace"),
+				verifyCount(1),
+				verifyObj(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "test-namespace",
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "pause",
+									Image: "registry.k8s.io/pause:latest",
+								},
+							},
+						},
+					}),
+			},
+		},
+		{
+			name: "Invalid Pod Template Path",
+			op: &createPodsOp{
+				Opcode:          createPodsOpcode,
+				Count:           1,
+				PodTemplatePath: ptr.To("non-existent-pod-template.json"),
+			},
+			expectedFailure: true,
+		},
+		{
+			name: "Create Pods with PersistentVolume",
+			op: &createPodsOp{
+				Opcode:                            createPodsOpcode,
+				Count:                             1,
+				Namespace:                         ptr.To("default"),
+				PodTemplatePath:                   newPodTemplateFile(t, "default"),
+				PersistentVolumeTemplatePath:      newPersistentVolumeTemplateFile(t),
+				PersistentVolumeClaimTemplatePath: newPersistentVolumeClaimTemplateFile(t, "default"),
+				SkipWaitToCompletion:              true,
+			},
+			verifyFuncs: []verifyFunc{
+				verifyCount(1),
+				verifyNamespaceCreated("default"),
+				verifyObj(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+						Spec: v1.PodSpec{
+							Volumes: []v1.Volume{
+								{
+									Name: "vol",
+									VolumeSource: v1.VolumeSource{
+										PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+											ClaimName: "pvc-0",
+										},
+									},
+								},
+							},
+							Containers: []v1.Container{
+								{
+									Name:  "pause",
+									Image: "registry.k8s.io/pause:latest",
+								},
+							},
+						},
+					}),
+			},
+		},
+		{
+			name: "Create Pods with CountParam",
+			op: &createPodsOp{
+				Opcode:               createPodsOpcode,
+				CountParam:           "$POD_COUNT",
+				Namespace:            ptr.To("default"),
+				PodTemplatePath:      newPodTemplateFile(t, "default"),
+				SkipWaitToCompletion: true,
+			},
+			workload: &Workload{
+				Name: "test-workload",
+				Params: params{
+					params: map[string]any{
+						"POD_COUNT": float64(2),
+					},
+					isUsed: map[string]bool{},
+				},
+			},
+			verifyFuncs: []verifyFunc{
+				verifyCount(2),
+				verifyNamespaceCreated("default"),
+			},
+		},
+		{
+			name: "Create multiple Pods with detailed verification",
+			op: &createPodsOp{
+				Opcode:               createPodsOpcode,
+				Count:                3,
+				Namespace:            ptr.To("test-namespace"),
+				PodTemplatePath:      newPodTemplateFile(t, "test-namespace"),
+				SkipWaitToCompletion: true,
+			},
+			verifyFuncs: []verifyFunc{
+				verifyCount(3),
+				verifyNamespaceCreated("test-namespace"),
+				verifyObj(
+					&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "test-namespace",
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "pause",
+									Image: "registry.k8s.io/pause:latest",
+								},
+							},
+						},
+					}),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -248,12 +404,36 @@ func TestRunOp(t *testing.T) {
 			client := fake.NewSimpleClientset()
 			tCtx = tCtx.WithClients(nil, nil, client, nil, nil)
 
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			podInformer := informerFactory.Core().V1().Pods()
+			informerFactory.Start(tCtx.Done())
+			informerFactory.WaitForCacheSync(tCtx.Done())
+
 			exec := &WorkloadExecutor{
 				numPodsScheduledPerNamespace: make(map[string]int),
 				nextNodeIndex:                0,
+				testCase: &testCase{
+					DefaultPodTemplatePath: newPodTemplateFile(t, "namespace-0"),
+				},
+				podInformer: podInformer,
+				workload:    tt.workload,
 			}
 
-			err := exec.runOp(tCtx, tt.op, 0)
+			opToRun := tt.op
+			opIndex := 0
+			if tt.workload != nil {
+				if patchable, ok := tt.op.(interface {
+					patchParams(w *Workload) (realOp, error)
+				}); ok {
+					patchedOp, err := patchable.patchParams(tt.workload)
+					if err != nil {
+						t.Fatalf("Failed to patch params: %v", err)
+					}
+					opToRun = patchedOp
+				}
+			}
+
+			err := exec.runOp(tCtx, opToRun, opIndex)
 
 			if tt.expectedFailure {
 				if err == nil {
@@ -268,7 +448,7 @@ func TestRunOp(t *testing.T) {
 
 			if tt.verifyFuncs != nil {
 				for i, vf := range tt.verifyFuncs {
-					if err := vf(t, tCtx, tt.op); err != nil {
+					if err := vf(t, tCtx, opToRun, opIndex); err != nil {
 						t.Fatalf("Verification function %d failed for test %q: %v", i, tt.name, err)
 					}
 				}
@@ -280,15 +460,27 @@ func TestRunOp(t *testing.T) {
 // verifyCount returns a verification function that checks if the number of existing objects
 // matches the expected count based on the operation type.
 func verifyCount(expectedCount int) verifyFunc {
-	return func(t *testing.T, tCtx ktesting.TContext, op realOp) error {
-		switch op.(type) {
+	return func(t *testing.T, tCtx ktesting.TContext, op realOp, opIndex int) error {
+		switch concreteOp := op.(type) {
 		case *createNodesOp:
-			nodes, err := tCtx.Client().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			nodes, err := tCtx.Client().CoreV1().Nodes().List(tCtx, metav1.ListOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to list nodes: %w", err)
 			}
 			if got := len(nodes.Items); got != expectedCount {
 				return fmt.Errorf("unexpected node count: got %d, want %d", got, expectedCount)
+			}
+		case *createPodsOp:
+			namespace := fmt.Sprintf("namespace-%d", opIndex)
+			if concreteOp.Namespace != nil {
+				namespace = *concreteOp.Namespace
+			}
+			pods, err := tCtx.Client().CoreV1().Pods(namespace).List(tCtx, metav1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to list pods: %w", err)
+			}
+			if got := len(pods.Items); got != expectedCount {
+				return fmt.Errorf("unexpected pod count: got %d, want %d", got, expectedCount)
 			}
 		default:
 			return fmt.Errorf("verifyCount doesn't support this operation type: %T", op)
@@ -299,7 +491,7 @@ func verifyCount(expectedCount int) verifyFunc {
 
 // verifyLabelValuesAllowed returns a verification function that checks if the label values for a given key.
 func verifyLabelValuesAllowed(key string, allowValues sets.Set[string]) verifyFunc {
-	return func(t *testing.T, tCtx ktesting.TContext, op realOp) error {
+	return func(t *testing.T, tCtx ktesting.TContext, op realOp, opIndex int) error {
 		labelValues, _, err := objLabelValues(t, tCtx, op, key)
 		if err != nil {
 			return fmt.Errorf("failed to get label values: %w", err)
@@ -317,7 +509,7 @@ func verifyLabelValuesAllowed(key string, allowValues sets.Set[string]) verifyFu
 
 // verifyUniqueLabelValues returns a verification function that checks if the label values for a given key are unique.
 func verifyUniqueLabelValues(key string) verifyFunc {
-	return func(t *testing.T, tCtx ktesting.TContext, op realOp) error {
+	return func(t *testing.T, tCtx ktesting.TContext, op realOp, opIndex int) error {
 		_, duplicatedValues, err := objLabelValues(t, tCtx, op, key)
 		if err != nil {
 			return fmt.Errorf("failed to get label values: %w", err)
@@ -342,7 +534,7 @@ func objLabelValues(t *testing.T, tCtx ktesting.TContext, op realOp, key string)
 
 	switch op.(type) {
 	case *createNodesOp:
-		nodes, err := tCtx.Client().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		nodes, err := tCtx.Client().CoreV1().Nodes().List(tCtx, metav1.ListOptions{})
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to list nodes for label verification: %w", err)
 		}
@@ -366,9 +558,10 @@ func objLabelValues(t *testing.T, tCtx ktesting.TContext, op realOp, key string)
 
 // verifyObj checks if listed objects match the expected template object using cmp.Diff.
 func verifyObj(expectedObj any) verifyFunc {
-	return func(t *testing.T, tCtx ktesting.TContext, op realOp) error {
+	return func(t *testing.T, tCtx ktesting.TContext, op realOp, opIndex int) error {
 		var got, want any
 		var cmpOpts []cmp.Option
+
 		switch opDetails := op.(type) {
 		case *createNodesOp:
 			nodesList, listErr := tCtx.Client().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -390,10 +583,7 @@ func verifyObj(expectedObj any) verifyFunc {
 
 			cmpOpts = []cmp.Option{
 				cmpopts.EquateEmpty(),
-				cmpopts.IgnoreFields(metav1.ObjectMeta{},
-					"UID", "ResourceVersion", "Generation", "CreationTimestamp", "ManagedFields", "SelfLink", "Name",
-					"Labels", // verifyObj doesn't care about labels.
-				),
+				cmpOptsIgnoreObjectMeta,
 				cmpopts.IgnoreFields(v1.NodeStatus{}, // This test isn't interested in these fields.
 					"Conditions",
 					"Phase",
@@ -401,6 +591,38 @@ func verifyObj(expectedObj any) verifyFunc {
 			}
 			got = gotNodes
 			want = wantNodes
+		case *createPodsOp:
+			expectedPodTemplate, ok := expectedObj.(*v1.Pod)
+			if !ok {
+				return fmt.Errorf("expectedObj must be *v1.Pod when op is *createPodsOp, got %T", expectedObj)
+			}
+
+			namespace := expectedPodTemplate.Namespace
+			if namespace == "" {
+				return fmt.Errorf("expectedPodTemplate.Namespace must be set")
+			}
+
+			podsList, listErr := tCtx.Client().CoreV1().Pods(namespace).List(tCtx, metav1.ListOptions{})
+			if listErr != nil {
+				return fmt.Errorf("failed to list pods: %w", listErr)
+			}
+			gotPods := podsList.Items
+
+			wantPods := make([]v1.Pod, len(gotPods))
+			for i := range gotPods {
+				wantPods[i] = *expectedPodTemplate
+			}
+
+			cmpOpts = []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmpOptsIgnoreObjectMeta,
+				cmpopts.IgnoreFields(v1.PodStatus{}, // This test isn't interested in these fields.
+					"Phase", "Conditions", "Message", "Reason", "NominatedNodeName",
+					"HostIP", "HostIPs", "PodIP", "PodIPs", "StartTime", "QOSClass", "ContainerStatuses",
+				),
+			}
+			got = gotPods
+			want = wantPods
 		default:
 			return fmt.Errorf("verifyObj doesn't support this operation type for cmp.Diff: %T", opDetails)
 		}
@@ -438,7 +660,7 @@ func createObjTemplateFile(t *testing.T, obj any) *string {
 	}()
 
 	switch obj := obj.(type) {
-	case *v1.Node:
+	case *v1.Node, *v1.Pod, *v1.PersistentVolume, *v1.PersistentVolumeClaim:
 		if err := json.NewEncoder(f).Encode(obj); err != nil {
 			t.Fatalf("Failed to encode the template to %s: %v", templateFile, err)
 		}
@@ -701,5 +923,76 @@ func TestMetricThreshold(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// cmpOptsIgnoreObjectMeta ignores metadata fields that are not relevant for object equality in these tests.
+var cmpOptsIgnoreObjectMeta = cmpopts.IgnoreFields(metav1.ObjectMeta{},
+	"UID", "ResourceVersion", "Generation", "CreationTimestamp", "ManagedFields", "SelfLink", "Name",
+	"Labels", // verifyObj doesn't care about labels.
+)
+
+func newPodTemplateFile(t *testing.T, namespace string) *string {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-{{.Index}}",
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "pause",
+					Image: "registry.k8s.io/pause:latest",
+				},
+			},
+		},
+	}
+	return createObjTemplateFile(t, pod)
+}
+
+func newPersistentVolumeTemplateFile(t *testing.T) *string {
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/tmp"},
+			},
+		},
+	}
+	return createObjTemplateFile(t, pv)
+}
+
+func newPersistentVolumeClaimTemplateFile(t *testing.T, namespace string) *string {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc",
+			Namespace: namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+	return createObjTemplateFile(t, pvc)
+}
+
+// verifyNamespaceCreated returns a verification function that checks if a namespace was created.
+func verifyNamespaceCreated(expectedNamespace string) verifyFunc {
+	return func(t *testing.T, tCtx ktesting.TContext, op realOp, opIndex int) error {
+		_, err := tCtx.Client().CoreV1().Namespaces().Get(tCtx, expectedNamespace, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("namespace %s was not created: %w", expectedNamespace, err)
+		}
+		return nil
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:

Add test cases for createPodsOp in scheduler_perf to enhance scheduler performance testing capabilities. This follows the same testing pattern established for createNodesOp.

 The tests verify:
  - Basic pod creation functionality
  - Custom namespace support
  - Custom pod template handling
  - Error cases with invalid templates

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Part of #127745

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
