### PR TITLE
modify the comment of DistributeCPUsAcrossCoresOption

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -242,10 +242,10 @@ func (s sortCPUsSpread) sort() []int {
 //
 // - CPUSortingOptionPacked sorts CPUs in a packed manner, where CPUs are grouped by core
 // before moving to the next core, resulting in packed cores, like:
-// 0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11
+// 0, 6, 2, 8, 4, 10, 1, 7, 3, 9, 5, 11
 // - CPUSortingOptionSpread sorts CPUs in a spread manner, where CPUs are spread across cores
 // before moving to the next CPU, resulting in spread-out cores, like:
-// 0, 6, 2, 8, 4, 10, 1, 7, 3, 9, 5, 11
+// 0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11
 //
 // By default, CPUSortingOptionPacked will be used, and CPUSortingOptionSpread will only be activated
 // when the user specifies the `DistributeCPUsAcrossCoresOption` static policy option.

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -651,7 +651,7 @@ func (p *staticPolicy) GetPodTopologyHints(s state.State, pod *v1.Pod) map[strin
 }
 
 // generateCPUTopologyHints generates a set of TopologyHints given the set of
-// available CPUs and the number of CPUs being requested.
+// available CPUs, a set of reusable CPUs and the number of CPUs being requested.
 //
 // It follows the convention of marking all hints that have the same number of
 // bits set as the narrowest matching NUMANodeAffinity with 'Preferred: true', and


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Correct the description of the DistributeCPUsAcrossCoresOption function to avoid confusion of understanding.

#### Which issue(s) this PR is related to:
CPUSortingOptionPacked sorts CPUs in a packed manner, where CPUs are grouped by core before moving to the next core, resulting in packed cores, like: 0, 6, 2, 8, 4, 10, 1, 7, 3, 9, 5, 11, not like 0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11.
CPUSortingOptionSpread sorts CPUs in a spread manner, where CPUs are spread across cores before moving to the next CPU, resulting in spread-out cores, like: 0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11, not like 0, 6, 2, 8, 4, 10, 1, 7, 3, 9, 5, 11.
