### PR TITLE
chore: remove utilpointer usage in package pkg/apis/admissionregistration

### DIFF
--- a/pkg/apis/admissionregistration/v1/defaults.go
+++ b/pkg/apis/admissionregistration/v1/defaults.go
@@ -20,7 +20,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -90,7 +90,7 @@ func SetDefaults_Rule(obj *admissionregistrationv1.Rule) {
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *admissionregistrationv1.ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32(443)
+		obj.Port = ptr.To[int32](443)
 	}
 }
 

--- a/pkg/apis/admissionregistration/v1/defaults_test.go
+++ b/pkg/apis/admissionregistration/v1/defaults_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaultAdmissionWebhook(t *testing.T) {
@@ -107,7 +107,7 @@ func TestDefaultAdmissionWebhook(t *testing.T) {
 				Webhooks: []v1.MutatingWebhook{{
 					ClientConfig: v1.WebhookClientConfig{
 						Service: &v1.ServiceReference{
-							Port: utilpointer.Int32(443), // defaulted
+							Port: ptr.To[int32](443), // defaulted
 						},
 					},
 					FailurePolicy:      &fail,

--- a/pkg/apis/admissionregistration/v1beta1/defaults.go
+++ b/pkg/apis/admissionregistration/v1beta1/defaults.go
@@ -20,7 +20,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -124,6 +124,6 @@ func SetDefaults_MutatingWebhook(obj *admissionregistrationv1beta1.MutatingWebho
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *admissionregistrationv1beta1.ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32(443)
+		obj.Port = ptr.To[int32](443)
 	}
 }

--- a/pkg/apis/admissionregistration/v1beta1/defaults_test.go
+++ b/pkg/apis/admissionregistration/v1beta1/defaults_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaultAdmissionWebhook(t *testing.T) {
@@ -114,7 +114,7 @@ func TestDefaultAdmissionWebhook(t *testing.T) {
 				Webhooks: []v1beta1.MutatingWebhook{{
 					ClientConfig: v1beta1.WebhookClientConfig{
 						Service: &v1beta1.ServiceReference{
-							Port: utilpointer.Int32(443), // defaulted
+							Port: ptr.To[int32](443), // defaulted
 						},
 					},
 					FailurePolicy:           &ignore,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086

#### Special notes for your reviewer:

Scoped utilpointer removal in package pkg/apis/admissionregistration

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE

