### PR TITLE
Cleanup: Remove field name from invalid field detail message

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -1009,7 +1009,7 @@ func validateVariable(compiler plugincel.Compiler, v *admissionregistration.Vari
 		allErrors = append(allErrors, field.Required(fldPath.Child("name"), "name is not specified"))
 	} else {
 		if !isCELIdentifier(v.Name) {
-			allErrors = append(allErrors, field.Invalid(fldPath.Child("name"), v.Name, "is not a valid CEL identifier"))
+			allErrors = append(allErrors, field.Invalid(fldPath.Child("name"), v.Name, "must be a valid CEL identifier"))
 		}
 	}
 	if len(v.Expression) == 0 || strings.TrimSpace(v.Expression) == "" {

--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -1009,7 +1009,7 @@ func validateVariable(compiler plugincel.Compiler, v *admissionregistration.Vari
 		allErrors = append(allErrors, field.Required(fldPath.Child("name"), "name is not specified"))
 	} else {
 		if !isCELIdentifier(v.Name) {
-			allErrors = append(allErrors, field.Invalid(fldPath.Child("name"), v.Name, "name is not a valid CEL identifier"))
+			allErrors = append(allErrors, field.Invalid(fldPath.Child("name"), v.Name, "is not a valid CEL identifier"))
 		}
 	}
 	if len(v.Expression) == 0 || strings.TrimSpace(v.Expression) == "" {
@@ -1057,9 +1057,9 @@ func validateValidation(compiler plugincel.Compiler, v *admissionregistration.Va
 		allErrors = append(allErrors, validateMessageExpression(compiler, v.MessageExpression, opts, fldPath.Child("messageExpression"))...)
 	}
 	if len(v.Message) > 0 && len(trimmedMsg) == 0 {
-		allErrors = append(allErrors, field.Invalid(fldPath.Child("message"), v.Message, "message must be non-empty if specified"))
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("message"), v.Message, "must be non-empty if specified"))
 	} else if hasNewlines(trimmedMsg) {
-		allErrors = append(allErrors, field.Invalid(fldPath.Child("message"), v.Message, "message must not contain line breaks"))
+		allErrors = append(allErrors, field.Invalid(fldPath.Child("message"), v.Message, "must not contain line breaks"))
 	} else if hasNewlines(trimmedMsg) && trimmedMsg == "" {
 		allErrors = append(allErrors, field.Required(fldPath.Child("message"), "message must be specified if expression contains line breaks"))
 	}

--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -2904,7 +2904,7 @@ func TestValidateValidatingAdmissionPolicy(t *testing.T) {
 				},
 			},
 		},
-		expectedError: `spec.variables[0].name: Invalid value: "4ever": is not a valid CEL identifier`,
+		expectedError: `spec.variables[0].name: Invalid value: "4ever": must be a valid CEL identifier`,
 	}, {
 		name: "variable composition cannot compile",
 		config: &admissionregistration.ValidatingAdmissionPolicy{

--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -2904,7 +2904,7 @@ func TestValidateValidatingAdmissionPolicy(t *testing.T) {
 				},
 			},
 		},
-		expectedError: `spec.variables[0].name: Invalid value: "4ever": name is not a valid CEL identifier`,
+		expectedError: `spec.variables[0].name: Invalid value: "4ever": is not a valid CEL identifier`,
 	}, {
 		name: "variable composition cannot compile",
 		config: &admissionregistration.ValidatingAdmissionPolicy{

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -514,7 +514,7 @@ func validateJobStatus(job *batch.Job, fldPath *field.Path, opts JobStatusValida
 	}
 	if opts.RejectCompletionTimeBeforeStartTime {
 		if status.StartTime != nil && status.CompletionTime != nil && status.CompletionTime.Before(status.StartTime) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("completionTime"), status.CompletionTime, "completionTime cannot be set before startTime"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("completionTime"), status.CompletionTime, "cannot be set before startTime"))
 		}
 	}
 	if opts.RejectFailedJobWithoutFailureTarget {
@@ -540,7 +540,7 @@ func validateJobStatus(job *batch.Job, fldPath *field.Path, opts JobStatusValida
 	}
 	if opts.RejectFinishedJobWithUncountedTerminatedPods {
 		if isJobFinished && status.UncountedTerminatedPods != nil && len(status.UncountedTerminatedPods.Failed)+len(status.UncountedTerminatedPods.Succeeded) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("uncountedTerminatedPods"), status.UncountedTerminatedPods, "uncountedTerminatedPods needs to be empty for finished job"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("uncountedTerminatedPods"), status.UncountedTerminatedPods, "needs to be empty for finished job"))
 		}
 	}
 	if opts.RejectInvalidCompletedIndexes {
@@ -692,7 +692,7 @@ func ValidateJobStatusUpdate(job, oldJob *batch.Job, opts JobStatusValidationOpt
 		// we don't want to block transitions to completionTime = nil when the job is not finished yet.
 		// Setting completionTime = nil for finished jobs is prevented in RejectCompleteJobWithoutCompletionTime.
 		if job.Status.CompletionTime != nil && oldJob.Status.CompletionTime != nil && !ptr.Equal(job.Status.CompletionTime, oldJob.Status.CompletionTime) {
-			allErrs = append(allErrs, field.Invalid(statusFld.Child("completionTime"), job.Status.CompletionTime, "completionTime cannot be mutated"))
+			allErrs = append(allErrs, field.Invalid(statusFld.Child("completionTime"), job.Status.CompletionTime, "cannot be mutated"))
 		}
 	}
 	if opts.RejectStartTimeUpdateForUnsuspendedJob {

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -514,7 +514,7 @@ func validateJobStatus(job *batch.Job, fldPath *field.Path, opts JobStatusValida
 	}
 	if opts.RejectCompletionTimeBeforeStartTime {
 		if status.StartTime != nil && status.CompletionTime != nil && status.CompletionTime.Before(status.StartTime) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("completionTime"), status.CompletionTime, "cannot be set before startTime"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("completionTime"), status.CompletionTime, "must be equal to or after `startTime`"))
 		}
 	}
 	if opts.RejectFailedJobWithoutFailureTarget {
@@ -540,7 +540,7 @@ func validateJobStatus(job *batch.Job, fldPath *field.Path, opts JobStatusValida
 	}
 	if opts.RejectFinishedJobWithUncountedTerminatedPods {
 		if isJobFinished && status.UncountedTerminatedPods != nil && len(status.UncountedTerminatedPods.Failed)+len(status.UncountedTerminatedPods.Succeeded) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("uncountedTerminatedPods"), status.UncountedTerminatedPods, "needs to be empty for finished job"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("uncountedTerminatedPods"), status.UncountedTerminatedPods, "must be empty for finished job"))
 		}
 	}
 	if opts.RejectInvalidCompletedIndexes {
@@ -692,7 +692,7 @@ func ValidateJobStatusUpdate(job, oldJob *batch.Job, opts JobStatusValidationOpt
 		// we don't want to block transitions to completionTime = nil when the job is not finished yet.
 		// Setting completionTime = nil for finished jobs is prevented in RejectCompleteJobWithoutCompletionTime.
 		if job.Status.CompletionTime != nil && oldJob.Status.CompletionTime != nil && !ptr.Equal(job.Status.CompletionTime, oldJob.Status.CompletionTime) {
-			allErrs = append(allErrs, field.Invalid(statusFld.Child("completionTime"), job.Status.CompletionTime, "cannot be mutated"))
+			allErrs = append(allErrs, field.Invalid(statusFld.Child("completionTime"), job.Status.CompletionTime, "field is immutable"))
 		}
 	}
 	if opts.RejectStartTimeUpdateForUnsuspendedJob {

--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -395,7 +395,7 @@ func ValidateIfMandatoryPriorityLevelConfigurationObject(pl *flowcontrol.Priorit
 func ValidatePriorityLevelConfigurationSpec(spec *flowcontrol.PriorityLevelConfigurationSpec, requestGV schema.GroupVersion, name string, fldPath *field.Path, opts PriorityLevelValidationOptions) field.ErrorList {
 	var allErrs field.ErrorList
 	if (name == flowcontrol.PriorityLevelConfigurationNameExempt) != (spec.Type == flowcontrol.PriorityLevelEnablementExempt) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), spec.Type, "must be 'Exempt' if and only if name is 'exempt'"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), spec.Type, "must be 'Exempt' if and only if `name` is 'exempt'"))
 	}
 	switch spec.Type {
 	case flowcontrol.PriorityLevelEnablementExempt:

--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -395,7 +395,7 @@ func ValidateIfMandatoryPriorityLevelConfigurationObject(pl *flowcontrol.Priorit
 func ValidatePriorityLevelConfigurationSpec(spec *flowcontrol.PriorityLevelConfigurationSpec, requestGV schema.GroupVersion, name string, fldPath *field.Path, opts PriorityLevelValidationOptions) field.ErrorList {
 	var allErrs field.ErrorList
 	if (name == flowcontrol.PriorityLevelConfigurationNameExempt) != (spec.Type == flowcontrol.PriorityLevelEnablementExempt) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), spec.Type, "type must be 'Exempt' if and only if name is 'exempt'"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), spec.Type, "must be 'Exempt' if and only if name is 'exempt'"))
 	}
 	switch spec.Type {
 	case flowcontrol.PriorityLevelEnablementExempt:

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -824,7 +824,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 			Spec: badSpec,
 		},
 		expectedErrors: field.ErrorList{
-			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "type must be 'Exempt' if and only if name is 'exempt'"),
+			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "must be 'Exempt' if and only if name is 'exempt'"),
 			field.Invalid(field.NewPath("spec"), badSpec, "spec of 'exempt' except the 'spec.exempt' field must equal the fixed value"),
 		},
 	}, {
@@ -855,7 +855,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 		name:                       "admins are not allowed to repurpose the 'exempt' pl to a limited type",
 		priorityLevelConfiguration: exemptTypeRepurposed,
 		expectedErrors: field.ErrorList{
-			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "type must be 'Exempt' if and only if name is 'exempt'"),
+			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "must be 'Exempt' if and only if name is 'exempt'"),
 			field.Forbidden(field.NewPath("spec").Child("exempt"), "must be nil if the type is Limited"),
 			field.Invalid(field.NewPath("spec"), exemptTypeRepurposed.Spec, "spec of 'exempt' except the 'spec.exempt' field must equal the fixed value"),
 		},

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -824,7 +824,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 			Spec: badSpec,
 		},
 		expectedErrors: field.ErrorList{
-			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "must be 'Exempt' if and only if name is 'exempt'"),
+			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "must be 'Exempt' if and only if `name` is 'exempt'"),
 			field.Invalid(field.NewPath("spec"), badSpec, "spec of 'exempt' except the 'spec.exempt' field must equal the fixed value"),
 		},
 	}, {
@@ -855,7 +855,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 		name:                       "admins are not allowed to repurpose the 'exempt' pl to a limited type",
 		priorityLevelConfiguration: exemptTypeRepurposed,
 		expectedErrors: field.ErrorList{
-			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "must be 'Exempt' if and only if name is 'exempt'"),
+			field.Invalid(field.NewPath("spec").Child("type"), flowcontrol.PriorityLevelEnablementLimited, "must be 'Exempt' if and only if `name` is 'exempt'"),
 			field.Forbidden(field.NewPath("spec").Child("exempt"), "must be nil if the type is Limited"),
 			field.Invalid(field.NewPath("spec"), exemptTypeRepurposed.Spec, "spec of 'exempt' except the 'spec.exempt' field must equal the fixed value"),
 		},

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1047,7 +1047,7 @@ func validateRawExtension(rawExtension runtime.RawExtension, fldPath *field.Path
 	} else if v == nil {
 		allErrs = append(allErrs, field.Required(fldPath, ""))
 	} else if _, isObject := v.(map[string]any); !isObject {
-		allErrs = append(allErrs, field.Invalid(fldPath, "<value omitted>", "parameters must be a valid JSON object"))
+		allErrs = append(allErrs, field.Invalid(fldPath, "<value omitted>", "must be a valid JSON object"))
 	}
 	return allErrs
 }

--- a/pkg/apis/resource/validation/validation_deviceclass_test.go
+++ b/pkg/apis/resource/validation/validation_deviceclass_test.go
@@ -225,7 +225,7 @@ func TestValidateClass(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "config").Index(1).Child("opaque", "driver"), "", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 				field.Required(field.NewPath("spec", "config").Index(1).Child("opaque", "parameters"), ""),
 				field.Invalid(field.NewPath("spec", "config").Index(2).Child("opaque", "parameters"), "<value omitted>", "error parsing data as JSON: invalid character 'x' looking for beginning of value"),
-				field.Invalid(field.NewPath("spec", "config").Index(3).Child("opaque", "parameters"), "<value omitted>", "parameters must be a valid JSON object"),
+				field.Invalid(field.NewPath("spec", "config").Index(3).Child("opaque", "parameters"), "<value omitted>", "must be a valid JSON object"),
 				field.Required(field.NewPath("spec", "config").Index(4).Child("opaque", "parameters"), ""),
 				field.Required(field.NewPath("spec", "config").Index(5).Child("opaque"), ""),
 				field.TooLong(field.NewPath("spec", "config").Index(7).Child("opaque", "parameters"), "" /* unused */, resource.OpaqueParametersMaxLength),

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -431,7 +431,7 @@ func TestValidateClaim(t *testing.T) {
 			wantFailures: field.ErrorList{
 				field.Required(field.NewPath("spec", "devices", "config").Index(0).Child("opaque", "parameters"), ""),
 				field.Invalid(field.NewPath("spec", "devices", "config").Index(1).Child("opaque", "parameters"), "<value omitted>", "error parsing data as JSON: unexpected end of JSON input"),
-				field.Invalid(field.NewPath("spec", "devices", "config").Index(2).Child("opaque", "parameters"), "<value omitted>", "parameters must be a valid JSON object"),
+				field.Invalid(field.NewPath("spec", "devices", "config").Index(2).Child("opaque", "parameters"), "<value omitted>", "must be a valid JSON object"),
 				field.Required(field.NewPath("spec", "devices", "config").Index(3).Child("opaque", "parameters"), ""),
 				field.TooLong(field.NewPath("spec", "devices", "config").Index(5).Child("opaque", "parameters"), "" /* unused */, resource.OpaqueParametersMaxLength),
 			},

--- a/pkg/apis/storagemigration/validation/validation.go
+++ b/pkg/apis/storagemigration/validation/validation.go
@@ -78,7 +78,7 @@ func ValidateStorageVersionMigrationStatusUpdate(newSVMBundle, oldSVMBundle *sto
 
 	// resource version should not change once it has been set
 	if len(oldSVMBundle.Status.ResourceVersion) != 0 && oldSVMBundle.Status.ResourceVersion != newSVMBundle.Status.ResourceVersion {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceVersion"), newSVMBundle.Status.ResourceVersion, "resourceVersion cannot be updated"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceVersion"), newSVMBundle.Status.ResourceVersion, "cannot be updated"))
 	}
 
 	// at most one of success or failed may be true

--- a/pkg/apis/storagemigration/validation/validation.go
+++ b/pkg/apis/storagemigration/validation/validation.go
@@ -78,7 +78,7 @@ func ValidateStorageVersionMigrationStatusUpdate(newSVMBundle, oldSVMBundle *sto
 
 	// resource version should not change once it has been set
 	if len(oldSVMBundle.Status.ResourceVersion) != 0 && oldSVMBundle.Status.ResourceVersion != newSVMBundle.Status.ResourceVersion {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceVersion"), newSVMBundle.Status.ResourceVersion, "cannot be updated"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceVersion"), newSVMBundle.Status.ResourceVersion, "field is immutable"))
 	}
 
 	// at most one of success or failed may be true

--- a/pkg/credentialprovider/plugin/config.go
+++ b/pkg/credentialprovider/plugin/config.go
@@ -175,7 +175,7 @@ func validateCredentialProviderConfig(config *kubeletconfig.CredentialProviderCo
 		}
 
 		if provider.DefaultCacheDuration != nil && provider.DefaultCacheDuration.Duration < 0 {
-			allErrs = append(allErrs, field.Invalid(fieldPath.Child("defaultCacheDuration"), provider.DefaultCacheDuration.Duration, "must be greater than or equal to 0"))
+			allErrs = append(allErrs, field.Invalid(fieldPath.Child("defaultCacheDuration"), provider.DefaultCacheDuration, "must be greater than or equal to 0"))
 		}
 
 		if provider.TokenAttributes != nil {

--- a/pkg/credentialprovider/plugin/config.go
+++ b/pkg/credentialprovider/plugin/config.go
@@ -175,7 +175,7 @@ func validateCredentialProviderConfig(config *kubeletconfig.CredentialProviderCo
 		}
 
 		if provider.DefaultCacheDuration != nil && provider.DefaultCacheDuration.Duration < 0 {
-			allErrs = append(allErrs, field.Invalid(fieldPath.Child("defaultCacheDuration"), provider.DefaultCacheDuration, "defaultCacheDuration must be greater than or equal to 0"))
+			allErrs = append(allErrs, field.Invalid(fieldPath.Child("defaultCacheDuration"), provider.DefaultCacheDuration.Duration, "must be greater than or equal to 0"))
 		}
 
 		if provider.TokenAttributes != nil {

--- a/pkg/credentialprovider/plugin/config_test.go
+++ b/pkg/credentialprovider/plugin/config_test.go
@@ -889,7 +889,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 					},
 				},
 			},
-			expectErr: "providers.defaultCacheDuration: Invalid value: -1m0s: must be greater than or equal to 0",
+			expectErr: "providers.defaultCacheDuration: Invalid value: \"-1m0s\": must be greater than or equal to 0",
 		},
 		{
 			name: "invalid match image",

--- a/pkg/credentialprovider/plugin/config_test.go
+++ b/pkg/credentialprovider/plugin/config_test.go
@@ -889,7 +889,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 					},
 				},
 			},
-			expectErr: "providers.defaultCacheDuration: Invalid value: \"-1m0s\": defaultCacheDuration must be greater than or equal to 0",
+			expectErr: "providers.defaultCacheDuration: Invalid value: -1m0s: must be greater than or equal to 0",
 		},
 		{
 			name: "invalid match image",

--- a/pkg/kubelet/kubelet_server_journal.go
+++ b/pkg/kubelet/kubelet_server_journal.go
@@ -136,7 +136,7 @@ func newNodeLogQuery(query url.Values) (*nodeLogQuery, field.ErrorList) {
 	// Prevent specifying  an empty or blank space query.
 	// Example: kubectl get --raw /api/v1/nodes/$node/proxy/logs?query="   "
 	if ok && (len(nlq.Files) == 0 && len(nlq.Services) == 0) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("query"), queries, "query cannot be empty"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("query"), queries, "cannot be empty"))
 	}
 
 	var sinceTime time.Time
@@ -243,7 +243,7 @@ func (n *nodeLogQuery) validate() field.ErrorList {
 	}
 
 	if n.Boot != nil && runtime.GOOS == "windows" {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("boot"), *n.Boot, "boot is not supported on Windows"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("boot"), *n.Boot, "is not supported on Windows"))
 	}
 
 	if n.Boot != nil && *n.Boot > 0 {

--- a/pkg/kubelet/kubelet_server_journal.go
+++ b/pkg/kubelet/kubelet_server_journal.go
@@ -136,7 +136,7 @@ func newNodeLogQuery(query url.Values) (*nodeLogQuery, field.ErrorList) {
 	// Prevent specifying  an empty or blank space query.
 	// Example: kubectl get --raw /api/v1/nodes/$node/proxy/logs?query="   "
 	if ok && (len(nlq.Files) == 0 && len(nlq.Services) == 0) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("query"), queries, "cannot be empty"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("query"), queries, "may not be empty"))
 	}
 
 	var sinceTime time.Time
@@ -243,7 +243,7 @@ func (n *nodeLogQuery) validate() field.ErrorList {
 	}
 
 	if n.Boot != nil && runtime.GOOS == "windows" {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("boot"), *n.Boot, "is not supported on Windows"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("boot"), *n.Boot, "not supported on Windows"))
 	}
 
 	if n.Boot != nil && *n.Boot > 0 {

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -237,7 +237,7 @@ func validateCommonQueueSort(path *field.Path, profiles []config.KubeSchedulerPr
 			curr = profiles[i].Plugins.QueueSort
 		}
 		if !apiequality.Semantic.DeepEqual(canon, curr) {
-			errs = append(errs, field.Invalid(path.Index(i).Child("plugins", "queueSort"), curr, "queueSort must be the same for all profiles"))
+			errs = append(errs, field.Invalid(path.Index(i).Child("plugins", "queueSort"), curr, "must be the same for all profiles"))
 		}
 		for _, cfg := range profiles[i].PluginConfig {
 			if cfg.Name == queueSortName && !apiequality.Semantic.DeepEqual(queueSortArgs, cfg.Args) {

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -188,7 +188,7 @@ func validateFunctionShape(shape []config.UtilizationShapePoint, path *field.Pat
 
 	for i := 1; i < len(shape); i++ {
 		if shape[i-1].Utilization >= shape[i].Utilization {
-			allErrs = append(allErrs, field.Invalid(path.Index(i).Child("utilization"), shape[i].Utilization, "utilization values must be sorted in increasing order"))
+			allErrs = append(allErrs, field.Invalid(path.Index(i).Child("utilization"), shape[i].Utilization, "values must be sorted in increasing order"))
 			break
 		}
 	}

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -215,7 +215,7 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 			config: resourceNameNotSet,
 			wantErrs: field.ErrorList{
 				&field.Error{
-					Type:  field.ErrorTypeInvalid,
+					Type:  field.ErrorTypeRequired,
 					Field: "leaderElection.resourceName",
 				},
 			},
@@ -224,7 +224,7 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 			config: resourceNamespaceNotSet,
 			wantErrs: field.ErrorList{
 				&field.Error{
-					Type:  field.ErrorTypeInvalid,
+					Type:  field.ErrorTypeRequired,
 					Field: "leaderElection.resourceNamespace",
 				},
 			},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -304,7 +304,7 @@ func validateCustomResourceDefinitionVersion(ctx context.Context, version *apiex
 
 	if len(version.SelectableFields) > 0 {
 		if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields"), "", "selectableFields may only be set when version.schema.openAPIV3Schema is not included"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields"), "", "may only be set when version.schema.openAPIV3Schema is not included"))
 		} else {
 			schema, err := structuralschema.NewStructural(version.Schema.OpenAPIV3Schema)
 			if err != nil {
@@ -477,7 +477,7 @@ func validateCustomResourceDefinitionSpec(ctx context.Context, spec *apiextensio
 
 	if len(spec.SelectableFields) > 0 {
 		if spec.Validation == nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields"), "", "selectableFields may only be set when validations.schema is included"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields"), "", "may only be set when validations.schema is included"))
 		} else {
 			schema, err := structuralschema.NewStructural(spec.Validation.OpenAPIV3Schema)
 			if err != nil {
@@ -1203,9 +1203,9 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 			if len(trimmedRule) == 0 {
 				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Required(fldPath.Child("x-kubernetes-validations").Index(i).Child("rule"), "rule is not specified"))
 			} else if len(rule.Message) > 0 && len(trimmedMsg) == 0 {
-				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("message"), rule.Message, "message must be non-empty if specified"))
+				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("message"), rule.Message, "must be non-empty if specified"))
 			} else if hasNewlines(trimmedMsg) {
-				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("message"), rule.Message, "message must not contain line breaks"))
+				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("message"), rule.Message, "must not contain line breaks"))
 			} else if hasNewlines(trimmedRule) && len(trimmedMsg) == 0 {
 				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Required(fldPath.Child("x-kubernetes-validations").Index(i).Child("message"), "message must be specified if rule contains line breaks"))
 			}
@@ -1217,14 +1217,14 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 			}
 			trimmedFieldPath := strings.TrimSpace(rule.FieldPath)
 			if len(rule.FieldPath) > 0 && len(trimmedFieldPath) == 0 {
-				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("fieldPath"), rule.FieldPath, "fieldPath must be non-empty if specified"))
+				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("fieldPath"), rule.FieldPath, "must be non-empty if specified"))
 			}
 			if hasNewlines(rule.FieldPath) {
-				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("fieldPath"), rule.FieldPath, "fieldPath must not contain line breaks"))
+				allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("fieldPath"), rule.FieldPath, "must not contain line breaks"))
 			}
 			if len(rule.FieldPath) > 0 {
 				if !pathValid(schema, rule.FieldPath) {
-					allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("fieldPath"), rule.FieldPath, "fieldPath must be a valid path"))
+					allErrs.SchemaErrors = append(allErrs.SchemaErrors, field.Invalid(fldPath.Child("x-kubernetes-validations").Index(i).Child("fieldPath"), rule.FieldPath, "must be a valid path"))
 				}
 
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -304,7 +304,7 @@ func validateCustomResourceDefinitionVersion(ctx context.Context, version *apiex
 
 	if len(version.SelectableFields) > 0 {
 		if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields"), "", "may only be set when version.schema.openAPIV3Schema is not included"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("selectableFields"), "", "may only be set when `version.schema.openAPIV3Schema` is not included"))
 		} else {
 			schema, err := structuralschema.NewStructural(version.Schema.OpenAPIV3Schema)
 			if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -74,13 +74,13 @@ func validateOwnerReference(ownerReference metav1.OwnerReference, fldPath *field
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("apiVersion"), ownerReference.APIVersion, "version must not be empty"))
 	}
 	if len(gvk.Kind) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), ownerReference.Kind, "kind must not be empty"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), ownerReference.Kind, "must not be empty"))
 	}
 	if len(ownerReference.Name) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ownerReference.Name, "name must not be empty"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ownerReference.Name, "must not be empty"))
 	}
 	if len(ownerReference.UID) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("uid"), ownerReference.UID, "uid must not be empty"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("uid"), ownerReference.UID, "must not be empty"))
 	}
 	if _, ok := BannedOwners[gvk]; ok {
 		allErrs = append(allErrs, field.Invalid(fldPath, ownerReference, fmt.Sprintf("%s is disallowed from being an owner", gvk)))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -241,7 +241,7 @@ func validateClaimValidationRules(compiler authenticationcel.Compiler, state *va
 		fldPath := fldPath.Index(i)
 
 		if len(rule.Expression) > 0 && !structuredAuthnFeatureEnabled {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("expression"), rule.Expression, "expression is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("expression"), rule.Expression, "is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 
 		switch {
@@ -251,7 +251,7 @@ func validateClaimValidationRules(compiler authenticationcel.Compiler, state *va
 			allErrs = append(allErrs, field.Required(fldPath, "claim or expression is required"))
 		case len(rule.Claim) > 0:
 			if len(rule.Message) > 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("message"), rule.Message, "message can't be set when claim is set"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("message"), rule.Message, "can't be set when claim is set"))
 			}
 			if seenClaims.Has(rule.Claim) {
 				allErrs = append(allErrs, field.Duplicate(fldPath.Child("claim"), rule.Claim))
@@ -259,7 +259,7 @@ func validateClaimValidationRules(compiler authenticationcel.Compiler, state *va
 			seenClaims.Insert(rule.Claim)
 		case len(rule.Expression) > 0:
 			if len(rule.RequiredValue) > 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("requiredValue"), rule.RequiredValue, "requiredValue can't be set when expression is set"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("requiredValue"), rule.RequiredValue, "can't be set when expression is set"))
 			}
 			if seenExpressions.Has(rule.Expression) {
 				allErrs = append(allErrs, field.Duplicate(fldPath.Child("expression"), rule.Expression))
@@ -295,16 +295,16 @@ func validateClaimMappings(compiler authenticationcel.Compiler, state *validatio
 
 	if !structuredAuthnFeatureEnabled {
 		if len(m.Username.Expression) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("username").Child("expression"), m.Username.Expression, "expression is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("username").Child("expression"), m.Username.Expression, "is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 		if len(m.Groups.Expression) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("groups").Child("expression"), m.Groups.Expression, "expression is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("groups").Child("expression"), m.Groups.Expression, "is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 		if len(m.UID.Claim) > 0 || len(m.UID.Expression) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("uid"), "", "uid claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("uid"), "", "claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 		if len(m.Extra) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("extra"), "", "extra claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("extra"), "", "claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 	}
 
@@ -350,7 +350,7 @@ func validateClaimMappings(compiler authenticationcel.Compiler, state *validatio
 		// IsDomainPrefixedPath checks for non-empty key and that the key is prefixed with a domain name.
 		allErrs = append(allErrs, utilvalidation.IsDomainPrefixedPath(fldPath.Child("key"), mapping.Key)...)
 		if mapping.Key != strings.ToLower(mapping.Key) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), mapping.Key, "key must be lowercase"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), mapping.Key, "must be lowercase"))
 		}
 
 		if isKubernetesDomainPrefix(mapping.Key) {
@@ -532,7 +532,7 @@ func validatePrefixClaimOrExpression(compiler authenticationcel.Compiler, mappin
 		var err *field.Error
 
 		if mapping.Prefix != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("prefix"), *mapping.Prefix, "prefix can't be set when expression is set"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("prefix"), *mapping.Prefix, "can't be set when expression is set"))
 		}
 		compilationResult, err = compileClaimsCELExpression(compiler, &authenticationcel.ClaimMappingExpression{
 			Expression: mapping.Expression,
@@ -753,7 +753,7 @@ func compileMatchConditions(compiler authorizationcel.Compiler, matchConditions 
 	var allErrs field.ErrorList
 	// should fail when match conditions are used without feature enabled
 	if len(matchConditions) > 0 && !structuredAuthzFeatureEnabled {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("matchConditions"), "", "matchConditions are not supported when StructuredAuthorizationConfiguration feature gate is disabled"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("matchConditions"), "", "are not supported when StructuredAuthorizationConfiguration feature gate is disabled"))
 	}
 	if len(matchConditions) > 64 {
 		allErrs = append(allErrs, field.TooMany(fldPath.Child("matchConditions"), len(matchConditions), 64))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -241,7 +241,7 @@ func validateClaimValidationRules(compiler authenticationcel.Compiler, state *va
 		fldPath := fldPath.Index(i)
 
 		if len(rule.Expression) > 0 && !structuredAuthnFeatureEnabled {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("expression"), rule.Expression, "is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("expression"), rule.Expression, "not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 
 		switch {
@@ -251,7 +251,7 @@ func validateClaimValidationRules(compiler authenticationcel.Compiler, state *va
 			allErrs = append(allErrs, field.Required(fldPath, "claim or expression is required"))
 		case len(rule.Claim) > 0:
 			if len(rule.Message) > 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("message"), rule.Message, "can't be set when claim is set"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("message"), rule.Message, "may not be specified when claim is set"))
 			}
 			if seenClaims.Has(rule.Claim) {
 				allErrs = append(allErrs, field.Duplicate(fldPath.Child("claim"), rule.Claim))
@@ -259,7 +259,7 @@ func validateClaimValidationRules(compiler authenticationcel.Compiler, state *va
 			seenClaims.Insert(rule.Claim)
 		case len(rule.Expression) > 0:
 			if len(rule.RequiredValue) > 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("requiredValue"), rule.RequiredValue, "can't be set when expression is set"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("requiredValue"), rule.RequiredValue, "may not be specified when expression is set"))
 			}
 			if seenExpressions.Has(rule.Expression) {
 				allErrs = append(allErrs, field.Duplicate(fldPath.Child("expression"), rule.Expression))
@@ -295,10 +295,10 @@ func validateClaimMappings(compiler authenticationcel.Compiler, state *validatio
 
 	if !structuredAuthnFeatureEnabled {
 		if len(m.Username.Expression) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("username").Child("expression"), m.Username.Expression, "is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("username").Child("expression"), m.Username.Expression, "not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 		if len(m.Groups.Expression) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("groups").Child("expression"), m.Groups.Expression, "is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("groups").Child("expression"), m.Groups.Expression, "not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
 		}
 		if len(m.UID.Claim) > 0 || len(m.UID.Expression) > 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("uid"), "", "claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled"))
@@ -532,7 +532,7 @@ func validatePrefixClaimOrExpression(compiler authenticationcel.Compiler, mappin
 		var err *field.Error
 
 		if mapping.Prefix != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("prefix"), *mapping.Prefix, "can't be set when expression is set"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("prefix"), *mapping.Prefix, "may not be specified when expression is set"))
 		}
 		compilationResult, err = compileClaimsCELExpression(compiler, &authenticationcel.ClaimMappingExpression{
 			Expression: mapping.Expression,
@@ -753,7 +753,7 @@ func compileMatchConditions(compiler authorizationcel.Compiler, matchConditions 
 	var allErrs field.ErrorList
 	// should fail when match conditions are used without feature enabled
 	if len(matchConditions) > 0 && !structuredAuthzFeatureEnabled {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("matchConditions"), "", "are not supported when StructuredAuthorizationConfiguration feature gate is disabled"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("matchConditions"), "", "not supported when StructuredAuthorizationConfiguration feature gate is disabled"))
 	}
 	if len(matchConditions) > 64 {
 		allErrs = append(allErrs, field.TooMany(fldPath.Child("matchConditions"), len(matchConditions), 64))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -990,7 +990,7 @@ func TestValidateClaimValidationRules(t *testing.T) {
 				{Claim: "claim", Message: "message"},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimValidationRules[0].message: Invalid value: "message": can't be set when claim is set`,
+			want:                          `issuer.claimValidationRules[0].message: Invalid value: "message": may not be specified when claim is set`,
 		},
 		{
 			name: "requiredValue set when expression is set",
@@ -998,7 +998,7 @@ func TestValidateClaimValidationRules(t *testing.T) {
 				{Expression: "claims.foo == 'bar'", RequiredValue: "value"},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimValidationRules[0].requiredValue: Invalid value: "value": can't be set when expression is set`,
+			want:                          `issuer.claimValidationRules[0].requiredValue: Invalid value: "value": may not be specified when expression is set`,
 		},
 		{
 			name: "duplicate claim",
@@ -1024,7 +1024,7 @@ func TestValidateClaimValidationRules(t *testing.T) {
 				{Expression: "claims.foo == 'bar'"},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want:                          `issuer.claimValidationRules[0].expression: Invalid value: "claims.foo == 'bar'": is not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
+			want:                          `issuer.claimValidationRules[0].expression: Invalid value: "claims.foo == 'bar'": not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
 		},
 		{
 			name: "CEL expression compilation error",
@@ -1141,7 +1141,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimMappings.username.prefix: Invalid value: "prefix": can't be set when expression is set`,
+			want:                          `issuer.claimMappings.username.prefix: Invalid value: "prefix": may not be specified when expression is set`,
 		},
 		{
 			name: "username prefix is nil when claim is set",
@@ -1193,7 +1193,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimMappings.groups.prefix: Invalid value: "prefix": can't be set when expression is set`,
+			want:                          `issuer.claimMappings.groups.prefix: Invalid value: "prefix": may not be specified when expression is set`,
 		},
 		{
 			name: "groups prefix is nil when claim is set",
@@ -1308,7 +1308,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want: `[issuer.claimMappings.username.expression: Invalid value: "foo.bar": is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.username.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
+			want: `[issuer.claimMappings.username.expression: Invalid value: "foo.bar": not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.username.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
  | foo.bar
  | ^]`,
 		},
@@ -1324,7 +1324,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want: `[issuer.claimMappings.groups.expression: Invalid value: "foo.bar": is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.groups.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
+			want: `[issuer.claimMappings.groups.expression: Invalid value: "foo.bar": not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.groups.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
  | foo.bar
  | ^]`,
 		},

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -990,7 +990,7 @@ func TestValidateClaimValidationRules(t *testing.T) {
 				{Claim: "claim", Message: "message"},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimValidationRules[0].message: Invalid value: "message": message can't be set when claim is set`,
+			want:                          `issuer.claimValidationRules[0].message: Invalid value: "message": can't be set when claim is set`,
 		},
 		{
 			name: "requiredValue set when expression is set",
@@ -998,7 +998,7 @@ func TestValidateClaimValidationRules(t *testing.T) {
 				{Expression: "claims.foo == 'bar'", RequiredValue: "value"},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimValidationRules[0].requiredValue: Invalid value: "value": requiredValue can't be set when expression is set`,
+			want:                          `issuer.claimValidationRules[0].requiredValue: Invalid value: "value": can't be set when expression is set`,
 		},
 		{
 			name: "duplicate claim",
@@ -1024,7 +1024,7 @@ func TestValidateClaimValidationRules(t *testing.T) {
 				{Expression: "claims.foo == 'bar'"},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want:                          `issuer.claimValidationRules[0].expression: Invalid value: "claims.foo == 'bar'": expression is not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
+			want:                          `issuer.claimValidationRules[0].expression: Invalid value: "claims.foo == 'bar'": is not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
 		},
 		{
 			name: "CEL expression compilation error",
@@ -1141,7 +1141,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimMappings.username.prefix: Invalid value: "prefix": prefix can't be set when expression is set`,
+			want:                          `issuer.claimMappings.username.prefix: Invalid value: "prefix": can't be set when expression is set`,
 		},
 		{
 			name: "username prefix is nil when claim is set",
@@ -1193,7 +1193,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimMappings.groups.prefix: Invalid value: "prefix": prefix can't be set when expression is set`,
+			want:                          `issuer.claimMappings.groups.prefix: Invalid value: "prefix": can't be set when expression is set`,
 		},
 		{
 			name: "groups prefix is nil when claim is set",
@@ -1308,7 +1308,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want: `[issuer.claimMappings.username.expression: Invalid value: "foo.bar": expression is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.username.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
+			want: `[issuer.claimMappings.username.expression: Invalid value: "foo.bar": is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.username.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
  | foo.bar
  | ^]`,
 		},
@@ -1324,7 +1324,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want: `[issuer.claimMappings.groups.expression: Invalid value: "foo.bar": expression is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.groups.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
+			want: `[issuer.claimMappings.groups.expression: Invalid value: "foo.bar": is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.groups.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
  | foo.bar
  | ^]`,
 		},
@@ -1340,7 +1340,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want: `[issuer.claimMappings.uid: Invalid value: "": uid claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.uid.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
+			want: `[issuer.claimMappings.uid: Invalid value: "": claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled, issuer.claimMappings.uid.expression: Invalid value: "foo.bar": compilation failed: ERROR: <input>:1:1: undeclared reference to 'foo' (in container '')
  | foo.bar
  | ^]`,
 		},
@@ -1356,7 +1356,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want:                          `issuer.claimMappings.uid: Invalid value: "": uid claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
+			want:                          `issuer.claimMappings.uid: Invalid value: "": claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
 		},
 		{
 			name: "extra mapping is invalid when structured authn feature is disabled",
@@ -1370,7 +1370,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: false,
-			want:                          `issuer.claimMappings.extra: Invalid value: "": extra claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
+			want:                          `issuer.claimMappings.extra: Invalid value: "": claim mapping is not supported when StructuredAuthenticationConfiguration feature gate is disabled`,
 		},
 		{
 			name: "duplicate extra mapping key",
@@ -1407,7 +1407,7 @@ func TestValidateClaimMappings(t *testing.T) {
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
-			want:                          `issuer.claimMappings.extra[0].key: Invalid value: "example.org/Foo": key must be lowercase`,
+			want:                          `issuer.claimMappings.extra[0].key: Invalid value: "example.org/Foo": must be lowercase`,
 		},
 		{
 			name: "extra mapping key prefix is k8.io",

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
@@ -165,7 +165,7 @@ func validateDirectConnection(connection apiserver.Connection, fldPath *field.Pa
 		return field.ErrorList{field.Invalid(
 			fldPath.Child("transport"),
 			"direct",
-			"Transport config should be absent for direct connect"),
+			"config should be absent for direct connect"),
 		}
 	}
 
@@ -178,7 +178,7 @@ func validateUDSConnection(udsConfig *apiserver.UDSTransport, fldPath *field.Pat
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("udsName"),
 			"nil",
-			"UDSName should be present for UDS connections"))
+			"should be present for UDS connections"))
 	}
 	return allErrs
 }
@@ -191,7 +191,7 @@ func validateTCPConnection(tcpConfig *apiserver.TCPTransport, fldPath *field.Pat
 			allErrs = append(allErrs, field.Invalid(
 				fldPath.Child("tlsConfig"),
 				"nil",
-				"TLSConfig config should not be present when using HTTP"))
+				"config should not be present when using HTTP"))
 		}
 	} else if strings.HasPrefix(tcpConfig.URL, "https://") {
 		return validateTLSConfig(tcpConfig.TLSConfig, fldPath)

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
@@ -165,7 +165,7 @@ func validateDirectConnection(connection apiserver.Connection, fldPath *field.Pa
 		return field.ErrorList{field.Invalid(
 			fldPath.Child("transport"),
 			"direct",
-			"config should be absent for direct connect"),
+			"config must be absent for direct connect"),
 		}
 	}
 
