### PR TITLE
Annotate LimitRangeSpec.Limits to be optional

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -24779,7 +24779,6 @@ func schema_k8sio_api_core_v1_LimitRangeSpec(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"limits"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2299,6 +2299,7 @@ message LimitRangeList {
 // LimitRangeSpec defines a min/max usage limit for resources that match on kind.
 message LimitRangeSpec {
   // Limits is the list of LimitRangeItem objects that are enforced.
+  // +optional
   // +listType=atomic
   repeated LimitRangeItem limits = 1;
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7311,6 +7311,7 @@ type LimitRangeItem struct {
 // LimitRangeSpec defines a min/max usage limit for resources that match on kind.
 type LimitRangeSpec struct {
 	// Limits is the list of LimitRangeItem objects that are enforced.
+	// +optional
 	// +listType=atomic
 	Limits []LimitRangeItem `json:"limits" protobuf:"bytes,1,rep,name=limits"`
 }


### PR DESCRIPTION
Setting an +optional annotation mark LimitRangeSpec.Limits  as optional in openapi, since API validation does allow that field to be unset on creation.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Setting an +optional annotation mark LimitRangeSpec.Limits  as optional in openapi, since API validation does allow that field to be unset on creation.

#### Which issue(s) this PR is related to:

Fixes #131316

#### Does this PR introduce a user-facing change?

```release-note

NONE

```