### PR TITLE
DRA: add E2E test for PerDeviceNodeSelection

### DIFF
--- a/test/e2e/dra/deploy.go
+++ b/test/e2e/dra/deploy.go
@@ -316,8 +316,9 @@ func (d *Driver) SetUp(nodes *Nodes, driverResources map[string]resourceslice.Dr
 							Generation:         pool.Generation,
 							ResourceSliceCount: int64(len(pool.Slices)),
 						},
-						NodeSelector: pool.NodeSelector,
-						Devices:      slice.Devices,
+						NodeSelector:           pool.NodeSelector,
+						PerDeviceNodeSelection: slice.PerDeviceNodeSelection,
+						Devices:                slice.Devices,
 					},
 				}
 				_, err := d.f.ClientSet.ResourceV1beta2().ResourceSlices().Create(ctx, resourceSlice, metav1.CreateOptions{})


### PR DESCRIPTION
Test Scenario:
Create a ResourceSlice that uses the PerDeviceNodeSelection and make sure that the devices ends up on the right nodes


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a test to the DRA feature that is under active development.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/132136

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4815-dra-partitionable-devices
```
