### PR TITLE
Enable OpenAPI formats immediately at release version

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -45,6 +45,7 @@ import (
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
 	apiservercel "k8s.io/apiserver/pkg/cel"
 	"k8s.io/apiserver/pkg/cel/environment"
+	"k8s.io/apiserver/pkg/util/compatibility"
 	"k8s.io/apiserver/pkg/util/webhook"
 )
 
@@ -963,7 +964,7 @@ func validateCustomResourceDefinitionValidation(ctx context.Context, customResou
 
 	// if validation passed otherwise, make sure we can actually construct a schema validator from this custom resource validation.
 	if len(allErrs) == 0 {
-		if _, _, err := apiservervalidation.NewSchemaValidator(customResourceValidation.OpenAPIV3Schema); err != nil {
+		if _, _, err := apiservervalidation.NewSchemaValidatorForVersion(customResourceValidation.OpenAPIV3Schema, compatibility.KubeComponentEffectiveVersion(compatibility.DefaultComponentGlobalsRegistry).EmulationVersion()); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath, "", fmt.Sprintf("error building validator: %v", err)))
 		}
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/validation.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	"k8s.io/apiserver/pkg/util/compatibility"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
@@ -73,7 +74,8 @@ func validate(ctx context.Context, pth *field.Path, s *structuralschema.Structur
 	isResourceRoot := s == rootSchema
 
 	if s.Default.Object != nil {
-		validator := apiservervalidation.NewSchemaValidatorFromOpenAPI(s.ToKubeOpenAPI())
+		formatRegistry := apiservervalidation.NewVersionedRegistry(compatibility.KubeComponentEffectiveVersion(compatibility.DefaultComponentGlobalsRegistry).EmulationVersion())
+		validator := apiservervalidation.NewSchemaValidatorFromOpenAPI(s.ToKubeOpenAPI(), formatRegistry)
 
 		if insideMeta {
 			obj, _, err := f(runtime.DeepCopyJSONValue(s.Default.Object))

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
@@ -90,14 +90,14 @@ func StripUnsupportedFormatsPostProcess(s *spec.Schema) error {
 
 // StripUnsupportedFormatsPostProcessorForVersion determines the supported formats at the given compatibility version and
 // sets unsupported formats to empty string.
-func StripUnsupportedFormatsPostProcessorForVersion(compatibilityVersion *version.Version) func(s *spec.Schema) error {
+func StripUnsupportedFormatsPostProcessorForVersion(emulationVersion *version.Version) func(s *spec.Schema) error {
 	return func(s *spec.Schema) error {
 		if len(s.Format) == 0 {
 			return nil
 		}
 
 		normalized := strings.ReplaceAll(s.Format, "-", "") // go-openapi default format name normalization
-		if !supportedFormatsAtVersion(compatibilityVersion).supported.Has(normalized) {
+		if !supportedFormatsAtVersion(emulationVersion).supported.Has(normalized) {
 			s.Format = ""
 		}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/metrics_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/metrics_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics"
@@ -254,7 +255,7 @@ func TestMetrics(t *testing.T) {
 			ms := testMetrics.Reset()
 			testRegistry.MustRegister(ms...)
 
-			schemaValidator, _, err := validation.NewSchemaValidator(&tt.schema)
+			schemaValidator, _, err := validation.NewSchemaValidatorForVersion(&tt.schema, version.MustParse("1.27.0"))
 			if err != nil {
 				t.Fatal(err)
 				return

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/cel/common"
-	"k8s.io/apiserver/pkg/util/compatibility"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	openapierrors "k8s.io/kube-openapi/pkg/validation/errors"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -92,13 +91,15 @@ func (s basicSchemaValidator) ValidateUpdate(new, old interface{}, options ...Va
 	return s.Validate(new, options...)
 }
 
-// NewSchemaValidator creates an openapi schema validator for the given CRD validation using environment.DefaultCompatibilityVersion().
+// NewSchemaValidator creates an openapi schema validator for the given CRD validation.
+// The validator is configured to understand only the formats defined for all versions of Kubernetes.
 func NewSchemaValidator(customResourceValidation *apiextensions.JSONSchemaProps) (SchemaValidator, *spec.Schema, error) {
-	return NewSchemaValidatorForVersion(customResourceValidation, compatibility.KubeComponentEffectiveVersion().EmulationVersion())
+	return NewSchemaValidatorForVersion(customResourceValidation, version.MustParse("1.0.0"))
 }
 
 // NewSchemaValidatorForVersion creates an openapi schema validator for the given CRD validation and
-// emulationVersion.
+// emulationVersion. The validator is configured to understand all formats defined in the given
+// emulationVersion of Kubernetes.
 //
 // If feature `CRDValidationRatcheting` is disabled, this returns a validator which
 // validates all `Update`s and `Create`s as a `Create` - without considering old value.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -116,15 +116,14 @@ func NewSchemaValidatorForVersion(customResourceValidation *apiextensions.JSONSc
 			return nil, nil, err
 		}
 	}
-	return NewSchemaValidatorFromOpenAPI(openapiSchema), openapiSchema, nil
+	return NewSchemaValidatorFromOpenAPI(openapiSchema, NewVersionedRegistry(emulationVersion)), openapiSchema, nil
 }
 
-func NewSchemaValidatorFromOpenAPI(openapiSchema *spec.Schema) SchemaValidator {
+func NewSchemaValidatorFromOpenAPI(openapiSchema *spec.Schema, formats strfmt.Registry) SchemaValidator {
 	if utilfeature.DefaultFeatureGate.Enabled(features.CRDValidationRatcheting) {
-		return NewRatchetingSchemaValidator(openapiSchema, nil, "", strfmt.Default)
+		return NewRatchetingSchemaValidator(openapiSchema, nil, "", formats)
 	}
-	return basicSchemaValidator{validate.NewSchemaValidator(openapiSchema, nil, "", strfmt.Default)}
-
+	return basicSchemaValidator{validate.NewSchemaValidator(openapiSchema, nil, "", formats)}
 }
 
 // ValidateCustomResourceUpdate validates the transition of Custom Resource from

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
@@ -160,12 +160,12 @@ type failingObject struct {
 
 func TestValidateCustomResource(t *testing.T) {
 	tests := []struct {
-		name           string
-		compatVersion  *version.Version
-		schema         apiextensions.JSONSchemaProps
-		objects        []interface{}
-		oldObjects     []interface{}
-		failingObjects []failingObject
+		name             string
+		emulationVersion *version.Version
+		schema           apiextensions.JSONSchemaProps
+		objects          []interface{}
+		oldObjects       []interface{}
+		failingObjects   []failingObject
 	}{
 		{name: "!nullable",
 			schema: apiextensions.JSONSchemaProps{
@@ -603,7 +603,7 @@ func TestValidateCustomResource(t *testing.T) {
 			},
 		},
 		{name: "k8sLongName",
-			compatVersion: version.MajorMinor(1, 34),
+			emulationVersion: version.MajorMinor(1, 34),
 			schema: apiextensions.JSONSchemaProps{
 				Type: "object",
 				Properties: map[string]apiextensions.JSONSchemaProps{
@@ -620,7 +620,7 @@ func TestValidateCustomResource(t *testing.T) {
 			},
 		},
 		{name: "k8sShortName",
-			compatVersion: version.MajorMinor(1, 34),
+			emulationVersion: version.MajorMinor(1, 34),
 			schema: apiextensions.JSONSchemaProps{
 				Type: "object",
 				Properties: map[string]apiextensions.JSONSchemaProps{
@@ -638,7 +638,7 @@ func TestValidateCustomResource(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		compatVersion := tt.compatVersion
+		compatVersion := tt.emulationVersion
 		if compatVersion == nil {
 			compatVersion = environment.DefaultCompatibilityVersion()
 		}

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -34,7 +34,6 @@ import (
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/util/compatibility"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	basecompatibility "k8s.io/component-base/compatibility"
 )
 
 // DefaultCompatibilityVersion returns a default compatibility version for use with EnvSet
@@ -50,11 +49,7 @@ import (
 // A default version number equal to the current Kubernetes major.minor version
 // indicates fast forward CEL features that can be used when rollback is no longer needed.
 func DefaultCompatibilityVersion() *version.Version {
-	effectiveVer := compatibility.DefaultComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent)
-	if effectiveVer == nil {
-		effectiveVer = compatibility.DefaultBuildEffectiveVersion()
-	}
-	return effectiveVer.MinCompatibilityVersion()
+	return compatibility.KubeComponentEffectiveVersion().MinCompatibilityVersion()
 }
 
 var baseOpts = append(baseOptsWithoutStrictCost, StrictCostOpt)

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -49,7 +49,7 @@ import (
 // A default version number equal to the current Kubernetes major.minor version
 // indicates fast forward CEL features that can be used when rollback is no longer needed.
 func DefaultCompatibilityVersion() *version.Version {
-	return compatibility.KubeComponentEffectiveVersion().MinCompatibilityVersion()
+	return compatibility.KubeComponentEffectiveVersion(compatibility.DefaultComponentGlobalsRegistry).MinCompatibilityVersion()
 }
 
 var baseOpts = append(baseOptsWithoutStrictCost, StrictCostOpt)

--- a/staging/src/k8s.io/apiserver/pkg/util/compatibility/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/compatibility/version.go
@@ -26,6 +26,18 @@ import (
 // so the emulation version cannot go lower than that.
 var minimumKubeEmulationVersion *version.Version = version.MajorMinor(1, 31)
 
+// KubeComponentEffectiveVersion returns the effective version of the kube component.
+// If the kube component is registered in the DefaultComponentGlobalsRegistry, the
+// effective version from the registry is returned. Otherwise, the DefaultBuildEffectiveVersion
+// is returned.
+func KubeComponentEffectiveVersion() basecompatibility.EffectiveVersion {
+	effectiveVer := DefaultComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent)
+	if effectiveVer == nil {
+		effectiveVer = DefaultBuildEffectiveVersion()
+	}
+	return effectiveVer
+}
+
 // DefaultBuildEffectiveVersion returns the MutableEffectiveVersion based on the
 // current build information.
 func DefaultBuildEffectiveVersion() basecompatibility.MutableEffectiveVersion {

--- a/staging/src/k8s.io/apiserver/pkg/util/compatibility/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/compatibility/version.go
@@ -27,11 +27,11 @@ import (
 var minimumKubeEmulationVersion *version.Version = version.MajorMinor(1, 31)
 
 // KubeComponentEffectiveVersion returns the effective version of the kube component.
-// If the kube component is registered in the DefaultComponentGlobalsRegistry, the
+// If the kube component is registered in the provided registry, the
 // effective version from the registry is returned. Otherwise, the DefaultBuildEffectiveVersion
 // is returned.
-func KubeComponentEffectiveVersion() basecompatibility.EffectiveVersion {
-	effectiveVer := DefaultComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent)
+func KubeComponentEffectiveVersion(registry basecompatibility.ComponentGlobalsRegistry) basecompatibility.EffectiveVersion {
+	effectiveVer := registry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent)
 	if effectiveVer == nil {
 		effectiveVer = DefaultBuildEffectiveVersion()
 	}

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -29,7 +29,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"sigs.k8s.io/yaml"
 
-	"k8s.io/apiserver/pkg/cel/environment"
+	"k8s.io/apiserver/pkg/util/compatibility"
 	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/utils/pointer"
 
@@ -699,7 +699,7 @@ func convertJSONSchemaProps(in []byte, out *spec.Schema) error {
 		return err
 	}
 	kubeOut := spec.Schema{}
-	formatPostProcessor := validation.StripUnsupportedFormatsPostProcessorForVersion(environment.DefaultCompatibilityVersion())
+	formatPostProcessor := validation.StripUnsupportedFormatsPostProcessorForVersion(compatibility.KubeComponentEffectiveVersion().EmulationVersion())
 	if err := validation.ConvertJSONSchemaPropsWithPostProcess(&internal, &kubeOut, formatPostProcessor); err != nil {
 		return err
 	}

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -699,7 +699,7 @@ func convertJSONSchemaProps(in []byte, out *spec.Schema) error {
 		return err
 	}
 	kubeOut := spec.Schema{}
-	formatPostProcessor := validation.StripUnsupportedFormatsPostProcessorForVersion(compatibility.KubeComponentEffectiveVersion().EmulationVersion())
+	formatPostProcessor := validation.StripUnsupportedFormatsPostProcessorForVersion(compatibility.KubeComponentEffectiveVersion(compatibility.DefaultComponentGlobalsRegistry).EmulationVersion())
 	if err := validation.ConvertJSONSchemaPropsWithPostProcess(&internal, &kubeOut, formatPostProcessor); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The JSON Schema specification states that unrecognized formats should be allowed, but ignored, by implementations.  Kubernetes honors this and allows
unrecognized formats in CRD OpenAPI schemas. The implication here is that formats like the newly introduced `k8s-long-name` can be put in CRD schemas, even in very old Kubernetes releases.  The apiserver will allow the unrecognized formats to be written into the CRD and will ignore them (we don't publish them into discovery OpenAPI endpoint, however).

Because of this, it is possible for us to enable newly supported formats in the same release the formats are introduced, eliminating a 1-release delay. This PR proposes making this change.  That is, instead using `introducedVersion>=minCompatibilityVersion`, we can use `introducedVersion>=emulationVersion`.

AFAIK, this change has no impact on downgrade. No matter what version we start enforcing a format, a downgrade to the previous version will cause the format to be ignored. Ratcheting ensures that unchanged fields will be treated as valid in the case of a downgrade/modify-field-to-invalid-value-according-to-format/upgrade.

There is also one reason this change might actually be SAFER:  Once we document the existence of a format, it is likely to be put to use.  With this change, we shorten the time window where the format is known the community but not enforced.

#### Does this PR introduce a user-facing change?

```release-note
Changed CustomResourceDefinitions to immediately enforce new OpenAPI formats on the same release the new formats are introduced.
```

/sig api-machinery