### PR TITLE
Add ServiceAccountTokenCacheType support to credential provider plugin

### DIFF
--- a/pkg/credentialprovider/plugin/config_test.go
+++ b/pkg/credentialprovider/plugin/config_test.go
@@ -929,6 +929,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience: "audience",
+							CacheType:                   kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
 							RequireServiceAccount:       ptr.To(true),
 						},
 					},
@@ -946,6 +947,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						DefaultCacheDuration: &metav1.Duration{Duration: time.Minute},
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
+							CacheType:                            kubeletconfig.TokenServiceAccountTokenCacheType,
 							RequiredServiceAccountAnnotationKeys: []string{"prefix.io/annotation-1", "prefix.io/annotation-2"},
 							RequireServiceAccount:                ptr.To(true),
 						},
@@ -954,6 +956,45 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 			},
 			saTokenForCredentialProviders: true,
 			expectErr:                     `providers.tokenAttributes.serviceAccountTokenAudience: Required value`,
+		},
+		{
+			name: "token attributes not nil but empty CacheType",
+			config: &kubeletconfig.CredentialProviderConfig{
+				Providers: []kubeletconfig.CredentialProvider{
+					{
+						Name:                 "foobar",
+						MatchImages:          []string{"foobar.registry.io"},
+						DefaultCacheDuration: &metav1.Duration{Duration: time.Minute},
+						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
+						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
+							ServiceAccountTokenAudience: "audience",
+							RequireServiceAccount:       ptr.To(true),
+						},
+					},
+				},
+			},
+			saTokenForCredentialProviders: true,
+			expectErr:                     `providers.tokenAttributes.cacheType: Required value: cacheType is required to be set when tokenAttributes is specified. Supported values are: ServiceAccount, Token`,
+		},
+		{
+			name: "token attributes not nil, invalid CacheType",
+			config: &kubeletconfig.CredentialProviderConfig{
+				Providers: []kubeletconfig.CredentialProvider{
+					{
+						Name:                 "foobar",
+						MatchImages:          []string{"foobar.registry.io"},
+						DefaultCacheDuration: &metav1.Duration{Duration: time.Minute},
+						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
+						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
+							ServiceAccountTokenAudience: "audience",
+							CacheType:                   "invalid-cache-type",
+							RequireServiceAccount:       ptr.To(true),
+						},
+					},
+				},
+			},
+			saTokenForCredentialProviders: true,
+			expectErr:                     `providers.tokenAttributes.cacheType: Unsupported value: "invalid-cache-type": supported values: "ServiceAccount", "Token"`,
 		},
 		{
 			name: "token attributes not nil but empty ServiceAccountTokenRequired",
@@ -966,6 +1007,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
 							RequiredServiceAccountAnnotationKeys: []string{"prefix.io/annotation-1", "prefix.io/annotation-2"},
 						},
 					},
@@ -985,6 +1027,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.TokenServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							RequiredServiceAccountAnnotationKeys: []string{"cantendwithadash-", "now-with-dashes/simple"}, // first key is invalid
 						},
@@ -1005,6 +1048,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							OptionalServiceAccountAnnotationKeys: []string{"cantendwithadash-", "now-with-dashes/simple"}, // first key is invalid
 						},
@@ -1025,6 +1069,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.TokenServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							RequiredServiceAccountAnnotationKeys: []string{"now-with-dashes/simple", "now-with-dashes/simple"},
 						},
@@ -1045,6 +1090,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							OptionalServiceAccountAnnotationKeys: []string{"now-with-dashes/simple", "now-with-dashes/simple"},
 						},
@@ -1065,6 +1111,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.TokenServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							RequiredServiceAccountAnnotationKeys: []string{"now-with-dashes/simple-1", "now-with-dashes/simple-2"},
 							OptionalServiceAccountAnnotationKeys: []string{"now-with-dashes/simple-2", "now-with-dashes/simple-3"},
@@ -1086,6 +1133,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(false),
 							RequiredServiceAccountAnnotationKeys: []string{"now-with-dashes/simple-1", "now-with-dashes/simple-2"},
 						},
@@ -1106,6 +1154,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.TokenServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							RequiredServiceAccountAnnotationKeys: []string{"now-with-dashes/simple-1", "now-with-dashes/simple-2"},
 							OptionalServiceAccountAnnotationKeys: []string{"now-with-dashes/simple-3"},
@@ -1126,6 +1175,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1alpha1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.TokenServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							RequiredServiceAccountAnnotationKeys: []string{"now-with-dashes/simple"},
 						},
