### PR TITLE
[PodLevelResources] Event for pod-level resource manager incompatibility

### DIFF
--- a/pkg/kubelet/cm/admission/errors.go
+++ b/pkg/kubelet/cm/admission/errors.go
@@ -20,11 +20,20 @@ import (
 	"errors"
 	"fmt"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
 const (
 	ErrorReasonUnexpected = "UnexpectedAdmissionError"
+
+	// Explicit reason when CPU/Memory manager's policy is incompatible with pod level resources.
+	PodLevelResourcesIncompatible = "PodLevelResourcesIncompatible"
+
+	// Warnings for pod level resources when manager's policy incompatibility.
+	CPUManagerPodLevelResourcesError    = "CPUManagerPodLevelResourcesError"
+	MemoryManagerPodLevelResourcesError = "MemoryManagerPodLevelResourcesError"
 )
 
 type Error interface {
@@ -49,14 +58,56 @@ func GetPodAdmitResult(err error) lifecycle.PodAdmitResult {
 		return lifecycle.PodAdmitResult{Admit: true}
 	}
 
+	var errs []error
+	// To support multiple pod-level resource errors, we need to check if the error
+	// is an aggregate error.
+	var agg utilerrors.Aggregate
+	if errors.As(err, &agg) {
+		errs = agg.Errors()
+	} else {
+		errs = []error{err}
+	}
+
+	var podLevelWarnings []error
+	var otherErrs []error
+	for _, e := range errs {
+		var admissionErr Error
+		if errors.As(e, &admissionErr) && (admissionErr.Type() == CPUManagerPodLevelResourcesError || admissionErr.Type() == MemoryManagerPodLevelResourcesError) {
+			podLevelWarnings = append(podLevelWarnings, e)
+		} else {
+			otherErrs = append(otherErrs, e)
+		}
+	}
+
+	// If all errors are pod-level resource errors, we should treat them as warnings
+	// and not block pod admission.
+	if len(otherErrs) == 0 && len(podLevelWarnings) > 0 {
+		return lifecycle.PodAdmitResult{
+			Admit:   true,
+			Reason:  PodLevelResourcesIncompatible,
+			Message: "",
+			Errors:  podLevelWarnings,
+		}
+	}
+
+	if len(otherErrs) == 0 {
+		// This should not happen if err != nil, but as a safeguard.
+		// This indicates a logical inconsistency where a primary error was
+		// detected, but supporting detailed errors are missing. This is a bug.
+		klog.ErrorS(err, "Logical inconsistency: Primary error detected, but 'otherErrs' list is empty")
+		return lifecycle.PodAdmitResult{Admit: true}
+	}
+
+	// At this point, we have at least one error that requires pod rejection.
+	firstErr := otherErrs[0]
 	var admissionErr Error
-	if !errors.As(err, &admissionErr) {
-		admissionErr = &unexpectedAdmissionError{err}
+	if !errors.As(firstErr, &admissionErr) {
+		admissionErr = &unexpectedAdmissionError{firstErr}
 	}
 
 	return lifecycle.PodAdmitResult{
+		Admit:   false,
 		Message: admissionErr.Error(),
 		Reason:  admissionErr.Type(),
-		Admit:   false,
 	}
 }

--- a/pkg/kubelet/cm/admission/errors.go
+++ b/pkg/kubelet/cm/admission/errors.go
@@ -20,20 +20,11 @@ import (
 	"errors"
 	"fmt"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
 const (
 	ErrorReasonUnexpected = "UnexpectedAdmissionError"
-
-	// Explicit reason when CPU/Memory manager's policy is incompatible with pod level resources.
-	PodLevelResourcesIncompatible = "PodLevelResourcesIncompatible"
-
-	// Warnings for pod level resources when manager's policy incompatibility.
-	CPUManagerPodLevelResourcesError    = "CPUManagerPodLevelResourcesError"
-	MemoryManagerPodLevelResourcesError = "MemoryManagerPodLevelResourcesError"
 )
 
 type Error interface {
@@ -58,51 +49,9 @@ func GetPodAdmitResult(err error) lifecycle.PodAdmitResult {
 		return lifecycle.PodAdmitResult{Admit: true}
 	}
 
-	var errs []error
-	// To support multiple pod-level resource errors, we need to check if the error
-	// is an aggregate error.
-	var agg utilerrors.Aggregate
-	if errors.As(err, &agg) {
-		errs = agg.Errors()
-	} else {
-		errs = []error{err}
-	}
-
-	var podLevelWarnings []error
-	var otherErrs []error
-	for _, e := range errs {
-		var admissionErr Error
-		if errors.As(e, &admissionErr) && (admissionErr.Type() == CPUManagerPodLevelResourcesError || admissionErr.Type() == MemoryManagerPodLevelResourcesError) {
-			podLevelWarnings = append(podLevelWarnings, e)
-		} else {
-			otherErrs = append(otherErrs, e)
-		}
-	}
-
-	// If all errors are pod-level resource errors, we should treat them as warnings
-	// and not block pod admission.
-	if len(otherErrs) == 0 && len(podLevelWarnings) > 0 {
-		return lifecycle.PodAdmitResult{
-			Admit:   true,
-			Reason:  PodLevelResourcesIncompatible,
-			Message: "",
-			Errors:  podLevelWarnings,
-		}
-	}
-
-	if len(otherErrs) == 0 {
-		// This should not happen if err != nil, but as a safeguard.
-		// This indicates a logical inconsistency where a primary error was
-		// detected, but supporting detailed errors are missing. This is a bug.
-		klog.ErrorS(err, "Logical inconsistency: Primary error detected, but 'otherErrs' list is empty")
-		return lifecycle.PodAdmitResult{Admit: true}
-	}
-
-	// At this point, we have at least one error that requires pod rejection.
-	firstErr := otherErrs[0]
 	var admissionErr Error
-	if !errors.As(firstErr, &admissionErr) {
-		admissionErr = &unexpectedAdmissionError{firstErr}
+	if !errors.As(err, &admissionErr) {
+		admissionErr = &unexpectedAdmissionError{err}
 	}
 
 	return lifecycle.PodAdmitResult{

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/utils/cpuset"
 )
@@ -88,6 +89,10 @@ func (m *fakeManager) GetCPUAffinity(podUID, containerName string) cpuset.CPUSet
 func (m *fakeManager) GetAllCPUs() cpuset.CPUSet {
 	klog.InfoS("GetAllCPUs")
 	return cpuset.CPUSet{}
+}
+
+func (m *fakeManager) GetWarnings(pod *v1.Pod) []lifecycle.PodAdmitWarning {
+	return nil
 }
 
 // NewFakeManager creates empty/fake cpu manager

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 )
 
@@ -99,6 +100,10 @@ func (m *fakeManager) GetMemory(ctx context.Context, podUID, containerName strin
 	logger := klog.LoggerWithValues(klog.FromContext(ctx), "podUID", podUID, "containerName", containerName)
 	logger.Info("Get Memory")
 	return []state.Block{}
+}
+
+func (m *fakeManager) GetWarnings(pod *v1.Pod) []lifecycle.PodAdmitWarning {
+	return nil
 }
 
 // NewFakeManager creates empty/fake memory manager

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -18,6 +18,7 @@ package memorymanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -273,6 +274,12 @@ func (m *manager) Allocate(pod *v1.Pod, container *v1.Container) error {
 
 	// Call down into the policy to assign this container memory if required.
 	if err := m.policy.Allocate(ctx, m.state, pod, container); err != nil {
+		// If it gets this error it means that the pod requires pod level resources but this is not aligned.
+		// We do not want the pod to fail to schedule on this error so we Admit it, this is just a warning
+		if errors.As(err, &MemoryManagerPodLevelResourcesError{}) {
+			return err
+		}
+
 		logger.Error(err, "Allocate error", "pod", klog.KObj(pod), "containerName", container.Name)
 		return err
 	}

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -19,8 +19,11 @@ package topologymanager
 import (
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -148,11 +151,21 @@ func (s *scope) admitPolicyNone(pod *v1.Pod) lifecycle.PodAdmitResult {
 // It would be better to implement this function in topologymanager instead of scope
 // but topologymanager do not track providers anymore
 func (s *scope) allocateAlignedResources(pod *v1.Pod, container *v1.Container) error {
+	isPodLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources)
+
+	var errs []error
 	for _, provider := range s.hintProviders {
 		err := provider.Allocate(pod, container)
-		if err != nil {
+		if err != nil && isPodLevelResourcesEnabled {
+			errs = append(errs, err)
+		} else if err != nil {
 			return err
 		}
 	}
+
+	if isPodLevelResourcesEnabled {
+		return utilerrors.NewAggregate(errs)
+	}
+
 	return nil
 }

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -19,11 +19,8 @@ package topologymanager
 import (
 	"sync"
 
-	v1 "k8s.io/api/core/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -151,21 +148,23 @@ func (s *scope) admitPolicyNone(pod *v1.Pod) lifecycle.PodAdmitResult {
 // It would be better to implement this function in topologymanager instead of scope
 // but topologymanager do not track providers anymore
 func (s *scope) allocateAlignedResources(pod *v1.Pod, container *v1.Container) error {
-	isPodLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources)
-
-	var errs []error
 	for _, provider := range s.hintProviders {
 		err := provider.Allocate(pod, container)
-		if err != nil && isPodLevelResourcesEnabled {
-			errs = append(errs, err)
-		} else if err != nil {
+		if err != nil {
 			return err
 		}
 	}
-
-	if isPodLevelResourcesEnabled {
-		return utilerrors.NewAggregate(errs)
-	}
-
 	return nil
+}
+
+func (s *scope) getWarnings(pod *v1.Pod) []lifecycle.PodAdmitWarning {
+	var warnings []lifecycle.PodAdmitWarning
+	for _, provider := range s.hintProviders {
+		warningProvider, ok := provider.(lifecycle.PodWarningProvider)
+		if !ok {
+			continue
+		}
+		warnings = append(warnings, warningProvider.GetWarnings(pod)...)
+	}
+	return warnings
 }

--- a/pkg/kubelet/cm/topologymanager/scope_container.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container.go
@@ -70,7 +70,9 @@ func (s *containerScope) Admit(pod *v1.Pod) lifecycle.PodAdmitResult {
 			metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedNUMANode).Inc()
 		}
 	}
-	return admission.GetPodAdmitResult(nil)
+	result := admission.GetPodAdmitResult(nil)
+	result.Warnings = s.getWarnings(pod)
+	return result
 }
 
 func (s *containerScope) accumulateProvidersHints(pod *v1.Pod, container *v1.Container) []map[string][]TopologyHint {

--- a/pkg/kubelet/cm/topologymanager/scope_pod.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod.go
@@ -71,7 +71,9 @@ func (s *podScope) Admit(pod *v1.Pod) lifecycle.PodAdmitResult {
 		klog.V(4).InfoS("Resource alignment at pod scope guaranteed", "pod", klog.KObj(pod))
 		metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopePod, metrics.AlignedNUMANode).Inc()
 	}
-	return admission.GetPodAdmitResult(nil)
+	result := admission.GetPodAdmitResult(nil)
+	result.Warnings = s.getWarnings(pod)
+	return result
 }
 
 func (s *podScope) accumulateProvidersHints(pod *v1.Pod) []map[string][]TopologyHint {

--- a/pkg/kubelet/lifecycle/interfaces.go
+++ b/pkg/kubelet/lifecycle/interfaces.go
@@ -35,6 +35,8 @@ type PodAdmitResult struct {
 	Reason string
 	// a brief message explaining why the pod could not be admitted.
 	Message string
+	// all errors for why the pod could not be admitted.
+	Errors []error
 }
 
 // PodAdmitHandler is notified during pod admission.

--- a/pkg/kubelet/lifecycle/interfaces.go
+++ b/pkg/kubelet/lifecycle/interfaces.go
@@ -35,8 +35,22 @@ type PodAdmitResult struct {
 	Reason string
 	// a brief message explaining why the pod could not be admitted.
 	Message string
-	// all errors for why the pod could not be admitted.
-	Errors []error
+	// any warnings that should be surfaced for the pod.
+	Warnings []PodAdmitWarning
+}
+
+// PodAdmitWarning represents a warning generated during pod admission.
+type PodAdmitWarning struct {
+	// a brief single-word reason for the warning
+	Reason string
+	// a brief message explaining the reason for the warning
+	Message string
+}
+
+// PodWarningProvider is an optional interface that admit handlers can implement
+// to provide warnings about a pod.
+type PodWarningProvider interface {
+	GetWarnings(pod *v1.Pod) []PodAdmitWarning
 }
 
 // PodAdmitHandler is notified during pod admission.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Refer to [[PodLevelResources] handle pod-level resource manager alignment](https://github.com/kubernetes/kubernetes/pull/133279/files#top) for the logic that prevents hint generation or allocation.

Refer to [[PodLevelResources] Event for unsupported pod-level resource manager alignment](https://github.com/kubernetes/kubernetes/pull/133256/files#top) for part of the discussion.

This PR allows to surface no CPU nor Memory alignment events when Pod level resources are used in the pod spec, the following changes are required:
1. Event pod-level resource manager incompatibility

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #132445

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Produces an event for CPU or Memory manager incompatibility when Pod Level resources are used in the pod spec.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: [kubernetes/enhancements#2837](https://github.com/kubernetes/enhancements/issues/2837)
```
