### PR TITLE
DRA plugin: handle gRPC serving failures

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/noderegistrar.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubeletplugin
 
 import (
+	"context"
 	"fmt"
 
 	"google.golang.org/grpc"
@@ -30,7 +31,7 @@ type nodeRegistrar struct {
 }
 
 // startRegistrar returns a running instance.
-func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, driverName string, supportedServices []string, draEndpointPath string, pluginRegistrationEndpoint endpoint) (*nodeRegistrar, error) {
+func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.UnaryServerInterceptor, streamInterceptors []grpc.StreamServerInterceptor, driverName string, supportedServices []string, draEndpointPath string, pluginRegistrationEndpoint endpoint, errHandler func(ctx context.Context, err error)) (*nodeRegistrar, error) {
 	n := &nodeRegistrar{
 		registrationServer: registrationServer{
 			driverName:        driverName,
@@ -38,7 +39,7 @@ func startRegistrar(logger klog.Logger, grpcVerbosity int, interceptors []grpc.U
 			supportedVersions: supportedServices, // DRA uses this field to describe provided services (e.g. "v1beta1.DRAPlugin").
 		},
 	}
-	s, err := startGRPCServer(logger, grpcVerbosity, interceptors, streamInterceptors, pluginRegistrationEndpoint, func(grpcServer *grpc.Server) {
+	s, err := startGRPCServer(logger, grpcVerbosity, interceptors, streamInterceptors, pluginRegistrationEndpoint, errHandler, func(grpcServer *grpc.Server) {
 		registerapi.RegisterRegistrationServer(grpcServer, n)
 	})
 	if err != nil {

--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -119,8 +119,9 @@ type FileOperations struct {
 	// file does not exist.
 	Remove func(name string) error
 
-	// ErrorHandler is an optional callback for ResourceSlice publishing problems.
-	ErrorHandler func(ctx context.Context, err error, msg string)
+	// HandleError is an optional callback for ResourceSlice publishing problems.
+	HandleError func(ctx context.Context, err error, msg string)
+
 	// DriverResources provides the information that the driver will use to
 	// construct the ResourceSlices that it will publish.
 	DriverResources *resourceslice.DriverResources
@@ -189,9 +190,9 @@ func (ex *ExamplePlugin) IsRegistered() bool {
 	return status.PluginRegistered
 }
 
-func (ex *ExamplePlugin) ErrorHandler(ctx context.Context, err error, msg string) {
-	if ex.fileOps.ErrorHandler != nil {
-		ex.fileOps.ErrorHandler(ctx, err, msg)
+func (ex *ExamplePlugin) HandleError(ctx context.Context, err error, msg string) {
+	if ex.fileOps.HandleError != nil {
+		ex.fileOps.HandleError(ctx, err, msg)
 		return
 	}
 	utilruntime.HandleErrorWithContext(ctx, err, msg)

--- a/test/e2e/dra/test-driver/app/options.go
+++ b/test/e2e/dra/test-driver/app/options.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+type options struct {
+}
+
+// TestOption implements the functional options pattern
+// dedicated for usage in testing code.
+type TestOption func(o *options) error

--- a/test/e2e/dra/test-driver/app/options.go
+++ b/test/e2e/dra/test-driver/app/options.go
@@ -16,9 +16,25 @@ limitations under the License.
 
 package app
 
+import "context"
+
 type options struct {
+	// cancelMainContext is used to cancel upper level
+	// context when a background error occurs.
+	// It's called by HandleError if set.
+	cancelMainContext context.CancelCauseFunc
 }
 
 // TestOption implements the functional options pattern
 // dedicated for usage in testing code.
 type TestOption func(o *options) error
+
+// CancelMainContext sets a context cancellation function for
+// the plugin. This function is called by HandleError
+// when an error occurs in the background.
+func CancelMainContext(cancel context.CancelCauseFunc) TestOption {
+	return func(o *options) error {
+		o.cancelMainContext = cancel
+		return nil
+	}
+}

--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -487,7 +487,7 @@ func (d *Driver) SetUp(nodes *Nodes, driverResources map[string]resourceslice.Dr
 				}
 				return d.removeFile(&pod, name)
 			},
-			ErrorHandler: func(ctx context.Context, err error, msg string) {
+			HandleError: func(ctx context.Context, err error, msg string) {
 				// Record a failure, but don't kill the background goroutine.
 				defer ginkgo.GinkgoRecover()
 				// During tests when canceling the context it is possible to get all kinds of

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -381,17 +381,17 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			}).WithTimeout(retryTestTimeout).Should(gomega.Equal(calls))
 		})
 
-		functionalListenAfterRegistration := func(ctx context.Context, socketPath string) {
+		functionalListenAfterRegistration := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
-			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, socketPath)
+			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, opts...)
 
 			ginkgo.By("wait for registration to complete")
 			gomega.Eventually(registrar.GetGRPCCalls).WithTimeout(pluginRegistrationTimeout).Should(testdrivergomega.BeRegistered)
 
 			ginkgo.By("start DRA plugin service")
-			draService := newDRAService(ctx, f.ClientSet, nodeName, driverName, socketPath)
+			draService := newDRAService(ctx, f.ClientSet, nodeName, driverName, datadir, opts...)
 
 			pod := createTestObjects(ctx, f.ClientSet, nodeName, f.Namespace.Name, "draclass", "external-claim", "drapod", false, []string{driverName})
 
@@ -405,20 +405,25 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		ginkgo.DescribeTable("must be functional when plugin starts to listen on a service socket after registration",
 			functionalListenAfterRegistration,
 			ginkgo.Entry("2 sockets", ""),
-			ginkgo.Entry("1 common socket", path.Join(kubeletplugin.KubeletRegistryDir, driverName+"-common.sock")),
+			ginkgo.Entry(
+				"1 common socket",
+				kubeletplugin.KubeletRegistryDir,
+				kubeletplugin.PluginDataDirectoryPath(kubeletplugin.KubeletRegistryDir),
+				kubeletplugin.PluginSocket(driverName+"-common.sock"),
+			),
 		)
 
-		functionalAfterServiceReconnect := func(ctx context.Context, socketPath string) {
+		functionalAfterServiceReconnect := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
-			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, socketPath)
+			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, opts...)
 
 			ginkgo.By("wait for registration to complete")
 			gomega.Eventually(registrar.GetGRPCCalls).WithTimeout(pluginRegistrationTimeout).Should(testdrivergomega.BeRegistered)
 
 			ginkgo.By("start DRA plugin service")
-			draService := newDRAService(ctx, f.ClientSet, nodeName, driverName, socketPath)
+			draService := newDRAService(ctx, f.ClientSet, nodeName, driverName, datadir, opts...)
 
 			pod := createTestObjects(ctx, f.ClientSet, getNodeName(ctx, f), f.Namespace.Name, "draclass", "external-claim", "drasleeppod" /* enables sleeping */, false /* pod is deleted below */, []string{driverName})
 
@@ -436,7 +441,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			gomega.Eventually(ctx, listResources(f.ClientSet)).Should(gomega.BeEmpty(), "ResourceSlices without plugin")
 
 			ginkgo.By("restarting plugin")
-			draService = newDRAService(ctx, f.ClientSet, nodeName, driverName, socketPath)
+			draService = newDRAService(ctx, f.ClientSet, nodeName, driverName, datadir, opts...)
 
 			ginkgo.By("stopping pod")
 			err = f.ClientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
@@ -446,7 +451,12 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		ginkgo.DescribeTable("must be functional after service reconnect",
 			functionalAfterServiceReconnect,
 			ginkgo.Entry("2 sockets", ""),
-			ginkgo.Entry("1 common socket", path.Join(kubeletplugin.KubeletRegistryDir, driverName+"-common.sock")),
+			ginkgo.Entry(
+				"1 common socket",
+				kubeletplugin.KubeletRegistryDir,
+				kubeletplugin.PluginDataDirectoryPath(kubeletplugin.KubeletRegistryDir),
+				kubeletplugin.PluginSocket(driverName+"-common.sock"),
+			),
 		)
 	})
 
@@ -664,17 +674,17 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			gomega.Consistently(ctx, listResources(f.ClientSet)).WithTimeout(5*time.Second).Should(gomega.BeEmpty(), "ResourceSlices with no plugin")
 		})
 