@@ -1146,6 +1196,7 @@ func Test_validateCredentialProviderConfig(t *testing.T) {
 						APIVersion:           "credentialprovider.kubelet.k8s.io/v1beta1",
 						TokenAttributes: &kubeletconfig.ServiceAccountTokenAttributes{
 							ServiceAccountTokenAudience:          "audience",
+							CacheType:                            kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
 							RequireServiceAccount:                ptr.To(true),
 							RequiredServiceAccountAnnotationKeys: []string{"now-with-dashes/simple"},
 						},

--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -451,6 +451,55 @@ func Test_Provide(t *testing.T) {
 			wantLog:      "Error getting service account token ns/sa-name: failed to get token",
 		},
 		{
+			name: "[service account mode] cache type not token but service account echoed back",
+			pluginProvider: &perPodPluginProvider{
+				provider: &pluginProvider{
+					clock:          tclock,
+					lastCachePurge: tclock.Now(),
+					matchImages:    []string{"test.registry.io"},
+					cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+					plugin: &fakeExecPlugin{
+						cacheKeyType: credentialproviderapi.ImagePluginCacheKeyType,
+						auth: map[string]credentialproviderapi.AuthConfig{
+							"test.registry.io/foo/bar": {
+								Username: "user",
+								Password: "token", // this is the service account token being echoed back
+							},
+						},
+					},
+					serviceAccountProvider: &serviceAccountProvider{
+						requireServiceAccount: true,
+						requiredServiceAccountAnnotationKeys: []string{
+							"domain.io/identity-id",
+						},
+						optionalServiceAccountAnnotationKeys: []string{
+							"domain.io/identity-type",
+						},
+						getServiceAccountFunc: func(_, _ string) (*v1.ServiceAccount, error) {
+							return &v1.ServiceAccount{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "sa-name",
+									Namespace: "ns",
+									Annotations: map[string]string{
+										"domain.io/identity-id": "id",
+									},
+								},
+							}, nil
+						},
+						getServiceAccountTokenFunc: func(_, _ string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+							return &authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil
+						},
+					},
+				},
+				podName:            "pod-name",
+				podNamespace:       "ns",
+				serviceAccountName: "sa-name",
+			},
+			image:        "test.registry.io/foo/bar",
+			dockerconfig: credentialprovider.DockerConfig{},
+			wantLog:      `Credential provider plugin returned the service account token as the password for image "test.registry.io/foo/bar", which is not allowed when service account cache type is not set to 'Token'`,
+		},
+		{
 			name: "[service account mode] exact image match",
 			pluginProvider: &perPodPluginProvider{
 				provider: &pluginProvider{
@@ -734,7 +783,18 @@ func Test_getCachedCredentials_pluginUsingServiceAccount(t *testing.T) {
 		},
 	}
 
-	serviceAccountCacheKey, err := generateServiceAccountCacheKey("namespace", "serviceAccountName", "service-account-uid", map[string]string{"prefix.io/annotation-1": "value1", "prefix.io/annotation-2": "value2"})
+	c := cacheKeyParams{
+		namespace:          "namespace",
+		serviceAccountName: "serviceAccountName",
+		serviceAccountUID:  "service-account-uid",
+		saAnnotations: map[string]string{
+			"prefix.io/annotation-1": "value1",
+			"prefix.io/annotation-2": "value2",
+		},
+		podName: "pod-name",
+		podUID:  "pod-uid",
+	}
+	serviceAccountCacheKey, err := generateServiceAccountCacheKey(c)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -1022,402 +1082,6 @@ func Test_decodeResponse(t *testing.T) {
 	}
 }
 
-func Test_RegistryCacheKeyType(t *testing.T) {
-	tclock := clock.RealClock{}
-
-	tests := []struct {
-		name              string
-		pluginProvider    *perPodPluginProvider
-		expectedCacheKeys func(p *pluginProvider) []string
-	}{
-		{
-			name: "plugin not using service account token",
-			pluginProvider: &perPodPluginProvider{
-				provider: &pluginProvider{
-					clock:          tclock,
-					lastCachePurge: tclock.Now(),
-					matchImages:    []string{"*.registry.io"},
-					cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
-					plugin: &fakeExecPlugin{
-						cacheKeyType:  credentialproviderapi.RegistryPluginCacheKeyType,
-						cacheDuration: time.Hour,
-						auth: map[string]credentialproviderapi.AuthConfig{
-							"*.registry.io": {
-								Username: "user",
-								Password: "password",
-							},
-						},
-					},
-				},
-				podName:            "pod-name",
-				podNamespace:       "namespace",
-				podUID:             types.UID("pod-uid"),
-				serviceAccountName: "service-account-name",
-			},
-			expectedCacheKeys: func(p *pluginProvider) []string {
-				return []string{"\x00\x10test.registry.io\x00\x00"}
-			},
-		},
-		{
-			name: "plugin using service account token",
-			pluginProvider: &perPodPluginProvider{
-				provider: &pluginProvider{
-					clock:          tclock,
-					lastCachePurge: tclock.Now(),
-					matchImages:    []string{"*.registry.io"},
-					cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
-					serviceAccountProvider: &serviceAccountProvider{
-						audience:                             "audience",
-						requiredServiceAccountAnnotationKeys: []string{"prefix.io/annotation-1", "prefix.io/annotation-2"},
-						getServiceAccountFunc: func(namespace, name string) (*v1.ServiceAccount, error) {
-							return &v1.ServiceAccount{
-								ObjectMeta: metav1.ObjectMeta{
-									Namespace: namespace,
-									Name:      name,
-									UID:       "service-account-uid",
-									Annotations: map[string]string{
-										"prefix.io/annotation-1": "value1",
-										"prefix.io/annotation-2": "value2",
-									},
-								},
-							}, nil
-						},
-						getServiceAccountTokenFunc: func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-							return &authenticationv1.TokenRequest{}, nil
-						},
-					},
-					plugin: &fakeExecPlugin{
-						cacheKeyType:  credentialproviderapi.RegistryPluginCacheKeyType,
-						cacheDuration: time.Hour,
-						auth: map[string]credentialproviderapi.AuthConfig{
-							"*.registry.io": {
-								Username: "user",
-								Password: "password",
-							},
-						},
-					},
-				},
-				podName:            "pod-name",
-				podNamespace:       "namespace",
-				podUID:             types.UID("pod-uid"),
-				serviceAccountName: "service-account-name",
-			},
-			expectedCacheKeys: func(p *pluginProvider) []string {
-				serviceAccountCacheKey, err := generateServiceAccountCacheKey("namespace", "service-account-name", "service-account-uid", map[string]string{"prefix.io/annotation-1": "value1", "prefix.io/annotation-2": "value2"})
-				if err != nil {
-					t.Fatalf("Unexpected error %v", err)
-				}
-				cacheKey, err := generateCacheKey("test.registry.io", serviceAccountCacheKey)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return []string{cacheKey}
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			expectedDockerConfig := credentialprovider.DockerConfig{
-				"*.registry.io": credentialprovider.DockerConfigEntry{
-					Username: "user",
-					Password: "password",
-				},
-			}
-
-			dockerConfig := test.pluginProvider.Provide("test.registry.io/foo/bar")
-			if !reflect.DeepEqual(dockerConfig, expectedDockerConfig) {
-				t.Logf("actual docker config: %v", dockerConfig)
-				t.Logf("expected docker config: %v", expectedDockerConfig)
-				t.Fatal("unexpected docker config")
-			}
-
-			cacheKeys := test.pluginProvider.provider.cache.ListKeys()
-
-			expectedCacheKeys := test.expectedCacheKeys(test.pluginProvider.provider)
-			if !reflect.DeepEqual(cacheKeys, expectedCacheKeys) {
-				t.Logf("actual cache keys: %#v", cacheKeys)
-				t.Logf("expected cache keys: %v", expectedCacheKeys)
-				t.Error("unexpected cache keys")
-			}
-
-			// nil out the exec plugin, this will test whether credentialproviderapi are fetched
-			// from cache, otherwise Provider should panic
-			test.pluginProvider.provider.plugin = nil
-			dockerConfig = test.pluginProvider.Provide("test.registry.io/foo/bar")
-			if !reflect.DeepEqual(dockerConfig, expectedDockerConfig) {
-				t.Logf("actual docker config: %v", dockerConfig)
-				t.Logf("expected docker config: %v", expectedDockerConfig)
-				t.Fatal("unexpected docker config")
-			}
-		})
-	}
-}
-
-func Test_ImageCacheKeyType(t *testing.T) {
-	tclock := clock.RealClock{}
-
-	tests := []struct {
-		name              string
-		pluginProvider    *perPodPluginProvider
-		expectedCacheKeys func(p *pluginProvider) []string
-	}{
-		{
-			name: "plugin not using service account token",
-			pluginProvider: &perPodPluginProvider{
-				provider: &pluginProvider{
-					clock:          tclock,
-					lastCachePurge: tclock.Now(),
-					matchImages:    []string{"*.registry.io"},
-					cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
-					plugin: &fakeExecPlugin{
-						cacheKeyType:  credentialproviderapi.ImagePluginCacheKeyType,
-						cacheDuration: time.Hour,
-						auth: map[string]credentialproviderapi.AuthConfig{
-							"*.registry.io": {
-								Username: "user",
-								Password: "password",
-							},
-						},
-					},
-				},
-				podName:            "pod-name",
-				podNamespace:       "namespace",
-				podUID:             types.UID("pod-uid"),
-				serviceAccountName: "service-account-name",
-			},
-			expectedCacheKeys: func(p *pluginProvider) []string {
-				return []string{"\x00\x18test.registry.io/foo/bar\x00\x00"}
-			},
-		},
-		{
-			name: "plugin using service account token",
-			pluginProvider: &perPodPluginProvider{
-				provider: &pluginProvider{
-					clock:          tclock,
-					lastCachePurge: tclock.Now(),
-					matchImages:    []string{"*.registry.io"},
-					cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
-					plugin: &fakeExecPlugin{
-						cacheKeyType:  credentialproviderapi.ImagePluginCacheKeyType,
-						cacheDuration: time.Hour,
-						auth: map[string]credentialproviderapi.AuthConfig{
-							"*.registry.io": {
-								Username: "user",
-								Password: "password",
-							},
-						},
-					},
-					serviceAccountProvider: &serviceAccountProvider{
-						audience:                             "audience",
-						requiredServiceAccountAnnotationKeys: []string{"prefix.io/annotation-1", "prefix.io/annotation-2"},
-						getServiceAccountFunc: func(namespace, name string) (*v1.ServiceAccount, error) {
-							return &v1.ServiceAccount{
-								ObjectMeta: metav1.ObjectMeta{
-									Namespace: namespace,
-									Name:      name,
-									UID:       "service-account-uid",
-									Annotations: map[string]string{
-										"prefix.io/annotation-1": "value1",
-										"prefix.io/annotation-2": "value2",
-									},
-								},
-							}, nil
-						},
-						getServiceAccountTokenFunc: func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-							return &authenticationv1.TokenRequest{}, nil
-						},
-					},
-				},
-				podName:            "pod-name",
-				podNamespace:       "namespace",
-				podUID:             types.UID("pod-uid"),
-				serviceAccountName: "service-account-name",
-			},
-			expectedCacheKeys: func(p *pluginProvider) []string {
-				serviceAccountCacheKey, err := generateServiceAccountCacheKey("namespace", "service-account-name", "service-account-uid", map[string]string{"prefix.io/annotation-1": "value1", "prefix.io/annotation-2": "value2"})
-				if err != nil {
-					t.Fatalf("Unexpected error %v", err)
-				}
-				cacheKey, err := generateCacheKey("test.registry.io/foo/bar", serviceAccountCacheKey)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return []string{cacheKey}
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			expectedDockerConfig := credentialprovider.DockerConfig{
-				"*.registry.io": credentialprovider.DockerConfigEntry{
-					Username: "user",
-					Password: "password",
-				},
-			}
-
-			dockerConfig := test.pluginProvider.Provide("test.registry.io/foo/bar")
-			if !reflect.DeepEqual(dockerConfig, expectedDockerConfig) {
-				t.Logf("actual docker config: %v", dockerConfig)
-				t.Logf("expected docker config: %v", expectedDockerConfig)
-				t.Fatal("unexpected docker config")
-			}
-
-			cacheKeys := test.pluginProvider.provider.cache.ListKeys()
-
-			expectedCacheKeys := test.expectedCacheKeys(test.pluginProvider.provider)
-			if !reflect.DeepEqual(cacheKeys, expectedCacheKeys) {
-				t.Logf("actual cache keys: %#v", cacheKeys)
-				t.Logf("expected cache keys: %v", expectedCacheKeys)
-				t.Error("unexpected cache keys")
-			}
-
-			// nil out the exec plugin, this will test whether credentialproviderapi are fetched
-			// from cache, otherwise Provider should panic
-			test.pluginProvider.provider.plugin = nil
-			dockerConfig = test.pluginProvider.Provide("test.registry.io/foo/bar")
-			if !reflect.DeepEqual(dockerConfig, expectedDockerConfig) {
-				t.Logf("actual docker config: %v", dockerConfig)
-				t.Logf("expected docker config: %v", expectedDockerConfig)
-				t.Fatal("unexpected docker config")
-			}
-		})
-	}
-}
-
-func Test_GlobalCacheKeyType(t *testing.T) {
-	tclock := clock.RealClock{}
-
-	tests := []struct {
-		name              string
-		pluginProvider    *perPodPluginProvider
-		expectedCacheKeys func(p *pluginProvider) []string
-	}{
-		{
-			name: "plugin not using service account token",
-			pluginProvider: &perPodPluginProvider{
-				provider: &pluginProvider{
-					clock:          tclock,
-					lastCachePurge: tclock.Now(),
-					matchImages:    []string{"*.registry.io"},
-					cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
-					plugin: &fakeExecPlugin{
-						cacheKeyType:  credentialproviderapi.GlobalPluginCacheKeyType,
-						cacheDuration: time.Hour,
-						auth: map[string]credentialproviderapi.AuthConfig{
-							"*.registry.io": {
-								Username: "user",
-								Password: "password",
-							},
-						},
-					},
-				},
-				podName:            "pod-name",
-				podNamespace:       "namespace",
-				podUID:             types.UID("pod-uid"),
-				serviceAccountName: "service-account-name",
-			},
-			expectedCacheKeys: func(p *pluginProvider) []string {
-				return []string{"\x00\x06global\x00\x00"}
-			},
-		},
-		{
-			name: "plugin using service account token",
-			pluginProvider: &perPodPluginProvider{
-				provider: &pluginProvider{
-					clock:          tclock,
-					lastCachePurge: tclock.Now(),
-					matchImages:    []string{"*.registry.io"},
-					cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
-					plugin: &fakeExecPlugin{
-						cacheKeyType:  credentialproviderapi.GlobalPluginCacheKeyType,
-						cacheDuration: time.Hour,
-						auth: map[string]credentialproviderapi.AuthConfig{
-							"*.registry.io": {
-								Username: "user",
-								Password: "password",
-							},
-						},
-					},
-					serviceAccountProvider: &serviceAccountProvider{
-						audience:                             "audience",
-						requiredServiceAccountAnnotationKeys: []string{"prefix.io/annotation-1", "prefix.io/annotation-2"},
-						getServiceAccountFunc: func(namespace, name string) (*v1.ServiceAccount, error) {
-							return &v1.ServiceAccount{
-								ObjectMeta: metav1.ObjectMeta{
-									Namespace: namespace,
-									Name:      name,
-									UID:       "service-account-uid",
-									Annotations: map[string]string{
-										"prefix.io/annotation-1": "value1",
-										"prefix.io/annotation-2": "value2",
-									},
-								},
-							}, nil
-						},
-						getServiceAccountTokenFunc: func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-							return &authenticationv1.TokenRequest{}, nil
-						},
-					},
-				},
-				podName:            "pod-name",
-				podNamespace:       "namespace",
-				podUID:             types.UID("pod-uid"),
-				serviceAccountName: "service-account-name",
-			},
-			expectedCacheKeys: func(p *pluginProvider) []string {
-				serviceAccountCacheKey, err := generateServiceAccountCacheKey("namespace", "service-account-name", "service-account-uid", map[string]string{"prefix.io/annotation-1": "value1", "prefix.io/annotation-2": "value2"})
-				if err != nil {
-					t.Fatalf("Unexpected error %v", err)
-				}
-				cacheKey, err := generateCacheKey(globalCacheKey, serviceAccountCacheKey)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return []string{cacheKey}
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			expectedDockerConfig := credentialprovider.DockerConfig{
-				"*.registry.io": credentialprovider.DockerConfigEntry{
-					Username: "user",
-					Password: "password",
-				},
-			}
-
-			dockerConfig := test.pluginProvider.Provide("test.registry.io/foo/bar")
-			if !reflect.DeepEqual(dockerConfig, expectedDockerConfig) {
-				t.Logf("actual docker config: %v", dockerConfig)
-				t.Logf("expected docker config: %v", expectedDockerConfig)
-				t.Fatal("unexpected docker config")
-			}
-
-			cacheKeys := test.pluginProvider.provider.cache.ListKeys()
-
-			expectedCacheKeys := test.expectedCacheKeys(test.pluginProvider.provider)
-			if !reflect.DeepEqual(cacheKeys, expectedCacheKeys) {
-				t.Logf("actual cache keys: %#v", cacheKeys)
-				t.Logf("expected cache keys: %v", expectedCacheKeys)
-				t.Error("unexpected cache keys")
-			}
-
-			// nil out the exec plugin, this will test whether credentialproviderapi are fetched
-			// from cache, otherwise Provider should panic
-			test.pluginProvider.provider.plugin = nil
-			dockerConfig = test.pluginProvider.Provide("test.registry.io/foo/bar")
-			if !reflect.DeepEqual(dockerConfig, expectedDockerConfig) {
-				t.Logf("actual docker config: %v", dockerConfig)
-				t.Logf("expected docker config: %v", expectedDockerConfig)
-				t.Fatal("unexpected docker config")
-			}
-		})
-	}
-}
-
 func Test_NoCacheResponse(t *testing.T) {
 	tclock := clock.RealClock{}
 	pluginProvider := &perPodPluginProvider{
@@ -1609,8 +1273,16 @@ func TestGenerateServiceAccountCacheKey_Deterministic(t *testing.T) {
 		for _, tc2 := range testCases {
 			tc2 := tc2
 			t.Run(fmt.Sprintf("%+v-%+v", tc, tc2), func(t *testing.T) {
-				serviceAccountCacheKey1, err1 := generateServiceAccountCacheKey(tc.serviceAccountNamespace, tc.serviceAccountName, tc.serviceAccountUID, tc.requiredAnnotations)
-				serviceAccountCacheKey2, err2 := generateServiceAccountCacheKey(tc2.serviceAccountNamespace, tc2.serviceAccountName, tc2.serviceAccountUID, tc2.requiredAnnotations)
+				serviceAccountCacheKey1, err1 := generateServiceAccountCacheKey(cacheKeyParams{
+					namespace:          tc.serviceAccountNamespace,
+					serviceAccountName: tc.serviceAccountName,
+					serviceAccountUID:  tc.serviceAccountUID,
+					saAnnotations:      tc.requiredAnnotations})
+				serviceAccountCacheKey2, err2 := generateServiceAccountCacheKey(cacheKeyParams{
+					namespace:          tc2.serviceAccountNamespace,
+					serviceAccountName: tc2.serviceAccountName,
+					serviceAccountUID:  tc2.serviceAccountUID,
+					saAnnotations:      tc2.requiredAnnotations})
 
 				if err1 != nil || err2 != nil {
 					t.Errorf("expected no error, but got err1=%v, err2=%v", err1, err2)
@@ -1642,6 +1314,7 @@ func TestGenerateServiceAccountCacheKey(t *testing.T) {
 		saName        string
 		saUID         types.UID
 		saAnnotations map[string]string
+		cacheType     kubeletconfig.ServiceAccountTokenCacheType
 		want          string
 	}{
 		{
@@ -1676,11 +1349,31 @@ func TestGenerateServiceAccountCacheKey(t *testing.T) {
 			saAnnotations: map[string]string{"domain.io/annotation-2": "value2", "domain.io/annotation-1": "value1"},
 			want:          "\x00\tnamespace\x00\x0fservice-account\x00\x13service-account-uid\x00\x00\x00\x02\x00\x16domain.io/annotation-1\x00\x06value1\x00\x16domain.io/annotation-2\x00\x06value2",
 		},
+		{
+			name:          "token hash included",
+			saNamespace:   "namespace",
+			saName:        "service-account",
+			saUID:         "service-account-uid",
+			saAnnotations: map[string]string{"domain.io/annotation-2": "value2", "domain.io/annotation-1": "value1"},
+			cacheType:     kubeletconfig.TokenServiceAccountTokenCacheType,
+			want:          "\x00\tnamespace\x00\x0fservice-account\x00\x13service-account-uid\x00\x00\x00\x02\x00\x16domain.io/annotation-1\x00\x06value1\x00\x16domain.io/annotation-2\x00\x06value2\x00\x05token\x00Gsha256:f7a41acb9633520e657fe58dedcd9e6a784e2d97e4c646492b45c61e28595c70",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := generateServiceAccountCacheKey(tc.saNamespace, tc.saName, tc.saUID, tc.saAnnotations)
+			c := cacheKeyParams{
+				namespace:          tc.saNamespace,
+				serviceAccountName: tc.saName,
+				serviceAccountUID:  tc.saUID,
+				saAnnotations:      tc.saAnnotations,
+				podName:            "pod-name",
+				podUID:             "pod-uid",
+				saTokenHash:        "sha256:f7a41acb9633520e657fe58dedcd9e6a784e2d97e4c646492b45c61e28595c70",
+				cacheType:          tc.cacheType,
+			}
+
+			got, err := generateServiceAccountCacheKey(c)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -1749,5 +1442,237 @@ func TestRequiredAnnotationNotFoundErr(t *testing.T) {
 				t.Errorf("expected %v, got %v", test.expected, got)
 			}
 		})
+	}
+}
+
+func Test_CacheKeyGeneration(t *testing.T) {
+	type cacheKeyTestCase struct {
+		name                    string
+		pluginCacheKeyType      credentialproviderapi.PluginCacheKeyType
+		serviceAccountCacheType kubeletconfig.ServiceAccountTokenCacheType // empty string means no SA mode
+		expectedCacheKeyFunc    func(t *testing.T, image string, saParams *cacheKeyParams) string
+	}
+
+	testCases := []cacheKeyTestCase{
+		{
+			name:                    "image-no-sa",
+			pluginCacheKeyType:      credentialproviderapi.ImagePluginCacheKeyType,
+			serviceAccountCacheType: "",
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				return generateExpectedCacheKey(t, image, "")
+			},
+		},
+		{
+			name:                    "image-sa-serviceaccount",
+			pluginCacheKeyType:      credentialproviderapi.ImagePluginCacheKeyType,
+			serviceAccountCacheType: kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				saKey := generateExpectedSACacheKey(t, saParams, kubeletconfig.ServiceAccountServiceAccountTokenCacheType)
+				return generateExpectedCacheKey(t, image, saKey)
+			},
+		},
+		{
+			name:                    "image-sa-token",
+			pluginCacheKeyType:      credentialproviderapi.ImagePluginCacheKeyType,
+			serviceAccountCacheType: kubeletconfig.TokenServiceAccountTokenCacheType,
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				saKey := generateExpectedSACacheKey(t, saParams, kubeletconfig.TokenServiceAccountTokenCacheType)
+				return generateExpectedCacheKey(t, image, saKey)
+			},
+		},
+		{
+			name:                    "registry-no-sa",
+			pluginCacheKeyType:      credentialproviderapi.RegistryPluginCacheKeyType,
+			serviceAccountCacheType: "",
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				registry := parseRegistry(image)
+				return generateExpectedCacheKey(t, registry, "")
+			},
+		},
+		{
+			name:                    "registry-sa-serviceaccount",
+			pluginCacheKeyType:      credentialproviderapi.RegistryPluginCacheKeyType,
+			serviceAccountCacheType: kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				registry := parseRegistry(image)
+				saKey := generateExpectedSACacheKey(t, saParams, kubeletconfig.ServiceAccountServiceAccountTokenCacheType)
+				return generateExpectedCacheKey(t, registry, saKey)
+			},
+		},
+		{
+			name:                    "registry-sa-token",
+			pluginCacheKeyType:      credentialproviderapi.RegistryPluginCacheKeyType,
+			serviceAccountCacheType: kubeletconfig.TokenServiceAccountTokenCacheType,
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				registry := parseRegistry(image)
+				saKey := generateExpectedSACacheKey(t, saParams, kubeletconfig.TokenServiceAccountTokenCacheType)
+				return generateExpectedCacheKey(t, registry, saKey)
+			},
+		},
+		{
+			name:                    "global-no-sa",
+			pluginCacheKeyType:      credentialproviderapi.GlobalPluginCacheKeyType,
+			serviceAccountCacheType: "",
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				return generateExpectedCacheKey(t, globalCacheKey, "")
+			},
+		},
+		{
+			name:                    "global-sa-serviceaccount",
+			pluginCacheKeyType:      credentialproviderapi.GlobalPluginCacheKeyType,
+			serviceAccountCacheType: kubeletconfig.ServiceAccountServiceAccountTokenCacheType,
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				saKey := generateExpectedSACacheKey(t, saParams, kubeletconfig.ServiceAccountServiceAccountTokenCacheType)
+				return generateExpectedCacheKey(t, globalCacheKey, saKey)
+			},
+		},
+		{
+			name:                    "global-sa-token",
+			pluginCacheKeyType:      credentialproviderapi.GlobalPluginCacheKeyType,
+			serviceAccountCacheType: kubeletconfig.TokenServiceAccountTokenCacheType,
+			expectedCacheKeyFunc: func(t *testing.T, image string, saParams *cacheKeyParams) string {
+				saKey := generateExpectedSACacheKey(t, saParams, kubeletconfig.TokenServiceAccountTokenCacheType)
+				return generateExpectedCacheKey(t, globalCacheKey, saKey)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var saTokenCacheType *kubeletconfig.ServiceAccountTokenCacheType
+			if tc.serviceAccountCacheType != "" {
+				saTokenCacheType = &tc.serviceAccountCacheType
+			}
+			pluginProvider := createTestPluginProvider(t, tc.pluginCacheKeyType, saTokenCacheType)
+
+			// Test image and expected SA parameters
+			testImage := "test.registry.io/foo/bar"
+			var cacheTypeValue kubeletconfig.ServiceAccountTokenCacheType
+			if saTokenCacheType != nil {
+				cacheTypeValue = *saTokenCacheType
+			}
+			saParams := &cacheKeyParams{
+				namespace:          "namespace",
+				serviceAccountName: "service-account-name",
+				serviceAccountUID:  "service-account-uid",
+				saAnnotations: map[string]string{
+					"prefix.io/annotation-1": "value1",
+					"prefix.io/annotation-2": "value2",
+				},
+				podName:     "pod-name",
+				podUID:      "pod-uid",
+				saTokenHash: getHashIfNotEmpty("token"),
+				cacheType:   cacheTypeValue,
+			}
+
+			dockerConfig := pluginProvider.Provide(testImage)
+			verifyDockerConfig(t, dockerConfig)
+
+			// Verify the cache key is as expected
+			expectedCacheKey := tc.expectedCacheKeyFunc(t, testImage, saParams)
+			actualCacheKeys := pluginProvider.provider.cache.ListKeys()
+
+			if len(actualCacheKeys) != 1 || actualCacheKeys[0] != expectedCacheKey {
+				t.Errorf("Expected cache key %q, got %v", expectedCacheKey, actualCacheKeys)
+			}
+
+			// Test cache hit (nil out plugin to ensure cache is used)
+			pluginProvider.provider.plugin = nil
+			cachedConfig := pluginProvider.Provide(testImage)
+			verifyDockerConfig(t, cachedConfig)
+		})
+	}
+}
+
+func createTestPluginProvider(t *testing.T, pluginCacheKeyType credentialproviderapi.PluginCacheKeyType, saTokenCacheType *kubeletconfig.ServiceAccountTokenCacheType) *perPodPluginProvider {
+	t.Helper()
+
+	tclock := clock.RealClock{}
+
+	provider := &pluginProvider{
+		clock:          tclock,
+		lastCachePurge: tclock.Now(),
+		matchImages:    []string{"*.registry.io"},
+		cache:          cache.NewExpirationStore(cacheKeyFunc, &cacheExpirationPolicy{clock: tclock}),
+		plugin: &fakeExecPlugin{
+			cacheKeyType:  pluginCacheKeyType,
+			cacheDuration: time.Hour,
+			auth: map[string]credentialproviderapi.AuthConfig{
+				"*.registry.io": {
+					Username: "user",
+					Password: "password",
+				},
+			},
+		},
+	}
+
+	// Add service account provider if needed
+	if saTokenCacheType != nil {
+		provider.serviceAccountProvider = &serviceAccountProvider{
+			audience:                             "audience",
+			requiredServiceAccountAnnotationKeys: []string{"prefix.io/annotation-1", "prefix.io/annotation-2"},
+			cacheType:                            *saTokenCacheType,
+			getServiceAccountFunc: func(namespace, name string) (*v1.ServiceAccount, error) {
+				return &v1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+						UID:       "service-account-uid",
+						Annotations: map[string]string{
+							"prefix.io/annotation-1": "value1",
+							"prefix.io/annotation-2": "value2",
+						},
+					},
+				}, nil
+			},
+			getServiceAccountTokenFunc: func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+				return &authenticationv1.TokenRequest{Status: authenticationv1.TokenRequestStatus{Token: "token"}}, nil
+			},
+		}
+	}
+
+	return &perPodPluginProvider{
+		provider:           provider,
+		podName:            "pod-name",
+		podNamespace:       "namespace",
+		podUID:             types.UID("pod-uid"),
+		serviceAccountName: "service-account-name",
+	}
+}
+
+func generateExpectedSACacheKey(t *testing.T, params *cacheKeyParams, cacheType kubeletconfig.ServiceAccountTokenCacheType) string {
+	t.Helper()
+
+	params.cacheType = cacheType
+	key, err := generateServiceAccountCacheKey(*params)
+	if err != nil {
+		t.Fatalf("Failed to generate SA cache key: %v", err)
+	}
+	return key
+}
+
+func generateExpectedCacheKey(t *testing.T, baseKey, saCacheKey string) string {
+	t.Helper()
+
+	key, err := generateCacheKey(baseKey, saCacheKey)
+	if err != nil {
+		t.Fatalf("Failed to generate cache key: %v", err)
+	}
+	return key
+}
+
+func verifyDockerConfig(t *testing.T, config credentialprovider.DockerConfig) {
+	t.Helper()
+
+	expected := credentialprovider.DockerConfig{
+		"*.registry.io": credentialprovider.DockerConfigEntry{
+			Username: "user",
+			Password: "password",
+		},
+	}
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Errorf("Docker config mismatch. Got %v, expected %v", config, expected)
 	}
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -65531,6 +65531,14 @@ func schema_k8sio_kubelet_config_v1_ServiceAccountTokenAttributes(ref common.Ref
 							Format:      "",
 						},
 					},
+					"cacheType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cacheType indicates the type of cache key use for caching the credentials returned by the plugin when the service account token is used. The most conservative option is to set this to \"Token\", which means the kubelet will cache returned credentials on a per-token basis. This should be set if the returned credential's lifetime is limited to the service account token's lifetime. If the plugin's credential retrieval logic depends only on the service account and not on pod-specific claims, then the plugin can set this to \"ServiceAccount\". In this case, the kubelet will cache returned credentials on a per-serviceaccount basis. Use this when the returned credential is valid for all pods using the same service account.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"requireServiceAccount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "requireServiceAccount indicates whether the plugin requires the pod to have a service account. If set to true, kubelet will only invoke the plugin if the pod has a service account. If set to false, kubelet will invoke the plugin even if the pod does not have a service account and will not include a token in the CredentialProviderRequest in that scenario. This is useful for plugins that are used to pull images for pods without service accounts (e.g., static pods).",
@@ -65579,7 +65587,7 @@ func schema_k8sio_kubelet_config_v1_ServiceAccountTokenAttributes(ref common.Ref
 						},
 					},
 				},
-				Required: []string{"serviceAccountTokenAudience", "requireServiceAccount"},
+				Required: []string{"serviceAccountTokenAudience", "cacheType", "requireServiceAccount"},
 			},
 		},
 	}

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -622,6 +622,23 @@ type SerializedNodeConfigSource struct {
 	Source v1.NodeConfigSource
 }
 
