### PR TITLE
Migrate devicemanager to context logging (1/5)

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -301,7 +301,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 
 	klog.InfoS("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(machineInfo.Topology, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(context.TODO(), machineInfo.Topology, cm.topologyManager)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +651,7 @@ func (cm *containerManagerImpl) Start(ctx context.Context, node *v1.Node,
 	}
 
 	// Starts device manager.
-	if err := cm.deviceManager.Start(devicemanager.ActivePodsFunc(activePods), sourcesReady, containerMap.Clone(), containerRunningSet); err != nil {
+	if err := cm.deviceManager.Start(ctx, devicemanager.ActivePodsFunc(activePods), sourcesReady, containerMap.Clone(), containerRunningSet); err != nil {
 		return err
 	}
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -110,7 +110,7 @@ func (cm *containerManagerImpl) Start(ctx context.Context, node *v1.Node,
 	}
 
 	// Starts device manager.
-	if err := cm.deviceManager.Start(devicemanager.ActivePodsFunc(activePods), sourcesReady, containerMap.Clone(), containerRunningSet); err != nil {
+	if err := cm.deviceManager.Start(ctx, devicemanager.ActivePodsFunc(activePods), sourcesReady, containerMap.Clone(), containerRunningSet); err != nil {
 		return err
 	}
 
@@ -183,7 +183,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 
 	klog.InfoS("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(nil, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(context.TODO(), nil, cm.topologyManager)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
@@ -42,8 +42,8 @@ import (
 type Server interface {
 	cache.PluginHandler
 	healthz.HealthChecker
-	Start() error
-	Stop() error
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
 	SocketPath() string
 }
 
@@ -62,14 +62,14 @@ type server struct {
 }
 
 // NewServer returns an initialized device plugin registration server.
-func NewServer(socketPath string, rh RegistrationHandler, ch ClientHandler) (Server, error) {
+func NewServer(ctx context.Context, socketPath string, rh RegistrationHandler, ch ClientHandler) (Server, error) {
 	if socketPath == "" || !filepath.IsAbs(socketPath) {
 		return nil, fmt.Errorf(errBadSocket+" %s", socketPath)
 	}
 
 	dir, name := filepath.Split(socketPath)
-
-	klog.V(2).InfoS("Creating device plugin registration server", "version", api.Version, "socket", socketPath)
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Creating device plugin registration server", "version", api.Version, "socket", socketPath)
 	s := &server{
 		socketName: name,
 		socketDir:  dir,
@@ -81,17 +81,18 @@ func NewServer(socketPath string, rh RegistrationHandler, ch ClientHandler) (Ser
 	return s, nil
 }
 
-func (s *server) Start() error {
-	klog.V(2).InfoS("Starting device plugin registration server")
+func (s *server) Start(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Starting device plugin registration server")
 
 	if err := os.MkdirAll(s.socketDir, 0750); err != nil {
-		klog.ErrorS(err, "Failed to create the device plugin socket directory", "directory", s.socketDir)
+		logger.Error(err, "Failed to create the device plugin socket directory", "directory", s.socketDir)
 		return err
 	}
 
 	if selinux.GetEnabled() {
 		if err := selinux.SetFileLabel(s.socketDir, config.KubeletPluginsDirSELinuxLabel); err != nil {
-			klog.ErrorS(err, "Unprivileged containerized plugins might not work. Could not set selinux context on socket dir", "path", s.socketDir)
+			logger.Error(err, "Unprivileged containerized plugins might not work. Could not set selinux context on socket dir", "path", s.socketDir)
 		}
 	}
 
@@ -99,13 +100,13 @@ func (s *server) Start() error {
 	// (even though we should in theory be able to just wipe the whole directory)
 	// because the Handler stores its checkpoint file (amongst others) in here.
 	if err := s.rhandler.CleanupPluginDirectory(s.socketDir); err != nil {
-		klog.ErrorS(err, "Failed to cleanup the device plugin directory", "directory", s.socketDir)
+		logger.Error(err, "Failed to cleanup the device plugin directory", "directory", s.socketDir)
 		return err
 	}
 
 	ln, err := net.Listen("unix", s.SocketPath())
 	if err != nil {
-		klog.ErrorS(err, "Failed to listen to socket while starting device plugin registry")
+		logger.Error(err, "Failed to listen to socket while starting device plugin registry")
 		return err
 	}
 
@@ -118,17 +119,18 @@ func (s *server) Start() error {
 		s.setHealthy()
 		if err = s.grpc.Serve(ln); err != nil {
 			s.setUnhealthy()
-			klog.ErrorS(err, "Error while serving device plugin registration grpc server")
+			logger.Error(err, "Error while serving device plugin registration grpc server")
 		}
 	}()
 
 	return nil
 }
 
-func (s *server) Stop() error {
+func (s *server) Stop(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
 	s.visitClients(func(r string, c Client) {
-		if err := s.disconnectClient(r, c); err != nil {
-			klog.ErrorS(err, "Failed to disconnect device plugin client", "resourceName", r)
+		if err := s.disconnectClient(ctx, r, c); err != nil {
+			logger.Error(err, "Failed to disconnect device plugin client", "resourceName", r)
 		}
 	})
 
@@ -145,7 +147,7 @@ func (s *server) Stop() error {
 	// During kubelet termination, we do not need the registration server,
 	// and we consider the kubelet to be healthy even when it is down.
 	s.setHealthy()
-	klog.V(2).InfoS("Stopping device plugin registration server")
+	logger.V(2).Info("Stopping device plugin registration server")
 
 	return nil
 }
@@ -155,23 +157,24 @@ func (s *server) SocketPath() string {
 }
 
 func (s *server) Register(ctx context.Context, r *api.RegisterRequest) (*api.Empty, error) {
-	klog.InfoS("Got registration request from device plugin with resource", "resourceName", r.ResourceName)
+	logger := klog.FromContext(ctx)
+	logger.Info("Got registration request from device plugin with resource", "resourceName", r.ResourceName)
 	metrics.DevicePluginRegistrationCount.WithLabelValues(r.ResourceName).Inc()
 
 	if !s.isVersionCompatibleWithPlugin(r.Version) {
 		err := fmt.Errorf(errUnsupportedVersion, r.Version, api.SupportedVersions)
-		klog.ErrorS(err, "Bad registration request from device plugin with resource", "resourceName", r.ResourceName)
+		logger.Error(err, "Bad registration request from device plugin with resource", "resourceName", r.ResourceName)
 		return &api.Empty{}, err
 	}
 
 	if !v1helper.IsExtendedResourceName(core.ResourceName(r.ResourceName)) {
 		err := fmt.Errorf(errInvalidResourceName, r.ResourceName)
-		klog.ErrorS(err, "Bad registration request from device plugin")
+		logger.Error(err, "Bad registration request from device plugin")
 		return &api.Empty{}, err
 	}
 
-	if err := s.connectClient(r.ResourceName, filepath.Join(s.socketDir, r.Endpoint)); err != nil {
-		klog.ErrorS(err, "Error connecting to device plugin client")
+	if err := s.connectClient(ctx, r.ResourceName, filepath.Join(s.socketDir, r.Endpoint)); err != nil {
+		logger.Error(err, "Error connecting to device plugin client")
 		return &api.Empty{}, err
 	}
 

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package devicemanager
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -35,7 +36,7 @@ import (
 // Manager manages all the Device Plugins running on a node.
 type Manager interface {
 	// Start starts device plugin registration service.
-	Start(activePods ActivePodsFunc, sourcesReady config.SourcesReady, initialContainers containermap.ContainerMap, initialContainerRunningSet sets.Set[string]) error
+	Start(ctx context.Context, activePods ActivePodsFunc, sourcesReady config.SourcesReady, initialContainers containermap.ContainerMap, initialContainerRunningSet sets.Set[string]) error
 
 	// Allocate configures and assigns devices to a container in a pod. From
 	// the requested device resources, Allocate will communicate with the
@@ -50,7 +51,7 @@ type Manager interface {
 	UpdatePluginResources(node *schedulerframework.NodeInfo, attrs *lifecycle.PodAdmitAttributes) error
 
 	// Stop stops the manager.
-	Stop() error
+	Stop(ctx context.Context) error
 
 	// GetDeviceRunContainerOptions checks whether we have cached containerDevices
 	// for the passed-in <pod, container> and returns its DeviceRunContainerOptions

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -583,7 +583,7 @@ func TestPrepareResources(t *testing.T) {
 			}
 			defer draServerInfo.teardownFn()
 			plg := manager.GetWatcherHandler()
-			if err := plg.RegisterPlugin(test.driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, pluginClientTimeout); err != nil {
+			if err := plg.RegisterPlugin(tCtx, test.driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, pluginClientTimeout); err != nil {
 				t.Fatalf("failed to register plugin %s, err: %v", test.driverName, err)
 			}
 
@@ -719,7 +719,7 @@ func TestUnprepareResources(t *testing.T) {
 			manager.initDRAPluginManager(tCtx, getFakeNode, time.Second /* very short wiping delay for testing */)
 
 			plg := manager.GetWatcherHandler()
-			if err := plg.RegisterPlugin(test.driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, pluginClientTimeout); err != nil {
+			if err := plg.RegisterPlugin(tCtx, test.driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, pluginClientTimeout); err != nil {
 				t.Fatalf("failed to register plugin %s, err: %v", test.driverName, err)
 			}
 
@@ -876,7 +876,7 @@ func TestParallelPrepareUnprepareResources(t *testing.T) {
 	manager.initDRAPluginManager(tCtx, getFakeNode, time.Second /* very short wiping delay for testing */)
 
 	plg := manager.GetWatcherHandler()
-	if err := plg.RegisterPlugin(driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, nil); err != nil {
+	if err := plg.RegisterPlugin(tCtx, driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, nil); err != nil {
 		t.Fatalf("failed to register plugin %s, err: %v", driverName, err)
 	}
 

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
@@ -307,7 +307,7 @@ func (pm *DRAPluginManager) get(driverName string) *DRAPlugin {
 // name>" format (e.g. "v1beta1.DRAPlugin"). This allows kubelet to determine
 // in advance which version to use resp. which optional services the plugin
 // supports.
-func (pm *DRAPluginManager) RegisterPlugin(driverName string, endpoint string, supportedServices []string, pluginClientTimeout *time.Duration) error {
+func (pm *DRAPluginManager) RegisterPlugin(_ context.Context, driverName string, endpoint string, supportedServices []string, pluginClientTimeout *time.Duration) error {
 	chosenService, err := pm.validateSupportedServices(driverName, supportedServices)
 	if err != nil {
 		return fmt.Errorf("invalid supported gRPC versions of DRA driver plugin %s at endpoint %s: %w", driverName, endpoint, err)
@@ -383,7 +383,7 @@ func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenServic
 // The plugin manager calls it after it has detected that
 // the plugin removed its registration socket,
 // signaling that it is no longer available.
-func (pm *DRAPluginManager) DeRegisterPlugin(driverName, endpoint string) {
+func (pm *DRAPluginManager) DeRegisterPlugin(_ context.Context, driverName, endpoint string) {
 	// remove could be removed (no pun intended) but is kept for the sake of symmetry.
 	pm.remove(driverName, endpoint)
 }
@@ -462,7 +462,7 @@ func (pm *DRAPluginManager) usable(driverName string) bool {
 //
 // The plugin manager calls it upon detection of a new registration socket
 // opened by DRA plugin.
-func (pm *DRAPluginManager) ValidatePlugin(driverName string, endpoint string, supportedServices []string) error {
+func (pm *DRAPluginManager) ValidatePlugin(_ context.Context, driverName string, endpoint string, supportedServices []string) error {
 	_, err := pm.validateSupportedServices(driverName, supportedServices)
 	if err != nil {
 		return fmt.Errorf("invalid supported gRPC versions of DRA driver plugin %s at endpoint %s: %w", driverName, endpoint, err)

--- a/pkg/kubelet/cm/dra/plugin/registration_test.go
+++ b/pkg/kubelet/cm/dra/plugin/registration_test.go
@@ -227,14 +227,14 @@ func TestRegistrationHandler(t *testing.T) {
 			}
 
 			// Simulate one existing plugin A.
-			err = draPlugins.RegisterPlugin(pluginA, endpointA, []string{drapb.DRAPluginService}, nil)
+			err = draPlugins.RegisterPlugin(tCtx, pluginA, endpointA, []string{drapb.DRAPluginService}, nil)
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				tCtx.Logf("Removing plugin %s", pluginA)
-				draPlugins.DeRegisterPlugin(pluginA, endpointA)
+				draPlugins.DeRegisterPlugin(tCtx, pluginA, endpointA)
 			})
 
-			err = draPlugins.ValidatePlugin(test.driverName, endpoint, test.supportedServices)
+			err = draPlugins.ValidatePlugin(tCtx, test.driverName, endpoint, test.supportedServices)
 			if test.shouldError {
 				require.Error(t, err)
 			} else {
@@ -248,7 +248,7 @@ func TestRegistrationHandler(t *testing.T) {
 			}
 
 			// Add plugin for the first time.
-			err = draPlugins.RegisterPlugin(test.driverName, endpoint, test.supportedServices, nil)
+			err = draPlugins.RegisterPlugin(tCtx, test.driverName, endpoint, test.supportedServices, nil)
 			if test.shouldError {
 				require.Error(t, err)
 			} else {
@@ -264,9 +264,9 @@ func TestRegistrationHandler(t *testing.T) {
 				}
 
 				tCtx.Logf("Removing plugin %s", test.driverName)
-				draPlugins.DeRegisterPlugin(test.driverName, endpoint)
+				draPlugins.DeRegisterPlugin(tCtx, test.driverName, endpoint)
 				// Nop.
-				draPlugins.DeRegisterPlugin(test.driverName, endpoint)
+				draPlugins.DeRegisterPlugin(tCtx, test.driverName, endpoint)
 				if test.withClient {
 					requireNoSlices(tCtx)
 				}
@@ -318,7 +318,7 @@ func TestConnectionHandling(t *testing.T) {
 			require.NoError(t, err)
 			defer teardown()
 
-			err = draPlugins.RegisterPlugin(driverName, endpoint, []string{service}, nil)
+			err = draPlugins.RegisterPlugin(tCtx, driverName, endpoint, []string{service}, nil)
 			require.NoError(t, err)
 
 			plugin := draPlugins.get(driverName)

--- a/pkg/kubelet/pluginmanager/cache/types.go
+++ b/pkg/kubelet/pluginmanager/cache/types.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package cache
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // PluginHandler is an interface a client of the pluginwatcher API needs to implement in
 // order to consume plugins
@@ -49,12 +52,12 @@ import "time"
 type PluginHandler interface {
 	// Validate returns an error if the information provided by
 	// the potential plugin is erroneous (unsupported version, ...)
-	ValidatePlugin(pluginName string, endpoint string, versions []string) error
+	ValidatePlugin(ctx context.Context, pluginName string, endpoint string, versions []string) error
 	// RegisterPlugin is called so that the plugin can be registered by any
 	// plugin consumer
 	// Error encountered here can still be Notified to the plugin.
-	RegisterPlugin(pluginName, endpoint string, versions []string, pluginClientTimeout *time.Duration) error
+	RegisterPlugin(ctx context.Context, pluginName, endpoint string, versions []string, pluginClientTimeout *time.Duration) error
 	// DeRegisterPlugin is called once the pluginwatcher observes that the socket has
 	// been deleted.
-	DeRegisterPlugin(pluginName, endpoint string)
+	DeRegisterPlugin(ctx context.Context, pluginName, endpoint string)
 }

--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pluginmanager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,7 +52,7 @@ func newFakePluginHandler() *fakePluginHandler {
 }
 
 // ValidatePlugin is a fake method
-func (f *fakePluginHandler) ValidatePlugin(pluginName string, endpoint string, versions []string) error {
+func (f *fakePluginHandler) ValidatePlugin(ctx context.Context, pluginName string, endpoint string, versions []string) error {
 	f.Lock()
 	defer f.Unlock()
 	f.events = append(f.events, "validate "+pluginName+" "+endpoint)
@@ -59,7 +60,7 @@ func (f *fakePluginHandler) ValidatePlugin(pluginName string, endpoint string, v
 }
 
 // RegisterPlugin is a fake method
-func (f *fakePluginHandler) RegisterPlugin(pluginName, endpoint string, versions []string, pluginClientTimeout *time.Duration) error {
+func (f *fakePluginHandler) RegisterPlugin(ctx context.Context, pluginName, endpoint string, versions []string, pluginClientTimeout *time.Duration) error {
 	f.Lock()
 	defer f.Unlock()
 	f.events = append(f.events, "register "+pluginName+" "+endpoint)
@@ -67,7 +68,7 @@ func (f *fakePluginHandler) RegisterPlugin(pluginName, endpoint string, versions
 }
 
 // DeRegisterPlugin is a fake method
-func (f *fakePluginHandler) DeRegisterPlugin(pluginName, endpoint string) {
+func (f *fakePluginHandler) DeRegisterPlugin(ctx context.Context, pluginName, endpoint string) {
 	f.Lock()
 	defer f.Unlock()
 	f.events = append(f.events, "deregister "+pluginName+" "+endpoint)

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,17 +123,17 @@ func NewDummyImpl() *DummyImpl {
 }
 
 // ValidatePlugin is a dummy implementation
-func (d *DummyImpl) ValidatePlugin(pluginName string, endpoint string, versions []string) error {
+func (d *DummyImpl) ValidatePlugin(ctx context.Context, pluginName string, endpoint string, versions []string) error {
 	return nil
 }
 
 // RegisterPlugin is a dummy implementation
-func (d *DummyImpl) RegisterPlugin(pluginName string, endpoint string, versions []string, pluginClientTimeout *time.Duration) error {
+func (d *DummyImpl) RegisterPlugin(ctx context.Context, pluginName string, endpoint string, versions []string, pluginClientTimeout *time.Duration) error {
 	return nil
 }
 
 // DeRegisterPlugin is a dummy implementation
-func (d *DummyImpl) DeRegisterPlugin(pluginName, endpoint string) {
+func (d *DummyImpl) DeRegisterPlugin(ctx context.Context, pluginName, endpoint string) {
 }
 
 // Calls Run()

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csi
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -1354,7 +1355,7 @@ func TestValidatePlugin(t *testing.T) {
 
 	for _, tc := range testCases {
 		// Arrange & Act
-		err := PluginHandler.ValidatePlugin(tc.pluginName, tc.endpoint, tc.versions)
+		err := PluginHandler.ValidatePlugin(context.Background(), tc.pluginName, tc.endpoint, tc.versions)
 
 		// Assert
 		if tc.shouldFail && err == nil {
@@ -1419,7 +1420,7 @@ func TestValidatePluginExistingDriver(t *testing.T) {
 		})
 
 		// Arrange & Act
-		err = PluginHandler.ValidatePlugin(tc.pluginName2, tc.endpoint2, tc.versions2)
+		err = PluginHandler.ValidatePlugin(context.Background(), tc.pluginName2, tc.endpoint2, tc.versions2)
 
 		// Assert
 		if tc.shouldFail && err == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

migrate pkg/kubelet/cm/devicemanager to contextual logging



#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:

This PR migrated:
- pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
- pkg/kubelet/cm/devicemanager/plugin/v1beta1/handler.go
- pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go 
- `NewManagerImpl`, `Start` and `Stop`  in pkg/kubelet/cm/devicemanager/manager.go

Sorry for this PR's size. I fall down the rabbit hole of plumbing through context :<. I will migrate following files with smaller PRs:
- pkg/kubelet/cm/devicemanager/manager.go
- pkg/kubelet/cm/devicemanager/pod_devices.go
- pkg/kubelet/cm/devicemanager/topology_hints.go
- pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go  

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
