### PR TITLE
fix: Truncate too long Deployment name in RS name

### DIFF
--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
@@ -198,7 +199,7 @@ func (dc *DeploymentController) getNewReplicaSet(ctx context.Context, d *apps.De
 	newRS := apps.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			// Make the name deterministic, to ensure idempotence
-			Name:            d.Name + "-" + podTemplateSpecHash,
+			Name:            generateReplicaSetName(d.Name, podTemplateSpecHash),
 			Namespace:       d.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(d, controllerKind)},
 			Labels:          newRSTemplate.Labels,
@@ -548,4 +549,16 @@ func (dc *DeploymentController) isScalingEvent(ctx context.Context, d *apps.Depl
 		}
 	}
 	return false, nil
+}
+
+// generateReplicaSetName generates a ReplicaSet name by adding a pod template spec hash
+// to a Deployment name, optionally truncating it to ensure the ReplicaSet name is within the limit.
+func generateReplicaSetName(deploymentName, podTemplateSpecHash string) string {
+	maxDeploymentNameLength := validation.DNS1123SubdomainMaxLength - 1 - len(podTemplateSpecHash)
+
+	if len(deploymentName) <= maxDeploymentNameLength {
+		return deploymentName + "-" + podTemplateSpecHash
+	}
+
+	return deploymentName[:maxDeploymentNameLength] + "-" + podTemplateSpecHash
 }

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -556,9 +556,9 @@ func (dc *DeploymentController) isScalingEvent(ctx context.Context, d *apps.Depl
 func generateReplicaSetName(deploymentName, podTemplateSpecHash string) string {
 	maxDeploymentNameLength := validation.DNS1123SubdomainMaxLength - 1 - len(podTemplateSpecHash)
 
-	if len(deploymentName) <= maxDeploymentNameLength {
-		return deploymentName + "-" + podTemplateSpecHash
+	if len(deploymentName) > maxDeploymentNameLength && maxDeploymentNameLength > 0 {
+		return deploymentName[:maxDeploymentNameLength] + "-" + podTemplateSpecHash
 	}
 
-	return deploymentName[:maxDeploymentNameLength] + "-" + podTemplateSpecHash
+	return deploymentName + "-" + podTemplateSpecHash
 }

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -698,10 +698,16 @@ func TestGenerateReplicaSetName(t *testing.T) {
 			want:           strings.Repeat("a", 242) + "-abcde12345",
 		},
 		{
-			name:           "too long need truncating",
+			name:           "very long deployment name is truncated",
 			deploymentName: strings.Repeat("b", 250),
 			hash:           "abcde12345",
 			want:           strings.Repeat("b", 242) + "-abcde12345",
+		},
+		{
+			name:           "very long hash is not truncated",
+			deploymentName: strings.Repeat("d", 252),
+			hash:           strings.Repeat("h", 252),
+			want:           strings.Repeat("d", 252) + "-" + strings.Repeat("h", 252),
 		},
 	}
 

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -597,21 +597,24 @@ func TestDeploymentController_cleanupDeploymentOrder(t *testing.T) {
 
 func TestDeploymentController_generateReplicaSetName(t *testing.T) {
 	tests := []struct {
-		name             string
-		deploymentName   string
-		wantRSNamePrefix string
+		name                  string
+		deploymentName        string
+		wantDeploymentPortion string
 	}{
 		{
-			name:           "short name",
-			deploymentName: "my-deployment",
+			name:                  "short name",
+			deploymentName:        "my-deployment",
+			wantDeploymentPortion: "my-deployment",
 		},
 		{
-			name:           "very long name truncated",
-			deploymentName: strings.Repeat("a", 250),
+			name:                  "very long name truncated",
+			deploymentName:        strings.Repeat("a", 250),
+			wantDeploymentPortion: strings.Repeat("a", 242),
 		},
 		{
-			name:           "very long name not truncated",
-			deploymentName: strings.Repeat("a", 242),
+			name:                  "very long name not truncated",
+			deploymentName:        strings.Repeat("a", 242),
+			wantDeploymentPortion: strings.Repeat("a", 242),
 		},
 	}
 
@@ -664,16 +667,17 @@ func TestDeploymentController_generateReplicaSetName(t *testing.T) {
 
 		deploymentPortion := strings.Join(parts[:len(parts)-1], "-")
 		if len(test.deploymentName) <= 242 {
-			if deploymentPortion != test.deploymentName {
-				t.Errorf("Deployment name portion mismatch: got %q, want %q", deploymentPortion, test.deploymentName)
+			if len(deploymentPortion) != len(test.deploymentName) {
+				t.Errorf("Deployment name portion should be %d chars, got %d", len(test.deploymentName), len(deploymentPortion))
 			}
 		} else {
 			if len(deploymentPortion) != 242 {
 				t.Errorf("Truncated deployment name should be 242 chars, got %d", len(deploymentPortion))
 			}
-			if want := test.deploymentName[:242]; deploymentPortion != want {
-				t.Errorf("Deployment name portion mismatch: got %q, want %q", deploymentPortion, want)
-			}
+		}
+
+		if deploymentPortion != test.wantDeploymentPortion {
+			t.Errorf("Deployment name portion mismatch: got %q, want %q", deploymentPortion, test.wantDeploymentPortion)
 		}
 	}
 }

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -648,8 +648,8 @@ func TestDeploymentController_generateReplicaSetName(t *testing.T) {
 		for _, action := range fake.Actions() {
 			if createAction, ok := action.(testclient.CreateAction); ok {
 				if createdRS, ok := createAction.GetObject().(*apps.ReplicaSet); ok {
-					if createdRS.ObjectMeta.Name != "" {
-						rsName = createdRS.ObjectMeta.Name
+					if createdRS.Name != "" {
+						rsName = createdRS.Name
 						break
 					}
 				}
@@ -662,6 +662,10 @@ func TestDeploymentController_generateReplicaSetName(t *testing.T) {
 
 		if !strings.HasPrefix(rsName, test.wantRSNamePrefix) {
 			t.Errorf("generated name %q, want prefix %q", rsName, test.wantRSNamePrefix)
+		}
+
+		if h := strings.TrimPrefix(rsName, test.wantRSNamePrefix); len(h) != 10 {
+			t.Errorf("generated name hash %q length %d, want length 10", h, len(h))
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When generating a replica set name, truncate the deployment name if it is too long. This fixes #116447 that fails to create a replica set when a deployment name is too long.

#### Which issue(s) this PR is related to:
Fixes #116447
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that fails to create a replica set when a deployment name is too long.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