+// ServiceAccountTokenCacheType is the type of cache key used for caching credentials returned by the plugin
+// when the service account token is used.
+type ServiceAccountTokenCacheType string
+
+const (
+	// TokenServiceAccountTokenCacheType means the kubelet will cache returned credentials
+	// on a per-token basis. This should be set if the returned credential's lifetime is limited
+	// to the input service account token's lifetime.
+	// For example, this must be used when returning the input service account token directly as a pull credential.
+	TokenServiceAccountTokenCacheType ServiceAccountTokenCacheType = "Token"
+	// ServiceAccountServiceAccountTokenCacheType means the kubelet will cache returned credentials
+	// on a per-serviceaccount basis. This should be set if the plugin's credential retrieval logic
+	// depends only on the service account and not on pod-specific claims.
+	// Use this when the returned credential is valid for all pods using the same service account.
+	ServiceAccountServiceAccountTokenCacheType ServiceAccountTokenCacheType = "ServiceAccount"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CredentialProviderConfig is the configuration containing information about
@@ -720,6 +737,17 @@ type ServiceAccountTokenAttributes struct {
 	// serviceAccountTokenAudience is the intended audience for the projected service account token.
 	// +required
 	ServiceAccountTokenAudience string
+
+	// cacheType indicates the type of cache key use for caching the credentials returned by the plugin
+	// when the service account token is used.
+	// The most conservative option is to set this to "Token", which means the kubelet will cache returned credentials
+	// on a per-token basis. This should be set if the returned credential's lifetime is limited to the service account
+	// token's lifetime.
+	// If the plugin's credential retrieval logic depends only on the service account and not on pod-specific claims,
+	// then the plugin can set this to "ServiceAccount". In this case, the kubelet will cache returned credentials
+	// on a per-serviceaccount basis. Use this when the returned credential is valid for all pods using the same service account.
+	// +required
+	CacheType ServiceAccountTokenCacheType
 
 	// requireServiceAccount indicates whether the plugin requires the pod to have a service account.
 	// If set to true, kubelet will only invoke the plugin if the pod has a service account.

--- a/pkg/kubelet/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1/zz_generated.conversion.go
@@ -157,6 +157,7 @@ func Convert_config_ExecEnvVar_To_v1_ExecEnvVar(in *config.ExecEnvVar, out *conf
 
 func autoConvert_v1_ServiceAccountTokenAttributes_To_config_ServiceAccountTokenAttributes(in *configv1.ServiceAccountTokenAttributes, out *config.ServiceAccountTokenAttributes, s conversion.Scope) error {
 	out.ServiceAccountTokenAudience = in.ServiceAccountTokenAudience
+	out.CacheType = config.ServiceAccountTokenCacheType(in.CacheType)
 	out.RequireServiceAccount = (*bool)(unsafe.Pointer(in.RequireServiceAccount))
 	out.RequiredServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.RequiredServiceAccountAnnotationKeys))
 	out.OptionalServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.OptionalServiceAccountAnnotationKeys))
