### PR TITLE
Improve ignore-not-found behavior

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -2218,8 +2218,8 @@ func TestWatchNonExistObject(t *testing.T) {
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	cmd.Flags().Set("watch", "true")
-	cmd.Flags().Set("output", "yaml")
+	cmd.Flags().Set("watch", "true")  //nolint:errcheck
+	cmd.Flags().Set("output", "yaml") //nolint:errcheck
 	cmd.Run(cmd, []string{"pods", "nonexistentpod"})
 
 	if buf.String() != "" {
@@ -2261,9 +2261,9 @@ func TestWatchNonExistObjectIgnoreNotFound(t *testing.T) {
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	cmd.Flags().Set("ignore-not-found", "true")
-	cmd.Flags().Set("watch", "true")
-	cmd.Flags().Set("output", "yaml")
+	cmd.Flags().Set("ignore-not-found", "true") //nolint:errcheck
+	cmd.Flags().Set("watch", "true")            //nolint:errcheck
+	cmd.Flags().Set("output", "yaml")           //nolint:errcheck
 	cmd.Run(cmd, []string{"pods", "nonexistentpod"})
 
 	if buf.String() != "" {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"net/http"
 	"reflect"
 	"strings"
@@ -711,7 +712,7 @@ func TestGetEmptyTable(t *testing.T) {
 	}
 }
 
-func TestGetObjectIgnoreNotFound(t *testing.T) {
+func TestGetNonExistObject(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
 
 	ns := &corev1.NamespaceList{
@@ -745,6 +746,63 @@ func TestGetObjectIgnoreNotFound(t *testing.T) {
 		}),
 	}
 
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		expectedErr := "Error from server (NotFound): the server could not find the requested resource (get pods nonexistentpod)"
+		if str != expectedErr {
+			t.Errorf("unexpected error: %s\nexpected: %s", str, expectedErr)
+		}
+	})
+
+	// Get nonexistentpod fails with above error message
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Run(cmd, []string{"pods", "nonexistentpod"})
+}
+
+func TestGetNonExistObjectIgnoreNotFound(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
+	ns := &corev1.NamespaceList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		},
+		Items: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "testns", Namespace: "test", ResourceVersion: "11"},
+				Spec:       corev1.NamespaceSpec{},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/pods/nonexistentpod" && m == "GET":
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			case p == "/api/v1/namespaces/test" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &ns.Items[0])}, nil
+			default:
+				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		expectedErr := ""
+		if str != expectedErr {
+			t.Errorf("unexpected error: %s\nexpected: %s", str, expectedErr)
+		}
+	})
+
+	// Get nonexistentpod passes without error when setting ignore-not-found to true
 	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
@@ -2123,6 +2181,93 @@ foo    <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
 		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+}
+
+func TestWatchNonExistObject(t *testing.T) {
+	pods, _ := watchTestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/pods/nonexistentpod" && m == "GET":
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			case p == "/api/v1/namespaces/test" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods[1])}, nil
+			default:
+				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		expectedErr := "Error from server (NotFound): the server could not find the requested resource (get pods nonexistentpod)"
+		if str != expectedErr {
+			t.Errorf("unexpected error: %s\nexpected: %s", str, expectedErr)
+		}
+	})
+
+	// Get nonexistentpod fails with above error message
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Flags().Set("watch", "true")
+	cmd.Flags().Set("output", "yaml")
+	cmd.Run(cmd, []string{"pods", "nonexistentpod"})
+
+	if buf.String() != "" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
+func TestWatchNonExistObjectIgnoreNotFound(t *testing.T) {
+	pods, _ := watchTestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/pods/nonexistentpod" && m == "GET":
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			case p == "/api/v1/namespaces/test" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods[1])}, nil
+			default:
+				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		expectedErr := ""
+		if str != expectedErr {
+			t.Errorf("unexpected error: %s\nexpected: %s", str, expectedErr)
+		}
+	})
+
+	// Get nonexistentpod passes without error when setting ignore-not-found to true
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Flags().Set("ignore-not-found", "true")
+	cmd.Flags().Set("watch", "true")
+	cmd.Flags().Set("output", "yaml")
+	cmd.Run(cmd, []string{"pods", "nonexistentpod"})
+
+	if buf.String() != "" {
+		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
1. Improve help message of ignore-not-found flag

before:

```
--ignore-not-found=false:
	If the requested object does not exist the command will return exit code 0.
```
after:

```
--ignore-not-found=false:
    If set to true, suppresses NotFound error for object(s) that do not exist and returns exit code 0. Using this flag with commands that query for collections of resources has no effect on the exit code.
```
2. Check ignore-not-found flag in `watch` operation as well; when it's set to true, ignore errors
3. Improve test coverage

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubectl/issues/1596

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes

```release-note
     Clarify help message of --ignore-not-found flag. Support --ignore-not-found in `watch` operation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
