### PR TITLE
WIP: API: enhance validation with ErrorMatcher

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -152,7 +152,7 @@ func ValidateQualifiedName(value string, fldPath *field.Path) field.ErrorList {
 func ValidateDNS1123SubdomainWithUnderScore(value string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, msg := range validation.IsDNS1123SubdomainWithUnderscore(value) {
-		allErrs = append(allErrs, field.Invalid(fldPath, value, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, value, msg)).WithOrigin("format=dns-subdomain-with-underscore")
 	}
 	return allErrs
 }
@@ -161,7 +161,7 @@ func ValidateDNS1123SubdomainWithUnderScore(value string, fldPath *field.Path) f
 func ValidateDNS1123Subdomain(value string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, msg := range validation.IsDNS1123Subdomain(value) {
-		allErrs = append(allErrs, field.Invalid(fldPath, value, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, value, msg)).WithOrigin("format=dns-subdomain")
 	}
 	return allErrs
 }
@@ -1700,7 +1700,7 @@ func ValidateCSIDriverName(driverName string, fldPath *field.Path) field.ErrorLi
 	}
 
 	for _, msg := range validation.IsDNS1123Subdomain(strings.ToLower(driverName)) {
-		allErrs = append(allErrs, field.Invalid(fldPath, driverName, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, driverName, msg).WithOrigin("format=dns-subdomain"))
 	}
 
 	return allErrs
@@ -4544,26 +4544,26 @@ func ValidateNodeSelectorRequirement(rq core.NodeSelectorRequirement, allowInval
 	switch rq.Operator {
 	case core.NodeSelectorOpIn, core.NodeSelectorOpNotIn:
 		if len(rq.Values) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'In' or 'NotIn'"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'In' or 'NotIn'").WithOrigin("node-selector-requirement"))
 		}
 	case core.NodeSelectorOpExists, core.NodeSelectorOpDoesNotExist:
 		if len(rq.Values) > 0 {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("values"), "may not be specified when `operator` is 'Exists' or 'DoesNotExist'"))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("values"), "may not be specified when `operator` is 'Exists' or 'DoesNotExist'").WithOrigin("node-selector-requirement"))
 		}
 
 	case core.NodeSelectorOpGt, core.NodeSelectorOpLt:
 		if len(rq.Values) != 1 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified single value when `operator` is 'Lt' or 'Gt'"))
+			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified single value when `operator` is 'Lt' or 'Gt'").WithOrigin("node-selector-requirement"))
 		}
 	default:
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), rq.Operator, "not a valid selector operator"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), rq.Operator, "not a valid selector operator").WithOrigin("node-selector-requirement"))
 	}
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabelName(rq.Key, fldPath.Child("key"))...)
 	if !allowInvalidLabelValueInRequiredNodeAffinity {
 		path := fldPath.Child("values")
 		for valueIndex, value := range rq.Values {
 			for _, msg := range validation.IsValidLabelValue(value) {
-				allErrs = append(allErrs, field.Invalid(path.Index(valueIndex), value, msg))
+				allErrs = append(allErrs, field.Invalid(path.Index(valueIndex), value, msg).WithOrigin("format=label-value"))
 			}
 		}
 	}
@@ -4582,14 +4582,14 @@ func ValidateNodeFieldSelectorRequirement(req core.NodeSelectorRequirement, fldP
 	case core.NodeSelectorOpIn, core.NodeSelectorOpNotIn:
 		if len(req.Values) != 1 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("values"),
-				"must be only one value when `operator` is 'In' or 'NotIn' for node field selector"))
+				"must be only one value when `operator` is 'In' or 'NotIn' for node field selector").WithOrigin("node-field-selector-requirement"))
 		}
 	default:
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), req.Operator, "not a valid selector operator"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), req.Operator, "not a valid selector operator").WithOrigin("node-field-selector-requirement"))
 	}
 
 	if vf, found := nodeFieldSelectorValidators[req.Key]; !found {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), req.Key, "not a valid field selector key"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("key"), req.Key, "not a valid field selector key").WithOrigin("node-field-selector-requirement"))
 	} else {
 		for i, v := range req.Values {
 			for _, msg := range vf(v, false) {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -17154,7 +17154,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 				rc.Spec.Selector = invalid
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec.template.labels"), nil, "").WithOrigin("labelKey"),
+				field.Invalid(field.NewPath("spec.template.labels"), nil, "").WithOrigin("format=qualified-name"),
 			},
 		},
 		"invalid pod": {
@@ -17303,7 +17303,7 @@ func TestValidateReplicationController(t *testing.T) {
 				}
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.labels"), nil, "").WithOrigin("labelKey"),
+				field.Invalid(field.NewPath("metadata.labels"), nil, "").WithOrigin("format=qualified-name"),
 			},
 		},
 		"invalid label 2": {
@@ -17314,7 +17314,7 @@ func TestValidateReplicationController(t *testing.T) {
 			}),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec.template.metadata.labels"), nil, "does not match template"),
