### PR TITLE
 Fixing go-vet finding  "call of reflect.DeepEqual copies lock value"…

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/desc_test.go
+++ b/staging/src/k8s.io/component-base/metrics/desc_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -150,15 +149,13 @@ func TestDescClearState(t *testing.T) {
 		tc := test
 		t.Run(tc.name, func(t *testing.T) {
 			descA := NewDesc(tc.fqName, tc.help, nil, nil, tc.stabilityLevel, tc.deprecatedVersion)
-			descB := NewDesc(tc.fqName, tc.help, nil, nil, tc.stabilityLevel, tc.deprecatedVersion)
-
 			descA.create(&currentVersion)
+
 			descA.ClearState()
 
-			// create
-			//nolint:govet // it's okay to compare sync.RWMutex, it's empty
-			if !reflect.DeepEqual(*descA, *descB) {
-				t.Fatal("descriptor state hasn't be cleaned up")
+			if descA.IsCreated() || descA.IsDeprecated() || descA.IsHidden() {
+				t.Fatalf("descriptor state hasn't be cleaned up; is created: %v, is deprecated: %v, is hidden: %v", descA.IsCreated(), descA.IsDeprecated(), descA.IsHidden())
+
 			}
 		})
 	}


### PR DESCRIPTION
… by just asserting on the basic fields that should be reset when ClearState() is called

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
Fixing go vet copylock findings in staging/src/k8s.io/component-base/metrics.
Remove reflect.deepequals which triggers the finding as it copies locks and just assert the basic fields that the ClearState() method would reset.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #132464 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
