### PR TITLE
Drop test that checks openAPI resource that checks OpenAPI resource name

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	runtimetesting "k8s.io/apimachinery/pkg/runtime/testing"
-	runtimetestingv1 "k8s.io/apimachinery/pkg/runtime/testing/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -1125,12 +1124,6 @@ func TestToOpenAPIDefinitionName(t *testing.T) {
 		out         string
 		wantErr     error
 	}{
-		{
-			name:        "built-registerObj type",
-			registerObj: &runtimetestingv1.ExternalSimple{},
-			gvk:         schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Simple"},
-			out:         "io.k8s.apimachinery.pkg.runtime.testing.v1.ExternalSimple",
-		},
 		{
 			name:        "unstructured type",
 			registerObj: &unstructured.Unstructured{},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Today, we don't guarantee OpenAPI resource name stability.  We only guarantee that references between names are valid, and we already have tests that verify references between types are valid.

Since test breaks in environments where the package path of the test differs from go.mod, and we don't offer a strong guarantee. It seems simplest to drop the test.  If, in the future we strengthen this guarantee, we will also add back tests like this.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig api-machinery
