### PR TITLE
DRA: fix deleting orphaned ResourceClaim on startup

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -338,7 +338,7 @@ func (ec *Controller) podNeedsWork(pod *v1.Pod) (bool, string) {
 }
 
 func (ec *Controller) enqueueResourceClaim(logger klog.Logger, oldObj, newObj interface{}) {
-	deleted := newObj != nil
+	deleted := newObj == nil
 	if d, ok := oldObj.(cache.DeletedFinalStateUnknown); ok {
 		oldObj = d.Obj
 	}

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -61,6 +62,7 @@ var (
 	testClaimAllocated     = allocateClaim(testClaim)
 	testClaimReserved      = reserveClaim(testClaimAllocated, testPodWithResource)
 	testClaimReservedTwice = reserveClaim(testClaimReserved, otherTestPod)
+	testClaimKey           = claimKeyPrefix + testClaim.Namespace + "/" + testClaim.Name
 
 	generatedTestClaim          = makeGeneratedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), nil)
 	generatedTestClaimWithAdmin = makeGeneratedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), ptr.To(true))
@@ -496,7 +498,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	templateInformer := informerFactory.Resource().V1beta1().ResourceClaimTemplates()
 	claimClient := fakeKubeClient.ResourceV1beta1().ResourceClaims(testNamespace)
 
-	_, err := NewController(tCtx.Logger(), Features{}, fakeKubeClient, podInformer, claimInformer, templateInformer)
+	ec, err := NewController(tCtx.Logger(), Features{}, fakeKubeClient, podInformer, claimInformer, templateInformer)
 	tCtx.ExpectNoError(err, "creating ephemeral controller")
 
 	informerFactory.Start(tCtx.Done())
@@ -508,11 +510,47 @@ func TestResourceClaimEventHandler(t *testing.T) {
 
 	var em numMetrics
 
+	expectQueue := func(tCtx ktesting.TContext, expectedKeys []string) {
+		g := gomega.NewWithT(tCtx)
+		tCtx.Helper()
+
+		lenDiffMessage := func() string {
+			actualKeys := []string{}
+			for ec.queue.Len() > 0 {
+				actual, _ := ec.queue.Get()
+				actualKeys = append(actualKeys, actual)
+				ec.queue.Forget(actual)
+				ec.queue.Done(actual)
+			}
+			return "Workqueue does not contain expected number of elements\n" +
+				"Diff of elements (- expected, + actual):\n" +
+				diff.Diff(expectedKeys, actualKeys)
+		}
+
+		g.Eventually(ec.queue.Len).
+			WithTimeout(5*time.Second).
+			Should(gomega.Equal(len(expectedKeys)), lenDiffMessage)
+		g.Consistently(ec.queue.Len).
+			WithTimeout(1*time.Second).
+			Should(gomega.Equal(len(expectedKeys)), lenDiffMessage)
+
+		for _, expected := range expectedKeys {
+			actual, shuttingDown := ec.queue.Get()
+			g.Expect(shuttingDown).To(gomega.BeFalseBecause("workqueue is unexpectedly shutting down"))
+			g.Expect(actual).To(gomega.Equal(expected))
+			ec.queue.Forget(actual)
+			ec.queue.Done(actual)
+		}
+	}
+
+	expectQueue(tCtx, []string{})
+
 	_, err = claimClient.Create(tCtx, testClaim, metav1.CreateOptions{})
 	em.claims++
 	ktesting.Step(tCtx, "create claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
+		expectQueue(tCtx, []string{testClaimKey})
 	})
 
 	modifiedClaim := testClaim.DeepCopy()
@@ -521,6 +559,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	ktesting.Step(tCtx, "modify claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Consistently(tCtx)
+		expectQueue(tCtx, []string{testClaimKey})
 	})
 
 	_, err = claimClient.Update(tCtx, testClaimAllocated, metav1.UpdateOptions{})
@@ -528,6 +567,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	ktesting.Step(tCtx, "allocate claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
+		expectQueue(tCtx, []string{testClaimKey})
 	})
 
 	modifiedClaim = testClaimAllocated.DeepCopy()
@@ -536,6 +576,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	ktesting.Step(tCtx, "modify claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Consistently(tCtx)
+		expectQueue(tCtx, []string{testClaimKey})
 	})
 
 	otherClaimAllocated := testClaimAllocated.DeepCopy()
@@ -546,6 +587,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	ktesting.Step(tCtx, "create allocated claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
+		expectQueue(tCtx, []string{testClaimKey + "2"})
 	})
 
 	_, err = claimClient.Update(tCtx, testClaim, metav1.UpdateOptions{})
@@ -553,6 +595,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	ktesting.Step(tCtx, "deallocate claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
+		expectQueue(tCtx, []string{testClaimKey})
 	})
 
 	err = claimClient.Delete(tCtx, testClaim.Name, metav1.DeleteOptions{})
@@ -560,6 +603,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	ktesting.Step(tCtx, "delete deallocated claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
+		expectQueue(tCtx, []string{})
 	})
 
 	err = claimClient.Delete(tCtx, otherClaimAllocated.Name, metav1.DeleteOptions{})
@@ -568,6 +612,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	ktesting.Step(tCtx, "delete allocated claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
+		expectQueue(tCtx, []string{})
 	})
 
 	em.Consistently(tCtx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:


This PR implements the fix for #132334 proposed by @pohly in that issue and tested in #132295. This change fixes the logic in the ResourceClaim controller to clean up deleted ResourceClaims in upgrade and similar scenarios involving kube-controller-manager restarts.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#132334

#### Special notes for your reviewer:

I plan to iterate on a test to reproduce the issue soon, but opened this PR now to unblock #132295.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```