-				field.Invalid(field.NewPath("spec.template.labels"), nil, "").WithOrigin("labelKey"),
+				field.Invalid(field.NewPath("spec.template.labels"), nil, "").WithOrigin("format=qualified-name"),
 			},
 		},
 		"invalid annotation": {
@@ -17324,7 +17324,7 @@ func TestValidateReplicationController(t *testing.T) {
 				}
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata.annotations"), nil, "name part must consist of"),
+				field.Invalid(field.NewPath("metadata.annotations"), nil, "").WithOrigin("format=qualified-name"),
 			},
 		},
 		"invalid restart policy 1": {
@@ -23492,7 +23492,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MatchLabelKeys:    []string{"/simple"},
 		}},
 		wantFieldErrors: field.ErrorList{
-			field.Invalid(fieldPathMatchLabelKeys.Index(0), nil, "").WithOrigin("labelKey"),
+			field.Invalid(fieldPathMatchLabelKeys.Index(0), nil, "").WithOrigin("format=qualified-name"),
 		},
 		opts: PodValidationOptions{
 			AllowMatchLabelKeysInPodTopologySpread:              true,
@@ -23508,7 +23508,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			MatchLabelKeys:    []string{"/simple"},
 		}},
 		wantFieldErrors: field.ErrorList{
-			field.Invalid(fieldPathMatchLabelKeys.Index(0), nil, "").WithOrigin("labelKey"),
+			field.Invalid(fieldPathMatchLabelKeys.Index(0), nil, "").WithOrigin("format=qualified-name"),
 		},
 		opts: PodValidationOptions{
 			AllowMatchLabelKeysInPodTopologySpread:              true,
@@ -23607,7 +23607,7 @@ func TestValidateTopologySpreadConstraints(t *testing.T) {
 			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"NoUppercaseOrSpecialCharsLike=Equals": "foo"}},
 		}},
 		wantFieldErrors: field.ErrorList{
-			field.Invalid(labelSelectorField.Child("matchLabels"), nil, "").WithOrigin("labelKey"),
+			field.Invalid(labelSelectorField.Child("matchLabels"), nil, "").WithOrigin("format=qualified-name"),
 		},
 		opts: PodValidationOptions{
 			AllowMatchLabelKeysInPodTopologySpread:              true,

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -559,7 +559,7 @@ func ValidateResourceClaimTemplateUpdate(template, oldTemplate *resource.Resourc
 func validateNodeName(name string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for _, msg := range corevalidation.ValidateNodeName(name, false) {
-		allErrs = append(allErrs, field.Invalid(fldPath, name, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, name, msg).WithOrigin("format=dns-subdomain"))
 	}
 	return allErrs
 }
@@ -1187,7 +1187,7 @@ func validateLabelValue(value string, fldPath *field.Path) field.ErrorList {
 
 	// There's no metav1validation.ValidateLabelValue.
 	for _, msg := range validation.IsValidLabelValue(value) {
-		allErrs = append(allErrs, field.Invalid(fldPath, value, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, value, msg).WithOrigin("format=label-value"))
 	}
 
 	return allErrs

--- a/pkg/apis/resource/validation/validation_common_test.go
+++ b/pkg/apis/resource/validation/validation_common_test.go
@@ -19,26 +19,18 @@ package validation
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/dynamic-resource-allocation/api"
 )
 
 // assertFailures compares the expected against the actual errors.
 //
-// If they differ, it also logs what the formatted errors would look
-// like to a user. This can be helpful to figure out whether an error
-// is informative.
-func assertFailures(tb testing.TB, want, got field.ErrorList) bool {
+// For the wanted error details it is okay to specify only a substring.
+func assertFailures(tb testing.TB, want, got field.ErrorList) {
 	tb.Helper()
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(field.Error{}, "Origin"), cmp.AllowUnexported(api.UniqueString{})); diff != "" {
-		tb.Errorf("unexpected field errors (-want, +got):\n%s", diff)
-		return false
-	}
-	return true
+	matcher := field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValue().ByDetailSubstring().WithUniqueMatches()
+	matcher.Test(tb, want, got)
 }
 
 func TestTruncateIfTooLong(t *testing.T) {

--- a/pkg/apis/resource/validation/validation_deviceclass_test.go
+++ b/pkg/apis/resource/validation/validation_deviceclass_test.go
@@ -53,7 +53,7 @@ func TestValidateClass(t *testing.T) {
 			class:        testClass(""),
 		},
 		"bad-name": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')") /* no WithOrigin https://github.com/kubernetes/kubernetes/blob/6ed5b60f71930d51bfcf8bfa6f3506b099811318/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L160 */},
 			class:        testClass(badName),
 		},
 		"generate-name": {
@@ -145,7 +145,7 @@ func TestValidateClass(t *testing.T) {
 			}(),
 		},
 		"bad-labels": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "labels"), badValue, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "labels"), badValue, "").WithOrigin("format=label-value")},
 			class: func() *resource.DeviceClass {
 				class := testClass(goodName)
 				class.Labels = map[string]string{
@@ -164,7 +164,7 @@ func TestValidateClass(t *testing.T) {
 			}(),
 		},
 		"bad-annotations": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "annotations"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "annotations"), badName, "").WithOrigin("format=qualified-name")},
 			class: func() *resource.DeviceClass {
 				class := testClass(goodName)
 				class.Annotations = map[string]string{
@@ -222,7 +222,7 @@ func TestValidateClass(t *testing.T) {
 		"configuration": {
 			wantFailures: field.ErrorList{
 				field.Required(field.NewPath("spec", "config").Index(1).Child("opaque", "driver"), ""),
-				field.Invalid(field.NewPath("spec", "config").Index(1).Child("opaque", "driver"), "", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				field.Invalid(field.NewPath("spec", "config").Index(1).Child("opaque", "driver"), "", "").WithOrigin("format=dns-subdomain"),
 				field.Required(field.NewPath("spec", "config").Index(1).Child("opaque", "parameters"), ""),
 				field.Invalid(field.NewPath("spec", "config").Index(2).Child("opaque", "parameters"), "<value omitted>", "error parsing data as JSON: invalid character 'x' looking for beginning of value"),
 				field.Invalid(field.NewPath("spec", "config").Index(3).Child("opaque", "parameters"), "<value omitted>", "parameters must be a valid JSON object"),

--- a/pkg/apis/resource/validation/validation_devicetaintrule_test.go
+++ b/pkg/apis/resource/validation/validation_devicetaintrule_test.go
@@ -67,7 +67,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 			taintRule:    testDeviceTaintRule("", validDeviceTaintRuleSpec),
 		},
 		"bad-name": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')") /* no WithOrigin https://github.com/kubernetes/kubernetes/blob/6ed5b60f71930d51bfcf8bfa6f3506b099811318/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L160 */},
 			taintRule:    testDeviceTaintRule(badName, validDeviceTaintRuleSpec),
 		},
 		"generate-name": {
@@ -159,7 +159,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 			}(),
 		},
 		"bad-labels": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "labels"), badValue, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "labels"), badValue, "").WithOrigin("format=label-value")},
 			taintRule: func() *resourceapi.DeviceTaintRule {
 				taintRule := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)
 				taintRule.Labels = map[string]string{
@@ -178,7 +178,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 			}(),
 		},
 		"bad-annotations": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "annotations"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "annotations"), badName, "").WithOrigin("format=qualified-name")},
 			taintRule: func() *resourceapi.DeviceTaintRule {
 				taintRule := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)
 				taintRule.Annotations = map[string]string{
@@ -188,7 +188,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 			}(),
 		},
 		"bad-class": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "deviceClassName"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "deviceClassName"), badName, "").WithOrigin("format=dns-subdomain")},
 			taintRule: func() *resourceapi.DeviceTaintRule {
 				taintRule := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)
 				taintRule.Spec.DeviceSelector.DeviceClassName = ptr.To(badName)
