### PR TITLE
E2E framework: sort tests in JUnit report

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -613,6 +614,19 @@ func AfterReadingAllFlags(t *TestContextType) {
 		}
 
 		ginkgo.ReportAfterSuite("Kubernetes e2e JUnit report", func(report ginkgo.Report) {
+			// Sort specs by full name. The default is by start (or completion?) time,
+			// which is less useful in spyglass because those times are not shown
+			// and thus tests seem to be listed with no apparent order.
+			slices.SortFunc(report.SpecReports, func(a, b types.SpecReport) int {
+				res := strings.Compare(a.FullText(), b.FullText())
+				if res == 0 {
+					// Use start time as tie-breaker in the unlikely
+					// case that two specs have the same full name.
+					return a.StartTime.Compare(b.StartTime)
+				}
+				return res
+			})
+
 			// With Ginkgo v1, we used to write one file per
 			// parallel node. Now Ginkgo v2 automatically merges
 			// all results into a report for us. The 01 suffix is


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is more useful when viewing results in spyglass because related tests are shown together. The default was to show them by start or end time (not exactly sure), which almost looked random because those times are not shown.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