-		removedIfPluginStopsAfterRegistration := func(ctx context.Context, socketPath string) {
+		removedIfPluginStopsAfterRegistration := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
-			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, socketPath)
+			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, opts...)
 
 			ginkgo.By("wait for registration to complete")
 			gomega.Eventually(registrar.GetGRPCCalls).WithTimeout(pluginRegistrationTimeout).Should(testdrivergomega.BeRegistered)
 
 			ginkgo.By("start DRA plugin service")
-			kubeletPlugin := newDRAService(ctx, f.ClientSet, nodeName, driverName, socketPath)
+			kubeletPlugin := newDRAService(ctx, f.ClientSet, nodeName, driverName, datadir, opts...)
 
 			ginkgo.By("wait for ResourceSlice to be created by plugin")
 			matchNode := gomega.ConsistOf(matchResourcesByNodeName(nodeName))
@@ -691,14 +701,19 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		ginkgo.DescribeTable("must be removed if plugin stops after registration",
 			removedIfPluginStopsAfterRegistration,
 			ginkgo.Entry("2 sockets", ""),
-			ginkgo.Entry("1 common socket", path.Join(kubeletplugin.KubeletRegistryDir, driverName+"-common.sock")),
+			ginkgo.Entry(
+				"1 common socket",
+				kubeletplugin.KubeletRegistryDir,
+				kubeletplugin.PluginDataDirectoryPath(kubeletplugin.KubeletRegistryDir),
+				kubeletplugin.PluginSocket(driverName+"-common.sock"),
+			),
 		)
 
 		f.It("must be removed if plugin is unresponsive after registration", func(ctx context.Context) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
-			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, "")
+			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName)
 			ginkgo.By("wait for registration to complete")
 			gomega.Eventually(registrar.GetGRPCCalls).WithTimeout(pluginRegistrationTimeout).Should(testdrivergomega.BeRegistered)
 
