### PR TITLE
Migrate devicemanager to context logging (3/5)

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -688,7 +688,7 @@ func (cm *containerManagerImpl) GetResources(ctx context.Context, pod *v1.Pod, c
 	}
 	// Allocate should already be called during predicateAdmitHandler.Admit(),
 	// just try to fetch device runtime information from cached state here
-	devOpts, err := cm.deviceManager.GetDeviceRunContainerOptions(pod, container)
+	devOpts, err := cm.deviceManager.GetDeviceRunContainerOptions(ctx, pod, container)
 	if err != nil {
 		return nil, err
 	} else if devOpts == nil {

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -264,7 +264,7 @@ func (cm *containerManagerImpl) GetResources(ctx context.Context, pod *v1.Pod, c
 	opts := &kubecontainer.RunContainerOptions{}
 	// Allocate should already be called during predicateAdmitHandler.Admit(),
 	// just try to fetch device runtime information from cached state here
-	devOpts, err := cm.deviceManager.GetDeviceRunContainerOptions(pod, container)
+	devOpts, err := cm.deviceManager.GetDeviceRunContainerOptions(ctx, pod, container)
 	if err != nil {
 		return nil, err
 	} else if devOpts == nil {

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/api.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/api.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+
 	api "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -30,7 +32,7 @@ type RegistrationHandler interface {
 type ClientHandler interface {
 	PluginConnected(string, DevicePlugin) error
 	PluginDisconnected(string)
-	PluginListAndWatchReceiver(string, *api.ListAndWatchResponse)
+	PluginListAndWatchReceiver(context.Context, string, *api.ListAndWatchResponse)
 }
 
 // TODO: evaluate whether we need these error definitions.

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
@@ -91,7 +91,7 @@ func (c *client) Run() {
 			return
 		}
 		klog.V(2).InfoS("State pushed for device plugin", "resource", c.resource, "resourceCapacity", len(response.Devices))
-		c.handler.PluginListAndWatchReceiver(c.resource, response)
+		c.handler.PluginListAndWatchReceiver(context.TODO(), c.resource, response)
 	}
 }
 

--- a/pkg/kubelet/cm/devicemanager/pod_devices_test.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices_test.go
@@ -27,6 +27,7 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestGetContainerDevices(t *testing.T) {
@@ -157,6 +158,7 @@ func expectResourceDeviceInstances(t *testing.T, resp ResourceDeviceInstances, e
 }
 
 func TestDeviceRunContainerOptions(t *testing.T) {
+	ctx := ktesting.Init(t)
 	const (
 		podUID        = "pod"
 		containerName = "container"
@@ -239,7 +241,7 @@ func TestDeviceRunContainerOptions(t *testing.T) {
 					response,
 				)
 			}
-			opts := podDevices.deviceRunContainerOptions(podUID, containerName)
+			opts := podDevices.deviceRunContainerOptions(ctx, podUID, containerName)
 
 			// The exact ordering of the options depends on the order of the resources in the map.
 			// We therefore use `ElementsMatch` instead of `Equal` on the member slices.

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package devicemanager
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -55,7 +56,7 @@ type Manager interface {
 	// GetDeviceRunContainerOptions checks whether we have cached containerDevices
 	// for the passed-in <pod, container> and returns its DeviceRunContainerOptions
 	// for the found one. An empty struct is returned in case no cached state is found.
-	GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Container) (*DeviceRunContainerOptions, error)
+	GetDeviceRunContainerOptions(ctx context.Context, pod *v1.Pod, container *v1.Container) (*DeviceRunContainerOptions, error)
 
 	// GetCapacity returns the amount of available device plugin resource capacity, resource allocatable
 	// and inactive device plugin resources previously registered on the node.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrate `pkg/kubelet/cm/devicemanager/pod_devices.go` to context logging



#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