@@ -178,7 +178,7 @@ func validateUDSConnection(udsConfig *apiserver.UDSTransport, fldPath *field.Pat
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("udsName"),
 			"nil",
-			"should be present for UDS connections"))
+			"must be present for UDS connections"))
 	}
 	return allErrs
 }
@@ -191,7 +191,7 @@ func validateTCPConnection(tcpConfig *apiserver.TCPTransport, fldPath *field.Pat
 			allErrs = append(allErrs, field.Invalid(
 				fldPath.Child("tlsConfig"),
 				"nil",
-				"config should not be present when using HTTP"))
+				"config must not be present when using HTTP"))
 		}
 	} else if strings.HasPrefix(tcpConfig.URL, "https://") {
 		return validateTLSConfig(tcpConfig.TLSConfig, fldPath)

--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -49,13 +49,13 @@ func ValidateLeaderElectionConfiguration(cc *config.LeaderElectionConfiguration,
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "must be greater than `RenewDeadline`"))
 	}
 	if len(cc.ResourceLock) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceLock"), cc.ResourceLock, "is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceLock"), ""))
 	}
 	if len(cc.ResourceNamespace) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceNamespace"), cc.ResourceNamespace, "is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceNamespace"), ""))
 	}
 	if len(cc.ResourceName) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceName"), cc.ResourceName, "is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceName"), ""))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -46,16 +46,16 @@ func ValidateLeaderElectionConfiguration(cc *config.LeaderElectionConfiguration,
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("retryPeriod"), cc.RetryPeriod, "must be greater than zero"))
 	}
 	if cc.LeaseDuration.Duration <= cc.RenewDeadline.Duration {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "LeaseDuration must be greater than RenewDeadline"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "must be greater than RenewDeadline"))
 	}
 	if len(cc.ResourceLock) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceLock"), cc.ResourceLock, "resourceLock is required"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceLock"), cc.ResourceLock, "is required"))
 	}
 	if len(cc.ResourceNamespace) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceNamespace"), cc.ResourceNamespace, "resourceNamespace is required"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceNamespace"), cc.ResourceNamespace, "is required"))
 	}
 	if len(cc.ResourceName) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceName"), cc.ResourceName, "resourceName is required"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceName"), cc.ResourceName, "is required"))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -46,7 +46,7 @@ func ValidateLeaderElectionConfiguration(cc *config.LeaderElectionConfiguration,
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("retryPeriod"), cc.RetryPeriod, "must be greater than zero"))
 	}
 	if cc.LeaseDuration.Duration <= cc.RenewDeadline.Duration {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "must be greater than RenewDeadline"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "must be greater than `RenewDeadline`"))
 	}
 	if len(cc.ResourceLock) == 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceLock"), cc.ResourceLock, "is required"))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This pull request addresses issue https://github.com/kubernetes/kubernetes/issues/111698 by removing redundant field name from `field.Invalid` detail message. It also modifies the detail message of the changed field to comply with validation [api-convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#validation).

Validation error message for invalid field already includes the field name,  a duplicate field name included in the detail message is unnecessary.

#### Which issue(s) this PR is related to:

Fixes #111698 


#### Special notes for your reviewer:

Here is a list of all the instances of `field.Invalid`: https://gist.github.com/xiaoweim/a5df612c03cead0293ecf25a8ea8b28e

#### Does this PR introduce a user-facing change?

```release-note
Simplied validation error message for invalid fields by removing redundant field name.
```