@@ -711,17 +726,17 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			gomega.Consistently(ctx, listResources(f.ClientSet)).WithTimeout(5*time.Second).Should(gomega.BeEmpty(), "ResourceSlices without plugin")
 		})
 
-		testRemoveIfRestartsQuickly := func(ctx context.Context, socketPath string) {
+		testRemoveIfRestartsQuickly := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
-			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, "")
+			registrar := newRegistrar(ctx, f.ClientSet, nodeName, driverName, opts...)
 
 			ginkgo.By("wait for registration to complete")
 			gomega.Eventually(registrar.GetGRPCCalls).WithTimeout(pluginRegistrationTimeout).Should(testdrivergomega.BeRegistered)
 
 			ginkgo.By("start DRA plugin service")
-			kubeletPlugin := newDRAService(ctx, f.ClientSet, nodeName, driverName, "")
+			kubeletPlugin := newDRAService(ctx, f.ClientSet, nodeName, driverName, datadir, opts...)
 
 			ginkgo.By("wait for ResourceSlice to be created by plugin")
 			matchNode := gomega.ConsistOf(matchResourcesByNodeName(nodeName))
@@ -739,7 +754,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			time.Sleep(5 * time.Second)
 
 			ginkgo.By("restarting plugin")
-			newDRAService(ctx, f.ClientSet, nodeName, driverName, "")
+			newDRAService(ctx, f.ClientSet, nodeName, driverName, datadir, opts...)
 
 			ginkgo.By("ensuring unchanged ResourceSlices")
 			gomega.Consistently(ctx, listResources(f.ClientSet)).WithTimeout(time.Minute).Should(gomega.Equal(slices), "ResourceSlices")
