### PR TITLE
GA the NodeSwap feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1421,6 +1421,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
 	},
 
 	NominatedNodeNameForExpectation: {

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -382,14 +382,6 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		},
 		errMsg: "invalid configuration: memorySwap.swapBehavior \"invalid-behavior\" must be one of: \"\", \"LimitedSwap\" or \"NoSwap\"",
 	}, {
-		name: "specify MemorySwap.SwapBehavior without enabling NodeSwap",
-		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
-			conf.FeatureGates = map[string]bool{"NodeSwap": false}
-			conf.MemorySwap.SwapBehavior = string(kubetypes.LimitedSwap)
-			return conf
-		},
-		errMsg: "invalid configuration: memorySwap.swapBehavior cannot be set when NodeSwap feature flag is disabled",
-	}, {
 		name: "CrashLoopBackOff.MaxContainerRestartPeriod too low",
 		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
 			conf.FeatureGates = map[string]bool{"KubeletCrashLoopBackOffMax": true}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -952,68 +952,55 @@ func TestGetContainerSwapBehavior(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 	tests := []struct {
-		name                       string
-		configuredMemorySwap       types.SwapBehavior
-		nodeSwapFeatureGateEnabled bool
-		isSwapControllerAvailable  bool
-		cgroupVersion              CgroupVersion
-		isCriticalPod              bool
-		qosClass                   v1.PodQOSClass
-		containerResourceOverride  func(container *v1.Container)
-		expected                   types.SwapBehavior
+		name                      string
+		configuredMemorySwap      types.SwapBehavior
+		isSwapControllerAvailable bool
+		cgroupVersion             CgroupVersion
+		isCriticalPod             bool
+		qosClass                  v1.PodQOSClass
+		containerResourceOverride func(container *v1.Container)
+		expected                  types.SwapBehavior
 	}{
 		{
-			name:                       "NoSwap, user set NoSwap behavior",
-			configuredMemorySwap:       types.NoSwap,
-			nodeSwapFeatureGateEnabled: false,
-			expected:                   types.NoSwap,
+			name:                 "NoSwap, user set NoSwap behavior",
+			configuredMemorySwap: types.NoSwap,
+			expected:             types.NoSwap,
 		},
 		{
-			name:                       "NoSwap, feature gate turned off",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: false,
-			expected:                   types.NoSwap,
+			name:                      "NoSwap, swap controller unavailable",
+			configuredMemorySwap:      types.LimitedSwap,
+			isSwapControllerAvailable: false,
+			expected:                  types.NoSwap,
 		},
 		{
-			name:                       "NoSwap, swap controller unavailable",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: true,
-			isSwapControllerAvailable:  false,
-			expected:                   types.NoSwap,
+			name:                      "NoSwap, cgroup v1",
+			configuredMemorySwap:      types.LimitedSwap,
+			isSwapControllerAvailable: true,
+			cgroupVersion:             cgroupV1,
+			expected:                  types.NoSwap,
 		},
 		{
-			name:                       "NoSwap, cgroup v1",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: true,
-			isSwapControllerAvailable:  true,
-			cgroupVersion:              cgroupV1,
-			expected:                   types.NoSwap,
+			name:                      "NoSwap, qos is Best-Effort",
+			configuredMemorySwap:      types.LimitedSwap,
+			isSwapControllerAvailable: true,
+			cgroupVersion:             cgroupV2,
+			qosClass:                  v1.PodQOSBestEffort,
+			expected:                  types.NoSwap,
 		},
 		{
-			name:                       "NoSwap, qos is Best-Effort",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: true,
-			isSwapControllerAvailable:  true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBestEffort,
-			expected:                   types.NoSwap,
+			name:                      "NoSwap, qos is Guaranteed",
+			configuredMemorySwap:      types.LimitedSwap,
+			isSwapControllerAvailable: true,
+			cgroupVersion:             cgroupV2,
+			qosClass:                  v1.PodQOSGuaranteed,
+			expected:                  types.NoSwap,
 		},
 		{
-			name:                       "NoSwap, qos is Guaranteed",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: true,
-			isSwapControllerAvailable:  true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSGuaranteed,
-			expected:                   types.NoSwap,
-		},
-		{
-			name:                       "NoSwap, zero memory",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: true,
-			isSwapControllerAvailable:  true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
+			name:                      "NoSwap, zero memory",
+			configuredMemorySwap:      types.LimitedSwap,
+			isSwapControllerAvailable: true,
+			cgroupVersion:             cgroupV2,
+			qosClass:                  v1.PodQOSBurstable,
 			containerResourceOverride: func(c *v1.Container) {
 				c.Resources.Requests = v1.ResourceList{
 					v1.ResourceMemory: resource.MustParse("0"),
@@ -1025,12 +1012,11 @@ func TestGetContainerSwapBehavior(t *testing.T) {
 			expected: types.NoSwap,
 		},
 		{
-			name:                       "NoSwap, memory request equal to limit",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: true,
-			isSwapControllerAvailable:  true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
+			name:                      "NoSwap, memory request equal to limit",
+			configuredMemorySwap:      types.LimitedSwap,
+			isSwapControllerAvailable: true,
+			cgroupVersion:             cgroupV2,
+			qosClass:                  v1.PodQOSBurstable,
 			containerResourceOverride: func(c *v1.Container) {
 				c.Resources.Requests = v1.ResourceList{
 					v1.ResourceMemory: resource.MustParse("100Mi"),
@@ -1042,13 +1028,12 @@ func TestGetContainerSwapBehavior(t *testing.T) {
 			expected: types.NoSwap,
 		},
 		{
-			name:                       "LimitedSwap, cgroup v2",
-			configuredMemorySwap:       types.LimitedSwap,
-			nodeSwapFeatureGateEnabled: true,
-			isSwapControllerAvailable:  true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			expected:                   types.LimitedSwap,
+			name:                      "LimitedSwap, cgroup v2",
+			configuredMemorySwap:      types.LimitedSwap,
+			isSwapControllerAvailable: true,
+			cgroupVersion:             cgroupV2,
+			qosClass:                  v1.PodQOSBurstable,
+			expected:                  types.LimitedSwap,
 		},
 	}
 
@@ -1057,7 +1042,6 @@ func TestGetContainerSwapBehavior(t *testing.T) {
 			m.memorySwapBehavior = string(tt.configuredMemorySwap)
 			setCgroupVersionDuringTest(tt.cgroupVersion)
 			defer setSwapControllerAvailableDuringTest(tt.isSwapControllerAvailable)()
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeSwap, tt.nodeSwapFeatureGateEnabled)
 			testpod := pod.DeepCopy()
 			testpod.Status.QOSClass = tt.qosClass
 			if tt.containerResourceOverride != nil {
@@ -1142,7 +1126,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 		cgroupVersion               CgroupVersion
 		qosClass                    v1.PodQOSClass
 		swapDisabledOnNode          bool
-		nodeSwapFeatureGateEnabled  bool
 		swapBehavior                types.SwapBehavior
 		addContainerWithoutRequests bool
 		addGuaranteedContainer      bool
@@ -1150,59 +1133,44 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 	}{
 		// With cgroup v1
 		{
-			name:                       "cgroups v1, LimitedSwap, Burstable QoS",
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:          "cgroups v1, LimitedSwap, Burstable QoS",
+			cgroupVersion: cgroupV1,
+			qosClass:      v1.PodQOSBurstable,
+			swapBehavior:  types.LimitedSwap,
 		},
 		{
-			name:                       "cgroups v1, LimitedSwap, Best-effort QoS",
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
-		},
-
-		// With feature gate turned off
-		{
-			name:                       "NodeSwap feature gate turned off, cgroups v2, LimitedSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: false,
-			swapBehavior:               types.LimitedSwap,
+			name:          "cgroups v1, LimitedSwap, Best-effort QoS",
+			cgroupVersion: cgroupV1,
+			qosClass:      v1.PodQOSBestEffort,
+			swapBehavior:  types.LimitedSwap,
 		},
 
 		// With no swapBehavior, NoSwap should be the default
 		{
-			name:                       "With no swapBehavior - NoSwap should be the default",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               "",
+			name:          "With no swapBehavior - NoSwap should be the default",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBestEffort,
+			swapBehavior:  "",
 		},
 
 		// With Guaranteed and Best-effort QoS
 		{
-			name:                       "Best-effort QoS, cgroups v2, NoSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               "NoSwap",
+			name:          "Best-effort QoS, cgroups v2, NoSwap",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBestEffort,
+			swapBehavior:  "NoSwap",
 		},
 		{
-			name:                       "Best-effort QoS, cgroups v2, LimitedSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:          "Best-effort QoS, cgroups v2, LimitedSwap",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBurstable,
+			swapBehavior:  types.LimitedSwap,
 		},
 		{
-			name:                       "Guaranteed QoS, cgroups v2, LimitedSwap",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSGuaranteed,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:          "Guaranteed QoS, cgroups v2, LimitedSwap",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSGuaranteed,
+			swapBehavior:  types.LimitedSwap,
 		},
 
 		// With a "guaranteed" container (when memory requests equal to limits)
@@ -1210,7 +1178,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			name:                        "Burstable QoS, cgroups v2, LimitedSwap, with a guaranteed container",
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      true,
@@ -1221,7 +1188,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			name:                        "Burstable QoS, cgroups v2, LimitedSwap",
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      false,
@@ -1230,65 +1196,49 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			name:                        "Burstable QoS, cgroups v2, LimitedSwap, with a container with no requests",
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: true,
 			addGuaranteedContainer:      false,
 		},
 		// All the above examples with Swap disabled on node
 		{
-			name:                       "Swap disabled on node, cgroups v1, LimitedSwap, Burstable QoS",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, cgroups v1, LimitedSwap, Burstable QoS",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV1,
+			qosClass:           v1.PodQOSBurstable,
+			swapBehavior:       types.LimitedSwap,
 		},
 		{
-			name:                       "Swap disabled on node, cgroups v1, LimitedSwap, Best-effort QoS",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV1,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
-		},
-
-		// With feature gate turned off
-		{
-			name:                       "Swap disabled on node, NodeSwap feature gate turned off, cgroups v2, LimitedSwap",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: false,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, cgroups v1, LimitedSwap, Best-effort QoS",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV1,
+			qosClass:           v1.PodQOSBestEffort,
+			swapBehavior:       types.LimitedSwap,
 		},
 
 		// With no swapBehavior, NoSwap should be the default
 		{
-			name:                       "Swap disabled on node, With no swapBehavior - NoSwap should be the default",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBestEffort,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               "",
+			name:               "Swap disabled on node, With no swapBehavior - NoSwap should be the default",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV2,
+			qosClass:           v1.PodQOSBestEffort,
+			swapBehavior:       "",
 		},
 
 		// With Guaranteed and Best-effort QoS
 		{
-			name:                       "Swap disabled on node, Best-effort QoS, cgroups v2, LimitedSwap",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, Best-effort QoS, cgroups v2, LimitedSwap",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV2,
+			qosClass:           v1.PodQOSBurstable,
+			swapBehavior:       types.LimitedSwap,
 		},
 		{
-			name:                       "Swap disabled on node, Guaranteed QoS, cgroups v2, LimitedSwap",
-			swapDisabledOnNode:         true,
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSGuaranteed,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
+			name:               "Swap disabled on node, Guaranteed QoS, cgroups v2, LimitedSwap",
+			swapDisabledOnNode: true,
+			cgroupVersion:      cgroupV2,
+			qosClass:           v1.PodQOSGuaranteed,
+			swapBehavior:       types.LimitedSwap,
 		},
 
 		// With a "guaranteed" container (when memory requests equal to limits)
@@ -1297,7 +1247,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			swapDisabledOnNode:          true,
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      true,
@@ -1309,7 +1258,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			swapDisabledOnNode:          true,
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: false,
 			addGuaranteedContainer:      false,
@@ -1319,7 +1267,6 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 			swapDisabledOnNode:          true,
 			cgroupVersion:               cgroupV2,
 			qosClass:                    v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled:  true,
 			swapBehavior:                types.LimitedSwap,
 			addContainerWithoutRequests: true,
 			addGuaranteedContainer:      false,
@@ -1327,18 +1274,16 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 
 		// When the pod is considered critical, disallow swap access
 		{
-			name:                       "Best-effort QoS, cgroups v2, LimitedSwap, critical pod",
-			cgroupVersion:              cgroupV2,
-			qosClass:                   v1.PodQOSBurstable,
-			nodeSwapFeatureGateEnabled: true,
-			swapBehavior:               types.LimitedSwap,
-			isCriticalPod:              true,
+			name:          "Best-effort QoS, cgroups v2, LimitedSwap, critical pod",
+			cgroupVersion: cgroupV2,
+			qosClass:      v1.PodQOSBurstable,
+			swapBehavior:  types.LimitedSwap,
+			isCriticalPod: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			setCgroupVersionDuringTest(tc.cgroupVersion)
 			defer setSwapControllerAvailableDuringTest(!tc.swapDisabledOnNode)()
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeSwap, tc.nodeSwapFeatureGateEnabled)
 			m.memorySwapBehavior = string(tc.swapBehavior)
 
 			var resourceReqsC1, resourceReqsC2 v1.ResourceRequirements
@@ -1383,7 +1328,7 @@ func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
 				return
 			}
 
-			if tc.isCriticalPod || !tc.nodeSwapFeatureGateEnabled || tc.cgroupVersion == cgroupV1 || (tc.swapBehavior == types.LimitedSwap && tc.qosClass != v1.PodQOSBurstable) {
+			if tc.isCriticalPod || tc.cgroupVersion == cgroupV1 || (tc.swapBehavior == types.LimitedSwap && tc.qosClass != v1.PodQOSBurstable) {
 				expectNoSwap(tc.cgroupVersion, resourcesC1, resourcesC2)
 				return
 			}

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1009,6 +1009,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.30"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.34"
 - name: NominatedNodeNameForExpectation
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig node

#### What this PR does / why we need it:
GA the NodeSwap feature gate.

#### Special notes for your reviewer:
This PR can be used for a tracker for the remaining work for swap GA:
- [x] Documentation: https://github.com/kubernetes/website/pull/51303.
- [x] Adding eviction tests to the swap-conformance lanes: https://github.com/kubernetes/test-infra/pull/35062.
	- Periodic test results can be found here:
		- https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-ubuntu-serial&width=20.
		- https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-fedora-serial&width=20.
- [x] KEP update: https://github.com/kubernetes/enhancements/pull/5434.

This work is nice-to-have, but not a GA blocker:
- [x] Add a container swap limit metric: https://github.com/kubernetes/kubernetes/pull/132348.

The plan for NodeSwap GA, including what we decided to include in this KEP or defer to future KEPs, can be found here: https://docs.google.com/document/d/14OLKSPl3BDzw2BBacdN0kHpDt-JN8AOTSei_XExh-2s/edit?usp=sharing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
