### PR TITLE
add validation logic for APIVersion fields of HPA

### DIFF
--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -170,12 +170,37 @@ func (autoscalerStatusStrategy) WarningsOnUpdate(ctx context.Context, obj, old r
 
 func validationOptionsForHorizontalPodAutoscaler(newHPA, oldHPA *autoscaling.HorizontalPodAutoscaler) validation.HorizontalPodAutoscalerSpecValidationOptions {
 	opts := validation.HorizontalPodAutoscalerSpecValidationOptions{
-		MinReplicasLowerBound: 1,
+		MinReplicasLowerBound:           1,
+		ScaleTargetRefValidationOptions: validation.CrossVersionObjectReferenceValidationOptions{AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false},
+		ObjectMetricsValidationOptions: validation.CrossVersionObjectReferenceValidationOptions{
+			AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+		},
 	}
 
 	oldHasZeroMinReplicas := oldHPA != nil && (oldHPA.Spec.MinReplicas != nil && *oldHPA.Spec.MinReplicas == 0)
 	if utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero) || oldHasZeroMinReplicas {
 		opts.MinReplicasLowerBound = 0
+	}
+
+	switch {
+	case oldHPA != nil && oldHPA.Spec.ScaleTargetRef.APIVersion == newHPA.Spec.ScaleTargetRef.APIVersion && oldHPA.Spec.ScaleTargetRef.Kind == newHPA.Spec.ScaleTargetRef.Kind:
+		// skip apiVersion validation on updates that don't change the kind/apiVersion.
+		opts.ScaleTargetRefValidationOptions.AllowInvalidAPIVersion = true
+	case newHPA.Spec.ScaleTargetRef.Kind == "ReplicationController":
+		// allow empty apiVersion for the only scalable type that exists in the core v1 API.
+		opts.ScaleTargetRefValidationOptions.AllowEmptyAPIGroup = true
+	}
+
+	if oldHPA != nil {
+		for _, metric := range oldHPA.Spec.Metrics {
+			if metric.Type == autoscaling.ObjectMetricSourceType && metric.Object != nil {
+				if err := validation.ValidateAPIVersion(metric.Object.DescribedObject, opts.ObjectMetricsValidationOptions); err != nil {
+					// metrics are already invalid.
+					opts.ObjectMetricsValidationOptions.AllowInvalidAPIVersion = true
+					break
+				}
+			}
+		}
 	}
 	return opts
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy_test.go
@@ -25,6 +25,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
+	"k8s.io/kubernetes/pkg/apis/autoscaling/validation"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
@@ -114,6 +115,277 @@ func TestValidateOptionsScaleToZeroDisabled(t *testing.T) {
 	opts = validationOptionsForHorizontalPodAutoscaler(&zeroReplicasHPA, &oneReplicasHPA)
 	if opts.MinReplicasLowerBound == 0 {
 		t.Errorf("Expected non-zero minReplicasLowerBound, got 0")
+	}
+}
+
+func TestValidationOptionsForHorizontalPodAutoscaler(t *testing.T) {
+	hpa := func(minReplicas int32, scaleTargetAPIVersion string, scaleTargetKind string, metrics []autoscaling.MetricSpec) *autoscaling.HorizontalPodAutoscaler {
+		return &autoscaling.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "myhpa", Namespace: "default"},
+			Spec: autoscaling.HorizontalPodAutoscalerSpec{
+				MinReplicas: &minReplicas,
+				MaxReplicas: 5,
+				ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+					Kind:       scaleTargetKind,
+					Name:       "name",
+					APIVersion: scaleTargetAPIVersion,
+				},
+				Metrics: metrics,
+			},
+		}
+	}
+
+	objectMetric := func(apiVersion string) autoscaling.MetricSpec {
+		return autoscaling.MetricSpec{
+			Type: autoscaling.ObjectMetricSourceType,
+			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					Kind:       "Deployment",
+					Name:       "mydeployment",
+					APIVersion: apiVersion,
+				},
+				Metric: autoscaling.MetricIdentifier{Name: "my-metric"},
+				Target: autoscaling.MetricTarget{Type: autoscaling.ValueMetricType, Value: resource.NewQuantity(10, resource.DecimalSI)},
+			},
+		}
+	}
+
+	podsMetric := autoscaling.MetricSpec{
+		Type: autoscaling.PodsMetricSourceType,
+		Pods: &autoscaling.PodsMetricSource{
+			Metric: autoscaling.MetricIdentifier{Name: "my-metric"},
+			Target: autoscaling.MetricTarget{Type: autoscaling.AverageValueMetricType, AverageValue: resource.NewQuantity(10, resource.DecimalSI)},
+		},
+	}
+
+	testCases := []struct {
+		name                               string
+		newHPA                             *autoscaling.HorizontalPodAutoscaler
+		oldHPA                             *autoscaling.HorizontalPodAutoscaler
+		scaleToZeroEnabled                 bool
+		expectMinReplicasLower             int32
+		expectScaleTargetRefValidationOpts validation.CrossVersionObjectReferenceValidationOptions
+		expectMetricsValidationOpts        validation.CrossVersionObjectReferenceValidationOptions
+	}{
+		// MinReplicasLowerBound tests
+		{
+			name:                   "scale to zero disabled, no old hpa",
+			newHPA:                 hpa(1, "apps/v1", "Deployment", nil),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "scale to zero disabled, old hpa has minReplicas=1",
+			newHPA:                 hpa(1, "apps/v1", "Deployment", nil),
+			oldHPA:                 hpa(1, "apps/v1", "Deployment", nil),
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "scale to zero disabled, old hpa has minReplicas=0",
+			newHPA:                 hpa(0, "apps/v1", "Deployment", nil),
+			oldHPA:                 hpa(0, "apps/v1", "Deployment", nil),
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 0,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "scale to zero enabled",
+			newHPA:                 hpa(0, "apps/v1", "Deployment", nil),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     true,
+			expectMinReplicasLower: 0,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		// ScaleTargetRefValidationOptions tests
+		{
+			name:                   "ReplicationController with the legacy API Version",
+			newHPA:                 hpa(1, "", "ReplicationController", nil),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "scale target ref api version changed",
+			newHPA:                 hpa(1, "apps/v1", "Deployment", nil),
+			oldHPA:                 hpa(1, "extensions/v1beta1", "RandomCR", nil),
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "scale target ref api version unchanged",
+			newHPA:                 hpa(1, "apps/v1", "", nil),
+			oldHPA:                 hpa(1, "apps/v1", "", nil),
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "scale target ref api and Kind are changed to ReplicationController",
+			newHPA:                 hpa(1, "", "ReplicationController", nil),
+			oldHPA:                 hpa(1, "apps/v1", "Deployment", nil),
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "Kind changed",
+			newHPA:                 hpa(1, "apps/v1", "CronJobs", nil),
+			oldHPA:                 hpa(1, "apps/v1", "Deployment", nil),
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		// MetricsValidationOptions tests
+		{
+			name:                   "no metrics",
+			newHPA:                 hpa(1, "apps/v1", "Deployment", nil),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "non-object metric",
+			newHPA:                 hpa(1, "", "", []autoscaling.MetricSpec{podsMetric}),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "new object metric with valid api version",
+			newHPA:                 hpa(1, "", "", []autoscaling.MetricSpec{objectMetric("apps/v1")}),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "old object metric with invalid api version",
+			newHPA:                 hpa(1, "apps/v1", "Deployment", []autoscaling.MetricSpec{objectMetric("apps/v1/v3")}),
+			oldHPA:                 hpa(2, "apps/v1", "Deployment", []autoscaling.MetricSpec{objectMetric("apps/v1/v2")}),
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: true, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name:                   "new object metric with invalid api version",
+			newHPA:                 hpa(1, "", "", []autoscaling.MetricSpec{objectMetric("apps/v1/v2")}),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+		{
+			name: "nil object Metrics",
+			newHPA: hpa(1, "", "", []autoscaling.MetricSpec{{
+				Type:   autoscaling.ObjectMetricSourceType,
+				Object: nil,
+			}}),
+			oldHPA:                 nil,
+			scaleToZeroEnabled:     false,
+			expectMinReplicasLower: 1,
+			expectScaleTargetRefValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: false,
+			},
+			expectMetricsValidationOpts: validation.CrossVersionObjectReferenceValidationOptions{
+				AllowInvalidAPIVersion: false, AllowEmptyAPIGroup: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, tc.scaleToZeroEnabled)
+			opts := validationOptionsForHorizontalPodAutoscaler(tc.newHPA, tc.oldHPA)
+
+			if opts.MinReplicasLowerBound != tc.expectMinReplicasLower {
+				t.Errorf("expected MinReplicasLowerBound %d, got %d", tc.expectMinReplicasLower, opts.MinReplicasLowerBound)
+			}
+			if opts.ScaleTargetRefValidationOptions != tc.expectScaleTargetRefValidationOpts {
+				t.Errorf("expected ScaleTargetRefValidationOptions %v, got %v", tc.expectScaleTargetRefValidationOpts, opts.ScaleTargetRefValidationOptions)
+			}
+			if opts.ObjectMetricsValidationOptions != tc.expectMetricsValidationOpts {
+				t.Errorf("expected ObjectMetricsValidationOptions %v, got %v", tc.expectMetricsValidationOpts, opts.ObjectMetricsValidationOptions)
+			}
+
+		})
 	}
 }
 

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -180,7 +180,7 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 
 		// k8s.io/kubernetes/pkg/apis/autoscaling/v1
 		gvr("autoscaling", "v1", "horizontalpodautoscalers"): {
-			Stub:              `{"metadata": {"name": "hpa2"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
+			Stub:              `{"metadata": {"name": "hpa2"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross", "apiVersion": "apps/v1"}}}`,
 			ExpectedEtcdPath:  "/registry/horizontalpodautoscalers/" + namespace + "/hpa2",
 			ExpectedGVK:       gvkP("autoscaling", "v2", "HorizontalPodAutoscaler"),
 			IntroducedVersion: "1.2",
@@ -189,7 +189,7 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 
 		// k8s.io/kubernetes/pkg/apis/autoscaling/v2
 		gvr("autoscaling", "v2", "horizontalpodautoscalers"): {
-			Stub:              `{"metadata": {"name": "hpa4"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
+			Stub:              `{"metadata": {"name": "hpa4"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross", "apiVersion": "apps/v1"}}}`,
 			ExpectedEtcdPath:  "/registry/horizontalpodautoscalers/" + namespace + "/hpa4",
 			IntroducedVersion: "1.23",
 		},


### PR DESCRIPTION
New validation logic follows the API ratcheting principle,  will not be executed for already stored invalid if the corresponding fields or item in array is not modified.



#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This adds validation logic on APIVersion fields of HorizontalPodAutoscaler type. There are no validation on this field, Invalid API version can result in non functioning HPA. 

This also adds additional checks for ScaleTargetRef field, to make sure it is not empty when Kind is not replicationController.

#### Which issue(s) this PR is related to:

Fixes #60511 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
APIVersion fields of the HorizontalPodAutoscaler API are now validated to ensure created API objects function properly
```
