### PR TITLE
[PodLevelResources] Add more comprehensive test cases to kubelet

### DIFF
--- a/test/e2e/common/node/pod_level_resources.go
+++ b/test/e2e/common/node/pod_level_resources.go
@@ -152,7 +152,7 @@ func podLevelResourcesTests(f *framework.Framework) {
 		// and limits for the pod. If pod-level resource specifications
 		// are specified, totalPodResources is equal to pod-level resources.
 		// Otherwise, it is calculated by aggregating resource requests and
-		// limits from all containers within the pod..
+		// limits from all containers within the pod.
 		totalPodResources *cgroups.ContainerResources
 	}
 
@@ -161,11 +161,19 @@ func podLevelResourcesTests(f *framework.Framework) {
 		podResources *cgroups.ContainerResources
 		containers   []containerInfo
 		expected     expectedPodConfig
+		// If expectedPodLevelResourcesOverride is not specified,
+		// we check the PodSpec to verify whether the API server correctly injected default values
+		// by comparing it with expected.totalPodResources. In most cases, this comparison works fine.
+		// However, if pod-level limits are not specified and all containers have their limits set,
+		// the cgroup for the pod will be configured with the aggregated container-level limits.
+		// Still, the pod-level limits field itself will not have default values set.
+		// To cover this pattern, we allow overriding the values when comparing against the PodSpec.
+		expectedPodLevelResourcesOverride *cgroups.ContainerResources
 	}
 
 	tests := []testCase{
 		{
-			name: "Guaranteed QoS pod with container resources",
+			name: "Guaranteed QoS pod with only container resources",
 			containers: []containerInfo{
 				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "50m", MemReq: "70Mi", MemLim: "70Mi"}},
 				{Name: "c2", Resources: &cgroups.ContainerResources{CPUReq: "70m", CPULim: "70m", MemReq: "50Mi", MemLim: "50Mi"}},
@@ -209,6 +217,121 @@ func podLevelResourcesTests(f *framework.Framework) {
 			},
 		},
 		{
+			name:         "Guaranteed QoS pod, pod resources limits, no container resources",
+			podResources: &cgroups.ContainerResources{CPULim: "100m", MemLim: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1"},
+				{Name: "c2"},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSGuaranteed,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources limits, container resources limits",
+			podResources: &cgroups.ContainerResources{CPULim: "100m", MemLim: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPULim: "50m", MemLim: "50Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPULim: "30m", MemLim: "30Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "80m", CPULim: "100m", MemReq: "80Mi", MemLim: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources limits, container resources requests",
+			podResources: &cgroups.ContainerResources{CPULim: "100m", MemLim: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "50m", MemReq: "50Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPUReq: "30m", MemReq: "30Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "80m", CPULim: "100m", MemReq: "80Mi", MemLim: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources requests, no container resources",
+			podResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			containers:   []containerInfo{{Name: "c1"}, {Name: "c2"}},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources requests, container resources requests",
+			podResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "50m", MemReq: "50Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPUReq: "30m", MemReq: "30Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources requests, container resources requests and partial limits",
+			podResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "50m", MemReq: "50Mi", MemLim: "50Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPUReq: "30m", MemReq: "30Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources requests, container resources limits",
+			podResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPULim: "50m", MemLim: "50Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPULim: "50m", MemLim: "50Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"},
+			},
+			expectedPodLevelResourcesOverride: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources requests, partial container resources limits",
+			podResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPULim: "50m", MemLim: "50Mi"}},
+				{Name: "c2"},
+			},
+			expected: expectedPodConfig{
+				qos: v1.PodQOSBurstable,
+				// If container-level limits are not specified for all containers,
+				// cpu.max and memory.max will not be set.
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			},
+			expectedPodLevelResourcesOverride: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources requests, container resources requests and limits",
+			podResources: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "30m", CPULim: "30m", MemReq: "30Mi", MemLim: "30Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPUReq: "30m", CPULim: "30m", MemReq: "30Mi", MemLim: "30Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos: v1.PodQOSBurstable,
+				// At first glance, this may seem invalid. However, the value of CPUReq is only used
+				// to calculate the ratio for cpu.weight (i.e., CPU shares), and the absolute value
+				// of CPUReq is not directly applied. Therefore, it’s not a problem even if CPUReq
+				// exceeds CPULim. Similarly, when the MemoryQoS feature is disabled, MemReq is not
+				// used for memory.min, so it’s also fine for MemReq to exceed MemLim.
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "60m", MemReq: "100Mi", MemLim: "60Mi"},
+			},
+			expectedPodLevelResourcesOverride: &cgroups.ContainerResources{CPUReq: "100m", MemReq: "100Mi"},
+		},
+		{
 			name:         "Burstable QoS pod, no container resources",
 			podResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
 			containers: []containerInfo{
@@ -244,6 +367,53 @@ func podLevelResourcesTests(f *framework.Framework) {
 				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
 			},
 		},
+		{
+			name:         "Burstable QoS pod, pod resources requests and limits, container resources limits",
+			podResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPULim: "30m", MemLim: "30Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{CPULim: "20m", MemLim: "20Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, pod resources requests and limits, container resources requests",
+			podResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "50m", MemReq: "30Mi"}},
+				{Name: "c2", Resources: &cgroups.ContainerResources{MemReq: "20Mi"}},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "100m", MemReq: "50Mi", MemLim: "100Mi"},
+			},
+		},
+		{
+			name:         "Burstable QoS pod, partial requests in pod level resources, 1 container with guaranteed resources",
+			podResources: &cgroups.ContainerResources{CPUReq: "", CPULim: "200m", MemReq: "200Mi", MemLim: "200Mi"},
+			containers: []containerInfo{
+				{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "100Mi", MemLim: "100Mi"}},
+				{Name: "c2"},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBurstable,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "200Mi"},
+			},
+		},
+		{
+			name: "BestEffort QoS no pod resources, no container resources",
+			containers: []containerInfo{
+				{Name: "c1"},
+				{Name: "c2"},
+			},
+			expected: expectedPodConfig{
+				qos:               v1.PodQOSBestEffort,
+				totalPodResources: &cgroups.ContainerResources{CPUReq: "", CPULim: "", MemReq: "", MemLim: ""},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -256,7 +426,11 @@ func podLevelResourcesTests(f *framework.Framework) {
 			pod := podClient.CreateSync(ctx, testPod)
 
 			ginkgo.By("verifying pod resources are as expected")
-			verifyPodResources(*pod, tc.podResources, tc.expected.totalPodResources)
+			expectedPodResources := tc.expected.totalPodResources
+			if tc.expectedPodLevelResourcesOverride != nil {
+				expectedPodResources = tc.expectedPodLevelResourcesOverride
+			}
+			verifyPodResources(*pod, tc.podResources, expectedPodResources)
 
 			ginkgo.By("verifying pod QoS as expected")
 			verifyQoS(*pod, tc.expected.qos)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Added comprehensive test cases to the kubelet unit tests and node E2E tests. For the node E2E tests, I've added test cases based on the table in the [Comprehensive Tabular View](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2837-pod-level-resource-spec/README.md#comprehensive-tabular-view) section of the PodSpec Validation Rules in the KEP.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

KEP: https://github.com/kubernetes/enhancements/issues/2837

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/2837
```
