### PR TITLE
kubeadm: graduate WaitForAllControlPlaneComponents to GA

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
@@ -40,10 +39,7 @@ func NewWaitControlPlanePhase() workflow.Phase {
 	phase := workflow.Phase{
 		Name:  "wait-control-plane",
 		Short: "Wait for the control plane to start",
-		// TODO: unhide this phase once WaitForAllControlPlaneComponents goes GA:
-		// https://github.com/kubernetes/kubeadm/issues/2907
-		Hidden: true,
-		Run:    runWaitControlPlanePhase,
+		Run:   runWaitControlPlanePhase,
 	}
 	return phase
 }
@@ -90,15 +86,11 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 
 	var podMap map[string]*v1.Pod
 	waiter.SetTimeout(data.Cfg().Timeouts.ControlPlaneComponentHealthCheck.Duration)
-	if features.Enabled(data.Cfg().ClusterConfiguration.FeatureGates, features.WaitForAllControlPlaneComponents) {
-		podMap, err = staticpodutil.ReadMultipleStaticPodsFromDisk(data.ManifestDir(),
-			constants.ControlPlaneComponents...)
-		if err == nil {
-			err = waiter.WaitForControlPlaneComponents(podMap,
-				data.Cfg().LocalAPIEndpoint.AdvertiseAddress)
-		}
-	} else {
-		err = waiter.WaitForAPI()
+	podMap, err = staticpodutil.ReadMultipleStaticPodsFromDisk(data.ManifestDir(),
+		constants.ControlPlaneComponents...)
+	if err == nil {
+		err = waiter.WaitForControlPlaneComponents(podMap,
+			data.Cfg().LocalAPIEndpoint.AdvertiseAddress)
 	}
 	if err != nil {
 		apiclient.PrintControlPlaneErrorHelpScreen(data.OutputWriter(), data.Cfg().NodeRegistration.CRISocket)

--- a/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
@@ -21,11 +21,9 @@ import (
 	"time"
 
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
@@ -35,10 +33,8 @@ import (
 // NewWaitControlPlanePhase is a hidden phase that runs after the control-plane and etcd phases
 func NewWaitControlPlanePhase() workflow.Phase {
 	phase := workflow.Phase{
-		Name: "wait-control-plane",
-		// TODO: remove this EXPERIMENTAL prefix once WaitForAllControlPlaneComponents goes GA:
-		// https://github.com/kubernetes/kubeadm/issues/2907
-		Short: "EXPERIMENTAL: Wait for the control plane to start",
+		Name:  "wait-control-plane",
+		Short: "Wait for the control plane to start",
 		Run:   runWaitControlPlanePhase,
 	}
 	return phase
@@ -51,18 +47,6 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 	}
 
 	if data.Cfg().ControlPlane == nil {
-		return nil
-	}
-
-	initCfg, err := data.InitCfg()
-	if err != nil {
-		return errors.Wrap(err, "could not obtain InitConfiguration during the wait-control-plane phase")
-	}
-
-	// TODO: remove this check once WaitForAllControlPlaneComponents goes GA
-	// https://github.com/kubernetes/kubeadm/issues/2907
-	if !features.Enabled(initCfg.ClusterConfiguration.FeatureGates, features.WaitForAllControlPlaneComponents) {
-		klog.V(5).Infof("[wait-control-plane] Skipping phase as the feature gate WaitForAllControlPlaneComponents is disabled")
 		return nil
 	}
 

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -61,7 +61,7 @@ var InitFeatureGates = FeatureList{
 		DeprecationMessage: "Deprecated in favor of the core kubelet feature UserNamespacesSupport which is beta since 1.30." +
 			" Once UserNamespacesSupport graduates to GA, kubeadm will start using it and RootlessControlPlane will be removed.",
 	},
-	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
+	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.GA, LockToDefault: true}},
 	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 	NodeLocalCRISocket:               {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 }

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -104,11 +104,6 @@ func (w *fakeWaiter) WaitForControlPlaneComponents(podsMap map[string]*v1.Pod, a
 	return nil
 }
 
-// WaitForAPI just returns a dummy nil, to indicate that the program should just proceed
-func (w *fakeWaiter) WaitForAPI() error {
-	return nil
-}
-
 // WaitForPodsWithLabel just returns an error if set from errsToReturn
 func (w *fakeWaiter) WaitForPodsWithLabel(kvLabel string) error {
 	return w.errsToReturn[waitForPodsWithLabel]

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -95,12 +95,6 @@ func (w *Waiter) WaitForControlPlaneComponents(podsMap map[string]*v1.Pod, apiSe
 	return nil
 }
 
-// WaitForAPI just returns a dummy nil, to indicate that the program should just proceed
-func (w *Waiter) WaitForAPI() error {
-	fmt.Println("[dryrun] Would wait for the API Server's /healthz endpoint to return 'ok'")
-	return nil
-}
-
 // WaitForPodsWithLabel just returns a dummy nil, to indicate that the program should just proceed
 func (w *Waiter) WaitForPodsWithLabel(kvLabel string) error {
 	fmt.Printf("[dryrun] Would wait for the Pods with the label %q in the %s namespace to become Running\n", kvLabel, metav1.NamespaceSystem)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Graduate the kubeadm specific feature gate WaitForAllControlPlaneComponents to GA.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

xref
- https://github.com/kubernetes/kubeadm/issues/2907

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: graduated the kubeadm specific feature gate WaitForAllControlPlaneComponents to GA. The feature gate is now locked to always enabled and on node initialization kubeadm will perform a health check for all control plane components and not only the kube-apiserver.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
