### PR TITLE
Add useful endpoints to kube-scheduler /statusz

### DIFF
--- a/staging/src/k8s.io/component-base/zpages/statusz/statusz.go
+++ b/staging/src/k8s.io/component-base/zpages/statusz/statusz.go
@@ -59,7 +59,7 @@ func handleStatusz(componentName string, reg statuszRegistry) http.HandlerFunc {
 		}
 
 		fmt.Fprintf(w, headerFmt, componentName)
-		data, err := populateStatuszData(reg)
+		data, err := populateStatuszData(componentName, reg)
 		if err != nil {
 			klog.Errorf("error while populating statusz data: %v", err)
 			http.Error(w, "error while populating statusz data", http.StatusInternalServerError)
@@ -71,7 +71,7 @@ func handleStatusz(componentName string, reg statuszRegistry) http.HandlerFunc {
 	}
 }
 
-func populateStatuszData(reg statuszRegistry) (string, error) {
+func populateStatuszData(componentName string, reg statuszRegistry) (string, error) {
 	randomIndex := rand.Intn(len(delimiters))
 	delim := html.EscapeString(delimiters[randomIndex])
 	startTime := html.EscapeString(reg.processStartTime().Format(time.UnixDate))
@@ -91,6 +91,22 @@ Go version%[1]s %[4]s
 Binary version%[1]s %[5]s
 %[6]s
 `, delim, startTime, uptime, goVersion, binaryVersion, emulationVersion)
+
+	// Add useful links for specific components
+	var usefulLinks string
+	if componentName == "kube-scheduler" {
+		usefulLinks = `
+Useful Endpoints:
+----------------
+"healthz": "/healthz",
+"livez": "/livez",
+"readyz": "/readyz",
+"metrics": "/metrics"`
+	}
+
+	if usefulLinks != "" {
+		status += usefulLinks
+	}
 
 	return status, nil
 }

--- a/staging/src/k8s.io/component-base/zpages/statusz/statusz_test.go
+++ b/staging/src/k8s.io/component-base/zpages/statusz/statusz_test.go
@@ -36,7 +36,7 @@ Up: %s
 Go version: %s
 Binary version: %v
 Emulation version: %v
-`
+%s`
 
 const wantTmplWithoutEmulation = `
 %s statusz
@@ -46,8 +46,7 @@ Started: %v
 Up: %s
 Go version: %s
 Binary version: %v
-
-`
+%s`
 
 func TestStatusz(t *testing.T) {
 	delimiters = []string{":"}
@@ -90,6 +89,7 @@ func TestStatusz(t *testing.T) {
 				fakeGoVersion,
 				fakeBinaryVersion,
 				fakeEmulationVersion,
+				"",
 			),
 		},
 		{
@@ -110,6 +110,35 @@ func TestStatusz(t *testing.T) {
 				fakeUptime,
 				fakeGoVersion,
 				fakeBinaryVersion,
+				"\n",
+			),
+		},
+		{
+			name:          "kube-scheduler with useful links",
+			componentName: "kube-scheduler",
+			reqHeader:     "text/plain; charset=utf-8",
+			registry: fakeRegistry{
+				startTime:    fakeStartTime,
+				goVer:        fakeGoVersion,
+				binaryVer:    fakeBinaryVersion,
+				emulationVer: fakeEmulationVersion,
+			},
+			wantStatusCode: http.StatusOK,
+			wantBody: fmt.Sprintf(
+				wantTmpl,
+				"kube-scheduler",
+				fakeStartTime.Format(time.UnixDate),
+				fakeUptime,
+				fakeGoVersion,
+				fakeBinaryVersion,
+				fakeEmulationVersion,
+				`
+Useful Endpoints:
+----------------
+"healthz": "/healthz",
+"livez": "/livez",
+"readyz": "/readyz",
+"metrics": "/metrics"`,
 			),
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature  
/sig scheduling  
/area observability  

---

**What this PR does / why we need it:**

This PR enhances the kube-scheduler’s `/statusz` endpoint by adding a "Useful Endpoints" section. It includes health and monitoring endpoints such as:

- `/livez`
- `/readyz`
- `/healthz`
- `/metrics`

This brings kube-scheduler in line with other control plane components like the kube-apiserver and improves operator experience by simplifying access to observability data. It's particularly beneficial for large-scale clusters and integration with third-party monitoring systems.

---

**Which issue(s) this PR is related to:**

Fixes #132539

---

**Special notes for your reviewer:**

- Follows the same approach as kube-apiserver  
- No changes to the behavior of existing endpoints  
- Improves UX for dashboards, tools, and SRE workflows

---

**Does this PR introduce a user-facing change?**

```release-note
Added a "Useful Endpoints" section to the kube-scheduler `/statusz` endpoint. This section lists key observability URLs such as `/livez`, `/readyz`, `/healthz`, and `/metrics`. This improves discoverability for monitoring and troubleshooting tools.
