### PR TITLE
[PodLevelResources] Update Downward API defaulting for resource limits

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -114,6 +114,26 @@ func IsPodLevelRequestsSet(pod *v1.Pod) bool {
 	return false
 }
 
+// IsPodLevelLimitsSet checks if pod-level limits are set. It returns true if
+// Limits map is non-empty and contains at least one supported pod-level resource.
+func IsPodLevelLimitsSet(pod *v1.Pod) bool {
+	if pod.Spec.Resources == nil {
+		return false
+	}
+
+	if len(pod.Spec.Resources.Limits) == 0 {
+		return false
+	}
+
+	for resourceName := range pod.Spec.Resources.Limits {
+		if IsSupportedPodLevelResource(resourceName) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // PodRequests computes the total pod requests per the PodResourcesOptions supplied.
 // If PodResourcesOptions is nil, then the requests are returned including pod overhead.
 // If the PodLevelResources feature is enabled AND the pod-level resources are set,

--- a/test/e2e/common/node/downwardapi.go
+++ b/test/e2e/common/node/downwardapi.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,11 +30,10 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-
-	"github.com/onsi/ginkgo/v2"
 )
 
 var _ = SIGDescribe("Downward API", func() {
@@ -412,6 +414,164 @@ var _ = SIGDescribe("Downward API", framework.WithSerial(), framework.WithDisrup
 		})
 	})
 
+})
+
+var _ = SIGDescribe("Downward API", feature.PodLevelResources, func() {
+	f := framework.NewDefaultFramework("downward-api")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("Downward API tests for pod level resources", func() {
+		ginkgo.It("should provide default limits.cpu/memory from pod level resources", func(ctx context.Context) {
+			podName := "downward-api-" + string(uuid.NewUUID())
+			env := []v1.EnvVar{
+				{
+					Name: "CPU_LIMIT",
+					ValueFrom: &v1.EnvVarSource{
+						ResourceFieldRef: &v1.ResourceFieldSelector{
+							Resource: "limits.cpu",
+						},
+					},
+				},
+				{
+					Name: "MEMORY_LIMIT",
+					ValueFrom: &v1.EnvVarSource{
+						ResourceFieldRef: &v1.ResourceFieldSelector{
+							Resource: "limits.memory",
+						},
+					},
+				},
+			}
+
+			expectations := []string{
+				// Although the CPU limit for Pod Level Resources is set to 1250m (which would be 1.25),
+				// the Downward API uses convertResourceCPUToString to convert the value to a string,
+				// and this function rounds up the decimal, resulting in 2 here.
+				// https://github.com/kubernetes/kubernetes/blob/49cd87182cac80a4f3d29e2e65e80c8f88e890da/pkg/api/v1/resource/helpers.go#L148-L153
+				"CPU_LIMIT=2",
+				"MEMORY_LIMIT=67108864",
+			}
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   podName,
+					Labels: map[string]string{"name": podName},
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1250m"),
+							v1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:    "dapi-container",
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"sh", "-c", "env"},
+							Env:     env,
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+			testDownwardAPIUsingPod(ctx, f, pod, env, expectations)
+		})
+
+		ginkgo.It("should provide default limits.cpu/memory from pod level resources or node allocatable", func(ctx context.Context) {
+			podName := "downward-api-" + string(uuid.NewUUID())
+			cName := "dapi-container"
+			env := []v1.EnvVar{
+				{
+					Name: "CPU_LIMIT",
+					ValueFrom: &v1.EnvVarSource{
+						ResourceFieldRef: &v1.ResourceFieldSelector{
+							Resource: "limits.cpu",
+						},
+					},
+				},
+				{
+					Name: "MEMORY_LIMIT",
+					ValueFrom: &v1.EnvVarSource{
+						ResourceFieldRef: &v1.ResourceFieldSelector{
+							Resource: "limits.memory",
+						},
+					},
+				},
+			}
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   podName,
+					Labels: map[string]string{"name": podName},
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("1250m"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:    cName,
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"sh", "-c", "env"},
+							Env:     env,
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+
+			// Before the Pod Level Resources feature was introduced, if container-level
+			// resource limits were not set, the Downward API would return the node's
+			// allocatable resources instead of 0. So, it was sufficient to simply check
+			// that the value set in the environment variable was non-zero.
+			// However, after the Pod Level Resources feature was introduced, the node's
+			// allocatable resources are used as a fallback when pod-level resource limits
+			// are not specified. Therefore, we now need to verify that the value
+			// in the environment variable matches the node's allocatable resources.
+			// Because we need to dynamically retrieve the node's allocatable resources,
+			// we cannot simply use e2epodoutput.TestContainerOutputRegexp here.
+			podClient := e2epod.NewPodClient(f)
+			createdPod := podClient.Create(ctx, pod)
+			ginkgo.DeferCleanup(func(ctx context.Context) {
+				ginkgo.By("delete the pods")
+				podClient.DeleteSync(ctx, createdPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+			})
+
+			// Wait for client pod to complete.
+			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, createdPod.Name, f.Namespace.Name, f.Timeouts.PodStart)
+			framework.ExpectNoError(err)
+
+			// Grab its logs.  Get host first.
+			podStatus, err := podClient.Get(ctx, createdPod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			// Get the node allocatable resources
+			nodeName := podStatus.Spec.NodeName
+			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			// Prepare expectations based on node allocatable resources
+			expectations := []string{
+				// Although the CPU limit for Pod Level Resources is set to 1250m (which would be 1.25),
+				// the Downward API uses convertResourceCPUToString to convert the value to a string,
+				// and this function rounds up the decimal, resulting in 2 here.
+				// https://github.com/kubernetes/kubernetes/blob/49cd87182cac80a4f3d29e2e65e80c8f88e890da/pkg/api/v1/resource/helpers.go#L148-L153
+				"CPU_LIMIT=2",
+				fmt.Sprintf("MEMORY_LIMIT=%d", node.Status.Allocatable.Memory().Value()),
+			}
+
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podStatus.Name, cName)
+			framework.ExpectNoError(err)
+
+			ginkgo.By(fmt.Sprintf("Checking logs from node %s pod %s container %s", nodeName, podStatus.Name, cName))
+			for _, expected := range expectations {
+				m := gomega.MatchRegexp(expected)
+				matches, err := m.Match(logs)
+				framework.ExpectNoError(err)
+				gomega.Expect(matches).To(gomega.BeTrueBecause("expected %q in container output: %s", expected, logs))
+			}
+		})
+	})
 })
 
 func testDownwardAPI(ctx context.Context, f *framework.Framework, podName string, env []v1.EnvVar, expectations []string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Using the Downward API's [resourceFieldRef](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-resourcefieldref), you can inject values specified in `resources.limits`, such as CPU, memory, or ephemeral storage into environment variables. Currently, when container-level resource limits were not specified and the Downward API was used to set environment variables referencing them, the node's allocatable resources were used as the fallback. With the introduction of the Pod Level Resources feature, this behavior should be updated.

- If container-level resource limits are not specified, the Downward API now uses the pod-level resource limits instead.
- If neither container-level nor pod-level resource limits are specified, the behavior remains unchanged. It falls back to the node's allocatable resources.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes: #132603
KEP: https://github.com/kubernetes/enhancements/issues/2837

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The fallback behavior of the Downward API's `resourceFieldRef` field has been updated to account for pod-level resources: if container-level limits are not set, pod-level limits are now used before falling back to node allocatable resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/2837
```
