### PR TITLE
Fix flake caused by invalid detection of active policies in VAP integration tests

### DIFF
--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -65,6 +65,8 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
 // Short term fix to refresh the policy source cache faster for tests
@@ -3004,8 +3006,17 @@ func secondaryAuthorizationServiceAccountClient(t *testing.T, adminClient *clien
 
 func withWaitReadyConstraintAndExpression(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *admissionregistrationv1.ValidatingAdmissionPolicy {
 	policy = policy.DeepCopy()
+
+	testMarkerName := fmt.Sprintf("test-marker-%s", utilrand.String(utilvalidation.DNS1123SubdomainMaxLength-len("test-marker-")))
+	annotations := policy.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["test-marker-name"] = testMarkerName
+	policy.SetAnnotations(annotations)
+
 	policy.Spec.MatchConstraints.ResourceRules = append(policy.Spec.MatchConstraints.ResourceRules, admissionregistrationv1.NamedRuleWithOperations{
-		ResourceNames: []string{"test-marker"},
+		ResourceNames: []string{testMarkerName},
 		RuleWithOperations: admissionregistrationv1.RuleWithOperations{
 			Operations: []admissionregistrationv1.OperationType{
 				"UPDATE",
@@ -3024,7 +3035,7 @@ func withWaitReadyConstraintAndExpression(policy *admissionregistrationv1.Valida
 		},
 	})
 	policy.Spec.Validations = append([]admissionregistrationv1.Validation{{
-		Expression: "object.metadata.name != 'test-marker'",
+		Expression: fmt.Sprintf("object.metadata.name != '%s'", testMarkerName),
 		Message:    "marker denied; policy is ready",
 	}}, policy.Spec.Validations...)
 	return policy
@@ -3039,14 +3050,23 @@ func createAndWaitReadyNamespaced(t *testing.T, client clientset.Interface, bind
 }
 
 func createAndWaitReadyNamespacedWithWarnHandler(t *testing.T, client clientset.Interface, binding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, matchLabels map[string]string, ns string, handler *warningHandler) error {
-	marker := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "test-marker", Namespace: ns, Labels: matchLabels}}
+	policy, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(context.TODO(), binding.Spec.PolicyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	testMarkerName := "test-marker"
+	if testMarkerNameAnnotation, ok := policy.GetAnnotations()["test-marker-name"]; ok {
+		testMarkerName = testMarkerNameAnnotation
+	}
+
+	marker := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: testMarkerName, Namespace: ns, Labels: matchLabels}}
 	defer func() {
 		err := client.CoreV1().Endpoints(ns).Delete(context.TODO(), marker.Name, metav1.DeleteOptions{})
 		if err != nil {
 			t.Logf("error deleting marker: %v", err)
 		}
 	}()
-	marker, err := client.CoreV1().Endpoints(ns).Create(context.TODO(), marker, metav1.CreateOptions{})
+	marker, err = client.CoreV1().Endpoints(ns).Create(context.TODO(), marker, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/sig api-machinery

#### What this PR does / why we need it:

Writes to policy resources don't instantaneously take effect in admission. ValidatingAdmissionPolicy
integration tests determine that the policies under test have taken effect by adding a sentinel
policy rule and polling until that rule is applied to a request.

If the marker resource names are the same for each test case in a series of test cases, then
observing a policy's effect on a marker request only indicates that _any_ test policy is in effect,
but it's not necessarily the policy the current test case is waiting for. For example:

1. Test 1 creates a policy and binding.

2. The policy and binding are observed by the admission plugin and take effect.

3. Test 1 observes that a policy is in effect via marker requests.

4. Test 1 exercises the behavior under test and successfully deletes the policy and binding it
created.

5. Test 2 creates a policy and binding.

6. Test 2 observes that a policy is in effect via marker requests, but the policy in effect is still
the one created by Test 1.

7. Test 2 exercises the behavior under test, which fails because it was evaluated against Test 1's
policy.

Generating a per-policy name for the marker resource in each test resolves the timing issue. In the
example, step (6) will not proceed until the admission plugin has observed the policy and binding
created in (5).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

@bertinatto first reported this in https://kubernetes.slack.com/archives/C02TTBG6LF4/p1746818599391839 after seeing this flake in OpenShift CI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
