### PR TITLE
Refactor: Use field.Required for missing field errors

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -149,7 +149,7 @@ func ValidateDiscovery(d *kubeadm.Discovery, fldPath *field.Path) field.ErrorLis
 	allErrs := field.ErrorList{}
 
 	if d.BootstrapToken == nil && d.File == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, "", "bootstrapToken or file must be set"))
+		allErrs = append(allErrs, field.Required(fldPath, "bootstrapToken or file must be set"))
 	}
 
 	if d.BootstrapToken != nil && d.File != nil {

--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -851,7 +851,7 @@ func validateParamKind(gvk admissionregistration.ParamKind, fldPath *field.Path)
 		}
 		// this matches the APIService version field validation
 		if len(gv.Version) == 0 {
-			allErrors = append(allErrors, field.Invalid(fldPath.Child("apiVersion"), gvk.APIVersion, "version must be specified"))
+			allErrors = append(allErrors, field.Required(fldPath.Child("apiVersion"), ""))
 		} else {
 			if errs := utilvalidation.IsDNS1035Label(gv.Version); len(errs) > 0 {
 				allErrors = append(allErrors, field.Invalid(fldPath.Child("apiVersion"), gv.Version, strings.Join(errs, ",")))

--- a/pkg/apis/authorization/validation/validation.go
+++ b/pkg/apis/authorization/validation/validation.go
@@ -34,10 +34,10 @@ func ValidateSubjectAccessReviewSpec(spec authorizationapi.SubjectAccessReviewSp
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("nonResourceAttributes"), spec.NonResourceAttributes, `cannot be specified in combination with resourceAttributes`))
 	}
 	if spec.ResourceAttributes == nil && spec.NonResourceAttributes == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceAttributes"), spec.NonResourceAttributes, `exactly one of nonResourceAttributes or resourceAttributes must be specified`))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceAttributes"), `exactly one of nonResourceAttributes or resourceAttributes must be specified`))
 	}
 	if len(spec.User) == 0 && len(spec.Groups) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("user"), spec.User, `at least one of user or group must be specified`))
+		allErrs = append(allErrs, field.Required(fldPath.Child("user"), `at least one of user or group must be specified`))
 	}
 	allErrs = append(allErrs, validateResourceAttributes(spec.ResourceAttributes, field.NewPath("spec.resourceAttributes"))...)
 
@@ -52,7 +52,7 @@ func ValidateSelfSubjectAccessReviewSpec(spec authorizationapi.SelfSubjectAccess
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("nonResourceAttributes"), spec.NonResourceAttributes, `cannot be specified in combination with resourceAttributes`))
 	}
 	if spec.ResourceAttributes == nil && spec.NonResourceAttributes == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceAttributes"), spec.NonResourceAttributes, `exactly one of nonResourceAttributes or resourceAttributes must be specified`))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceAttributes"), `exactly one of nonResourceAttributes or resourceAttributes must be specified`))
 	}
 	allErrs = append(allErrs, validateResourceAttributes(spec.ResourceAttributes, field.NewPath("spec.resourceAttributes"))...)
 

--- a/pkg/apis/authorization/validation/validation_test.go
+++ b/pkg/apis/authorization/validation/validation_test.go
@@ -101,7 +101,7 @@ func TestValidateSARSpec(t *testing.T) {
 		obj: authorizationapi.SubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationapi.ResourceAttributes{},
 		},
