### PR TITLE
Applyconfiguration-Gen: Only the root AC should implement runtime.ApplyConfiguration

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/examplespec.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/examplespec.go
@@ -30,7 +30,6 @@ type ExampleSpecApplyConfiguration struct {
 func ExampleSpec() *ExampleSpecApplyConfiguration {
 	return &ExampleSpecApplyConfiguration{}
 }
-func (b ExampleSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithFoo sets the Foo field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/examplestatus.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/examplestatus.go
@@ -34,7 +34,6 @@ type ExampleStatusApplyConfiguration struct {
 func ExampleStatus() *ExampleStatusApplyConfiguration {
 	return &ExampleStatusApplyConfiguration{}
 }
-func (b ExampleStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithState sets the State field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcecolumndefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcecolumndefinition.go
@@ -34,7 +34,6 @@ type CustomResourceColumnDefinitionApplyConfiguration struct {
 func CustomResourceColumnDefinition() *CustomResourceColumnDefinitionApplyConfiguration {
 	return &CustomResourceColumnDefinitionApplyConfiguration{}
 }
-func (b CustomResourceColumnDefinitionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourceconversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourceconversion.go
@@ -34,7 +34,6 @@ type CustomResourceConversionApplyConfiguration struct {
 func CustomResourceConversion() *CustomResourceConversionApplyConfiguration {
 	return &CustomResourceConversionApplyConfiguration{}
 }
-func (b CustomResourceConversionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStrategy sets the Strategy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitioncondition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitioncondition.go
@@ -38,7 +38,6 @@ type CustomResourceDefinitionConditionApplyConfiguration struct {
 func CustomResourceDefinitionCondition() *CustomResourceDefinitionConditionApplyConfiguration {
 	return &CustomResourceDefinitionConditionApplyConfiguration{}
 }
-func (b CustomResourceDefinitionConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionnames.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionnames.go
@@ -34,7 +34,6 @@ type CustomResourceDefinitionNamesApplyConfiguration struct {
 func CustomResourceDefinitionNames() *CustomResourceDefinitionNamesApplyConfiguration {
 	return &CustomResourceDefinitionNamesApplyConfiguration{}
 }
-func (b CustomResourceDefinitionNamesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPlural sets the Plural field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionspec.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionspec.go
@@ -38,7 +38,6 @@ type CustomResourceDefinitionSpecApplyConfiguration struct {
 func CustomResourceDefinitionSpec() *CustomResourceDefinitionSpecApplyConfiguration {
 	return &CustomResourceDefinitionSpecApplyConfiguration{}
 }
-func (b CustomResourceDefinitionSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionstatus.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionstatus.go
@@ -31,7 +31,6 @@ type CustomResourceDefinitionStatusApplyConfiguration struct {
 func CustomResourceDefinitionStatus() *CustomResourceDefinitionStatusApplyConfiguration {
 	return &CustomResourceDefinitionStatusApplyConfiguration{}
 }
-func (b CustomResourceDefinitionStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionversion.go
@@ -37,7 +37,6 @@ type CustomResourceDefinitionVersionApplyConfiguration struct {
 func CustomResourceDefinitionVersion() *CustomResourceDefinitionVersionApplyConfiguration {
 	return &CustomResourceDefinitionVersionApplyConfiguration{}
 }
-func (b CustomResourceDefinitionVersionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcesubresources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcesubresources.go
@@ -34,7 +34,6 @@ type CustomResourceSubresourcesApplyConfiguration struct {
 func CustomResourceSubresources() *CustomResourceSubresourcesApplyConfiguration {
 	return &CustomResourceSubresourcesApplyConfiguration{}
 }
-func (b CustomResourceSubresourcesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStatus sets the Status field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcesubresourcescale.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcesubresourcescale.go
@@ -31,7 +31,6 @@ type CustomResourceSubresourceScaleApplyConfiguration struct {
 func CustomResourceSubresourceScale() *CustomResourceSubresourceScaleApplyConfiguration {
 	return &CustomResourceSubresourceScaleApplyConfiguration{}
 }
-func (b CustomResourceSubresourceScaleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSpecReplicasPath sets the SpecReplicasPath field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcevalidation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcevalidation.go
@@ -29,7 +29,6 @@ type CustomResourceValidationApplyConfiguration struct {
 func CustomResourceValidation() *CustomResourceValidationApplyConfiguration {
 	return &CustomResourceValidationApplyConfiguration{}
 }
-func (b CustomResourceValidationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithOpenAPIV3Schema sets the OpenAPIV3Schema field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/externaldocumentation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/externaldocumentation.go
@@ -30,7 +30,6 @@ type ExternalDocumentationApplyConfiguration struct {
 func ExternalDocumentation() *ExternalDocumentationApplyConfiguration {
 	return &ExternalDocumentationApplyConfiguration{}
 }
-func (b ExternalDocumentationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDescription sets the Description field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/jsonschemaprops.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/jsonschemaprops.go
@@ -76,7 +76,6 @@ type JSONSchemaPropsApplyConfiguration struct {
 func JSONSchemaProps() *JSONSchemaPropsApplyConfiguration {
 	return &JSONSchemaPropsApplyConfiguration{}
 }
-func (b JSONSchemaPropsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithID sets the ID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/selectablefield.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/selectablefield.go
@@ -29,7 +29,6 @@ type SelectableFieldApplyConfiguration struct {
 func SelectableField() *SelectableFieldApplyConfiguration {
 	return &SelectableFieldApplyConfiguration{}
 }
-func (b SelectableFieldApplyConfiguration) IsApplyConfiguration() {}
 
 // WithJSONPath sets the JSONPath field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/servicereference.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/servicereference.go
@@ -32,7 +32,6 @@ type ServiceReferenceApplyConfiguration struct {
 func ServiceReference() *ServiceReferenceApplyConfiguration {
 	return &ServiceReferenceApplyConfiguration{}
 }
-func (b ServiceReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/validationrule.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/validationrule.go
@@ -38,7 +38,6 @@ type ValidationRuleApplyConfiguration struct {
 func ValidationRule() *ValidationRuleApplyConfiguration {
 	return &ValidationRuleApplyConfiguration{}
 }
-func (b ValidationRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRule sets the Rule field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookclientconfig.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookclientconfig.go
@@ -31,7 +31,6 @@ type WebhookClientConfigApplyConfiguration struct {
 func WebhookClientConfig() *WebhookClientConfigApplyConfiguration {
 	return &WebhookClientConfigApplyConfiguration{}
 }
-func (b WebhookClientConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithURL sets the URL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookconversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookconversion.go
@@ -30,7 +30,6 @@ type WebhookConversionApplyConfiguration struct {
 func WebhookConversion() *WebhookConversionApplyConfiguration {
 	return &WebhookConversionApplyConfiguration{}
 }
-func (b WebhookConversionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithClientConfig sets the ClientConfig field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcecolumndefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcecolumndefinition.go
@@ -34,7 +34,6 @@ type CustomResourceColumnDefinitionApplyConfiguration struct {
 func CustomResourceColumnDefinition() *CustomResourceColumnDefinitionApplyConfiguration {
 	return &CustomResourceColumnDefinitionApplyConfiguration{}
 }
-func (b CustomResourceColumnDefinitionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourceconversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourceconversion.go
@@ -35,7 +35,6 @@ type CustomResourceConversionApplyConfiguration struct {
 func CustomResourceConversion() *CustomResourceConversionApplyConfiguration {
 	return &CustomResourceConversionApplyConfiguration{}
 }
-func (b CustomResourceConversionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStrategy sets the Strategy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitioncondition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitioncondition.go
@@ -38,7 +38,6 @@ type CustomResourceDefinitionConditionApplyConfiguration struct {
 func CustomResourceDefinitionCondition() *CustomResourceDefinitionConditionApplyConfiguration {
 	return &CustomResourceDefinitionConditionApplyConfiguration{}
 }
-func (b CustomResourceDefinitionConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionnames.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionnames.go
@@ -34,7 +34,6 @@ type CustomResourceDefinitionNamesApplyConfiguration struct {
 func CustomResourceDefinitionNames() *CustomResourceDefinitionNamesApplyConfiguration {
 	return &CustomResourceDefinitionNamesApplyConfiguration{}
 }
-func (b CustomResourceDefinitionNamesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPlural sets the Plural field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionspec.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionspec.go
@@ -43,7 +43,6 @@ type CustomResourceDefinitionSpecApplyConfiguration struct {
 func CustomResourceDefinitionSpec() *CustomResourceDefinitionSpecApplyConfiguration {
 	return &CustomResourceDefinitionSpecApplyConfiguration{}
 }
-func (b CustomResourceDefinitionSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionstatus.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionstatus.go
@@ -31,7 +31,6 @@ type CustomResourceDefinitionStatusApplyConfiguration struct {
 func CustomResourceDefinitionStatus() *CustomResourceDefinitionStatusApplyConfiguration {
 	return &CustomResourceDefinitionStatusApplyConfiguration{}
 }
-func (b CustomResourceDefinitionStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionversion.go
@@ -37,7 +37,6 @@ type CustomResourceDefinitionVersionApplyConfiguration struct {
 func CustomResourceDefinitionVersion() *CustomResourceDefinitionVersionApplyConfiguration {
 	return &CustomResourceDefinitionVersionApplyConfiguration{}
 }
-func (b CustomResourceDefinitionVersionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcesubresources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcesubresources.go
@@ -34,7 +34,6 @@ type CustomResourceSubresourcesApplyConfiguration struct {
 func CustomResourceSubresources() *CustomResourceSubresourcesApplyConfiguration {
 	return &CustomResourceSubresourcesApplyConfiguration{}
 }
-func (b CustomResourceSubresourcesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStatus sets the Status field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcesubresourcescale.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcesubresourcescale.go
@@ -31,7 +31,6 @@ type CustomResourceSubresourceScaleApplyConfiguration struct {
 func CustomResourceSubresourceScale() *CustomResourceSubresourceScaleApplyConfiguration {
 	return &CustomResourceSubresourceScaleApplyConfiguration{}
 }
-func (b CustomResourceSubresourceScaleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSpecReplicasPath sets the SpecReplicasPath field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcevalidation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcevalidation.go
@@ -29,7 +29,6 @@ type CustomResourceValidationApplyConfiguration struct {
 func CustomResourceValidation() *CustomResourceValidationApplyConfiguration {
 	return &CustomResourceValidationApplyConfiguration{}
 }
-func (b CustomResourceValidationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithOpenAPIV3Schema sets the OpenAPIV3Schema field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/externaldocumentation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/externaldocumentation.go
@@ -30,7 +30,6 @@ type ExternalDocumentationApplyConfiguration struct {
 func ExternalDocumentation() *ExternalDocumentationApplyConfiguration {
 	return &ExternalDocumentationApplyConfiguration{}
 }
-func (b ExternalDocumentationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDescription sets the Description field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/jsonschemaprops.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/jsonschemaprops.go
@@ -76,7 +76,6 @@ type JSONSchemaPropsApplyConfiguration struct {
 func JSONSchemaProps() *JSONSchemaPropsApplyConfiguration {
 	return &JSONSchemaPropsApplyConfiguration{}
 }
-func (b JSONSchemaPropsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithID sets the ID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/selectablefield.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/selectablefield.go
@@ -29,7 +29,6 @@ type SelectableFieldApplyConfiguration struct {
 func SelectableField() *SelectableFieldApplyConfiguration {
 	return &SelectableFieldApplyConfiguration{}
 }
-func (b SelectableFieldApplyConfiguration) IsApplyConfiguration() {}
 
 // WithJSONPath sets the JSONPath field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/servicereference.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/servicereference.go
@@ -32,7 +32,6 @@ type ServiceReferenceApplyConfiguration struct {
 func ServiceReference() *ServiceReferenceApplyConfiguration {
 	return &ServiceReferenceApplyConfiguration{}
 }
-func (b ServiceReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/validationrule.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/validationrule.go
@@ -38,7 +38,6 @@ type ValidationRuleApplyConfiguration struct {
 func ValidationRule() *ValidationRuleApplyConfiguration {
 	return &ValidationRuleApplyConfiguration{}
 }
-func (b ValidationRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRule sets the Rule field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/webhookclientconfig.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/webhookclientconfig.go
@@ -31,7 +31,6 @@ type WebhookClientConfigApplyConfiguration struct {
 func WebhookClientConfig() *WebhookClientConfigApplyConfiguration {
 	return &WebhookClientConfigApplyConfiguration{}
 }
-func (b WebhookClientConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithURL sets the URL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/auditannotation.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/auditannotation.go
@@ -30,7 +30,6 @@ type AuditAnnotationApplyConfiguration struct {
 func AuditAnnotation() *AuditAnnotationApplyConfiguration {
 	return &AuditAnnotationApplyConfiguration{}
 }
-func (b AuditAnnotationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/expressionwarning.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/expressionwarning.go
@@ -30,7 +30,6 @@ type ExpressionWarningApplyConfiguration struct {
 func ExpressionWarning() *ExpressionWarningApplyConfiguration {
 	return &ExpressionWarningApplyConfiguration{}
 }
-func (b ExpressionWarningApplyConfiguration) IsApplyConfiguration() {}
 
 // WithFieldRef sets the FieldRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/matchcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/matchcondition.go
@@ -30,7 +30,6 @@ type MatchConditionApplyConfiguration struct {
 func MatchCondition() *MatchConditionApplyConfiguration {
 	return &MatchConditionApplyConfiguration{}
 }
-func (b MatchConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/matchresources.go
@@ -38,7 +38,6 @@ type MatchResourcesApplyConfiguration struct {
 func MatchResources() *MatchResourcesApplyConfiguration {
 	return &MatchResourcesApplyConfiguration{}
 }
-func (b MatchResourcesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespaceSelector sets the NamespaceSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
@@ -45,7 +45,6 @@ type MutatingWebhookApplyConfiguration struct {
 func MutatingWebhook() *MutatingWebhookApplyConfiguration {
 	return &MutatingWebhookApplyConfiguration{}
 }
-func (b MutatingWebhookApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/namedrulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/namedrulewithoperations.go
@@ -34,7 +34,6 @@ type NamedRuleWithOperationsApplyConfiguration struct {
 func NamedRuleWithOperations() *NamedRuleWithOperationsApplyConfiguration {
 	return &NamedRuleWithOperationsApplyConfiguration{}
 }
-func (b NamedRuleWithOperationsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/paramkind.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/paramkind.go
@@ -30,7 +30,6 @@ type ParamKindApplyConfiguration struct {
 func ParamKind() *ParamKindApplyConfiguration {
 	return &ParamKindApplyConfiguration{}
 }
-func (b ParamKindApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIVersion sets the APIVersion field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/paramref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/paramref.go
@@ -37,7 +37,6 @@ type ParamRefApplyConfiguration struct {
 func ParamRef() *ParamRefApplyConfiguration {
 	return &ParamRefApplyConfiguration{}
 }
-func (b ParamRefApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rule.go
@@ -36,7 +36,6 @@ type RuleApplyConfiguration struct {
 func Rule() *RuleApplyConfiguration {
 	return &RuleApplyConfiguration{}
 }
-func (b RuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rulewithoperations.go
@@ -34,7 +34,6 @@ type RuleWithOperationsApplyConfiguration struct {
 func RuleWithOperations() *RuleWithOperationsApplyConfiguration {
 	return &RuleWithOperationsApplyConfiguration{}
 }
-func (b RuleWithOperationsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithOperations adds the given value to the Operations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/servicereference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/servicereference.go
@@ -32,7 +32,6 @@ type ServiceReferenceApplyConfiguration struct {
 func ServiceReference() *ServiceReferenceApplyConfiguration {
 	return &ServiceReferenceApplyConfiguration{}
 }
-func (b ServiceReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/typechecking.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/typechecking.go
@@ -29,7 +29,6 @@ type TypeCheckingApplyConfiguration struct {
 func TypeChecking() *TypeCheckingApplyConfiguration {
 	return &TypeCheckingApplyConfiguration{}
 }
-func (b TypeCheckingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpressionWarnings adds the given value to the ExpressionWarnings field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybindingspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybindingspec.go
@@ -36,7 +36,6 @@ type ValidatingAdmissionPolicyBindingSpecApplyConfiguration struct {
 func ValidatingAdmissionPolicyBindingSpec() *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
 	return &ValidatingAdmissionPolicyBindingSpecApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicyBindingSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPolicyName sets the PolicyName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicyspec.go
@@ -39,7 +39,6 @@ type ValidatingAdmissionPolicySpecApplyConfiguration struct {
 func ValidatingAdmissionPolicySpec() *ValidatingAdmissionPolicySpecApplyConfiguration {
 	return &ValidatingAdmissionPolicySpecApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicySpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithParamKind sets the ParamKind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicystatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicystatus.go
@@ -35,7 +35,6 @@ type ValidatingAdmissionPolicyStatusApplyConfiguration struct {
 func ValidatingAdmissionPolicyStatus() *ValidatingAdmissionPolicyStatusApplyConfiguration {
 	return &ValidatingAdmissionPolicyStatusApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicyStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
@@ -44,7 +44,6 @@ type ValidatingWebhookApplyConfiguration struct {
 func ValidatingWebhook() *ValidatingWebhookApplyConfiguration {
 	return &ValidatingWebhookApplyConfiguration{}
 }
-func (b ValidatingWebhookApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validation.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validation.go
@@ -36,7 +36,6 @@ type ValidationApplyConfiguration struct {
 func Validation() *ValidationApplyConfiguration {
 	return &ValidationApplyConfiguration{}
 }
-func (b ValidationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/variable.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/variable.go
@@ -30,7 +30,6 @@ type VariableApplyConfiguration struct {
 func Variable() *VariableApplyConfiguration {
 	return &VariableApplyConfiguration{}
 }
-func (b VariableApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/webhookclientconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/webhookclientconfig.go
@@ -31,7 +31,6 @@ type WebhookClientConfigApplyConfiguration struct {
 func WebhookClientConfig() *WebhookClientConfigApplyConfiguration {
 	return &WebhookClientConfigApplyConfiguration{}
 }
-func (b WebhookClientConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithURL sets the URL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/applyconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/applyconfiguration.go
@@ -29,7 +29,6 @@ type ApplyConfigurationApplyConfiguration struct {
 func ApplyConfiguration() *ApplyConfigurationApplyConfiguration {
 	return &ApplyConfigurationApplyConfiguration{}
 }
-func (b ApplyConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/auditannotation.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/auditannotation.go
@@ -30,7 +30,6 @@ type AuditAnnotationApplyConfiguration struct {
 func AuditAnnotation() *AuditAnnotationApplyConfiguration {
 	return &AuditAnnotationApplyConfiguration{}
 }
-func (b AuditAnnotationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/expressionwarning.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/expressionwarning.go
@@ -30,7 +30,6 @@ type ExpressionWarningApplyConfiguration struct {
 func ExpressionWarning() *ExpressionWarningApplyConfiguration {
 	return &ExpressionWarningApplyConfiguration{}
 }
-func (b ExpressionWarningApplyConfiguration) IsApplyConfiguration() {}
 
 // WithFieldRef sets the FieldRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/jsonpatch.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/jsonpatch.go
@@ -29,7 +29,6 @@ type JSONPatchApplyConfiguration struct {
 func JSONPatch() *JSONPatchApplyConfiguration {
 	return &JSONPatchApplyConfiguration{}
 }
-func (b JSONPatchApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchcondition.go
@@ -30,7 +30,6 @@ type MatchConditionApplyConfiguration struct {
 func MatchCondition() *MatchConditionApplyConfiguration {
 	return &MatchConditionApplyConfiguration{}
 }
-func (b MatchConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchresources.go
@@ -38,7 +38,6 @@ type MatchResourcesApplyConfiguration struct {
 func MatchResources() *MatchResourcesApplyConfiguration {
 	return &MatchResourcesApplyConfiguration{}
 }
-func (b MatchResourcesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespaceSelector sets the NamespaceSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicybindingspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicybindingspec.go
@@ -31,7 +31,6 @@ type MutatingAdmissionPolicyBindingSpecApplyConfiguration struct {
 func MutatingAdmissionPolicyBindingSpec() *MutatingAdmissionPolicyBindingSpecApplyConfiguration {
 	return &MutatingAdmissionPolicyBindingSpecApplyConfiguration{}
 }
-func (b MutatingAdmissionPolicyBindingSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPolicyName sets the PolicyName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicyspec.go
@@ -40,7 +40,6 @@ type MutatingAdmissionPolicySpecApplyConfiguration struct {
 func MutatingAdmissionPolicySpec() *MutatingAdmissionPolicySpecApplyConfiguration {
 	return &MutatingAdmissionPolicySpecApplyConfiguration{}
 }
-func (b MutatingAdmissionPolicySpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithParamKind sets the ParamKind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutation.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutation.go
@@ -35,7 +35,6 @@ type MutationApplyConfiguration struct {
 func Mutation() *MutationApplyConfiguration {
 	return &MutationApplyConfiguration{}
 }
-func (b MutationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPatchType sets the PatchType field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/namedrulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/namedrulewithoperations.go
@@ -35,7 +35,6 @@ type NamedRuleWithOperationsApplyConfiguration struct {
 func NamedRuleWithOperations() *NamedRuleWithOperationsApplyConfiguration {
 	return &NamedRuleWithOperationsApplyConfiguration{}
 }
-func (b NamedRuleWithOperationsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/paramkind.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/paramkind.go
@@ -30,7 +30,6 @@ type ParamKindApplyConfiguration struct {
 func ParamKind() *ParamKindApplyConfiguration {
 	return &ParamKindApplyConfiguration{}
 }
-func (b ParamKindApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIVersion sets the APIVersion field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/paramref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/paramref.go
@@ -37,7 +37,6 @@ type ParamRefApplyConfiguration struct {
 func ParamRef() *ParamRefApplyConfiguration {
 	return &ParamRefApplyConfiguration{}
 }
-func (b ParamRefApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/typechecking.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/typechecking.go
@@ -29,7 +29,6 @@ type TypeCheckingApplyConfiguration struct {
 func TypeChecking() *TypeCheckingApplyConfiguration {
 	return &TypeCheckingApplyConfiguration{}
 }
-func (b TypeCheckingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpressionWarnings adds the given value to the ExpressionWarnings field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybindingspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybindingspec.go
@@ -36,7 +36,6 @@ type ValidatingAdmissionPolicyBindingSpecApplyConfiguration struct {
 func ValidatingAdmissionPolicyBindingSpec() *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
 	return &ValidatingAdmissionPolicyBindingSpecApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicyBindingSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPolicyName sets the PolicyName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
@@ -39,7 +39,6 @@ type ValidatingAdmissionPolicySpecApplyConfiguration struct {
 func ValidatingAdmissionPolicySpec() *ValidatingAdmissionPolicySpecApplyConfiguration {
 	return &ValidatingAdmissionPolicySpecApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicySpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithParamKind sets the ParamKind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicystatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicystatus.go
@@ -35,7 +35,6 @@ type ValidatingAdmissionPolicyStatusApplyConfiguration struct {
 func ValidatingAdmissionPolicyStatus() *ValidatingAdmissionPolicyStatusApplyConfiguration {
 	return &ValidatingAdmissionPolicyStatusApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicyStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validation.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validation.go
@@ -36,7 +36,6 @@ type ValidationApplyConfiguration struct {
 func Validation() *ValidationApplyConfiguration {
 	return &ValidationApplyConfiguration{}
 }
-func (b ValidationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/variable.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/variable.go
@@ -30,7 +30,6 @@ type VariableApplyConfiguration struct {
 func Variable() *VariableApplyConfiguration {
 	return &VariableApplyConfiguration{}
 }
-func (b VariableApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/auditannotation.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/auditannotation.go
@@ -30,7 +30,6 @@ type AuditAnnotationApplyConfiguration struct {
 func AuditAnnotation() *AuditAnnotationApplyConfiguration {
 	return &AuditAnnotationApplyConfiguration{}
 }
-func (b AuditAnnotationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/expressionwarning.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/expressionwarning.go
@@ -30,7 +30,6 @@ type ExpressionWarningApplyConfiguration struct {
 func ExpressionWarning() *ExpressionWarningApplyConfiguration {
 	return &ExpressionWarningApplyConfiguration{}
 }
-func (b ExpressionWarningApplyConfiguration) IsApplyConfiguration() {}
 
 // WithFieldRef sets the FieldRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchcondition.go
@@ -30,7 +30,6 @@ type MatchConditionApplyConfiguration struct {
 func MatchCondition() *MatchConditionApplyConfiguration {
 	return &MatchConditionApplyConfiguration{}
 }
-func (b MatchConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchresources.go
@@ -38,7 +38,6 @@ type MatchResourcesApplyConfiguration struct {
 func MatchResources() *MatchResourcesApplyConfiguration {
 	return &MatchResourcesApplyConfiguration{}
 }
-func (b MatchResourcesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespaceSelector sets the NamespaceSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
@@ -46,7 +46,6 @@ type MutatingWebhookApplyConfiguration struct {
 func MutatingWebhook() *MutatingWebhookApplyConfiguration {
 	return &MutatingWebhookApplyConfiguration{}
 }
-func (b MutatingWebhookApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/namedrulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/namedrulewithoperations.go
@@ -35,7 +35,6 @@ type NamedRuleWithOperationsApplyConfiguration struct {
 func NamedRuleWithOperations() *NamedRuleWithOperationsApplyConfiguration {
 	return &NamedRuleWithOperationsApplyConfiguration{}
 }
-func (b NamedRuleWithOperationsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/paramkind.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/paramkind.go
@@ -30,7 +30,6 @@ type ParamKindApplyConfiguration struct {
 func ParamKind() *ParamKindApplyConfiguration {
 	return &ParamKindApplyConfiguration{}
 }
-func (b ParamKindApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIVersion sets the APIVersion field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/paramref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/paramref.go
@@ -37,7 +37,6 @@ type ParamRefApplyConfiguration struct {
 func ParamRef() *ParamRefApplyConfiguration {
 	return &ParamRefApplyConfiguration{}
 }
-func (b ParamRefApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/servicereference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/servicereference.go
@@ -32,7 +32,6 @@ type ServiceReferenceApplyConfiguration struct {
 func ServiceReference() *ServiceReferenceApplyConfiguration {
 	return &ServiceReferenceApplyConfiguration{}
 }
-func (b ServiceReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/typechecking.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/typechecking.go
@@ -29,7 +29,6 @@ type TypeCheckingApplyConfiguration struct {
 func TypeChecking() *TypeCheckingApplyConfiguration {
 	return &TypeCheckingApplyConfiguration{}
 }
-func (b TypeCheckingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpressionWarnings adds the given value to the ExpressionWarnings field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybindingspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybindingspec.go
@@ -36,7 +36,6 @@ type ValidatingAdmissionPolicyBindingSpecApplyConfiguration struct {
 func ValidatingAdmissionPolicyBindingSpec() *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
 	return &ValidatingAdmissionPolicyBindingSpecApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicyBindingSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPolicyName sets the PolicyName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicyspec.go
@@ -39,7 +39,6 @@ type ValidatingAdmissionPolicySpecApplyConfiguration struct {
 func ValidatingAdmissionPolicySpec() *ValidatingAdmissionPolicySpecApplyConfiguration {
 	return &ValidatingAdmissionPolicySpecApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicySpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithParamKind sets the ParamKind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicystatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicystatus.go
@@ -35,7 +35,6 @@ type ValidatingAdmissionPolicyStatusApplyConfiguration struct {
 func ValidatingAdmissionPolicyStatus() *ValidatingAdmissionPolicyStatusApplyConfiguration {
 	return &ValidatingAdmissionPolicyStatusApplyConfiguration{}
 }
-func (b ValidatingAdmissionPolicyStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
@@ -45,7 +45,6 @@ type ValidatingWebhookApplyConfiguration struct {
 func ValidatingWebhook() *ValidatingWebhookApplyConfiguration {
 	return &ValidatingWebhookApplyConfiguration{}
 }
-func (b ValidatingWebhookApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validation.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validation.go
@@ -36,7 +36,6 @@ type ValidationApplyConfiguration struct {
 func Validation() *ValidationApplyConfiguration {
 	return &ValidationApplyConfiguration{}
 }
-func (b ValidationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/variable.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/variable.go
@@ -30,7 +30,6 @@ type VariableApplyConfiguration struct {
 func Variable() *VariableApplyConfiguration {
 	return &VariableApplyConfiguration{}
 }
-func (b VariableApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/webhookclientconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/webhookclientconfig.go
@@ -31,7 +31,6 @@ type WebhookClientConfigApplyConfiguration struct {
 func WebhookClientConfig() *WebhookClientConfigApplyConfiguration {
 	return &WebhookClientConfigApplyConfiguration{}
 }
-func (b WebhookClientConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithURL sets the URL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/serverstorageversion.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/serverstorageversion.go
@@ -32,7 +32,6 @@ type ServerStorageVersionApplyConfiguration struct {
 func ServerStorageVersion() *ServerStorageVersionApplyConfiguration {
 	return &ServerStorageVersionApplyConfiguration{}
 }
-func (b ServerStorageVersionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIServerID sets the APIServerID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversioncondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversioncondition.go
@@ -39,7 +39,6 @@ type StorageVersionConditionApplyConfiguration struct {
 func StorageVersionCondition() *StorageVersionConditionApplyConfiguration {
 	return &StorageVersionConditionApplyConfiguration{}
 }
-func (b StorageVersionConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversionstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversionstatus.go
@@ -31,7 +31,6 @@ type StorageVersionStatusApplyConfiguration struct {
 func StorageVersionStatus() *StorageVersionStatusApplyConfiguration {
 	return &StorageVersionStatusApplyConfiguration{}
 }
-func (b StorageVersionStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStorageVersions adds the given value to the StorageVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetcondition.go
@@ -39,7 +39,6 @@ type DaemonSetConditionApplyConfiguration struct {
 func DaemonSetCondition() *DaemonSetConditionApplyConfiguration {
 	return &DaemonSetConditionApplyConfiguration{}
 }
-func (b DaemonSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetspec.go
@@ -38,7 +38,6 @@ type DaemonSetSpecApplyConfiguration struct {
 func DaemonSetSpec() *DaemonSetSpecApplyConfiguration {
 	return &DaemonSetSpecApplyConfiguration{}
 }
-func (b DaemonSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSelector sets the Selector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetstatus.go
@@ -38,7 +38,6 @@ type DaemonSetStatusApplyConfiguration struct {
 func DaemonSetStatus() *DaemonSetStatusApplyConfiguration {
 	return &DaemonSetStatusApplyConfiguration{}
 }
-func (b DaemonSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCurrentNumberScheduled sets the CurrentNumberScheduled field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetupdatestrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetupdatestrategy.go
@@ -34,7 +34,6 @@ type DaemonSetUpdateStrategyApplyConfiguration struct {
 func DaemonSetUpdateStrategy() *DaemonSetUpdateStrategyApplyConfiguration {
 	return &DaemonSetUpdateStrategyApplyConfiguration{}
 }
-func (b DaemonSetUpdateStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentcondition.go
@@ -40,7 +40,6 @@ type DeploymentConditionApplyConfiguration struct {
 func DeploymentCondition() *DeploymentConditionApplyConfiguration {
 	return &DeploymentConditionApplyConfiguration{}
 }
-func (b DeploymentConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentspec.go
@@ -41,7 +41,6 @@ type DeploymentSpecApplyConfiguration struct {
 func DeploymentSpec() *DeploymentSpecApplyConfiguration {
 	return &DeploymentSpecApplyConfiguration{}
 }
-func (b DeploymentSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstatus.go
@@ -37,7 +37,6 @@ type DeploymentStatusApplyConfiguration struct {
 func DeploymentStatus() *DeploymentStatusApplyConfiguration {
 	return &DeploymentStatusApplyConfiguration{}
 }
-func (b DeploymentStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstrategy.go
@@ -34,7 +34,6 @@ type DeploymentStrategyApplyConfiguration struct {
 func DeploymentStrategy() *DeploymentStrategyApplyConfiguration {
 	return &DeploymentStrategyApplyConfiguration{}
 }
-func (b DeploymentStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetcondition.go
@@ -39,7 +39,6 @@ type ReplicaSetConditionApplyConfiguration struct {
 func ReplicaSetCondition() *ReplicaSetConditionApplyConfiguration {
 	return &ReplicaSetConditionApplyConfiguration{}
 }
-func (b ReplicaSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetspec.go
@@ -37,7 +37,6 @@ type ReplicaSetSpecApplyConfiguration struct {
 func ReplicaSetSpec() *ReplicaSetSpecApplyConfiguration {
 	return &ReplicaSetSpecApplyConfiguration{}
 }
-func (b ReplicaSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetstatus.go
@@ -35,7 +35,6 @@ type ReplicaSetStatusApplyConfiguration struct {
 func ReplicaSetStatus() *ReplicaSetStatusApplyConfiguration {
 	return &ReplicaSetStatusApplyConfiguration{}
 }
-func (b ReplicaSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/rollingupdatedaemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/rollingupdatedaemonset.go
@@ -34,7 +34,6 @@ type RollingUpdateDaemonSetApplyConfiguration struct {
 func RollingUpdateDaemonSet() *RollingUpdateDaemonSetApplyConfiguration {
 	return &RollingUpdateDaemonSetApplyConfiguration{}
 }
-func (b RollingUpdateDaemonSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxUnavailable sets the MaxUnavailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/rollingupdatedeployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/rollingupdatedeployment.go
@@ -34,7 +34,6 @@ type RollingUpdateDeploymentApplyConfiguration struct {
 func RollingUpdateDeployment() *RollingUpdateDeploymentApplyConfiguration {
 	return &RollingUpdateDeploymentApplyConfiguration{}
 }
-func (b RollingUpdateDeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxUnavailable sets the MaxUnavailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/rollingupdatestatefulsetstrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/rollingupdatestatefulsetstrategy.go
@@ -34,7 +34,6 @@ type RollingUpdateStatefulSetStrategyApplyConfiguration struct {
 func RollingUpdateStatefulSetStrategy() *RollingUpdateStatefulSetStrategyApplyConfiguration {
 	return &RollingUpdateStatefulSetStrategyApplyConfiguration{}
 }
-func (b RollingUpdateStatefulSetStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPartition sets the Partition field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetcondition.go
@@ -39,7 +39,6 @@ type StatefulSetConditionApplyConfiguration struct {
 func StatefulSetCondition() *StatefulSetConditionApplyConfiguration {
 	return &StatefulSetConditionApplyConfiguration{}
 }
-func (b StatefulSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetordinals.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetordinals.go
@@ -29,7 +29,6 @@ type StatefulSetOrdinalsApplyConfiguration struct {
 func StatefulSetOrdinals() *StatefulSetOrdinalsApplyConfiguration {
 	return &StatefulSetOrdinalsApplyConfiguration{}
 }
-func (b StatefulSetOrdinalsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStart sets the Start field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetpersistentvolumeclaimretentionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetpersistentvolumeclaimretentionpolicy.go
@@ -34,7 +34,6 @@ type StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration struct {
 func StatefulSetPersistentVolumeClaimRetentionPolicy() *StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration {
 	return &StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration{}
 }
-func (b StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithWhenDeleted sets the WhenDeleted field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetspec.go
@@ -45,7 +45,6 @@ type StatefulSetSpecApplyConfiguration struct {
 func StatefulSetSpec() *StatefulSetSpecApplyConfiguration {
 	return &StatefulSetSpecApplyConfiguration{}
 }
-func (b StatefulSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetstatus.go
@@ -38,7 +38,6 @@ type StatefulSetStatusApplyConfiguration struct {
 func StatefulSetStatus() *StatefulSetStatusApplyConfiguration {
 	return &StatefulSetStatusApplyConfiguration{}
 }
-func (b StatefulSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetupdatestrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetupdatestrategy.go
@@ -34,7 +34,6 @@ type StatefulSetUpdateStrategyApplyConfiguration struct {
 func StatefulSetUpdateStrategy() *StatefulSetUpdateStrategyApplyConfiguration {
 	return &StatefulSetUpdateStrategyApplyConfiguration{}
 }
-func (b StatefulSetUpdateStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentcondition.go
@@ -40,7 +40,6 @@ type DeploymentConditionApplyConfiguration struct {
 func DeploymentCondition() *DeploymentConditionApplyConfiguration {
 	return &DeploymentConditionApplyConfiguration{}
 }
-func (b DeploymentConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentspec.go
@@ -42,7 +42,6 @@ type DeploymentSpecApplyConfiguration struct {
 func DeploymentSpec() *DeploymentSpecApplyConfiguration {
 	return &DeploymentSpecApplyConfiguration{}
 }
-func (b DeploymentSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstatus.go
@@ -37,7 +37,6 @@ type DeploymentStatusApplyConfiguration struct {
 func DeploymentStatus() *DeploymentStatusApplyConfiguration {
 	return &DeploymentStatusApplyConfiguration{}
 }
-func (b DeploymentStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstrategy.go
@@ -34,7 +34,6 @@ type DeploymentStrategyApplyConfiguration struct {
 func DeploymentStrategy() *DeploymentStrategyApplyConfiguration {
 	return &DeploymentStrategyApplyConfiguration{}
 }
-func (b DeploymentStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/rollbackconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/rollbackconfig.go
@@ -29,7 +29,6 @@ type RollbackConfigApplyConfiguration struct {
 func RollbackConfig() *RollbackConfigApplyConfiguration {
 	return &RollbackConfigApplyConfiguration{}
 }
-func (b RollbackConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRevision sets the Revision field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/rollingupdatedeployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/rollingupdatedeployment.go
@@ -34,7 +34,6 @@ type RollingUpdateDeploymentApplyConfiguration struct {
 func RollingUpdateDeployment() *RollingUpdateDeploymentApplyConfiguration {
 	return &RollingUpdateDeploymentApplyConfiguration{}
 }
-func (b RollingUpdateDeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxUnavailable sets the MaxUnavailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/rollingupdatestatefulsetstrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/rollingupdatestatefulsetstrategy.go
@@ -34,7 +34,6 @@ type RollingUpdateStatefulSetStrategyApplyConfiguration struct {
 func RollingUpdateStatefulSetStrategy() *RollingUpdateStatefulSetStrategyApplyConfiguration {
 	return &RollingUpdateStatefulSetStrategyApplyConfiguration{}
 }
-func (b RollingUpdateStatefulSetStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPartition sets the Partition field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetcondition.go
@@ -39,7 +39,6 @@ type StatefulSetConditionApplyConfiguration struct {
 func StatefulSetCondition() *StatefulSetConditionApplyConfiguration {
 	return &StatefulSetConditionApplyConfiguration{}
 }
-func (b StatefulSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetordinals.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetordinals.go
@@ -29,7 +29,6 @@ type StatefulSetOrdinalsApplyConfiguration struct {
 func StatefulSetOrdinals() *StatefulSetOrdinalsApplyConfiguration {
 	return &StatefulSetOrdinalsApplyConfiguration{}
 }
-func (b StatefulSetOrdinalsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStart sets the Start field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetpersistentvolumeclaimretentionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetpersistentvolumeclaimretentionpolicy.go
@@ -34,7 +34,6 @@ type StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration struct {
 func StatefulSetPersistentVolumeClaimRetentionPolicy() *StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration {
 	return &StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration{}
 }
-func (b StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithWhenDeleted sets the WhenDeleted field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetspec.go
@@ -45,7 +45,6 @@ type StatefulSetSpecApplyConfiguration struct {
 func StatefulSetSpec() *StatefulSetSpecApplyConfiguration {
 	return &StatefulSetSpecApplyConfiguration{}
 }
-func (b StatefulSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetstatus.go
@@ -38,7 +38,6 @@ type StatefulSetStatusApplyConfiguration struct {
 func StatefulSetStatus() *StatefulSetStatusApplyConfiguration {
 	return &StatefulSetStatusApplyConfiguration{}
 }
-func (b StatefulSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetupdatestrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetupdatestrategy.go
@@ -34,7 +34,6 @@ type StatefulSetUpdateStrategyApplyConfiguration struct {
 func StatefulSetUpdateStrategy() *StatefulSetUpdateStrategyApplyConfiguration {
 	return &StatefulSetUpdateStrategyApplyConfiguration{}
 }
-func (b StatefulSetUpdateStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetcondition.go
@@ -39,7 +39,6 @@ type DaemonSetConditionApplyConfiguration struct {
 func DaemonSetCondition() *DaemonSetConditionApplyConfiguration {
 	return &DaemonSetConditionApplyConfiguration{}
 }
-func (b DaemonSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetspec.go
@@ -38,7 +38,6 @@ type DaemonSetSpecApplyConfiguration struct {
 func DaemonSetSpec() *DaemonSetSpecApplyConfiguration {
 	return &DaemonSetSpecApplyConfiguration{}
 }
-func (b DaemonSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSelector sets the Selector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetstatus.go
@@ -38,7 +38,6 @@ type DaemonSetStatusApplyConfiguration struct {
 func DaemonSetStatus() *DaemonSetStatusApplyConfiguration {
 	return &DaemonSetStatusApplyConfiguration{}
 }
-func (b DaemonSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCurrentNumberScheduled sets the CurrentNumberScheduled field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetupdatestrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetupdatestrategy.go
@@ -34,7 +34,6 @@ type DaemonSetUpdateStrategyApplyConfiguration struct {
 func DaemonSetUpdateStrategy() *DaemonSetUpdateStrategyApplyConfiguration {
 	return &DaemonSetUpdateStrategyApplyConfiguration{}
 }
-func (b DaemonSetUpdateStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentcondition.go
@@ -40,7 +40,6 @@ type DeploymentConditionApplyConfiguration struct {
 func DeploymentCondition() *DeploymentConditionApplyConfiguration {
 	return &DeploymentConditionApplyConfiguration{}
 }
-func (b DeploymentConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentspec.go
@@ -41,7 +41,6 @@ type DeploymentSpecApplyConfiguration struct {
 func DeploymentSpec() *DeploymentSpecApplyConfiguration {
 	return &DeploymentSpecApplyConfiguration{}
 }
-func (b DeploymentSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstatus.go
@@ -37,7 +37,6 @@ type DeploymentStatusApplyConfiguration struct {
 func DeploymentStatus() *DeploymentStatusApplyConfiguration {
 	return &DeploymentStatusApplyConfiguration{}
 }
-func (b DeploymentStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstrategy.go
@@ -34,7 +34,6 @@ type DeploymentStrategyApplyConfiguration struct {
 func DeploymentStrategy() *DeploymentStrategyApplyConfiguration {
 	return &DeploymentStrategyApplyConfiguration{}
 }
-func (b DeploymentStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetcondition.go
@@ -39,7 +39,6 @@ type ReplicaSetConditionApplyConfiguration struct {
 func ReplicaSetCondition() *ReplicaSetConditionApplyConfiguration {
 	return &ReplicaSetConditionApplyConfiguration{}
 }
-func (b ReplicaSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetspec.go
@@ -37,7 +37,6 @@ type ReplicaSetSpecApplyConfiguration struct {
 func ReplicaSetSpec() *ReplicaSetSpecApplyConfiguration {
 	return &ReplicaSetSpecApplyConfiguration{}
 }
-func (b ReplicaSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetstatus.go
@@ -35,7 +35,6 @@ type ReplicaSetStatusApplyConfiguration struct {
 func ReplicaSetStatus() *ReplicaSetStatusApplyConfiguration {
 	return &ReplicaSetStatusApplyConfiguration{}
 }
-func (b ReplicaSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/rollingupdatedaemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/rollingupdatedaemonset.go
@@ -34,7 +34,6 @@ type RollingUpdateDaemonSetApplyConfiguration struct {
 func RollingUpdateDaemonSet() *RollingUpdateDaemonSetApplyConfiguration {
 	return &RollingUpdateDaemonSetApplyConfiguration{}
 }
-func (b RollingUpdateDaemonSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxUnavailable sets the MaxUnavailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/rollingupdatedeployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/rollingupdatedeployment.go
@@ -34,7 +34,6 @@ type RollingUpdateDeploymentApplyConfiguration struct {
 func RollingUpdateDeployment() *RollingUpdateDeploymentApplyConfiguration {
 	return &RollingUpdateDeploymentApplyConfiguration{}
 }
-func (b RollingUpdateDeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxUnavailable sets the MaxUnavailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/rollingupdatestatefulsetstrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/rollingupdatestatefulsetstrategy.go
@@ -34,7 +34,6 @@ type RollingUpdateStatefulSetStrategyApplyConfiguration struct {
 func RollingUpdateStatefulSetStrategy() *RollingUpdateStatefulSetStrategyApplyConfiguration {
 	return &RollingUpdateStatefulSetStrategyApplyConfiguration{}
 }
-func (b RollingUpdateStatefulSetStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPartition sets the Partition field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetcondition.go
@@ -39,7 +39,6 @@ type StatefulSetConditionApplyConfiguration struct {
 func StatefulSetCondition() *StatefulSetConditionApplyConfiguration {
 	return &StatefulSetConditionApplyConfiguration{}
 }
-func (b StatefulSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetordinals.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetordinals.go
@@ -29,7 +29,6 @@ type StatefulSetOrdinalsApplyConfiguration struct {
 func StatefulSetOrdinals() *StatefulSetOrdinalsApplyConfiguration {
 	return &StatefulSetOrdinalsApplyConfiguration{}
 }
-func (b StatefulSetOrdinalsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStart sets the Start field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetpersistentvolumeclaimretentionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetpersistentvolumeclaimretentionpolicy.go
@@ -34,7 +34,6 @@ type StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration struct {
 func StatefulSetPersistentVolumeClaimRetentionPolicy() *StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration {
 	return &StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration{}
 }
-func (b StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithWhenDeleted sets the WhenDeleted field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetspec.go
@@ -45,7 +45,6 @@ type StatefulSetSpecApplyConfiguration struct {
 func StatefulSetSpec() *StatefulSetSpecApplyConfiguration {
 	return &StatefulSetSpecApplyConfiguration{}
 }
-func (b StatefulSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetstatus.go
@@ -38,7 +38,6 @@ type StatefulSetStatusApplyConfiguration struct {
 func StatefulSetStatus() *StatefulSetStatusApplyConfiguration {
 	return &StatefulSetStatusApplyConfiguration{}
 }
-func (b StatefulSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetupdatestrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetupdatestrategy.go
@@ -34,7 +34,6 @@ type StatefulSetUpdateStrategyApplyConfiguration struct {
 func StatefulSetUpdateStrategy() *StatefulSetUpdateStrategyApplyConfiguration {
 	return &StatefulSetUpdateStrategyApplyConfiguration{}
 }
-func (b StatefulSetUpdateStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/crossversionobjectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/crossversionobjectreference.go
@@ -31,7 +31,6 @@ type CrossVersionObjectReferenceApplyConfiguration struct {
 func CrossVersionObjectReference() *CrossVersionObjectReferenceApplyConfiguration {
 	return &CrossVersionObjectReferenceApplyConfiguration{}
 }
-func (b CrossVersionObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscalerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscalerspec.go
@@ -32,7 +32,6 @@ type HorizontalPodAutoscalerSpecApplyConfiguration struct {
 func HorizontalPodAutoscalerSpec() *HorizontalPodAutoscalerSpecApplyConfiguration {
 	return &HorizontalPodAutoscalerSpecApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithScaleTargetRef sets the ScaleTargetRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscalerstatus.go
@@ -37,7 +37,6 @@ type HorizontalPodAutoscalerStatusApplyConfiguration struct {
 func HorizontalPodAutoscalerStatus() *HorizontalPodAutoscalerStatusApplyConfiguration {
 	return &HorizontalPodAutoscalerStatusApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scalespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scalespec.go
@@ -29,7 +29,6 @@ type ScaleSpecApplyConfiguration struct {
 func ScaleSpec() *ScaleSpecApplyConfiguration {
 	return &ScaleSpecApplyConfiguration{}
 }
-func (b ScaleSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scalestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scalestatus.go
@@ -30,7 +30,6 @@ type ScaleStatusApplyConfiguration struct {
 func ScaleStatus() *ScaleStatusApplyConfiguration {
 	return &ScaleStatusApplyConfiguration{}
 }
-func (b ScaleStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/containerresourcemetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/containerresourcemetricsource.go
@@ -35,7 +35,6 @@ type ContainerResourceMetricSourceApplyConfiguration struct {
 func ContainerResourceMetricSource() *ContainerResourceMetricSourceApplyConfiguration {
 	return &ContainerResourceMetricSourceApplyConfiguration{}
 }
-func (b ContainerResourceMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/containerresourcemetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/containerresourcemetricstatus.go
@@ -35,7 +35,6 @@ type ContainerResourceMetricStatusApplyConfiguration struct {
 func ContainerResourceMetricStatus() *ContainerResourceMetricStatusApplyConfiguration {
 	return &ContainerResourceMetricStatusApplyConfiguration{}
 }
-func (b ContainerResourceMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/crossversionobjectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/crossversionobjectreference.go
@@ -31,7 +31,6 @@ type CrossVersionObjectReferenceApplyConfiguration struct {
 func CrossVersionObjectReference() *CrossVersionObjectReferenceApplyConfiguration {
 	return &CrossVersionObjectReferenceApplyConfiguration{}
 }
-func (b CrossVersionObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/externalmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/externalmetricsource.go
@@ -30,7 +30,6 @@ type ExternalMetricSourceApplyConfiguration struct {
 func ExternalMetricSource() *ExternalMetricSourceApplyConfiguration {
 	return &ExternalMetricSourceApplyConfiguration{}
 }
-func (b ExternalMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/externalmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/externalmetricstatus.go
@@ -30,7 +30,6 @@ type ExternalMetricStatusApplyConfiguration struct {
 func ExternalMetricStatus() *ExternalMetricStatusApplyConfiguration {
 	return &ExternalMetricStatusApplyConfiguration{}
 }
-func (b ExternalMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerbehavior.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerbehavior.go
@@ -30,7 +30,6 @@ type HorizontalPodAutoscalerBehaviorApplyConfiguration struct {
 func HorizontalPodAutoscalerBehavior() *HorizontalPodAutoscalerBehaviorApplyConfiguration {
 	return &HorizontalPodAutoscalerBehaviorApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerBehaviorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithScaleUp sets the ScaleUp field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalercondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalercondition.go
@@ -39,7 +39,6 @@ type HorizontalPodAutoscalerConditionApplyConfiguration struct {
 func HorizontalPodAutoscalerCondition() *HorizontalPodAutoscalerConditionApplyConfiguration {
 	return &HorizontalPodAutoscalerConditionApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerspec.go
@@ -33,7 +33,6 @@ type HorizontalPodAutoscalerSpecApplyConfiguration struct {
 func HorizontalPodAutoscalerSpec() *HorizontalPodAutoscalerSpecApplyConfiguration {
 	return &HorizontalPodAutoscalerSpecApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithScaleTargetRef sets the ScaleTargetRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerstatus.go
@@ -38,7 +38,6 @@ type HorizontalPodAutoscalerStatusApplyConfiguration struct {
 func HorizontalPodAutoscalerStatus() *HorizontalPodAutoscalerStatusApplyConfiguration {
 	return &HorizontalPodAutoscalerStatusApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/hpascalingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/hpascalingpolicy.go
@@ -35,7 +35,6 @@ type HPAScalingPolicyApplyConfiguration struct {
 func HPAScalingPolicy() *HPAScalingPolicyApplyConfiguration {
 	return &HPAScalingPolicyApplyConfiguration{}
 }
-func (b HPAScalingPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/hpascalingrules.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/hpascalingrules.go
@@ -37,7 +37,6 @@ type HPAScalingRulesApplyConfiguration struct {
 func HPAScalingRules() *HPAScalingRulesApplyConfiguration {
 	return &HPAScalingRulesApplyConfiguration{}
 }
-func (b HPAScalingRulesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStabilizationWindowSeconds sets the StabilizationWindowSeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricidentifier.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricidentifier.go
@@ -34,7 +34,6 @@ type MetricIdentifierApplyConfiguration struct {
 func MetricIdentifier() *MetricIdentifierApplyConfiguration {
 	return &MetricIdentifierApplyConfiguration{}
 }
-func (b MetricIdentifierApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricspec.go
@@ -38,7 +38,6 @@ type MetricSpecApplyConfiguration struct {
 func MetricSpec() *MetricSpecApplyConfiguration {
 	return &MetricSpecApplyConfiguration{}
 }
-func (b MetricSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricstatus.go
@@ -38,7 +38,6 @@ type MetricStatusApplyConfiguration struct {
 func MetricStatus() *MetricStatusApplyConfiguration {
 	return &MetricStatusApplyConfiguration{}
 }
-func (b MetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metrictarget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metrictarget.go
@@ -37,7 +37,6 @@ type MetricTargetApplyConfiguration struct {
 func MetricTarget() *MetricTargetApplyConfiguration {
 	return &MetricTargetApplyConfiguration{}
 }
-func (b MetricTargetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricvaluestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/metricvaluestatus.go
@@ -35,7 +35,6 @@ type MetricValueStatusApplyConfiguration struct {
 func MetricValueStatus() *MetricValueStatusApplyConfiguration {
 	return &MetricValueStatusApplyConfiguration{}
 }
-func (b MetricValueStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithValue sets the Value field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/objectmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/objectmetricsource.go
@@ -31,7 +31,6 @@ type ObjectMetricSourceApplyConfiguration struct {
 func ObjectMetricSource() *ObjectMetricSourceApplyConfiguration {
 	return &ObjectMetricSourceApplyConfiguration{}
 }
-func (b ObjectMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDescribedObject sets the DescribedObject field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/objectmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/objectmetricstatus.go
@@ -31,7 +31,6 @@ type ObjectMetricStatusApplyConfiguration struct {
 func ObjectMetricStatus() *ObjectMetricStatusApplyConfiguration {
 	return &ObjectMetricStatusApplyConfiguration{}
 }
-func (b ObjectMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/podsmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/podsmetricsource.go
@@ -30,7 +30,6 @@ type PodsMetricSourceApplyConfiguration struct {
 func PodsMetricSource() *PodsMetricSourceApplyConfiguration {
 	return &PodsMetricSourceApplyConfiguration{}
 }
-func (b PodsMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/podsmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/podsmetricstatus.go
@@ -30,7 +30,6 @@ type PodsMetricStatusApplyConfiguration struct {
 func PodsMetricStatus() *PodsMetricStatusApplyConfiguration {
 	return &PodsMetricStatusApplyConfiguration{}
 }
-func (b PodsMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/resourcemetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/resourcemetricsource.go
@@ -34,7 +34,6 @@ type ResourceMetricSourceApplyConfiguration struct {
 func ResourceMetricSource() *ResourceMetricSourceApplyConfiguration {
 	return &ResourceMetricSourceApplyConfiguration{}
 }
-func (b ResourceMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/resourcemetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/resourcemetricstatus.go
@@ -34,7 +34,6 @@ type ResourceMetricStatusApplyConfiguration struct {
 func ResourceMetricStatus() *ResourceMetricStatusApplyConfiguration {
 	return &ResourceMetricStatusApplyConfiguration{}
 }
-func (b ResourceMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/containerresourcemetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/containerresourcemetricsource.go
@@ -37,7 +37,6 @@ type ContainerResourceMetricSourceApplyConfiguration struct {
 func ContainerResourceMetricSource() *ContainerResourceMetricSourceApplyConfiguration {
 	return &ContainerResourceMetricSourceApplyConfiguration{}
 }
-func (b ContainerResourceMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/containerresourcemetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/containerresourcemetricstatus.go
@@ -37,7 +37,6 @@ type ContainerResourceMetricStatusApplyConfiguration struct {
 func ContainerResourceMetricStatus() *ContainerResourceMetricStatusApplyConfiguration {
 	return &ContainerResourceMetricStatusApplyConfiguration{}
 }
-func (b ContainerResourceMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/crossversionobjectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/crossversionobjectreference.go
@@ -31,7 +31,6 @@ type CrossVersionObjectReferenceApplyConfiguration struct {
 func CrossVersionObjectReference() *CrossVersionObjectReferenceApplyConfiguration {
 	return &CrossVersionObjectReferenceApplyConfiguration{}
 }
-func (b CrossVersionObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/externalmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/externalmetricsource.go
@@ -37,7 +37,6 @@ type ExternalMetricSourceApplyConfiguration struct {
 func ExternalMetricSource() *ExternalMetricSourceApplyConfiguration {
 	return &ExternalMetricSourceApplyConfiguration{}
 }
-func (b ExternalMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetricName sets the MetricName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/externalmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/externalmetricstatus.go
@@ -37,7 +37,6 @@ type ExternalMetricStatusApplyConfiguration struct {
 func ExternalMetricStatus() *ExternalMetricStatusApplyConfiguration {
 	return &ExternalMetricStatusApplyConfiguration{}
 }
-func (b ExternalMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetricName sets the MetricName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalercondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalercondition.go
@@ -39,7 +39,6 @@ type HorizontalPodAutoscalerConditionApplyConfiguration struct {
 func HorizontalPodAutoscalerCondition() *HorizontalPodAutoscalerConditionApplyConfiguration {
 	return &HorizontalPodAutoscalerConditionApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerspec.go
@@ -32,7 +32,6 @@ type HorizontalPodAutoscalerSpecApplyConfiguration struct {
 func HorizontalPodAutoscalerSpec() *HorizontalPodAutoscalerSpecApplyConfiguration {
 	return &HorizontalPodAutoscalerSpecApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithScaleTargetRef sets the ScaleTargetRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerstatus.go
@@ -38,7 +38,6 @@ type HorizontalPodAutoscalerStatusApplyConfiguration struct {
 func HorizontalPodAutoscalerStatus() *HorizontalPodAutoscalerStatusApplyConfiguration {
 	return &HorizontalPodAutoscalerStatusApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/metricspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/metricspec.go
@@ -38,7 +38,6 @@ type MetricSpecApplyConfiguration struct {
 func MetricSpec() *MetricSpecApplyConfiguration {
 	return &MetricSpecApplyConfiguration{}
 }
-func (b MetricSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/metricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/metricstatus.go
@@ -38,7 +38,6 @@ type MetricStatusApplyConfiguration struct {
 func MetricStatus() *MetricStatusApplyConfiguration {
 	return &MetricStatusApplyConfiguration{}
 }
-func (b MetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/objectmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/objectmetricsource.go
@@ -38,7 +38,6 @@ type ObjectMetricSourceApplyConfiguration struct {
 func ObjectMetricSource() *ObjectMetricSourceApplyConfiguration {
 	return &ObjectMetricSourceApplyConfiguration{}
 }
-func (b ObjectMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTarget sets the Target field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/objectmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/objectmetricstatus.go
@@ -38,7 +38,6 @@ type ObjectMetricStatusApplyConfiguration struct {
 func ObjectMetricStatus() *ObjectMetricStatusApplyConfiguration {
 	return &ObjectMetricStatusApplyConfiguration{}
 }
-func (b ObjectMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTarget sets the Target field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/podsmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/podsmetricsource.go
@@ -36,7 +36,6 @@ type PodsMetricSourceApplyConfiguration struct {
 func PodsMetricSource() *PodsMetricSourceApplyConfiguration {
 	return &PodsMetricSourceApplyConfiguration{}
 }
-func (b PodsMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetricName sets the MetricName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/podsmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/podsmetricstatus.go
@@ -36,7 +36,6 @@ type PodsMetricStatusApplyConfiguration struct {
 func PodsMetricStatus() *PodsMetricStatusApplyConfiguration {
 	return &PodsMetricStatusApplyConfiguration{}
 }
-func (b PodsMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetricName sets the MetricName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/resourcemetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/resourcemetricsource.go
@@ -36,7 +36,6 @@ type ResourceMetricSourceApplyConfiguration struct {
 func ResourceMetricSource() *ResourceMetricSourceApplyConfiguration {
 	return &ResourceMetricSourceApplyConfiguration{}
 }
-func (b ResourceMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/resourcemetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/resourcemetricstatus.go
@@ -36,7 +36,6 @@ type ResourceMetricStatusApplyConfiguration struct {
 func ResourceMetricStatus() *ResourceMetricStatusApplyConfiguration {
 	return &ResourceMetricStatusApplyConfiguration{}
 }
-func (b ResourceMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/containerresourcemetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/containerresourcemetricsource.go
@@ -35,7 +35,6 @@ type ContainerResourceMetricSourceApplyConfiguration struct {
 func ContainerResourceMetricSource() *ContainerResourceMetricSourceApplyConfiguration {
 	return &ContainerResourceMetricSourceApplyConfiguration{}
 }
-func (b ContainerResourceMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/containerresourcemetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/containerresourcemetricstatus.go
@@ -35,7 +35,6 @@ type ContainerResourceMetricStatusApplyConfiguration struct {
 func ContainerResourceMetricStatus() *ContainerResourceMetricStatusApplyConfiguration {
 	return &ContainerResourceMetricStatusApplyConfiguration{}
 }
-func (b ContainerResourceMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/crossversionobjectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/crossversionobjectreference.go
@@ -31,7 +31,6 @@ type CrossVersionObjectReferenceApplyConfiguration struct {
 func CrossVersionObjectReference() *CrossVersionObjectReferenceApplyConfiguration {
 	return &CrossVersionObjectReferenceApplyConfiguration{}
 }
-func (b CrossVersionObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/externalmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/externalmetricsource.go
@@ -30,7 +30,6 @@ type ExternalMetricSourceApplyConfiguration struct {
 func ExternalMetricSource() *ExternalMetricSourceApplyConfiguration {
 	return &ExternalMetricSourceApplyConfiguration{}
 }
-func (b ExternalMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/externalmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/externalmetricstatus.go
@@ -30,7 +30,6 @@ type ExternalMetricStatusApplyConfiguration struct {
 func ExternalMetricStatus() *ExternalMetricStatusApplyConfiguration {
 	return &ExternalMetricStatusApplyConfiguration{}
 }
-func (b ExternalMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerbehavior.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerbehavior.go
@@ -30,7 +30,6 @@ type HorizontalPodAutoscalerBehaviorApplyConfiguration struct {
 func HorizontalPodAutoscalerBehavior() *HorizontalPodAutoscalerBehaviorApplyConfiguration {
 	return &HorizontalPodAutoscalerBehaviorApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerBehaviorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithScaleUp sets the ScaleUp field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalercondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalercondition.go
@@ -39,7 +39,6 @@ type HorizontalPodAutoscalerConditionApplyConfiguration struct {
 func HorizontalPodAutoscalerCondition() *HorizontalPodAutoscalerConditionApplyConfiguration {
 	return &HorizontalPodAutoscalerConditionApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerspec.go
@@ -33,7 +33,6 @@ type HorizontalPodAutoscalerSpecApplyConfiguration struct {
 func HorizontalPodAutoscalerSpec() *HorizontalPodAutoscalerSpecApplyConfiguration {
 	return &HorizontalPodAutoscalerSpecApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithScaleTargetRef sets the ScaleTargetRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerstatus.go
@@ -38,7 +38,6 @@ type HorizontalPodAutoscalerStatusApplyConfiguration struct {
 func HorizontalPodAutoscalerStatus() *HorizontalPodAutoscalerStatusApplyConfiguration {
 	return &HorizontalPodAutoscalerStatusApplyConfiguration{}
 }
-func (b HorizontalPodAutoscalerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/hpascalingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/hpascalingpolicy.go
@@ -35,7 +35,6 @@ type HPAScalingPolicyApplyConfiguration struct {
 func HPAScalingPolicy() *HPAScalingPolicyApplyConfiguration {
 	return &HPAScalingPolicyApplyConfiguration{}
 }
-func (b HPAScalingPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/hpascalingrules.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/hpascalingrules.go
@@ -35,7 +35,6 @@ type HPAScalingRulesApplyConfiguration struct {
 func HPAScalingRules() *HPAScalingRulesApplyConfiguration {
 	return &HPAScalingRulesApplyConfiguration{}
 }
-func (b HPAScalingRulesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStabilizationWindowSeconds sets the StabilizationWindowSeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricidentifier.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricidentifier.go
@@ -34,7 +34,6 @@ type MetricIdentifierApplyConfiguration struct {
 func MetricIdentifier() *MetricIdentifierApplyConfiguration {
 	return &MetricIdentifierApplyConfiguration{}
 }
-func (b MetricIdentifierApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricspec.go
@@ -38,7 +38,6 @@ type MetricSpecApplyConfiguration struct {
 func MetricSpec() *MetricSpecApplyConfiguration {
 	return &MetricSpecApplyConfiguration{}
 }
-func (b MetricSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricstatus.go
@@ -38,7 +38,6 @@ type MetricStatusApplyConfiguration struct {
 func MetricStatus() *MetricStatusApplyConfiguration {
 	return &MetricStatusApplyConfiguration{}
 }
-func (b MetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metrictarget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metrictarget.go
@@ -37,7 +37,6 @@ type MetricTargetApplyConfiguration struct {
 func MetricTarget() *MetricTargetApplyConfiguration {
 	return &MetricTargetApplyConfiguration{}
 }
-func (b MetricTargetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricvaluestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/metricvaluestatus.go
@@ -35,7 +35,6 @@ type MetricValueStatusApplyConfiguration struct {
 func MetricValueStatus() *MetricValueStatusApplyConfiguration {
 	return &MetricValueStatusApplyConfiguration{}
 }
-func (b MetricValueStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithValue sets the Value field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/objectmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/objectmetricsource.go
@@ -31,7 +31,6 @@ type ObjectMetricSourceApplyConfiguration struct {
 func ObjectMetricSource() *ObjectMetricSourceApplyConfiguration {
 	return &ObjectMetricSourceApplyConfiguration{}
 }
-func (b ObjectMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDescribedObject sets the DescribedObject field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/objectmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/objectmetricstatus.go
@@ -31,7 +31,6 @@ type ObjectMetricStatusApplyConfiguration struct {
 func ObjectMetricStatus() *ObjectMetricStatusApplyConfiguration {
 	return &ObjectMetricStatusApplyConfiguration{}
 }
-func (b ObjectMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/podsmetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/podsmetricsource.go
@@ -30,7 +30,6 @@ type PodsMetricSourceApplyConfiguration struct {
 func PodsMetricSource() *PodsMetricSourceApplyConfiguration {
 	return &PodsMetricSourceApplyConfiguration{}
 }
-func (b PodsMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/podsmetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/podsmetricstatus.go
@@ -30,7 +30,6 @@ type PodsMetricStatusApplyConfiguration struct {
 func PodsMetricStatus() *PodsMetricStatusApplyConfiguration {
 	return &PodsMetricStatusApplyConfiguration{}
 }
-func (b PodsMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMetric sets the Metric field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/resourcemetricsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/resourcemetricsource.go
@@ -34,7 +34,6 @@ type ResourceMetricSourceApplyConfiguration struct {
 func ResourceMetricSource() *ResourceMetricSourceApplyConfiguration {
 	return &ResourceMetricSourceApplyConfiguration{}
 }
-func (b ResourceMetricSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/resourcemetricstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/resourcemetricstatus.go
@@ -34,7 +34,6 @@ type ResourceMetricStatusApplyConfiguration struct {
 func ResourceMetricStatus() *ResourceMetricStatusApplyConfiguration {
 	return &ResourceMetricStatusApplyConfiguration{}
 }
-func (b ResourceMetricStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjobspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjobspec.go
@@ -40,7 +40,6 @@ type CronJobSpecApplyConfiguration struct {
 func CronJobSpec() *CronJobSpecApplyConfiguration {
 	return &CronJobSpecApplyConfiguration{}
 }
-func (b CronJobSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSchedule sets the Schedule field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjobstatus.go
@@ -36,7 +36,6 @@ type CronJobStatusApplyConfiguration struct {
 func CronJobStatus() *CronJobStatusApplyConfiguration {
 	return &CronJobStatusApplyConfiguration{}
 }
-func (b CronJobStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithActive adds the given value to the Active field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobcondition.go
@@ -40,7 +40,6 @@ type JobConditionApplyConfiguration struct {
 func JobCondition() *JobConditionApplyConfiguration {
 	return &JobConditionApplyConfiguration{}
 }
-func (b JobConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobspec.go
@@ -50,7 +50,6 @@ type JobSpecApplyConfiguration struct {
 func JobSpec() *JobSpecApplyConfiguration {
 	return &JobSpecApplyConfiguration{}
 }
-func (b JobSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithParallelism sets the Parallelism field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
@@ -43,7 +43,6 @@ type JobStatusApplyConfiguration struct {
 func JobStatus() *JobStatusApplyConfiguration {
 	return &JobStatusApplyConfiguration{}
 }
-func (b JobStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobtemplatespec.go
@@ -36,7 +36,6 @@ type JobTemplateSpecApplyConfiguration struct {
 func JobTemplateSpec() *JobTemplateSpecApplyConfiguration {
 	return &JobTemplateSpecApplyConfiguration{}
 }
-func (b JobTemplateSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicy.go
@@ -29,7 +29,6 @@ type PodFailurePolicyApplyConfiguration struct {
 func PodFailurePolicy() *PodFailurePolicyApplyConfiguration {
 	return &PodFailurePolicyApplyConfiguration{}
 }
-func (b PodFailurePolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyonexitcodesrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyonexitcodesrequirement.go
@@ -35,7 +35,6 @@ type PodFailurePolicyOnExitCodesRequirementApplyConfiguration struct {
 func PodFailurePolicyOnExitCodesRequirement() *PodFailurePolicyOnExitCodesRequirementApplyConfiguration {
 	return &PodFailurePolicyOnExitCodesRequirementApplyConfiguration{}
 }
-func (b PodFailurePolicyOnExitCodesRequirementApplyConfiguration) IsApplyConfiguration() {}
 
 // WithContainerName sets the ContainerName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyonpodconditionspattern.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyonpodconditionspattern.go
@@ -34,7 +34,6 @@ type PodFailurePolicyOnPodConditionsPatternApplyConfiguration struct {
 func PodFailurePolicyOnPodConditionsPattern() *PodFailurePolicyOnPodConditionsPatternApplyConfiguration {
 	return &PodFailurePolicyOnPodConditionsPatternApplyConfiguration{}
 }
-func (b PodFailurePolicyOnPodConditionsPatternApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyrule.go
@@ -35,7 +35,6 @@ type PodFailurePolicyRuleApplyConfiguration struct {
 func PodFailurePolicyRule() *PodFailurePolicyRuleApplyConfiguration {
 	return &PodFailurePolicyRuleApplyConfiguration{}
 }
-func (b PodFailurePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAction sets the Action field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/successpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/successpolicy.go
@@ -29,7 +29,6 @@ type SuccessPolicyApplyConfiguration struct {
 func SuccessPolicy() *SuccessPolicyApplyConfiguration {
 	return &SuccessPolicyApplyConfiguration{}
 }
-func (b SuccessPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/successpolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/successpolicyrule.go
@@ -30,7 +30,6 @@ type SuccessPolicyRuleApplyConfiguration struct {
 func SuccessPolicyRule() *SuccessPolicyRuleApplyConfiguration {
 	return &SuccessPolicyRuleApplyConfiguration{}
 }
-func (b SuccessPolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSucceededIndexes sets the SucceededIndexes field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/uncountedterminatedpods.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/uncountedterminatedpods.go
@@ -34,7 +34,6 @@ type UncountedTerminatedPodsApplyConfiguration struct {
 func UncountedTerminatedPods() *UncountedTerminatedPodsApplyConfiguration {
 	return &UncountedTerminatedPodsApplyConfiguration{}
 }
-func (b UncountedTerminatedPodsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSucceeded adds the given value to the Succeeded field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjobspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjobspec.go
@@ -40,7 +40,6 @@ type CronJobSpecApplyConfiguration struct {
 func CronJobSpec() *CronJobSpecApplyConfiguration {
 	return &CronJobSpecApplyConfiguration{}
 }
-func (b CronJobSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSchedule sets the Schedule field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjobstatus.go
@@ -36,7 +36,6 @@ type CronJobStatusApplyConfiguration struct {
 func CronJobStatus() *CronJobStatusApplyConfiguration {
 	return &CronJobStatusApplyConfiguration{}
 }
-func (b CronJobStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithActive adds the given value to the Active field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/jobtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/jobtemplatespec.go
@@ -37,7 +37,6 @@ type JobTemplateSpecApplyConfiguration struct {
 func JobTemplateSpec() *JobTemplateSpecApplyConfiguration {
 	return &JobTemplateSpecApplyConfiguration{}
 }
-func (b JobTemplateSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequestcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequestcondition.go
@@ -40,7 +40,6 @@ type CertificateSigningRequestConditionApplyConfiguration struct {
 func CertificateSigningRequestCondition() *CertificateSigningRequestConditionApplyConfiguration {
 	return &CertificateSigningRequestConditionApplyConfiguration{}
 }
-func (b CertificateSigningRequestConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequestspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequestspec.go
@@ -40,7 +40,6 @@ type CertificateSigningRequestSpecApplyConfiguration struct {
 func CertificateSigningRequestSpec() *CertificateSigningRequestSpecApplyConfiguration {
 	return &CertificateSigningRequestSpecApplyConfiguration{}
 }
-func (b CertificateSigningRequestSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequest adds the given value to the Request field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequeststatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequeststatus.go
@@ -30,7 +30,6 @@ type CertificateSigningRequestStatusApplyConfiguration struct {
 func CertificateSigningRequestStatus() *CertificateSigningRequestStatusApplyConfiguration {
 	return &CertificateSigningRequestStatusApplyConfiguration{}
 }
-func (b CertificateSigningRequestStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundlespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundlespec.go
@@ -30,7 +30,6 @@ type ClusterTrustBundleSpecApplyConfiguration struct {
 func ClusterTrustBundleSpec() *ClusterTrustBundleSpecApplyConfiguration {
 	return &ClusterTrustBundleSpecApplyConfiguration{}
 }
-func (b ClusterTrustBundleSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSignerName sets the SignerName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequestcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequestcondition.go
@@ -40,7 +40,6 @@ type CertificateSigningRequestConditionApplyConfiguration struct {
 func CertificateSigningRequestCondition() *CertificateSigningRequestConditionApplyConfiguration {
 	return &CertificateSigningRequestConditionApplyConfiguration{}
 }
-func (b CertificateSigningRequestConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequestspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequestspec.go
@@ -40,7 +40,6 @@ type CertificateSigningRequestSpecApplyConfiguration struct {
 func CertificateSigningRequestSpec() *CertificateSigningRequestSpecApplyConfiguration {
 	return &CertificateSigningRequestSpecApplyConfiguration{}
 }
-func (b CertificateSigningRequestSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequest adds the given value to the Request field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequeststatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequeststatus.go
@@ -30,7 +30,6 @@ type CertificateSigningRequestStatusApplyConfiguration struct {
 func CertificateSigningRequestStatus() *CertificateSigningRequestStatusApplyConfiguration {
 	return &CertificateSigningRequestStatusApplyConfiguration{}
 }
-func (b CertificateSigningRequestStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/clustertrustbundlespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/clustertrustbundlespec.go
@@ -30,7 +30,6 @@ type ClusterTrustBundleSpecApplyConfiguration struct {
 func ClusterTrustBundleSpec() *ClusterTrustBundleSpecApplyConfiguration {
 	return &ClusterTrustBundleSpecApplyConfiguration{}
 }
-func (b ClusterTrustBundleSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSignerName sets the SignerName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/leasespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/leasespec.go
@@ -40,7 +40,6 @@ type LeaseSpecApplyConfiguration struct {
 func LeaseSpec() *LeaseSpecApplyConfiguration {
 	return &LeaseSpecApplyConfiguration{}
 }
-func (b LeaseSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHolderIdentity sets the HolderIdentity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidatespec.go
@@ -39,7 +39,6 @@ type LeaseCandidateSpecApplyConfiguration struct {
 func LeaseCandidateSpec() *LeaseCandidateSpecApplyConfiguration {
 	return &LeaseCandidateSpecApplyConfiguration{}
 }
-func (b LeaseCandidateSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLeaseName sets the LeaseName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidatespec.go
@@ -39,7 +39,6 @@ type LeaseCandidateSpecApplyConfiguration struct {
 func LeaseCandidateSpec() *LeaseCandidateSpecApplyConfiguration {
 	return &LeaseCandidateSpecApplyConfiguration{}
 }
-func (b LeaseCandidateSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLeaseName sets the LeaseName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasespec.go
@@ -40,7 +40,6 @@ type LeaseSpecApplyConfiguration struct {
 func LeaseSpec() *LeaseSpecApplyConfiguration {
 	return &LeaseSpecApplyConfiguration{}
 }
-func (b LeaseSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHolderIdentity sets the HolderIdentity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/affinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/affinity.go
@@ -31,7 +31,6 @@ type AffinityApplyConfiguration struct {
 func Affinity() *AffinityApplyConfiguration {
 	return &AffinityApplyConfiguration{}
 }
-func (b AffinityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNodeAffinity sets the NodeAffinity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/apparmorprofile.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/apparmorprofile.go
@@ -34,7 +34,6 @@ type AppArmorProfileApplyConfiguration struct {
 func AppArmorProfile() *AppArmorProfileApplyConfiguration {
 	return &AppArmorProfileApplyConfiguration{}
 }
-func (b AppArmorProfileApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/attachedvolume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/attachedvolume.go
@@ -34,7 +34,6 @@ type AttachedVolumeApplyConfiguration struct {
 func AttachedVolume() *AttachedVolumeApplyConfiguration {
 	return &AttachedVolumeApplyConfiguration{}
 }
-func (b AttachedVolumeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/awselasticblockstorevolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/awselasticblockstorevolumesource.go
@@ -32,7 +32,6 @@ type AWSElasticBlockStoreVolumeSourceApplyConfiguration struct {
 func AWSElasticBlockStoreVolumeSource() *AWSElasticBlockStoreVolumeSourceApplyConfiguration {
 	return &AWSElasticBlockStoreVolumeSourceApplyConfiguration{}
 }
-func (b AWSElasticBlockStoreVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumeID sets the VolumeID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/azurediskvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/azurediskvolumesource.go
@@ -38,7 +38,6 @@ type AzureDiskVolumeSourceApplyConfiguration struct {
 func AzureDiskVolumeSource() *AzureDiskVolumeSourceApplyConfiguration {
 	return &AzureDiskVolumeSourceApplyConfiguration{}
 }
-func (b AzureDiskVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDiskName sets the DiskName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/azurefilepersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/azurefilepersistentvolumesource.go
@@ -32,7 +32,6 @@ type AzureFilePersistentVolumeSourceApplyConfiguration struct {
 func AzureFilePersistentVolumeSource() *AzureFilePersistentVolumeSourceApplyConfiguration {
 	return &AzureFilePersistentVolumeSourceApplyConfiguration{}
 }
-func (b AzureFilePersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSecretName sets the SecretName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/azurefilevolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/azurefilevolumesource.go
@@ -31,7 +31,6 @@ type AzureFileVolumeSourceApplyConfiguration struct {
 func AzureFileVolumeSource() *AzureFileVolumeSourceApplyConfiguration {
 	return &AzureFileVolumeSourceApplyConfiguration{}
 }
-func (b AzureFileVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSecretName sets the SecretName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/capabilities.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/capabilities.go
@@ -34,7 +34,6 @@ type CapabilitiesApplyConfiguration struct {
 func Capabilities() *CapabilitiesApplyConfiguration {
 	return &CapabilitiesApplyConfiguration{}
 }
-func (b CapabilitiesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAdd adds the given value to the Add field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfspersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfspersistentvolumesource.go
@@ -34,7 +34,6 @@ type CephFSPersistentVolumeSourceApplyConfiguration struct {
 func CephFSPersistentVolumeSource() *CephFSPersistentVolumeSourceApplyConfiguration {
 	return &CephFSPersistentVolumeSourceApplyConfiguration{}
 }
-func (b CephFSPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMonitors adds the given value to the Monitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfsvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfsvolumesource.go
@@ -34,7 +34,6 @@ type CephFSVolumeSourceApplyConfiguration struct {
 func CephFSVolumeSource() *CephFSVolumeSourceApplyConfiguration {
 	return &CephFSVolumeSourceApplyConfiguration{}
 }
-func (b CephFSVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMonitors adds the given value to the Monitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cinderpersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cinderpersistentvolumesource.go
@@ -32,7 +32,6 @@ type CinderPersistentVolumeSourceApplyConfiguration struct {
 func CinderPersistentVolumeSource() *CinderPersistentVolumeSourceApplyConfiguration {
 	return &CinderPersistentVolumeSourceApplyConfiguration{}
 }
-func (b CinderPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumeID sets the VolumeID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cindervolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cindervolumesource.go
@@ -32,7 +32,6 @@ type CinderVolumeSourceApplyConfiguration struct {
 func CinderVolumeSource() *CinderVolumeSourceApplyConfiguration {
 	return &CinderVolumeSourceApplyConfiguration{}
 }
-func (b CinderVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumeID sets the VolumeID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/clientipconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/clientipconfig.go
@@ -29,7 +29,6 @@ type ClientIPConfigApplyConfiguration struct {
 func ClientIPConfig() *ClientIPConfigApplyConfiguration {
 	return &ClientIPConfigApplyConfiguration{}
 }
-func (b ClientIPConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTimeoutSeconds sets the TimeoutSeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/clustertrustbundleprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/clustertrustbundleprojection.go
@@ -37,7 +37,6 @@ type ClusterTrustBundleProjectionApplyConfiguration struct {
 func ClusterTrustBundleProjection() *ClusterTrustBundleProjectionApplyConfiguration {
 	return &ClusterTrustBundleProjectionApplyConfiguration{}
 }
-func (b ClusterTrustBundleProjectionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentcondition.go
@@ -36,7 +36,6 @@ type ComponentConditionApplyConfiguration struct {
 func ComponentCondition() *ComponentConditionApplyConfiguration {
 	return &ComponentConditionApplyConfiguration{}
 }
-func (b ComponentConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapenvsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapenvsource.go
@@ -30,7 +30,6 @@ type ConfigMapEnvSourceApplyConfiguration struct {
 func ConfigMapEnvSource() *ConfigMapEnvSourceApplyConfiguration {
 	return &ConfigMapEnvSourceApplyConfiguration{}
 }
-func (b ConfigMapEnvSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapkeyselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapkeyselector.go
@@ -31,7 +31,6 @@ type ConfigMapKeySelectorApplyConfiguration struct {
 func ConfigMapKeySelector() *ConfigMapKeySelectorApplyConfiguration {
 	return &ConfigMapKeySelectorApplyConfiguration{}
 }
-func (b ConfigMapKeySelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapnodeconfigsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapnodeconfigsource.go
@@ -37,7 +37,6 @@ type ConfigMapNodeConfigSourceApplyConfiguration struct {
 func ConfigMapNodeConfigSource() *ConfigMapNodeConfigSourceApplyConfiguration {
 	return &ConfigMapNodeConfigSourceApplyConfiguration{}
 }
-func (b ConfigMapNodeConfigSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapprojection.go
@@ -31,7 +31,6 @@ type ConfigMapProjectionApplyConfiguration struct {
 func ConfigMapProjection() *ConfigMapProjectionApplyConfiguration {
 	return &ConfigMapProjectionApplyConfiguration{}
 }
-func (b ConfigMapProjectionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapvolumesource.go
@@ -32,7 +32,6 @@ type ConfigMapVolumeSourceApplyConfiguration struct {
 func ConfigMapVolumeSource() *ConfigMapVolumeSourceApplyConfiguration {
 	return &ConfigMapVolumeSourceApplyConfiguration{}
 }
-func (b ConfigMapVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
@@ -56,7 +56,6 @@ type ContainerApplyConfiguration struct {
 func Container() *ContainerApplyConfiguration {
 	return &ContainerApplyConfiguration{}
 }
-func (b ContainerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerimage.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerimage.go
@@ -30,7 +30,6 @@ type ContainerImageApplyConfiguration struct {
 func ContainerImage() *ContainerImageApplyConfiguration {
 	return &ContainerImageApplyConfiguration{}
 }
-func (b ContainerImageApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNames adds the given value to the Names field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerport.go
@@ -37,7 +37,6 @@ type ContainerPortApplyConfiguration struct {
 func ContainerPort() *ContainerPortApplyConfiguration {
 	return &ContainerPortApplyConfiguration{}
 }
-func (b ContainerPortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerresizepolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerresizepolicy.go
@@ -34,7 +34,6 @@ type ContainerResizePolicyApplyConfiguration struct {
 func ContainerResizePolicy() *ContainerResizePolicyApplyConfiguration {
 	return &ContainerResizePolicyApplyConfiguration{}
 }
-func (b ContainerResizePolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResourceName sets the ResourceName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstate.go
@@ -31,7 +31,6 @@ type ContainerStateApplyConfiguration struct {
 func ContainerState() *ContainerStateApplyConfiguration {
 	return &ContainerStateApplyConfiguration{}
 }
-func (b ContainerStateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithWaiting sets the Waiting field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstaterunning.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstaterunning.go
@@ -33,7 +33,6 @@ type ContainerStateRunningApplyConfiguration struct {
 func ContainerStateRunning() *ContainerStateRunningApplyConfiguration {
 	return &ContainerStateRunningApplyConfiguration{}
 }
-func (b ContainerStateRunningApplyConfiguration) IsApplyConfiguration() {}
 
 // WithStartedAt sets the StartedAt field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstateterminated.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstateterminated.go
@@ -39,7 +39,6 @@ type ContainerStateTerminatedApplyConfiguration struct {
 func ContainerStateTerminated() *ContainerStateTerminatedApplyConfiguration {
 	return &ContainerStateTerminatedApplyConfiguration{}
 }
-func (b ContainerStateTerminatedApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExitCode sets the ExitCode field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstatewaiting.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstatewaiting.go
@@ -30,7 +30,6 @@ type ContainerStateWaitingApplyConfiguration struct {
 func ContainerStateWaiting() *ContainerStateWaitingApplyConfiguration {
 	return &ContainerStateWaitingApplyConfiguration{}
 }
-func (b ContainerStateWaitingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReason sets the Reason field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstatus.go
@@ -47,7 +47,6 @@ type ContainerStatusApplyConfiguration struct {
 func ContainerStatus() *ContainerStatusApplyConfiguration {
 	return &ContainerStatusApplyConfiguration{}
 }
-func (b ContainerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containeruser.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containeruser.go
@@ -29,7 +29,6 @@ type ContainerUserApplyConfiguration struct {
 func ContainerUser() *ContainerUserApplyConfiguration {
 	return &ContainerUserApplyConfiguration{}
 }
-func (b ContainerUserApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLinux sets the Linux field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/csipersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/csipersistentvolumesource.go
@@ -38,7 +38,6 @@ type CSIPersistentVolumeSourceApplyConfiguration struct {
 func CSIPersistentVolumeSource() *CSIPersistentVolumeSourceApplyConfiguration {
 	return &CSIPersistentVolumeSourceApplyConfiguration{}
 }
-func (b CSIPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/csivolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/csivolumesource.go
@@ -33,7 +33,6 @@ type CSIVolumeSourceApplyConfiguration struct {
 func CSIVolumeSource() *CSIVolumeSourceApplyConfiguration {
 	return &CSIVolumeSourceApplyConfiguration{}
 }
-func (b CSIVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/daemonendpoint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/daemonendpoint.go
@@ -29,7 +29,6 @@ type DaemonEndpointApplyConfiguration struct {
 func DaemonEndpoint() *DaemonEndpointApplyConfiguration {
 	return &DaemonEndpointApplyConfiguration{}
 }
-func (b DaemonEndpointApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapiprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapiprojection.go
@@ -29,7 +29,6 @@ type DownwardAPIProjectionApplyConfiguration struct {
 func DownwardAPIProjection() *DownwardAPIProjectionApplyConfiguration {
 	return &DownwardAPIProjectionApplyConfiguration{}
 }
-func (b DownwardAPIProjectionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapivolumefile.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapivolumefile.go
@@ -32,7 +32,6 @@ type DownwardAPIVolumeFileApplyConfiguration struct {
 func DownwardAPIVolumeFile() *DownwardAPIVolumeFileApplyConfiguration {
 	return &DownwardAPIVolumeFileApplyConfiguration{}
 }
-func (b DownwardAPIVolumeFileApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPath sets the Path field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapivolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapivolumesource.go
@@ -30,7 +30,6 @@ type DownwardAPIVolumeSourceApplyConfiguration struct {
 func DownwardAPIVolumeSource() *DownwardAPIVolumeSourceApplyConfiguration {
 	return &DownwardAPIVolumeSourceApplyConfiguration{}
 }
-func (b DownwardAPIVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/emptydirvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/emptydirvolumesource.go
@@ -35,7 +35,6 @@ type EmptyDirVolumeSourceApplyConfiguration struct {
 func EmptyDirVolumeSource() *EmptyDirVolumeSourceApplyConfiguration {
 	return &EmptyDirVolumeSourceApplyConfiguration{}
 }
-func (b EmptyDirVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMedium sets the Medium field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointaddress.go
@@ -32,7 +32,6 @@ type EndpointAddressApplyConfiguration struct {
 func EndpointAddress() *EndpointAddressApplyConfiguration {
 	return &EndpointAddressApplyConfiguration{}
 }
-func (b EndpointAddressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointport.go
@@ -36,7 +36,6 @@ type EndpointPortApplyConfiguration struct {
 func EndpointPort() *EndpointPortApplyConfiguration {
 	return &EndpointPortApplyConfiguration{}
 }
-func (b EndpointPortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointsubset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointsubset.go
@@ -31,7 +31,6 @@ type EndpointSubsetApplyConfiguration struct {
 func EndpointSubset() *EndpointSubsetApplyConfiguration {
 	return &EndpointSubsetApplyConfiguration{}
 }
-func (b EndpointSubsetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAddresses adds the given value to the Addresses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/envfromsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/envfromsource.go
@@ -31,7 +31,6 @@ type EnvFromSourceApplyConfiguration struct {
 func EnvFromSource() *EnvFromSourceApplyConfiguration {
 	return &EnvFromSourceApplyConfiguration{}
 }
-func (b EnvFromSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPrefix sets the Prefix field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/envvar.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/envvar.go
@@ -31,7 +31,6 @@ type EnvVarApplyConfiguration struct {
 func EnvVar() *EnvVarApplyConfiguration {
 	return &EnvVarApplyConfiguration{}
 }
-func (b EnvVarApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/envvarsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/envvarsource.go
@@ -32,7 +32,6 @@ type EnvVarSourceApplyConfiguration struct {
 func EnvVarSource() *EnvVarSourceApplyConfiguration {
 	return &EnvVarSourceApplyConfiguration{}
 }
-func (b EnvVarSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithFieldRef sets the FieldRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainer.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainer.go
@@ -34,7 +34,6 @@ type EphemeralContainerApplyConfiguration struct {
 func EphemeralContainer() *EphemeralContainerApplyConfiguration {
 	return &EphemeralContainerApplyConfiguration{}
 }
-func (b EphemeralContainerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
@@ -56,7 +56,6 @@ type EphemeralContainerCommonApplyConfiguration struct {
 func EphemeralContainerCommon() *EphemeralContainerCommonApplyConfiguration {
 	return &EphemeralContainerCommonApplyConfiguration{}
 }
-func (b EphemeralContainerCommonApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralvolumesource.go
@@ -29,7 +29,6 @@ type EphemeralVolumeSourceApplyConfiguration struct {
 func EphemeralVolumeSource() *EphemeralVolumeSourceApplyConfiguration {
 	return &EphemeralVolumeSourceApplyConfiguration{}
 }
-func (b EphemeralVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumeClaimTemplate sets the VolumeClaimTemplate field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/eventseries.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/eventseries.go
@@ -34,7 +34,6 @@ type EventSeriesApplyConfiguration struct {
 func EventSeries() *EventSeriesApplyConfiguration {
 	return &EventSeriesApplyConfiguration{}
 }
-func (b EventSeriesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCount sets the Count field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/eventsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/eventsource.go
@@ -30,7 +30,6 @@ type EventSourceApplyConfiguration struct {
 func EventSource() *EventSourceApplyConfiguration {
 	return &EventSourceApplyConfiguration{}
 }
-func (b EventSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithComponent sets the Component field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/execaction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/execaction.go
@@ -29,7 +29,6 @@ type ExecActionApplyConfiguration struct {
 func ExecAction() *ExecActionApplyConfiguration {
 	return &ExecActionApplyConfiguration{}
 }
-func (b ExecActionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCommand adds the given value to the Command field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/fcvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/fcvolumesource.go
@@ -33,7 +33,6 @@ type FCVolumeSourceApplyConfiguration struct {
 func FCVolumeSource() *FCVolumeSourceApplyConfiguration {
 	return &FCVolumeSourceApplyConfiguration{}
 }
-func (b FCVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTargetWWNs adds the given value to the TargetWWNs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/flexpersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/flexpersistentvolumesource.go
@@ -33,7 +33,6 @@ type FlexPersistentVolumeSourceApplyConfiguration struct {
 func FlexPersistentVolumeSource() *FlexPersistentVolumeSourceApplyConfiguration {
 	return &FlexPersistentVolumeSourceApplyConfiguration{}
 }
-func (b FlexPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/flexvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/flexvolumesource.go
@@ -33,7 +33,6 @@ type FlexVolumeSourceApplyConfiguration struct {
 func FlexVolumeSource() *FlexVolumeSourceApplyConfiguration {
 	return &FlexVolumeSourceApplyConfiguration{}
 }
-func (b FlexVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/flockervolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/flockervolumesource.go
@@ -30,7 +30,6 @@ type FlockerVolumeSourceApplyConfiguration struct {
 func FlockerVolumeSource() *FlockerVolumeSourceApplyConfiguration {
 	return &FlockerVolumeSourceApplyConfiguration{}
 }
-func (b FlockerVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDatasetName sets the DatasetName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/gcepersistentdiskvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/gcepersistentdiskvolumesource.go
@@ -32,7 +32,6 @@ type GCEPersistentDiskVolumeSourceApplyConfiguration struct {
 func GCEPersistentDiskVolumeSource() *GCEPersistentDiskVolumeSourceApplyConfiguration {
 	return &GCEPersistentDiskVolumeSourceApplyConfiguration{}
 }
-func (b GCEPersistentDiskVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPDName sets the PDName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/gitrepovolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/gitrepovolumesource.go
@@ -31,7 +31,6 @@ type GitRepoVolumeSourceApplyConfiguration struct {
 func GitRepoVolumeSource() *GitRepoVolumeSourceApplyConfiguration {
 	return &GitRepoVolumeSourceApplyConfiguration{}
 }
-func (b GitRepoVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRepository sets the Repository field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/glusterfspersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/glusterfspersistentvolumesource.go
@@ -32,7 +32,6 @@ type GlusterfsPersistentVolumeSourceApplyConfiguration struct {
 func GlusterfsPersistentVolumeSource() *GlusterfsPersistentVolumeSourceApplyConfiguration {
 	return &GlusterfsPersistentVolumeSourceApplyConfiguration{}
 }
-func (b GlusterfsPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithEndpointsName sets the EndpointsName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/glusterfsvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/glusterfsvolumesource.go
@@ -31,7 +31,6 @@ type GlusterfsVolumeSourceApplyConfiguration struct {
 func GlusterfsVolumeSource() *GlusterfsVolumeSourceApplyConfiguration {
 	return &GlusterfsVolumeSourceApplyConfiguration{}
 }
-func (b GlusterfsVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithEndpointsName sets the EndpointsName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/grpcaction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/grpcaction.go
@@ -30,7 +30,6 @@ type GRPCActionApplyConfiguration struct {
 func GRPCAction() *GRPCActionApplyConfiguration {
 	return &GRPCActionApplyConfiguration{}
 }
-func (b GRPCActionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostalias.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostalias.go
@@ -30,7 +30,6 @@ type HostAliasApplyConfiguration struct {
 func HostAlias() *HostAliasApplyConfiguration {
 	return &HostAliasApplyConfiguration{}
 }
-func (b HostAliasApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostip.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostip.go
@@ -29,7 +29,6 @@ type HostIPApplyConfiguration struct {
 func HostIP() *HostIPApplyConfiguration {
 	return &HostIPApplyConfiguration{}
 }
-func (b HostIPApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostpathvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostpathvolumesource.go
@@ -34,7 +34,6 @@ type HostPathVolumeSourceApplyConfiguration struct {
 func HostPathVolumeSource() *HostPathVolumeSourceApplyConfiguration {
 	return &HostPathVolumeSourceApplyConfiguration{}
 }
-func (b HostPathVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPath sets the Path field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/httpgetaction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/httpgetaction.go
@@ -38,7 +38,6 @@ type HTTPGetActionApplyConfiguration struct {
 func HTTPGetAction() *HTTPGetActionApplyConfiguration {
 	return &HTTPGetActionApplyConfiguration{}
 }
-func (b HTTPGetActionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPath sets the Path field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/httpheader.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/httpheader.go
@@ -30,7 +30,6 @@ type HTTPHeaderApplyConfiguration struct {
 func HTTPHeader() *HTTPHeaderApplyConfiguration {
 	return &HTTPHeaderApplyConfiguration{}
 }
-func (b HTTPHeaderApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/imagevolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/imagevolumesource.go
@@ -34,7 +34,6 @@ type ImageVolumeSourceApplyConfiguration struct {
 func ImageVolumeSource() *ImageVolumeSourceApplyConfiguration {
 	return &ImageVolumeSourceApplyConfiguration{}
 }
-func (b ImageVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReference sets the Reference field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsipersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsipersistentvolumesource.go
@@ -39,7 +39,6 @@ type ISCSIPersistentVolumeSourceApplyConfiguration struct {
 func ISCSIPersistentVolumeSource() *ISCSIPersistentVolumeSourceApplyConfiguration {
 	return &ISCSIPersistentVolumeSourceApplyConfiguration{}
 }
-func (b ISCSIPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTargetPortal sets the TargetPortal field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsivolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsivolumesource.go
@@ -39,7 +39,6 @@ type ISCSIVolumeSourceApplyConfiguration struct {
 func ISCSIVolumeSource() *ISCSIVolumeSourceApplyConfiguration {
 	return &ISCSIVolumeSourceApplyConfiguration{}
 }
-func (b ISCSIVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTargetPortal sets the TargetPortal field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/keytopath.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/keytopath.go
@@ -31,7 +31,6 @@ type KeyToPathApplyConfiguration struct {
 func KeyToPath() *KeyToPathApplyConfiguration {
 	return &KeyToPathApplyConfiguration{}
 }
-func (b KeyToPathApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/lifecycle.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/lifecycle.go
@@ -35,7 +35,6 @@ type LifecycleApplyConfiguration struct {
 func Lifecycle() *LifecycleApplyConfiguration {
 	return &LifecycleApplyConfiguration{}
 }
-func (b LifecycleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPostStart sets the PostStart field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/lifecyclehandler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/lifecyclehandler.go
@@ -32,7 +32,6 @@ type LifecycleHandlerApplyConfiguration struct {
 func LifecycleHandler() *LifecycleHandlerApplyConfiguration {
 	return &LifecycleHandlerApplyConfiguration{}
 }
-func (b LifecycleHandlerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExec sets the Exec field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrangeitem.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrangeitem.go
@@ -38,7 +38,6 @@ type LimitRangeItemApplyConfiguration struct {
 func LimitRangeItem() *LimitRangeItemApplyConfiguration {
 	return &LimitRangeItemApplyConfiguration{}
 }
-func (b LimitRangeItemApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrangespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrangespec.go
@@ -29,7 +29,6 @@ type LimitRangeSpecApplyConfiguration struct {
 func LimitRangeSpec() *LimitRangeSpecApplyConfiguration {
 	return &LimitRangeSpecApplyConfiguration{}
 }
-func (b LimitRangeSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLimits adds the given value to the Limits field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/linuxcontaineruser.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/linuxcontaineruser.go
@@ -31,7 +31,6 @@ type LinuxContainerUserApplyConfiguration struct {
 func LinuxContainerUser() *LinuxContainerUserApplyConfiguration {
 	return &LinuxContainerUserApplyConfiguration{}
 }
-func (b LinuxContainerUserApplyConfiguration) IsApplyConfiguration() {}
 
 // WithUID sets the UID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalanceringress.go
@@ -36,7 +36,6 @@ type LoadBalancerIngressApplyConfiguration struct {
 func LoadBalancerIngress() *LoadBalancerIngressApplyConfiguration {
 	return &LoadBalancerIngressApplyConfiguration{}
 }
-func (b LoadBalancerIngressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalancerstatus.go
@@ -29,7 +29,6 @@ type LoadBalancerStatusApplyConfiguration struct {
 func LoadBalancerStatus() *LoadBalancerStatusApplyConfiguration {
 	return &LoadBalancerStatusApplyConfiguration{}
 }
-func (b LoadBalancerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/localobjectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/localobjectreference.go
@@ -29,7 +29,6 @@ type LocalObjectReferenceApplyConfiguration struct {
 func LocalObjectReference() *LocalObjectReferenceApplyConfiguration {
 	return &LocalObjectReferenceApplyConfiguration{}
 }
-func (b LocalObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/localvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/localvolumesource.go
@@ -30,7 +30,6 @@ type LocalVolumeSourceApplyConfiguration struct {
 func LocalVolumeSource() *LocalVolumeSourceApplyConfiguration {
 	return &LocalVolumeSourceApplyConfiguration{}
 }
-func (b LocalVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPath sets the Path field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/modifyvolumestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/modifyvolumestatus.go
@@ -34,7 +34,6 @@ type ModifyVolumeStatusApplyConfiguration struct {
 func ModifyVolumeStatus() *ModifyVolumeStatusApplyConfiguration {
 	return &ModifyVolumeStatusApplyConfiguration{}
 }
-func (b ModifyVolumeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTargetVolumeAttributesClassName sets the TargetVolumeAttributesClassName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacecondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacecondition.go
@@ -38,7 +38,6 @@ type NamespaceConditionApplyConfiguration struct {
 func NamespaceCondition() *NamespaceConditionApplyConfiguration {
 	return &NamespaceConditionApplyConfiguration{}
 }
-func (b NamespaceConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacespec.go
@@ -33,7 +33,6 @@ type NamespaceSpecApplyConfiguration struct {
 func NamespaceSpec() *NamespaceSpecApplyConfiguration {
 	return &NamespaceSpecApplyConfiguration{}
 }
-func (b NamespaceSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacestatus.go
@@ -34,7 +34,6 @@ type NamespaceStatusApplyConfiguration struct {
 func NamespaceStatus() *NamespaceStatusApplyConfiguration {
 	return &NamespaceStatusApplyConfiguration{}
 }
-func (b NamespaceStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPhase sets the Phase field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nfsvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nfsvolumesource.go
@@ -31,7 +31,6 @@ type NFSVolumeSourceApplyConfiguration struct {
 func NFSVolumeSource() *NFSVolumeSourceApplyConfiguration {
 	return &NFSVolumeSourceApplyConfiguration{}
 }
-func (b NFSVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithServer sets the Server field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeaddress.go
@@ -34,7 +34,6 @@ type NodeAddressApplyConfiguration struct {
 func NodeAddress() *NodeAddressApplyConfiguration {
 	return &NodeAddressApplyConfiguration{}
 }
-func (b NodeAddressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeaffinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeaffinity.go
@@ -30,7 +30,6 @@ type NodeAffinityApplyConfiguration struct {
 func NodeAffinity() *NodeAffinityApplyConfiguration {
 	return &NodeAffinityApplyConfiguration{}
 }
-func (b NodeAffinityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequiredDuringSchedulingIgnoredDuringExecution sets the RequiredDuringSchedulingIgnoredDuringExecution field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodecondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodecondition.go
@@ -39,7 +39,6 @@ type NodeConditionApplyConfiguration struct {
 func NodeCondition() *NodeConditionApplyConfiguration {
 	return &NodeConditionApplyConfiguration{}
 }
-func (b NodeConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeconfigsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeconfigsource.go
@@ -29,7 +29,6 @@ type NodeConfigSourceApplyConfiguration struct {
 func NodeConfigSource() *NodeConfigSourceApplyConfiguration {
 	return &NodeConfigSourceApplyConfiguration{}
 }
-func (b NodeConfigSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConfigMap sets the ConfigMap field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeconfigstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeconfigstatus.go
@@ -32,7 +32,6 @@ type NodeConfigStatusApplyConfiguration struct {
 func NodeConfigStatus() *NodeConfigStatusApplyConfiguration {
 	return &NodeConfigStatusApplyConfiguration{}
 }
-func (b NodeConfigStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAssigned sets the Assigned field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodedaemonendpoints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodedaemonendpoints.go
@@ -29,7 +29,6 @@ type NodeDaemonEndpointsApplyConfiguration struct {
 func NodeDaemonEndpoints() *NodeDaemonEndpointsApplyConfiguration {
 	return &NodeDaemonEndpointsApplyConfiguration{}
 }
-func (b NodeDaemonEndpointsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKubeletEndpoint sets the KubeletEndpoint field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodefeatures.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodefeatures.go
@@ -29,7 +29,6 @@ type NodeFeaturesApplyConfiguration struct {
 func NodeFeatures() *NodeFeaturesApplyConfiguration {
 	return &NodeFeaturesApplyConfiguration{}
 }
-func (b NodeFeaturesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSupplementalGroupsPolicy sets the SupplementalGroupsPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/noderuntimehandler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/noderuntimehandler.go
@@ -30,7 +30,6 @@ type NodeRuntimeHandlerApplyConfiguration struct {
 func NodeRuntimeHandler() *NodeRuntimeHandlerApplyConfiguration {
 	return &NodeRuntimeHandlerApplyConfiguration{}
 }
-func (b NodeRuntimeHandlerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/noderuntimehandlerfeatures.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/noderuntimehandlerfeatures.go
@@ -30,7 +30,6 @@ type NodeRuntimeHandlerFeaturesApplyConfiguration struct {
 func NodeRuntimeHandlerFeatures() *NodeRuntimeHandlerFeaturesApplyConfiguration {
 	return &NodeRuntimeHandlerFeaturesApplyConfiguration{}
 }
-func (b NodeRuntimeHandlerFeaturesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRecursiveReadOnlyMounts sets the RecursiveReadOnlyMounts field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselector.go
@@ -29,7 +29,6 @@ type NodeSelectorApplyConfiguration struct {
 func NodeSelector() *NodeSelectorApplyConfiguration {
 	return &NodeSelectorApplyConfiguration{}
 }
-func (b NodeSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNodeSelectorTerms adds the given value to the NodeSelectorTerms field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorrequirement.go
@@ -35,7 +35,6 @@ type NodeSelectorRequirementApplyConfiguration struct {
 func NodeSelectorRequirement() *NodeSelectorRequirementApplyConfiguration {
 	return &NodeSelectorRequirementApplyConfiguration{}
 }
-func (b NodeSelectorRequirementApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorterm.go
@@ -30,7 +30,6 @@ type NodeSelectorTermApplyConfiguration struct {
 func NodeSelectorTerm() *NodeSelectorTermApplyConfiguration {
 	return &NodeSelectorTermApplyConfiguration{}
 }
-func (b NodeSelectorTermApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMatchExpressions adds the given value to the MatchExpressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodespec.go
@@ -35,7 +35,6 @@ type NodeSpecApplyConfiguration struct {
 func NodeSpec() *NodeSpecApplyConfiguration {
 	return &NodeSpecApplyConfiguration{}
 }
-func (b NodeSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodCIDR sets the PodCIDR field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodestatus.go
@@ -45,7 +45,6 @@ type NodeStatusApplyConfiguration struct {
 func NodeStatus() *NodeStatusApplyConfiguration {
 	return &NodeStatusApplyConfiguration{}
 }
-func (b NodeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCapacity sets the Capacity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeswapstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeswapstatus.go
@@ -29,7 +29,6 @@ type NodeSwapStatusApplyConfiguration struct {
 func NodeSwapStatus() *NodeSwapStatusApplyConfiguration {
 	return &NodeSwapStatusApplyConfiguration{}
 }
-func (b NodeSwapStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCapacity sets the Capacity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodesysteminfo.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodesysteminfo.go
@@ -39,7 +39,6 @@ type NodeSystemInfoApplyConfiguration struct {
 func NodeSystemInfo() *NodeSystemInfoApplyConfiguration {
 	return &NodeSystemInfoApplyConfiguration{}
 }
-func (b NodeSystemInfoApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMachineID sets the MachineID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/objectfieldselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/objectfieldselector.go
@@ -30,7 +30,6 @@ type ObjectFieldSelectorApplyConfiguration struct {
 func ObjectFieldSelector() *ObjectFieldSelectorApplyConfiguration {
 	return &ObjectFieldSelectorApplyConfiguration{}
 }
-func (b ObjectFieldSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIVersion sets the APIVersion field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/objectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/objectreference.go
@@ -39,7 +39,6 @@ type ObjectReferenceApplyConfiguration struct {
 func ObjectReference() *ObjectReferenceApplyConfiguration {
 	return &ObjectReferenceApplyConfiguration{}
 }
-func (b ObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimcondition.go
@@ -39,7 +39,6 @@ type PersistentVolumeClaimConditionApplyConfiguration struct {
 func PersistentVolumeClaimCondition() *PersistentVolumeClaimConditionApplyConfiguration {
 	return &PersistentVolumeClaimConditionApplyConfiguration{}
 }
-func (b PersistentVolumeClaimConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimspec.go
@@ -42,7 +42,6 @@ type PersistentVolumeClaimSpecApplyConfiguration struct {
 func PersistentVolumeClaimSpec() *PersistentVolumeClaimSpecApplyConfiguration {
 	return &PersistentVolumeClaimSpecApplyConfiguration{}
 }
-func (b PersistentVolumeClaimSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAccessModes adds the given value to the AccessModes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimstatus.go
@@ -40,7 +40,6 @@ type PersistentVolumeClaimStatusApplyConfiguration struct {
 func PersistentVolumeClaimStatus() *PersistentVolumeClaimStatusApplyConfiguration {
 	return &PersistentVolumeClaimStatusApplyConfiguration{}
 }
-func (b PersistentVolumeClaimStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPhase sets the Phase field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimtemplate.go
@@ -36,7 +36,6 @@ type PersistentVolumeClaimTemplateApplyConfiguration struct {
 func PersistentVolumeClaimTemplate() *PersistentVolumeClaimTemplateApplyConfiguration {
 	return &PersistentVolumeClaimTemplateApplyConfiguration{}
 }
-func (b PersistentVolumeClaimTemplateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimvolumesource.go
@@ -30,7 +30,6 @@ type PersistentVolumeClaimVolumeSourceApplyConfiguration struct {
 func PersistentVolumeClaimVolumeSource() *PersistentVolumeClaimVolumeSourceApplyConfiguration {
 	return &PersistentVolumeClaimVolumeSourceApplyConfiguration{}
 }
-func (b PersistentVolumeClaimVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithClaimName sets the ClaimName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumesource.go
@@ -50,7 +50,6 @@ type PersistentVolumeSourceApplyConfiguration struct {
 func PersistentVolumeSource() *PersistentVolumeSourceApplyConfiguration {
 	return &PersistentVolumeSourceApplyConfiguration{}
 }
-func (b PersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGCEPersistentDisk sets the GCEPersistentDisk field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumespec.go
@@ -42,7 +42,6 @@ type PersistentVolumeSpecApplyConfiguration struct {
 func PersistentVolumeSpec() *PersistentVolumeSpecApplyConfiguration {
 	return &PersistentVolumeSpecApplyConfiguration{}
 }
-func (b PersistentVolumeSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCapacity sets the Capacity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumestatus.go
@@ -37,7 +37,6 @@ type PersistentVolumeStatusApplyConfiguration struct {
 func PersistentVolumeStatus() *PersistentVolumeStatusApplyConfiguration {
 	return &PersistentVolumeStatusApplyConfiguration{}
 }
-func (b PersistentVolumeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPhase sets the Phase field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/photonpersistentdiskvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/photonpersistentdiskvolumesource.go
@@ -30,7 +30,6 @@ type PhotonPersistentDiskVolumeSourceApplyConfiguration struct {
 func PhotonPersistentDiskVolumeSource() *PhotonPersistentDiskVolumeSourceApplyConfiguration {
 	return &PhotonPersistentDiskVolumeSourceApplyConfiguration{}
 }
-func (b PhotonPersistentDiskVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPdID sets the PdID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinity.go
@@ -30,7 +30,6 @@ type PodAffinityApplyConfiguration struct {
 func PodAffinity() *PodAffinityApplyConfiguration {
 	return &PodAffinityApplyConfiguration{}
 }
-func (b PodAffinityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequiredDuringSchedulingIgnoredDuringExecution adds the given value to the RequiredDuringSchedulingIgnoredDuringExecution field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinityterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinityterm.go
@@ -38,7 +38,6 @@ type PodAffinityTermApplyConfiguration struct {
 func PodAffinityTerm() *PodAffinityTermApplyConfiguration {
 	return &PodAffinityTermApplyConfiguration{}
 }
-func (b PodAffinityTermApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLabelSelector sets the LabelSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podantiaffinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podantiaffinity.go
@@ -30,7 +30,6 @@ type PodAntiAffinityApplyConfiguration struct {
 func PodAntiAffinity() *PodAntiAffinityApplyConfiguration {
 	return &PodAntiAffinityApplyConfiguration{}
 }
-func (b PodAntiAffinityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequiredDuringSchedulingIgnoredDuringExecution adds the given value to the RequiredDuringSchedulingIgnoredDuringExecution field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podcondition.go
@@ -40,7 +40,6 @@ type PodConditionApplyConfiguration struct {
 func PodCondition() *PodConditionApplyConfiguration {
 	return &PodConditionApplyConfiguration{}
 }
-func (b PodConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/poddnsconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/poddnsconfig.go
@@ -31,7 +31,6 @@ type PodDNSConfigApplyConfiguration struct {
 func PodDNSConfig() *PodDNSConfigApplyConfiguration {
 	return &PodDNSConfigApplyConfiguration{}
 }
-func (b PodDNSConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNameservers adds the given value to the Nameservers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/poddnsconfigoption.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/poddnsconfigoption.go
@@ -30,7 +30,6 @@ type PodDNSConfigOptionApplyConfiguration struct {
 func PodDNSConfigOption() *PodDNSConfigOptionApplyConfiguration {
 	return &PodDNSConfigOptionApplyConfiguration{}
 }
-func (b PodDNSConfigOptionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podip.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podip.go
@@ -29,7 +29,6 @@ type PodIPApplyConfiguration struct {
 func PodIP() *PodIPApplyConfiguration {
 	return &PodIPApplyConfiguration{}
 }
-func (b PodIPApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podos.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podos.go
@@ -33,7 +33,6 @@ type PodOSApplyConfiguration struct {
 func PodOS() *PodOSApplyConfiguration {
 	return &PodOSApplyConfiguration{}
 }
-func (b PodOSApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podreadinessgate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podreadinessgate.go
@@ -33,7 +33,6 @@ type PodReadinessGateApplyConfiguration struct {
 func PodReadinessGate() *PodReadinessGateApplyConfiguration {
 	return &PodReadinessGateApplyConfiguration{}
 }
-func (b PodReadinessGateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditionType sets the ConditionType field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podresourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podresourceclaim.go
@@ -31,7 +31,6 @@ type PodResourceClaimApplyConfiguration struct {
 func PodResourceClaim() *PodResourceClaimApplyConfiguration {
 	return &PodResourceClaimApplyConfiguration{}
 }
-func (b PodResourceClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podresourceclaimstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podresourceclaimstatus.go
@@ -30,7 +30,6 @@ type PodResourceClaimStatusApplyConfiguration struct {
 func PodResourceClaimStatus() *PodResourceClaimStatusApplyConfiguration {
 	return &PodResourceClaimStatusApplyConfiguration{}
 }
-func (b PodResourceClaimStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podschedulinggate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podschedulinggate.go
@@ -29,7 +29,6 @@ type PodSchedulingGateApplyConfiguration struct {
 func PodSchedulingGate() *PodSchedulingGateApplyConfiguration {
 	return &PodSchedulingGateApplyConfiguration{}
 }
-func (b PodSchedulingGateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podsecuritycontext.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podsecuritycontext.go
@@ -45,7 +45,6 @@ type PodSecurityContextApplyConfiguration struct {
 func PodSecurityContext() *PodSecurityContextApplyConfiguration {
 	return &PodSecurityContextApplyConfiguration{}
 }
-func (b PodSecurityContextApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSELinuxOptions sets the SELinuxOptions field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
@@ -72,7 +72,6 @@ type PodSpecApplyConfiguration struct {
 func PodSpec() *PodSpecApplyConfiguration {
 	return &PodSpecApplyConfiguration{}
 }
-func (b PodSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumes adds the given value to the Volumes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podstatus.go
@@ -50,7 +50,6 @@ type PodStatusApplyConfiguration struct {
 func PodStatus() *PodStatusApplyConfiguration {
 	return &PodStatusApplyConfiguration{}
 }
-func (b PodStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplatespec.go
@@ -36,7 +36,6 @@ type PodTemplateSpecApplyConfiguration struct {
 func PodTemplateSpec() *PodTemplateSpecApplyConfiguration {
 	return &PodTemplateSpecApplyConfiguration{}
 }
-func (b PodTemplateSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/portstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/portstatus.go
@@ -35,7 +35,6 @@ type PortStatusApplyConfiguration struct {
 func PortStatus() *PortStatusApplyConfiguration {
 	return &PortStatusApplyConfiguration{}
 }
-func (b PortStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/portworxvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/portworxvolumesource.go
@@ -31,7 +31,6 @@ type PortworxVolumeSourceApplyConfiguration struct {
 func PortworxVolumeSource() *PortworxVolumeSourceApplyConfiguration {
 	return &PortworxVolumeSourceApplyConfiguration{}
 }
-func (b PortworxVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumeID sets the VolumeID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/preferredschedulingterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/preferredschedulingterm.go
@@ -30,7 +30,6 @@ type PreferredSchedulingTermApplyConfiguration struct {
 func PreferredSchedulingTerm() *PreferredSchedulingTermApplyConfiguration {
 	return &PreferredSchedulingTermApplyConfiguration{}
 }
-func (b PreferredSchedulingTermApplyConfiguration) IsApplyConfiguration() {}
 
 // WithWeight sets the Weight field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/probe.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/probe.go
@@ -35,7 +35,6 @@ type ProbeApplyConfiguration struct {
 func Probe() *ProbeApplyConfiguration {
 	return &ProbeApplyConfiguration{}
 }
-func (b ProbeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExec sets the Exec field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/probehandler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/probehandler.go
@@ -32,7 +32,6 @@ type ProbeHandlerApplyConfiguration struct {
 func ProbeHandler() *ProbeHandlerApplyConfiguration {
 	return &ProbeHandlerApplyConfiguration{}
 }
-func (b ProbeHandlerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExec sets the Exec field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/projectedvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/projectedvolumesource.go
@@ -30,7 +30,6 @@ type ProjectedVolumeSourceApplyConfiguration struct {
 func ProjectedVolumeSource() *ProjectedVolumeSourceApplyConfiguration {
 	return &ProjectedVolumeSourceApplyConfiguration{}
 }
-func (b ProjectedVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSources adds the given value to the Sources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/quobytevolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/quobytevolumesource.go
@@ -34,7 +34,6 @@ type QuobyteVolumeSourceApplyConfiguration struct {
 func QuobyteVolumeSource() *QuobyteVolumeSourceApplyConfiguration {
 	return &QuobyteVolumeSourceApplyConfiguration{}
 }
-func (b QuobyteVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRegistry sets the Registry field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdpersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdpersistentvolumesource.go
@@ -36,7 +36,6 @@ type RBDPersistentVolumeSourceApplyConfiguration struct {
 func RBDPersistentVolumeSource() *RBDPersistentVolumeSourceApplyConfiguration {
 	return &RBDPersistentVolumeSourceApplyConfiguration{}
 }
-func (b RBDPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCephMonitors adds the given value to the CephMonitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdvolumesource.go
@@ -36,7 +36,6 @@ type RBDVolumeSourceApplyConfiguration struct {
 func RBDVolumeSource() *RBDVolumeSourceApplyConfiguration {
 	return &RBDVolumeSourceApplyConfiguration{}
 }
-func (b RBDVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCephMonitors adds the given value to the CephMonitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollercondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollercondition.go
@@ -38,7 +38,6 @@ type ReplicationControllerConditionApplyConfiguration struct {
 func ReplicationControllerCondition() *ReplicationControllerConditionApplyConfiguration {
 	return &ReplicationControllerConditionApplyConfiguration{}
 }
-func (b ReplicationControllerConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerspec.go
@@ -32,7 +32,6 @@ type ReplicationControllerSpecApplyConfiguration struct {
 func ReplicationControllerSpec() *ReplicationControllerSpecApplyConfiguration {
 	return &ReplicationControllerSpecApplyConfiguration{}
 }
-func (b ReplicationControllerSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerstatus.go
@@ -34,7 +34,6 @@ type ReplicationControllerStatusApplyConfiguration struct {
 func ReplicationControllerStatus() *ReplicationControllerStatusApplyConfiguration {
 	return &ReplicationControllerStatusApplyConfiguration{}
 }
-func (b ReplicationControllerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourceclaim.go
@@ -30,7 +30,6 @@ type ResourceClaimApplyConfiguration struct {
 func ResourceClaim() *ResourceClaimApplyConfiguration {
 	return &ResourceClaimApplyConfiguration{}
 }
-func (b ResourceClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcefieldselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcefieldselector.go
@@ -35,7 +35,6 @@ type ResourceFieldSelectorApplyConfiguration struct {
 func ResourceFieldSelector() *ResourceFieldSelectorApplyConfiguration {
 	return &ResourceFieldSelectorApplyConfiguration{}
 }
-func (b ResourceFieldSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithContainerName sets the ContainerName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcehealth.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcehealth.go
@@ -34,7 +34,6 @@ type ResourceHealthApplyConfiguration struct {
 func ResourceHealth() *ResourceHealthApplyConfiguration {
 	return &ResourceHealthApplyConfiguration{}
 }
-func (b ResourceHealthApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResourceID sets the ResourceID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequotaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequotaspec.go
@@ -35,7 +35,6 @@ type ResourceQuotaSpecApplyConfiguration struct {
 func ResourceQuotaSpec() *ResourceQuotaSpecApplyConfiguration {
 	return &ResourceQuotaSpecApplyConfiguration{}
 }
-func (b ResourceQuotaSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHard sets the Hard field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequotastatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequotastatus.go
@@ -34,7 +34,6 @@ type ResourceQuotaStatusApplyConfiguration struct {
 func ResourceQuotaStatus() *ResourceQuotaStatusApplyConfiguration {
 	return &ResourceQuotaStatusApplyConfiguration{}
 }
-func (b ResourceQuotaStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHard sets the Hard field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcerequirements.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcerequirements.go
@@ -35,7 +35,6 @@ type ResourceRequirementsApplyConfiguration struct {
 func ResourceRequirements() *ResourceRequirementsApplyConfiguration {
 	return &ResourceRequirementsApplyConfiguration{}
 }
-func (b ResourceRequirementsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLimits sets the Limits field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcestatus.go
@@ -34,7 +34,6 @@ type ResourceStatusApplyConfiguration struct {
 func ResourceStatus() *ResourceStatusApplyConfiguration {
 	return &ResourceStatusApplyConfiguration{}
 }
-func (b ResourceStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scaleiopersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scaleiopersistentvolumesource.go
@@ -38,7 +38,6 @@ type ScaleIOPersistentVolumeSourceApplyConfiguration struct {
 func ScaleIOPersistentVolumeSource() *ScaleIOPersistentVolumeSourceApplyConfiguration {
 	return &ScaleIOPersistentVolumeSourceApplyConfiguration{}
 }
-func (b ScaleIOPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGateway sets the Gateway field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scaleiovolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scaleiovolumesource.go
@@ -38,7 +38,6 @@ type ScaleIOVolumeSourceApplyConfiguration struct {
 func ScaleIOVolumeSource() *ScaleIOVolumeSourceApplyConfiguration {
 	return &ScaleIOVolumeSourceApplyConfiguration{}
 }
-func (b ScaleIOVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGateway sets the Gateway field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopedresourceselectorrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopedresourceselectorrequirement.go
@@ -35,7 +35,6 @@ type ScopedResourceSelectorRequirementApplyConfiguration struct {
 func ScopedResourceSelectorRequirement() *ScopedResourceSelectorRequirementApplyConfiguration {
 	return &ScopedResourceSelectorRequirementApplyConfiguration{}
 }
-func (b ScopedResourceSelectorRequirementApplyConfiguration) IsApplyConfiguration() {}
 
 // WithScopeName sets the ScopeName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopeselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopeselector.go
@@ -29,7 +29,6 @@ type ScopeSelectorApplyConfiguration struct {
 func ScopeSelector() *ScopeSelectorApplyConfiguration {
 	return &ScopeSelectorApplyConfiguration{}
 }
-func (b ScopeSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMatchExpressions adds the given value to the MatchExpressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/seccompprofile.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/seccompprofile.go
@@ -34,7 +34,6 @@ type SeccompProfileApplyConfiguration struct {
 func SeccompProfile() *SeccompProfileApplyConfiguration {
 	return &SeccompProfileApplyConfiguration{}
 }
-func (b SeccompProfileApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretenvsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretenvsource.go
@@ -30,7 +30,6 @@ type SecretEnvSourceApplyConfiguration struct {
 func SecretEnvSource() *SecretEnvSourceApplyConfiguration {
 	return &SecretEnvSourceApplyConfiguration{}
 }
-func (b SecretEnvSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretkeyselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretkeyselector.go
@@ -31,7 +31,6 @@ type SecretKeySelectorApplyConfiguration struct {
 func SecretKeySelector() *SecretKeySelectorApplyConfiguration {
 	return &SecretKeySelectorApplyConfiguration{}
 }
-func (b SecretKeySelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretprojection.go
@@ -31,7 +31,6 @@ type SecretProjectionApplyConfiguration struct {
 func SecretProjection() *SecretProjectionApplyConfiguration {
 	return &SecretProjectionApplyConfiguration{}
 }
-func (b SecretProjectionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretreference.go
@@ -30,7 +30,6 @@ type SecretReferenceApplyConfiguration struct {
 func SecretReference() *SecretReferenceApplyConfiguration {
 	return &SecretReferenceApplyConfiguration{}
 }
-func (b SecretReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretvolumesource.go
@@ -32,7 +32,6 @@ type SecretVolumeSourceApplyConfiguration struct {
 func SecretVolumeSource() *SecretVolumeSourceApplyConfiguration {
 	return &SecretVolumeSourceApplyConfiguration{}
 }
-func (b SecretVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSecretName sets the SecretName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/securitycontext.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/securitycontext.go
@@ -44,7 +44,6 @@ type SecurityContextApplyConfiguration struct {
 func SecurityContext() *SecurityContextApplyConfiguration {
 	return &SecurityContextApplyConfiguration{}
 }
-func (b SecurityContextApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCapabilities sets the Capabilities field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/selinuxoptions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/selinuxoptions.go
@@ -32,7 +32,6 @@ type SELinuxOptionsApplyConfiguration struct {
 func SELinuxOptions() *SELinuxOptionsApplyConfiguration {
 	return &SELinuxOptionsApplyConfiguration{}
 }
-func (b SELinuxOptionsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithUser sets the User field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccounttokenprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccounttokenprojection.go
@@ -31,7 +31,6 @@ type ServiceAccountTokenProjectionApplyConfiguration struct {
 func ServiceAccountTokenProjection() *ServiceAccountTokenProjectionApplyConfiguration {
 	return &ServiceAccountTokenProjectionApplyConfiguration{}
 }
-func (b ServiceAccountTokenProjectionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAudience sets the Audience field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceport.go
@@ -39,7 +39,6 @@ type ServicePortApplyConfiguration struct {
 func ServicePort() *ServicePortApplyConfiguration {
 	return &ServicePortApplyConfiguration{}
 }
-func (b ServicePortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
@@ -52,7 +52,6 @@ type ServiceSpecApplyConfiguration struct {
 func ServiceSpec() *ServiceSpecApplyConfiguration {
 	return &ServiceSpecApplyConfiguration{}
 }
-func (b ServiceSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicestatus.go
@@ -34,7 +34,6 @@ type ServiceStatusApplyConfiguration struct {
 func ServiceStatus() *ServiceStatusApplyConfiguration {
 	return &ServiceStatusApplyConfiguration{}
 }
-func (b ServiceStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLoadBalancer sets the LoadBalancer field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/sessionaffinityconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/sessionaffinityconfig.go
@@ -29,7 +29,6 @@ type SessionAffinityConfigApplyConfiguration struct {
 func SessionAffinityConfig() *SessionAffinityConfigApplyConfiguration {
 	return &SessionAffinityConfigApplyConfiguration{}
 }
-func (b SessionAffinityConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithClientIP sets the ClientIP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/sleepaction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/sleepaction.go
@@ -29,7 +29,6 @@ type SleepActionApplyConfiguration struct {
 func SleepAction() *SleepActionApplyConfiguration {
 	return &SleepActionApplyConfiguration{}
 }
-func (b SleepActionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSeconds sets the Seconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/storageospersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/storageospersistentvolumesource.go
@@ -33,7 +33,6 @@ type StorageOSPersistentVolumeSourceApplyConfiguration struct {
 func StorageOSPersistentVolumeSource() *StorageOSPersistentVolumeSourceApplyConfiguration {
 	return &StorageOSPersistentVolumeSourceApplyConfiguration{}
 }
-func (b StorageOSPersistentVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumeName sets the VolumeName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/storageosvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/storageosvolumesource.go
@@ -33,7 +33,6 @@ type StorageOSVolumeSourceApplyConfiguration struct {
 func StorageOSVolumeSource() *StorageOSVolumeSourceApplyConfiguration {
 	return &StorageOSVolumeSourceApplyConfiguration{}
 }
-func (b StorageOSVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumeName sets the VolumeName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/sysctl.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/sysctl.go
@@ -30,7 +30,6 @@ type SysctlApplyConfiguration struct {
 func Sysctl() *SysctlApplyConfiguration {
 	return &SysctlApplyConfiguration{}
 }
-func (b SysctlApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/taint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/taint.go
@@ -37,7 +37,6 @@ type TaintApplyConfiguration struct {
 func Taint() *TaintApplyConfiguration {
 	return &TaintApplyConfiguration{}
 }
-func (b TaintApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/tcpsocketaction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/tcpsocketaction.go
@@ -34,7 +34,6 @@ type TCPSocketActionApplyConfiguration struct {
 func TCPSocketAction() *TCPSocketActionApplyConfiguration {
 	return &TCPSocketActionApplyConfiguration{}
 }
-func (b TCPSocketActionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/toleration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/toleration.go
@@ -37,7 +37,6 @@ type TolerationApplyConfiguration struct {
 func Toleration() *TolerationApplyConfiguration {
 	return &TolerationApplyConfiguration{}
 }
-func (b TolerationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorlabelrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorlabelrequirement.go
@@ -30,7 +30,6 @@ type TopologySelectorLabelRequirementApplyConfiguration struct {
 func TopologySelectorLabelRequirement() *TopologySelectorLabelRequirementApplyConfiguration {
 	return &TopologySelectorLabelRequirementApplyConfiguration{}
 }
-func (b TopologySelectorLabelRequirementApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorterm.go
@@ -29,7 +29,6 @@ type TopologySelectorTermApplyConfiguration struct {
 func TopologySelectorTerm() *TopologySelectorTermApplyConfiguration {
 	return &TopologySelectorTermApplyConfiguration{}
 }
-func (b TopologySelectorTermApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMatchLabelExpressions adds the given value to the MatchLabelExpressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyspreadconstraint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyspreadconstraint.go
@@ -41,7 +41,6 @@ type TopologySpreadConstraintApplyConfiguration struct {
 func TopologySpreadConstraint() *TopologySpreadConstraintApplyConfiguration {
 	return &TopologySpreadConstraintApplyConfiguration{}
 }
-func (b TopologySpreadConstraintApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxSkew sets the MaxSkew field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/typedlocalobjectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/typedlocalobjectreference.go
@@ -31,7 +31,6 @@ type TypedLocalObjectReferenceApplyConfiguration struct {
 func TypedLocalObjectReference() *TypedLocalObjectReferenceApplyConfiguration {
 	return &TypedLocalObjectReferenceApplyConfiguration{}
 }
-func (b TypedLocalObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/typedobjectreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/typedobjectreference.go
@@ -32,7 +32,6 @@ type TypedObjectReferenceApplyConfiguration struct {
 func TypedObjectReference() *TypedObjectReferenceApplyConfiguration {
 	return &TypedObjectReferenceApplyConfiguration{}
 }
-func (b TypedObjectReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volume.go
@@ -30,7 +30,6 @@ type VolumeApplyConfiguration struct {
 func Volume() *VolumeApplyConfiguration {
 	return &VolumeApplyConfiguration{}
 }
-func (b VolumeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumedevice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumedevice.go
@@ -30,7 +30,6 @@ type VolumeDeviceApplyConfiguration struct {
 func VolumeDevice() *VolumeDeviceApplyConfiguration {
 	return &VolumeDeviceApplyConfiguration{}
 }
-func (b VolumeDeviceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumemount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumemount.go
@@ -39,7 +39,6 @@ type VolumeMountApplyConfiguration struct {
 func VolumeMount() *VolumeMountApplyConfiguration {
 	return &VolumeMountApplyConfiguration{}
 }
-func (b VolumeMountApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumemountstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumemountstatus.go
@@ -36,7 +36,6 @@ type VolumeMountStatusApplyConfiguration struct {
 func VolumeMountStatus() *VolumeMountStatusApplyConfiguration {
 	return &VolumeMountStatusApplyConfiguration{}
 }
-func (b VolumeMountStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumenodeaffinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumenodeaffinity.go
@@ -29,7 +29,6 @@ type VolumeNodeAffinityApplyConfiguration struct {
 func VolumeNodeAffinity() *VolumeNodeAffinityApplyConfiguration {
 	return &VolumeNodeAffinityApplyConfiguration{}
 }
-func (b VolumeNodeAffinityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequired sets the Required field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumeprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumeprojection.go
@@ -33,7 +33,6 @@ type VolumeProjectionApplyConfiguration struct {
 func VolumeProjection() *VolumeProjectionApplyConfiguration {
 	return &VolumeProjectionApplyConfiguration{}
 }
-func (b VolumeProjectionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSecret sets the Secret field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumeresourcerequirements.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumeresourcerequirements.go
@@ -34,7 +34,6 @@ type VolumeResourceRequirementsApplyConfiguration struct {
 func VolumeResourceRequirements() *VolumeResourceRequirementsApplyConfiguration {
 	return &VolumeResourceRequirementsApplyConfiguration{}
 }
-func (b VolumeResourceRequirementsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLimits sets the Limits field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/volumesource.go
@@ -58,7 +58,6 @@ type VolumeSourceApplyConfiguration struct {
 func VolumeSource() *VolumeSourceApplyConfiguration {
 	return &VolumeSourceApplyConfiguration{}
 }
-func (b VolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHostPath sets the HostPath field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/vspherevirtualdiskvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/vspherevirtualdiskvolumesource.go
@@ -32,7 +32,6 @@ type VsphereVirtualDiskVolumeSourceApplyConfiguration struct {
 func VsphereVirtualDiskVolumeSource() *VsphereVirtualDiskVolumeSourceApplyConfiguration {
 	return &VsphereVirtualDiskVolumeSourceApplyConfiguration{}
 }
-func (b VsphereVirtualDiskVolumeSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVolumePath sets the VolumePath field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/weightedpodaffinityterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/weightedpodaffinityterm.go
@@ -30,7 +30,6 @@ type WeightedPodAffinityTermApplyConfiguration struct {
 func WeightedPodAffinityTerm() *WeightedPodAffinityTermApplyConfiguration {
 	return &WeightedPodAffinityTermApplyConfiguration{}
 }
-func (b WeightedPodAffinityTermApplyConfiguration) IsApplyConfiguration() {}
 
 // WithWeight sets the Weight field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/windowssecuritycontextoptions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/windowssecuritycontextoptions.go
@@ -32,7 +32,6 @@ type WindowsSecurityContextOptionsApplyConfiguration struct {
 func WindowsSecurityContextOptions() *WindowsSecurityContextOptionsApplyConfiguration {
 	return &WindowsSecurityContextOptionsApplyConfiguration{}
 }
-func (b WindowsSecurityContextOptionsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGMSACredentialSpecName sets the GMSACredentialSpecName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpoint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpoint.go
@@ -40,7 +40,6 @@ type EndpointApplyConfiguration struct {
 func Endpoint() *EndpointApplyConfiguration {
 	return &EndpointApplyConfiguration{}
 }
-func (b EndpointApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAddresses adds the given value to the Addresses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointconditions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointconditions.go
@@ -31,7 +31,6 @@ type EndpointConditionsApplyConfiguration struct {
 func EndpointConditions() *EndpointConditionsApplyConfiguration {
 	return &EndpointConditionsApplyConfiguration{}
 }
-func (b EndpointConditionsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReady sets the Ready field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointhints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointhints.go
@@ -30,7 +30,6 @@ type EndpointHintsApplyConfiguration struct {
 func EndpointHints() *EndpointHintsApplyConfiguration {
 	return &EndpointHintsApplyConfiguration{}
 }
-func (b EndpointHintsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithForZones adds the given value to the ForZones field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointport.go
@@ -36,7 +36,6 @@ type EndpointPortApplyConfiguration struct {
 func EndpointPort() *EndpointPortApplyConfiguration {
 	return &EndpointPortApplyConfiguration{}
 }
-func (b EndpointPortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/fornode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/fornode.go
@@ -29,7 +29,6 @@ type ForNodeApplyConfiguration struct {
 func ForNode() *ForNodeApplyConfiguration {
 	return &ForNodeApplyConfiguration{}
 }
-func (b ForNodeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/forzone.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/forzone.go
@@ -29,7 +29,6 @@ type ForZoneApplyConfiguration struct {
 func ForZone() *ForZoneApplyConfiguration {
 	return &ForZoneApplyConfiguration{}
 }
-func (b ForZoneApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpoint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpoint.go
@@ -39,7 +39,6 @@ type EndpointApplyConfiguration struct {
 func Endpoint() *EndpointApplyConfiguration {
 	return &EndpointApplyConfiguration{}
 }
-func (b EndpointApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAddresses adds the given value to the Addresses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointconditions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointconditions.go
@@ -31,7 +31,6 @@ type EndpointConditionsApplyConfiguration struct {
 func EndpointConditions() *EndpointConditionsApplyConfiguration {
 	return &EndpointConditionsApplyConfiguration{}
 }
-func (b EndpointConditionsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReady sets the Ready field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointhints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointhints.go
@@ -30,7 +30,6 @@ type EndpointHintsApplyConfiguration struct {
 func EndpointHints() *EndpointHintsApplyConfiguration {
 	return &EndpointHintsApplyConfiguration{}
 }
-func (b EndpointHintsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithForZones adds the given value to the ForZones field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointport.go
@@ -36,7 +36,6 @@ type EndpointPortApplyConfiguration struct {
 func EndpointPort() *EndpointPortApplyConfiguration {
 	return &EndpointPortApplyConfiguration{}
 }
-func (b EndpointPortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/fornode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/fornode.go
@@ -29,7 +29,6 @@ type ForNodeApplyConfiguration struct {
 func ForNode() *ForNodeApplyConfiguration {
 	return &ForNodeApplyConfiguration{}
 }
-func (b ForNodeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/forzone.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/forzone.go
@@ -29,7 +29,6 @@ type ForZoneApplyConfiguration struct {
 func ForZone() *ForZoneApplyConfiguration {
 	return &ForZoneApplyConfiguration{}
 }
-func (b ForZoneApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1/eventseries.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1/eventseries.go
@@ -34,7 +34,6 @@ type EventSeriesApplyConfiguration struct {
 func EventSeries() *EventSeriesApplyConfiguration {
 	return &EventSeriesApplyConfiguration{}
 }
-func (b EventSeriesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCount sets the Count field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/eventseries.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/eventseries.go
@@ -34,7 +34,6 @@ type EventSeriesApplyConfiguration struct {
 func EventSeries() *EventSeriesApplyConfiguration {
 	return &EventSeriesApplyConfiguration{}
 }
-func (b EventSeriesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCount sets the Count field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetcondition.go
@@ -39,7 +39,6 @@ type DaemonSetConditionApplyConfiguration struct {
 func DaemonSetCondition() *DaemonSetConditionApplyConfiguration {
 	return &DaemonSetConditionApplyConfiguration{}
 }
-func (b DaemonSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetspec.go
@@ -39,7 +39,6 @@ type DaemonSetSpecApplyConfiguration struct {
 func DaemonSetSpec() *DaemonSetSpecApplyConfiguration {
 	return &DaemonSetSpecApplyConfiguration{}
 }
-func (b DaemonSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSelector sets the Selector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetstatus.go
@@ -38,7 +38,6 @@ type DaemonSetStatusApplyConfiguration struct {
 func DaemonSetStatus() *DaemonSetStatusApplyConfiguration {
 	return &DaemonSetStatusApplyConfiguration{}
 }
-func (b DaemonSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCurrentNumberScheduled sets the CurrentNumberScheduled field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetupdatestrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetupdatestrategy.go
@@ -34,7 +34,6 @@ type DaemonSetUpdateStrategyApplyConfiguration struct {
 func DaemonSetUpdateStrategy() *DaemonSetUpdateStrategyApplyConfiguration {
 	return &DaemonSetUpdateStrategyApplyConfiguration{}
 }
-func (b DaemonSetUpdateStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentcondition.go
@@ -40,7 +40,6 @@ type DeploymentConditionApplyConfiguration struct {
 func DeploymentCondition() *DeploymentConditionApplyConfiguration {
 	return &DeploymentConditionApplyConfiguration{}
 }
-func (b DeploymentConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentspec.go
@@ -42,7 +42,6 @@ type DeploymentSpecApplyConfiguration struct {
 func DeploymentSpec() *DeploymentSpecApplyConfiguration {
 	return &DeploymentSpecApplyConfiguration{}
 }
-func (b DeploymentSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstatus.go
@@ -37,7 +37,6 @@ type DeploymentStatusApplyConfiguration struct {
 func DeploymentStatus() *DeploymentStatusApplyConfiguration {
 	return &DeploymentStatusApplyConfiguration{}
 }
-func (b DeploymentStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstrategy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstrategy.go
@@ -34,7 +34,6 @@ type DeploymentStrategyApplyConfiguration struct {
 func DeploymentStrategy() *DeploymentStrategyApplyConfiguration {
 	return &DeploymentStrategyApplyConfiguration{}
 }
-func (b DeploymentStrategyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/httpingresspath.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/httpingresspath.go
@@ -35,7 +35,6 @@ type HTTPIngressPathApplyConfiguration struct {
 func HTTPIngressPath() *HTTPIngressPathApplyConfiguration {
 	return &HTTPIngressPathApplyConfiguration{}
 }
-func (b HTTPIngressPathApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPath sets the Path field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/httpingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/httpingressrulevalue.go
@@ -29,7 +29,6 @@ type HTTPIngressRuleValueApplyConfiguration struct {
 func HTTPIngressRuleValue() *HTTPIngressRuleValueApplyConfiguration {
 	return &HTTPIngressRuleValueApplyConfiguration{}
 }
-func (b HTTPIngressRuleValueApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPaths adds the given value to the Paths field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressbackend.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressbackend.go
@@ -36,7 +36,6 @@ type IngressBackendApplyConfiguration struct {
 func IngressBackend() *IngressBackendApplyConfiguration {
 	return &IngressBackendApplyConfiguration{}
 }
-func (b IngressBackendApplyConfiguration) IsApplyConfiguration() {}
 
 // WithServiceName sets the ServiceName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalanceringress.go
@@ -31,7 +31,6 @@ type IngressLoadBalancerIngressApplyConfiguration struct {
 func IngressLoadBalancerIngress() *IngressLoadBalancerIngressApplyConfiguration {
 	return &IngressLoadBalancerIngressApplyConfiguration{}
 }
-func (b IngressLoadBalancerIngressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalancerstatus.go
@@ -29,7 +29,6 @@ type IngressLoadBalancerStatusApplyConfiguration struct {
 func IngressLoadBalancerStatus() *IngressLoadBalancerStatusApplyConfiguration {
 	return &IngressLoadBalancerStatusApplyConfiguration{}
 }
-func (b IngressLoadBalancerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressportstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressportstatus.go
@@ -35,7 +35,6 @@ type IngressPortStatusApplyConfiguration struct {
 func IngressPortStatus() *IngressPortStatusApplyConfiguration {
 	return &IngressPortStatusApplyConfiguration{}
 }
-func (b IngressPortStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressrule.go
@@ -30,7 +30,6 @@ type IngressRuleApplyConfiguration struct {
 func IngressRule() *IngressRuleApplyConfiguration {
 	return &IngressRuleApplyConfiguration{}
 }
-func (b IngressRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHost sets the Host field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressrulevalue.go
@@ -29,7 +29,6 @@ type IngressRuleValueApplyConfiguration struct {
 func IngressRuleValue() *IngressRuleValueApplyConfiguration {
 	return &IngressRuleValueApplyConfiguration{}
 }
-func (b IngressRuleValueApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHTTP sets the HTTP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressspec.go
@@ -32,7 +32,6 @@ type IngressSpecApplyConfiguration struct {
 func IngressSpec() *IngressSpecApplyConfiguration {
 	return &IngressSpecApplyConfiguration{}
 }
-func (b IngressSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIngressClassName sets the IngressClassName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressstatus.go
@@ -29,7 +29,6 @@ type IngressStatusApplyConfiguration struct {
 func IngressStatus() *IngressStatusApplyConfiguration {
 	return &IngressStatusApplyConfiguration{}
 }
-func (b IngressStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLoadBalancer sets the LoadBalancer field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingresstls.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingresstls.go
@@ -30,7 +30,6 @@ type IngressTLSApplyConfiguration struct {
 func IngressTLS() *IngressTLSApplyConfiguration {
 	return &IngressTLSApplyConfiguration{}
 }
-func (b IngressTLSApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHosts adds the given value to the Hosts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ipblock.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ipblock.go
@@ -30,7 +30,6 @@ type IPBlockApplyConfiguration struct {
 func IPBlock() *IPBlockApplyConfiguration {
 	return &IPBlockApplyConfiguration{}
 }
-func (b IPBlockApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCIDR sets the CIDR field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyegressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyegressrule.go
@@ -30,7 +30,6 @@ type NetworkPolicyEgressRuleApplyConfiguration struct {
 func NetworkPolicyEgressRule() *NetworkPolicyEgressRuleApplyConfiguration {
 	return &NetworkPolicyEgressRuleApplyConfiguration{}
 }
-func (b NetworkPolicyEgressRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyingressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyingressrule.go
@@ -30,7 +30,6 @@ type NetworkPolicyIngressRuleApplyConfiguration struct {
 func NetworkPolicyIngressRule() *NetworkPolicyIngressRuleApplyConfiguration {
 	return &NetworkPolicyIngressRuleApplyConfiguration{}
 }
-func (b NetworkPolicyIngressRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicypeer.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicypeer.go
@@ -35,7 +35,6 @@ type NetworkPolicyPeerApplyConfiguration struct {
 func NetworkPolicyPeer() *NetworkPolicyPeerApplyConfiguration {
 	return &NetworkPolicyPeerApplyConfiguration{}
 }
-func (b NetworkPolicyPeerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodSelector sets the PodSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyport.go
@@ -36,7 +36,6 @@ type NetworkPolicyPortApplyConfiguration struct {
 func NetworkPolicyPort() *NetworkPolicyPortApplyConfiguration {
 	return &NetworkPolicyPortApplyConfiguration{}
 }
-func (b NetworkPolicyPortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithProtocol sets the Protocol field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyspec.go
@@ -37,7 +37,6 @@ type NetworkPolicySpecApplyConfiguration struct {
 func NetworkPolicySpec() *NetworkPolicySpecApplyConfiguration {
 	return &NetworkPolicySpecApplyConfiguration{}
 }
-func (b NetworkPolicySpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodSelector sets the PodSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetcondition.go
@@ -39,7 +39,6 @@ type ReplicaSetConditionApplyConfiguration struct {
 func ReplicaSetCondition() *ReplicaSetConditionApplyConfiguration {
 	return &ReplicaSetConditionApplyConfiguration{}
 }
-func (b ReplicaSetConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetspec.go
@@ -37,7 +37,6 @@ type ReplicaSetSpecApplyConfiguration struct {
 func ReplicaSetSpec() *ReplicaSetSpecApplyConfiguration {
 	return &ReplicaSetSpecApplyConfiguration{}
 }
-func (b ReplicaSetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetstatus.go
@@ -35,7 +35,6 @@ type ReplicaSetStatusApplyConfiguration struct {
 func ReplicaSetStatus() *ReplicaSetStatusApplyConfiguration {
 	return &ReplicaSetStatusApplyConfiguration{}
 }
-func (b ReplicaSetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/rollbackconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/rollbackconfig.go
@@ -29,7 +29,6 @@ type RollbackConfigApplyConfiguration struct {
 func RollbackConfig() *RollbackConfigApplyConfiguration {
 	return &RollbackConfigApplyConfiguration{}
 }
-func (b RollbackConfigApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRevision sets the Revision field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/rollingupdatedaemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/rollingupdatedaemonset.go
@@ -34,7 +34,6 @@ type RollingUpdateDaemonSetApplyConfiguration struct {
 func RollingUpdateDaemonSet() *RollingUpdateDaemonSetApplyConfiguration {
 	return &RollingUpdateDaemonSetApplyConfiguration{}
 }
-func (b RollingUpdateDaemonSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxUnavailable sets the MaxUnavailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/rollingupdatedeployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/rollingupdatedeployment.go
@@ -34,7 +34,6 @@ type RollingUpdateDeploymentApplyConfiguration struct {
 func RollingUpdateDeployment() *RollingUpdateDeploymentApplyConfiguration {
 	return &RollingUpdateDeploymentApplyConfiguration{}
 }
-func (b RollingUpdateDeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMaxUnavailable sets the MaxUnavailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/exemptprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/exemptprioritylevelconfiguration.go
@@ -30,7 +30,6 @@ type ExemptPriorityLevelConfigurationApplyConfiguration struct {
 func ExemptPriorityLevelConfiguration() *ExemptPriorityLevelConfigurationApplyConfiguration {
 	return &ExemptPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b ExemptPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNominalConcurrencyShares sets the NominalConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowdistinguishermethod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowdistinguishermethod.go
@@ -33,7 +33,6 @@ type FlowDistinguisherMethodApplyConfiguration struct {
 func FlowDistinguisherMethod() *FlowDistinguisherMethodApplyConfiguration {
 	return &FlowDistinguisherMethodApplyConfiguration{}
 }
-func (b FlowDistinguisherMethodApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemacondition.go
@@ -38,7 +38,6 @@ type FlowSchemaConditionApplyConfiguration struct {
 func FlowSchemaCondition() *FlowSchemaConditionApplyConfiguration {
 	return &FlowSchemaConditionApplyConfiguration{}
 }
-func (b FlowSchemaConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemaspec.go
@@ -32,7 +32,6 @@ type FlowSchemaSpecApplyConfiguration struct {
 func FlowSchemaSpec() *FlowSchemaSpecApplyConfiguration {
 	return &FlowSchemaSpecApplyConfiguration{}
 }
-func (b FlowSchemaSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPriorityLevelConfiguration sets the PriorityLevelConfiguration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemastatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschemastatus.go
@@ -29,7 +29,6 @@ type FlowSchemaStatusApplyConfiguration struct {
 func FlowSchemaStatus() *FlowSchemaStatusApplyConfiguration {
 	return &FlowSchemaStatusApplyConfiguration{}
 }
-func (b FlowSchemaStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/groupsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/groupsubject.go
@@ -29,7 +29,6 @@ type GroupSubjectApplyConfiguration struct {
 func GroupSubject() *GroupSubjectApplyConfiguration {
 	return &GroupSubjectApplyConfiguration{}
 }
-func (b GroupSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/limitedprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/limitedprioritylevelconfiguration.go
@@ -32,7 +32,6 @@ type LimitedPriorityLevelConfigurationApplyConfiguration struct {
 func LimitedPriorityLevelConfiguration() *LimitedPriorityLevelConfigurationApplyConfiguration {
 	return &LimitedPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b LimitedPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNominalConcurrencyShares sets the NominalConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/limitresponse.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/limitresponse.go
@@ -34,7 +34,6 @@ type LimitResponseApplyConfiguration struct {
 func LimitResponse() *LimitResponseApplyConfiguration {
 	return &LimitResponseApplyConfiguration{}
 }
-func (b LimitResponseApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/nonresourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/nonresourcepolicyrule.go
@@ -30,7 +30,6 @@ type NonResourcePolicyRuleApplyConfiguration struct {
 func NonResourcePolicyRule() *NonResourcePolicyRuleApplyConfiguration {
 	return &NonResourcePolicyRuleApplyConfiguration{}
 }
-func (b NonResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/policyruleswithsubjects.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/policyruleswithsubjects.go
@@ -31,7 +31,6 @@ type PolicyRulesWithSubjectsApplyConfiguration struct {
 func PolicyRulesWithSubjects() *PolicyRulesWithSubjectsApplyConfiguration {
 	return &PolicyRulesWithSubjectsApplyConfiguration{}
 }
-func (b PolicyRulesWithSubjectsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationcondition.go
@@ -38,7 +38,6 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 func PriorityLevelConfigurationCondition() *PriorityLevelConfigurationConditionApplyConfiguration {
 	return &PriorityLevelConfigurationConditionApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationreference.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationReferenceApplyConfiguration struct {
 func PriorityLevelConfigurationReference() *PriorityLevelConfigurationReferenceApplyConfiguration {
 	return &PriorityLevelConfigurationReferenceApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationspec.go
@@ -35,7 +35,6 @@ type PriorityLevelConfigurationSpecApplyConfiguration struct {
 func PriorityLevelConfigurationSpec() *PriorityLevelConfigurationSpecApplyConfiguration {
 	return &PriorityLevelConfigurationSpecApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfigurationstatus.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationStatusApplyConfiguration struct {
 func PriorityLevelConfigurationStatus() *PriorityLevelConfigurationStatusApplyConfiguration {
 	return &PriorityLevelConfigurationStatusApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/queuingconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/queuingconfiguration.go
@@ -31,7 +31,6 @@ type QueuingConfigurationApplyConfiguration struct {
 func QueuingConfiguration() *QueuingConfigurationApplyConfiguration {
 	return &QueuingConfigurationApplyConfiguration{}
 }
-func (b QueuingConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithQueues sets the Queues field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/resourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/resourcepolicyrule.go
@@ -33,7 +33,6 @@ type ResourcePolicyRuleApplyConfiguration struct {
 func ResourcePolicyRule() *ResourcePolicyRuleApplyConfiguration {
 	return &ResourcePolicyRuleApplyConfiguration{}
 }
-func (b ResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/serviceaccountsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/serviceaccountsubject.go
@@ -30,7 +30,6 @@ type ServiceAccountSubjectApplyConfiguration struct {
 func ServiceAccountSubject() *ServiceAccountSubjectApplyConfiguration {
 	return &ServiceAccountSubjectApplyConfiguration{}
 }
-func (b ServiceAccountSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/subject.go
@@ -36,7 +36,6 @@ type SubjectApplyConfiguration struct {
 func Subject() *SubjectApplyConfiguration {
 	return &SubjectApplyConfiguration{}
 }
-func (b SubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/usersubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/usersubject.go
@@ -29,7 +29,6 @@ type UserSubjectApplyConfiguration struct {
 func UserSubject() *UserSubjectApplyConfiguration {
 	return &UserSubjectApplyConfiguration{}
 }
-func (b UserSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/exemptprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/exemptprioritylevelconfiguration.go
@@ -30,7 +30,6 @@ type ExemptPriorityLevelConfigurationApplyConfiguration struct {
 func ExemptPriorityLevelConfiguration() *ExemptPriorityLevelConfigurationApplyConfiguration {
 	return &ExemptPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b ExemptPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNominalConcurrencyShares sets the NominalConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowdistinguishermethod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowdistinguishermethod.go
@@ -33,7 +33,6 @@ type FlowDistinguisherMethodApplyConfiguration struct {
 func FlowDistinguisherMethod() *FlowDistinguisherMethodApplyConfiguration {
 	return &FlowDistinguisherMethodApplyConfiguration{}
 }
-func (b FlowDistinguisherMethodApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemacondition.go
@@ -38,7 +38,6 @@ type FlowSchemaConditionApplyConfiguration struct {
 func FlowSchemaCondition() *FlowSchemaConditionApplyConfiguration {
 	return &FlowSchemaConditionApplyConfiguration{}
 }
-func (b FlowSchemaConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemaspec.go
@@ -32,7 +32,6 @@ type FlowSchemaSpecApplyConfiguration struct {
 func FlowSchemaSpec() *FlowSchemaSpecApplyConfiguration {
 	return &FlowSchemaSpecApplyConfiguration{}
 }
-func (b FlowSchemaSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPriorityLevelConfiguration sets the PriorityLevelConfiguration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemastatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemastatus.go
@@ -29,7 +29,6 @@ type FlowSchemaStatusApplyConfiguration struct {
 func FlowSchemaStatus() *FlowSchemaStatusApplyConfiguration {
 	return &FlowSchemaStatusApplyConfiguration{}
 }
-func (b FlowSchemaStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/groupsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/groupsubject.go
@@ -29,7 +29,6 @@ type GroupSubjectApplyConfiguration struct {
 func GroupSubject() *GroupSubjectApplyConfiguration {
 	return &GroupSubjectApplyConfiguration{}
 }
-func (b GroupSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/limitedprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/limitedprioritylevelconfiguration.go
@@ -32,7 +32,6 @@ type LimitedPriorityLevelConfigurationApplyConfiguration struct {
 func LimitedPriorityLevelConfiguration() *LimitedPriorityLevelConfigurationApplyConfiguration {
 	return &LimitedPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b LimitedPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAssuredConcurrencyShares sets the AssuredConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/limitresponse.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/limitresponse.go
@@ -34,7 +34,6 @@ type LimitResponseApplyConfiguration struct {
 func LimitResponse() *LimitResponseApplyConfiguration {
 	return &LimitResponseApplyConfiguration{}
 }
-func (b LimitResponseApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/nonresourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/nonresourcepolicyrule.go
@@ -30,7 +30,6 @@ type NonResourcePolicyRuleApplyConfiguration struct {
 func NonResourcePolicyRule() *NonResourcePolicyRuleApplyConfiguration {
 	return &NonResourcePolicyRuleApplyConfiguration{}
 }
-func (b NonResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/policyruleswithsubjects.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/policyruleswithsubjects.go
@@ -31,7 +31,6 @@ type PolicyRulesWithSubjectsApplyConfiguration struct {
 func PolicyRulesWithSubjects() *PolicyRulesWithSubjectsApplyConfiguration {
 	return &PolicyRulesWithSubjectsApplyConfiguration{}
 }
-func (b PolicyRulesWithSubjectsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationcondition.go
@@ -38,7 +38,6 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 func PriorityLevelConfigurationCondition() *PriorityLevelConfigurationConditionApplyConfiguration {
 	return &PriorityLevelConfigurationConditionApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationreference.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationReferenceApplyConfiguration struct {
 func PriorityLevelConfigurationReference() *PriorityLevelConfigurationReferenceApplyConfiguration {
 	return &PriorityLevelConfigurationReferenceApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationspec.go
@@ -35,7 +35,6 @@ type PriorityLevelConfigurationSpecApplyConfiguration struct {
 func PriorityLevelConfigurationSpec() *PriorityLevelConfigurationSpecApplyConfiguration {
 	return &PriorityLevelConfigurationSpecApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfigurationstatus.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationStatusApplyConfiguration struct {
 func PriorityLevelConfigurationStatus() *PriorityLevelConfigurationStatusApplyConfiguration {
 	return &PriorityLevelConfigurationStatusApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/queuingconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/queuingconfiguration.go
@@ -31,7 +31,6 @@ type QueuingConfigurationApplyConfiguration struct {
 func QueuingConfiguration() *QueuingConfigurationApplyConfiguration {
 	return &QueuingConfigurationApplyConfiguration{}
 }
-func (b QueuingConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithQueues sets the Queues field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/resourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/resourcepolicyrule.go
@@ -33,7 +33,6 @@ type ResourcePolicyRuleApplyConfiguration struct {
 func ResourcePolicyRule() *ResourcePolicyRuleApplyConfiguration {
 	return &ResourcePolicyRuleApplyConfiguration{}
 }
-func (b ResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/serviceaccountsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/serviceaccountsubject.go
@@ -30,7 +30,6 @@ type ServiceAccountSubjectApplyConfiguration struct {
 func ServiceAccountSubject() *ServiceAccountSubjectApplyConfiguration {
 	return &ServiceAccountSubjectApplyConfiguration{}
 }
-func (b ServiceAccountSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/subject.go
@@ -36,7 +36,6 @@ type SubjectApplyConfiguration struct {
 func Subject() *SubjectApplyConfiguration {
 	return &SubjectApplyConfiguration{}
 }
-func (b SubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/usersubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/usersubject.go
@@ -29,7 +29,6 @@ type UserSubjectApplyConfiguration struct {
 func UserSubject() *UserSubjectApplyConfiguration {
 	return &UserSubjectApplyConfiguration{}
 }
-func (b UserSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/exemptprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/exemptprioritylevelconfiguration.go
@@ -30,7 +30,6 @@ type ExemptPriorityLevelConfigurationApplyConfiguration struct {
 func ExemptPriorityLevelConfiguration() *ExemptPriorityLevelConfigurationApplyConfiguration {
 	return &ExemptPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b ExemptPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNominalConcurrencyShares sets the NominalConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowdistinguishermethod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowdistinguishermethod.go
@@ -33,7 +33,6 @@ type FlowDistinguisherMethodApplyConfiguration struct {
 func FlowDistinguisherMethod() *FlowDistinguisherMethodApplyConfiguration {
 	return &FlowDistinguisherMethodApplyConfiguration{}
 }
-func (b FlowDistinguisherMethodApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemacondition.go
@@ -38,7 +38,6 @@ type FlowSchemaConditionApplyConfiguration struct {
 func FlowSchemaCondition() *FlowSchemaConditionApplyConfiguration {
 	return &FlowSchemaConditionApplyConfiguration{}
 }
-func (b FlowSchemaConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemaspec.go
@@ -32,7 +32,6 @@ type FlowSchemaSpecApplyConfiguration struct {
 func FlowSchemaSpec() *FlowSchemaSpecApplyConfiguration {
 	return &FlowSchemaSpecApplyConfiguration{}
 }
-func (b FlowSchemaSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPriorityLevelConfiguration sets the PriorityLevelConfiguration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemastatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemastatus.go
@@ -29,7 +29,6 @@ type FlowSchemaStatusApplyConfiguration struct {
 func FlowSchemaStatus() *FlowSchemaStatusApplyConfiguration {
 	return &FlowSchemaStatusApplyConfiguration{}
 }
-func (b FlowSchemaStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/groupsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/groupsubject.go
@@ -29,7 +29,6 @@ type GroupSubjectApplyConfiguration struct {
 func GroupSubject() *GroupSubjectApplyConfiguration {
 	return &GroupSubjectApplyConfiguration{}
 }
-func (b GroupSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/limitedprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/limitedprioritylevelconfiguration.go
@@ -32,7 +32,6 @@ type LimitedPriorityLevelConfigurationApplyConfiguration struct {
 func LimitedPriorityLevelConfiguration() *LimitedPriorityLevelConfigurationApplyConfiguration {
 	return &LimitedPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b LimitedPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAssuredConcurrencyShares sets the AssuredConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/limitresponse.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/limitresponse.go
@@ -34,7 +34,6 @@ type LimitResponseApplyConfiguration struct {
 func LimitResponse() *LimitResponseApplyConfiguration {
 	return &LimitResponseApplyConfiguration{}
 }
-func (b LimitResponseApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/nonresourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/nonresourcepolicyrule.go
@@ -30,7 +30,6 @@ type NonResourcePolicyRuleApplyConfiguration struct {
 func NonResourcePolicyRule() *NonResourcePolicyRuleApplyConfiguration {
 	return &NonResourcePolicyRuleApplyConfiguration{}
 }
-func (b NonResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/policyruleswithsubjects.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/policyruleswithsubjects.go
@@ -31,7 +31,6 @@ type PolicyRulesWithSubjectsApplyConfiguration struct {
 func PolicyRulesWithSubjects() *PolicyRulesWithSubjectsApplyConfiguration {
 	return &PolicyRulesWithSubjectsApplyConfiguration{}
 }
-func (b PolicyRulesWithSubjectsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationcondition.go
@@ -38,7 +38,6 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 func PriorityLevelConfigurationCondition() *PriorityLevelConfigurationConditionApplyConfiguration {
 	return &PriorityLevelConfigurationConditionApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationreference.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationReferenceApplyConfiguration struct {
 func PriorityLevelConfigurationReference() *PriorityLevelConfigurationReferenceApplyConfiguration {
 	return &PriorityLevelConfigurationReferenceApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationspec.go
@@ -35,7 +35,6 @@ type PriorityLevelConfigurationSpecApplyConfiguration struct {
 func PriorityLevelConfigurationSpec() *PriorityLevelConfigurationSpecApplyConfiguration {
 	return &PriorityLevelConfigurationSpecApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfigurationstatus.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationStatusApplyConfiguration struct {
 func PriorityLevelConfigurationStatus() *PriorityLevelConfigurationStatusApplyConfiguration {
 	return &PriorityLevelConfigurationStatusApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/queuingconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/queuingconfiguration.go
@@ -31,7 +31,6 @@ type QueuingConfigurationApplyConfiguration struct {
 func QueuingConfiguration() *QueuingConfigurationApplyConfiguration {
 	return &QueuingConfigurationApplyConfiguration{}
 }
-func (b QueuingConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithQueues sets the Queues field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/resourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/resourcepolicyrule.go
@@ -33,7 +33,6 @@ type ResourcePolicyRuleApplyConfiguration struct {
 func ResourcePolicyRule() *ResourcePolicyRuleApplyConfiguration {
 	return &ResourcePolicyRuleApplyConfiguration{}
 }
-func (b ResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/serviceaccountsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/serviceaccountsubject.go
@@ -30,7 +30,6 @@ type ServiceAccountSubjectApplyConfiguration struct {
 func ServiceAccountSubject() *ServiceAccountSubjectApplyConfiguration {
 	return &ServiceAccountSubjectApplyConfiguration{}
 }
-func (b ServiceAccountSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/subject.go
@@ -36,7 +36,6 @@ type SubjectApplyConfiguration struct {
 func Subject() *SubjectApplyConfiguration {
 	return &SubjectApplyConfiguration{}
 }
-func (b SubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/usersubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/usersubject.go
@@ -29,7 +29,6 @@ type UserSubjectApplyConfiguration struct {
 func UserSubject() *UserSubjectApplyConfiguration {
 	return &UserSubjectApplyConfiguration{}
 }
-func (b UserSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/exemptprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/exemptprioritylevelconfiguration.go
@@ -30,7 +30,6 @@ type ExemptPriorityLevelConfigurationApplyConfiguration struct {
 func ExemptPriorityLevelConfiguration() *ExemptPriorityLevelConfigurationApplyConfiguration {
 	return &ExemptPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b ExemptPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNominalConcurrencyShares sets the NominalConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowdistinguishermethod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowdistinguishermethod.go
@@ -33,7 +33,6 @@ type FlowDistinguisherMethodApplyConfiguration struct {
 func FlowDistinguisherMethod() *FlowDistinguisherMethodApplyConfiguration {
 	return &FlowDistinguisherMethodApplyConfiguration{}
 }
-func (b FlowDistinguisherMethodApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemacondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemacondition.go
@@ -38,7 +38,6 @@ type FlowSchemaConditionApplyConfiguration struct {
 func FlowSchemaCondition() *FlowSchemaConditionApplyConfiguration {
 	return &FlowSchemaConditionApplyConfiguration{}
 }
-func (b FlowSchemaConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemaspec.go
@@ -32,7 +32,6 @@ type FlowSchemaSpecApplyConfiguration struct {
 func FlowSchemaSpec() *FlowSchemaSpecApplyConfiguration {
 	return &FlowSchemaSpecApplyConfiguration{}
 }
-func (b FlowSchemaSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPriorityLevelConfiguration sets the PriorityLevelConfiguration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemastatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemastatus.go
@@ -29,7 +29,6 @@ type FlowSchemaStatusApplyConfiguration struct {
 func FlowSchemaStatus() *FlowSchemaStatusApplyConfiguration {
 	return &FlowSchemaStatusApplyConfiguration{}
 }
-func (b FlowSchemaStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/groupsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/groupsubject.go
@@ -29,7 +29,6 @@ type GroupSubjectApplyConfiguration struct {
 func GroupSubject() *GroupSubjectApplyConfiguration {
 	return &GroupSubjectApplyConfiguration{}
 }
-func (b GroupSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/limitedprioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/limitedprioritylevelconfiguration.go
@@ -32,7 +32,6 @@ type LimitedPriorityLevelConfigurationApplyConfiguration struct {
 func LimitedPriorityLevelConfiguration() *LimitedPriorityLevelConfigurationApplyConfiguration {
 	return &LimitedPriorityLevelConfigurationApplyConfiguration{}
 }
-func (b LimitedPriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNominalConcurrencyShares sets the NominalConcurrencyShares field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/limitresponse.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/limitresponse.go
@@ -34,7 +34,6 @@ type LimitResponseApplyConfiguration struct {
 func LimitResponse() *LimitResponseApplyConfiguration {
 	return &LimitResponseApplyConfiguration{}
 }
-func (b LimitResponseApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/nonresourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/nonresourcepolicyrule.go
@@ -30,7 +30,6 @@ type NonResourcePolicyRuleApplyConfiguration struct {
 func NonResourcePolicyRule() *NonResourcePolicyRuleApplyConfiguration {
 	return &NonResourcePolicyRuleApplyConfiguration{}
 }
-func (b NonResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/policyruleswithsubjects.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/policyruleswithsubjects.go
@@ -31,7 +31,6 @@ type PolicyRulesWithSubjectsApplyConfiguration struct {
 func PolicyRulesWithSubjects() *PolicyRulesWithSubjectsApplyConfiguration {
 	return &PolicyRulesWithSubjectsApplyConfiguration{}
 }
-func (b PolicyRulesWithSubjectsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationcondition.go
@@ -38,7 +38,6 @@ type PriorityLevelConfigurationConditionApplyConfiguration struct {
 func PriorityLevelConfigurationCondition() *PriorityLevelConfigurationConditionApplyConfiguration {
 	return &PriorityLevelConfigurationConditionApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationreference.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationReferenceApplyConfiguration struct {
 func PriorityLevelConfigurationReference() *PriorityLevelConfigurationReferenceApplyConfiguration {
 	return &PriorityLevelConfigurationReferenceApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationspec.go
@@ -35,7 +35,6 @@ type PriorityLevelConfigurationSpecApplyConfiguration struct {
 func PriorityLevelConfigurationSpec() *PriorityLevelConfigurationSpecApplyConfiguration {
 	return &PriorityLevelConfigurationSpecApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationstatus.go
@@ -29,7 +29,6 @@ type PriorityLevelConfigurationStatusApplyConfiguration struct {
 func PriorityLevelConfigurationStatus() *PriorityLevelConfigurationStatusApplyConfiguration {
 	return &PriorityLevelConfigurationStatusApplyConfiguration{}
 }
-func (b PriorityLevelConfigurationStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/queuingconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/queuingconfiguration.go
@@ -31,7 +31,6 @@ type QueuingConfigurationApplyConfiguration struct {
 func QueuingConfiguration() *QueuingConfigurationApplyConfiguration {
 	return &QueuingConfigurationApplyConfiguration{}
 }
-func (b QueuingConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithQueues sets the Queues field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/resourcepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/resourcepolicyrule.go
@@ -33,7 +33,6 @@ type ResourcePolicyRuleApplyConfiguration struct {
 func ResourcePolicyRule() *ResourcePolicyRuleApplyConfiguration {
 	return &ResourcePolicyRuleApplyConfiguration{}
 }
-func (b ResourcePolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/serviceaccountsubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/serviceaccountsubject.go
@@ -30,7 +30,6 @@ type ServiceAccountSubjectApplyConfiguration struct {
 func ServiceAccountSubject() *ServiceAccountSubjectApplyConfiguration {
 	return &ServiceAccountSubjectApplyConfiguration{}
 }
-func (b ServiceAccountSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNamespace sets the Namespace field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/subject.go
@@ -36,7 +36,6 @@ type SubjectApplyConfiguration struct {
 func Subject() *SubjectApplyConfiguration {
 	return &SubjectApplyConfiguration{}
 }
-func (b SubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/usersubject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/usersubject.go
@@ -29,7 +29,6 @@ type UserSubjectApplyConfiguration struct {
 func UserSubject() *UserSubjectApplyConfiguration {
 	return &UserSubjectApplyConfiguration{}
 }
-func (b UserSubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewcontainerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewcontainerspec.go
@@ -29,7 +29,6 @@ type ImageReviewContainerSpecApplyConfiguration struct {
 func ImageReviewContainerSpec() *ImageReviewContainerSpecApplyConfiguration {
 	return &ImageReviewContainerSpecApplyConfiguration{}
 }
-func (b ImageReviewContainerSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithImage sets the Image field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewspec.go
@@ -31,7 +31,6 @@ type ImageReviewSpecApplyConfiguration struct {
 func ImageReviewSpec() *ImageReviewSpecApplyConfiguration {
 	return &ImageReviewSpecApplyConfiguration{}
 }
-func (b ImageReviewSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithContainers adds the given value to the Containers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewstatus.go
@@ -31,7 +31,6 @@ type ImageReviewStatusApplyConfiguration struct {
 func ImageReviewStatus() *ImageReviewStatusApplyConfiguration {
 	return &ImageReviewStatusApplyConfiguration{}
 }
-func (b ImageReviewStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAllowed sets the Allowed field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/condition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/condition.go
@@ -38,7 +38,6 @@ type ConditionApplyConfiguration struct {
 func Condition() *ConditionApplyConfiguration {
 	return &ConditionApplyConfiguration{}
 }
-func (b ConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselector.go
@@ -30,7 +30,6 @@ type LabelSelectorApplyConfiguration struct {
 func LabelSelector() *LabelSelectorApplyConfiguration {
 	return &LabelSelectorApplyConfiguration{}
 }
-func (b LabelSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMatchLabels puts the entries into the MatchLabels field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselectorrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselectorrequirement.go
@@ -35,7 +35,6 @@ type LabelSelectorRequirementApplyConfiguration struct {
 func LabelSelectorRequirement() *LabelSelectorRequirementApplyConfiguration {
 	return &LabelSelectorRequirementApplyConfiguration{}
 }
-func (b LabelSelectorRequirementApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/managedfieldsentry.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/managedfieldsentry.go
@@ -39,7 +39,6 @@ type ManagedFieldsEntryApplyConfiguration struct {
 func ManagedFieldsEntry() *ManagedFieldsEntryApplyConfiguration {
 	return &ManagedFieldsEntryApplyConfiguration{}
 }
-func (b ManagedFieldsEntryApplyConfiguration) IsApplyConfiguration() {}
 
 // WithManager sets the Manager field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/objectmeta.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/objectmeta.go
@@ -46,7 +46,6 @@ type ObjectMetaApplyConfiguration struct {
 func ObjectMeta() *ObjectMetaApplyConfiguration {
 	return &ObjectMetaApplyConfiguration{}
 }
-func (b ObjectMetaApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/ownerreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/ownerreference.go
@@ -38,7 +38,6 @@ type OwnerReferenceApplyConfiguration struct {
 func OwnerReference() *OwnerReferenceApplyConfiguration {
 	return &OwnerReferenceApplyConfiguration{}
 }
-func (b OwnerReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIVersion sets the APIVersion field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/preconditions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/preconditions.go
@@ -34,7 +34,6 @@ type PreconditionsApplyConfiguration struct {
 func Preconditions() *PreconditionsApplyConfiguration {
 	return &PreconditionsApplyConfiguration{}
 }
-func (b PreconditionsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithUID sets the UID field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/typemeta.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/typemeta.go
@@ -30,7 +30,6 @@ type TypeMetaApplyConfiguration struct {
 func TypeMeta() *TypeMetaApplyConfiguration {
 	return &TypeMetaApplyConfiguration{}
 }
-func (b TypeMetaApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/httpingresspath.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/httpingresspath.go
@@ -35,7 +35,6 @@ type HTTPIngressPathApplyConfiguration struct {
 func HTTPIngressPath() *HTTPIngressPathApplyConfiguration {
 	return &HTTPIngressPathApplyConfiguration{}
 }
-func (b HTTPIngressPathApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPath sets the Path field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/httpingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/httpingressrulevalue.go
@@ -29,7 +29,6 @@ type HTTPIngressRuleValueApplyConfiguration struct {
 func HTTPIngressRuleValue() *HTTPIngressRuleValueApplyConfiguration {
 	return &HTTPIngressRuleValueApplyConfiguration{}
 }
-func (b HTTPIngressRuleValueApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPaths adds the given value to the Paths field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressbackend.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressbackend.go
@@ -34,7 +34,6 @@ type IngressBackendApplyConfiguration struct {
 func IngressBackend() *IngressBackendApplyConfiguration {
 	return &IngressBackendApplyConfiguration{}
 }
-func (b IngressBackendApplyConfiguration) IsApplyConfiguration() {}
 
 // WithService sets the Service field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclassparametersreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclassparametersreference.go
@@ -33,7 +33,6 @@ type IngressClassParametersReferenceApplyConfiguration struct {
 func IngressClassParametersReference() *IngressClassParametersReferenceApplyConfiguration {
 	return &IngressClassParametersReferenceApplyConfiguration{}
 }
-func (b IngressClassParametersReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclassspec.go
@@ -30,7 +30,6 @@ type IngressClassSpecApplyConfiguration struct {
 func IngressClassSpec() *IngressClassSpecApplyConfiguration {
 	return &IngressClassSpecApplyConfiguration{}
 }
-func (b IngressClassSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithController sets the Controller field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalanceringress.go
@@ -31,7 +31,6 @@ type IngressLoadBalancerIngressApplyConfiguration struct {
 func IngressLoadBalancerIngress() *IngressLoadBalancerIngressApplyConfiguration {
 	return &IngressLoadBalancerIngressApplyConfiguration{}
 }
-func (b IngressLoadBalancerIngressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalancerstatus.go
@@ -29,7 +29,6 @@ type IngressLoadBalancerStatusApplyConfiguration struct {
 func IngressLoadBalancerStatus() *IngressLoadBalancerStatusApplyConfiguration {
 	return &IngressLoadBalancerStatusApplyConfiguration{}
 }
-func (b IngressLoadBalancerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressportstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressportstatus.go
@@ -35,7 +35,6 @@ type IngressPortStatusApplyConfiguration struct {
 func IngressPortStatus() *IngressPortStatusApplyConfiguration {
 	return &IngressPortStatusApplyConfiguration{}
 }
-func (b IngressPortStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressrule.go
@@ -30,7 +30,6 @@ type IngressRuleApplyConfiguration struct {
 func IngressRule() *IngressRuleApplyConfiguration {
 	return &IngressRuleApplyConfiguration{}
 }
-func (b IngressRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHost sets the Host field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressrulevalue.go
@@ -29,7 +29,6 @@ type IngressRuleValueApplyConfiguration struct {
 func IngressRuleValue() *IngressRuleValueApplyConfiguration {
 	return &IngressRuleValueApplyConfiguration{}
 }
-func (b IngressRuleValueApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHTTP sets the HTTP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressservicebackend.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressservicebackend.go
@@ -30,7 +30,6 @@ type IngressServiceBackendApplyConfiguration struct {
 func IngressServiceBackend() *IngressServiceBackendApplyConfiguration {
 	return &IngressServiceBackendApplyConfiguration{}
 }
-func (b IngressServiceBackendApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressspec.go
@@ -32,7 +32,6 @@ type IngressSpecApplyConfiguration struct {
 func IngressSpec() *IngressSpecApplyConfiguration {
 	return &IngressSpecApplyConfiguration{}
 }
-func (b IngressSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIngressClassName sets the IngressClassName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressstatus.go
@@ -29,7 +29,6 @@ type IngressStatusApplyConfiguration struct {
 func IngressStatus() *IngressStatusApplyConfiguration {
 	return &IngressStatusApplyConfiguration{}
 }
-func (b IngressStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLoadBalancer sets the LoadBalancer field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingresstls.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingresstls.go
@@ -30,7 +30,6 @@ type IngressTLSApplyConfiguration struct {
 func IngressTLS() *IngressTLSApplyConfiguration {
 	return &IngressTLSApplyConfiguration{}
 }
-func (b IngressTLSApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHosts adds the given value to the Hosts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipaddressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipaddressspec.go
@@ -29,7 +29,6 @@ type IPAddressSpecApplyConfiguration struct {
 func IPAddressSpec() *IPAddressSpecApplyConfiguration {
 	return &IPAddressSpecApplyConfiguration{}
 }
-func (b IPAddressSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithParentRef sets the ParentRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipblock.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipblock.go
@@ -30,7 +30,6 @@ type IPBlockApplyConfiguration struct {
 func IPBlock() *IPBlockApplyConfiguration {
 	return &IPBlockApplyConfiguration{}
 }
-func (b IPBlockApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCIDR sets the CIDR field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyegressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyegressrule.go
@@ -30,7 +30,6 @@ type NetworkPolicyEgressRuleApplyConfiguration struct {
 func NetworkPolicyEgressRule() *NetworkPolicyEgressRuleApplyConfiguration {
 	return &NetworkPolicyEgressRuleApplyConfiguration{}
 }
-func (b NetworkPolicyEgressRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyingressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyingressrule.go
@@ -30,7 +30,6 @@ type NetworkPolicyIngressRuleApplyConfiguration struct {
 func NetworkPolicyIngressRule() *NetworkPolicyIngressRuleApplyConfiguration {
 	return &NetworkPolicyIngressRuleApplyConfiguration{}
 }
-func (b NetworkPolicyIngressRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicypeer.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicypeer.go
@@ -35,7 +35,6 @@ type NetworkPolicyPeerApplyConfiguration struct {
 func NetworkPolicyPeer() *NetworkPolicyPeerApplyConfiguration {
 	return &NetworkPolicyPeerApplyConfiguration{}
 }
-func (b NetworkPolicyPeerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodSelector sets the PodSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyport.go
@@ -36,7 +36,6 @@ type NetworkPolicyPortApplyConfiguration struct {
 func NetworkPolicyPort() *NetworkPolicyPortApplyConfiguration {
 	return &NetworkPolicyPortApplyConfiguration{}
 }
-func (b NetworkPolicyPortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithProtocol sets the Protocol field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyspec.go
@@ -37,7 +37,6 @@ type NetworkPolicySpecApplyConfiguration struct {
 func NetworkPolicySpec() *NetworkPolicySpecApplyConfiguration {
 	return &NetworkPolicySpecApplyConfiguration{}
 }
-func (b NetworkPolicySpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodSelector sets the PodSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/parentreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/parentreference.go
@@ -32,7 +32,6 @@ type ParentReferenceApplyConfiguration struct {
 func ParentReference() *ParentReferenceApplyConfiguration {
 	return &ParentReferenceApplyConfiguration{}
 }
-func (b ParentReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicebackendport.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicebackendport.go
@@ -30,7 +30,6 @@ type ServiceBackendPortApplyConfiguration struct {
 func ServiceBackendPort() *ServiceBackendPortApplyConfiguration {
 	return &ServiceBackendPortApplyConfiguration{}
 }
-func (b ServiceBackendPortApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicecidrspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicecidrspec.go
@@ -29,7 +29,6 @@ type ServiceCIDRSpecApplyConfiguration struct {
 func ServiceCIDRSpec() *ServiceCIDRSpecApplyConfiguration {
 	return &ServiceCIDRSpecApplyConfiguration{}
 }
-func (b ServiceCIDRSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCIDRs adds the given value to the CIDRs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicecidrstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicecidrstatus.go
@@ -33,7 +33,6 @@ type ServiceCIDRStatusApplyConfiguration struct {
 func ServiceCIDRStatus() *ServiceCIDRStatusApplyConfiguration {
 	return &ServiceCIDRStatusApplyConfiguration{}
 }
-func (b ServiceCIDRStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/httpingresspath.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/httpingresspath.go
@@ -35,7 +35,6 @@ type HTTPIngressPathApplyConfiguration struct {
 func HTTPIngressPath() *HTTPIngressPathApplyConfiguration {
 	return &HTTPIngressPathApplyConfiguration{}
 }
-func (b HTTPIngressPathApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPath sets the Path field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/httpingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/httpingressrulevalue.go
@@ -29,7 +29,6 @@ type HTTPIngressRuleValueApplyConfiguration struct {
 func HTTPIngressRuleValue() *HTTPIngressRuleValueApplyConfiguration {
 	return &HTTPIngressRuleValueApplyConfiguration{}
 }
-func (b HTTPIngressRuleValueApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPaths adds the given value to the Paths field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressbackend.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressbackend.go
@@ -36,7 +36,6 @@ type IngressBackendApplyConfiguration struct {
 func IngressBackend() *IngressBackendApplyConfiguration {
 	return &IngressBackendApplyConfiguration{}
 }
-func (b IngressBackendApplyConfiguration) IsApplyConfiguration() {}
 
 // WithServiceName sets the ServiceName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclassparametersreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclassparametersreference.go
@@ -33,7 +33,6 @@ type IngressClassParametersReferenceApplyConfiguration struct {
 func IngressClassParametersReference() *IngressClassParametersReferenceApplyConfiguration {
 	return &IngressClassParametersReferenceApplyConfiguration{}
 }
-func (b IngressClassParametersReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclassspec.go
@@ -30,7 +30,6 @@ type IngressClassSpecApplyConfiguration struct {
 func IngressClassSpec() *IngressClassSpecApplyConfiguration {
 	return &IngressClassSpecApplyConfiguration{}
 }
-func (b IngressClassSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithController sets the Controller field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalanceringress.go
@@ -31,7 +31,6 @@ type IngressLoadBalancerIngressApplyConfiguration struct {
 func IngressLoadBalancerIngress() *IngressLoadBalancerIngressApplyConfiguration {
 	return &IngressLoadBalancerIngressApplyConfiguration{}
 }
-func (b IngressLoadBalancerIngressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIP sets the IP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalancerstatus.go
@@ -29,7 +29,6 @@ type IngressLoadBalancerStatusApplyConfiguration struct {
 func IngressLoadBalancerStatus() *IngressLoadBalancerStatusApplyConfiguration {
 	return &IngressLoadBalancerStatusApplyConfiguration{}
 }
-func (b IngressLoadBalancerStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressportstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressportstatus.go
@@ -35,7 +35,6 @@ type IngressPortStatusApplyConfiguration struct {
 func IngressPortStatus() *IngressPortStatusApplyConfiguration {
 	return &IngressPortStatusApplyConfiguration{}
 }
-func (b IngressPortStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressrule.go
@@ -30,7 +30,6 @@ type IngressRuleApplyConfiguration struct {
 func IngressRule() *IngressRuleApplyConfiguration {
 	return &IngressRuleApplyConfiguration{}
 }
-func (b IngressRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHost sets the Host field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressrulevalue.go
@@ -29,7 +29,6 @@ type IngressRuleValueApplyConfiguration struct {
 func IngressRuleValue() *IngressRuleValueApplyConfiguration {
 	return &IngressRuleValueApplyConfiguration{}
 }
-func (b IngressRuleValueApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHTTP sets the HTTP field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressspec.go
@@ -32,7 +32,6 @@ type IngressSpecApplyConfiguration struct {
 func IngressSpec() *IngressSpecApplyConfiguration {
 	return &IngressSpecApplyConfiguration{}
 }
-func (b IngressSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIngressClassName sets the IngressClassName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressstatus.go
@@ -29,7 +29,6 @@ type IngressStatusApplyConfiguration struct {
 func IngressStatus() *IngressStatusApplyConfiguration {
 	return &IngressStatusApplyConfiguration{}
 }
-func (b IngressStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithLoadBalancer sets the LoadBalancer field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingresstls.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingresstls.go
@@ -30,7 +30,6 @@ type IngressTLSApplyConfiguration struct {
 func IngressTLS() *IngressTLSApplyConfiguration {
 	return &IngressTLSApplyConfiguration{}
 }
-func (b IngressTLSApplyConfiguration) IsApplyConfiguration() {}
 
 // WithHosts adds the given value to the Hosts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ipaddressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ipaddressspec.go
@@ -29,7 +29,6 @@ type IPAddressSpecApplyConfiguration struct {
 func IPAddressSpec() *IPAddressSpecApplyConfiguration {
 	return &IPAddressSpecApplyConfiguration{}
 }
-func (b IPAddressSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithParentRef sets the ParentRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/parentreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/parentreference.go
@@ -32,7 +32,6 @@ type ParentReferenceApplyConfiguration struct {
 func ParentReference() *ParentReferenceApplyConfiguration {
 	return &ParentReferenceApplyConfiguration{}
 }
-func (b ParentReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/servicecidrspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/servicecidrspec.go
@@ -29,7 +29,6 @@ type ServiceCIDRSpecApplyConfiguration struct {
 func ServiceCIDRSpec() *ServiceCIDRSpecApplyConfiguration {
 	return &ServiceCIDRSpecApplyConfiguration{}
 }
-func (b ServiceCIDRSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCIDRs adds the given value to the CIDRs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/servicecidrstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/servicecidrstatus.go
@@ -33,7 +33,6 @@ type ServiceCIDRStatusApplyConfiguration struct {
 func ServiceCIDRStatus() *ServiceCIDRStatusApplyConfiguration {
 	return &ServiceCIDRStatusApplyConfiguration{}
 }
-func (b ServiceCIDRStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/overhead.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/overhead.go
@@ -33,7 +33,6 @@ type OverheadApplyConfiguration struct {
 func Overhead() *OverheadApplyConfiguration {
 	return &OverheadApplyConfiguration{}
 }
-func (b OverheadApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodFixed sets the PodFixed field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/scheduling.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/scheduling.go
@@ -34,7 +34,6 @@ type SchedulingApplyConfiguration struct {
 func Scheduling() *SchedulingApplyConfiguration {
 	return &SchedulingApplyConfiguration{}
 }
-func (b SchedulingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNodeSelector puts the entries into the NodeSelector field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/overhead.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/overhead.go
@@ -33,7 +33,6 @@ type OverheadApplyConfiguration struct {
 func Overhead() *OverheadApplyConfiguration {
 	return &OverheadApplyConfiguration{}
 }
-func (b OverheadApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodFixed sets the PodFixed field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclassspec.go
@@ -31,7 +31,6 @@ type RuntimeClassSpecApplyConfiguration struct {
 func RuntimeClassSpec() *RuntimeClassSpecApplyConfiguration {
 	return &RuntimeClassSpecApplyConfiguration{}
 }
-func (b RuntimeClassSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRuntimeHandler sets the RuntimeHandler field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/scheduling.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/scheduling.go
@@ -34,7 +34,6 @@ type SchedulingApplyConfiguration struct {
 func Scheduling() *SchedulingApplyConfiguration {
 	return &SchedulingApplyConfiguration{}
 }
-func (b SchedulingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNodeSelector puts the entries into the NodeSelector field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/overhead.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/overhead.go
@@ -33,7 +33,6 @@ type OverheadApplyConfiguration struct {
 func Overhead() *OverheadApplyConfiguration {
 	return &OverheadApplyConfiguration{}
 }
-func (b OverheadApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPodFixed sets the PodFixed field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/scheduling.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/scheduling.go
@@ -34,7 +34,6 @@ type SchedulingApplyConfiguration struct {
 func Scheduling() *SchedulingApplyConfiguration {
 	return &SchedulingApplyConfiguration{}
 }
-func (b SchedulingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithNodeSelector puts the entries into the NodeSelector field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetspec.go
@@ -38,7 +38,6 @@ type PodDisruptionBudgetSpecApplyConfiguration struct {
 func PodDisruptionBudgetSpec() *PodDisruptionBudgetSpecApplyConfiguration {
 	return &PodDisruptionBudgetSpecApplyConfiguration{}
 }
-func (b PodDisruptionBudgetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMinAvailable sets the MinAvailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetstatus.go
@@ -40,7 +40,6 @@ type PodDisruptionBudgetStatusApplyConfiguration struct {
 func PodDisruptionBudgetStatus() *PodDisruptionBudgetStatusApplyConfiguration {
 	return &PodDisruptionBudgetStatusApplyConfiguration{}
 }
-func (b PodDisruptionBudgetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudgetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudgetspec.go
@@ -38,7 +38,6 @@ type PodDisruptionBudgetSpecApplyConfiguration struct {
 func PodDisruptionBudgetSpec() *PodDisruptionBudgetSpecApplyConfiguration {
 	return &PodDisruptionBudgetSpecApplyConfiguration{}
 }
-func (b PodDisruptionBudgetSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithMinAvailable sets the MinAvailable field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudgetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudgetstatus.go
@@ -40,7 +40,6 @@ type PodDisruptionBudgetStatusApplyConfiguration struct {
 func PodDisruptionBudgetStatus() *PodDisruptionBudgetStatusApplyConfiguration {
 	return &PodDisruptionBudgetStatusApplyConfiguration{}
 }
-func (b PodDisruptionBudgetStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/aggregationrule.go
@@ -33,7 +33,6 @@ type AggregationRuleApplyConfiguration struct {
 func AggregationRule() *AggregationRuleApplyConfiguration {
 	return &AggregationRuleApplyConfiguration{}
 }
-func (b AggregationRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithClusterRoleSelectors adds the given value to the ClusterRoleSelectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/policyrule.go
@@ -33,7 +33,6 @@ type PolicyRuleApplyConfiguration struct {
 func PolicyRule() *PolicyRuleApplyConfiguration {
 	return &PolicyRuleApplyConfiguration{}
 }
-func (b PolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/roleref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/roleref.go
@@ -31,7 +31,6 @@ type RoleRefApplyConfiguration struct {
 func RoleRef() *RoleRefApplyConfiguration {
 	return &RoleRefApplyConfiguration{}
 }
-func (b RoleRefApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/subject.go
@@ -32,7 +32,6 @@ type SubjectApplyConfiguration struct {
 func Subject() *SubjectApplyConfiguration {
 	return &SubjectApplyConfiguration{}
 }
-func (b SubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/aggregationrule.go
@@ -33,7 +33,6 @@ type AggregationRuleApplyConfiguration struct {
 func AggregationRule() *AggregationRuleApplyConfiguration {
 	return &AggregationRuleApplyConfiguration{}
 }
-func (b AggregationRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithClusterRoleSelectors adds the given value to the ClusterRoleSelectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/policyrule.go
@@ -33,7 +33,6 @@ type PolicyRuleApplyConfiguration struct {
 func PolicyRule() *PolicyRuleApplyConfiguration {
 	return &PolicyRuleApplyConfiguration{}
 }
-func (b PolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/roleref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/roleref.go
@@ -31,7 +31,6 @@ type RoleRefApplyConfiguration struct {
 func RoleRef() *RoleRefApplyConfiguration {
 	return &RoleRefApplyConfiguration{}
 }
-func (b RoleRefApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/subject.go
@@ -32,7 +32,6 @@ type SubjectApplyConfiguration struct {
 func Subject() *SubjectApplyConfiguration {
 	return &SubjectApplyConfiguration{}
 }
-func (b SubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/aggregationrule.go
@@ -33,7 +33,6 @@ type AggregationRuleApplyConfiguration struct {
 func AggregationRule() *AggregationRuleApplyConfiguration {
 	return &AggregationRuleApplyConfiguration{}
 }
-func (b AggregationRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithClusterRoleSelectors adds the given value to the ClusterRoleSelectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/policyrule.go
@@ -33,7 +33,6 @@ type PolicyRuleApplyConfiguration struct {
 func PolicyRule() *PolicyRuleApplyConfiguration {
 	return &PolicyRuleApplyConfiguration{}
 }
-func (b PolicyRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/roleref.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/roleref.go
@@ -31,7 +31,6 @@ type RoleRefApplyConfiguration struct {
 func RoleRef() *RoleRefApplyConfiguration {
 	return &RoleRefApplyConfiguration{}
 }
-func (b RoleRefApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/subject.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/subject.go
@@ -32,7 +32,6 @@ type SubjectApplyConfiguration struct {
 func Subject() *SubjectApplyConfiguration {
 	return &SubjectApplyConfiguration{}
 }
-func (b SubjectApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/celdeviceselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/celdeviceselector.go
@@ -29,7 +29,6 @@ type CELDeviceSelectorApplyConfiguration struct {
 func CELDeviceSelector() *CELDeviceSelectorApplyConfiguration {
 	return &CELDeviceSelectorApplyConfiguration{}
 }
-func (b CELDeviceSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/deviceselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/deviceselector.go
@@ -29,7 +29,6 @@ type DeviceSelectorApplyConfiguration struct {
 func DeviceSelector() *DeviceSelectorApplyConfiguration {
 	return &DeviceSelectorApplyConfiguration{}
 }
-func (b DeviceSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCEL sets the CEL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaint.go
@@ -37,7 +37,6 @@ type DeviceTaintApplyConfiguration struct {
 func DeviceTaint() *DeviceTaintApplyConfiguration {
 	return &DeviceTaintApplyConfiguration{}
 }
-func (b DeviceTaintApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaintrulespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaintrulespec.go
@@ -30,7 +30,6 @@ type DeviceTaintRuleSpecApplyConfiguration struct {
 func DeviceTaintRuleSpec() *DeviceTaintRuleSpecApplyConfiguration {
 	return &DeviceTaintRuleSpecApplyConfiguration{}
 }
-func (b DeviceTaintRuleSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDeviceSelector sets the DeviceSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaintselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaintselector.go
@@ -33,7 +33,6 @@ type DeviceTaintSelectorApplyConfiguration struct {
 func DeviceTaintSelector() *DeviceTaintSelectorApplyConfiguration {
 	return &DeviceTaintSelectorApplyConfiguration{}
 }
-func (b DeviceTaintSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDeviceClassName sets the DeviceClassName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/allocateddevicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/allocateddevicestatus.go
@@ -39,7 +39,6 @@ type AllocatedDeviceStatusApplyConfiguration struct {
 func AllocatedDeviceStatus() *AllocatedDeviceStatusApplyConfiguration {
 	return &AllocatedDeviceStatusApplyConfiguration{}
 }
-func (b AllocatedDeviceStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/allocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/allocationresult.go
@@ -34,7 +34,6 @@ type AllocationResultApplyConfiguration struct {
 func AllocationResult() *AllocationResultApplyConfiguration {
 	return &AllocationResultApplyConfiguration{}
 }
-func (b AllocationResultApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDevices sets the Devices field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/basicdevice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/basicdevice.go
@@ -40,7 +40,6 @@ type BasicDeviceApplyConfiguration struct {
 func BasicDevice() *BasicDeviceApplyConfiguration {
 	return &BasicDeviceApplyConfiguration{}
 }
-func (b BasicDeviceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttributes puts the entries into the Attributes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/celdeviceselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/celdeviceselector.go
@@ -29,7 +29,6 @@ type CELDeviceSelectorApplyConfiguration struct {
 func CELDeviceSelector() *CELDeviceSelectorApplyConfiguration {
 	return &CELDeviceSelectorApplyConfiguration{}
 }
-func (b CELDeviceSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/counter.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/counter.go
@@ -33,7 +33,6 @@ type CounterApplyConfiguration struct {
 func Counter() *CounterApplyConfiguration {
 	return &CounterApplyConfiguration{}
 }
-func (b CounterApplyConfiguration) IsApplyConfiguration() {}
 
 // WithValue sets the Value field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/counterset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/counterset.go
@@ -30,7 +30,6 @@ type CounterSetApplyConfiguration struct {
 func CounterSet() *CounterSetApplyConfiguration {
 	return &CounterSetApplyConfiguration{}
 }
-func (b CounterSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/device.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/device.go
@@ -30,7 +30,6 @@ type DeviceApplyConfiguration struct {
 func Device() *DeviceApplyConfiguration {
 	return &DeviceApplyConfiguration{}
 }
-func (b DeviceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceallocationconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceallocationconfiguration.go
@@ -35,7 +35,6 @@ type DeviceAllocationConfigurationApplyConfiguration struct {
 func DeviceAllocationConfiguration() *DeviceAllocationConfigurationApplyConfiguration {
 	return &DeviceAllocationConfigurationApplyConfiguration{}
 }
-func (b DeviceAllocationConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSource sets the Source field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceallocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceallocationresult.go
@@ -30,7 +30,6 @@ type DeviceAllocationResultApplyConfiguration struct {
 func DeviceAllocationResult() *DeviceAllocationResultApplyConfiguration {
 	return &DeviceAllocationResultApplyConfiguration{}
 }
-func (b DeviceAllocationResultApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResults adds the given value to the Results field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceattribute.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceattribute.go
@@ -32,7 +32,6 @@ type DeviceAttributeApplyConfiguration struct {
 func DeviceAttribute() *DeviceAttributeApplyConfiguration {
 	return &DeviceAttributeApplyConfiguration{}
 }
-func (b DeviceAttributeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIntValue sets the IntValue field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicecapacity.go
@@ -33,7 +33,6 @@ type DeviceCapacityApplyConfiguration struct {
 func DeviceCapacity() *DeviceCapacityApplyConfiguration {
 	return &DeviceCapacityApplyConfiguration{}
 }
-func (b DeviceCapacityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithValue sets the Value field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclaim.go
@@ -31,7 +31,6 @@ type DeviceClaimApplyConfiguration struct {
 func DeviceClaim() *DeviceClaimApplyConfiguration {
 	return &DeviceClaimApplyConfiguration{}
 }
-func (b DeviceClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequests adds the given value to the Requests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclaimconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclaimconfiguration.go
@@ -30,7 +30,6 @@ type DeviceClaimConfigurationApplyConfiguration struct {
 func DeviceClaimConfiguration() *DeviceClaimConfigurationApplyConfiguration {
 	return &DeviceClaimConfigurationApplyConfiguration{}
 }
-func (b DeviceClaimConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequests adds the given value to the Requests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclassconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclassconfiguration.go
@@ -29,7 +29,6 @@ type DeviceClassConfigurationApplyConfiguration struct {
 func DeviceClassConfiguration() *DeviceClassConfigurationApplyConfiguration {
 	return &DeviceClassConfigurationApplyConfiguration{}
 }
-func (b DeviceClassConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithOpaque sets the Opaque field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclassspec.go
@@ -30,7 +30,6 @@ type DeviceClassSpecApplyConfiguration struct {
 func DeviceClassSpec() *DeviceClassSpecApplyConfiguration {
 	return &DeviceClassSpecApplyConfiguration{}
 }
-func (b DeviceClassSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSelectors adds the given value to the Selectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceconfiguration.go
@@ -29,7 +29,6 @@ type DeviceConfigurationApplyConfiguration struct {
 func DeviceConfiguration() *DeviceConfigurationApplyConfiguration {
 	return &DeviceConfigurationApplyConfiguration{}
 }
-func (b DeviceConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithOpaque sets the Opaque field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceconstraint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceconstraint.go
@@ -34,7 +34,6 @@ type DeviceConstraintApplyConfiguration struct {
 func DeviceConstraint() *DeviceConstraintApplyConfiguration {
 	return &DeviceConstraintApplyConfiguration{}
 }
-func (b DeviceConstraintApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequests adds the given value to the Requests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicecounterconsumption.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicecounterconsumption.go
@@ -30,7 +30,6 @@ type DeviceCounterConsumptionApplyConfiguration struct {
 func DeviceCounterConsumption() *DeviceCounterConsumptionApplyConfiguration {
 	return &DeviceCounterConsumptionApplyConfiguration{}
 }
-func (b DeviceCounterConsumptionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCounterSet sets the CounterSet field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicerequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicerequest.go
@@ -40,7 +40,6 @@ type DeviceRequestApplyConfiguration struct {
 func DeviceRequest() *DeviceRequestApplyConfiguration {
 	return &DeviceRequestApplyConfiguration{}
 }
-func (b DeviceRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicerequestallocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicerequestallocationresult.go
@@ -34,7 +34,6 @@ type DeviceRequestAllocationResultApplyConfiguration struct {
 func DeviceRequestAllocationResult() *DeviceRequestAllocationResultApplyConfiguration {
 	return &DeviceRequestAllocationResultApplyConfiguration{}
 }
-func (b DeviceRequestAllocationResultApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequest sets the Request field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceselector.go
@@ -29,7 +29,6 @@ type DeviceSelectorApplyConfiguration struct {
 func DeviceSelector() *DeviceSelectorApplyConfiguration {
 	return &DeviceSelectorApplyConfiguration{}
 }
-func (b DeviceSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCEL sets the CEL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicesubrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicesubrequest.go
@@ -38,7 +38,6 @@ type DeviceSubRequestApplyConfiguration struct {
 func DeviceSubRequest() *DeviceSubRequestApplyConfiguration {
 	return &DeviceSubRequestApplyConfiguration{}
 }
-func (b DeviceSubRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicetaint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicetaint.go
@@ -37,7 +37,6 @@ type DeviceTaintApplyConfiguration struct {
 func DeviceTaint() *DeviceTaintApplyConfiguration {
 	return &DeviceTaintApplyConfiguration{}
 }
-func (b DeviceTaintApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicetoleration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicetoleration.go
@@ -37,7 +37,6 @@ type DeviceTolerationApplyConfiguration struct {
 func DeviceToleration() *DeviceTolerationApplyConfiguration {
 	return &DeviceTolerationApplyConfiguration{}
 }
-func (b DeviceTolerationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/networkdevicedata.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/networkdevicedata.go
@@ -31,7 +31,6 @@ type NetworkDeviceDataApplyConfiguration struct {
 func NetworkDeviceData() *NetworkDeviceDataApplyConfiguration {
 	return &NetworkDeviceDataApplyConfiguration{}
 }
-func (b NetworkDeviceDataApplyConfiguration) IsApplyConfiguration() {}
 
 // WithInterfaceName sets the InterfaceName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/opaquedeviceconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/opaquedeviceconfiguration.go
@@ -34,7 +34,6 @@ type OpaqueDeviceConfigurationApplyConfiguration struct {
 func OpaqueDeviceConfiguration() *OpaqueDeviceConfigurationApplyConfiguration {
 	return &OpaqueDeviceConfigurationApplyConfiguration{}
 }
-func (b OpaqueDeviceConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimconsumerreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimconsumerreference.go
@@ -36,7 +36,6 @@ type ResourceClaimConsumerReferenceApplyConfiguration struct {
 func ResourceClaimConsumerReference() *ResourceClaimConsumerReferenceApplyConfiguration {
 	return &ResourceClaimConsumerReferenceApplyConfiguration{}
 }
-func (b ResourceClaimConsumerReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimspec.go
@@ -29,7 +29,6 @@ type ResourceClaimSpecApplyConfiguration struct {
 func ResourceClaimSpec() *ResourceClaimSpecApplyConfiguration {
 	return &ResourceClaimSpecApplyConfiguration{}
 }
-func (b ResourceClaimSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDevices sets the Devices field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimstatus.go
@@ -31,7 +31,6 @@ type ResourceClaimStatusApplyConfiguration struct {
 func ResourceClaimStatus() *ResourceClaimStatusApplyConfiguration {
 	return &ResourceClaimStatusApplyConfiguration{}
 }
-func (b ResourceClaimStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAllocation sets the Allocation field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimtemplatespec.go
@@ -36,7 +36,6 @@ type ResourceClaimTemplateSpecApplyConfiguration struct {
 func ResourceClaimTemplateSpec() *ResourceClaimTemplateSpecApplyConfiguration {
 	return &ResourceClaimTemplateSpecApplyConfiguration{}
 }
-func (b ResourceClaimTemplateSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourcepool.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourcepool.go
@@ -31,7 +31,6 @@ type ResourcePoolApplyConfiguration struct {
 func ResourcePool() *ResourcePoolApplyConfiguration {
 	return &ResourcePoolApplyConfiguration{}
 }
-func (b ResourcePoolApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslicespec.go
@@ -40,7 +40,6 @@ type ResourceSliceSpecApplyConfiguration struct {
 func ResourceSliceSpec() *ResourceSliceSpecApplyConfiguration {
 	return &ResourceSliceSpecApplyConfiguration{}
 }
-func (b ResourceSliceSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/allocateddevicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/allocateddevicestatus.go
@@ -39,7 +39,6 @@ type AllocatedDeviceStatusApplyConfiguration struct {
 func AllocatedDeviceStatus() *AllocatedDeviceStatusApplyConfiguration {
 	return &AllocatedDeviceStatusApplyConfiguration{}
 }
-func (b AllocatedDeviceStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/allocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/allocationresult.go
@@ -34,7 +34,6 @@ type AllocationResultApplyConfiguration struct {
 func AllocationResult() *AllocationResultApplyConfiguration {
 	return &AllocationResultApplyConfiguration{}
 }
-func (b AllocationResultApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDevices sets the Devices field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/celdeviceselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/celdeviceselector.go
@@ -29,7 +29,6 @@ type CELDeviceSelectorApplyConfiguration struct {
 func CELDeviceSelector() *CELDeviceSelectorApplyConfiguration {
 	return &CELDeviceSelectorApplyConfiguration{}
 }
-func (b CELDeviceSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithExpression sets the Expression field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/counter.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/counter.go
@@ -33,7 +33,6 @@ type CounterApplyConfiguration struct {
 func Counter() *CounterApplyConfiguration {
 	return &CounterApplyConfiguration{}
 }
-func (b CounterApplyConfiguration) IsApplyConfiguration() {}
 
 // WithValue sets the Value field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/counterset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/counterset.go
@@ -30,7 +30,6 @@ type CounterSetApplyConfiguration struct {
 func CounterSet() *CounterSetApplyConfiguration {
 	return &CounterSetApplyConfiguration{}
 }
-func (b CounterSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/device.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/device.go
@@ -41,7 +41,6 @@ type DeviceApplyConfiguration struct {
 func Device() *DeviceApplyConfiguration {
 	return &DeviceApplyConfiguration{}
 }
-func (b DeviceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceallocationconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceallocationconfiguration.go
@@ -35,7 +35,6 @@ type DeviceAllocationConfigurationApplyConfiguration struct {
 func DeviceAllocationConfiguration() *DeviceAllocationConfigurationApplyConfiguration {
 	return &DeviceAllocationConfigurationApplyConfiguration{}
 }
-func (b DeviceAllocationConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSource sets the Source field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceallocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceallocationresult.go
@@ -30,7 +30,6 @@ type DeviceAllocationResultApplyConfiguration struct {
 func DeviceAllocationResult() *DeviceAllocationResultApplyConfiguration {
 	return &DeviceAllocationResultApplyConfiguration{}
 }
-func (b DeviceAllocationResultApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResults adds the given value to the Results field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceattribute.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceattribute.go
@@ -32,7 +32,6 @@ type DeviceAttributeApplyConfiguration struct {
 func DeviceAttribute() *DeviceAttributeApplyConfiguration {
 	return &DeviceAttributeApplyConfiguration{}
 }
-func (b DeviceAttributeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithIntValue sets the IntValue field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicecapacity.go
@@ -33,7 +33,6 @@ type DeviceCapacityApplyConfiguration struct {
 func DeviceCapacity() *DeviceCapacityApplyConfiguration {
 	return &DeviceCapacityApplyConfiguration{}
 }
-func (b DeviceCapacityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithValue sets the Value field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclaim.go
@@ -31,7 +31,6 @@ type DeviceClaimApplyConfiguration struct {
 func DeviceClaim() *DeviceClaimApplyConfiguration {
 	return &DeviceClaimApplyConfiguration{}
 }
-func (b DeviceClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequests adds the given value to the Requests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclaimconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclaimconfiguration.go
@@ -30,7 +30,6 @@ type DeviceClaimConfigurationApplyConfiguration struct {
 func DeviceClaimConfiguration() *DeviceClaimConfigurationApplyConfiguration {
 	return &DeviceClaimConfigurationApplyConfiguration{}
 }
-func (b DeviceClaimConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequests adds the given value to the Requests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclassconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclassconfiguration.go
@@ -29,7 +29,6 @@ type DeviceClassConfigurationApplyConfiguration struct {
 func DeviceClassConfiguration() *DeviceClassConfigurationApplyConfiguration {
 	return &DeviceClassConfigurationApplyConfiguration{}
 }
-func (b DeviceClassConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithOpaque sets the Opaque field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclassspec.go
@@ -30,7 +30,6 @@ type DeviceClassSpecApplyConfiguration struct {
 func DeviceClassSpec() *DeviceClassSpecApplyConfiguration {
 	return &DeviceClassSpecApplyConfiguration{}
 }
-func (b DeviceClassSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithSelectors adds the given value to the Selectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceconfiguration.go
@@ -29,7 +29,6 @@ type DeviceConfigurationApplyConfiguration struct {
 func DeviceConfiguration() *DeviceConfigurationApplyConfiguration {
 	return &DeviceConfigurationApplyConfiguration{}
 }
-func (b DeviceConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithOpaque sets the Opaque field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceconstraint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceconstraint.go
@@ -34,7 +34,6 @@ type DeviceConstraintApplyConfiguration struct {
 func DeviceConstraint() *DeviceConstraintApplyConfiguration {
 	return &DeviceConstraintApplyConfiguration{}
 }
-func (b DeviceConstraintApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequests adds the given value to the Requests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicecounterconsumption.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicecounterconsumption.go
@@ -30,7 +30,6 @@ type DeviceCounterConsumptionApplyConfiguration struct {
 func DeviceCounterConsumption() *DeviceCounterConsumptionApplyConfiguration {
 	return &DeviceCounterConsumptionApplyConfiguration{}
 }
-func (b DeviceCounterConsumptionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCounterSet sets the CounterSet field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicerequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicerequest.go
@@ -31,7 +31,6 @@ type DeviceRequestApplyConfiguration struct {
 func DeviceRequest() *DeviceRequestApplyConfiguration {
 	return &DeviceRequestApplyConfiguration{}
 }
-func (b DeviceRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicerequestallocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicerequestallocationresult.go
@@ -34,7 +34,6 @@ type DeviceRequestAllocationResultApplyConfiguration struct {
 func DeviceRequestAllocationResult() *DeviceRequestAllocationResultApplyConfiguration {
 	return &DeviceRequestAllocationResultApplyConfiguration{}
 }
-func (b DeviceRequestAllocationResultApplyConfiguration) IsApplyConfiguration() {}
 
 // WithRequest sets the Request field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceselector.go
@@ -29,7 +29,6 @@ type DeviceSelectorApplyConfiguration struct {
 func DeviceSelector() *DeviceSelectorApplyConfiguration {
 	return &DeviceSelectorApplyConfiguration{}
 }
-func (b DeviceSelectorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCEL sets the CEL field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicesubrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicesubrequest.go
@@ -38,7 +38,6 @@ type DeviceSubRequestApplyConfiguration struct {
 func DeviceSubRequest() *DeviceSubRequestApplyConfiguration {
 	return &DeviceSubRequestApplyConfiguration{}
 }
-func (b DeviceSubRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicetaint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicetaint.go
@@ -37,7 +37,6 @@ type DeviceTaintApplyConfiguration struct {
 func DeviceTaint() *DeviceTaintApplyConfiguration {
 	return &DeviceTaintApplyConfiguration{}
 }
-func (b DeviceTaintApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicetoleration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicetoleration.go
@@ -37,7 +37,6 @@ type DeviceTolerationApplyConfiguration struct {
 func DeviceToleration() *DeviceTolerationApplyConfiguration {
 	return &DeviceTolerationApplyConfiguration{}
 }
-func (b DeviceTolerationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/exactdevicerequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/exactdevicerequest.go
@@ -38,7 +38,6 @@ type ExactDeviceRequestApplyConfiguration struct {
 func ExactDeviceRequest() *ExactDeviceRequestApplyConfiguration {
 	return &ExactDeviceRequestApplyConfiguration{}
 }
-func (b ExactDeviceRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDeviceClassName sets the DeviceClassName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/networkdevicedata.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/networkdevicedata.go
@@ -31,7 +31,6 @@ type NetworkDeviceDataApplyConfiguration struct {
 func NetworkDeviceData() *NetworkDeviceDataApplyConfiguration {
 	return &NetworkDeviceDataApplyConfiguration{}
 }
-func (b NetworkDeviceDataApplyConfiguration) IsApplyConfiguration() {}
 
 // WithInterfaceName sets the InterfaceName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/opaquedeviceconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/opaquedeviceconfiguration.go
@@ -34,7 +34,6 @@ type OpaqueDeviceConfigurationApplyConfiguration struct {
 func OpaqueDeviceConfiguration() *OpaqueDeviceConfigurationApplyConfiguration {
 	return &OpaqueDeviceConfigurationApplyConfiguration{}
 }
-func (b OpaqueDeviceConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimconsumerreference.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimconsumerreference.go
@@ -36,7 +36,6 @@ type ResourceClaimConsumerReferenceApplyConfiguration struct {
 func ResourceClaimConsumerReference() *ResourceClaimConsumerReferenceApplyConfiguration {
 	return &ResourceClaimConsumerReferenceApplyConfiguration{}
 }
-func (b ResourceClaimConsumerReferenceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAPIGroup sets the APIGroup field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimspec.go
@@ -29,7 +29,6 @@ type ResourceClaimSpecApplyConfiguration struct {
 func ResourceClaimSpec() *ResourceClaimSpecApplyConfiguration {
 	return &ResourceClaimSpecApplyConfiguration{}
 }
-func (b ResourceClaimSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDevices sets the Devices field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimstatus.go
@@ -31,7 +31,6 @@ type ResourceClaimStatusApplyConfiguration struct {
 func ResourceClaimStatus() *ResourceClaimStatusApplyConfiguration {
 	return &ResourceClaimStatusApplyConfiguration{}
 }
-func (b ResourceClaimStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAllocation sets the Allocation field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimtemplatespec.go
@@ -36,7 +36,6 @@ type ResourceClaimTemplateSpecApplyConfiguration struct {
 func ResourceClaimTemplateSpec() *ResourceClaimTemplateSpecApplyConfiguration {
 	return &ResourceClaimTemplateSpecApplyConfiguration{}
 }
-func (b ResourceClaimTemplateSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourcepool.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourcepool.go
@@ -31,7 +31,6 @@ type ResourcePoolApplyConfiguration struct {
 func ResourcePool() *ResourcePoolApplyConfiguration {
 	return &ResourcePoolApplyConfiguration{}
 }
-func (b ResourcePoolApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceslicespec.go
@@ -40,7 +40,6 @@ type ResourceSliceSpecApplyConfiguration struct {
 func ResourceSliceSpec() *ResourceSliceSpecApplyConfiguration {
 	return &ResourceSliceSpecApplyConfiguration{}
 }
-func (b ResourceSliceSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDriver sets the Driver field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriverspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriverspec.go
@@ -41,7 +41,6 @@ type CSIDriverSpecApplyConfiguration struct {
 func CSIDriverSpec() *CSIDriverSpecApplyConfiguration {
 	return &CSIDriverSpecApplyConfiguration{}
 }
-func (b CSIDriverSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttachRequired sets the AttachRequired field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodedriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodedriver.go
@@ -32,7 +32,6 @@ type CSINodeDriverApplyConfiguration struct {
 func CSINodeDriver() *CSINodeDriverApplyConfiguration {
 	return &CSINodeDriverApplyConfiguration{}
 }
-func (b CSINodeDriverApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodespec.go
@@ -29,7 +29,6 @@ type CSINodeSpecApplyConfiguration struct {
 func CSINodeSpec() *CSINodeSpecApplyConfiguration {
 	return &CSINodeSpecApplyConfiguration{}
 }
-func (b CSINodeSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDrivers adds the given value to the Drivers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/tokenrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/tokenrequest.go
@@ -30,7 +30,6 @@ type TokenRequestApplyConfiguration struct {
 func TokenRequest() *TokenRequestApplyConfiguration {
 	return &TokenRequestApplyConfiguration{}
 }
-func (b TokenRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAudience sets the Audience field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachmentsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachmentsource.go
@@ -34,7 +34,6 @@ type VolumeAttachmentSourceApplyConfiguration struct {
 func VolumeAttachmentSource() *VolumeAttachmentSourceApplyConfiguration {
 	return &VolumeAttachmentSourceApplyConfiguration{}
 }
-func (b VolumeAttachmentSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPersistentVolumeName sets the PersistentVolumeName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachmentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachmentspec.go
@@ -31,7 +31,6 @@ type VolumeAttachmentSpecApplyConfiguration struct {
 func VolumeAttachmentSpec() *VolumeAttachmentSpecApplyConfiguration {
 	return &VolumeAttachmentSpecApplyConfiguration{}
 }
-func (b VolumeAttachmentSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttacher sets the Attacher field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachmentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachmentstatus.go
@@ -32,7 +32,6 @@ type VolumeAttachmentStatusApplyConfiguration struct {
 func VolumeAttachmentStatus() *VolumeAttachmentStatusApplyConfiguration {
 	return &VolumeAttachmentStatusApplyConfiguration{}
 }
-func (b VolumeAttachmentStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttached sets the Attached field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeerror.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeerror.go
@@ -35,7 +35,6 @@ type VolumeErrorApplyConfiguration struct {
 func VolumeError() *VolumeErrorApplyConfiguration {
 	return &VolumeErrorApplyConfiguration{}
 }
-func (b VolumeErrorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTime sets the Time field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumenoderesources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumenoderesources.go
@@ -29,7 +29,6 @@ type VolumeNodeResourcesApplyConfiguration struct {
 func VolumeNodeResources() *VolumeNodeResourcesApplyConfiguration {
 	return &VolumeNodeResourcesApplyConfiguration{}
 }
-func (b VolumeNodeResourcesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCount sets the Count field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachmentsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachmentsource.go
@@ -34,7 +34,6 @@ type VolumeAttachmentSourceApplyConfiguration struct {
 func VolumeAttachmentSource() *VolumeAttachmentSourceApplyConfiguration {
 	return &VolumeAttachmentSourceApplyConfiguration{}
 }
-func (b VolumeAttachmentSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPersistentVolumeName sets the PersistentVolumeName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachmentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachmentspec.go
@@ -31,7 +31,6 @@ type VolumeAttachmentSpecApplyConfiguration struct {
 func VolumeAttachmentSpec() *VolumeAttachmentSpecApplyConfiguration {
 	return &VolumeAttachmentSpecApplyConfiguration{}
 }
-func (b VolumeAttachmentSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttacher sets the Attacher field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachmentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachmentstatus.go
@@ -32,7 +32,6 @@ type VolumeAttachmentStatusApplyConfiguration struct {
 func VolumeAttachmentStatus() *VolumeAttachmentStatusApplyConfiguration {
 	return &VolumeAttachmentStatusApplyConfiguration{}
 }
-func (b VolumeAttachmentStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttached sets the Attached field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeerror.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeerror.go
@@ -35,7 +35,6 @@ type VolumeErrorApplyConfiguration struct {
 func VolumeError() *VolumeErrorApplyConfiguration {
 	return &VolumeErrorApplyConfiguration{}
 }
-func (b VolumeErrorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTime sets the Time field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriverspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriverspec.go
@@ -41,7 +41,6 @@ type CSIDriverSpecApplyConfiguration struct {
 func CSIDriverSpec() *CSIDriverSpecApplyConfiguration {
 	return &CSIDriverSpecApplyConfiguration{}
 }
-func (b CSIDriverSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttachRequired sets the AttachRequired field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodedriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodedriver.go
@@ -32,7 +32,6 @@ type CSINodeDriverApplyConfiguration struct {
 func CSINodeDriver() *CSINodeDriverApplyConfiguration {
 	return &CSINodeDriverApplyConfiguration{}
 }
-func (b CSINodeDriverApplyConfiguration) IsApplyConfiguration() {}
 
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodespec.go
@@ -29,7 +29,6 @@ type CSINodeSpecApplyConfiguration struct {
 func CSINodeSpec() *CSINodeSpecApplyConfiguration {
 	return &CSINodeSpecApplyConfiguration{}
 }
-func (b CSINodeSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithDrivers adds the given value to the Drivers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/tokenrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/tokenrequest.go
@@ -30,7 +30,6 @@ type TokenRequestApplyConfiguration struct {
 func TokenRequest() *TokenRequestApplyConfiguration {
 	return &TokenRequestApplyConfiguration{}
 }
-func (b TokenRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAudience sets the Audience field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachmentsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachmentsource.go
@@ -34,7 +34,6 @@ type VolumeAttachmentSourceApplyConfiguration struct {
 func VolumeAttachmentSource() *VolumeAttachmentSourceApplyConfiguration {
 	return &VolumeAttachmentSourceApplyConfiguration{}
 }
-func (b VolumeAttachmentSourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithPersistentVolumeName sets the PersistentVolumeName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachmentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachmentspec.go
@@ -31,7 +31,6 @@ type VolumeAttachmentSpecApplyConfiguration struct {
 func VolumeAttachmentSpec() *VolumeAttachmentSpecApplyConfiguration {
 	return &VolumeAttachmentSpecApplyConfiguration{}
 }
-func (b VolumeAttachmentSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttacher sets the Attacher field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachmentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachmentstatus.go
@@ -32,7 +32,6 @@ type VolumeAttachmentStatusApplyConfiguration struct {
 func VolumeAttachmentStatus() *VolumeAttachmentStatusApplyConfiguration {
 	return &VolumeAttachmentStatusApplyConfiguration{}
 }
-func (b VolumeAttachmentStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithAttached sets the Attached field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeerror.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeerror.go
@@ -35,7 +35,6 @@ type VolumeErrorApplyConfiguration struct {
 func VolumeError() *VolumeErrorApplyConfiguration {
 	return &VolumeErrorApplyConfiguration{}
 }
-func (b VolumeErrorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithTime sets the Time field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumenoderesources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumenoderesources.go
@@ -29,7 +29,6 @@ type VolumeNodeResourcesApplyConfiguration struct {
 func VolumeNodeResources() *VolumeNodeResourcesApplyConfiguration {
 	return &VolumeNodeResourcesApplyConfiguration{}
 }
-func (b VolumeNodeResourcesApplyConfiguration) IsApplyConfiguration() {}
 
 // WithCount sets the Count field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/groupversionresource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/groupversionresource.go
@@ -31,7 +31,6 @@ type GroupVersionResourceApplyConfiguration struct {
 func GroupVersionResource() *GroupVersionResourceApplyConfiguration {
 	return &GroupVersionResourceApplyConfiguration{}
 }
-func (b GroupVersionResourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithGroup sets the Group field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/migrationcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/migrationcondition.go
@@ -39,7 +39,6 @@ type MigrationConditionApplyConfiguration struct {
 func MigrationCondition() *MigrationConditionApplyConfiguration {
 	return &MigrationConditionApplyConfiguration{}
 }
-func (b MigrationConditionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigrationspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigrationspec.go
@@ -30,7 +30,6 @@ type StorageVersionMigrationSpecApplyConfiguration struct {
 func StorageVersionMigrationSpec() *StorageVersionMigrationSpecApplyConfiguration {
 	return &StorageVersionMigrationSpecApplyConfiguration{}
 }
-func (b StorageVersionMigrationSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithResource sets the Resource field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigrationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigrationstatus.go
@@ -30,7 +30,6 @@ type StorageVersionMigrationStatusApplyConfiguration struct {
 func StorageVersionMigrationStatus() *StorageVersionMigrationStatusApplyConfiguration {
 	return &StorageVersionMigrationStatusApplyConfiguration{}
 }
-func (b StorageVersionMigrationStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -115,7 +115,10 @@ func (g *applyConfigurationGenerator) GenerateType(c *generator.Context, t *type
 			sw.Do(constructor, typeParams)
 		}
 	}
-	g.generateIsApplyConfiguration(typeParams.ApplyConfig.ApplyConfiguration, sw)
+
+	if typeParams.Tags.GenerateClient || hasTypeMetaField(t) {
+		g.generateIsApplyConfiguration(typeParams.ApplyConfig.ApplyConfiguration, sw)
+	}
 	g.generateWithFuncs(t, typeParams, sw, nil, &[]string{})
 	g.generateGetters(t, typeParams, sw, nil)
 	return sw.Error()

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttypestatus.go
@@ -29,7 +29,6 @@ type ClusterTestTypeStatusApplyConfiguration struct {
 func ClusterTestTypeStatus() *ClusterTestTypeStatusApplyConfiguration {
 	return &ClusterTestTypeStatusApplyConfiguration{}
 }
-func (b ClusterTestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtypestatus.go
@@ -29,7 +29,6 @@ type TestTypeStatusApplyConfiguration struct {
 func TestTypeStatus() *TestTypeStatusApplyConfiguration {
 	return &TestTypeStatusApplyConfiguration{}
 }
-func (b TestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttypestatus.go
@@ -29,7 +29,6 @@ type ClusterTestTypeStatusApplyConfiguration struct {
 func ClusterTestTypeStatus() *ClusterTestTypeStatusApplyConfiguration {
 	return &ClusterTestTypeStatusApplyConfiguration{}
 }
-func (b ClusterTestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtypestatus.go
@@ -29,7 +29,6 @@ type TestTypeStatusApplyConfiguration struct {
 func TestTypeStatus() *TestTypeStatusApplyConfiguration {
 	return &TestTypeStatusApplyConfiguration{}
 }
-func (b TestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testembeddedtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testembeddedtype.go
@@ -30,7 +30,6 @@ type TestEmbeddedTypeApplyConfiguration struct {
 func TestEmbeddedType() *TestEmbeddedTypeApplyConfiguration {
 	return &TestEmbeddedTypeApplyConfiguration{}
 }
-func (b TestEmbeddedTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testtypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testtypestatus.go
@@ -34,7 +34,6 @@ type TestTypeStatusApplyConfiguration struct {
 func TestTypeStatus() *TestTypeStatusApplyConfiguration {
 	return &TestTypeStatusApplyConfiguration{}
 }
-func (b TestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttypestatus.go
@@ -29,7 +29,6 @@ type ClusterTestTypeStatusApplyConfiguration struct {
 func ClusterTestTypeStatus() *ClusterTestTypeStatusApplyConfiguration {
 	return &ClusterTestTypeStatusApplyConfiguration{}
 }
-func (b ClusterTestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtypestatus.go
@@ -29,7 +29,6 @@ type TestTypeStatusApplyConfiguration struct {
 func TestTypeStatus() *TestTypeStatusApplyConfiguration {
 	return &TestTypeStatusApplyConfiguration{}
 }
-func (b TestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtypestatus.go
@@ -29,7 +29,6 @@ type TestTypeStatusApplyConfiguration struct {
 func TestTypeStatus() *TestTypeStatusApplyConfiguration {
 	return &TestTypeStatusApplyConfiguration{}
 }
-func (b TestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testtypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testtypestatus.go
@@ -29,7 +29,6 @@ type TestTypeStatusApplyConfiguration struct {
 func TestTypeStatus() *TestTypeStatusApplyConfiguration {
 	return &TestTypeStatusApplyConfiguration{}
 }
-func (b TestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/clustertesttypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/clustertesttypestatus.go
@@ -29,7 +29,6 @@ type ClusterTestTypeStatusApplyConfiguration struct {
 func ClusterTestTypeStatus() *ClusterTestTypeStatusApplyConfiguration {
 	return &ClusterTestTypeStatusApplyConfiguration{}
 }
-func (b ClusterTestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/testtypestatus.go
+++ b/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/testtypestatus.go
@@ -29,7 +29,6 @@ type TestTypeStatusApplyConfiguration struct {
 func TestTypeStatus() *TestTypeStatusApplyConfiguration {
 	return &TestTypeStatusApplyConfiguration{}
 }
-func (b TestTypeStatusApplyConfiguration) IsApplyConfiguration() {}
 
 // WithBlah sets the Blah field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunderspec.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunderspec.go
@@ -34,7 +34,6 @@ type FlunderSpecApplyConfiguration struct {
 func FlunderSpec() *FlunderSpecApplyConfiguration {
 	return &FlunderSpecApplyConfiguration{}
 }
-func (b FlunderSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithReference sets the Reference field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunderspec.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunderspec.go
@@ -35,7 +35,6 @@ type FlunderSpecApplyConfiguration struct {
 func FlunderSpec() *FlunderSpecApplyConfiguration {
 	return &FlunderSpecApplyConfiguration{}
 }
-func (b FlunderSpecApplyConfiguration) IsApplyConfiguration() {}
 
 // WithFlunderReference sets the FlunderReference field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

The update to applyconfiguration-gen in https://github.com/kubernetes/kubernetes/pull/132194 incorrectly made it generate an implementation of runtime.ApplyConfiguration for all structs it generates rather than just the root applyconfig, this change fixes that.

#### What type of PR is this?

/king bug
/sig api-machinery

<!--
Add one of the following kinds:
/kin bug
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