@@ -747,7 +762,12 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 		ginkgo.DescribeTable("must not be removed if plugin restarts quickly enough",
 			testRemoveIfRestartsQuickly,
 			ginkgo.Entry("2 sockets", ""),
-			ginkgo.Entry("1 common socket", path.Join(kubeletplugin.KubeletRegistryDir, driverName+"-common.sock")),
+			ginkgo.Entry(
+				"1 common socket",
+				kubeletplugin.KubeletRegistryDir,
+				kubeletplugin.PluginDataDirectoryPath(kubeletplugin.KubeletRegistryDir),
+				kubeletplugin.PluginSocket(driverName+"-common.sock"),
+			),
 		)
 	})
 })
@@ -804,18 +824,11 @@ func newKubeletPlugin(ctx context.Context, clientSet kubernetes.Interface, nodeN
 }
 
 // newRegistrar starts a registrar for the specified DRA driver, without the DRA gRPC service.
-func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName, serviceSocketPath string) *testdriver.ExamplePlugin {
+func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName string, opts ...kubeletplugin.Option) *testdriver.ExamplePlugin {
 	ginkgo.By("start only Kubelet plugin registrar")
 	logger := klog.LoggerWithValues(klog.LoggerWithName(klog.Background(), "kubelet plugin registrar "+driverName))
 	ctx = klog.NewContext(ctx, logger)
-	opts := []kubeletplugin.Option{
-		kubeletplugin.DRAService(false),
-	}
-	if serviceSocketPath != "" {
-		dir, file := path.Split(serviceSocketPath)
-		opts = append(opts, kubeletplugin.PluginDataDirectoryPath(dir))
-		opts = append(opts, kubeletplugin.PluginSocket(file))
-	}
+	opts = append(opts, kubeletplugin.DRAService(false))
 	registrar, err := testdriver.StartPlugin(
 		ctx,
 		cdiDir,
@@ -829,31 +842,35 @@ func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName,
 	return registrar
 }
 
-// newDRAService starts the DRA gRPC service for the specified DRA driver, without the registrar.
-func newDRAService(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName, socketPath string) *testdriver.ExamplePlugin {
+// newDRAService starts the DRA gRPC service for the specified node and driver.
+// It ensures that necessary directories exist, starts the plugin and registers
+// cleanup functions to remove created resources after the test.
+// Parameters:
+//   - ctx: The context for controlling cancellation and logging.
+//   - clientSet: Kubernetes client interface for interacting with the cluster.
+//   - nodeName: The name of the node where the plugin will run.
+//   - driverName: The name of the DRA driver.
+//   - datadir: The directory for the DRA socket and state files.
+//     Must match what is specified via [kubeletplugin.PluginDataDirectoryPath].
+//     May be empty if that option is not used, then the default path is used.
+//   - opts: Additional options for plugin configuration.
+//
+// Returns:
+//   - A pointer to the started ExamplePlugin instance.
+func newDRAService(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName, datadir string, opts ...kubeletplugin.Option) *testdriver.ExamplePlugin {
 	ginkgo.By("start only Kubelet plugin")
 	logger := klog.LoggerWithValues(klog.LoggerWithName(klog.Background(), "kubelet plugin "+driverName), "node", nodeName)
 	ctx = klog.NewContext(ctx, logger)
+
+	opts = append(opts, kubeletplugin.RegistrationService(false))
 
 	// Ensure that directories exist, creating them if necessary. We want
 	// to know early if there is a setup problem that would prevent
 	// creating those directories.
 	err := os.MkdirAll(cdiDir, os.FileMode(0750))
 	framework.ExpectNoError(err, "create CDI directory")
-	opts := []kubeletplugin.Option{
-		kubeletplugin.RegistrationService(false),
-	}
-	var datadir string
-	if socketPath == "" {
-		// The default, not set as option.
+	if datadir == "" {
 		datadir = path.Join(kubeletplugin.KubeletPluginsDir, driverName)
-	} else {
-		dir, file := path.Split(socketPath)
-		opts = append(opts,
-			kubeletplugin.PluginDataDirectoryPath(dir),
-			kubeletplugin.PluginSocket(file),
-		)
-		datadir = dir
 	}
 	err = os.MkdirAll(datadir, 0750)
 	framework.ExpectNoError(err, "create DRA socket directory")

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -381,7 +381,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			}).WithTimeout(retryTestTimeout).Should(gomega.Equal(calls))
 		})
 