-		msg: `spec.user: Invalid value: "": at least one of user or group must be specified`,
+		msg: `spec.user: Required value: at least one of user or group must be specified`,
 	}, {
 		name: "resource attributes: field selector specify both",
 		obj: authorizationapi.SubjectAccessReviewSpec{

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -348,7 +348,7 @@ func validatePodFailurePolicyRule(spec *batch.JobSpec, rule *batch.PodFailurePol
 		allErrs = append(allErrs, field.Invalid(rulePath, field.OmitValueType{}, "specifying both OnExitCodes and OnPodConditions is not supported"))
 	}
 	if rule.OnExitCodes == nil && len(rule.OnPodConditions) == 0 {
-		allErrs = append(allErrs, field.Invalid(rulePath, field.OmitValueType{}, "specifying one of OnExitCodes and OnPodConditions is required"))
+		allErrs = append(allErrs, field.Required(rulePath, "specifying one of OnExitCodes and OnPodConditions is required"))
 	}
 	return allErrs
 }
@@ -384,7 +384,7 @@ func validatePodFailurePolicyRuleOnExitCodes(onExitCode *batch.PodFailurePolicyO
 	}
 	valuesPath := onExitCodesPath.Child("values")
 	if len(onExitCode.Values) == 0 {
-		allErrs = append(allErrs, field.Invalid(valuesPath, onExitCode.Values, "at least one value is required"))
+		allErrs = append(allErrs, field.Required(valuesPath, "at least one value is required"))
 	} else if len(onExitCode.Values) > maxPodFailurePolicyOnExitCodesValues {
 		allErrs = append(allErrs, field.TooMany(valuesPath, len(onExitCode.Values), maxPodFailurePolicyOnExitCodesValues))
 	}
@@ -474,7 +474,7 @@ func validateJobStatus(job *batch.Job, fldPath *field.Path, opts JobStatusValida
 		for i, k := range status.UncountedTerminatedPods.Succeeded {
 			p := path.Child("succeeded").Index(i)
 			if k == "" {
-				allErrs = append(allErrs, field.Invalid(p, k, "must not be empty"))
+				allErrs = append(allErrs, field.Required(p, ""))
 			} else if seen.Has(k) {
 				allErrs = append(allErrs, field.Duplicate(p, k))
 			} else {
@@ -484,7 +484,7 @@ func validateJobStatus(job *batch.Job, fldPath *field.Path, opts JobStatusValida
 		for i, k := range status.UncountedTerminatedPods.Failed {
 			p := path.Child("failed").Index(i)
 			if k == "" {
-				allErrs = append(allErrs, field.Invalid(p, k, "must not be empty"))
+				allErrs = append(allErrs, field.Required(p, ""))
 			} else if seen.Has(k) {
 				allErrs = append(allErrs, field.Duplicate(p, k))
 			} else {

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -611,7 +611,7 @@ func TestValidateJob(t *testing.T) {
 			},
 			opts: JobValidationOptions{RequirePrefixedLabels: true},
 		},
-		`spec.podFailurePolicy.rules[0]: Invalid value: specifying one of OnExitCodes and OnPodConditions is required`: {
+		`spec.podFailurePolicy.rules[0]: Required value: specifying one of OnExitCodes and OnPodConditions is required`: {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
@@ -758,7 +758,7 @@ func TestValidateJob(t *testing.T) {
 			},
 			opts: JobValidationOptions{RequirePrefixedLabels: true},
 		},
-		`spec.podFailurePolicy.rules[0].onExitCodes.values: Invalid value: []int32{}: at least one value is required`: {
+		`spec.podFailurePolicy.rules[0].onExitCodes.values: Required value: at least one value is required`: {
 			job: batch.Job{
 				ObjectMeta: validJobObjectMeta,
 				Spec: batch.JobSpec{
@@ -2384,10 +2384,10 @@ func TestValidateJobUpdateStatus(t *testing.T) {
 			},
 			wantErrs: field.ErrorList{
 				{Type: field.ErrorTypeDuplicate, Field: "status.uncountedTerminatedPods.succeeded[3]"},
-				{Type: field.ErrorTypeInvalid, Field: "status.uncountedTerminatedPods.succeeded[4]"},
+				{Type: field.ErrorTypeRequired, Field: "status.uncountedTerminatedPods.succeeded[4]"},
 				{Type: field.ErrorTypeDuplicate, Field: "status.uncountedTerminatedPods.failed[0]"},
 				{Type: field.ErrorTypeDuplicate, Field: "status.uncountedTerminatedPods.failed[3]"},
-				{Type: field.ErrorTypeInvalid, Field: "status.uncountedTerminatedPods.failed[4]"},
+				{Type: field.ErrorTypeRequired, Field: "status.uncountedTerminatedPods.failed[4]"},
 			},
 		},
 	}

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -561,7 +561,7 @@ func validateTrustBundle(path *field.Path, in string) field.ErrorList {
 	}
 
 	if len(blockDedupe) == 0 {
-		allErrors = append(allErrors, field.Invalid(path, "<value omitted>", "at least one trust anchor must be provided"))
+		allErrors = append(allErrors, field.Required(path, "at least one trust anchor must be provided"))
 	}
 
 	for _, indices := range blockDedupe {

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -1226,7 +1226,7 @@ func TestValidateClusterTrustBundle(t *testing.T) {
 				Spec: capi.ClusterTrustBundleSpec{},
 			},
 			wantErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "trustBundle"), "<value omitted>", "at least one trust anchor must be provided"),
+				field.Required(field.NewPath("spec", "trustBundle"), "at least one trust anchor must be provided"),
 			},
 		}, {
 			description: "invalid, no trust anchors",
@@ -1239,7 +1239,7 @@ func TestValidateClusterTrustBundle(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "trustBundle"), "<value omitted>", "at least one trust anchor must be provided"),
+				field.Required(field.NewPath("spec", "trustBundle"), "at least one trust anchor must be provided"),
 			},
 		}, {
 			description: "invalid, bad signer name",
@@ -1266,7 +1266,7 @@ func TestValidateClusterTrustBundle(t *testing.T) {
 				},
 			},
 			wantErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "trustBundle"), "<value omitted>", "at least one trust anchor must be provided"),
+				field.Required(field.NewPath("spec", "trustBundle"), "at least one trust anchor must be provided"),
 			},
 		}, {
 			description: "invalid, bad block type",
@@ -1467,7 +1467,7 @@ func TestValidateClusterTrustBundleUpdate(t *testing.T) {
 			},
 		},
 		wantErrors: field.ErrorList{
-			field.Invalid(field.NewPath("spec", "trustBundle"), "<value omitted>", "at least one trust anchor must be provided"),
+			field.Required(field.NewPath("spec", "trustBundle"), "at least one trust anchor must be provided"),
 		},
 	}, {
 		description: "emptying trustBundle (replace with non-block garbage) disallowed",
@@ -1490,7 +1490,7 @@ func TestValidateClusterTrustBundleUpdate(t *testing.T) {
 			},
 		},
 		wantErrors: field.ErrorList{
-			field.Invalid(field.NewPath("spec", "trustBundle"), "<value omitted>", "at least one trust anchor must be provided"),
+			field.Required(field.NewPath("spec", "trustBundle"), "at least one trust anchor must be provided"),
 		},
 	}}
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2690,7 +2690,7 @@ func validateEnvVarValueFrom(ev core.EnvVar, fldPath *field.Path, opts PodValida
 	}
 
 	if numSources == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, "", "must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`"))
