### PR TITLE
Fix CEL library doc string whitespace

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
@@ -70,7 +70,7 @@ import (
 //
 //   - asInteger: returns a representation of the current value as an int64 if
 //     possible or results in an error if conversion would result in overflow
-//	   or loss of precision.
+//     or loss of precision.
 //
 //   - asApproximateFloat: returns a float64 representation of the quantity which may
 //     lose precision. If the value of the quantity is outside the range of a float64
@@ -119,7 +119,6 @@ import (
 //
 //   - compareTo: Compares receiver to operand and returns 0 if they are equal, 1 if the receiver is greater, or -1 if the receiver is less than the operand
 //
-//
 //     <Quantity>.isLessThan(<quantity>) <bool>
 //     <Quantity>.isGreaterThan(<quantity>) <bool>
 //     <Quantity>.compareTo(<quantity>) <int>
@@ -133,7 +132,6 @@ import (
 // quantity("50Mi").isGreaterThan(quantity("100Mi")) // returns false
 // quantity("50M").isLessThan(quantity("100M")) // returns true
 // quantity("100M").isLessThan(quantity("50M")) // returns false
-
 func Quantity() cel.EnvOption {
 	return cel.Lib(quantityLib)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/semverlib.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/semverlib.go
@@ -37,6 +37,7 @@ import (
 // to semver.org documentation for information on accepted patterns.
 // An optional "normalize" argument can be passed to enable normalization. Normalization removes any "v" prefix, adds a
 // 0 minor and patch numbers to versions with only major or major.minor components specified, and removes any leading 0s.
+//
 //	semver(<string>) <Semver>
 //	semver(<string>, <bool>) <Semver>
 //
@@ -65,7 +66,7 @@ import (
 //
 //	isSemver('1.0.0') // returns true
 //	isSemver('hello') // returns false
-//  isSemver('v1.0')  // returns false (leading "v" is not allowed unless normalization is enabled)
+//	isSemver('v1.0')  // returns false (leading "v" is not allowed unless normalization is enabled)
 //	isSemver('v1.0', true) // Applies normalization to remove leading "v". returns true
 //	semver('1.0', true) // Applies normalization to add the missing patch version. Returns true
 //	semver('01.01.01', true) // Applies normalization to remove leading zeros. Returns true
@@ -88,7 +89,6 @@ import (
 //
 //   - compareTo: Compares receiver to operand and returns 0 if they are equal, 1 if the receiver is greater, or -1 if the receiver is less than the operand
 //
-//
 //     <Semver>.isLessThan(<semver>) <bool>
 //     <Semver>.isGreaterThan(<semver>) <bool>
 //     <Semver>.compareTo(<semver>) <int>
@@ -98,7 +98,6 @@ import (
 // semver("1.2.3").compareTo(semver("1.2.3")) // returns 0
 // semver("1.2.3").compareTo(semver("2.0.0")) // returns -1
 // semver("1.2.3").compareTo(semver("0.1.2")) // returns 1
-
 func SemverLib(options ...SemverOption) cel.EnvOption {
 	semverLib := &semverLibType{}
 	for _, o := range options {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes an issue I noticed where the [`library.Quantity`](https://pkg.go.dev/k8s.io/apiserver@v0.33.2/pkg/cel/library#Quantity) and [`library.SemverLib`](https://pkg.go.dev/k8s.io/apiserver@v0.33.2/pkg/cel/library#SemverLib) doc comments aren't being rendered on pkg.go.dev because their comments and type definitions are separated by a blank line. The other whitespace changes to those comments are the result of `gofmt`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

These changes can be verified locally by running
```
go run golang.org/x/pkgsite/cmd/pkgsite@latest
```
and navigating to http://localhost:8080/k8s.io/apiserver@v0.0.0/pkg/cel/library

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```