### PR TITLE
feat: increment an internal metric when duplicate validation errors are found

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -153,6 +153,7 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 
 	errs = append(errs, strategy.ValidateUpdate(ctx, obj, old)...)
 	if len(errs) > 0 {
+		RecordDuplicateValidationErrors(ctx, kind.GroupKind(), errs)
 		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -34,6 +34,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/validation"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 )
 
@@ -676,6 +679,71 @@ func TestValidateUpdateDeclarativelyWithRecovery(t *testing.T) {
 			t.Errorf("Expected errors but got nil")
 		}
 	})
+}
+
+func TestRecordDuplicateValidationErrors(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name           string
+		qualifiedKind  schema.GroupKind
+		errs           field.ErrorList
+		expectedMetric string
+	}{
+		{
+			name:          "detect duplicates and increment metric",
+			qualifiedKind: schema.GroupKind{Group: "apps", Kind: "ReplicaSet"},
+			errs: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicas"), -1, "must be greater than or equal to 0").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec").Child("replicas"), -1, "must be greater than or equal to 0").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec").Child("selector"), &metav1.LabelSelector{MatchLabels: map[string]string{}, MatchExpressions: []metav1.LabelSelectorRequirement{}}, "empty selector is invalid for deployment"),
+				field.Invalid(field.NewPath("spec").Child("selector"), &metav1.LabelSelector{MatchLabels: map[string]string{}, MatchExpressions: []metav1.LabelSelectorRequirement{}}, "empty selector is invalid for deployment"),
+			},
+			expectedMetric: `
+			# HELP apiserver_validation_duplicate_validation_error_total [INTERNAL] Number of duplicate validation errors during validation.
+			# TYPE apiserver_validation_duplicate_validation_error_total counter
+			apiserver_validation_duplicate_validation_error_total 2
+			`,
+		},
+		{
+			name:          "detect duplicates with all fields but origin being equal",
+			qualifiedKind: schema.GroupKind{Group: "apps", Kind: "ReplicaSet"},
+			errs: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicas"), -1, "must be greater than or equal to 0").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec").Child("replicas"), -1, "must be greater than or equal to 0").WithOrigin("min"),
+			},
+			expectedMetric: `
+			# HELP apiserver_validation_duplicate_validation_error_total [INTERNAL] Number of duplicate validation errors during validation.
+			# TYPE apiserver_validation_duplicate_validation_error_total counter
+			apiserver_validation_duplicate_validation_error_total 1
+			`,
+		},
+		{
+			name:          "no duplicates",
+			qualifiedKind: schema.GroupKind{Group: "apps", Kind: "ReplicaSet"},
+			errs: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("replicas"), -1, "must be greater than or equal to 0").WithOrigin("minimum"),
+				field.Invalid(field.NewPath("spec").Child("selector"), &metav1.LabelSelector{MatchLabels: map[string]string{}, MatchExpressions: []metav1.LabelSelectorRequirement{}}, "empty selector is invalid for deployment"),
+			},
+			expectedMetric: `
+			# HELP apiserver_validation_duplicate_validation_error_total [INTERNAL] Number of duplicate validation errors during validation.
+			# TYPE apiserver_validation_duplicate_validation_error_total counter
+			apiserver_validation_duplicate_validation_error_total 0
+			`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer legacyregistry.Reset()
+			defer validation.ResetValidationMetricsInstance()
+			RecordDuplicateValidationErrors(ctx, tc.qualifiedKind, tc.errs)
+
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedMetric), "apiserver_validation_duplicate_validation_error_total"); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }
 
 func equalErrorLists(a, b field.ErrorList) bool {

--- a/staging/src/k8s.io/apiserver/pkg/validation/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/validation/metrics.go
@@ -30,6 +30,7 @@ const (
 type ValidationMetrics interface {
 	IncDeclarativeValidationMismatchMetric()
 	IncDeclarativeValidationPanicMetric()
+	IncDuplicateValidationErrorMetric()
 	Reset()
 }
 
@@ -52,6 +53,15 @@ var validationMetricsInstance = &validationMetrics{
 			StabilityLevel: metrics.BETA,
 		},
 	),
+	DuplicateValidationErrorCounter: metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "duplicate_validation_error_total",
+			Help:           "Number of duplicate validation errors during validation.",
+			StabilityLevel: metrics.INTERNAL,
+		},
+	),
 }
 
 // Metrics provides access to validation metrics.
@@ -60,17 +70,20 @@ var Metrics ValidationMetrics = validationMetricsInstance
 func init() {
 	legacyregistry.MustRegister(validationMetricsInstance.DeclarativeValidationMismatchCounter)
 	legacyregistry.MustRegister(validationMetricsInstance.DeclarativeValidationPanicCounter)
+	legacyregistry.MustRegister(validationMetricsInstance.DuplicateValidationErrorCounter)
 }
 
 type validationMetrics struct {
 	DeclarativeValidationMismatchCounter *metrics.Counter
 	DeclarativeValidationPanicCounter    *metrics.Counter
+	DuplicateValidationErrorCounter      *metrics.Counter
 }
 
 // Reset resets the validation metrics.
 func (m *validationMetrics) Reset() {
 	m.DeclarativeValidationMismatchCounter.Reset()
 	m.DeclarativeValidationPanicCounter.Reset()
+	m.DuplicateValidationErrorCounter.Reset()
 }
 
 // IncDeclarativeValidationMismatchMetric increments the counter for the declarative_validation_mismatch_total metric.
@@ -81,6 +94,11 @@ func (m *validationMetrics) IncDeclarativeValidationMismatchMetric() {
 // IncDeclarativeValidationPanicMetric increments the counter for the declarative_validation_panic_total metric.
 func (m *validationMetrics) IncDeclarativeValidationPanicMetric() {
 	m.DeclarativeValidationPanicCounter.Inc()
+}
+
+// IncDuplicateValidationErrorMetric increments the counter for the duplicate_validation_error_total metric.
+func (m *validationMetrics) IncDuplicateValidationErrorMetric() {
+	m.DuplicateValidationErrorCounter.Inc()
 }
 
 func ResetValidationMetricsInstance() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Several resources currently emit duplicate validation errors during update operations. This results in bloated and confusing API responses and redundant processing. I've submitted a few PRs to address specific cases, but there are likely many more instances still present in the codebase.

Detecting these duplicates is challenging because kubectl deduplicates error messages before displaying them to the user and hiding the issue.

This PR introduces an internal metric and a log message to track the duplicate validation errors. It provides visibility into remaining duplicates and help to identify opportunities for further cleanup.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #130656

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