+		allErrs = append(allErrs, field.Required(fldPath, "must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`"))
 	} else if len(ev.Value) != 0 {
 		if numSources != 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath, "", "may not be specified when `value` is not empty"))
@@ -2789,7 +2789,7 @@ func ValidateEnvFrom(vars []core.EnvFromSource, fldPath *field.Path, opts PodVal
 		}
 
 		if numSources == 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath, "", "must specify one of: `configMapRef` or `secretRef`"))
+			allErrs = append(allErrs, field.Required(fldPath, "must specify one of: `configMapRef` or `secretRef`"))
 		} else if numSources > 1 {
 			allErrs = append(allErrs, field.Invalid(fldPath, "", "may not have more than one field specified at a time"))
 		}
@@ -3058,7 +3058,7 @@ func validatePodResourceClaim(podMeta *metav1.ObjectMeta, claim core.PodResource
 		allErrs = append(allErrs, field.Invalid(fldPath, claim, "at most one of `resourceClaimName` or `resourceClaimTemplateName` may be specified"))
 	}
 	if claim.ResourceClaimName == nil && claim.ResourceClaimTemplateName == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, claim, "must specify one of: `resourceClaimName`, `resourceClaimTemplateName`"))
+		allErrs = append(allErrs, field.Required(fldPath, "must specify one of: `resourceClaimName`, `resourceClaimTemplateName`"))
 	}
 	if claim.ResourceClaimName != nil {
 		for _, detail := range ValidateResourceClaimName(*claim.ResourceClaimName, false) {
@@ -8434,7 +8434,7 @@ func validateUpgradeDowngradeClusterIPs(oldService, service *core.Service) field
 		// user *must* set IPFamilyPolicy == SingleStack
 		if len(service.Spec.ClusterIPs) == 1 {
 			if service.Spec.IPFamilyPolicy == nil || *(service.Spec.IPFamilyPolicy) != core.IPFamilyPolicySingleStack {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "ipFamilyPolicy"), service.Spec.IPFamilyPolicy, "must be set to 'SingleStack' when releasing the secondary clusterIP"))
+				allErrs = append(allErrs, field.Required(field.NewPath("spec", "ipFamilyPolicy"), "must be set to 'SingleStack' when releasing the secondary clusterIP"))
 			}
 		}
 	case len(oldService.Spec.ClusterIPs) < len(service.Spec.ClusterIPs):
