### PR TITLE
Validate OS not windows for PodLevelResources

### DIFF
--- a/pkg/kubelet/allocation/features_linux.go
+++ b/pkg/kubelet/allocation/features_linux.go
@@ -35,3 +35,10 @@ func IsInPlacePodVerticalScalingAllowed(pod *v1.Pod) (allowed bool, msg string) 
 	}
 	return true, ""
 }
+
+func IsPodLevelResourcesAllowed(_ *v1.Pod) (allowed bool, err string) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) {
+		return false, "PodLevelResources feature gate is disabled"
+	}
+	return true, ""
+}

--- a/pkg/kubelet/allocation/features_unsupported.go
+++ b/pkg/kubelet/allocation/features_unsupported.go
@@ -24,3 +24,7 @@ import v1 "k8s.io/api/core/v1"
 func IsInPlacePodVerticalScalingAllowed(_ *v1.Pod) (allowed bool, msg string) {
 	return false, "In-place pod resize is not supported on this node"
 }
+
+func IsPodLevelResourcesAllowed(_ *v1.Pod) (allowed bool, err string) {
+	return false, "pod-level resources are not supported on this node"
+}

--- a/pkg/kubelet/allocation/features_windows.go
+++ b/pkg/kubelet/allocation/features_windows.go
@@ -24,3 +24,7 @@ import v1 "k8s.io/api/core/v1"
 func IsInPlacePodVerticalScalingAllowed(_ *v1.Pod) (allowed bool, msg string) {
 	return false, "In-place pod resize is not supported on Windows"
 }
+
+func IsPodLevelResourcesAllowed(_ *v1.Pod) (allowed bool, err string) {
+	return false, "pod-level resources are not supported on Windows"
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1133,6 +1133,10 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 //  8. Create normal containers.
 func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff) (result kubecontainer.PodSyncResult) {
 	// Step 1: Compute sandbox and container changes.
+	if isAllowed, msg := allocation.IsPodLevelResourcesAllowed(pod); pod.Spec.Resources != nil && !isAllowed {
+		result.Fail(fmt.Errorf("unable to set pod-level resources for pod %q: %s", pod.Name, msg))
+		return
+	}
 	podContainerChanges := m.computePodActions(ctx, pod, podStatus)
 	klog.V(3).InfoS("computePodActions got for pod", "podActions", podContainerChanges, "pod", klog.KObj(pod))
 	if podContainerChanges.CreateSandbox {


### PR DESCRIPTION
Reject Pod with PodLevelResources in spec if Pod targets Windows OS.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds check to
* API server to reject Pod with PodLevelResources if Pod targets Windows OS.
* kubelet to reject Pod with PodLevelResources on nodes other than Linux OS.

#### Which issue(s) this PR is related to:

Fixes #132582.
PodLevelResources KEP that documents this behavior: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2837-pod-level-resource-spec/README.md#future-kep-consideration-in-135-support-for-windows.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added validation to reject Pods using the `PodLevelResources` feature on Windows OS due to lack of support. The API server rejects Pods with Pod-level resources and a `Pod.spec.os.name` targeting Windows. Kubelet on nodes running Windows also rejects Pods with Pod-level resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#example-2
```
