### PR TITLE
fix(kubectl): recognize absolute Windows paths

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -168,6 +168,13 @@ var (
 )
 
 func extractFileSpec(arg string) (fileSpec, error) {
+	// Check for Windows absolute path first.
+	if isWindowsAbsolutePath(arg) {
+		return fileSpec{
+			File: newLocalPath(arg),
+		}, nil
+	}
+
 	i := strings.Index(arg, ":")
 
 	// filespec starting with a semicolon is invalid


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug where `kubectl cp` would incorrectly interpret Windows absolute paths as pod specifications. Before this change, paths like `C:\temp\file.txt` would be parsed as a pod named `C` with file path `\temp\file.txt` because the colon character was used as a delimiter to separate pod specifications from file paths.

The fix adds Windows-specific path detection that checks for the Windows absolute path pattern before attempting to parse pod specifications. This ensures that Windows users can use absolute paths with `kubectl cp` without running into parsing errors.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #101985

#### Special notes for your reviewer:

- The fix is Windows-specific and only activates when `runtime.GOOS == "windows"`.
- I added test coverage for Windows path scenarios, but the new tests only run on Windows.
- I've done my best to maintain backward compatibility and not affect Unix/Linux path handling.
- All existing tests continue to pass, and new Windows-specific tests have been added. The rest of the tests in `staging/src/k8s.io/kubectl/pkg/cmd/` now pass on Windows after these changes.

Besides the above, just a disclaimer that I am completely new to contributing to this repository. I don't have a good mental model of how all of the pieces fit together here. Though, I've done my best to try, and I am happy for any feedback or guidance.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl cp now correctly handles Windows absolute paths, such as C:\path\to\file, instead of incorrectly interpreting them as pod specifications.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A
