### PR TITLE
cleanup: Migrate more usages of deprecated function ExtractCommentTags

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	codegennamer "k8s.io/code-generator/pkg/namer"
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
@@ -275,14 +276,18 @@ NextGroup:
 // first field (somegroup) as the name of the group in Go code, e.g. as the func name in a clientset.
 //
 // If the first field of the groupName is not unique within the clientset, use "// +groupName=unique
-func applyGroupOverrides(universe types.Universe, args *args.Args) {
+func applyGroupOverrides(universe types.Universe, args *args.Args) error {
 	// Create a map from "old GV" to "new GV" so we know what changes we need to make.
 	changes := make(map[clientgentypes.GroupVersion]clientgentypes.GroupVersion)
 	for gv, inputDir := range args.GroupVersionPackages() {
 		p := universe.Package(inputDir)
-		if override := gengo.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
+		override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupName"}, p.Comments)
+		if err != nil {
+			return fmt.Errorf("cannot extract groupName tags: %w", err)
+		}
+		if override["groupName"] != nil {
 			newGV := clientgentypes.GroupVersion{
-				Group:   clientgentypes.Group(override[0]),
+				Group:   clientgentypes.Group(override["groupName"][0]),
 				Version: gv.Version,
 			}
 			changes[gv] = newGV
@@ -310,6 +315,7 @@ func applyGroupOverrides(universe types.Universe, args *args.Args) {
 		}
 	}
 	args.Groups = newGroups
+	return nil
 }
 
 // Because we try to assemble inputs from an input-base and a set of
@@ -353,7 +359,9 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 	if err := sanitizePackagePaths(context, args); err != nil {
 		klog.Fatalf("cannot sanitize inputs: %v", err)
 	}
-	applyGroupOverrides(context.Universe, args)
+	if err := applyGroupOverrides(context.Universe, args); err != nil {
+		klog.Fatalf("cannot apply group overrides: %v", err)
+	}
 
 	gvToTypes := map[clientgentypes.GroupVersion][]*types.Type{}
 	groupGoNames := make(map[clientgentypes.GroupVersion]string)
@@ -363,8 +371,12 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 		// If there's a comment of the form "// +groupGoName=SomeUniqueShortName", use that as
 		// the Go group identifier in CamelCase. It defaults
 		groupGoNames[gv] = namer.IC(strings.Split(gv.Group.NonEmpty(), ".")[0])
-		if override := gengo.ExtractCommentTags("+", p.Comments)["groupGoName"]; override != nil {
-			groupGoNames[gv] = namer.IC(override[0])
+		override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupGoName"}, p.Comments)
+		if err != nil {
+			klog.Fatalf("cannot extract groupGoName tags: %v", err)
+		}
+		if override["groupGoName"] != nil {
+			groupGoNames[gv] = namer.IC(override["groupGoName"][0])
 		}
 
 		for n, t := range p.Types {

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
@@ -54,21 +54,24 @@ func extractEnabledTypeTag(t *types.Type) *enabledTagValue {
 }
 
 func extractEnabledTag(comments []string) *enabledTagValue {
-	tagVals := gengo.ExtractCommentTags("+", comments)[tagEnabledName]
-	if tagVals == nil {
+	tags, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{tagEnabledName}, comments)
+	if err != nil {
+		klog.Fatalf("Error extracting %s tags: %v", tagEnabledName, err)
+	}
+	if tags[tagEnabledName] == nil {
 		// No match for the tag.
 		return nil
 	}
 	// If there are multiple values, abort.
-	if len(tagVals) > 1 {
-		klog.Fatalf("Found %d %s tags: %q", len(tagVals), tagEnabledName, tagVals)
+	if len(tags[tagEnabledName]) > 1 {
+		klog.Fatalf("Found %d %s tags: %q", len(tags[tagEnabledName]), tagEnabledName, tags[tagEnabledName])
 	}
 
 	// If we got here we are returning something.
 	tag := &enabledTagValue{}
 
 	// Get the primary value.
-	parts := strings.Split(tagVals[0], ",")
+	parts := strings.Split(tags[tagEnabledName][0], ",")
 	if len(parts) >= 1 {
 		tag.value = parts[0]
 	}
@@ -452,8 +455,11 @@ func (g *genDeepCopy) needsGeneration(t *types.Type) bool {
 func extractInterfacesTag(t *types.Type) []string {
 	var result []string
 	comments := append(append([]string{}, t.SecondClosestCommentLines...), t.CommentLines...)
-	values := gengo.ExtractCommentTags("+", comments)[interfacesTagName]
-	for _, v := range values {
+	tags, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{interfacesTagName}, comments)
+	if err != nil {
+		klog.Fatalf("Error extracting %s tags: %v", interfacesTagName, err)
+	}
+	for _, v := range tags[interfacesTagName] {
 		if len(v) == 0 {
 			continue
 		}

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
@@ -80,17 +81,20 @@ func (g *genProtoIDL) Namers(c *generator.Context) namer.NameSystems {
 
 // Filter ignores types that are identified as not exportable.
 func (g *genProtoIDL) Filter(c *generator.Context, t *types.Type) bool {
-	tagVals := gengo.ExtractCommentTags("+", t.CommentLines)["protobuf"]
-	if tagVals != nil {
-		if tagVals[0] == "false" {
+	tags, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"protobuf"}, t.CommentLines)
+	if err != nil {
+		klog.Fatalf(`Error extracting tag "protobuf": %v`, err)
+	}
+	if tags["protobuf"] != nil {
+		if tags["protobuf"][0] == "false" {
 			// Type specified "false".
 			return false
 		}
-		if tagVals[0] == "true" {
+		if tags["protobuf"][0] == "true" {
 			// Type specified "true".
 			return true
 		}
-		klog.Fatalf(`Comment tag "protobuf" must be true or false, found: %q`, tagVals[0])
+		klog.Fatalf(`Comment tag "protobuf" must be true or false, found: %q`, tags["protobuf"][0])
 	}
 	if !g.generateAll {
 		// We're not generating everything.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/targets.go
@@ -144,15 +144,23 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 		// If there's a comment of the form "// +groupName=somegroup" or
 		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
 		// group when generating.
-		if override := gengo.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
-			gv.Group = clientgentypes.Group(override[0])
+		override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupName"}, p.Comments)
+		if err != nil {
+			klog.Fatalf("error extracting groupName tags: %v", err)
+		}
+		if override["groupName"] != nil {
+			gv.Group = clientgentypes.Group(override["groupName"][0])
 		}
 
 		// If there's a comment of the form "// +groupGoName=SomeUniqueShortName", use that as
 		// the Go group identifier in CamelCase. It defaults
 		groupGoNames[groupPackageName] = namer.IC(strings.Split(gv.Group.NonEmpty(), ".")[0])
-		if override := gengo.ExtractCommentTags("+", p.Comments)["groupGoName"]; override != nil {
-			groupGoNames[groupPackageName] = namer.IC(override[0])
+		override, err = genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupGoName"}, p.Comments)
+		if err != nil {
+			klog.Fatalf("error extracting groupGoName tags: %v", err)
+		}
+		if override["groupGoName"] != nil {
+			groupGoNames[groupPackageName] = namer.IC(override["groupGoName"][0])
 		}
 
 		var typesToGenerate []*types.Type

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/code-generator/cmd/lister-gen/args"
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
@@ -101,8 +102,12 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 		// If there's a comment of the form "// +groupName=somegroup" or
 		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
 		// group when generating.
-		if override := gengo.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
-			gv.Group = clientgentypes.Group(strings.SplitN(override[0], ".", 2)[0])
+		override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupName"}, p.Comments)
+		if err != nil {
+			klog.Fatalf("error extracting groupName tags: %v", err)
+		}
+		if override["groupName"] != nil {
+			gv.Group = clientgentypes.Group(strings.SplitN(override["groupName"][0], ".", 2)[0])
 		}
 
 		var typesToGenerate []*types.Type

--- a/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
+++ b/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
@@ -137,21 +137,24 @@ func extractReplacementTag(t *types.Type) (group, version, kind string, hasRepla
 }
 
 func extractTag(tagName string, comments []string) *tagValue {
-	tagVals := gengo.ExtractCommentTags("+", comments)[tagName]
-	if tagVals == nil {
+	tags, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{tagName}, comments)
+	if err != nil {
+		klog.Fatalf("Error extracting %s tags: %v", tagName, err)
+	}
+	if tags[tagName] == nil {
 		// No match for the tag.
 		return nil
 	}
 	// If there are multiple values, abort.
-	if len(tagVals) > 1 {
-		klog.Fatalf("Found %d %s tags: %q", len(tagVals), tagName, tagVals)
+	if len(tags[tagName]) > 1 {
+		klog.Fatalf("Found %d %s tags: %q", len(tags[tagName]), tagName, tags[tagName])
 	}
 
 	// If we got here we are returning something.
 	tag := &tagValue{}
 
 	// Get the primary value.
-	parts := strings.Split(tagVals[0], ",")
+	parts := strings.Split(tags[tagName][0], ",")
 	if len(parts) >= 1 {
 		tag.value = parts[0]
 	}

--- a/staging/src/k8s.io/code-generator/cmd/register-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/register-gen/generators/targets.go
@@ -26,6 +26,7 @@ import (
 
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/code-generator/cmd/register-gen/args"
+	genutil "k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
@@ -83,8 +84,13 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 
 			// if there is a comment of the form "// +groupName=somegroup" or "// +groupName=somegroup.foo.bar.io",
 			// extract the fully qualified API group name from it and overwrite the group inferred from the package path
-			if override := gengo.ExtractCommentTags("+", pkg.Comments)["groupName"]; override != nil {
-				groupName := override[0]
+			override, err := genutil.ExtractCommentTagsWithoutArguments("+", []string{"groupName"}, pkg.Comments)
+			if err != nil {
+				klog.Errorf("error extracting groupName tags: %v", err)
+				continue
+			}
+			if override["groupName"] != nil {
+				groupName := override["groupName"][0]
 				klog.V(5).Infof("overriding the group name with = %s", groupName)
 				gv.Group = clientgentypes.Group(groupName)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

[ExtractCommentTags](https://pkg.go.dev/k8s.io/gengo/v2#ExtractCommentTags) is deprecated, and we need to migrate the usages to ExtractFunctionStyleCommentTags.

This is a continuation of #131711.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Part of #130358

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
