### PR TITLE
[WIP] E2E test PodLevelResources feature gate enable->disable->enable

### DIFF
--- a/test/e2e_node/pod_level_resources_gate.go
+++ b/test/e2e_node/pod_level_resources_gate.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/common/node/framework/cgroups"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// DISCLAIMER: I have not verified that any part of this test works.
+// This is a test written entirely on high-level, theoretical knowledge.
+// Consumers will more than likely need to tweak this code.
+//
+// TODO: May need other checks for node, windows, and cgroup2.
+var _ = SIGDescribe("Pod-level Resources Feature Gate", framework.WithSerial(), ginkgo.Ordered, feature.PodLevelResources, framework.WithFeatureGate(features.PodLevelResources), func() {
+	f := framework.NewDefaultFramework("pod-level-resources-feature-gate")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var podClient *pod.PodClient
+	var normalPod, disabledPod *v1.Pod
+	var podResources *cgroups.ContainerResources
+	ginkgo.BeforeEach(func() {
+		podClient = pod.NewPodClient(f)
+		podResources = &cgroups.ContainerResources{
+			CPUReq: "100m",
+			CPULim: "100m",
+			MemReq: "100Mi",
+			MemLim: "100Mi",
+		}
+		normalPod = singleContainerPodWithNameAndResources(f, "happy-path", podResources)
+		disabledPod = singleContainerPodWithNameAndResources(f, "rejected-when-disabled", podResources)
+	})
+	ginkgo.Context("Enable pod-level resources", func() {
+		ginkgo.It("Create pod with pod-level resource specification", func(ctx context.Context) {
+			gotNormalPod := podClient.CreateSync(ctx, normalPod)
+			verifySingleContainerPod(ctx, f, podResources, gotNormalPod)
+		})
+	})
+	ginkgo.Context("Disable pod-level resources", func() {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *config.KubeletConfiguration) {
+			initialConfig.FeatureGates = map[string]bool{"PodLevelResources": false}
+		})
+		ginkgo.It("New pod with pod-level resources rejected", func(ctx context.Context) {
+			gotDisabledPod := podClient.Create(ctx, disabledPod)
+			// TODO(132446): Once the blockers for this issue are fixed,
+			// determine the failure reason from testing, either manually or by running this test.
+			err := pod.WaitForPodContainerToFail(ctx, f.ClientSet, f.Namespace.Name, gotDisabledPod.Name, 0, "CrashLoopBackOff", 1*time.Minute)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+
+			gotNormalPod, err := podClient.Get(ctx, normalPod.Name, metav1.GetOptions{
+				TypeMeta: normalPod.TypeMeta,
+			})
+			framework.ExpectNoError(err, "failed to get existing pod with pod-level resources: %s", err)
+			verifySingleContainerPod(ctx, f, podResources, gotNormalPod)
+		})
+	})
+	ginkgo.Context("Pod-level resources re-enabled", func() {
+		ginkgo.It("All pods running", func(ctx context.Context) {
+			err := pod.WaitForPodRunningInNamespace(ctx, f.ClientSet, disabledPod)
+			framework.ExpectNoError(err, "pod not running even after enabling pod-level resources: %s", err)
+			gotDisabledPod, err := podClient.Get(ctx, disabledPod.Name, metav1.GetOptions{
+				TypeMeta: disabledPod.TypeMeta,
+			})
+			framework.ExpectNoError(err, "failed to get existing pod with pod-level resources: %s", err)
+			verifySingleContainerPod(ctx, f, podResources, gotDisabledPod)
+
+			gotNormalPod, err := podClient.Get(ctx, normalPod.Name, metav1.GetOptions{
+				TypeMeta: normalPod.TypeMeta,
+			})
+			framework.ExpectNoError(err, "failed to get existing pod with pod-level resources: %s", err)
+			verifySingleContainerPod(ctx, f, podResources, gotNormalPod)
+		})
+	})
+	ginkgo.AfterAll(func() {
+		ctx := context.Background()
+		err := pod.DeletePodWithWait(ctx, f.ClientSet, normalPod)
+		framework.ExpectNoError(err, "failed to delete pod %s", err)
+		err = pod.DeletePodWithWait(ctx, f.ClientSet, disabledPod)
+		framework.ExpectNoError(err, "failed to delete pod %s", err)
+	})
+})
+
+func singleContainerPodWithNameAndResources(f *framework.Framework, name string, podResources *cgroups.ContainerResources) *v1.Pod {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: f.Namespace.Name,
+			Labels:    map[string]string{"time": strconv.Itoa(time.Now().Nanosecond())},
+		},
+		Spec: v1.PodSpec{
+			Resources: podResources.ResourceRequirements(),
+			Containers: []v1.Container{
+				cgroups.MakeContainerWithResources("c1", podResources, pod.InfiniteSleepCommand),
+			},
+		},
+	}
+	cgroups.ConfigureHostPathForPodCgroup(testPod)
+	return testPod
+}
+
+func verifySingleContainerPod(ctx context.Context, f *framework.Framework, podResources *cgroups.ContainerResources, gotPod *v1.Pod) {
+	isReady := pod.CheckPodsRunningReady(ctx, f.ClientSet, gotPod.Namespace, []string{
+		gotPod.Name,
+	}, 1*time.Minute)
+	gomega.Expect(isReady).To(gomega.BeTrue())
+
+	requirements := podResources.ResourceRequirements()
+	gomega.Expect(gotPod.Spec.Resources).To(gomega.Equal(requirements))
+	err := cgroups.VerifyPodCgroups(ctx, f, gotPod, podResources)
+	framework.ExpectNoError(err, "failed to verify pod's cgroup values: %v", err)
+
+	gomega.Expect(gotPod.Spec.Containers).To(gomega.HaveLen(1))
+	gomega.Expect(gotPod.Spec.Containers[0].Resources).To(gomega.Equal(requirements))
+	containerName := gotPod.Spec.Containers[0].Name
+	err = cgroups.VerifyContainerMemoryLimit(f, gotPod, containerName, requirements, true)
+	framework.ExpectNoError(err, "failed to verify memory limit cgroup value: %v", err)
+	err = cgroups.VerifyContainerCPULimit(f, gotPod, containerName, requirements, true)
+	framework.ExpectNoError(err, "failed to verify cpu limit cgroup value: %v", err)
+}


### PR DESCRIPTION
Test the PodLevelResources feature gate enable, disable, then re-enable on kubelet. Verify that pods with pod-level resources continue to exist when the feature gate is disabled, but new pods are rejected until the feature gate is re-enabled.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Share progress on Scenario 2 of #132446 for future assignees.

#### Which issue(s) this PR is related to:

Targets Scenario 2 of #132446.

#### Special notes for your reviewer:

This test code has never been run. Treat only as reference and not as authoritative.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