@@ -8498,7 +8498,7 @@ func validateUpgradeDowngradeIPFamilies(oldService, service *core.Service) field
 		// user *must* set IPFamilyPolicy == SingleStack
 		if len(service.Spec.IPFamilies) == 1 {
 			if service.Spec.IPFamilyPolicy == nil || *(service.Spec.IPFamilyPolicy) != core.IPFamilyPolicySingleStack {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "ipFamilyPolicy"), service.Spec.IPFamilyPolicy, "must be set to 'SingleStack' when releasing the secondary ipFamily"))
+				allErrs = append(allErrs, field.Required(field.NewPath("spec", "ipFamilyPolicy"), "must be set to 'SingleStack' when releasing the secondary ipFamily"))
 			}
 		}
 	case len(oldService.Spec.IPFamilies) < len(service.Spec.IPFamilies):

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -6137,7 +6137,7 @@ func TestRelaxedValidateEnv(t *testing.T) {
 			Name:      "abc",
 			ValueFrom: &core.EnvVarSource{},
 		}},
-		expectedError: "[0].valueFrom: Invalid value: \"\": must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`",
+		expectedError: "[0].valueFrom: Required value: must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`",
 	}, {
 		name: "valueFrom.fieldRef and valueFrom.secretKeyRef specified",
 		envs: []core.EnvVar{{
@@ -6547,7 +6547,7 @@ func TestValidateEnv(t *testing.T) {
 			Name:      "abc",
 			ValueFrom: &core.EnvVarSource{},
 		}},
-		expectedError: "[0].valueFrom: Invalid value: \"\": must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`",
+		expectedError: "[0].valueFrom: Required value: must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`",
 	}, {
 		name: "valueFrom.fieldRef and valueFrom.secretKeyRef specified",
 		envs: []core.EnvVar{{
@@ -6930,7 +6930,7 @@ func TestValidateEnvFrom(t *testing.T) {
 		envs: []core.EnvFromSource{
 			{},
 		},
-		expectedError: "field: Invalid value: \"\": must specify one of: `configMapRef` or `secretRef`",
+		expectedError: "field: Required value: must specify one of: `configMapRef` or `secretRef`",
 	}, {
 		name: "multiple refs",
 		envs: []core.EnvFromSource{{
@@ -7046,7 +7046,7 @@ func TestRelaxedValidateEnvFrom(t *testing.T) {
 			envs: []core.EnvFromSource{
 				{},
 			},
-			expectedError: "field: Invalid value: \"\": must specify one of: `configMapRef` or `secretRef`",
+			expectedError: "field: Required value: must specify one of: `configMapRef` or `secretRef`",
 		}, {
 			name: "multiple refs",
 			envs: []core.EnvFromSource{{

--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -542,7 +542,7 @@ func ValidatePriorityLevelConfigurationCondition(condition *flowcontrol.Priority
 //  4. Wildcard "*" should only do suffix glob matching. Note that wildcard also matches slashes.
 func ValidateNonResourceURLPath(path string, fldPath *field.Path) *field.Error {
 	if len(path) == 0 {
-		return field.Invalid(fldPath, path, "must not be empty")
+		return field.Required(fldPath, "")
 	}
 	if path == "/" { // root path
 		return nil

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -534,7 +534,7 @@ func validateIngressBackend(backend *networking.IngressBackend, fldPath *field.P
 			allErrs = append(allErrs, field.Required(fldPath, "port name or number is required"))
 		}
 	default:
-		allErrs = append(allErrs, field.Invalid(fldPath, "", "resource or service backend is required"))
+		allErrs = append(allErrs, field.Required(fldPath, "resource or service backend is required"))
 	}
 	return allErrs
 }

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -763,7 +763,7 @@ func validateDevice(device resource.Device, fldPath *field.Path, sharedCounterTo
 				setFields = append(setFields, "`nodeName`")
 				allErrs = append(allErrs, validateNodeName(*device.NodeName, fldPath.Child("nodeName"))...)
 			} else {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeName"), *device.NodeName, "must not be empty"))
+				allErrs = append(allErrs, field.Required(fldPath.Child("nodeName"), ""))
 			}
 
 		}

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -324,8 +324,7 @@ func TestValidateResourceSlice(t *testing.T) {
 			wantFailures: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(badName), badName, "a valid C identifier must start with alphabetic character or '_', followed by a string of alphanumeric characters or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName', regex used for validation is '[A-Za-z_][A-Za-z0-9_]*')"),
 				field.Required(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(badName), "exactly one value must be specified"),
-				field.Invalid(field.NewPath("spec", "devices").Index(2).Child("attributes").Key(goodName), resourceapi.DeviceAttribute{StringValue: ptr.To("x"), VersionValue: ptr.To("1.2.3")}, "exactly one value must be specified"),
-				field.Invalid(field.NewPath("spec", "devices").Index(3).Child("attributes").Key(goodName).Child("version"), strings.Repeat("x", resourceapi.DeviceAttributeMaxValueLength+1), "must be a string compatible with semver.org spec 2.0.0"),
+				field.Invalid(field.NewPath("spec", "devices").Index(2).Child("attributes").Key(goodName), resourceapi.DeviceAttribute{StringValue: ptr.To("x"), VersionValue: ptr.To("1.2.3")}, "exactly one value must be specified"), field.Invalid(field.NewPath("spec", "devices").Index(3).Child("attributes").Key(goodName).Child("version"), strings.Repeat("x", resourceapi.DeviceAttributeMaxValueLength+1), "must be a string compatible with semver.org spec 2.0.0"),
 				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(3).Child("attributes").Key(goodName).Child("version"), strings.Repeat("x", resourceapi.DeviceAttributeMaxValueLength+1), resourceapi.DeviceAttributeMaxValueLength),
 				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(4).Child("attributes").Key(goodName).Child("string"), strings.Repeat("x", resourceapi.DeviceAttributeMaxValueLength+1), resourceapi.DeviceAttributeMaxValueLength),
 			},
@@ -567,7 +566,7 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"invalid-node-selector-in-basicdevice": {
 			wantFailures: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeName"), "", "must not be empty"),
+				field.Required(field.NewPath("spec", "devices").Index(0).Child("nodeName"), ""),
 				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("allNodes"), false, "must be either unset or set to true"),
 				field.Required(field.NewPath("spec", "devices").Index(0), "exactly one of `nodeName`, `nodeSelector`, or `allNodes` is required when `perDeviceNodeSelection` is set to true in the ResourceSlice spec"),
 			},

--- a/pkg/kubelet/kubelet_server_journal.go
+++ b/pkg/kubelet/kubelet_server_journal.go
@@ -136,7 +136,7 @@ func newNodeLogQuery(query url.Values) (*nodeLogQuery, field.ErrorList) {
 	// Prevent specifying  an empty or blank space query.
 	// Example: kubectl get --raw /api/v1/nodes/$node/proxy/logs?query="   "
 	if ok && (len(nlq.Files) == 0 && len(nlq.Services) == 0) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("query"), queries, "query cannot be empty"))
+		allErrs = append(allErrs, field.Required(field.NewPath("query"), ""))
 	}
 
 	var sinceTime time.Time

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -301,7 +301,7 @@ func validateShowHiddenMetricsVersion(version string, fldPath *field.Path) field
 func validateInterface(iface string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(iface) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, iface, "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath, ""))
 	}
 	return allErrs
 }

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -774,7 +774,7 @@ func TestValidateDetectLocalConfiguration(t *testing.T) {
 			config: kubeproxyconfig.DetectLocalConfiguration{
 				InterfaceNamePrefix: "",
 			},
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("DetectLocal").Child("InterfacePrefix"), "", "must not be empty")},
+			expectedErrs: field.ErrorList{field.Required(newPath.Child("DetectLocal").Child("InterfacePrefix"), "")},
 		},
 		{
 			name: "bridgeInterfaceName is empty",
@@ -782,7 +782,7 @@ func TestValidateDetectLocalConfiguration(t *testing.T) {
 			config: kubeproxyconfig.DetectLocalConfiguration{
 				InterfaceNamePrefix: "eth0", // we won't care about prefix since mode is not prefix
 			},
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("DetectLocal").Child("InterfaceName"), "", "must not be empty")},
+			expectedErrs: field.ErrorList{field.Required(newPath.Child("DetectLocal").Child("InterfaceName"), "")},
 		},
 		{
 			name: "valid cluster cidr",

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -215,7 +215,7 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 			config: resourceNameNotSet,
 			wantErrs: field.ErrorList{
 				&field.Error{
-					Type:  field.ErrorTypeInvalid,
+					Type:  field.ErrorTypeRequired,
 					Field: "leaderElection.resourceName",
 				},
 			},
@@ -224,7 +224,7 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 			config: resourceNamespaceNotSet,
 			wantErrs: field.ErrorList{
 				&field.Error{
-					Type:  field.ErrorTypeInvalid,
+					Type:  field.ErrorTypeRequired,
 					Field: "leaderElection.resourceNamespace",
 				},
 			},

--- a/plugin/pkg/admission/eventratelimit/apis/eventratelimit/validation/validation.go
+++ b/plugin/pkg/admission/eventratelimit/apis/eventratelimit/validation/validation.go
@@ -34,7 +34,7 @@ func ValidateConfiguration(config *eventratelimitapi.Configuration) field.ErrorL
 	allErrs := field.ErrorList{}
 	limitsPath := field.NewPath("limits")
 	if len(config.Limits) == 0 {
-		allErrs = append(allErrs, field.Invalid(limitsPath, config.Limits, "must not be empty"))
+		allErrs = append(allErrs, field.Required(limitsPath, ""))
 	}
 	for i, limit := range config.Limits {
 		idxPath := limitsPath.Index(i)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -1539,7 +1539,7 @@ func validateSimpleJSONPath(s string, fldPath *field.Path) field.ErrorList {
 
 	switch {
 	case len(s) == 0:
-		allErrs = append(allErrs, field.Invalid(fldPath, s, "must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath, ""))
 	case s[0] != '.':
 		allErrs = append(allErrs, field.Invalid(fldPath, s, "must be a simple json path starting with ."))
 	case s != ".":

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation.go
@@ -80,7 +80,7 @@ func validateEmbeddedResource(pth *field.Path, x map[string]interface{}, s *stru
 
 	// require apiVersion and kind, but not metadata
 	if _, found := x["apiVersion"]; !found {
-		allErrs = append(allErrs, field.Required(pth.Child("apiVersion"), "must not be empty"))
+		allErrs = append(allErrs, field.Required(pth.Child("apiVersion"), ""))
 	}
 	if _, found := x["kind"]; !found {
 		allErrs = append(allErrs, field.Required(pth.Child("kind"), "must not be empty"))
@@ -92,7 +92,7 @@ func validateEmbeddedResource(pth *field.Path, x map[string]interface{}, s *stru
 			if apiVersion, ok := v.(string); !ok {
 				allErrs = append(allErrs, field.Invalid(pth.Child("apiVersion"), v, "must be a string"))
 			} else if len(apiVersion) == 0 {
-				allErrs = append(allErrs, field.Invalid(pth.Child("apiVersion"), apiVersion, "must not be empty"))
+				allErrs = append(allErrs, field.Required(pth.Child("apiVersion"), ""))
 			} else if _, err := schema.ParseGroupVersion(apiVersion); err != nil {
 				allErrs = append(allErrs, field.Invalid(pth.Child("apiVersion"), apiVersion, err.Error()))
 			}
@@ -100,7 +100,7 @@ func validateEmbeddedResource(pth *field.Path, x map[string]interface{}, s *stru
 			if kind, ok := v.(string); !ok {
 				allErrs = append(allErrs, field.Invalid(pth.Child("kind"), v, "must be a string"))
 			} else if len(kind) == 0 {
-				allErrs = append(allErrs, field.Invalid(pth.Child("kind"), kind, "must not be empty"))
+				allErrs = append(allErrs, field.Required(pth.Child("kind"), ""))
 			} else if errs := utilvalidation.IsDNS1035Label(strings.ToLower(kind)); len(errs) > 0 {
 				allErrs = append(allErrs, field.Invalid(pth.Child("kind"), kind, "may have mixed case, but should otherwise match: "+strings.Join(errs, ",")))
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -71,16 +71,16 @@ func validateOwnerReference(ownerReference metav1.OwnerReference, fldPath *field
 	gvk := schema.FromAPIVersionAndKind(ownerReference.APIVersion, ownerReference.Kind)
 	// gvk.Group is empty for the legacy group.
 	if len(gvk.Version) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("apiVersion"), ownerReference.APIVersion, "version must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("apiVersion"), ""))
 	}
 	if len(gvk.Kind) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("kind"), ownerReference.Kind, "kind must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("kind"), ""))
 	}
 	if len(ownerReference.Name) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ownerReference.Name, "name must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
 	}
 	if len(ownerReference.UID) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("uid"), ownerReference.UID, "uid must not be empty"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("uid"), ""))
 	}
 	if _, ok := BannedOwners[gvk]; ok {
 		allErrs = append(allErrs, field.Invalid(fldPath, ownerReference, fmt.Sprintf("%s is disallowed from being an owner", gvk)))
@@ -241,7 +241,7 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
 
 	// Reject updates that don't specify a resource version
 	if len(newMeta.GetResourceVersion()) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceVersion"), newMeta.GetResourceVersion(), "must be specified for an update"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceVersion"), "must be specified for an update"))
 	}
 
 	// Generation shouldn't be decremented

--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -49,13 +49,13 @@ func ValidateLeaderElectionConfiguration(cc *config.LeaderElectionConfiguration,
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("leaseDuration"), cc.RenewDeadline, "LeaseDuration must be greater than RenewDeadline"))
 	}
 	if len(cc.ResourceLock) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceLock"), cc.ResourceLock, "resourceLock is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceLock"), ""))
 	}
 	if len(cc.ResourceNamespace) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceNamespace"), cc.ResourceNamespace, "resourceNamespace is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceNamespace"), ""))
 	}
 	if len(cc.ResourceName) == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("resourceName"), cc.ResourceName, "resourceName is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceName"), ""))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/pod-security-admission/admission/api/validation/validation.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/validation/validation.go