-		functionalListenAfterRegistration := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
+		functionalListenAfterRegistration := func(ctx context.Context, datadir string, opts ...any) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
@@ -413,7 +413,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			),
 		)
 
-		functionalAfterServiceReconnect := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
+		functionalAfterServiceReconnect := func(ctx context.Context, datadir string, opts ...any) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
@@ -674,7 +674,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			gomega.Consistently(ctx, listResources(f.ClientSet)).WithTimeout(5*time.Second).Should(gomega.BeEmpty(), "ResourceSlices with no plugin")
 		})
 
-		removedIfPluginStopsAfterRegistration := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
+		removedIfPluginStopsAfterRegistration := func(ctx context.Context, datadir string, opts ...any) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
@@ -726,7 +726,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 			gomega.Consistently(ctx, listResources(f.ClientSet)).WithTimeout(5*time.Second).Should(gomega.BeEmpty(), "ResourceSlices without plugin")
 		})
 
-		testRemoveIfRestartsQuickly := func(ctx context.Context, datadir string, opts ...kubeletplugin.Option) {
+		testRemoveIfRestartsQuickly := func(ctx context.Context, datadir string, opts ...any) {
 			nodeName := getNodeName(ctx, f)
 
 			ginkgo.By("start DRA registrar")
@@ -824,7 +824,7 @@ func newKubeletPlugin(ctx context.Context, clientSet kubernetes.Interface, nodeN
 }
 
 // newRegistrar starts a registrar for the specified DRA driver, without the DRA gRPC service.
-func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName string, opts ...kubeletplugin.Option) *testdriver.ExamplePlugin {
+func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName string, opts ...any) *testdriver.ExamplePlugin {
 	ginkgo.By("start only Kubelet plugin registrar")
 	logger := klog.LoggerWithValues(klog.LoggerWithName(klog.Background(), "kubelet plugin registrar "+driverName))
 	ctx = klog.NewContext(ctx, logger)
@@ -857,7 +857,7 @@ func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName,
 //
 // Returns:
 //   - A pointer to the started ExamplePlugin instance.
-func newDRAService(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName, datadir string, opts ...kubeletplugin.Option) *testdriver.ExamplePlugin {
+func newDRAService(ctx context.Context, clientSet kubernetes.Interface, nodeName, driverName, datadir string, opts ...any) *testdriver.ExamplePlugin {
 	ginkgo.By("start only Kubelet plugin")
 	logger := klog.LoggerWithValues(klog.LoggerWithName(klog.Background(), "kubelet plugin "+driverName), "node", nodeName)
 	ctx = klog.NewContext(ctx, logger)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

It implements a way to catch fatal errors that happen in go-routines. DRA plugin can catch them
and perform graceful shutdown. The implementation demonstrates this approach on catching
grpc.Server.Serve() error, which was not processed before, resulting in a DRA driver running,
but absolutely non functional after grpc.Server.Serve failure.

#### Special notes for your reviewer:

If this PR is accepted I'm going to modify example driver to fail on serving failures.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
