### PR TITLE
add applyset support to kubectl diff

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -689,18 +689,15 @@ func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 			}
 
 			tooling := apply.ApplySetTooling{Name: "kubectl", Version: apply.ApplySetToolVersion}
-			restClient, err := f.UnstructuredClientForMapping(parent.RESTMapping)
-			if err != nil {
+			if restClient, err := f.UnstructuredClientForMapping(parent.RESTMapping); err != nil {
 				return fmt.Errorf("failed to initialize RESTClient for ApplySet: %w", err)
-			}
-			if restClient == nil {
+			} else if restClient == nil {
 				return fmt.Errorf("could not build RESTClient for ApplySet")
-			}
-
-			o.applySet = apply.NewApplySet(parent, tooling, mapper, restClient)
-
-			if err := o.applySet.Validate(cmd.Context(), o.DynamicClient); err != nil {
-				return err
+			} else {
+				o.applySet = apply.NewApplySet(parent, tooling, mapper, restClient)
+				if err := o.applySet.Validate(cmd.Context(), o.DynamicClient); err != nil {
+					return err
+				}
 			}
 
 		} else {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -807,7 +807,7 @@ func TestDiffWithPruneV2(t *testing.T) {
 							"kind":       "Namespace",
 							"metadata": map[string]interface{}{
 								"name": "foo",
-								"uid":  "some-fake-uid", // Add a UID for realism
+								"uid":  "some-fake-uid",
 							},
 						},
 					}),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -747,7 +747,7 @@ func fatalNoExit(t *testing.T, ioStreams genericiooptions.IOStreams) func(msg st
 			if !strings.HasSuffix(msg, "\n") {
 				msg += "\n"
 			}
-			fmt.Fprint(ioStreams.ErrOut, msg)
+			_, _ = fmt.Fprint(ioStreams.ErrOut, msg)
 		}
 	}
 }
@@ -854,11 +854,10 @@ func TestDiffWithPruneV2(t *testing.T) {
 		ioStreams, _, outBuf, _ := genericiooptions.NewTestIOStreams()
 		cmdutil.BehaviorOnFatal(fatalNoExit(t, ioStreams))
 		defer cmdutil.DefaultBehaviorOnFatal()
-
 		cmd := NewCmdDiff(tf, ioStreams)
-		cmd.Flags().Set("filename", filepath.Join(testdir, "sample_manifest.yaml"))
-		cmd.Flags().Set("applyset", "simple")
-		cmd.Flags().Set("prune", "true")
+		cmdutil.CheckErr(cmd.Flags().Set("filename", filepath.Join(testdir, "sample_manifest.yaml")))
+		cmdutil.CheckErr(cmd.Flags().Set("applyset", "simple"))
+		cmdutil.CheckErr(cmd.Flags().Set("prune", "true"))
 
 		cmd.Run(cmd, []string{})
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/testdata/prune/sample_manifest.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/testdata/prune/sample_manifest.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

[KEP-3659](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3659-kubectl-apply-prune#kubectl-commands-and-flags) outlines that to improve the behavior of pruning we need to support applyset behavior for the kubectl diff command

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3659-kubectl-apply-prune#kubectl-commands-and-flags

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added: --applyset support to kubectl diff command
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: 
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3659-kubectl-apply-prune#kubectl-commands-and-flags
```