@@ -112,7 +112,7 @@ func validateUsernames(configuration *admissionapi.PodSecurityConfiguration) fie
 	for i, uname := range configuration.Exemptions.Usernames {
 		if uname == "" {
 			path := field.NewPath("exemptions", "usernames").Index(i)
-			errs = append(errs, field.Invalid(path, uname, "username must not be empty"))
+			errs = append(errs, field.Required(path, ""))
 			continue
 		}
 		if validSet.Has(uname) {

--- a/staging/src/k8s.io/pod-security-admission/admission/api/validation/validation_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/validation/validation_test.go
@@ -52,7 +52,7 @@ func TestValidatePodSecurityConfiguration(t *testing.T) {
 				field.Invalid(exemptionsPath("runtimeClasses", 1), invalidValueChars, "..."),
 				field.Invalid(exemptionsPath("runtimeClasses", 2), invalidValueUppercase, "..."),
 				field.Duplicate(exemptionsPath("runtimeClasses", 4), validValue),
-				field.Invalid(exemptionsPath("usernames", 0), invalidValueEmpty, "..."),
+				field.Required(exemptionsPath("usernames", 0), invalidValueEmpty),
 				field.Duplicate(exemptionsPath("usernames", 2), validValue),
 			},
 			configuration: api.PodSecurityConfiguration{

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/validation/validation.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/validation/validation.go
@@ -41,9 +41,9 @@ func ValidateFlunderSpec(s *wardle.FlunderSpec, fldPath *field.Path) field.Error
 	} else if len(s.FischerReference) != 0 && s.ReferenceType != wardle.FischerReferenceType {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("fischerReference"), s.FischerReference, "cannot be set if referenceType is not Fischer"))
 	} else if len(s.FischerReference) == 0 && s.ReferenceType == wardle.FischerReferenceType {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("fischerReference"), s.FischerReference, "cannot be empty if referenceType is Fischer"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("fischerReference"), "cannot be empty if referenceType is Fischer"))
 	} else if len(s.FlunderReference) == 0 && s.ReferenceType == wardle.FlunderReferenceType {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("flunderReference"), s.FlunderReference, "cannot be empty if referenceType is Flunder"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("flunderReference"), "cannot be empty if referenceType is Flunder"))
 	}
 
 	if len(s.ReferenceType) != 0 && s.ReferenceType != wardle.FischerReferenceType && s.ReferenceType != wardle.FlunderReferenceType {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit refactors validation logic to use `field.Required` in cases
where `field.Invalid` was previously used to indicate that a field was
missing. According to the issue description, `field.Invalid` was sometimes
used with a detail message like "must be set", which is semantically
a "required" error.

This is the third and final part of the cleanup work for this issue [#111698](https://github.com/kubernetes/kubernetes/issues/111698)

#### Which issue(s) this PR is related to:

Fixes [111698](https://github.com/kubernetes/kubernetes/issues/111698)

#### Does this PR introduce a user-facing change?
```release-note
Clarified validation error messages by using Required instead of Invalid when a required field is missing
```
