### PR TITLE
KEP-4601: Graduate selector authorization to stable

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3278,7 +3278,7 @@
       "properties": {
         "fieldSelector": {
           "$ref": "#/definitions/io.k8s.api.authorization.v1.FieldSelectorAttributes",
-          "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
+          "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it."
         },
         "group": {
           "description": "Group is the API Group of the Resource.  \"*\" means all.",
@@ -3286,7 +3286,7 @@
         },
         "labelSelector": {
           "$ref": "#/definitions/io.k8s.api.authorization.v1.LabelSelectorAttributes",
-          "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
+          "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it."
         },
         "name": {
           "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",

--- a/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
@@ -148,7 +148,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.authorization.v1.FieldSelectorAttributes"
               }
             ],
-            "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
+            "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it."
           },
           "group": {
             "description": "Group is the API Group of the Resource.  \"*\" means all.",
@@ -160,7 +160,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.authorization.v1.LabelSelectorAttributes"
               }
             ],
-            "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
+            "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it."
           },
           "name": {
             "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",

--- a/pkg/apis/authorization/types.go
+++ b/pkg/apis/authorization/types.go
@@ -88,15 +88,9 @@ type ResourceAttributes struct {
 	// Name is the name of the resource being requested for a "get" or deleted for a "delete". "" (empty) means all.
 	Name string
 	// fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.
-	//
-	// This field  is alpha-level. To use this field, you must enable the
-	// `AuthorizeWithSelectors` feature gate (disabled by default).
 	// +optional
 	FieldSelector *FieldSelectorAttributes
 	// labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.
-	//
-	// This field  is alpha-level. To use this field, you must enable the
-	// `AuthorizeWithSelectors` feature gate (disabled by default).
 	// +optional
 	LabelSelector *LabelSelectorAttributes
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1029,6 +1029,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	AuthorizeNodeWithSelectors: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
 	},
 
 	CPUCFSQuotaPeriod: {
@@ -1753,6 +1754,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	genericfeatures.AuthorizeWithSelectors: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
 	},
 
 	genericfeatures.BtreeWatchCache: {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -12353,13 +12353,13 @@ func schema_k8sio_api_authorization_v1_ResourceAttributes(ref common.ReferenceCa
 					},
 					"fieldSelector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default).",
+							Description: "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.",
 							Ref:         ref("k8s.io/api/authorization/v1.FieldSelectorAttributes"),
 						},
 					},
 					"labelSelector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default).",
+							Description: "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.",
 							Ref:         ref("k8s.io/api/authorization/v1.LabelSelectorAttributes"),
 						},
 					},

--- a/pkg/registry/authorization/subjectaccessreview/rest_test.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest_test.go
@@ -29,10 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/rest"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 )
 
@@ -235,8 +232,6 @@ func TestCreate(t *testing.T) {
 			},
 		},
 	}
