### PR TITLE
Add json-patch v4 compatibility test

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -14,6 +14,7 @@
       "github.com/bketelsen/crypt": "unused, crypto",
       "github.com/containerd/cgroups": "standardize on single cgroups library from runc, refer #128157",
       "github.com/davecgh/go-spew": "refer to #103942",
+      "github.com/evanphx/json-patch/v5": "refer to https://github.com/kubernetes/kubernetes/pull/91622#issuecomment-637087847",
       "github.com/form3tech-oss/jwt-go": "unmaintained, archive mode",
       "github.com/getsentry/raven-go": "unmaintained, archive mode",
       "github.com/go-bindata/go-bindata": "refer to #99829",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,6 +248,15 @@ func TestJSONPatch(t *testing.T) {
 		{
 			name:  "valid-negative-index-patch",
 			patch: `[{"op": "test", "value": "foo", "path": "/metadata/finalizers/-1"}]`,
+		},
+		// This demonstrates out-of-spec behavior json-patch v4 allows,
+		// which Kubernetes clients may depend on, and which updating to json-patch v5 currently breaks
+		{
+			name: "replace-missing-path-allowed",
+			patch: `[
+				{"op":"replace", "path":"/metadata/path", "value":"foo"},
+				{"op":"test", "path":"/metadata/path", "value":"foo"}
+			]`,
 		},
 	} {
 		p := &patcher{


### PR DESCRIPTION
#### What type of PR is this?

/kind test

#### What this PR does / why we need it:

Marks json-patch v5 as an unwanted dependency update due to compatibility issues, and adds a unit test demonstrating currently allowed (out-of-spec) behavior that v4 allows which v5 breaks.

#### Which issue(s) this PR is related to:

xref 
* https://github.com/kubernetes/kubernetes/pull/132366
* https://github.com/kubernetes/kubernetes/pull/129988
* https://github.com/kubernetes/kubernetes/pull/129855
* https://github.com/kubernetes/kubernetes/pull/91622#issuecomment-637087847

#### Special notes for your reviewer:

Includes / updates https://github.com/kubernetes/kubernetes/pull/129988

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig architecture
/sig api-machinery
/cc @dims @skitt 