### PR TITLE
Fix gRPC listener error message and some minor (subjective) renaming

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
@@ -30,11 +30,11 @@ type nodeRegistrar struct {
 }
 
 // startRegistrar returns a running instance.
-func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, driverName string, supportedServices []string, socketpath string, pluginRegistrationEndpoint endpoint) (*nodeRegistrar, error) {
+func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, driverName string, supportedServices []string, draEndpointPath string, pluginRegistrationEndpoint endpoint) (*nodeRegistrar, error) {
 	n := &nodeRegistrar{
 		registrationServer: registrationServer{
 			driverName:        driverName,
-			endpoint:          socketpath,
+			draEndpointPath:   draEndpointPath,
 			supportedVersions: supportedServices, // DRA uses this field to describe provided services (e.g. "v1beta1.DRAPlugin").
 		},
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go
@@ -32,7 +32,6 @@ type grpcServer struct {
 	grpcVerbosity int
 	wg            sync.WaitGroup
 	endpoint      endpoint
-	socketpath    string
 	server        *grpc.Server
 }
 
@@ -50,7 +49,7 @@ func startGRPCServer(logger klog.Logger, grpcVerbosity int, unaryInterceptors []
 
 	listener, err := endpoint.listen(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("listen on %q: %w", s.socketpath, err)
+		return nil, fmt.Errorf("listen on %q: %w", s.endpoint.path(), err)
 	}
 
 	// Run a gRPC server. It will close the listening socket when

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/registrationserver.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/registrationserver.go
@@ -27,7 +27,7 @@ import (
 // registrationServer implements the kubelet plugin registration gRPC interface.
 type registrationServer struct {
 	driverName        string
-	endpoint          string
+	draEndpointPath   string
 	supportedVersions []string
 	status            *registerapi.RegistrationStatus
 
@@ -44,7 +44,7 @@ func (e *registrationServer) GetInfo(ctx context.Context, req *registerapi.InfoR
 	return &registerapi.PluginInfo{
 		Type:              registerapi.DRAPlugin,
 		Name:              e.driverName,
-		Endpoint:          e.endpoint,
+		Endpoint:          e.draEndpointPath,
 		SupportedVersions: e.supportedVersions,
 	}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

- Minor fix to log the correct path for which the listener failed to get created in `staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go`
- Rest is some subjective renaming at an attempt to distinguish the endpoints for the driver and the registration server. (I'd be willing to revert it if people feel otherwise.)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/wg device-management