@@ -170,6 +171,7 @@ func Convert_v1_ServiceAccountTokenAttributes_To_config_ServiceAccountTokenAttri
 
 func autoConvert_config_ServiceAccountTokenAttributes_To_v1_ServiceAccountTokenAttributes(in *config.ServiceAccountTokenAttributes, out *configv1.ServiceAccountTokenAttributes, s conversion.Scope) error {
 	out.ServiceAccountTokenAudience = in.ServiceAccountTokenAudience
+	out.CacheType = configv1.ServiceAccountTokenCacheType(in.CacheType)
 	out.RequireServiceAccount = (*bool)(unsafe.Pointer(in.RequireServiceAccount))
 	out.RequiredServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.RequiredServiceAccountAnnotationKeys))
 	out.OptionalServiceAccountAnnotationKeys = *(*[]string)(unsafe.Pointer(&in.OptionalServiceAccountAnnotationKeys))

--- a/staging/src/k8s.io/kubelet/config/v1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1/types.go
@@ -20,6 +20,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ServiceAccountTokenCacheType is the type of cache key used for caching credentials returned by the plugin
+// when the service account token is used.
+type ServiceAccountTokenCacheType string
+
+const (
+	// TokenServiceAccountTokenCacheType means the kubelet will cache returned credentials
+	// on a per-token basis. This should be set if the returned credential's lifetime is limited
+	// to the input service account token's lifetime.
+	// For example, this must be used when returning the input service account token directly as a pull credential.
+	TokenServiceAccountTokenCacheType ServiceAccountTokenCacheType = "Token"
+	// ServiceAccountServiceAccountTokenCacheType means the kubelet will cache returned credentials
+	// on a per-serviceaccount basis. This should be set if the plugin's credential retrieval logic
+	// depends only on the service account and not on pod-specific claims.
+	// Use this when the returned credential is valid for all pods using the same service account.
+	ServiceAccountServiceAccountTokenCacheType ServiceAccountTokenCacheType = "ServiceAccount"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CredentialProviderConfig is the configuration containing information about
@@ -116,6 +133,17 @@ type ServiceAccountTokenAttributes struct {
 	// serviceAccountTokenAudience is the intended audience for the projected service account token.
 	// +required
 	ServiceAccountTokenAudience string `json:"serviceAccountTokenAudience"`
+
+	// cacheType indicates the type of cache key use for caching the credentials returned by the plugin
+	// when the service account token is used.
+	// The most conservative option is to set this to "Token", which means the kubelet will cache returned credentials
+	// on a per-token basis. This should be set if the returned credential's lifetime is limited to the service account
+	// token's lifetime.
+	// If the plugin's credential retrieval logic depends only on the service account and not on pod-specific claims,
+	// then the plugin can set this to "ServiceAccount". In this case, the kubelet will cache returned credentials
+	// on a per-serviceaccount basis. Use this when the returned credential is valid for all pods using the same service account.
+	// +required
+	CacheType ServiceAccountTokenCacheType `json:"cacheType"`
 
 	// requireServiceAccount indicates whether the plugin requires the pod to have a service account.
 	// If set to true, kubelet will only invoke the plugin if the pod has a service account.

--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -71,6 +71,7 @@ providers:
    defaultCacheDuration: 1m
    tokenAttributes:
      serviceAccountTokenAudience: test-audience
+     cacheType: Token
      requireServiceAccount: true
      requiredServiceAccountAnnotationKeys:
      - "domain.io/identity-id"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add `cacheType` field to `tokenAttributes` in credential provider config. This field is required to be set when configuring a provider that uses service account to fetch registry credentials.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

part of https://github.com/kubernetes/kubernetes/issues/130709
KEP: https://github.com/kubernetes/enhancements/issues/4412

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `tokenAttributes.cacheType` field to v1 credential provider config. This field is required to be set to either ServiceAccount or Token when configuring a provider that uses service account to fetch registry credentials.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/README.md
```

/sig auth
/triage accepted
/milestone v1.34
/priority important-soon