### PR TITLE
WIP: Format memory quantity to human readable string

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -844,7 +844,7 @@ func describePod(pod *corev1.Pod, events *corev1.EventList) (string, error) {
 
 		if pod.Spec.Resources != nil {
 			w.Write(LEVEL_0, "Resources:\n")
-			describeResources(pod.Spec.Resources, w, LEVEL_1)
+			describeResources(pod.Spec.Resources, w, LEVEL_1, false)
 		}
 
 		if len(pod.Spec.InitContainers) > 0 {
@@ -1811,7 +1811,7 @@ func describeContainers(label string, containers []corev1.Container, containerSt
 		if ok {
 			describeContainerState(status, w)
 		}
-		describeResources(&container.Resources, w, LEVEL_2)
+		describeResources(&container.Resources, w, LEVEL_2, false)
 		describeContainerProbe(container, w)
 		if len(container.EnvFrom) > 0 {
 			describeContainerEnvFrom(container, resolverFn, w)
@@ -1897,7 +1897,7 @@ func describeContainerCommand(container corev1.Container, w PrefixWriter) {
 	}
 }
 
-func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, level int) {
+func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, level int, humanReadableFlag bool) {
 	if resources == nil {
 		return
 	}
@@ -1907,7 +1907,12 @@ func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, l
 	}
 	for _, name := range SortedResourceNames(resources.Limits) {
 		quantity := resources.Limits[name]
-		w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		// todo: introduce a flag to determine if we want to display a human readable string
+		if humanReadableFlag {
+			w.Write(level+1, "%s:\t%s\n", name, quantity.HumanReadableString())
+		} else {
+			w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		}
 	}
 
 	if len(resources.Requests) > 0 {
@@ -1915,7 +1920,12 @@ func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, l
 	}
 	for _, name := range SortedResourceNames(resources.Requests) {
 		quantity := resources.Requests[name]
-		w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		// todo: introduce a flag to determine if we want to display a human readable string
+		if humanReadableFlag {
+			w.Write(level+1, "%s:\t%s\n", name, quantity.HumanReadableString())
+		} else {
+			w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To improve UX, this PR implements a feature (may need to be controlled by a flag) that converts fractional memory quantities into a human-readable format when using `kubectl describe`. This change only affects the display output (with `kubectl describe`) and should not impact the underlying API interactions.

For instance, if a requested memory is 0.1Gi, the API should still use its byte value, 107374182400m, during CREATE or GET operations. However, when describing the resource, 107374182400m would be converted and presented as 0.1Gi.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubectl/issues/1729 and https://github.com/kubernetes/kubectl/issues/1597

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes

```release-note
TBD
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
