### PR TITLE
scheduler_perf: add logs to report the failure of measuring SchedulingThroughput

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -648,7 +648,7 @@ func (tc *throughputCollector) collect() []DataItem {
 	// tc.schedulingThroughputs can be empty if the scenario doesn't have
 	// enough number of pods and nodes to take more than throughputSampleInterval (i.e. 1 second).
 	if throughputSummary.Data == nil {
-		klog.Warningf("Failed to measure SchedulingThroughput for %s. You would need to increase the number of pods and nodes.", tc.resultLabels["Name"])
+		klog.Warningf("Failed to measure SchedulingThroughput for %s. The scenario needs to have enough pods and nodes to take more than 1 second.", tc.resultLabels["Name"])
 	}
 
 	return []DataItem{throughputSummary}

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -645,5 +645,11 @@ func (tc *throughputCollector) collect() []DataItem {
 		throughputSummary.Unit = "pods/s"
 	}
 
+	// tc.schedulingThroughputs can be empty if the scenario doesn't have
+	// enough number of pods and nodes to take more than throughputSampleInterval (i.e. 1 second).
+	if throughputSummary.Data == nil {
+		klog.Warningf("Failed to measure SchedulingThroughput for %s. You would need to increase the number of pods and nodes.", tc.resultLabels["Name"])
+	}
+
 	return []DataItem{throughputSummary}
 }

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -648,7 +648,7 @@ func (tc *throughputCollector) collect() []DataItem {
 	// tc.schedulingThroughputs can be empty if the scenario doesn't have
 	// enough number of pods and nodes to take more than throughputSampleInterval (i.e. 1 second).
 	if throughputSummary.Data == nil {
-		klog.Warningf("Failed to measure SchedulingThroughput for %s. The scenario needs to have enough pods and nodes to take more than %s.", tc.resultLabels["Name"], throughputSampleInterval,)
+		klog.Warningf("Failed to measure SchedulingThroughput for %s. The scenario needs to have enough pods and nodes to take more than %s.", tc.resultLabels["Name"], throughputSampleInterval)
 	}
 
 	return []DataItem{throughputSummary}

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -648,7 +648,7 @@ func (tc *throughputCollector) collect() []DataItem {
 	// tc.schedulingThroughputs can be empty if the scenario doesn't have
 	// enough number of pods and nodes to take more than throughputSampleInterval (i.e. 1 second).
 	if throughputSummary.Data == nil {
-		klog.Warningf("Failed to measure SchedulingThroughput for %s. The scenario needs to have enough pods and nodes to take more than %s.", tc.resultLabels["Name"], throughputSampleInterval)
+		klog.Warningf("Failed to measure SchedulingThroughput for %s. Increase pods and/or nodes to make scheduling take longer", tc.resultLabels["Name"])
 	}
 
 	return []DataItem{throughputSummary}

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -627,29 +627,30 @@ func (tc *throughputCollector) collect() []DataItem {
 		progress: tc.progress,
 		start:    tc.start,
 	}
-	if length := len(tc.schedulingThroughputs); length > 0 {
-		sort.Float64s(tc.schedulingThroughputs)
-		sum := 0.0
-		for i := range tc.schedulingThroughputs {
-			sum += tc.schedulingThroughputs[i]
-		}
-
-		throughputSummary.Labels["Metric"] = "SchedulingThroughput"
-		throughputSummary.Data = map[string]float64{
-			"Average": sum / float64(length),
-			"Perc50":  tc.schedulingThroughputs[int(math.Ceil(float64(length*50)/100))-1],
-			"Perc90":  tc.schedulingThroughputs[int(math.Ceil(float64(length*90)/100))-1],
-			"Perc95":  tc.schedulingThroughputs[int(math.Ceil(float64(length*95)/100))-1],
-			"Perc99":  tc.schedulingThroughputs[int(math.Ceil(float64(length*99)/100))-1],
-		}
-		throughputSummary.Unit = "pods/s"
-	}
 
 	// tc.schedulingThroughputs can be empty if the scenario doesn't have
 	// enough number of pods and nodes to take more than throughputSampleInterval (i.e. 1 second).
-	if throughputSummary.Data == nil {
+	length := len(tc.schedulingThroughputs)
+	if length == 0 {
 		klog.Warningf("Failed to measure SchedulingThroughput for %s. Increase pods and/or nodes to make scheduling take longer", tc.resultLabels["Name"])
+		return []DataItem{throughputSummary}
 	}
+
+	sort.Float64s(tc.schedulingThroughputs)
+	sum := 0.0
+	for i := range tc.schedulingThroughputs {
+		sum += tc.schedulingThroughputs[i]
+	}
+
+	throughputSummary.Labels["Metric"] = "SchedulingThroughput"
+	throughputSummary.Data = map[string]float64{
+		"Average": sum / float64(length),
+		"Perc50":  tc.schedulingThroughputs[int(math.Ceil(float64(length*50)/100))-1],
+		"Perc90":  tc.schedulingThroughputs[int(math.Ceil(float64(length*90)/100))-1],
+		"Perc95":  tc.schedulingThroughputs[int(math.Ceil(float64(length*95)/100))-1],
+		"Perc99":  tc.schedulingThroughputs[int(math.Ceil(float64(length*99)/100))-1],
+	}
+	throughputSummary.Unit = "pods/s"
 
 	return []DataItem{throughputSummary}
 }

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -648,7 +648,7 @@ func (tc *throughputCollector) collect() []DataItem {
 	// tc.schedulingThroughputs can be empty if the scenario doesn't have
 	// enough number of pods and nodes to take more than throughputSampleInterval (i.e. 1 second).
 	if throughputSummary.Data == nil {
-		klog.Warningf("Failed to measure SchedulingThroughput for %s. The scenario needs to have enough pods and nodes to take more than 1 second.", tc.resultLabels["Name"])
+		klog.Warningf("Failed to measure SchedulingThroughput for %s. The scenario needs to have enough pods and nodes to take more than %s.", tc.resultLabels["Name"], throughputSampleInterval,)
 	}
 
 	return []DataItem{throughputSummary}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig-scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

scheduler_perf sometimes fails to record `SchedulingThroughput`. The cause is that the scenario doesn't have enough pods and nodes to take more than `throughputSampleInterval` (i.e. 1 sec) and `throughputCollector` collects no record.

In the current implementation it reports nothing when this issue occurs, so users of scheduler_perf wouldn't know why `SchedulingThroughput` is not recorded. This PR avoids such a situation by logging that the scenario lacks the number of pods and nodes.

#### Which issue(s) this PR is related to:

#132188 

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
