### PR TITLE
test: assert pkg removal in pkg/scheduler

### DIFF
--- a/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
@@ -24,8 +24,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2/ktesting"
@@ -43,20 +42,24 @@ type frameworkContract interface {
 func TestFrameworkContract(t *testing.T) {
 	var f framework.Framework
 	var c frameworkContract = f
-	assert.Nil(t, c)
+	if !cmp.Equal(c, nil) {
+		t.Fatal("frameworkContract expected to be nil")
+	}
 }
 
 func TestNewFramework(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	var f interface{}
 	if f, _ = runtime.NewFramework(ctx, nil, nil); f != nil {
-		_, ok := f.(framework.Framework)
-		assert.True(t, ok)
+		if _, ok := f.(framework.Framework); !ok {
+			t.Fatalf("expected type to be framework.Framework, got %T", f)
+		}
 	}
 }
 
 func TestNewCycleState(t *testing.T) {
 	var state interface{} = framework.NewCycleState()
-	_, ok := state.(*framework.CycleState)
-	assert.True(t, ok)
+	if _, ok := state.(*framework.CycleState); !ok {
+		t.Fatalf("expected type to be framework.CycleState, got %T", state)
+	}
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1073,8 +1072,12 @@ func TestVolumeBinding(t *testing.T) {
 
 			t.Logf("Verify: call PreFilter and check status")
 			gotPreFilterResult, gotPreFilterStatus := p.PreFilter(ctx, state, item.pod, nil)
-			assert.Equal(t, item.wantPreFilterStatus, gotPreFilterStatus)
-			assert.Equal(t, item.wantPreFilterResult, gotPreFilterResult)
+			if !cmp.Equal(item.wantPreFilterStatus, gotPreFilterStatus) {
+				t.Fatalf("preFilter status mismatch (-want,+got):\n%s", cmp.Diff(item.wantPreFilterStatus, gotPreFilterStatus))
+			}
+			if !cmp.Equal(item.wantPreFilterResult, gotPreFilterResult) {
+				t.Fatalf("preFilter result mismatch (-want,+got):\n%s", cmp.Diff(item.wantPreFilterResult, gotPreFilterResult))
+			}
 
 			if !gotPreFilterStatus.IsSuccess() {
 				// scheduler framework will skip Filter if PreFilter fails
@@ -1104,7 +1107,9 @@ func TestVolumeBinding(t *testing.T) {
 			t.Logf("Verify: call Filter and check status")
 			for i, nodeInfo := range nodeInfos {
 				gotStatus := p.Filter(ctx, state, item.pod, nodeInfo)
-				assert.Equal(t, item.wantFilterStatus[i], gotStatus)
+				if !cmp.Equal(item.wantFilterStatus[i], gotStatus) {
+					t.Fatalf("filter status mismatch (-want,+got):\n%s", cmp.Diff(item.wantFilterStatus[i], gotStatus))
+				}
 			}
 
 			t.Logf("Verify: call PreScore and check status")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:

Scheduler testing cleanup according to SIG Scheduling [guidelines](https://github.com/kubernetes/community/blob/master/sig-scheduling/CONTRIBUTING.md#technical-and-style-guidelines)

#### Which issue(s) this PR is related to:

Issue https://github.com/kubernetes/kubernetes/issues/130407

#### Special notes for your reviewer:

Introduced a custom `eventuallyHelpper` implementation for `require.EventuallyWithT` removal, which referenced `assert.CollectT` (Plan to launch `"github.com/stretchr/testify/require"` removal in a separated PR).

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
