### PR TITLE
Avoid killing kops etcd-manager

### DIFF
--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -74,7 +74,7 @@ var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
 		etcdFailTest(
 			ctx,
 			f,
-			"pgrep etcd | xargs -I {} sudo kill -9 {}",
+			"pgrep etcd | grep -v etcd-manager | xargs -I {} sudo kill -9 {}",
 			"echo 'do nothing. monit should restart etcd.'",
 		)
 	})


### PR DESCRIPTION
Looking at flakiness in:
https://testgrid.k8s.io/amazon-ec2-kops#ci-kubernetes-e2e-al2023-aws-disruptive-canary&width=20

![image](https://github.com/user-attachments/assets/5d575723-b60a-47fc-9450-9eb9f3713488)


looking at log snippets like this:
```
> Enter [It] should recover from SIGKILL - k8s.io/kubernetes/test/e2e/apimachinery/etcd_failure.go:73 @ 06/26/25 08:02:23.787
STEP: failing etcd - k8s.io/kubernetes/test/e2e/apimachinery/etcd_failure.go:99 @ 06/26/25 08:02:23.788
I0626 08:02:26.757498 15885 ssh.go:363] ssh ec2-user@43.205.98.219:22: command:   pgrep etcd | xargs -I {} sudo kill -9 {}
I0626 08:02:26.757522 15885 ssh.go:364] ssh ec2-user@43.205.98.219:22: stdout:    ""
I0626 08:02:26.757528 15885 ssh.go:365] ssh ec2-user@43.205.98.219:22: stderr:    "kill: sending signal to 29684 failed: No such process\nkill: sending signal to 29692 failed: No such process\n"
I0626 08:02:26.757534 15885 ssh.go:366] ssh ec2-user@43.205.98.219:22: exit code: 123
I0626 08:02:29.528536 15885 ssh.go:363] ssh ec2-user@43.205.98.219:22: command:   pgrep etcd | xargs -I {} sudo kill -9 {}
I0626 08:02:29.528563 15885 ssh.go:364] ssh ec2-user@43.205.98.219:22: stdout:    ""
I0626 08:02:29.528569 15885 ssh.go:365] ssh ec2-user@43.205.98.219:22: stderr:    "kill: sending signal to 49316 failed: No such process\nkill: sending signal to 49322 failed: No such process\n"
I0626 08:02:29.528572 15885 ssh.go:366] ssh ec2-user@43.205.98.219:22: exit code: 123
[FAILED] master exec command returned non-zero
In [It] at: k8s.io/kubernetes/test/e2e/apimachinery/etc
```

Looks like the code is assuming that it has to kill every process with `etcd` in the string, but since we have etcd-manager running in kops by default, we may be doing the wrong thing causing flakiness.

Let's try screening the etcd-manager process out and see if that stabilizes the test in this specific CI job.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