-
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, true)
 
 	for k, tc := range testcases {
 		auth := &fakeAuthorizer{

--- a/pkg/registry/authorization/util/helpers_test.go
+++ b/pkg/registry/authorization/util/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericfeatures "k8s.io/apiserver/pkg/features"
@@ -636,7 +637,10 @@ func TestAuthorizationAttributesFrom(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, tt.enableAuthorizationSelector)
+			if !tt.enableAuthorizationSelector {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, false)
+			}
 
 			if got := AuthorizationAttributesFrom(tt.args.spec); !reflect.DeepEqual(got, tt.want) {
 				if got.LabelSelectorParsingErr != nil {

--- a/staging/src/k8s.io/api/authorization/v1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1/generated.proto
@@ -167,16 +167,10 @@ message ResourceAttributes {
   optional string name = 7;
 
   // fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.
-  //
-  // This field  is alpha-level. To use this field, you must enable the
-  // `AuthorizeWithSelectors` feature gate (disabled by default).
   // +optional
   optional FieldSelectorAttributes fieldSelector = 8;
 
   // labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.
-  //
-  // This field  is alpha-level. To use this field, you must enable the
-  // `AuthorizeWithSelectors` feature gate (disabled by default).
   // +optional
   optional LabelSelectorAttributes labelSelector = 9;
 }

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -119,15 +119,9 @@ type ResourceAttributes struct {
 	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,7,opt,name=name"`
 	// fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.
-	//
-	// This field  is alpha-level. To use this field, you must enable the
-	// `AuthorizeWithSelectors` feature gate (disabled by default).
 	// +optional
 	FieldSelector *FieldSelectorAttributes `json:"fieldSelector,omitempty" protobuf:"bytes,8,opt,name=fieldSelector"`
 	// labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.
-	//
-	// This field  is alpha-level. To use this field, you must enable the
-	// `AuthorizeWithSelectors` feature gate (disabled by default).
 	// +optional
 	LabelSelector *LabelSelectorAttributes `json:"labelSelector,omitempty" protobuf:"bytes,9,opt,name=labelSelector"`
 }

--- a/staging/src/k8s.io/api/authorization/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/authorization/v1/types_swagger_doc_generated.go
@@ -87,8 +87,8 @@ var map_ResourceAttributes = map[string]string{
 	"resource":      "Resource is one of the existing resource types.  \"*\" means all.",
 	"subresource":   "Subresource is one of the existing resource types.  \"\" means none.",
 	"name":          "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
-	"fieldSelector": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default).",
-	"labelSelector": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default).",
+	"fieldSelector": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.",
+	"labelSelector": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.",
 }
 
 func (ResourceAttributes) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/authorizer/caching_authorizer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/authorizer/caching_authorizer_test.go
@@ -26,9 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	genericfeatures "k8s.io/apiserver/pkg/features"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 func mustParseLabelSelector(str string) labels.Requirements {
@@ -41,8 +38,6 @@ func mustParseLabelSelector(str string) labels.Requirements {
 }
 
 func TestCachingAuthorizer(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, true)
-
 	type result struct {
 		decision authorizer.Decision
 		reason   string

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition_test.go
@@ -920,7 +920,10 @@ func TestCondition(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			environment.DisableBaseEnvSetCachingForTests()
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, tc.enableSelectors)
+			if !tc.enableSelectors {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, false)
+			}
 
 			if tc.testPerCallLimit == 0 {
 				tc.testPerCallLimit = celconfig.PerCallLimit

--- a/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile_test.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 	apiservercel "k8s.io/apiserver/pkg/cel"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -98,7 +99,10 @@ func TestCompileCELExpression(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, tc.authorizeWithSelectorsEnabled)
+			if !tc.authorizeWithSelectorsEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, false)
+			}
 
 			// create new compiler because it depends on the feature gate
 			compiler := NewDefaultCompiler()
@@ -117,7 +121,6 @@ func TestCompileCELExpression(t *testing.T) {
 }
 
 func TestBuildRequestType(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, true)
 	f := func(name string, declType *apiservercel.DeclType, required bool) *apiservercel.DeclField {
 		return apiservercel.NewDeclField(name, declType, required, nil, nil)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -25,9 +25,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	genericfeatures "k8s.io/apiserver/pkg/features"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 func TestGetAPIRequestInfo(t *testing.T) {
@@ -314,8 +311,6 @@ func TestSelectorParsing(t *testing.T) {
 	}
 
 	resolver := newTestRequestInfoResolver()
-
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, true)
 
 	for _, tc := range tests {
 		ctx := t.Context()

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -301,6 +301,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	AuthorizeWithSelectors: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.37
 	},
 
 	BtreeWatchCache: {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -322,7 +323,10 @@ func Test_resourceAttributesFrom(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, tt.enableAuthorizationSelector)
+			if !tt.enableAuthorizationSelector {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, false)
+			}
 
 			if got := resourceAttributesFrom(tt.args.attr); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("resourceAttributesFrom() = %v, want %v", got, tt.want)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -783,7 +784,10 @@ func TestStructuredAuthzConfigFeatureEnablement(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AuthorizeWithSelectors, test.selectorEnabled)
+			if !test.selectorEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AuthorizeWithSelectors, false)
+			}
 
 			// create new compiler because it depends on the feature gate
 			compiler := authorizationcel.NewDefaultCompiler()

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -141,6 +141,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.32"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.34"
 - name: AuthorizeWithSelectors
   versionedSpecs:
   - default: false
@@ -151,6 +155,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.32"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.34"
 - name: BtreeWatchCache
   versionedSpecs:
   - default: true

--- a/test/integration/apiserver/cel/authorizerselector/helper.go
+++ b/test/integration/apiserver/cel/authorizerselector/helper.go
@@ -30,8 +30,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/cel/environment"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/utils/ptr"
@@ -44,6 +47,10 @@ func RunAuthzSelectorsLibraryTests(t *testing.T, featureEnabled bool) {
 		// If this check fails, uncomment the debug.PrintStack() when the authz selectors
 		// library is first initialized to find the culprit, and modify it to be lazily initialized on first use.
 		t.Fatalf("authz selector library was initialized before feature gates were finalized (possibly from an init() or package variable)")
+	}
+
+	if !featureEnabled {
+		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
 	}
 
 	// Start the server with the desired feature enablement

--- a/test/integration/auth/authz_config_test.go
+++ b/test/integration/auth/authz_config_test.go
@@ -41,13 +41,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	celmetrics "k8s.io/apiserver/pkg/authorization/cel"
 	authorizationmetrics "k8s.io/apiserver/pkg/authorization/metrics"
-	"k8s.io/apiserver/pkg/features"
 	authzmetrics "k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	webhookmetrics "k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/authutil"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -124,7 +121,6 @@ authorizers:
 func TestMultiWebhookAuthzConfig(t *testing.T) {
 	authzmetrics.ResetMetricsForTest()
 	defer authzmetrics.ResetMetricsForTest()
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AuthorizeWithSelectors, true)
 
 	dir := t.TempDir()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Graduates KEP-4601 to GA.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/enhancements/issues/4601

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
The `AuthorizeWithSelectors` and `AuthorizeNodeWithSelectors` feature gates are promoted to stable and locked on.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/issues/4601
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4601
- [Node authorization]: https://kubernetes.io/docs/reference/access-authn-authz/node/
- [CEL authorization]: https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#AuthzSelectors
- [Webhook authorization]: https://kubernetes.io/docs/reference/access-authn-authz/webhook/
```

/sig auth
/cc @deads2k 