### PR TITLE
add paths section to scheduler statusz endpoint

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -392,7 +392,7 @@ func newEndpointsHandler(config *kubeschedulerconfig.KubeSchedulerConfiguration,
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
-		statusz.Install(pathRecorderMux, kubeScheduler, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion()))
+		statusz.Install(pathRecorderMux, kubeScheduler, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion(), statusz.WithListedPaths(pathRecorderMux.ListedPaths())))
 	}
 
 	return pathRecorderMux

--- a/test/integration/scheduler/serving/endpoints_test.go
+++ b/test/integration/scheduler/serving/endpoints_test.go
@@ -136,10 +136,11 @@ func TestEndpointHandlers(t *testing.T) {
 			path:             "/statusz",
 			requestHeader:    map[string]string{"Accept": "text/plain"},
 			wantResponseCode: http.StatusOK,
-			wantResponseBodyRegx: `^\n` +
+			wantResponseBodyRegx: `(?s)^\n` +
 				`kube-scheduler statusz\n` +
 				`Warning: This endpoint is not meant to be machine parseable, ` +
-				`has no formatting compatibility guarantees and is for debugging purposes only.`,
+				`has no formatting compatibility guarantees and is for debugging purposes only.+` +
+				`Paths([:=\s]+)/configz /flagz /healthz /livez /metrics /readyz\n$`,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #132539


```release-note
add paths section to scheduler statusz endpoint
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Example Response:

```
kube-scheduler statusz
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

Started:  Mon Jul 28 18:40:54 UTC 2025
Up:  0 hr 00 min 25 sec
Go version:  go1.24.5
Binary version:  1.34.0-alpha.2.1135+8057b7d344b577
Emulation version:  1.34
Paths:   /configz /healthz /livez /metrics /readyz

```