@@ -196,7 +196,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 			}(),
 		},
 		"bad-driver": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "driver"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "driver"), badName, "").WithOrigin("format=dns-subdomain")},
 			taintRule: func() *resourceapi.DeviceTaintRule {
 				taintRule := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)
 				taintRule.Spec.DeviceSelector.Driver = ptr.To(badName)
@@ -204,7 +204,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 			}(),
 		},
 		"bad-pool": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "pool"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "pool"), badName, "").WithOrigin("format=dns-subdomain")},
 			taintRule: func() *resourceapi.DeviceTaintRule {
 				taintRule := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)
 				taintRule.Spec.DeviceSelector.Pool = ptr.To(badName)
@@ -212,7 +212,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 			}(),
 		},
 		"bad-device": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "device"), badName, "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "deviceSelector", "device"), badName, "").WithOrigin("format=dns-label")},
 			taintRule: func() *resourceapi.DeviceTaintRule {
 				taintRule := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)
 				taintRule.Spec.DeviceSelector.Device = ptr.To(badName)

--- a/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
@@ -53,7 +53,7 @@ func TestValidateClaimTemplate(t *testing.T) {
 			template:     testClaimTemplate("", goodNS, validClaimSpec),
 		},
 		"bad-name": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')") /* no WithOrigin https://github.com/kubernetes/kubernetes/blob/6ed5b60f71930d51bfcf8bfa6f3506b099811318/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L160 */},
 			template:     testClaimTemplate(badName, goodNS, validClaimSpec),
 		},
 		"missing-namespace": {
@@ -149,7 +149,7 @@ func TestValidateClaimTemplate(t *testing.T) {
 			}(),
 		},
 		"bad-labels": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "labels"), badValue, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "labels"), badValue, "").WithOrigin("format=label-value")},
 			template: func() *resource.ResourceClaimTemplate {
 				template := testClaimTemplate(goodName, goodNS, validClaimSpec)
 				template.Labels = map[string]string{
@@ -168,7 +168,7 @@ func TestValidateClaimTemplate(t *testing.T) {
 			}(),
 		},
 		"bad-annotations": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "annotations"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "annotations"), badName, "").WithOrigin("format=qualified-name")},
 			template: func() *resource.ResourceClaimTemplate {
 				template := testClaimTemplate(goodName, goodNS, validClaimSpec)
 				template.Annotations = map[string]string{
@@ -178,7 +178,7 @@ func TestValidateClaimTemplate(t *testing.T) {
 			}(),
 		},
 		"bad-classname": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "deviceClassName"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "deviceClassName"), badName, "").WithOrigin("format=dns-subdomain")},
 			template: func() *resource.ResourceClaimTemplate {
 				template := testClaimTemplate(goodName, goodNS, validClaimSpec)
 				template.Spec.Spec.Devices.Requests[0].Exactly.DeviceClassName = badName
@@ -203,7 +203,7 @@ func TestValidateClaimTemplate(t *testing.T) {
 			}(),
 		},
 		"prioritized-list-bad-class-name-on-subrequest": {
-			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), badName, "").WithOrigin("format=dns-subdomain")},
 			template: func() *resource.ResourceClaimTemplate {
 				template := testClaimTemplate(goodName, goodNS, validClaimSpecWithFirstAvailable)
 				template.Spec.Spec.Devices.Requests[0].FirstAvailable[0].DeviceClassName = badName


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The use of ErrorMatcher and origins makes it possible to remove special detail strings from the resource.k8s.io validation, which is good because it's shorter and avoids the need to update those tests when the shared validation helpers change.

For that to be more complete, several missing WithOrigin calls were added and some were changed to make them consistent. The following rationale was used:
- All origins should be named after the code generating them. "labelKey" in ValidateLabelName did not follow that because it passed through errors from IsQualifiedName, so this was changed to "format=qualified-name", making it consistent with ValidateQualifiedName.
- WithOrigin is useful when the corresponding error has a non-trivial detail string, because then validation code can check for the origin instead of string.
- WithOrigin is not useful for errors with no detail string, for example field.Required, because adding one would just make error matching harder without a benefit.

Unfortunately object meta name validation still has to match strings because the current code has no knowledge about which origin to add. Changing that is a bigger internal code change.

For resource.k8s.io validation, matching the same wanted error against multiple actual errors is undesirable because it could be a bug in the test case. The new WithUniqueMatches makes the matching stricter than the current default.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/132314#issuecomment-3007618395

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @thockin 