### PR TITLE
Update test/e2e/node/events.go with gomega.Eventually

### DIFF
--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -90,7 +90,7 @@ var _ = SIGDescribe("Events", func() {
 			framework.Failf("Failed to get pod: %v", err)
 		}
 		framework.Logf("%+v\n", podWithUID)
-		var events *v1.EventList
+
 		// Check for scheduler event about the pod.
 		ginkgo.By("checking for scheduler event about the pod")
 		schedulerSelector := fields.Set{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

The PR involves replacing the use of wait.Poll with  gomega.Eventually in-place.

/kind cleanup

#### What this PR does / why we need it:

The PR improves tests debuggability by improving the logging in case test fails due to timeouts. 

#### Which issue(s) this PR is related to:

#106575

#### Special notes for your reviewer: 

First time contributor :)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

