### PR TITLE
applyconfiguration-gen: add ExtractFrom with subresource support

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/example.go
@@ -43,6 +43,7 @@ func Example(name, namespace string) *ExampleApplyConfiguration {
 	b.WithAPIVersion("cr.example.apiextensions.k8s.io/v1")
 	return b
 }
+
 func (b ExampleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
@@ -42,6 +42,7 @@ func CustomResourceDefinition(name string) *CustomResourceDefinitionApplyConfigu
 	b.WithAPIVersion("apiextensions.k8s.io/v1")
 	return b
 }
+
 func (b CustomResourceDefinitionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
@@ -42,6 +42,7 @@ func CustomResourceDefinition(name string) *CustomResourceDefinitionApplyConfigu
 	b.WithAPIVersion("apiextensions.k8s.io/v1beta1")
 	return b
 }
+
 func (b CustomResourceDefinitionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -45,6 +45,27 @@ func MutatingWebhookConfiguration(name string) *MutatingWebhookConfigurationAppl
 	return b
 }
 
+// ExtractMutatingWebhookConfigurationFrom extracts the applied configuration owned by fieldManager from
+// mutatingWebhookConfiguration for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// mutatingWebhookConfiguration must be a unmodified MutatingWebhookConfiguration API object that was retrieved from the Kubernetes API.
+// ExtractMutatingWebhookConfigurationFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractMutatingWebhookConfigurationFrom(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+	b := &MutatingWebhookConfigurationApplyConfiguration{}
+	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(mutatingWebhookConfiguration.Name)
+
+	b.WithKind("MutatingWebhookConfiguration")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractMutatingWebhookConfiguration extracts the applied configuration owned by fieldManager from
 // mutatingWebhookConfiguration. If no managedFields are found in mutatingWebhookConfiguration for fieldManager, a
 // MutatingWebhookConfigurationApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func MutatingWebhookConfiguration(name string) *MutatingWebhookConfigurationAppl
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
-	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "")
+	return ExtractMutatingWebhookConfigurationFrom(mutatingWebhookConfiguration, fieldManager, "")
 }
 
-// ExtractMutatingWebhookConfigurationStatus is the same as ExtractMutatingWebhookConfiguration except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractMutatingWebhookConfigurationStatus(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
-	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "status")
-}
-
-func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
-	b := &MutatingWebhookConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(mutatingWebhookConfiguration.Name)
-
-	b.WithKind("MutatingWebhookConfiguration")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1")
-	return b, nil
-}
 func (b MutatingWebhookConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicy.go
@@ -46,6 +46,27 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 	return b
 }
 
+// ExtractValidatingAdmissionPolicyFrom extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicy for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// validatingAdmissionPolicy must be a unmodified ValidatingAdmissionPolicy API object that was retrieved from the Kubernetes API.
+// ExtractValidatingAdmissionPolicyFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+	b := &ValidatingAdmissionPolicyApplyConfiguration{}
+	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(validatingAdmissionPolicy.Name)
+
+	b.WithKind("ValidatingAdmissionPolicy")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractValidatingAdmissionPolicy extracts the applied configuration owned by fieldManager from
 // validatingAdmissionPolicy. If no managedFields are found in validatingAdmissionPolicy for fieldManager, a
 // ValidatingAdmissionPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "")
+	return ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy, fieldManager, "")
 }
 
-// ExtractValidatingAdmissionPolicyStatus is the same as ExtractValidatingAdmissionPolicy except
-// that it extracts the status subresource applied configuration.
+// ExtractValidatingAdmissionPolicyStatus extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicy for the status subresource.
 // Experimental!
 func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "status")
+	return ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	b := &ValidatingAdmissionPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(validatingAdmissionPolicy.Name)
-
-	b.WithKind("ValidatingAdmissionPolicy")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1")
-	return b, nil
-}
 func (b ValidatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -45,6 +45,27 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 	return b
 }
 
+// ExtractValidatingAdmissionPolicyBindingFrom extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicyBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// validatingAdmissionPolicyBinding must be a unmodified ValidatingAdmissionPolicyBinding API object that was retrieved from the Kubernetes API.
+// ExtractValidatingAdmissionPolicyBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractValidatingAdmissionPolicyBindingFrom(validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
+	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(validatingAdmissionPolicyBinding.Name)
+
+	b.WithKind("ValidatingAdmissionPolicyBinding")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractValidatingAdmissionPolicyBinding extracts the applied configuration owned by fieldManager from
 // validatingAdmissionPolicyBinding. If no managedFields are found in validatingAdmissionPolicyBinding for fieldManager, a
 // ValidatingAdmissionPolicyBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "")
+	return ExtractValidatingAdmissionPolicyBindingFrom(validatingAdmissionPolicyBinding, fieldManager, "")
 }
 
-// ExtractValidatingAdmissionPolicyBindingStatus is the same as ExtractValidatingAdmissionPolicyBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "status")
-}
-
-func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(validatingAdmissionPolicyBinding.Name)
-
-	b.WithKind("ValidatingAdmissionPolicyBinding")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1")
-	return b, nil
-}
 func (b ValidatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -45,6 +45,27 @@ func MutatingAdmissionPolicyBinding(name string) *MutatingAdmissionPolicyBinding
 	return b
 }
 
+// ExtractMutatingAdmissionPolicyBindingFrom extracts the applied configuration owned by fieldManager from
+// mutatingAdmissionPolicyBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// mutatingAdmissionPolicyBinding must be a unmodified MutatingAdmissionPolicyBinding API object that was retrieved from the Kubernetes API.
+// ExtractMutatingAdmissionPolicyBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractMutatingAdmissionPolicyBindingFrom(mutatingAdmissionPolicyBinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, fieldManager string, subresource string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
+	b := &MutatingAdmissionPolicyBindingApplyConfiguration{}
+	err := managedfields.ExtractInto(mutatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicyBinding"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(mutatingAdmissionPolicyBinding.Name)
+
+	b.WithKind("MutatingAdmissionPolicyBinding")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractMutatingAdmissionPolicyBinding extracts the applied configuration owned by fieldManager from
 // mutatingAdmissionPolicyBinding. If no managedFields are found in mutatingAdmissionPolicyBinding for fieldManager, a
 // MutatingAdmissionPolicyBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func MutatingAdmissionPolicyBinding(name string) *MutatingAdmissionPolicyBinding
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, fieldManager string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding, fieldManager, "")
+	return ExtractMutatingAdmissionPolicyBindingFrom(mutatingAdmissionPolicyBinding, fieldManager, "")
 }
 
-// ExtractMutatingAdmissionPolicyBindingStatus is the same as ExtractMutatingAdmissionPolicyBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractMutatingAdmissionPolicyBindingStatus(mutatingAdmissionPolicyBinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, fieldManager string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding, fieldManager, "status")
-}
-
-func extractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, fieldManager string, subresource string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
-	b := &MutatingAdmissionPolicyBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(mutatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicyBinding"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(mutatingAdmissionPolicyBinding.Name)
-
-	b.WithKind("MutatingAdmissionPolicyBinding")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b MutatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -46,6 +46,27 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 	return b
 }
 
+// ExtractValidatingAdmissionPolicyFrom extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicy for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// validatingAdmissionPolicy must be a unmodified ValidatingAdmissionPolicy API object that was retrieved from the Kubernetes API.
+// ExtractValidatingAdmissionPolicyFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+	b := &ValidatingAdmissionPolicyApplyConfiguration{}
+	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(validatingAdmissionPolicy.Name)
+
+	b.WithKind("ValidatingAdmissionPolicy")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractValidatingAdmissionPolicy extracts the applied configuration owned by fieldManager from
 // validatingAdmissionPolicy. If no managedFields are found in validatingAdmissionPolicy for fieldManager, a
 // ValidatingAdmissionPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "")
+	return ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy, fieldManager, "")
 }
 
-// ExtractValidatingAdmissionPolicyStatus is the same as ExtractValidatingAdmissionPolicy except
-// that it extracts the status subresource applied configuration.
+// ExtractValidatingAdmissionPolicyStatus extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicy for the status subresource.
 // Experimental!
 func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "status")
+	return ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	b := &ValidatingAdmissionPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(validatingAdmissionPolicy.Name)
-
-	b.WithKind("ValidatingAdmissionPolicy")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b ValidatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -45,6 +45,27 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 	return b
 }
 
+// ExtractValidatingAdmissionPolicyBindingFrom extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicyBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// validatingAdmissionPolicyBinding must be a unmodified ValidatingAdmissionPolicyBinding API object that was retrieved from the Kubernetes API.
+// ExtractValidatingAdmissionPolicyBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractValidatingAdmissionPolicyBindingFrom(validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
+	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(validatingAdmissionPolicyBinding.Name)
+
+	b.WithKind("ValidatingAdmissionPolicyBinding")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractValidatingAdmissionPolicyBinding extracts the applied configuration owned by fieldManager from
 // validatingAdmissionPolicyBinding. If no managedFields are found in validatingAdmissionPolicyBinding for fieldManager, a
 // ValidatingAdmissionPolicyBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "")
+	return ExtractValidatingAdmissionPolicyBindingFrom(validatingAdmissionPolicyBinding, fieldManager, "")
 }
 
-// ExtractValidatingAdmissionPolicyBindingStatus is the same as ExtractValidatingAdmissionPolicyBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "status")
-}
-
-func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(validatingAdmissionPolicyBinding.Name)
-
-	b.WithKind("ValidatingAdmissionPolicyBinding")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b ValidatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingadmissionpolicy.go
@@ -45,6 +45,27 @@ func MutatingAdmissionPolicy(name string) *MutatingAdmissionPolicyApplyConfigura
 	return b
 }
 
+// ExtractMutatingAdmissionPolicyFrom extracts the applied configuration owned by fieldManager from
+// mutatingAdmissionPolicy for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// mutatingAdmissionPolicy must be a unmodified MutatingAdmissionPolicy API object that was retrieved from the Kubernetes API.
+// ExtractMutatingAdmissionPolicyFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractMutatingAdmissionPolicyFrom(mutatingAdmissionPolicy *admissionregistrationv1beta1.MutatingAdmissionPolicy, fieldManager string, subresource string) (*MutatingAdmissionPolicyApplyConfiguration, error) {
+	b := &MutatingAdmissionPolicyApplyConfiguration{}
+	err := managedfields.ExtractInto(mutatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicy"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(mutatingAdmissionPolicy.Name)
+
+	b.WithKind("MutatingAdmissionPolicy")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractMutatingAdmissionPolicy extracts the applied configuration owned by fieldManager from
 // mutatingAdmissionPolicy. If no managedFields are found in mutatingAdmissionPolicy for fieldManager, a
 // MutatingAdmissionPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func MutatingAdmissionPolicy(name string) *MutatingAdmissionPolicyApplyConfigura
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractMutatingAdmissionPolicy(mutatingAdmissionPolicy *admissionregistrationv1beta1.MutatingAdmissionPolicy, fieldManager string) (*MutatingAdmissionPolicyApplyConfiguration, error) {
-	return extractMutatingAdmissionPolicy(mutatingAdmissionPolicy, fieldManager, "")
+	return ExtractMutatingAdmissionPolicyFrom(mutatingAdmissionPolicy, fieldManager, "")
 }
 
-// ExtractMutatingAdmissionPolicyStatus is the same as ExtractMutatingAdmissionPolicy except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractMutatingAdmissionPolicyStatus(mutatingAdmissionPolicy *admissionregistrationv1beta1.MutatingAdmissionPolicy, fieldManager string) (*MutatingAdmissionPolicyApplyConfiguration, error) {
-	return extractMutatingAdmissionPolicy(mutatingAdmissionPolicy, fieldManager, "status")
-}
-
-func extractMutatingAdmissionPolicy(mutatingAdmissionPolicy *admissionregistrationv1beta1.MutatingAdmissionPolicy, fieldManager string, subresource string) (*MutatingAdmissionPolicyApplyConfiguration, error) {
-	b := &MutatingAdmissionPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(mutatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicy"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(mutatingAdmissionPolicy.Name)
-
-	b.WithKind("MutatingAdmissionPolicy")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
-	return b, nil
-}
 func (b MutatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
@@ -45,6 +45,27 @@ func MutatingAdmissionPolicyBinding(name string) *MutatingAdmissionPolicyBinding
 	return b
 }
 
+// ExtractMutatingAdmissionPolicyBindingFrom extracts the applied configuration owned by fieldManager from
+// mutatingAdmissionPolicyBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// mutatingAdmissionPolicyBinding must be a unmodified MutatingAdmissionPolicyBinding API object that was retrieved from the Kubernetes API.
+// ExtractMutatingAdmissionPolicyBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractMutatingAdmissionPolicyBindingFrom(mutatingAdmissionPolicyBinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, fieldManager string, subresource string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
+	b := &MutatingAdmissionPolicyBindingApplyConfiguration{}
+	err := managedfields.ExtractInto(mutatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyBinding"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(mutatingAdmissionPolicyBinding.Name)
+
+	b.WithKind("MutatingAdmissionPolicyBinding")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractMutatingAdmissionPolicyBinding extracts the applied configuration owned by fieldManager from
 // mutatingAdmissionPolicyBinding. If no managedFields are found in mutatingAdmissionPolicyBinding for fieldManager, a
 // MutatingAdmissionPolicyBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func MutatingAdmissionPolicyBinding(name string) *MutatingAdmissionPolicyBinding
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, fieldManager string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding, fieldManager, "")
+	return ExtractMutatingAdmissionPolicyBindingFrom(mutatingAdmissionPolicyBinding, fieldManager, "")
 }
 
-// ExtractMutatingAdmissionPolicyBindingStatus is the same as ExtractMutatingAdmissionPolicyBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractMutatingAdmissionPolicyBindingStatus(mutatingAdmissionPolicyBinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, fieldManager string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding, fieldManager, "status")
-}
-
-func extractMutatingAdmissionPolicyBinding(mutatingAdmissionPolicyBinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, fieldManager string, subresource string) (*MutatingAdmissionPolicyBindingApplyConfiguration, error) {
-	b := &MutatingAdmissionPolicyBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(mutatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyBinding"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(mutatingAdmissionPolicyBinding.Name)
-
-	b.WithKind("MutatingAdmissionPolicyBinding")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
-	return b, nil
-}
 func (b MutatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -46,6 +46,27 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 	return b
 }
 
+// ExtractValidatingAdmissionPolicyFrom extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicy for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// validatingAdmissionPolicy must be a unmodified ValidatingAdmissionPolicy API object that was retrieved from the Kubernetes API.
+// ExtractValidatingAdmissionPolicyFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+	b := &ValidatingAdmissionPolicyApplyConfiguration{}
+	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(validatingAdmissionPolicy.Name)
+
+	b.WithKind("ValidatingAdmissionPolicy")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractValidatingAdmissionPolicy extracts the applied configuration owned by fieldManager from
 // validatingAdmissionPolicy. If no managedFields are found in validatingAdmissionPolicy for fieldManager, a
 // ValidatingAdmissionPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "")
+	return ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy, fieldManager, "")
 }
 
-// ExtractValidatingAdmissionPolicyStatus is the same as ExtractValidatingAdmissionPolicy except
-// that it extracts the status subresource applied configuration.
+// ExtractValidatingAdmissionPolicyStatus extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicy for the status subresource.
 // Experimental!
 func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "status")
+	return ExtractValidatingAdmissionPolicyFrom(validatingAdmissionPolicy, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
-	b := &ValidatingAdmissionPolicyApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(validatingAdmissionPolicy.Name)
-
-	b.WithKind("ValidatingAdmissionPolicy")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
-	return b, nil
-}
 func (b ValidatingAdmissionPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -45,6 +45,27 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 	return b
 }
 
+// ExtractValidatingAdmissionPolicyBindingFrom extracts the applied configuration owned by fieldManager from
+// validatingAdmissionPolicyBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// validatingAdmissionPolicyBinding must be a unmodified ValidatingAdmissionPolicyBinding API object that was retrieved from the Kubernetes API.
+// ExtractValidatingAdmissionPolicyBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractValidatingAdmissionPolicyBindingFrom(validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
+	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(validatingAdmissionPolicyBinding.Name)
+
+	b.WithKind("ValidatingAdmissionPolicyBinding")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractValidatingAdmissionPolicyBinding extracts the applied configuration owned by fieldManager from
 // validatingAdmissionPolicyBinding. If no managedFields are found in validatingAdmissionPolicyBinding for fieldManager, a
 // ValidatingAdmissionPolicyBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "")
+	return ExtractValidatingAdmissionPolicyBindingFrom(validatingAdmissionPolicyBinding, fieldManager, "")
 }
 
-// ExtractValidatingAdmissionPolicyBindingStatus is the same as ExtractValidatingAdmissionPolicyBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "status")
-}
-
-func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
-	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(validatingAdmissionPolicyBinding.Name)
-
-	b.WithKind("ValidatingAdmissionPolicyBinding")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
-	return b, nil
-}
 func (b ValidatingAdmissionPolicyBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -45,6 +45,27 @@ func ValidatingWebhookConfiguration(name string) *ValidatingWebhookConfiguration
 	return b
 }
 
+// ExtractValidatingWebhookConfigurationFrom extracts the applied configuration owned by fieldManager from
+// validatingWebhookConfiguration for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// validatingWebhookConfiguration must be a unmodified ValidatingWebhookConfiguration API object that was retrieved from the Kubernetes API.
+// ExtractValidatingWebhookConfigurationFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractValidatingWebhookConfigurationFrom(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+	b := &ValidatingWebhookConfigurationApplyConfiguration{}
+	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(validatingWebhookConfiguration.Name)
+
+	b.WithKind("ValidatingWebhookConfiguration")
+	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractValidatingWebhookConfiguration extracts the applied configuration owned by fieldManager from
 // validatingWebhookConfiguration. If no managedFields are found in validatingWebhookConfiguration for fieldManager, a
 // ValidatingWebhookConfigurationApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ValidatingWebhookConfiguration(name string) *ValidatingWebhookConfiguration
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
-	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "")
+	return ExtractValidatingWebhookConfigurationFrom(validatingWebhookConfiguration, fieldManager, "")
 }
 
-// ExtractValidatingWebhookConfigurationStatus is the same as ExtractValidatingWebhookConfiguration except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractValidatingWebhookConfigurationStatus(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
-	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "status")
-}
-
-func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
-	b := &ValidatingWebhookConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(validatingWebhookConfiguration.Name)
-
-	b.WithKind("ValidatingWebhookConfiguration")
-	b.WithAPIVersion("admissionregistration.k8s.io/v1beta1")
-	return b, nil
-}
 func (b ValidatingWebhookConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
@@ -48,29 +48,15 @@ func ControllerRevision(name, namespace string) *ControllerRevisionApplyConfigur
 	return b
 }
 
-// ExtractControllerRevision extracts the applied configuration owned by fieldManager from
-// controllerRevision. If no managedFields are found in controllerRevision for fieldManager, a
-// ControllerRevisionApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractControllerRevisionFrom extracts the applied configuration owned by fieldManager from
+// controllerRevision for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // controllerRevision must be a unmodified ControllerRevision API object that was retrieved from the Kubernetes API.
-// ExtractControllerRevision provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractControllerRevisionFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractControllerRevision(controllerRevision *appsv1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
-	return extractControllerRevision(controllerRevision, fieldManager, "")
-}
-
-// ExtractControllerRevisionStatus is the same as ExtractControllerRevision except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractControllerRevisionStatus(controllerRevision *appsv1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
-	return extractControllerRevision(controllerRevision, fieldManager, "status")
-}
-
-func extractControllerRevision(controllerRevision *appsv1.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
+func ExtractControllerRevisionFrom(controllerRevision *appsv1.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
 	b := &ControllerRevisionApplyConfiguration{}
 	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1.ControllerRevision"), fieldManager, b, subresource)
 	if err != nil {
@@ -83,6 +69,22 @@ func extractControllerRevision(controllerRevision *appsv1.ControllerRevision, fi
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+
+// ExtractControllerRevision extracts the applied configuration owned by fieldManager from
+// controllerRevision. If no managedFields are found in controllerRevision for fieldManager, a
+// ControllerRevisionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// controllerRevision must be a unmodified ControllerRevision API object that was retrieved from the Kubernetes API.
+// ExtractControllerRevision provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractControllerRevision(controllerRevision *appsv1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return ExtractControllerRevisionFrom(controllerRevision, fieldManager, "")
+}
+
 func (b ControllerRevisionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
@@ -47,29 +47,15 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 	return b
 }
 
-// ExtractDaemonSet extracts the applied configuration owned by fieldManager from
-// daemonSet. If no managedFields are found in daemonSet for fieldManager, a
-// DaemonSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractDaemonSetFrom extracts the applied configuration owned by fieldManager from
+// daemonSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // daemonSet must be a unmodified DaemonSet API object that was retrieved from the Kubernetes API.
-// ExtractDaemonSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractDaemonSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDaemonSet(daemonSet *appsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
-	return extractDaemonSet(daemonSet, fieldManager, "")
-}
-
-// ExtractDaemonSetStatus is the same as ExtractDaemonSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDaemonSetStatus(daemonSet *appsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
-	return extractDaemonSet(daemonSet, fieldManager, "status")
-}
-
-func extractDaemonSet(daemonSet *appsv1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSetFrom(daemonSet *appsv1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
 	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractDaemonSet(daemonSet *appsv1.DaemonSet, fieldManager string, subresou
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+
+// ExtractDaemonSet extracts the applied configuration owned by fieldManager from
+// daemonSet. If no managedFields are found in daemonSet for fieldManager, a
+// DaemonSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// daemonSet must be a unmodified DaemonSet API object that was retrieved from the Kubernetes API.
+// ExtractDaemonSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDaemonSet(daemonSet *appsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return ExtractDaemonSetFrom(daemonSet, fieldManager, "")
+}
+
+// ExtractDaemonSetStatus extracts the applied configuration owned by fieldManager from
+// daemonSet for the status subresource.
+// Experimental!
+func ExtractDaemonSetStatus(daemonSet *appsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return ExtractDaemonSetFrom(daemonSet, fieldManager, "status")
+}
+
 func (b DaemonSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
@@ -47,29 +47,15 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 	return b
 }
 
-// ExtractDeployment extracts the applied configuration owned by fieldManager from
-// deployment. If no managedFields are found in deployment for fieldManager, a
-// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractDeploymentFrom extracts the applied configuration owned by fieldManager from
+// deployment for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
-// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractDeploymentFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *appsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "")
-}
-
-// ExtractDeploymentStatus is the same as ExtractDeployment except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeploymentStatus(deployment *appsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "status")
-}
-
-func extractDeployment(deployment *appsv1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentFrom(deployment *appsv1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1.Deployment"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,36 @@ func extractDeployment(deployment *appsv1.Deployment, fieldManager string, subre
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+
+// ExtractDeployment extracts the applied configuration owned by fieldManager from
+// deployment. If no managedFields are found in deployment for fieldManager, a
+// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
+// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeployment(deployment *appsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentScale extracts the applied configuration owned by fieldManager from
+// deployment for the scale subresource.
+// Experimental!
+func ExtractDeploymentScale(deployment *appsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "scale")
+}
+
+// ExtractDeploymentStatus extracts the applied configuration owned by fieldManager from
+// deployment for the status subresource.
+// Experimental!
+func ExtractDeploymentStatus(deployment *appsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "status")
+}
+
 func (b DeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
@@ -47,29 +47,15 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 	return b
 }
 
-// ExtractReplicaSet extracts the applied configuration owned by fieldManager from
-// replicaSet. If no managedFields are found in replicaSet for fieldManager, a
-// ReplicaSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractReplicaSetFrom extracts the applied configuration owned by fieldManager from
+// replicaSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // replicaSet must be a unmodified ReplicaSet API object that was retrieved from the Kubernetes API.
-// ExtractReplicaSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractReplicaSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicaSet(replicaSet *appsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
-	return extractReplicaSet(replicaSet, fieldManager, "")
-}
-
-// ExtractReplicaSetStatus is the same as ExtractReplicaSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractReplicaSetStatus(replicaSet *appsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
-	return extractReplicaSet(replicaSet, fieldManager, "status")
-}
-
-func extractReplicaSet(replicaSet *appsv1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSetFrom(replicaSet *appsv1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
 	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,36 @@ func extractReplicaSet(replicaSet *appsv1.ReplicaSet, fieldManager string, subre
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+
+// ExtractReplicaSet extracts the applied configuration owned by fieldManager from
+// replicaSet. If no managedFields are found in replicaSet for fieldManager, a
+// ReplicaSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// replicaSet must be a unmodified ReplicaSet API object that was retrieved from the Kubernetes API.
+// ExtractReplicaSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractReplicaSet(replicaSet *appsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "")
+}
+
+// ExtractReplicaSetScale extracts the applied configuration owned by fieldManager from
+// replicaSet for the scale subresource.
+// Experimental!
+func ExtractReplicaSetScale(replicaSet *appsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "scale")
+}
+
+// ExtractReplicaSetStatus extracts the applied configuration owned by fieldManager from
+// replicaSet for the status subresource.
+// Experimental!
+func ExtractReplicaSetStatus(replicaSet *appsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "status")
+}
+
 func (b ReplicaSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
@@ -47,29 +47,15 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 	return b
 }
 
-// ExtractStatefulSet extracts the applied configuration owned by fieldManager from
-// statefulSet. If no managedFields are found in statefulSet for fieldManager, a
-// StatefulSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractStatefulSetFrom extracts the applied configuration owned by fieldManager from
+// statefulSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // statefulSet must be a unmodified StatefulSet API object that was retrieved from the Kubernetes API.
-// ExtractStatefulSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractStatefulSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractStatefulSet(statefulSet *appsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
-	return extractStatefulSet(statefulSet, fieldManager, "")
-}
-
-// ExtractStatefulSetStatus is the same as ExtractStatefulSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractStatefulSetStatus(statefulSet *appsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
-	return extractStatefulSet(statefulSet, fieldManager, "status")
-}
-
-func extractStatefulSet(statefulSet *appsv1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSetFrom(statefulSet *appsv1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
 	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,36 @@ func extractStatefulSet(statefulSet *appsv1.StatefulSet, fieldManager string, su
 	b.WithAPIVersion("apps/v1")
 	return b, nil
 }
+
+// ExtractStatefulSet extracts the applied configuration owned by fieldManager from
+// statefulSet. If no managedFields are found in statefulSet for fieldManager, a
+// StatefulSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// statefulSet must be a unmodified StatefulSet API object that was retrieved from the Kubernetes API.
+// ExtractStatefulSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractStatefulSet(statefulSet *appsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "")
+}
+
+// ExtractStatefulSetScale extracts the applied configuration owned by fieldManager from
+// statefulSet for the scale subresource.
+// Experimental!
+func ExtractStatefulSetScale(statefulSet *appsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "scale")
+}
+
+// ExtractStatefulSetStatus extracts the applied configuration owned by fieldManager from
+// statefulSet for the status subresource.
+// Experimental!
+func ExtractStatefulSetStatus(statefulSet *appsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "status")
+}
+
 func (b StatefulSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
@@ -48,29 +48,15 @@ func ControllerRevision(name, namespace string) *ControllerRevisionApplyConfigur
 	return b
 }
 
-// ExtractControllerRevision extracts the applied configuration owned by fieldManager from
-// controllerRevision. If no managedFields are found in controllerRevision for fieldManager, a
-// ControllerRevisionApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractControllerRevisionFrom extracts the applied configuration owned by fieldManager from
+// controllerRevision for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // controllerRevision must be a unmodified ControllerRevision API object that was retrieved from the Kubernetes API.
-// ExtractControllerRevision provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractControllerRevisionFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractControllerRevision(controllerRevision *appsv1beta1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
-	return extractControllerRevision(controllerRevision, fieldManager, "")
-}
-
-// ExtractControllerRevisionStatus is the same as ExtractControllerRevision except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractControllerRevisionStatus(controllerRevision *appsv1beta1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
-	return extractControllerRevision(controllerRevision, fieldManager, "status")
-}
-
-func extractControllerRevision(controllerRevision *appsv1beta1.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
+func ExtractControllerRevisionFrom(controllerRevision *appsv1beta1.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
 	b := &ControllerRevisionApplyConfiguration{}
 	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1beta1.ControllerRevision"), fieldManager, b, subresource)
 	if err != nil {
@@ -83,6 +69,22 @@ func extractControllerRevision(controllerRevision *appsv1beta1.ControllerRevisio
 	b.WithAPIVersion("apps/v1beta1")
 	return b, nil
 }
+
+// ExtractControllerRevision extracts the applied configuration owned by fieldManager from
+// controllerRevision. If no managedFields are found in controllerRevision for fieldManager, a
+// ControllerRevisionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// controllerRevision must be a unmodified ControllerRevision API object that was retrieved from the Kubernetes API.
+// ExtractControllerRevision provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractControllerRevision(controllerRevision *appsv1beta1.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return ExtractControllerRevisionFrom(controllerRevision, fieldManager, "")
+}
+
 func (b ControllerRevisionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
@@ -47,29 +47,15 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 	return b
 }
 
-// ExtractDeployment extracts the applied configuration owned by fieldManager from
-// deployment. If no managedFields are found in deployment for fieldManager, a
-// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractDeploymentFrom extracts the applied configuration owned by fieldManager from
+// deployment for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
-// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractDeploymentFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "")
-}
-
-// ExtractDeploymentStatus is the same as ExtractDeployment except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeploymentStatus(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "status")
-}
-
-func extractDeployment(deployment *appsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentFrom(deployment *appsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta1.Deployment"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractDeployment(deployment *appsv1beta1.Deployment, fieldManager string, 
 	b.WithAPIVersion("apps/v1beta1")
 	return b, nil
 }
+
+// ExtractDeployment extracts the applied configuration owned by fieldManager from
+// deployment. If no managedFields are found in deployment for fieldManager, a
+// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
+// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeployment(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentStatus extracts the applied configuration owned by fieldManager from
+// deployment for the status subresource.
+// Experimental!
+func ExtractDeploymentStatus(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "status")
+}
+
 func (b DeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
@@ -47,29 +47,15 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 	return b
 }
 
-// ExtractStatefulSet extracts the applied configuration owned by fieldManager from
-// statefulSet. If no managedFields are found in statefulSet for fieldManager, a
-// StatefulSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractStatefulSetFrom extracts the applied configuration owned by fieldManager from
+// statefulSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // statefulSet must be a unmodified StatefulSet API object that was retrieved from the Kubernetes API.
-// ExtractStatefulSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractStatefulSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
-	return extractStatefulSet(statefulSet, fieldManager, "")
-}
-
-// ExtractStatefulSetStatus is the same as ExtractStatefulSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractStatefulSetStatus(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
-	return extractStatefulSet(statefulSet, fieldManager, "status")
-}
-
-func extractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSetFrom(statefulSet *appsv1beta1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
 	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta1.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager strin
 	b.WithAPIVersion("apps/v1beta1")
 	return b, nil
 }
+
+// ExtractStatefulSet extracts the applied configuration owned by fieldManager from
+// statefulSet. If no managedFields are found in statefulSet for fieldManager, a
+// StatefulSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// statefulSet must be a unmodified StatefulSet API object that was retrieved from the Kubernetes API.
+// ExtractStatefulSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "")
+}
+
+// ExtractStatefulSetStatus extracts the applied configuration owned by fieldManager from
+// statefulSet for the status subresource.
+// Experimental!
+func ExtractStatefulSetStatus(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "status")
+}
+
 func (b StatefulSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
@@ -48,29 +48,15 @@ func ControllerRevision(name, namespace string) *ControllerRevisionApplyConfigur
 	return b
 }
 
-// ExtractControllerRevision extracts the applied configuration owned by fieldManager from
-// controllerRevision. If no managedFields are found in controllerRevision for fieldManager, a
-// ControllerRevisionApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractControllerRevisionFrom extracts the applied configuration owned by fieldManager from
+// controllerRevision for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // controllerRevision must be a unmodified ControllerRevision API object that was retrieved from the Kubernetes API.
-// ExtractControllerRevision provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractControllerRevisionFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractControllerRevision(controllerRevision *appsv1beta2.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
-	return extractControllerRevision(controllerRevision, fieldManager, "")
-}
-
-// ExtractControllerRevisionStatus is the same as ExtractControllerRevision except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractControllerRevisionStatus(controllerRevision *appsv1beta2.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
-	return extractControllerRevision(controllerRevision, fieldManager, "status")
-}
-
-func extractControllerRevision(controllerRevision *appsv1beta2.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
+func ExtractControllerRevisionFrom(controllerRevision *appsv1beta2.ControllerRevision, fieldManager string, subresource string) (*ControllerRevisionApplyConfiguration, error) {
 	b := &ControllerRevisionApplyConfiguration{}
 	err := managedfields.ExtractInto(controllerRevision, internal.Parser().Type("io.k8s.api.apps.v1beta2.ControllerRevision"), fieldManager, b, subresource)
 	if err != nil {
@@ -83,6 +69,22 @@ func extractControllerRevision(controllerRevision *appsv1beta2.ControllerRevisio
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+
+// ExtractControllerRevision extracts the applied configuration owned by fieldManager from
+// controllerRevision. If no managedFields are found in controllerRevision for fieldManager, a
+// ControllerRevisionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// controllerRevision must be a unmodified ControllerRevision API object that was retrieved from the Kubernetes API.
+// ExtractControllerRevision provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractControllerRevision(controllerRevision *appsv1beta2.ControllerRevision, fieldManager string) (*ControllerRevisionApplyConfiguration, error) {
+	return ExtractControllerRevisionFrom(controllerRevision, fieldManager, "")
+}
+
 func (b ControllerRevisionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
@@ -47,29 +47,15 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 	return b
 }
 
-// ExtractDaemonSet extracts the applied configuration owned by fieldManager from
-// daemonSet. If no managedFields are found in daemonSet for fieldManager, a
-// DaemonSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractDaemonSetFrom extracts the applied configuration owned by fieldManager from
+// daemonSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // daemonSet must be a unmodified DaemonSet API object that was retrieved from the Kubernetes API.
-// ExtractDaemonSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractDaemonSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
-	return extractDaemonSet(daemonSet, fieldManager, "")
-}
-
-// ExtractDaemonSetStatus is the same as ExtractDaemonSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDaemonSetStatus(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
-	return extractDaemonSet(daemonSet, fieldManager, "status")
-}
-
-func extractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSetFrom(daemonSet *appsv1beta2.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
 	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string, sub
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+
+// ExtractDaemonSet extracts the applied configuration owned by fieldManager from
+// daemonSet. If no managedFields are found in daemonSet for fieldManager, a
+// DaemonSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// daemonSet must be a unmodified DaemonSet API object that was retrieved from the Kubernetes API.
+// ExtractDaemonSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return ExtractDaemonSetFrom(daemonSet, fieldManager, "")
+}
+
+// ExtractDaemonSetStatus extracts the applied configuration owned by fieldManager from
+// daemonSet for the status subresource.
+// Experimental!
+func ExtractDaemonSetStatus(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return ExtractDaemonSetFrom(daemonSet, fieldManager, "status")
+}
+
 func (b DaemonSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
@@ -47,29 +47,15 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 	return b
 }
 
-// ExtractDeployment extracts the applied configuration owned by fieldManager from
-// deployment. If no managedFields are found in deployment for fieldManager, a
-// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractDeploymentFrom extracts the applied configuration owned by fieldManager from
+// deployment for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
-// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractDeploymentFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "")
-}
-
-// ExtractDeploymentStatus is the same as ExtractDeployment except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeploymentStatus(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "status")
-}
-
-func extractDeployment(deployment *appsv1beta2.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentFrom(deployment *appsv1beta2.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta2.Deployment"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractDeployment(deployment *appsv1beta2.Deployment, fieldManager string, 
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+
+// ExtractDeployment extracts the applied configuration owned by fieldManager from
+// deployment. If no managedFields are found in deployment for fieldManager, a
+// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
+// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeployment(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentStatus extracts the applied configuration owned by fieldManager from
+// deployment for the status subresource.
+// Experimental!
+func ExtractDeploymentStatus(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "status")
+}
+
 func (b DeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
@@ -47,29 +47,15 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 	return b
 }
 
-// ExtractReplicaSet extracts the applied configuration owned by fieldManager from
-// replicaSet. If no managedFields are found in replicaSet for fieldManager, a
-// ReplicaSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractReplicaSetFrom extracts the applied configuration owned by fieldManager from
+// replicaSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // replicaSet must be a unmodified ReplicaSet API object that was retrieved from the Kubernetes API.
-// ExtractReplicaSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractReplicaSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
-	return extractReplicaSet(replicaSet, fieldManager, "")
-}
-
-// ExtractReplicaSetStatus is the same as ExtractReplicaSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractReplicaSetStatus(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
-	return extractReplicaSet(replicaSet, fieldManager, "status")
-}
-
-func extractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSetFrom(replicaSet *appsv1beta2.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
 	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string, 
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+
+// ExtractReplicaSet extracts the applied configuration owned by fieldManager from
+// replicaSet. If no managedFields are found in replicaSet for fieldManager, a
+// ReplicaSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// replicaSet must be a unmodified ReplicaSet API object that was retrieved from the Kubernetes API.
+// ExtractReplicaSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "")
+}
+
+// ExtractReplicaSetStatus extracts the applied configuration owned by fieldManager from
+// replicaSet for the status subresource.
+// Experimental!
+func ExtractReplicaSetStatus(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "status")
+}
+
 func (b ReplicaSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/scale.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/scale.go
@@ -42,6 +42,7 @@ func Scale() *ScaleApplyConfiguration {
 	b.WithAPIVersion("apps/v1beta2")
 	return b
 }
+
 func (b ScaleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
@@ -47,29 +47,15 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 	return b
 }
 
-// ExtractStatefulSet extracts the applied configuration owned by fieldManager from
-// statefulSet. If no managedFields are found in statefulSet for fieldManager, a
-// StatefulSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractStatefulSetFrom extracts the applied configuration owned by fieldManager from
+// statefulSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // statefulSet must be a unmodified StatefulSet API object that was retrieved from the Kubernetes API.
-// ExtractStatefulSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractStatefulSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
-	return extractStatefulSet(statefulSet, fieldManager, "")
-}
-
-// ExtractStatefulSetStatus is the same as ExtractStatefulSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractStatefulSetStatus(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
-	return extractStatefulSet(statefulSet, fieldManager, "status")
-}
-
-func extractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSetFrom(statefulSet *appsv1beta2.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
 	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,36 @@ func extractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager strin
 	b.WithAPIVersion("apps/v1beta2")
 	return b, nil
 }
+
+// ExtractStatefulSet extracts the applied configuration owned by fieldManager from
+// statefulSet. If no managedFields are found in statefulSet for fieldManager, a
+// StatefulSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// statefulSet must be a unmodified StatefulSet API object that was retrieved from the Kubernetes API.
+// ExtractStatefulSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "")
+}
+
+// ExtractStatefulSetScale extracts the applied configuration owned by fieldManager from
+// statefulSet for the scale subresource.
+// Experimental!
+func ExtractStatefulSetScale(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "scale")
+}
+
+// ExtractStatefulSetStatus extracts the applied configuration owned by fieldManager from
+// statefulSet for the status subresource.
+// Experimental!
+func ExtractStatefulSetStatus(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+	return ExtractStatefulSetFrom(statefulSet, fieldManager, "status")
+}
+
 func (b StatefulSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
@@ -47,29 +47,15 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 	return b
 }
 
-// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
-// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
-// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractHorizontalPodAutoscalerFrom extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
-// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractHorizontalPodAutoscalerFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
-}
-
-// ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
-}
-
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv1.Horiz
 	b.WithAPIVersion("autoscaling/v1")
 	return b, nil
 }
+
+// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
+// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
+// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "")
+}
+
+// ExtractHorizontalPodAutoscalerStatus extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the status subresource.
+// Experimental!
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "status")
+}
+
 func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scale.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scale.go
@@ -41,6 +41,7 @@ func Scale() *ScaleApplyConfiguration {
 	b.WithAPIVersion("autoscaling/v1")
 	return b
 }
+
 func (b ScaleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
@@ -47,29 +47,15 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 	return b
 }
 
-// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
-// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
-// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractHorizontalPodAutoscalerFrom extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
-// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractHorizontalPodAutoscalerFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
-}
-
-// ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
-}
-
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2.Horiz
 	b.WithAPIVersion("autoscaling/v2")
 	return b, nil
 }
+
+// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
+// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
+// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "")
+}
+
+// ExtractHorizontalPodAutoscalerStatus extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the status subresource.
+// Experimental!
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "status")
+}
+
 func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -47,29 +47,15 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 	return b
 }
 
-// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
-// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
-// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractHorizontalPodAutoscalerFrom extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
-// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractHorizontalPodAutoscalerFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
-}
-
-// ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
-}
-
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.
 	b.WithAPIVersion("autoscaling/v2beta1")
 	return b, nil
 }
+
+// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
+// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
+// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "")
+}
+
+// ExtractHorizontalPodAutoscalerStatus extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the status subresource.
+// Experimental!
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "status")
+}
+
 func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -47,29 +47,15 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 	return b
 }
 
-// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
-// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
-// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractHorizontalPodAutoscalerFrom extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
-// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractHorizontalPodAutoscalerFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
-}
-
-// ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
-	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
-}
-
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.
 	b.WithAPIVersion("autoscaling/v2beta2")
 	return b, nil
 }
+
+// ExtractHorizontalPodAutoscaler extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler. If no managedFields are found in horizontalPodAutoscaler for fieldManager, a
+// HorizontalPodAutoscalerApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// horizontalPodAutoscaler must be a unmodified HorizontalPodAutoscaler API object that was retrieved from the Kubernetes API.
+// ExtractHorizontalPodAutoscaler provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "")
+}
+
+// ExtractHorizontalPodAutoscalerStatus extracts the applied configuration owned by fieldManager from
+// horizontalPodAutoscaler for the status subresource.
+// Experimental!
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+	return ExtractHorizontalPodAutoscalerFrom(horizontalPodAutoscaler, fieldManager, "status")
+}
+
 func (b HorizontalPodAutoscalerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
@@ -47,29 +47,15 @@ func CronJob(name, namespace string) *CronJobApplyConfiguration {
 	return b
 }
 
-// ExtractCronJob extracts the applied configuration owned by fieldManager from
-// cronJob. If no managedFields are found in cronJob for fieldManager, a
-// CronJobApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractCronJobFrom extracts the applied configuration owned by fieldManager from
+// cronJob for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // cronJob must be a unmodified CronJob API object that was retrieved from the Kubernetes API.
-// ExtractCronJob provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractCronJobFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCronJob(cronJob *batchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
-	return extractCronJob(cronJob, fieldManager, "")
-}
-
-// ExtractCronJobStatus is the same as ExtractCronJob except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCronJobStatus(cronJob *batchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
-	return extractCronJob(cronJob, fieldManager, "status")
-}
-
-func extractCronJob(cronJob *batchv1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
+func ExtractCronJobFrom(cronJob *batchv1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
 	b := &CronJobApplyConfiguration{}
 	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1.CronJob"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractCronJob(cronJob *batchv1.CronJob, fieldManager string, subresource s
 	b.WithAPIVersion("batch/v1")
 	return b, nil
 }
+
+// ExtractCronJob extracts the applied configuration owned by fieldManager from
+// cronJob. If no managedFields are found in cronJob for fieldManager, a
+// CronJobApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// cronJob must be a unmodified CronJob API object that was retrieved from the Kubernetes API.
+// ExtractCronJob provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCronJob(cronJob *batchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return ExtractCronJobFrom(cronJob, fieldManager, "")
+}
+
+// ExtractCronJobStatus extracts the applied configuration owned by fieldManager from
+// cronJob for the status subresource.
+// Experimental!
+func ExtractCronJobStatus(cronJob *batchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return ExtractCronJobFrom(cronJob, fieldManager, "status")
+}
+
 func (b CronJobApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
@@ -47,29 +47,15 @@ func Job(name, namespace string) *JobApplyConfiguration {
 	return b
 }
 
-// ExtractJob extracts the applied configuration owned by fieldManager from
-// job. If no managedFields are found in job for fieldManager, a
-// JobApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractJobFrom extracts the applied configuration owned by fieldManager from
+// job for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // job must be a unmodified Job API object that was retrieved from the Kubernetes API.
-// ExtractJob provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractJobFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractJob(job *batchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
-	return extractJob(job, fieldManager, "")
-}
-
-// ExtractJobStatus is the same as ExtractJob except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractJobStatus(job *batchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
-	return extractJob(job, fieldManager, "status")
-}
-
-func extractJob(job *batchv1.Job, fieldManager string, subresource string) (*JobApplyConfiguration, error) {
+func ExtractJobFrom(job *batchv1.Job, fieldManager string, subresource string) (*JobApplyConfiguration, error) {
 	b := &JobApplyConfiguration{}
 	err := managedfields.ExtractInto(job, internal.Parser().Type("io.k8s.api.batch.v1.Job"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractJob(job *batchv1.Job, fieldManager string, subresource string) (*Job
 	b.WithAPIVersion("batch/v1")
 	return b, nil
 }
+
+// ExtractJob extracts the applied configuration owned by fieldManager from
+// job. If no managedFields are found in job for fieldManager, a
+// JobApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// job must be a unmodified Job API object that was retrieved from the Kubernetes API.
+// ExtractJob provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractJob(job *batchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
+	return ExtractJobFrom(job, fieldManager, "")
+}
+
+// ExtractJobStatus extracts the applied configuration owned by fieldManager from
+// job for the status subresource.
+// Experimental!
+func ExtractJobStatus(job *batchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
+	return ExtractJobFrom(job, fieldManager, "status")
+}
+
 func (b JobApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
@@ -47,29 +47,15 @@ func CronJob(name, namespace string) *CronJobApplyConfiguration {
 	return b
 }
 
-// ExtractCronJob extracts the applied configuration owned by fieldManager from
-// cronJob. If no managedFields are found in cronJob for fieldManager, a
-// CronJobApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractCronJobFrom extracts the applied configuration owned by fieldManager from
+// cronJob for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // cronJob must be a unmodified CronJob API object that was retrieved from the Kubernetes API.
-// ExtractCronJob provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractCronJobFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
-	return extractCronJob(cronJob, fieldManager, "")
-}
-
-// ExtractCronJobStatus is the same as ExtractCronJob except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCronJobStatus(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
-	return extractCronJob(cronJob, fieldManager, "status")
-}
-
-func extractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
+func ExtractCronJobFrom(cronJob *batchv1beta1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
 	b := &CronJobApplyConfiguration{}
 	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1beta1.CronJob"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string, subresou
 	b.WithAPIVersion("batch/v1beta1")
 	return b, nil
 }
+
+// ExtractCronJob extracts the applied configuration owned by fieldManager from
+// cronJob. If no managedFields are found in cronJob for fieldManager, a
+// CronJobApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// cronJob must be a unmodified CronJob API object that was retrieved from the Kubernetes API.
+// ExtractCronJob provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return ExtractCronJobFrom(cronJob, fieldManager, "")
+}
+
+// ExtractCronJobStatus extracts the applied configuration owned by fieldManager from
+// cronJob for the status subresource.
+// Experimental!
+func ExtractCronJobStatus(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+	return ExtractCronJobFrom(cronJob, fieldManager, "status")
+}
+
 func (b CronJobApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
@@ -46,6 +46,27 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 	return b
 }
 
+// ExtractCertificateSigningRequestFrom extracts the applied configuration owned by fieldManager from
+// certificateSigningRequest for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// certificateSigningRequest must be a unmodified CertificateSigningRequest API object that was retrieved from the Kubernetes API.
+// ExtractCertificateSigningRequestFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCertificateSigningRequestFrom(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
+	b := &CertificateSigningRequestApplyConfiguration{}
+	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1.CertificateSigningRequest"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(certificateSigningRequest.Name)
+
+	b.WithKind("CertificateSigningRequest")
+	b.WithAPIVersion("certificates.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractCertificateSigningRequest extracts the applied configuration owned by fieldManager from
 // certificateSigningRequest. If no managedFields are found in certificateSigningRequest for fieldManager, a
 // CertificateSigningRequestApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,23 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCertificateSigningRequest(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
-	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "")
+	return ExtractCertificateSigningRequestFrom(certificateSigningRequest, fieldManager, "")
 }
 
-// ExtractCertificateSigningRequestStatus is the same as ExtractCertificateSigningRequest except
-// that it extracts the status subresource applied configuration.
+// ExtractCertificateSigningRequestApproval extracts the applied configuration owned by fieldManager from
+// certificateSigningRequest for the approval subresource.
+// Experimental!
+func ExtractCertificateSigningRequestApproval(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+	return ExtractCertificateSigningRequestFrom(certificateSigningRequest, fieldManager, "approval")
+}
+
+// ExtractCertificateSigningRequestStatus extracts the applied configuration owned by fieldManager from
+// certificateSigningRequest for the status subresource.
 // Experimental!
 func ExtractCertificateSigningRequestStatus(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
-	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "status")
+	return ExtractCertificateSigningRequestFrom(certificateSigningRequest, fieldManager, "status")
 }
 
-func extractCertificateSigningRequest(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
-	b := &CertificateSigningRequestApplyConfiguration{}
-	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1.CertificateSigningRequest"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(certificateSigningRequest.Name)
-
-	b.WithKind("CertificateSigningRequest")
-	b.WithAPIVersion("certificates.k8s.io/v1")
-	return b, nil
-}
 func (b CertificateSigningRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
@@ -45,6 +45,27 @@ func ClusterTrustBundle(name string) *ClusterTrustBundleApplyConfiguration {
 	return b
 }
 
+// ExtractClusterTrustBundleFrom extracts the applied configuration owned by fieldManager from
+// clusterTrustBundle for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// clusterTrustBundle must be a unmodified ClusterTrustBundle API object that was retrieved from the Kubernetes API.
+// ExtractClusterTrustBundleFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractClusterTrustBundleFrom(clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, fieldManager string, subresource string) (*ClusterTrustBundleApplyConfiguration, error) {
+	b := &ClusterTrustBundleApplyConfiguration{}
+	err := managedfields.ExtractInto(clusterTrustBundle, internal.Parser().Type("io.k8s.api.certificates.v1alpha1.ClusterTrustBundle"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(clusterTrustBundle.Name)
+
+	b.WithKind("ClusterTrustBundle")
+	b.WithAPIVersion("certificates.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractClusterTrustBundle extracts the applied configuration owned by fieldManager from
 // clusterTrustBundle. If no managedFields are found in clusterTrustBundle for fieldManager, a
 // ClusterTrustBundleApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ClusterTrustBundle(name string) *ClusterTrustBundleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterTrustBundle(clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
-	return extractClusterTrustBundle(clusterTrustBundle, fieldManager, "")
+	return ExtractClusterTrustBundleFrom(clusterTrustBundle, fieldManager, "")
 }
 
-// ExtractClusterTrustBundleStatus is the same as ExtractClusterTrustBundle except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractClusterTrustBundleStatus(clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
-	return extractClusterTrustBundle(clusterTrustBundle, fieldManager, "status")
-}
-
-func extractClusterTrustBundle(clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, fieldManager string, subresource string) (*ClusterTrustBundleApplyConfiguration, error) {
-	b := &ClusterTrustBundleApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterTrustBundle, internal.Parser().Type("io.k8s.api.certificates.v1alpha1.ClusterTrustBundle"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(clusterTrustBundle.Name)
-
-	b.WithKind("ClusterTrustBundle")
-	b.WithAPIVersion("certificates.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b ClusterTrustBundleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/podcertificaterequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/podcertificaterequest.go
@@ -47,29 +47,15 @@ func PodCertificateRequest(name, namespace string) *PodCertificateRequestApplyCo
 	return b
 }
 
-// ExtractPodCertificateRequest extracts the applied configuration owned by fieldManager from
-// podCertificateRequest. If no managedFields are found in podCertificateRequest for fieldManager, a
-// PodCertificateRequestApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractPodCertificateRequestFrom extracts the applied configuration owned by fieldManager from
+// podCertificateRequest for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // podCertificateRequest must be a unmodified PodCertificateRequest API object that was retrieved from the Kubernetes API.
-// ExtractPodCertificateRequest provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractPodCertificateRequestFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodCertificateRequest(podCertificateRequest *certificatesv1alpha1.PodCertificateRequest, fieldManager string) (*PodCertificateRequestApplyConfiguration, error) {
-	return extractPodCertificateRequest(podCertificateRequest, fieldManager, "")
-}
-
-// ExtractPodCertificateRequestStatus is the same as ExtractPodCertificateRequest except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPodCertificateRequestStatus(podCertificateRequest *certificatesv1alpha1.PodCertificateRequest, fieldManager string) (*PodCertificateRequestApplyConfiguration, error) {
-	return extractPodCertificateRequest(podCertificateRequest, fieldManager, "status")
-}
-
-func extractPodCertificateRequest(podCertificateRequest *certificatesv1alpha1.PodCertificateRequest, fieldManager string, subresource string) (*PodCertificateRequestApplyConfiguration, error) {
+func ExtractPodCertificateRequestFrom(podCertificateRequest *certificatesv1alpha1.PodCertificateRequest, fieldManager string, subresource string) (*PodCertificateRequestApplyConfiguration, error) {
 	b := &PodCertificateRequestApplyConfiguration{}
 	err := managedfields.ExtractInto(podCertificateRequest, internal.Parser().Type("io.k8s.api.certificates.v1alpha1.PodCertificateRequest"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractPodCertificateRequest(podCertificateRequest *certificatesv1alpha1.Po
 	b.WithAPIVersion("certificates.k8s.io/v1alpha1")
 	return b, nil
 }
+
+// ExtractPodCertificateRequest extracts the applied configuration owned by fieldManager from
+// podCertificateRequest. If no managedFields are found in podCertificateRequest for fieldManager, a
+// PodCertificateRequestApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// podCertificateRequest must be a unmodified PodCertificateRequest API object that was retrieved from the Kubernetes API.
+// ExtractPodCertificateRequest provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPodCertificateRequest(podCertificateRequest *certificatesv1alpha1.PodCertificateRequest, fieldManager string) (*PodCertificateRequestApplyConfiguration, error) {
+	return ExtractPodCertificateRequestFrom(podCertificateRequest, fieldManager, "")
+}
+
+// ExtractPodCertificateRequestStatus extracts the applied configuration owned by fieldManager from
+// podCertificateRequest for the status subresource.
+// Experimental!
+func ExtractPodCertificateRequestStatus(podCertificateRequest *certificatesv1alpha1.PodCertificateRequest, fieldManager string) (*PodCertificateRequestApplyConfiguration, error) {
+	return ExtractPodCertificateRequestFrom(podCertificateRequest, fieldManager, "status")
+}
+
 func (b PodCertificateRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
@@ -46,6 +46,27 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 	return b
 }
 
+// ExtractCertificateSigningRequestFrom extracts the applied configuration owned by fieldManager from
+// certificateSigningRequest for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// certificateSigningRequest must be a unmodified CertificateSigningRequest API object that was retrieved from the Kubernetes API.
+// ExtractCertificateSigningRequestFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCertificateSigningRequestFrom(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
+	b := &CertificateSigningRequestApplyConfiguration{}
+	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1beta1.CertificateSigningRequest"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(certificateSigningRequest.Name)
+
+	b.WithKind("CertificateSigningRequest")
+	b.WithAPIVersion("certificates.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractCertificateSigningRequest extracts the applied configuration owned by fieldManager from
 // certificateSigningRequest. If no managedFields are found in certificateSigningRequest for fieldManager, a
 // CertificateSigningRequestApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCertificateSigningRequest(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
-	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "")
+	return ExtractCertificateSigningRequestFrom(certificateSigningRequest, fieldManager, "")
 }
 
-// ExtractCertificateSigningRequestStatus is the same as ExtractCertificateSigningRequest except
-// that it extracts the status subresource applied configuration.
+// ExtractCertificateSigningRequestStatus extracts the applied configuration owned by fieldManager from
+// certificateSigningRequest for the status subresource.
 // Experimental!
 func ExtractCertificateSigningRequestStatus(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
-	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "status")
+	return ExtractCertificateSigningRequestFrom(certificateSigningRequest, fieldManager, "status")
 }
 
-func extractCertificateSigningRequest(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
-	b := &CertificateSigningRequestApplyConfiguration{}
-	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1beta1.CertificateSigningRequest"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(certificateSigningRequest.Name)
-
-	b.WithKind("CertificateSigningRequest")
-	b.WithAPIVersion("certificates.k8s.io/v1beta1")
-	return b, nil
-}
 func (b CertificateSigningRequestApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/clustertrustbundle.go
@@ -45,6 +45,27 @@ func ClusterTrustBundle(name string) *ClusterTrustBundleApplyConfiguration {
 	return b
 }
 
+// ExtractClusterTrustBundleFrom extracts the applied configuration owned by fieldManager from
+// clusterTrustBundle for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// clusterTrustBundle must be a unmodified ClusterTrustBundle API object that was retrieved from the Kubernetes API.
+// ExtractClusterTrustBundleFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractClusterTrustBundleFrom(clusterTrustBundle *certificatesv1beta1.ClusterTrustBundle, fieldManager string, subresource string) (*ClusterTrustBundleApplyConfiguration, error) {
+	b := &ClusterTrustBundleApplyConfiguration{}
+	err := managedfields.ExtractInto(clusterTrustBundle, internal.Parser().Type("io.k8s.api.certificates.v1beta1.ClusterTrustBundle"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(clusterTrustBundle.Name)
+
+	b.WithKind("ClusterTrustBundle")
+	b.WithAPIVersion("certificates.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractClusterTrustBundle extracts the applied configuration owned by fieldManager from
 // clusterTrustBundle. If no managedFields are found in clusterTrustBundle for fieldManager, a
 // ClusterTrustBundleApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ClusterTrustBundle(name string) *ClusterTrustBundleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterTrustBundle(clusterTrustBundle *certificatesv1beta1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
-	return extractClusterTrustBundle(clusterTrustBundle, fieldManager, "")
+	return ExtractClusterTrustBundleFrom(clusterTrustBundle, fieldManager, "")
 }
 
-// ExtractClusterTrustBundleStatus is the same as ExtractClusterTrustBundle except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractClusterTrustBundleStatus(clusterTrustBundle *certificatesv1beta1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
-	return extractClusterTrustBundle(clusterTrustBundle, fieldManager, "status")
-}
-
-func extractClusterTrustBundle(clusterTrustBundle *certificatesv1beta1.ClusterTrustBundle, fieldManager string, subresource string) (*ClusterTrustBundleApplyConfiguration, error) {
-	b := &ClusterTrustBundleApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterTrustBundle, internal.Parser().Type("io.k8s.api.certificates.v1beta1.ClusterTrustBundle"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(clusterTrustBundle.Name)
-
-	b.WithKind("ClusterTrustBundle")
-	b.WithAPIVersion("certificates.k8s.io/v1beta1")
-	return b, nil
-}
 func (b ClusterTrustBundleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
@@ -46,29 +46,15 @@ func Lease(name, namespace string) *LeaseApplyConfiguration {
 	return b
 }
 
-// ExtractLease extracts the applied configuration owned by fieldManager from
-// lease. If no managedFields are found in lease for fieldManager, a
-// LeaseApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractLeaseFrom extracts the applied configuration owned by fieldManager from
+// lease for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // lease must be a unmodified Lease API object that was retrieved from the Kubernetes API.
-// ExtractLease provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractLeaseFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLease(lease *coordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
-	return extractLease(lease, fieldManager, "")
-}
-
-// ExtractLeaseStatus is the same as ExtractLease except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractLeaseStatus(lease *coordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
-	return extractLease(lease, fieldManager, "status")
-}
-
-func extractLease(lease *coordinationv1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
+func ExtractLeaseFrom(lease *coordinationv1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
 	b := &LeaseApplyConfiguration{}
 	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1.Lease"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractLease(lease *coordinationv1.Lease, fieldManager string, subresource 
 	b.WithAPIVersion("coordination.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractLease extracts the applied configuration owned by fieldManager from
+// lease. If no managedFields are found in lease for fieldManager, a
+// LeaseApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// lease must be a unmodified Lease API object that was retrieved from the Kubernetes API.
+// ExtractLease provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractLease(lease *coordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+	return ExtractLeaseFrom(lease, fieldManager, "")
+}
+
 func (b LeaseApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1alpha2/leasecandidate.go
@@ -46,29 +46,15 @@ func LeaseCandidate(name, namespace string) *LeaseCandidateApplyConfiguration {
 	return b
 }
 
-// ExtractLeaseCandidate extracts the applied configuration owned by fieldManager from
-// leaseCandidate. If no managedFields are found in leaseCandidate for fieldManager, a
-// LeaseCandidateApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractLeaseCandidateFrom extracts the applied configuration owned by fieldManager from
+// leaseCandidate for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // leaseCandidate must be a unmodified LeaseCandidate API object that was retrieved from the Kubernetes API.
-// ExtractLeaseCandidate provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractLeaseCandidateFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLeaseCandidate(leaseCandidate *coordinationv1alpha2.LeaseCandidate, fieldManager string) (*LeaseCandidateApplyConfiguration, error) {
-	return extractLeaseCandidate(leaseCandidate, fieldManager, "")
-}
-
-// ExtractLeaseCandidateStatus is the same as ExtractLeaseCandidate except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractLeaseCandidateStatus(leaseCandidate *coordinationv1alpha2.LeaseCandidate, fieldManager string) (*LeaseCandidateApplyConfiguration, error) {
-	return extractLeaseCandidate(leaseCandidate, fieldManager, "status")
-}
-
-func extractLeaseCandidate(leaseCandidate *coordinationv1alpha2.LeaseCandidate, fieldManager string, subresource string) (*LeaseCandidateApplyConfiguration, error) {
+func ExtractLeaseCandidateFrom(leaseCandidate *coordinationv1alpha2.LeaseCandidate, fieldManager string, subresource string) (*LeaseCandidateApplyConfiguration, error) {
 	b := &LeaseCandidateApplyConfiguration{}
 	err := managedfields.ExtractInto(leaseCandidate, internal.Parser().Type("io.k8s.api.coordination.v1alpha2.LeaseCandidate"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractLeaseCandidate(leaseCandidate *coordinationv1alpha2.LeaseCandidate, 
 	b.WithAPIVersion("coordination.k8s.io/v1alpha2")
 	return b, nil
 }
+
+// ExtractLeaseCandidate extracts the applied configuration owned by fieldManager from
+// leaseCandidate. If no managedFields are found in leaseCandidate for fieldManager, a
+// LeaseCandidateApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// leaseCandidate must be a unmodified LeaseCandidate API object that was retrieved from the Kubernetes API.
+// ExtractLeaseCandidate provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractLeaseCandidate(leaseCandidate *coordinationv1alpha2.LeaseCandidate, fieldManager string) (*LeaseCandidateApplyConfiguration, error) {
+	return ExtractLeaseCandidateFrom(leaseCandidate, fieldManager, "")
+}
+
 func (b LeaseCandidateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
@@ -46,29 +46,15 @@ func Lease(name, namespace string) *LeaseApplyConfiguration {
 	return b
 }
 
-// ExtractLease extracts the applied configuration owned by fieldManager from
-// lease. If no managedFields are found in lease for fieldManager, a
-// LeaseApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractLeaseFrom extracts the applied configuration owned by fieldManager from
+// lease for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // lease must be a unmodified Lease API object that was retrieved from the Kubernetes API.
-// ExtractLease provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractLeaseFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLease(lease *coordinationv1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
-	return extractLease(lease, fieldManager, "")
-}
-
-// ExtractLeaseStatus is the same as ExtractLease except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractLeaseStatus(lease *coordinationv1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
-	return extractLease(lease, fieldManager, "status")
-}
-
-func extractLease(lease *coordinationv1beta1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
+func ExtractLeaseFrom(lease *coordinationv1beta1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
 	b := &LeaseApplyConfiguration{}
 	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1beta1.Lease"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractLease(lease *coordinationv1beta1.Lease, fieldManager string, subreso
 	b.WithAPIVersion("coordination.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractLease extracts the applied configuration owned by fieldManager from
+// lease. If no managedFields are found in lease for fieldManager, a
+// LeaseApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// lease must be a unmodified Lease API object that was retrieved from the Kubernetes API.
+// ExtractLease provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractLease(lease *coordinationv1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+	return ExtractLeaseFrom(lease, fieldManager, "")
+}
+
 func (b LeaseApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/leasecandidate.go
@@ -46,29 +46,15 @@ func LeaseCandidate(name, namespace string) *LeaseCandidateApplyConfiguration {
 	return b
 }
 
-// ExtractLeaseCandidate extracts the applied configuration owned by fieldManager from
-// leaseCandidate. If no managedFields are found in leaseCandidate for fieldManager, a
-// LeaseCandidateApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractLeaseCandidateFrom extracts the applied configuration owned by fieldManager from
+// leaseCandidate for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // leaseCandidate must be a unmodified LeaseCandidate API object that was retrieved from the Kubernetes API.
-// ExtractLeaseCandidate provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractLeaseCandidateFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLeaseCandidate(leaseCandidate *coordinationv1beta1.LeaseCandidate, fieldManager string) (*LeaseCandidateApplyConfiguration, error) {
-	return extractLeaseCandidate(leaseCandidate, fieldManager, "")
-}
-
-// ExtractLeaseCandidateStatus is the same as ExtractLeaseCandidate except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractLeaseCandidateStatus(leaseCandidate *coordinationv1beta1.LeaseCandidate, fieldManager string) (*LeaseCandidateApplyConfiguration, error) {
-	return extractLeaseCandidate(leaseCandidate, fieldManager, "status")
-}
-
-func extractLeaseCandidate(leaseCandidate *coordinationv1beta1.LeaseCandidate, fieldManager string, subresource string) (*LeaseCandidateApplyConfiguration, error) {
+func ExtractLeaseCandidateFrom(leaseCandidate *coordinationv1beta1.LeaseCandidate, fieldManager string, subresource string) (*LeaseCandidateApplyConfiguration, error) {
 	b := &LeaseCandidateApplyConfiguration{}
 	err := managedfields.ExtractInto(leaseCandidate, internal.Parser().Type("io.k8s.api.coordination.v1beta1.LeaseCandidate"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractLeaseCandidate(leaseCandidate *coordinationv1beta1.LeaseCandidate, f
 	b.WithAPIVersion("coordination.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractLeaseCandidate extracts the applied configuration owned by fieldManager from
+// leaseCandidate. If no managedFields are found in leaseCandidate for fieldManager, a
+// LeaseCandidateApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// leaseCandidate must be a unmodified LeaseCandidate API object that was retrieved from the Kubernetes API.
+// ExtractLeaseCandidate provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractLeaseCandidate(leaseCandidate *coordinationv1beta1.LeaseCandidate, fieldManager string) (*LeaseCandidateApplyConfiguration, error) {
+	return ExtractLeaseCandidateFrom(leaseCandidate, fieldManager, "")
+}
+
 func (b LeaseCandidateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
@@ -48,29 +48,15 @@ func ConfigMap(name, namespace string) *ConfigMapApplyConfiguration {
 	return b
 }
 
-// ExtractConfigMap extracts the applied configuration owned by fieldManager from
-// configMap. If no managedFields are found in configMap for fieldManager, a
-// ConfigMapApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractConfigMapFrom extracts the applied configuration owned by fieldManager from
+// configMap for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // configMap must be a unmodified ConfigMap API object that was retrieved from the Kubernetes API.
-// ExtractConfigMap provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractConfigMapFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractConfigMap(configMap *corev1.ConfigMap, fieldManager string) (*ConfigMapApplyConfiguration, error) {
-	return extractConfigMap(configMap, fieldManager, "")
-}
-
-// ExtractConfigMapStatus is the same as ExtractConfigMap except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractConfigMapStatus(configMap *corev1.ConfigMap, fieldManager string) (*ConfigMapApplyConfiguration, error) {
-	return extractConfigMap(configMap, fieldManager, "status")
-}
-
-func extractConfigMap(configMap *corev1.ConfigMap, fieldManager string, subresource string) (*ConfigMapApplyConfiguration, error) {
+func ExtractConfigMapFrom(configMap *corev1.ConfigMap, fieldManager string, subresource string) (*ConfigMapApplyConfiguration, error) {
 	b := &ConfigMapApplyConfiguration{}
 	err := managedfields.ExtractInto(configMap, internal.Parser().Type("io.k8s.api.core.v1.ConfigMap"), fieldManager, b, subresource)
 	if err != nil {
@@ -83,6 +69,22 @@ func extractConfigMap(configMap *corev1.ConfigMap, fieldManager string, subresou
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractConfigMap extracts the applied configuration owned by fieldManager from
+// configMap. If no managedFields are found in configMap for fieldManager, a
+// ConfigMapApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// configMap must be a unmodified ConfigMap API object that was retrieved from the Kubernetes API.
+// ExtractConfigMap provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractConfigMap(configMap *corev1.ConfigMap, fieldManager string) (*ConfigMapApplyConfiguration, error) {
+	return ExtractConfigMapFrom(configMap, fieldManager, "")
+}
+
 func (b ConfigMapApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
@@ -46,29 +46,15 @@ func Endpoints(name, namespace string) *EndpointsApplyConfiguration {
 	return b
 }
 
-// ExtractEndpoints extracts the applied configuration owned by fieldManager from
-// endpoints. If no managedFields are found in endpoints for fieldManager, a
-// EndpointsApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEndpointsFrom extracts the applied configuration owned by fieldManager from
+// endpoints for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // endpoints must be a unmodified Endpoints API object that was retrieved from the Kubernetes API.
-// ExtractEndpoints provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEndpointsFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEndpoints(endpoints *corev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
-	return extractEndpoints(endpoints, fieldManager, "")
-}
-
-// ExtractEndpointsStatus is the same as ExtractEndpoints except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEndpointsStatus(endpoints *corev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
-	return extractEndpoints(endpoints, fieldManager, "status")
-}
-
-func extractEndpoints(endpoints *corev1.Endpoints, fieldManager string, subresource string) (*EndpointsApplyConfiguration, error) {
+func ExtractEndpointsFrom(endpoints *corev1.Endpoints, fieldManager string, subresource string) (*EndpointsApplyConfiguration, error) {
 	b := &EndpointsApplyConfiguration{}
 	err := managedfields.ExtractInto(endpoints, internal.Parser().Type("io.k8s.api.core.v1.Endpoints"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractEndpoints(endpoints *corev1.Endpoints, fieldManager string, subresou
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractEndpoints extracts the applied configuration owned by fieldManager from
+// endpoints. If no managedFields are found in endpoints for fieldManager, a
+// EndpointsApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// endpoints must be a unmodified Endpoints API object that was retrieved from the Kubernetes API.
+// ExtractEndpoints provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEndpoints(endpoints *corev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
+	return ExtractEndpointsFrom(endpoints, fieldManager, "")
+}
+
 func (b EndpointsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
@@ -59,29 +59,15 @@ func Event(name, namespace string) *EventApplyConfiguration {
 	return b
 }
 
-// ExtractEvent extracts the applied configuration owned by fieldManager from
-// event. If no managedFields are found in event for fieldManager, a
-// EventApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEventFrom extracts the applied configuration owned by fieldManager from
+// event for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // event must be a unmodified Event API object that was retrieved from the Kubernetes API.
-// ExtractEvent provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEventFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEvent(event *corev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
-	return extractEvent(event, fieldManager, "")
-}
-
-// ExtractEventStatus is the same as ExtractEvent except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEventStatus(event *corev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
-	return extractEvent(event, fieldManager, "status")
-}
-
-func extractEvent(event *corev1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
+func ExtractEventFrom(event *corev1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
 	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.core.v1.Event"), fieldManager, b, subresource)
 	if err != nil {
@@ -94,6 +80,22 @@ func extractEvent(event *corev1.Event, fieldManager string, subresource string) 
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractEvent extracts the applied configuration owned by fieldManager from
+// event. If no managedFields are found in event for fieldManager, a
+// EventApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// event must be a unmodified Event API object that was retrieved from the Kubernetes API.
+// ExtractEvent provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEvent(event *corev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return ExtractEventFrom(event, fieldManager, "")
+}
+
 func (b EventApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
@@ -46,29 +46,15 @@ func LimitRange(name, namespace string) *LimitRangeApplyConfiguration {
 	return b
 }
 
-// ExtractLimitRange extracts the applied configuration owned by fieldManager from
-// limitRange. If no managedFields are found in limitRange for fieldManager, a
-// LimitRangeApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractLimitRangeFrom extracts the applied configuration owned by fieldManager from
+// limitRange for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // limitRange must be a unmodified LimitRange API object that was retrieved from the Kubernetes API.
-// ExtractLimitRange provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractLimitRangeFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLimitRange(limitRange *corev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
-	return extractLimitRange(limitRange, fieldManager, "")
-}
-
-// ExtractLimitRangeStatus is the same as ExtractLimitRange except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractLimitRangeStatus(limitRange *corev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
-	return extractLimitRange(limitRange, fieldManager, "status")
-}
-
-func extractLimitRange(limitRange *corev1.LimitRange, fieldManager string, subresource string) (*LimitRangeApplyConfiguration, error) {
+func ExtractLimitRangeFrom(limitRange *corev1.LimitRange, fieldManager string, subresource string) (*LimitRangeApplyConfiguration, error) {
 	b := &LimitRangeApplyConfiguration{}
 	err := managedfields.ExtractInto(limitRange, internal.Parser().Type("io.k8s.api.core.v1.LimitRange"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractLimitRange(limitRange *corev1.LimitRange, fieldManager string, subre
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractLimitRange extracts the applied configuration owned by fieldManager from
+// limitRange. If no managedFields are found in limitRange for fieldManager, a
+// LimitRangeApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// limitRange must be a unmodified LimitRange API object that was retrieved from the Kubernetes API.
+// ExtractLimitRange provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractLimitRange(limitRange *corev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
+	return ExtractLimitRangeFrom(limitRange, fieldManager, "")
+}
+
 func (b LimitRangeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
@@ -47,29 +47,15 @@ func PersistentVolumeClaim(name, namespace string) *PersistentVolumeClaimApplyCo
 	return b
 }
 
-// ExtractPersistentVolumeClaim extracts the applied configuration owned by fieldManager from
-// persistentVolumeClaim. If no managedFields are found in persistentVolumeClaim for fieldManager, a
-// PersistentVolumeClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractPersistentVolumeClaimFrom extracts the applied configuration owned by fieldManager from
+// persistentVolumeClaim for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // persistentVolumeClaim must be a unmodified PersistentVolumeClaim API object that was retrieved from the Kubernetes API.
-// ExtractPersistentVolumeClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractPersistentVolumeClaimFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPersistentVolumeClaim(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
-	return extractPersistentVolumeClaim(persistentVolumeClaim, fieldManager, "")
-}
-
-// ExtractPersistentVolumeClaimStatus is the same as ExtractPersistentVolumeClaim except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPersistentVolumeClaimStatus(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
-	return extractPersistentVolumeClaim(persistentVolumeClaim, fieldManager, "status")
-}
-
-func extractPersistentVolumeClaim(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string, subresource string) (*PersistentVolumeClaimApplyConfiguration, error) {
+func ExtractPersistentVolumeClaimFrom(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string, subresource string) (*PersistentVolumeClaimApplyConfiguration, error) {
 	b := &PersistentVolumeClaimApplyConfiguration{}
 	err := managedfields.ExtractInto(persistentVolumeClaim, internal.Parser().Type("io.k8s.api.core.v1.PersistentVolumeClaim"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractPersistentVolumeClaim(persistentVolumeClaim *corev1.PersistentVolume
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractPersistentVolumeClaim extracts the applied configuration owned by fieldManager from
+// persistentVolumeClaim. If no managedFields are found in persistentVolumeClaim for fieldManager, a
+// PersistentVolumeClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// persistentVolumeClaim must be a unmodified PersistentVolumeClaim API object that was retrieved from the Kubernetes API.
+// ExtractPersistentVolumeClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPersistentVolumeClaim(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
+	return ExtractPersistentVolumeClaimFrom(persistentVolumeClaim, fieldManager, "")
+}
+
+// ExtractPersistentVolumeClaimStatus extracts the applied configuration owned by fieldManager from
+// persistentVolumeClaim for the status subresource.
+// Experimental!
+func ExtractPersistentVolumeClaimStatus(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
+	return ExtractPersistentVolumeClaimFrom(persistentVolumeClaim, fieldManager, "status")
+}
+
 func (b PersistentVolumeClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
@@ -47,29 +47,15 @@ func Pod(name, namespace string) *PodApplyConfiguration {
 	return b
 }
 
-// ExtractPod extracts the applied configuration owned by fieldManager from
-// pod. If no managedFields are found in pod for fieldManager, a
-// PodApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractPodFrom extracts the applied configuration owned by fieldManager from
+// pod for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // pod must be a unmodified Pod API object that was retrieved from the Kubernetes API.
-// ExtractPod provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractPodFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPod(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
-	return extractPod(pod, fieldManager, "")
-}
-
-// ExtractPodStatus is the same as ExtractPod except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPodStatus(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
-	return extractPod(pod, fieldManager, "status")
-}
-
-func extractPod(pod *corev1.Pod, fieldManager string, subresource string) (*PodApplyConfiguration, error) {
+func ExtractPodFrom(pod *corev1.Pod, fieldManager string, subresource string) (*PodApplyConfiguration, error) {
 	b := &PodApplyConfiguration{}
 	err := managedfields.ExtractInto(pod, internal.Parser().Type("io.k8s.api.core.v1.Pod"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,43 @@ func extractPod(pod *corev1.Pod, fieldManager string, subresource string) (*PodA
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractPod extracts the applied configuration owned by fieldManager from
+// pod. If no managedFields are found in pod for fieldManager, a
+// PodApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// pod must be a unmodified Pod API object that was retrieved from the Kubernetes API.
+// ExtractPod provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPod(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+	return ExtractPodFrom(pod, fieldManager, "")
+}
+
+// ExtractPodEphemeralcontainers extracts the applied configuration owned by fieldManager from
+// pod for the ephemeralcontainers subresource.
+// Experimental!
+func ExtractPodEphemeralcontainers(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+	return ExtractPodFrom(pod, fieldManager, "ephemeralcontainers")
+}
+
+// ExtractPodResize extracts the applied configuration owned by fieldManager from
+// pod for the resize subresource.
+// Experimental!
+func ExtractPodResize(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+	return ExtractPodFrom(pod, fieldManager, "resize")
+}
+
+// ExtractPodStatus extracts the applied configuration owned by fieldManager from
+// pod for the status subresource.
+// Experimental!
+func ExtractPodStatus(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+	return ExtractPodFrom(pod, fieldManager, "status")
+}
+
 func (b PodApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
@@ -46,29 +46,15 @@ func PodTemplate(name, namespace string) *PodTemplateApplyConfiguration {
 	return b
 }
 
-// ExtractPodTemplate extracts the applied configuration owned by fieldManager from
-// podTemplate. If no managedFields are found in podTemplate for fieldManager, a
-// PodTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractPodTemplateFrom extracts the applied configuration owned by fieldManager from
+// podTemplate for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // podTemplate must be a unmodified PodTemplate API object that was retrieved from the Kubernetes API.
-// ExtractPodTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractPodTemplateFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodTemplate(podTemplate *corev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
-	return extractPodTemplate(podTemplate, fieldManager, "")
-}
-
-// ExtractPodTemplateStatus is the same as ExtractPodTemplate except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPodTemplateStatus(podTemplate *corev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
-	return extractPodTemplate(podTemplate, fieldManager, "status")
-}
-
-func extractPodTemplate(podTemplate *corev1.PodTemplate, fieldManager string, subresource string) (*PodTemplateApplyConfiguration, error) {
+func ExtractPodTemplateFrom(podTemplate *corev1.PodTemplate, fieldManager string, subresource string) (*PodTemplateApplyConfiguration, error) {
 	b := &PodTemplateApplyConfiguration{}
 	err := managedfields.ExtractInto(podTemplate, internal.Parser().Type("io.k8s.api.core.v1.PodTemplate"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractPodTemplate(podTemplate *corev1.PodTemplate, fieldManager string, su
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractPodTemplate extracts the applied configuration owned by fieldManager from
+// podTemplate. If no managedFields are found in podTemplate for fieldManager, a
+// PodTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// podTemplate must be a unmodified PodTemplate API object that was retrieved from the Kubernetes API.
+// ExtractPodTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPodTemplate(podTemplate *corev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
+	return ExtractPodTemplateFrom(podTemplate, fieldManager, "")
+}
+
 func (b PodTemplateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
@@ -47,29 +47,15 @@ func ReplicationController(name, namespace string) *ReplicationControllerApplyCo
 	return b
 }
 
-// ExtractReplicationController extracts the applied configuration owned by fieldManager from
-// replicationController. If no managedFields are found in replicationController for fieldManager, a
-// ReplicationControllerApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractReplicationControllerFrom extracts the applied configuration owned by fieldManager from
+// replicationController for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // replicationController must be a unmodified ReplicationController API object that was retrieved from the Kubernetes API.
-// ExtractReplicationController provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractReplicationControllerFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicationController(replicationController *corev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
-	return extractReplicationController(replicationController, fieldManager, "")
-}
-
-// ExtractReplicationControllerStatus is the same as ExtractReplicationController except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractReplicationControllerStatus(replicationController *corev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
-	return extractReplicationController(replicationController, fieldManager, "status")
-}
-
-func extractReplicationController(replicationController *corev1.ReplicationController, fieldManager string, subresource string) (*ReplicationControllerApplyConfiguration, error) {
+func ExtractReplicationControllerFrom(replicationController *corev1.ReplicationController, fieldManager string, subresource string) (*ReplicationControllerApplyConfiguration, error) {
 	b := &ReplicationControllerApplyConfiguration{}
 	err := managedfields.ExtractInto(replicationController, internal.Parser().Type("io.k8s.api.core.v1.ReplicationController"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,36 @@ func extractReplicationController(replicationController *corev1.ReplicationContr
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractReplicationController extracts the applied configuration owned by fieldManager from
+// replicationController. If no managedFields are found in replicationController for fieldManager, a
+// ReplicationControllerApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// replicationController must be a unmodified ReplicationController API object that was retrieved from the Kubernetes API.
+// ExtractReplicationController provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractReplicationController(replicationController *corev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
+	return ExtractReplicationControllerFrom(replicationController, fieldManager, "")
+}
+
+// ExtractReplicationControllerScale extracts the applied configuration owned by fieldManager from
+// replicationController for the scale subresource.
+// Experimental!
+func ExtractReplicationControllerScale(replicationController *corev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
+	return ExtractReplicationControllerFrom(replicationController, fieldManager, "scale")
+}
+
+// ExtractReplicationControllerStatus extracts the applied configuration owned by fieldManager from
+// replicationController for the status subresource.
+// Experimental!
+func ExtractReplicationControllerStatus(replicationController *corev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
+	return ExtractReplicationControllerFrom(replicationController, fieldManager, "status")
+}
+
 func (b ReplicationControllerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
@@ -47,29 +47,15 @@ func ResourceQuota(name, namespace string) *ResourceQuotaApplyConfiguration {
 	return b
 }
 
-// ExtractResourceQuota extracts the applied configuration owned by fieldManager from
-// resourceQuota. If no managedFields are found in resourceQuota for fieldManager, a
-// ResourceQuotaApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractResourceQuotaFrom extracts the applied configuration owned by fieldManager from
+// resourceQuota for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // resourceQuota must be a unmodified ResourceQuota API object that was retrieved from the Kubernetes API.
-// ExtractResourceQuota provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractResourceQuotaFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceQuota(resourceQuota *corev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
-	return extractResourceQuota(resourceQuota, fieldManager, "")
-}
-
-// ExtractResourceQuotaStatus is the same as ExtractResourceQuota except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceQuotaStatus(resourceQuota *corev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
-	return extractResourceQuota(resourceQuota, fieldManager, "status")
-}
-
-func extractResourceQuota(resourceQuota *corev1.ResourceQuota, fieldManager string, subresource string) (*ResourceQuotaApplyConfiguration, error) {
+func ExtractResourceQuotaFrom(resourceQuota *corev1.ResourceQuota, fieldManager string, subresource string) (*ResourceQuotaApplyConfiguration, error) {
 	b := &ResourceQuotaApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceQuota, internal.Parser().Type("io.k8s.api.core.v1.ResourceQuota"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractResourceQuota(resourceQuota *corev1.ResourceQuota, fieldManager stri
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractResourceQuota extracts the applied configuration owned by fieldManager from
+// resourceQuota. If no managedFields are found in resourceQuota for fieldManager, a
+// ResourceQuotaApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// resourceQuota must be a unmodified ResourceQuota API object that was retrieved from the Kubernetes API.
+// ExtractResourceQuota provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceQuota(resourceQuota *corev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
+	return ExtractResourceQuotaFrom(resourceQuota, fieldManager, "")
+}
+
+// ExtractResourceQuotaStatus extracts the applied configuration owned by fieldManager from
+// resourceQuota for the status subresource.
+// Experimental!
+func ExtractResourceQuotaStatus(resourceQuota *corev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
+	return ExtractResourceQuotaFrom(resourceQuota, fieldManager, "status")
+}
+
 func (b ResourceQuotaApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
@@ -49,29 +49,15 @@ func Secret(name, namespace string) *SecretApplyConfiguration {
 	return b
 }
 
-// ExtractSecret extracts the applied configuration owned by fieldManager from
-// secret. If no managedFields are found in secret for fieldManager, a
-// SecretApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractSecretFrom extracts the applied configuration owned by fieldManager from
+// secret for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // secret must be a unmodified Secret API object that was retrieved from the Kubernetes API.
-// ExtractSecret provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractSecretFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractSecret(secret *corev1.Secret, fieldManager string) (*SecretApplyConfiguration, error) {
-	return extractSecret(secret, fieldManager, "")
-}
-
-// ExtractSecretStatus is the same as ExtractSecret except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractSecretStatus(secret *corev1.Secret, fieldManager string) (*SecretApplyConfiguration, error) {
-	return extractSecret(secret, fieldManager, "status")
-}
-
-func extractSecret(secret *corev1.Secret, fieldManager string, subresource string) (*SecretApplyConfiguration, error) {
+func ExtractSecretFrom(secret *corev1.Secret, fieldManager string, subresource string) (*SecretApplyConfiguration, error) {
 	b := &SecretApplyConfiguration{}
 	err := managedfields.ExtractInto(secret, internal.Parser().Type("io.k8s.api.core.v1.Secret"), fieldManager, b, subresource)
 	if err != nil {
@@ -84,6 +70,22 @@ func extractSecret(secret *corev1.Secret, fieldManager string, subresource strin
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractSecret extracts the applied configuration owned by fieldManager from
+// secret. If no managedFields are found in secret for fieldManager, a
+// SecretApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// secret must be a unmodified Secret API object that was retrieved from the Kubernetes API.
+// ExtractSecret provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractSecret(secret *corev1.Secret, fieldManager string) (*SecretApplyConfiguration, error) {
+	return ExtractSecretFrom(secret, fieldManager, "")
+}
+
 func (b SecretApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
@@ -47,29 +47,15 @@ func Service(name, namespace string) *ServiceApplyConfiguration {
 	return b
 }
 
-// ExtractService extracts the applied configuration owned by fieldManager from
-// service. If no managedFields are found in service for fieldManager, a
-// ServiceApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractServiceFrom extracts the applied configuration owned by fieldManager from
+// service for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // service must be a unmodified Service API object that was retrieved from the Kubernetes API.
-// ExtractService provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractServiceFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractService(service *corev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
-	return extractService(service, fieldManager, "")
-}
-
-// ExtractServiceStatus is the same as ExtractService except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractServiceStatus(service *corev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
-	return extractService(service, fieldManager, "status")
-}
-
-func extractService(service *corev1.Service, fieldManager string, subresource string) (*ServiceApplyConfiguration, error) {
+func ExtractServiceFrom(service *corev1.Service, fieldManager string, subresource string) (*ServiceApplyConfiguration, error) {
 	b := &ServiceApplyConfiguration{}
 	err := managedfields.ExtractInto(service, internal.Parser().Type("io.k8s.api.core.v1.Service"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractService(service *corev1.Service, fieldManager string, subresource st
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractService extracts the applied configuration owned by fieldManager from
+// service. If no managedFields are found in service for fieldManager, a
+// ServiceApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// service must be a unmodified Service API object that was retrieved from the Kubernetes API.
+// ExtractService provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractService(service *corev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
+	return ExtractServiceFrom(service, fieldManager, "")
+}
+
+// ExtractServiceStatus extracts the applied configuration owned by fieldManager from
+// service for the status subresource.
+// Experimental!
+func ExtractServiceStatus(service *corev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
+	return ExtractServiceFrom(service, fieldManager, "status")
+}
+
 func (b ServiceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
@@ -48,29 +48,15 @@ func ServiceAccount(name, namespace string) *ServiceAccountApplyConfiguration {
 	return b
 }
 
-// ExtractServiceAccount extracts the applied configuration owned by fieldManager from
-// serviceAccount. If no managedFields are found in serviceAccount for fieldManager, a
-// ServiceAccountApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractServiceAccountFrom extracts the applied configuration owned by fieldManager from
+// serviceAccount for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // serviceAccount must be a unmodified ServiceAccount API object that was retrieved from the Kubernetes API.
-// ExtractServiceAccount provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractServiceAccountFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractServiceAccount(serviceAccount *corev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
-	return extractServiceAccount(serviceAccount, fieldManager, "")
-}
-
-// ExtractServiceAccountStatus is the same as ExtractServiceAccount except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractServiceAccountStatus(serviceAccount *corev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
-	return extractServiceAccount(serviceAccount, fieldManager, "status")
-}
-
-func extractServiceAccount(serviceAccount *corev1.ServiceAccount, fieldManager string, subresource string) (*ServiceAccountApplyConfiguration, error) {
+func ExtractServiceAccountFrom(serviceAccount *corev1.ServiceAccount, fieldManager string, subresource string) (*ServiceAccountApplyConfiguration, error) {
 	b := &ServiceAccountApplyConfiguration{}
 	err := managedfields.ExtractInto(serviceAccount, internal.Parser().Type("io.k8s.api.core.v1.ServiceAccount"), fieldManager, b, subresource)
 	if err != nil {
@@ -83,6 +69,29 @@ func extractServiceAccount(serviceAccount *corev1.ServiceAccount, fieldManager s
 	b.WithAPIVersion("v1")
 	return b, nil
 }
+
+// ExtractServiceAccount extracts the applied configuration owned by fieldManager from
+// serviceAccount. If no managedFields are found in serviceAccount for fieldManager, a
+// ServiceAccountApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// serviceAccount must be a unmodified ServiceAccount API object that was retrieved from the Kubernetes API.
+// ExtractServiceAccount provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractServiceAccount(serviceAccount *corev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
+	return ExtractServiceAccountFrom(serviceAccount, fieldManager, "")
+}
+
+// ExtractServiceAccountToken extracts the applied configuration owned by fieldManager from
+// serviceAccount for the token subresource.
+// Experimental!
+func ExtractServiceAccountToken(serviceAccount *corev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
+	return ExtractServiceAccountFrom(serviceAccount, fieldManager, "token")
+}
+
 func (b ServiceAccountApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
@@ -48,29 +48,15 @@ func EndpointSlice(name, namespace string) *EndpointSliceApplyConfiguration {
 	return b
 }
 
-// ExtractEndpointSlice extracts the applied configuration owned by fieldManager from
-// endpointSlice. If no managedFields are found in endpointSlice for fieldManager, a
-// EndpointSliceApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEndpointSliceFrom extracts the applied configuration owned by fieldManager from
+// endpointSlice for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // endpointSlice must be a unmodified EndpointSlice API object that was retrieved from the Kubernetes API.
-// ExtractEndpointSlice provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEndpointSliceFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
-	return extractEndpointSlice(endpointSlice, fieldManager, "")
-}
-
-// ExtractEndpointSliceStatus is the same as ExtractEndpointSlice except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEndpointSliceStatus(endpointSlice *discoveryv1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
-	return extractEndpointSlice(endpointSlice, fieldManager, "status")
-}
-
-func extractEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, fieldManager string, subresource string) (*EndpointSliceApplyConfiguration, error) {
+func ExtractEndpointSliceFrom(endpointSlice *discoveryv1.EndpointSlice, fieldManager string, subresource string) (*EndpointSliceApplyConfiguration, error) {
 	b := &EndpointSliceApplyConfiguration{}
 	err := managedfields.ExtractInto(endpointSlice, internal.Parser().Type("io.k8s.api.discovery.v1.EndpointSlice"), fieldManager, b, subresource)
 	if err != nil {
@@ -83,6 +69,22 @@ func extractEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, fieldManager
 	b.WithAPIVersion("discovery.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractEndpointSlice extracts the applied configuration owned by fieldManager from
+// endpointSlice. If no managedFields are found in endpointSlice for fieldManager, a
+// EndpointSliceApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// endpointSlice must be a unmodified EndpointSlice API object that was retrieved from the Kubernetes API.
+// ExtractEndpointSlice provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
+	return ExtractEndpointSliceFrom(endpointSlice, fieldManager, "")
+}
+
 func (b EndpointSliceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
@@ -48,29 +48,15 @@ func EndpointSlice(name, namespace string) *EndpointSliceApplyConfiguration {
 	return b
 }
 
-// ExtractEndpointSlice extracts the applied configuration owned by fieldManager from
-// endpointSlice. If no managedFields are found in endpointSlice for fieldManager, a
-// EndpointSliceApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEndpointSliceFrom extracts the applied configuration owned by fieldManager from
+// endpointSlice for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // endpointSlice must be a unmodified EndpointSlice API object that was retrieved from the Kubernetes API.
-// ExtractEndpointSlice provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEndpointSliceFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEndpointSlice(endpointSlice *discoveryv1beta1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
-	return extractEndpointSlice(endpointSlice, fieldManager, "")
-}
-
-// ExtractEndpointSliceStatus is the same as ExtractEndpointSlice except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEndpointSliceStatus(endpointSlice *discoveryv1beta1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
-	return extractEndpointSlice(endpointSlice, fieldManager, "status")
-}
-
-func extractEndpointSlice(endpointSlice *discoveryv1beta1.EndpointSlice, fieldManager string, subresource string) (*EndpointSliceApplyConfiguration, error) {
+func ExtractEndpointSliceFrom(endpointSlice *discoveryv1beta1.EndpointSlice, fieldManager string, subresource string) (*EndpointSliceApplyConfiguration, error) {
 	b := &EndpointSliceApplyConfiguration{}
 	err := managedfields.ExtractInto(endpointSlice, internal.Parser().Type("io.k8s.api.discovery.v1beta1.EndpointSlice"), fieldManager, b, subresource)
 	if err != nil {
@@ -83,6 +69,22 @@ func extractEndpointSlice(endpointSlice *discoveryv1beta1.EndpointSlice, fieldMa
 	b.WithAPIVersion("discovery.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractEndpointSlice extracts the applied configuration owned by fieldManager from
+// endpointSlice. If no managedFields are found in endpointSlice for fieldManager, a
+// EndpointSliceApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// endpointSlice must be a unmodified EndpointSlice API object that was retrieved from the Kubernetes API.
+// ExtractEndpointSlice provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEndpointSlice(endpointSlice *discoveryv1beta1.EndpointSlice, fieldManager string) (*EndpointSliceApplyConfiguration, error) {
+	return ExtractEndpointSliceFrom(endpointSlice, fieldManager, "")
+}
+
 func (b EndpointSliceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
@@ -60,29 +60,15 @@ func Event(name, namespace string) *EventApplyConfiguration {
 	return b
 }
 
-// ExtractEvent extracts the applied configuration owned by fieldManager from
-// event. If no managedFields are found in event for fieldManager, a
-// EventApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEventFrom extracts the applied configuration owned by fieldManager from
+// event for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // event must be a unmodified Event API object that was retrieved from the Kubernetes API.
-// ExtractEvent provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEventFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEvent(event *eventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
-	return extractEvent(event, fieldManager, "")
-}
-
-// ExtractEventStatus is the same as ExtractEvent except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEventStatus(event *eventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
-	return extractEvent(event, fieldManager, "status")
-}
-
-func extractEvent(event *eventsv1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
+func ExtractEventFrom(event *eventsv1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
 	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1.Event"), fieldManager, b, subresource)
 	if err != nil {
@@ -95,6 +81,22 @@ func extractEvent(event *eventsv1.Event, fieldManager string, subresource string
 	b.WithAPIVersion("events.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractEvent extracts the applied configuration owned by fieldManager from
+// event. If no managedFields are found in event for fieldManager, a
+// EventApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// event must be a unmodified Event API object that was retrieved from the Kubernetes API.
+// ExtractEvent provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEvent(event *eventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return ExtractEventFrom(event, fieldManager, "")
+}
+
 func (b EventApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
@@ -60,29 +60,15 @@ func Event(name, namespace string) *EventApplyConfiguration {
 	return b
 }
 
-// ExtractEvent extracts the applied configuration owned by fieldManager from
-// event. If no managedFields are found in event for fieldManager, a
-// EventApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEventFrom extracts the applied configuration owned by fieldManager from
+// event for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // event must be a unmodified Event API object that was retrieved from the Kubernetes API.
-// ExtractEvent provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEventFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEvent(event *eventsv1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
-	return extractEvent(event, fieldManager, "")
-}
-
-// ExtractEventStatus is the same as ExtractEvent except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEventStatus(event *eventsv1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
-	return extractEvent(event, fieldManager, "status")
-}
-
-func extractEvent(event *eventsv1beta1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
+func ExtractEventFrom(event *eventsv1beta1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
 	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1beta1.Event"), fieldManager, b, subresource)
 	if err != nil {
@@ -95,6 +81,22 @@ func extractEvent(event *eventsv1beta1.Event, fieldManager string, subresource s
 	b.WithAPIVersion("events.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractEvent extracts the applied configuration owned by fieldManager from
+// event. If no managedFields are found in event for fieldManager, a
+// EventApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// event must be a unmodified Event API object that was retrieved from the Kubernetes API.
+// ExtractEvent provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEvent(event *eventsv1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+	return ExtractEventFrom(event, fieldManager, "")
+}
+
 func (b EventApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
@@ -47,29 +47,15 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 	return b
 }
 
-// ExtractDaemonSet extracts the applied configuration owned by fieldManager from
-// daemonSet. If no managedFields are found in daemonSet for fieldManager, a
-// DaemonSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractDaemonSetFrom extracts the applied configuration owned by fieldManager from
+// daemonSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // daemonSet must be a unmodified DaemonSet API object that was retrieved from the Kubernetes API.
-// ExtractDaemonSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractDaemonSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
-	return extractDaemonSet(daemonSet, fieldManager, "")
-}
-
-// ExtractDaemonSetStatus is the same as ExtractDaemonSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDaemonSetStatus(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
-	return extractDaemonSet(daemonSet, fieldManager, "status")
-}
-
-func extractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSetFrom(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
 	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager strin
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+
+// ExtractDaemonSet extracts the applied configuration owned by fieldManager from
+// daemonSet. If no managedFields are found in daemonSet for fieldManager, a
+// DaemonSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// daemonSet must be a unmodified DaemonSet API object that was retrieved from the Kubernetes API.
+// ExtractDaemonSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return ExtractDaemonSetFrom(daemonSet, fieldManager, "")
+}
+
+// ExtractDaemonSetStatus extracts the applied configuration owned by fieldManager from
+// daemonSet for the status subresource.
+// Experimental!
+func ExtractDaemonSetStatus(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+	return ExtractDaemonSetFrom(daemonSet, fieldManager, "status")
+}
+
 func (b DaemonSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
@@ -47,29 +47,15 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 	return b
 }
 
-// ExtractDeployment extracts the applied configuration owned by fieldManager from
-// deployment. If no managedFields are found in deployment for fieldManager, a
-// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractDeploymentFrom extracts the applied configuration owned by fieldManager from
+// deployment for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
-// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractDeploymentFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "")
-}
-
-// ExtractDeploymentStatus is the same as ExtractDeployment except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeploymentStatus(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
-	return extractDeployment(deployment, fieldManager, "status")
-}
-
-func extractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentFrom(deployment *extensionsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Deployment"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,36 @@ func extractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager st
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+
+// ExtractDeployment extracts the applied configuration owned by fieldManager from
+// deployment. If no managedFields are found in deployment for fieldManager, a
+// DeploymentApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// deployment must be a unmodified Deployment API object that was retrieved from the Kubernetes API.
+// ExtractDeployment provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "")
+}
+
+// ExtractDeploymentScale extracts the applied configuration owned by fieldManager from
+// deployment for the scale subresource.
+// Experimental!
+func ExtractDeploymentScale(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "scale")
+}
+
+// ExtractDeploymentStatus extracts the applied configuration owned by fieldManager from
+// deployment for the status subresource.
+// Experimental!
+func ExtractDeploymentStatus(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+	return ExtractDeploymentFrom(deployment, fieldManager, "status")
+}
+
 func (b DeploymentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
@@ -47,29 +47,15 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 	return b
 }
 
-// ExtractIngress extracts the applied configuration owned by fieldManager from
-// ingress. If no managedFields are found in ingress for fieldManager, a
-// IngressApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractIngressFrom extracts the applied configuration owned by fieldManager from
+// ingress for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // ingress must be a unmodified Ingress API object that was retrieved from the Kubernetes API.
-// ExtractIngress provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractIngressFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
-	return extractIngress(ingress, fieldManager, "")
-}
-
-// ExtractIngressStatus is the same as ExtractIngress except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractIngressStatus(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
-	return extractIngress(ingress, fieldManager, "status")
-}
-
-func extractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
+func ExtractIngressFrom(ingress *extensionsv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
 	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Ingress"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string, sub
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+
+// ExtractIngress extracts the applied configuration owned by fieldManager from
+// ingress. If no managedFields are found in ingress for fieldManager, a
+// IngressApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// ingress must be a unmodified Ingress API object that was retrieved from the Kubernetes API.
+// ExtractIngress provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return ExtractIngressFrom(ingress, fieldManager, "")
+}
+
+// ExtractIngressStatus extracts the applied configuration owned by fieldManager from
+// ingress for the status subresource.
+// Experimental!
+func ExtractIngressStatus(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return ExtractIngressFrom(ingress, fieldManager, "status")
+}
+
 func (b IngressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
@@ -46,29 +46,15 @@ func NetworkPolicy(name, namespace string) *NetworkPolicyApplyConfiguration {
 	return b
 }
 
-// ExtractNetworkPolicy extracts the applied configuration owned by fieldManager from
-// networkPolicy. If no managedFields are found in networkPolicy for fieldManager, a
-// NetworkPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractNetworkPolicyFrom extracts the applied configuration owned by fieldManager from
+// networkPolicy for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // networkPolicy must be a unmodified NetworkPolicy API object that was retrieved from the Kubernetes API.
-// ExtractNetworkPolicy provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractNetworkPolicyFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
-	return extractNetworkPolicy(networkPolicy, fieldManager, "")
-}
-
-// ExtractNetworkPolicyStatus is the same as ExtractNetworkPolicy except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractNetworkPolicyStatus(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
-	return extractNetworkPolicy(networkPolicy, fieldManager, "status")
-}
-
-func extractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
+func ExtractNetworkPolicyFrom(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
 	b := &NetworkPolicyApplyConfiguration{}
 	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.extensions.v1beta1.NetworkPolicy"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldM
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+
+// ExtractNetworkPolicy extracts the applied configuration owned by fieldManager from
+// networkPolicy. If no managedFields are found in networkPolicy for fieldManager, a
+// NetworkPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// networkPolicy must be a unmodified NetworkPolicy API object that was retrieved from the Kubernetes API.
+// ExtractNetworkPolicy provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+	return ExtractNetworkPolicyFrom(networkPolicy, fieldManager, "")
+}
+
 func (b NetworkPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
@@ -47,29 +47,15 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 	return b
 }
 
-// ExtractReplicaSet extracts the applied configuration owned by fieldManager from
-// replicaSet. If no managedFields are found in replicaSet for fieldManager, a
-// ReplicaSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractReplicaSetFrom extracts the applied configuration owned by fieldManager from
+// replicaSet for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // replicaSet must be a unmodified ReplicaSet API object that was retrieved from the Kubernetes API.
-// ExtractReplicaSet provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractReplicaSetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
-	return extractReplicaSet(replicaSet, fieldManager, "")
-}
-
-// ExtractReplicaSetStatus is the same as ExtractReplicaSet except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractReplicaSetStatus(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
-	return extractReplicaSet(replicaSet, fieldManager, "status")
-}
-
-func extractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSetFrom(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
 	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,36 @@ func extractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager st
 	b.WithAPIVersion("extensions/v1beta1")
 	return b, nil
 }
+
+// ExtractReplicaSet extracts the applied configuration owned by fieldManager from
+// replicaSet. If no managedFields are found in replicaSet for fieldManager, a
+// ReplicaSetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// replicaSet must be a unmodified ReplicaSet API object that was retrieved from the Kubernetes API.
+// ExtractReplicaSet provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "")
+}
+
+// ExtractReplicaSetScale extracts the applied configuration owned by fieldManager from
+// replicaSet for the scale subresource.
+// Experimental!
+func ExtractReplicaSetScale(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "scale")
+}
+
+// ExtractReplicaSetStatus extracts the applied configuration owned by fieldManager from
+// replicaSet for the status subresource.
+// Experimental!
+func ExtractReplicaSetStatus(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+	return ExtractReplicaSetFrom(replicaSet, fieldManager, "status")
+}
+
 func (b ReplicaSetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/scale.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/scale.go
@@ -42,6 +42,7 @@ func Scale() *ScaleApplyConfiguration {
 	b.WithAPIVersion("extensions/v1beta1")
 	return b
 }
+
 func (b ScaleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschema.go
@@ -46,6 +46,27 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 	return b
 }
 
+// ExtractFlowSchemaFrom extracts the applied configuration owned by fieldManager from
+// flowSchema for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// flowSchema must be a unmodified FlowSchema API object that was retrieved from the Kubernetes API.
+// ExtractFlowSchemaFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractFlowSchemaFrom(flowSchema *flowcontrolv1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
+	b := &FlowSchemaApplyConfiguration{}
+	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1.FlowSchema"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(flowSchema.Name)
+
+	b.WithKind("FlowSchema")
+	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractFlowSchema extracts the applied configuration owned by fieldManager from
 // flowSchema. If no managedFields are found in flowSchema for fieldManager, a
 // FlowSchemaApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractFlowSchema(flowSchema *flowcontrolv1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
-	return extractFlowSchema(flowSchema, fieldManager, "")
+	return ExtractFlowSchemaFrom(flowSchema, fieldManager, "")
 }
 
-// ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
-// that it extracts the status subresource applied configuration.
+// ExtractFlowSchemaStatus extracts the applied configuration owned by fieldManager from
+// flowSchema for the status subresource.
 // Experimental!
 func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
-	return extractFlowSchema(flowSchema, fieldManager, "status")
+	return ExtractFlowSchemaFrom(flowSchema, fieldManager, "status")
 }
 
-func extractFlowSchema(flowSchema *flowcontrolv1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
-	b := &FlowSchemaApplyConfiguration{}
-	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1.FlowSchema"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(flowSchema.Name)
-
-	b.WithKind("FlowSchema")
-	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1")
-	return b, nil
-}
 func (b FlowSchemaApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfiguration.go
@@ -46,6 +46,27 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 	return b
 }
 
+// ExtractPriorityLevelConfigurationFrom extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// priorityLevelConfiguration must be a unmodified PriorityLevelConfiguration API object that was retrieved from the Kubernetes API.
+// ExtractPriorityLevelConfigurationFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	b := &PriorityLevelConfigurationApplyConfiguration{}
+	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1.PriorityLevelConfiguration"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(priorityLevelConfiguration.Name)
+
+	b.WithKind("PriorityLevelConfiguration")
+	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractPriorityLevelConfiguration extracts the applied configuration owned by fieldManager from
 // priorityLevelConfiguration. If no managedFields are found in priorityLevelConfiguration for fieldManager, a
 // PriorityLevelConfigurationApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "")
 }
 
-// ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
-// that it extracts the status subresource applied configuration.
+// ExtractPriorityLevelConfigurationStatus extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the status subresource.
 // Experimental!
 func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	b := &PriorityLevelConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1.PriorityLevelConfiguration"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(priorityLevelConfiguration.Name)
-
-	b.WithKind("PriorityLevelConfiguration")
-	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1")
-	return b, nil
-}
 func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -46,6 +46,27 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 	return b
 }
 
+// ExtractPriorityLevelConfigurationFrom extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// priorityLevelConfiguration must be a unmodified PriorityLevelConfiguration API object that was retrieved from the Kubernetes API.
+// ExtractPriorityLevelConfigurationFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	b := &PriorityLevelConfigurationApplyConfiguration{}
+	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(priorityLevelConfiguration.Name)
+
+	b.WithKind("PriorityLevelConfiguration")
+	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractPriorityLevelConfiguration extracts the applied configuration owned by fieldManager from
 // priorityLevelConfiguration. If no managedFields are found in priorityLevelConfiguration for fieldManager, a
 // PriorityLevelConfigurationApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "")
 }
 
-// ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
-// that it extracts the status subresource applied configuration.
+// ExtractPriorityLevelConfigurationStatus extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the status subresource.
 // Experimental!
 func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	b := &PriorityLevelConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(priorityLevelConfiguration.Name)
-
-	b.WithKind("PriorityLevelConfiguration")
-	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta1")
-	return b, nil
-}
 func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
@@ -46,6 +46,27 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 	return b
 }
 
+// ExtractFlowSchemaFrom extracts the applied configuration owned by fieldManager from
+// flowSchema for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// flowSchema must be a unmodified FlowSchema API object that was retrieved from the Kubernetes API.
+// ExtractFlowSchemaFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractFlowSchemaFrom(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
+	b := &FlowSchemaApplyConfiguration{}
+	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta2.FlowSchema"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(flowSchema.Name)
+
+	b.WithKind("FlowSchema")
+	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta2")
+	return b, nil
+}
+
 // ExtractFlowSchema extracts the applied configuration owned by fieldManager from
 // flowSchema. If no managedFields are found in flowSchema for fieldManager, a
 // FlowSchemaApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractFlowSchema(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
-	return extractFlowSchema(flowSchema, fieldManager, "")
+	return ExtractFlowSchemaFrom(flowSchema, fieldManager, "")
 }
 
-// ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
-// that it extracts the status subresource applied configuration.
+// ExtractFlowSchemaStatus extracts the applied configuration owned by fieldManager from
+// flowSchema for the status subresource.
 // Experimental!
 func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
-	return extractFlowSchema(flowSchema, fieldManager, "status")
+	return ExtractFlowSchemaFrom(flowSchema, fieldManager, "status")
 }
 
-func extractFlowSchema(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
-	b := &FlowSchemaApplyConfiguration{}
-	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta2.FlowSchema"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(flowSchema.Name)
-
-	b.WithKind("FlowSchema")
-	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta2")
-	return b, nil
-}
 func (b FlowSchemaApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -46,6 +46,27 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 	return b
 }
 
+// ExtractPriorityLevelConfigurationFrom extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// priorityLevelConfiguration must be a unmodified PriorityLevelConfiguration API object that was retrieved from the Kubernetes API.
+// ExtractPriorityLevelConfigurationFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	b := &PriorityLevelConfigurationApplyConfiguration{}
+	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(priorityLevelConfiguration.Name)
+
+	b.WithKind("PriorityLevelConfiguration")
+	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta2")
+	return b, nil
+}
+
 // ExtractPriorityLevelConfiguration extracts the applied configuration owned by fieldManager from
 // priorityLevelConfiguration. If no managedFields are found in priorityLevelConfiguration for fieldManager, a
 // PriorityLevelConfigurationApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "")
 }
 
-// ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
-// that it extracts the status subresource applied configuration.
+// ExtractPriorityLevelConfigurationStatus extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the status subresource.
 // Experimental!
 func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	b := &PriorityLevelConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(priorityLevelConfiguration.Name)
-
-	b.WithKind("PriorityLevelConfiguration")
-	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta2")
-	return b, nil
-}
 func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
@@ -46,6 +46,27 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 	return b
 }
 
+// ExtractFlowSchemaFrom extracts the applied configuration owned by fieldManager from
+// flowSchema for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// flowSchema must be a unmodified FlowSchema API object that was retrieved from the Kubernetes API.
+// ExtractFlowSchemaFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractFlowSchemaFrom(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
+	b := &FlowSchemaApplyConfiguration{}
+	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta3.FlowSchema"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(flowSchema.Name)
+
+	b.WithKind("FlowSchema")
+	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta3")
+	return b, nil
+}
+
 // ExtractFlowSchema extracts the applied configuration owned by fieldManager from
 // flowSchema. If no managedFields are found in flowSchema for fieldManager, a
 // FlowSchemaApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractFlowSchema(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
-	return extractFlowSchema(flowSchema, fieldManager, "")
+	return ExtractFlowSchemaFrom(flowSchema, fieldManager, "")
 }
 
-// ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
-// that it extracts the status subresource applied configuration.
+// ExtractFlowSchemaStatus extracts the applied configuration owned by fieldManager from
+// flowSchema for the status subresource.
 // Experimental!
 func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
-	return extractFlowSchema(flowSchema, fieldManager, "status")
+	return ExtractFlowSchemaFrom(flowSchema, fieldManager, "status")
 }
 
-func extractFlowSchema(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
-	b := &FlowSchemaApplyConfiguration{}
-	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta3.FlowSchema"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(flowSchema.Name)
-
-	b.WithKind("FlowSchema")
-	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta3")
-	return b, nil
-}
 func (b FlowSchemaApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -46,6 +46,27 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 	return b
 }
 
+// ExtractPriorityLevelConfigurationFrom extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// priorityLevelConfiguration must be a unmodified PriorityLevelConfiguration API object that was retrieved from the Kubernetes API.
+// ExtractPriorityLevelConfigurationFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+	b := &PriorityLevelConfigurationApplyConfiguration{}
+	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfiguration"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(priorityLevelConfiguration.Name)
+
+	b.WithKind("PriorityLevelConfiguration")
+	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta3")
+	return b, nil
+}
+
 // ExtractPriorityLevelConfiguration extracts the applied configuration owned by fieldManager from
 // priorityLevelConfiguration. If no managedFields are found in priorityLevelConfiguration for fieldManager, a
 // PriorityLevelConfigurationApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "")
 }
 
-// ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
-// that it extracts the status subresource applied configuration.
+// ExtractPriorityLevelConfigurationStatus extracts the applied configuration owned by fieldManager from
+// priorityLevelConfiguration for the status subresource.
 // Experimental!
 func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
+	return ExtractPriorityLevelConfigurationFrom(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
-	b := &PriorityLevelConfigurationApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfiguration"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(priorityLevelConfiguration.Name)
-
-	b.WithKind("PriorityLevelConfiguration")
-	b.WithAPIVersion("flowcontrol.apiserver.k8s.io/v1beta3")
-	return b, nil
-}
 func (b PriorityLevelConfigurationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/deleteoptions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/deleteoptions.go
@@ -42,6 +42,7 @@ func DeleteOptions() *DeleteOptionsApplyConfiguration {
 	b.WithAPIVersion("meta.k8s.io/v1")
 	return b
 }
+
 func (b DeleteOptionsApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
@@ -47,29 +47,15 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 	return b
 }
 
-// ExtractIngress extracts the applied configuration owned by fieldManager from
-// ingress. If no managedFields are found in ingress for fieldManager, a
-// IngressApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractIngressFrom extracts the applied configuration owned by fieldManager from
+// ingress for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // ingress must be a unmodified Ingress API object that was retrieved from the Kubernetes API.
-// ExtractIngress provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractIngressFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngress(ingress *networkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
-	return extractIngress(ingress, fieldManager, "")
-}
-
-// ExtractIngressStatus is the same as ExtractIngress except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractIngressStatus(ingress *networkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
-	return extractIngress(ingress, fieldManager, "status")
-}
-
-func extractIngress(ingress *networkingv1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
+func ExtractIngressFrom(ingress *networkingv1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
 	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1.Ingress"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractIngress(ingress *networkingv1.Ingress, fieldManager string, subresou
 	b.WithAPIVersion("networking.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractIngress extracts the applied configuration owned by fieldManager from
+// ingress. If no managedFields are found in ingress for fieldManager, a
+// IngressApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// ingress must be a unmodified Ingress API object that was retrieved from the Kubernetes API.
+// ExtractIngress provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractIngress(ingress *networkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return ExtractIngressFrom(ingress, fieldManager, "")
+}
+
+// ExtractIngressStatus extracts the applied configuration owned by fieldManager from
+// ingress for the status subresource.
+// Experimental!
+func ExtractIngressStatus(ingress *networkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return ExtractIngressFrom(ingress, fieldManager, "status")
+}
+
 func (b IngressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
@@ -45,6 +45,27 @@ func IngressClass(name string) *IngressClassApplyConfiguration {
 	return b
 }
 
+// ExtractIngressClassFrom extracts the applied configuration owned by fieldManager from
+// ingressClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// ingressClass must be a unmodified IngressClass API object that was retrieved from the Kubernetes API.
+// ExtractIngressClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractIngressClassFrom(ingressClass *networkingv1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
+	b := &IngressClassApplyConfiguration{}
+	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1.IngressClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(ingressClass.Name)
+
+	b.WithKind("IngressClass")
+	b.WithAPIVersion("networking.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractIngressClass extracts the applied configuration owned by fieldManager from
 // ingressClass. If no managedFields are found in ingressClass for fieldManager, a
 // IngressClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func IngressClass(name string) *IngressClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIngressClass(ingressClass *networkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
-	return extractIngressClass(ingressClass, fieldManager, "")
+	return ExtractIngressClassFrom(ingressClass, fieldManager, "")
 }
 
-// ExtractIngressClassStatus is the same as ExtractIngressClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractIngressClassStatus(ingressClass *networkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
-	return extractIngressClass(ingressClass, fieldManager, "status")
-}
-
-func extractIngressClass(ingressClass *networkingv1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
-	b := &IngressClassApplyConfiguration{}
-	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1.IngressClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(ingressClass.Name)
-
-	b.WithKind("IngressClass")
-	b.WithAPIVersion("networking.k8s.io/v1")
-	return b, nil
-}
 func (b IngressClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipaddress.go
@@ -45,6 +45,27 @@ func IPAddress(name string) *IPAddressApplyConfiguration {
 	return b
 }
 
+// ExtractIPAddressFrom extracts the applied configuration owned by fieldManager from
+// iPAddress for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// iPAddress must be a unmodified IPAddress API object that was retrieved from the Kubernetes API.
+// ExtractIPAddressFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractIPAddressFrom(iPAddress *networkingv1.IPAddress, fieldManager string, subresource string) (*IPAddressApplyConfiguration, error) {
+	b := &IPAddressApplyConfiguration{}
+	err := managedfields.ExtractInto(iPAddress, internal.Parser().Type("io.k8s.api.networking.v1.IPAddress"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(iPAddress.Name)
+
+	b.WithKind("IPAddress")
+	b.WithAPIVersion("networking.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractIPAddress extracts the applied configuration owned by fieldManager from
 // iPAddress. If no managedFields are found in iPAddress for fieldManager, a
 // IPAddressApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func IPAddress(name string) *IPAddressApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIPAddress(iPAddress *networkingv1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
-	return extractIPAddress(iPAddress, fieldManager, "")
+	return ExtractIPAddressFrom(iPAddress, fieldManager, "")
 }
 
-// ExtractIPAddressStatus is the same as ExtractIPAddress except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractIPAddressStatus(iPAddress *networkingv1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
-	return extractIPAddress(iPAddress, fieldManager, "status")
-}
-
-func extractIPAddress(iPAddress *networkingv1.IPAddress, fieldManager string, subresource string) (*IPAddressApplyConfiguration, error) {
-	b := &IPAddressApplyConfiguration{}
-	err := managedfields.ExtractInto(iPAddress, internal.Parser().Type("io.k8s.api.networking.v1.IPAddress"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(iPAddress.Name)
-
-	b.WithKind("IPAddress")
-	b.WithAPIVersion("networking.k8s.io/v1")
-	return b, nil
-}
 func (b IPAddressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
@@ -46,29 +46,15 @@ func NetworkPolicy(name, namespace string) *NetworkPolicyApplyConfiguration {
 	return b
 }
 
-// ExtractNetworkPolicy extracts the applied configuration owned by fieldManager from
-// networkPolicy. If no managedFields are found in networkPolicy for fieldManager, a
-// NetworkPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractNetworkPolicyFrom extracts the applied configuration owned by fieldManager from
+// networkPolicy for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // networkPolicy must be a unmodified NetworkPolicy API object that was retrieved from the Kubernetes API.
-// ExtractNetworkPolicy provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractNetworkPolicyFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
-	return extractNetworkPolicy(networkPolicy, fieldManager, "")
-}
-
-// ExtractNetworkPolicyStatus is the same as ExtractNetworkPolicy except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractNetworkPolicyStatus(networkPolicy *networkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
-	return extractNetworkPolicy(networkPolicy, fieldManager, "status")
-}
-
-func extractNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
+func ExtractNetworkPolicyFrom(networkPolicy *networkingv1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
 	b := &NetworkPolicyApplyConfiguration{}
 	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.networking.v1.NetworkPolicy"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, fieldManage
 	b.WithAPIVersion("networking.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractNetworkPolicy extracts the applied configuration owned by fieldManager from
+// networkPolicy. If no managedFields are found in networkPolicy for fieldManager, a
+// NetworkPolicyApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// networkPolicy must be a unmodified NetworkPolicy API object that was retrieved from the Kubernetes API.
+// ExtractNetworkPolicy provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+	return ExtractNetworkPolicyFrom(networkPolicy, fieldManager, "")
+}
+
 func (b NetworkPolicyApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/servicecidr.go
@@ -46,6 +46,27 @@ func ServiceCIDR(name string) *ServiceCIDRApplyConfiguration {
 	return b
 }
 
+// ExtractServiceCIDRFrom extracts the applied configuration owned by fieldManager from
+// serviceCIDR for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// serviceCIDR must be a unmodified ServiceCIDR API object that was retrieved from the Kubernetes API.
+// ExtractServiceCIDRFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractServiceCIDRFrom(serviceCIDR *networkingv1.ServiceCIDR, fieldManager string, subresource string) (*ServiceCIDRApplyConfiguration, error) {
+	b := &ServiceCIDRApplyConfiguration{}
+	err := managedfields.ExtractInto(serviceCIDR, internal.Parser().Type("io.k8s.api.networking.v1.ServiceCIDR"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(serviceCIDR.Name)
+
+	b.WithKind("ServiceCIDR")
+	b.WithAPIVersion("networking.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractServiceCIDR extracts the applied configuration owned by fieldManager from
 // serviceCIDR. If no managedFields are found in serviceCIDR for fieldManager, a
 // ServiceCIDRApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func ServiceCIDR(name string) *ServiceCIDRApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractServiceCIDR(serviceCIDR *networkingv1.ServiceCIDR, fieldManager string) (*ServiceCIDRApplyConfiguration, error) {
-	return extractServiceCIDR(serviceCIDR, fieldManager, "")
+	return ExtractServiceCIDRFrom(serviceCIDR, fieldManager, "")
 }
 
-// ExtractServiceCIDRStatus is the same as ExtractServiceCIDR except
-// that it extracts the status subresource applied configuration.
+// ExtractServiceCIDRStatus extracts the applied configuration owned by fieldManager from
+// serviceCIDR for the status subresource.
 // Experimental!
 func ExtractServiceCIDRStatus(serviceCIDR *networkingv1.ServiceCIDR, fieldManager string) (*ServiceCIDRApplyConfiguration, error) {
-	return extractServiceCIDR(serviceCIDR, fieldManager, "status")
+	return ExtractServiceCIDRFrom(serviceCIDR, fieldManager, "status")
 }
 
-func extractServiceCIDR(serviceCIDR *networkingv1.ServiceCIDR, fieldManager string, subresource string) (*ServiceCIDRApplyConfiguration, error) {
-	b := &ServiceCIDRApplyConfiguration{}
-	err := managedfields.ExtractInto(serviceCIDR, internal.Parser().Type("io.k8s.api.networking.v1.ServiceCIDR"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(serviceCIDR.Name)
-
-	b.WithKind("ServiceCIDR")
-	b.WithAPIVersion("networking.k8s.io/v1")
-	return b, nil
-}
 func (b ServiceCIDRApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
@@ -47,29 +47,15 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 	return b
 }
 
-// ExtractIngress extracts the applied configuration owned by fieldManager from
-// ingress. If no managedFields are found in ingress for fieldManager, a
-// IngressApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractIngressFrom extracts the applied configuration owned by fieldManager from
+// ingress for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // ingress must be a unmodified Ingress API object that was retrieved from the Kubernetes API.
-// ExtractIngress provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractIngressFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngress(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
-	return extractIngress(ingress, fieldManager, "")
-}
-
-// ExtractIngressStatus is the same as ExtractIngress except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractIngressStatus(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
-	return extractIngress(ingress, fieldManager, "status")
-}
-
-func extractIngress(ingress *networkingv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
+func ExtractIngressFrom(ingress *networkingv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
 	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1beta1.Ingress"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractIngress(ingress *networkingv1beta1.Ingress, fieldManager string, sub
 	b.WithAPIVersion("networking.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractIngress extracts the applied configuration owned by fieldManager from
+// ingress. If no managedFields are found in ingress for fieldManager, a
+// IngressApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// ingress must be a unmodified Ingress API object that was retrieved from the Kubernetes API.
+// ExtractIngress provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractIngress(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return ExtractIngressFrom(ingress, fieldManager, "")
+}
+
+// ExtractIngressStatus extracts the applied configuration owned by fieldManager from
+// ingress for the status subresource.
+// Experimental!
+func ExtractIngressStatus(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+	return ExtractIngressFrom(ingress, fieldManager, "status")
+}
+
 func (b IngressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ipaddress.go
@@ -45,6 +45,27 @@ func IPAddress(name string) *IPAddressApplyConfiguration {
 	return b
 }
 
+// ExtractIPAddressFrom extracts the applied configuration owned by fieldManager from
+// iPAddress for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// iPAddress must be a unmodified IPAddress API object that was retrieved from the Kubernetes API.
+// ExtractIPAddressFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractIPAddressFrom(iPAddress *networkingv1beta1.IPAddress, fieldManager string, subresource string) (*IPAddressApplyConfiguration, error) {
+	b := &IPAddressApplyConfiguration{}
+	err := managedfields.ExtractInto(iPAddress, internal.Parser().Type("io.k8s.api.networking.v1beta1.IPAddress"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(iPAddress.Name)
+
+	b.WithKind("IPAddress")
+	b.WithAPIVersion("networking.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractIPAddress extracts the applied configuration owned by fieldManager from
 // iPAddress. If no managedFields are found in iPAddress for fieldManager, a
 // IPAddressApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func IPAddress(name string) *IPAddressApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractIPAddress(iPAddress *networkingv1beta1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
-	return extractIPAddress(iPAddress, fieldManager, "")
+	return ExtractIPAddressFrom(iPAddress, fieldManager, "")
 }
 
-// ExtractIPAddressStatus is the same as ExtractIPAddress except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractIPAddressStatus(iPAddress *networkingv1beta1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
-	return extractIPAddress(iPAddress, fieldManager, "status")
-}
-
-func extractIPAddress(iPAddress *networkingv1beta1.IPAddress, fieldManager string, subresource string) (*IPAddressApplyConfiguration, error) {
-	b := &IPAddressApplyConfiguration{}
-	err := managedfields.ExtractInto(iPAddress, internal.Parser().Type("io.k8s.api.networking.v1beta1.IPAddress"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(iPAddress.Name)
-
-	b.WithKind("IPAddress")
-	b.WithAPIVersion("networking.k8s.io/v1beta1")
-	return b, nil
-}
 func (b IPAddressApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
@@ -47,6 +47,27 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 	return b
 }
 
+// ExtractRuntimeClassFrom extracts the applied configuration owned by fieldManager from
+// runtimeClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// runtimeClass must be a unmodified RuntimeClass API object that was retrieved from the Kubernetes API.
+// ExtractRuntimeClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRuntimeClassFrom(runtimeClass *nodev1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
+	b := &RuntimeClassApplyConfiguration{}
+	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1.RuntimeClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(runtimeClass.Name)
+
+	b.WithKind("RuntimeClass")
+	b.WithAPIVersion("node.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractRuntimeClass extracts the applied configuration owned by fieldManager from
 // runtimeClass. If no managedFields are found in runtimeClass for fieldManager, a
 // RuntimeClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -59,28 +80,9 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRuntimeClass(runtimeClass *nodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
-	return extractRuntimeClass(runtimeClass, fieldManager, "")
+	return ExtractRuntimeClassFrom(runtimeClass, fieldManager, "")
 }
 
-// ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRuntimeClassStatus(runtimeClass *nodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
-	return extractRuntimeClass(runtimeClass, fieldManager, "status")
-}
-
-func extractRuntimeClass(runtimeClass *nodev1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
-	b := &RuntimeClassApplyConfiguration{}
-	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1.RuntimeClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(runtimeClass.Name)
-
-	b.WithKind("RuntimeClass")
-	b.WithAPIVersion("node.k8s.io/v1")
-	return b, nil
-}
 func (b RuntimeClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
@@ -47,6 +47,27 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 	return b
 }
 
+// ExtractRuntimeClassFrom extracts the applied configuration owned by fieldManager from
+// runtimeClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// runtimeClass must be a unmodified RuntimeClass API object that was retrieved from the Kubernetes API.
+// ExtractRuntimeClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRuntimeClassFrom(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
+	b := &RuntimeClassApplyConfiguration{}
+	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1beta1.RuntimeClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(runtimeClass.Name)
+
+	b.WithKind("RuntimeClass")
+	b.WithAPIVersion("node.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractRuntimeClass extracts the applied configuration owned by fieldManager from
 // runtimeClass. If no managedFields are found in runtimeClass for fieldManager, a
 // RuntimeClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -59,28 +80,9 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
-	return extractRuntimeClass(runtimeClass, fieldManager, "")
+	return ExtractRuntimeClassFrom(runtimeClass, fieldManager, "")
 }
 
-// ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRuntimeClassStatus(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
-	return extractRuntimeClass(runtimeClass, fieldManager, "status")
-}
-
-func extractRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
-	b := &RuntimeClassApplyConfiguration{}
-	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1beta1.RuntimeClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(runtimeClass.Name)
-
-	b.WithKind("RuntimeClass")
-	b.WithAPIVersion("node.k8s.io/v1beta1")
-	return b, nil
-}
 func (b RuntimeClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
@@ -46,29 +46,15 @@ func Eviction(name, namespace string) *EvictionApplyConfiguration {
 	return b
 }
 
-// ExtractEviction extracts the applied configuration owned by fieldManager from
-// eviction. If no managedFields are found in eviction for fieldManager, a
-// EvictionApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEvictionFrom extracts the applied configuration owned by fieldManager from
+// eviction for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // eviction must be a unmodified Eviction API object that was retrieved from the Kubernetes API.
-// ExtractEviction provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEvictionFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEviction(eviction *policyv1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
-	return extractEviction(eviction, fieldManager, "")
-}
-
-// ExtractEvictionStatus is the same as ExtractEviction except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEvictionStatus(eviction *policyv1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
-	return extractEviction(eviction, fieldManager, "status")
-}
-
-func extractEviction(eviction *policyv1.Eviction, fieldManager string, subresource string) (*EvictionApplyConfiguration, error) {
+func ExtractEvictionFrom(eviction *policyv1.Eviction, fieldManager string, subresource string) (*EvictionApplyConfiguration, error) {
 	b := &EvictionApplyConfiguration{}
 	err := managedfields.ExtractInto(eviction, internal.Parser().Type("io.k8s.api.policy.v1.Eviction"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractEviction(eviction *policyv1.Eviction, fieldManager string, subresour
 	b.WithAPIVersion("policy/v1")
 	return b, nil
 }
+
+// ExtractEviction extracts the applied configuration owned by fieldManager from
+// eviction. If no managedFields are found in eviction for fieldManager, a
+// EvictionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// eviction must be a unmodified Eviction API object that was retrieved from the Kubernetes API.
+// ExtractEviction provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEviction(eviction *policyv1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return ExtractEvictionFrom(eviction, fieldManager, "")
+}
+
 func (b EvictionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
@@ -47,29 +47,15 @@ func PodDisruptionBudget(name, namespace string) *PodDisruptionBudgetApplyConfig
 	return b
 }
 
-// ExtractPodDisruptionBudget extracts the applied configuration owned by fieldManager from
-// podDisruptionBudget. If no managedFields are found in podDisruptionBudget for fieldManager, a
-// PodDisruptionBudgetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractPodDisruptionBudgetFrom extracts the applied configuration owned by fieldManager from
+// podDisruptionBudget for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // podDisruptionBudget must be a unmodified PodDisruptionBudget API object that was retrieved from the Kubernetes API.
-// ExtractPodDisruptionBudget provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractPodDisruptionBudgetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodDisruptionBudget(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
-	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "")
-}
-
-// ExtractPodDisruptionBudgetStatus is the same as ExtractPodDisruptionBudget except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
-	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "status")
-}
-
-func extractPodDisruptionBudget(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func ExtractPodDisruptionBudgetFrom(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	b := &PodDisruptionBudgetApplyConfiguration{}
 	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1.PodDisruptionBudget"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractPodDisruptionBudget(podDisruptionBudget *policyv1.PodDisruptionBudge
 	b.WithAPIVersion("policy/v1")
 	return b, nil
 }
+
+// ExtractPodDisruptionBudget extracts the applied configuration owned by fieldManager from
+// podDisruptionBudget. If no managedFields are found in podDisruptionBudget for fieldManager, a
+// PodDisruptionBudgetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// podDisruptionBudget must be a unmodified PodDisruptionBudget API object that was retrieved from the Kubernetes API.
+// ExtractPodDisruptionBudget provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPodDisruptionBudget(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return ExtractPodDisruptionBudgetFrom(podDisruptionBudget, fieldManager, "")
+}
+
+// ExtractPodDisruptionBudgetStatus extracts the applied configuration owned by fieldManager from
+// podDisruptionBudget for the status subresource.
+// Experimental!
+func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return ExtractPodDisruptionBudgetFrom(podDisruptionBudget, fieldManager, "status")
+}
+
 func (b PodDisruptionBudgetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
@@ -46,29 +46,15 @@ func Eviction(name, namespace string) *EvictionApplyConfiguration {
 	return b
 }
 
-// ExtractEviction extracts the applied configuration owned by fieldManager from
-// eviction. If no managedFields are found in eviction for fieldManager, a
-// EvictionApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractEvictionFrom extracts the applied configuration owned by fieldManager from
+// eviction for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // eviction must be a unmodified Eviction API object that was retrieved from the Kubernetes API.
-// ExtractEviction provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractEvictionFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEviction(eviction *policyv1beta1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
-	return extractEviction(eviction, fieldManager, "")
-}
-
-// ExtractEvictionStatus is the same as ExtractEviction except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractEvictionStatus(eviction *policyv1beta1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
-	return extractEviction(eviction, fieldManager, "status")
-}
-
-func extractEviction(eviction *policyv1beta1.Eviction, fieldManager string, subresource string) (*EvictionApplyConfiguration, error) {
+func ExtractEvictionFrom(eviction *policyv1beta1.Eviction, fieldManager string, subresource string) (*EvictionApplyConfiguration, error) {
 	b := &EvictionApplyConfiguration{}
 	err := managedfields.ExtractInto(eviction, internal.Parser().Type("io.k8s.api.policy.v1beta1.Eviction"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractEviction(eviction *policyv1beta1.Eviction, fieldManager string, subr
 	b.WithAPIVersion("policy/v1beta1")
 	return b, nil
 }
+
+// ExtractEviction extracts the applied configuration owned by fieldManager from
+// eviction. If no managedFields are found in eviction for fieldManager, a
+// EvictionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// eviction must be a unmodified Eviction API object that was retrieved from the Kubernetes API.
+// ExtractEviction provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractEviction(eviction *policyv1beta1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return ExtractEvictionFrom(eviction, fieldManager, "")
+}
+
 func (b EvictionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
@@ -47,29 +47,15 @@ func PodDisruptionBudget(name, namespace string) *PodDisruptionBudgetApplyConfig
 	return b
 }
 
-// ExtractPodDisruptionBudget extracts the applied configuration owned by fieldManager from
-// podDisruptionBudget. If no managedFields are found in podDisruptionBudget for fieldManager, a
-// PodDisruptionBudgetApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractPodDisruptionBudgetFrom extracts the applied configuration owned by fieldManager from
+// podDisruptionBudget for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // podDisruptionBudget must be a unmodified PodDisruptionBudget API object that was retrieved from the Kubernetes API.
-// ExtractPodDisruptionBudget provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractPodDisruptionBudgetFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
-	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "")
-}
-
-// ExtractPodDisruptionBudgetStatus is the same as ExtractPodDisruptionBudget except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
-	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "status")
-}
-
-func extractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func ExtractPodDisruptionBudgetFrom(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	b := &PodDisruptionBudgetApplyConfiguration{}
 	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1beta1.PodDisruptionBudget"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruption
 	b.WithAPIVersion("policy/v1beta1")
 	return b, nil
 }
+
+// ExtractPodDisruptionBudget extracts the applied configuration owned by fieldManager from
+// podDisruptionBudget. If no managedFields are found in podDisruptionBudget for fieldManager, a
+// PodDisruptionBudgetApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// podDisruptionBudget must be a unmodified PodDisruptionBudget API object that was retrieved from the Kubernetes API.
+// ExtractPodDisruptionBudget provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return ExtractPodDisruptionBudgetFrom(podDisruptionBudget, fieldManager, "")
+}
+
+// ExtractPodDisruptionBudgetStatus extracts the applied configuration owned by fieldManager from
+// podDisruptionBudget for the status subresource.
+// Experimental!
+func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+	return ExtractPodDisruptionBudgetFrom(podDisruptionBudget, fieldManager, "status")
+}
+
 func (b PodDisruptionBudgetApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
@@ -46,29 +46,15 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 	return b
 }
 
-// ExtractRole extracts the applied configuration owned by fieldManager from
-// role. If no managedFields are found in role for fieldManager, a
-// RoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractRoleFrom extracts the applied configuration owned by fieldManager from
+// role for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // role must be a unmodified Role API object that was retrieved from the Kubernetes API.
-// ExtractRole provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractRoleFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRole(role *rbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
-	return extractRole(role, fieldManager, "")
-}
-
-// ExtractRoleStatus is the same as ExtractRole except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRoleStatus(role *rbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
-	return extractRole(role, fieldManager, "status")
-}
-
-func extractRole(role *rbacv1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
+func ExtractRoleFrom(role *rbacv1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
 	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1.Role"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractRole(role *rbacv1.Role, fieldManager string, subresource string) (*R
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractRole extracts the applied configuration owned by fieldManager from
+// role. If no managedFields are found in role for fieldManager, a
+// RoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// role must be a unmodified Role API object that was retrieved from the Kubernetes API.
+// ExtractRole provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRole(role *rbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return ExtractRoleFrom(role, fieldManager, "")
+}
+
 func (b RoleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
@@ -47,29 +47,15 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 	return b
 }
 
-// ExtractRoleBinding extracts the applied configuration owned by fieldManager from
-// roleBinding. If no managedFields are found in roleBinding for fieldManager, a
-// RoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractRoleBindingFrom extracts the applied configuration owned by fieldManager from
+// roleBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // roleBinding must be a unmodified RoleBinding API object that was retrieved from the Kubernetes API.
-// ExtractRoleBinding provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractRoleBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRoleBinding(roleBinding *rbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
-	return extractRoleBinding(roleBinding, fieldManager, "")
-}
-
-// ExtractRoleBindingStatus is the same as ExtractRoleBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRoleBindingStatus(roleBinding *rbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
-	return extractRoleBinding(roleBinding, fieldManager, "status")
-}
-
-func extractRoleBinding(roleBinding *rbacv1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBindingFrom(roleBinding *rbacv1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,22 @@ func extractRoleBinding(roleBinding *rbacv1.RoleBinding, fieldManager string, su
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractRoleBinding extracts the applied configuration owned by fieldManager from
+// roleBinding. If no managedFields are found in roleBinding for fieldManager, a
+// RoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// roleBinding must be a unmodified RoleBinding API object that was retrieved from the Kubernetes API.
+// ExtractRoleBinding provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRoleBinding(roleBinding *rbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return ExtractRoleBindingFrom(roleBinding, fieldManager, "")
+}
+
 func (b RoleBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
@@ -46,6 +46,27 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 	return b
 }
 
+// ExtractClusterRoleFrom extracts the applied configuration owned by fieldManager from
+// clusterRole for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// clusterRole must be a unmodified ClusterRole API object that was retrieved from the Kubernetes API.
+// ExtractClusterRoleFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractClusterRoleFrom(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
+	b := &ClusterRoleApplyConfiguration{}
+	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRole"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(clusterRole.Name)
+
+	b.WithKind("ClusterRole")
+	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractClusterRole extracts the applied configuration owned by fieldManager from
 // clusterRole. If no managedFields are found in clusterRole for fieldManager, a
 // ClusterRoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,9 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRole(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
-	return extractClusterRole(clusterRole, fieldManager, "")
+	return ExtractClusterRoleFrom(clusterRole, fieldManager, "")
 }
 
-// ExtractClusterRoleStatus is the same as ExtractClusterRole except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractClusterRoleStatus(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
-	return extractClusterRole(clusterRole, fieldManager, "status")
-}
-
-func extractClusterRole(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
-	b := &ClusterRoleApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRole"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(clusterRole.Name)
-
-	b.WithKind("ClusterRole")
-	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b ClusterRoleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
@@ -46,6 +46,27 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 	return b
 }
 
+// ExtractClusterRoleBindingFrom extracts the applied configuration owned by fieldManager from
+// clusterRoleBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// clusterRoleBinding must be a unmodified ClusterRoleBinding API object that was retrieved from the Kubernetes API.
+// ExtractClusterRoleBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractClusterRoleBindingFrom(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
+	b := &ClusterRoleBindingApplyConfiguration{}
+	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRoleBinding"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(clusterRoleBinding.Name)
+
+	b.WithKind("ClusterRoleBinding")
+	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractClusterRoleBinding extracts the applied configuration owned by fieldManager from
 // clusterRoleBinding. If no managedFields are found in clusterRoleBinding for fieldManager, a
 // ClusterRoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,9 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRoleBinding(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
-	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
+	return ExtractClusterRoleBindingFrom(clusterRoleBinding, fieldManager, "")
 }
 
-// ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractClusterRoleBindingStatus(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
-	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
-}
-
-func extractClusterRoleBinding(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
-	b := &ClusterRoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRoleBinding"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(clusterRoleBinding.Name)
-
-	b.WithKind("ClusterRoleBinding")
-	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b ClusterRoleBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
@@ -46,29 +46,15 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 	return b
 }
 
-// ExtractRole extracts the applied configuration owned by fieldManager from
-// role. If no managedFields are found in role for fieldManager, a
-// RoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractRoleFrom extracts the applied configuration owned by fieldManager from
+// role for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // role must be a unmodified Role API object that was retrieved from the Kubernetes API.
-// ExtractRole provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractRoleFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRole(role *rbacv1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
-	return extractRole(role, fieldManager, "")
-}
-
-// ExtractRoleStatus is the same as ExtractRole except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRoleStatus(role *rbacv1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
-	return extractRole(role, fieldManager, "status")
-}
-
-func extractRole(role *rbacv1alpha1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
+func ExtractRoleFrom(role *rbacv1alpha1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
 	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.Role"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractRole(role *rbacv1alpha1.Role, fieldManager string, subresource strin
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
 	return b, nil
 }
+
+// ExtractRole extracts the applied configuration owned by fieldManager from
+// role. If no managedFields are found in role for fieldManager, a
+// RoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// role must be a unmodified Role API object that was retrieved from the Kubernetes API.
+// ExtractRole provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRole(role *rbacv1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return ExtractRoleFrom(role, fieldManager, "")
+}
+
 func (b RoleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
@@ -47,29 +47,15 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 	return b
 }
 
-// ExtractRoleBinding extracts the applied configuration owned by fieldManager from
-// roleBinding. If no managedFields are found in roleBinding for fieldManager, a
-// RoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractRoleBindingFrom extracts the applied configuration owned by fieldManager from
+// roleBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // roleBinding must be a unmodified RoleBinding API object that was retrieved from the Kubernetes API.
-// ExtractRoleBinding provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractRoleBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
-	return extractRoleBinding(roleBinding, fieldManager, "")
-}
-
-// ExtractRoleBindingStatus is the same as ExtractRoleBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRoleBindingStatus(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
-	return extractRoleBinding(roleBinding, fieldManager, "status")
-}
-
-func extractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBindingFrom(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,22 @@ func extractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager stri
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1alpha1")
 	return b, nil
 }
+
+// ExtractRoleBinding extracts the applied configuration owned by fieldManager from
+// roleBinding. If no managedFields are found in roleBinding for fieldManager, a
+// RoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// roleBinding must be a unmodified RoleBinding API object that was retrieved from the Kubernetes API.
+// ExtractRoleBinding provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return ExtractRoleBindingFrom(roleBinding, fieldManager, "")
+}
+
 func (b RoleBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
@@ -46,6 +46,27 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 	return b
 }
 
+// ExtractClusterRoleFrom extracts the applied configuration owned by fieldManager from
+// clusterRole for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// clusterRole must be a unmodified ClusterRole API object that was retrieved from the Kubernetes API.
+// ExtractClusterRoleFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractClusterRoleFrom(clusterRole *rbacv1beta1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
+	b := &ClusterRoleApplyConfiguration{}
+	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRole"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(clusterRole.Name)
+
+	b.WithKind("ClusterRole")
+	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractClusterRole extracts the applied configuration owned by fieldManager from
 // clusterRole. If no managedFields are found in clusterRole for fieldManager, a
 // ClusterRoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,9 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRole(clusterRole *rbacv1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
-	return extractClusterRole(clusterRole, fieldManager, "")
+	return ExtractClusterRoleFrom(clusterRole, fieldManager, "")
 }
 
-// ExtractClusterRoleStatus is the same as ExtractClusterRole except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractClusterRoleStatus(clusterRole *rbacv1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
-	return extractClusterRole(clusterRole, fieldManager, "status")
-}
-
-func extractClusterRole(clusterRole *rbacv1beta1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
-	b := &ClusterRoleApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRole"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(clusterRole.Name)
-
-	b.WithKind("ClusterRole")
-	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
-	return b, nil
-}
 func (b ClusterRoleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
@@ -46,6 +46,27 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 	return b
 }
 
+// ExtractClusterRoleBindingFrom extracts the applied configuration owned by fieldManager from
+// clusterRoleBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// clusterRoleBinding must be a unmodified ClusterRoleBinding API object that was retrieved from the Kubernetes API.
+// ExtractClusterRoleBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractClusterRoleBindingFrom(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
+	b := &ClusterRoleBindingApplyConfiguration{}
+	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRoleBinding"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(clusterRoleBinding.Name)
+
+	b.WithKind("ClusterRoleBinding")
+	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractClusterRoleBinding extracts the applied configuration owned by fieldManager from
 // clusterRoleBinding. If no managedFields are found in clusterRoleBinding for fieldManager, a
 // ClusterRoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,9 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractClusterRoleBinding(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
-	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
+	return ExtractClusterRoleBindingFrom(clusterRoleBinding, fieldManager, "")
 }
 
-// ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractClusterRoleBindingStatus(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
-	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
-}
-
-func extractClusterRoleBinding(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
-	b := &ClusterRoleBindingApplyConfiguration{}
-	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRoleBinding"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(clusterRoleBinding.Name)
-
-	b.WithKind("ClusterRoleBinding")
-	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
-	return b, nil
-}
 func (b ClusterRoleBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
@@ -46,29 +46,15 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 	return b
 }
 
-// ExtractRole extracts the applied configuration owned by fieldManager from
-// role. If no managedFields are found in role for fieldManager, a
-// RoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractRoleFrom extracts the applied configuration owned by fieldManager from
+// role for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // role must be a unmodified Role API object that was retrieved from the Kubernetes API.
-// ExtractRole provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractRoleFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRole(role *rbacv1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
-	return extractRole(role, fieldManager, "")
-}
-
-// ExtractRoleStatus is the same as ExtractRole except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRoleStatus(role *rbacv1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
-	return extractRole(role, fieldManager, "status")
-}
-
-func extractRole(role *rbacv1beta1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
+func ExtractRoleFrom(role *rbacv1beta1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
 	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1beta1.Role"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractRole(role *rbacv1beta1.Role, fieldManager string, subresource string
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractRole extracts the applied configuration owned by fieldManager from
+// role. If no managedFields are found in role for fieldManager, a
+// RoleApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// role must be a unmodified Role API object that was retrieved from the Kubernetes API.
+// ExtractRole provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRole(role *rbacv1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+	return ExtractRoleFrom(role, fieldManager, "")
+}
+
 func (b RoleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
@@ -47,29 +47,15 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 	return b
 }
 
-// ExtractRoleBinding extracts the applied configuration owned by fieldManager from
-// roleBinding. If no managedFields are found in roleBinding for fieldManager, a
-// RoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractRoleBindingFrom extracts the applied configuration owned by fieldManager from
+// roleBinding for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // roleBinding must be a unmodified RoleBinding API object that was retrieved from the Kubernetes API.
-// ExtractRoleBinding provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractRoleBindingFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
-	return extractRoleBinding(roleBinding, fieldManager, "")
-}
-
-// ExtractRoleBindingStatus is the same as ExtractRoleBinding except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractRoleBindingStatus(roleBinding *rbacv1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
-	return extractRoleBinding(roleBinding, fieldManager, "status")
-}
-
-func extractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBindingFrom(roleBinding *rbacv1beta1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,22 @@ func extractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager strin
 	b.WithAPIVersion("rbac.authorization.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractRoleBinding extracts the applied configuration owned by fieldManager from
+// roleBinding. If no managedFields are found in roleBinding for fieldManager, a
+// RoleBindingApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// roleBinding must be a unmodified RoleBinding API object that was retrieved from the Kubernetes API.
+// ExtractRoleBinding provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+	return ExtractRoleBindingFrom(roleBinding, fieldManager, "")
+}
+
 func (b RoleBindingApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/deviceclass.go
@@ -45,6 +45,27 @@ func DeviceClass(name string) *DeviceClassApplyConfiguration {
 	return b
 }
 
+// ExtractDeviceClassFrom extracts the applied configuration owned by fieldManager from
+// deviceClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// deviceClass must be a unmodified DeviceClass API object that was retrieved from the Kubernetes API.
+// ExtractDeviceClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeviceClassFrom(deviceClass *resourcev1.DeviceClass, fieldManager string, subresource string) (*DeviceClassApplyConfiguration, error) {
+	b := &DeviceClassApplyConfiguration{}
+	err := managedfields.ExtractInto(deviceClass, internal.Parser().Type("io.k8s.api.resource.v1.DeviceClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(deviceClass.Name)
+
+	b.WithKind("DeviceClass")
+	b.WithAPIVersion("resource.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractDeviceClass extracts the applied configuration owned by fieldManager from
 // deviceClass. If no managedFields are found in deviceClass for fieldManager, a
 // DeviceClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func DeviceClass(name string) *DeviceClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeviceClass(deviceClass *resourcev1.DeviceClass, fieldManager string) (*DeviceClassApplyConfiguration, error) {
-	return extractDeviceClass(deviceClass, fieldManager, "")
+	return ExtractDeviceClassFrom(deviceClass, fieldManager, "")
 }
 
-// ExtractDeviceClassStatus is the same as ExtractDeviceClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeviceClassStatus(deviceClass *resourcev1.DeviceClass, fieldManager string) (*DeviceClassApplyConfiguration, error) {
-	return extractDeviceClass(deviceClass, fieldManager, "status")
-}
-
-func extractDeviceClass(deviceClass *resourcev1.DeviceClass, fieldManager string, subresource string) (*DeviceClassApplyConfiguration, error) {
-	b := &DeviceClassApplyConfiguration{}
-	err := managedfields.ExtractInto(deviceClass, internal.Parser().Type("io.k8s.api.resource.v1.DeviceClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(deviceClass.Name)
-
-	b.WithKind("DeviceClass")
-	b.WithAPIVersion("resource.k8s.io/v1")
-	return b, nil
-}
 func (b DeviceClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceclaim.go
@@ -47,29 +47,15 @@ func ResourceClaim(name, namespace string) *ResourceClaimApplyConfiguration {
 	return b
 }
 
-// ExtractResourceClaim extracts the applied configuration owned by fieldManager from
-// resourceClaim. If no managedFields are found in resourceClaim for fieldManager, a
-// ResourceClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractResourceClaimFrom extracts the applied configuration owned by fieldManager from
+// resourceClaim for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // resourceClaim must be a unmodified ResourceClaim API object that was retrieved from the Kubernetes API.
-// ExtractResourceClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractResourceClaimFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaim(resourceClaim *resourcev1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
-	return extractResourceClaim(resourceClaim, fieldManager, "")
-}
-
-// ExtractResourceClaimStatus is the same as ExtractResourceClaim except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceClaimStatus(resourceClaim *resourcev1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
-	return extractResourceClaim(resourceClaim, fieldManager, "status")
-}
-
-func extractResourceClaim(resourceClaim *resourcev1.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
+func ExtractResourceClaimFrom(resourceClaim *resourcev1.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
 	b := &ResourceClaimApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaim, internal.Parser().Type("io.k8s.api.resource.v1.ResourceClaim"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractResourceClaim(resourceClaim *resourcev1.ResourceClaim, fieldManager 
 	b.WithAPIVersion("resource.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractResourceClaim extracts the applied configuration owned by fieldManager from
+// resourceClaim. If no managedFields are found in resourceClaim for fieldManager, a
+// ResourceClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// resourceClaim must be a unmodified ResourceClaim API object that was retrieved from the Kubernetes API.
+// ExtractResourceClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceClaim(resourceClaim *resourcev1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+	return ExtractResourceClaimFrom(resourceClaim, fieldManager, "")
+}
+
+// ExtractResourceClaimStatus extracts the applied configuration owned by fieldManager from
+// resourceClaim for the status subresource.
+// Experimental!
+func ExtractResourceClaimStatus(resourceClaim *resourcev1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+	return ExtractResourceClaimFrom(resourceClaim, fieldManager, "status")
+}
+
 func (b ResourceClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceclaimtemplate.go
@@ -46,29 +46,15 @@ func ResourceClaimTemplate(name, namespace string) *ResourceClaimTemplateApplyCo
 	return b
 }
 
-// ExtractResourceClaimTemplate extracts the applied configuration owned by fieldManager from
-// resourceClaimTemplate. If no managedFields are found in resourceClaimTemplate for fieldManager, a
-// ResourceClaimTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractResourceClaimTemplateFrom extracts the applied configuration owned by fieldManager from
+// resourceClaimTemplate for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // resourceClaimTemplate must be a unmodified ResourceClaimTemplate API object that was retrieved from the Kubernetes API.
-// ExtractResourceClaimTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractResourceClaimTemplateFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaimTemplate(resourceClaimTemplate *resourcev1.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
-	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "")
-}
-
-// ExtractResourceClaimTemplateStatus is the same as ExtractResourceClaimTemplate except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceClaimTemplateStatus(resourceClaimTemplate *resourcev1.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
-	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "status")
-}
-
-func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
+func ExtractResourceClaimTemplateFrom(resourceClaimTemplate *resourcev1.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
 	b := &ResourceClaimTemplateApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaimTemplate, internal.Parser().Type("io.k8s.api.resource.v1.ResourceClaimTemplate"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1.ResourceClai
 	b.WithAPIVersion("resource.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractResourceClaimTemplate extracts the applied configuration owned by fieldManager from
+// resourceClaimTemplate. If no managedFields are found in resourceClaimTemplate for fieldManager, a
+// ResourceClaimTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// resourceClaimTemplate must be a unmodified ResourceClaimTemplate API object that was retrieved from the Kubernetes API.
+// ExtractResourceClaimTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceClaimTemplate(resourceClaimTemplate *resourcev1.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
+	return ExtractResourceClaimTemplateFrom(resourceClaimTemplate, fieldManager, "")
+}
+
 func (b ResourceClaimTemplateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceslice.go
@@ -45,6 +45,27 @@ func ResourceSlice(name string) *ResourceSliceApplyConfiguration {
 	return b
 }
 
+// ExtractResourceSliceFrom extracts the applied configuration owned by fieldManager from
+// resourceSlice for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// resourceSlice must be a unmodified ResourceSlice API object that was retrieved from the Kubernetes API.
+// ExtractResourceSliceFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceSliceFrom(resourceSlice *resourcev1.ResourceSlice, fieldManager string, subresource string) (*ResourceSliceApplyConfiguration, error) {
+	b := &ResourceSliceApplyConfiguration{}
+	err := managedfields.ExtractInto(resourceSlice, internal.Parser().Type("io.k8s.api.resource.v1.ResourceSlice"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(resourceSlice.Name)
+
+	b.WithKind("ResourceSlice")
+	b.WithAPIVersion("resource.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractResourceSlice extracts the applied configuration owned by fieldManager from
 // resourceSlice. If no managedFields are found in resourceSlice for fieldManager, a
 // ResourceSliceApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ResourceSlice(name string) *ResourceSliceApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractResourceSlice(resourceSlice *resourcev1.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
-	return extractResourceSlice(resourceSlice, fieldManager, "")
+	return ExtractResourceSliceFrom(resourceSlice, fieldManager, "")
 }
 
-// ExtractResourceSliceStatus is the same as ExtractResourceSlice except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceSliceStatus(resourceSlice *resourcev1.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
-	return extractResourceSlice(resourceSlice, fieldManager, "status")
-}
-
-func extractResourceSlice(resourceSlice *resourcev1.ResourceSlice, fieldManager string, subresource string) (*ResourceSliceApplyConfiguration, error) {
-	b := &ResourceSliceApplyConfiguration{}
-	err := managedfields.ExtractInto(resourceSlice, internal.Parser().Type("io.k8s.api.resource.v1.ResourceSlice"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(resourceSlice.Name)
-
-	b.WithKind("ResourceSlice")
-	b.WithAPIVersion("resource.k8s.io/v1")
-	return b, nil
-}
 func (b ResourceSliceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha3/devicetaintrule.go
@@ -45,6 +45,27 @@ func DeviceTaintRule(name string) *DeviceTaintRuleApplyConfiguration {
 	return b
 }
 
+// ExtractDeviceTaintRuleFrom extracts the applied configuration owned by fieldManager from
+// deviceTaintRule for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// deviceTaintRule must be a unmodified DeviceTaintRule API object that was retrieved from the Kubernetes API.
+// ExtractDeviceTaintRuleFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeviceTaintRuleFrom(deviceTaintRule *resourcev1alpha3.DeviceTaintRule, fieldManager string, subresource string) (*DeviceTaintRuleApplyConfiguration, error) {
+	b := &DeviceTaintRuleApplyConfiguration{}
+	err := managedfields.ExtractInto(deviceTaintRule, internal.Parser().Type("io.k8s.api.resource.v1alpha3.DeviceTaintRule"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(deviceTaintRule.Name)
+
+	b.WithKind("DeviceTaintRule")
+	b.WithAPIVersion("resource.k8s.io/v1alpha3")
+	return b, nil
+}
+
 // ExtractDeviceTaintRule extracts the applied configuration owned by fieldManager from
 // deviceTaintRule. If no managedFields are found in deviceTaintRule for fieldManager, a
 // DeviceTaintRuleApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func DeviceTaintRule(name string) *DeviceTaintRuleApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeviceTaintRule(deviceTaintRule *resourcev1alpha3.DeviceTaintRule, fieldManager string) (*DeviceTaintRuleApplyConfiguration, error) {
-	return extractDeviceTaintRule(deviceTaintRule, fieldManager, "")
+	return ExtractDeviceTaintRuleFrom(deviceTaintRule, fieldManager, "")
 }
 
-// ExtractDeviceTaintRuleStatus is the same as ExtractDeviceTaintRule except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeviceTaintRuleStatus(deviceTaintRule *resourcev1alpha3.DeviceTaintRule, fieldManager string) (*DeviceTaintRuleApplyConfiguration, error) {
-	return extractDeviceTaintRule(deviceTaintRule, fieldManager, "status")
-}
-
-func extractDeviceTaintRule(deviceTaintRule *resourcev1alpha3.DeviceTaintRule, fieldManager string, subresource string) (*DeviceTaintRuleApplyConfiguration, error) {
-	b := &DeviceTaintRuleApplyConfiguration{}
-	err := managedfields.ExtractInto(deviceTaintRule, internal.Parser().Type("io.k8s.api.resource.v1alpha3.DeviceTaintRule"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(deviceTaintRule.Name)
-
-	b.WithKind("DeviceTaintRule")
-	b.WithAPIVersion("resource.k8s.io/v1alpha3")
-	return b, nil
-}
 func (b DeviceTaintRuleApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclass.go
@@ -45,6 +45,27 @@ func DeviceClass(name string) *DeviceClassApplyConfiguration {
 	return b
 }
 
+// ExtractDeviceClassFrom extracts the applied configuration owned by fieldManager from
+// deviceClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// deviceClass must be a unmodified DeviceClass API object that was retrieved from the Kubernetes API.
+// ExtractDeviceClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeviceClassFrom(deviceClass *resourcev1beta1.DeviceClass, fieldManager string, subresource string) (*DeviceClassApplyConfiguration, error) {
+	b := &DeviceClassApplyConfiguration{}
+	err := managedfields.ExtractInto(deviceClass, internal.Parser().Type("io.k8s.api.resource.v1beta1.DeviceClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(deviceClass.Name)
+
+	b.WithKind("DeviceClass")
+	b.WithAPIVersion("resource.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractDeviceClass extracts the applied configuration owned by fieldManager from
 // deviceClass. If no managedFields are found in deviceClass for fieldManager, a
 // DeviceClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func DeviceClass(name string) *DeviceClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeviceClass(deviceClass *resourcev1beta1.DeviceClass, fieldManager string) (*DeviceClassApplyConfiguration, error) {
-	return extractDeviceClass(deviceClass, fieldManager, "")
+	return ExtractDeviceClassFrom(deviceClass, fieldManager, "")
 }
 
-// ExtractDeviceClassStatus is the same as ExtractDeviceClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeviceClassStatus(deviceClass *resourcev1beta1.DeviceClass, fieldManager string) (*DeviceClassApplyConfiguration, error) {
-	return extractDeviceClass(deviceClass, fieldManager, "status")
-}
-
-func extractDeviceClass(deviceClass *resourcev1beta1.DeviceClass, fieldManager string, subresource string) (*DeviceClassApplyConfiguration, error) {
-	b := &DeviceClassApplyConfiguration{}
-	err := managedfields.ExtractInto(deviceClass, internal.Parser().Type("io.k8s.api.resource.v1beta1.DeviceClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(deviceClass.Name)
-
-	b.WithKind("DeviceClass")
-	b.WithAPIVersion("resource.k8s.io/v1beta1")
-	return b, nil
-}
 func (b DeviceClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaim.go
@@ -47,29 +47,15 @@ func ResourceClaim(name, namespace string) *ResourceClaimApplyConfiguration {
 	return b
 }
 
-// ExtractResourceClaim extracts the applied configuration owned by fieldManager from
-// resourceClaim. If no managedFields are found in resourceClaim for fieldManager, a
-// ResourceClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractResourceClaimFrom extracts the applied configuration owned by fieldManager from
+// resourceClaim for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // resourceClaim must be a unmodified ResourceClaim API object that was retrieved from the Kubernetes API.
-// ExtractResourceClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractResourceClaimFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaim(resourceClaim *resourcev1beta1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
-	return extractResourceClaim(resourceClaim, fieldManager, "")
-}
-
-// ExtractResourceClaimStatus is the same as ExtractResourceClaim except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceClaimStatus(resourceClaim *resourcev1beta1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
-	return extractResourceClaim(resourceClaim, fieldManager, "status")
-}
-
-func extractResourceClaim(resourceClaim *resourcev1beta1.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
+func ExtractResourceClaimFrom(resourceClaim *resourcev1beta1.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
 	b := &ResourceClaimApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaim, internal.Parser().Type("io.k8s.api.resource.v1beta1.ResourceClaim"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractResourceClaim(resourceClaim *resourcev1beta1.ResourceClaim, fieldMan
 	b.WithAPIVersion("resource.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractResourceClaim extracts the applied configuration owned by fieldManager from
+// resourceClaim. If no managedFields are found in resourceClaim for fieldManager, a
+// ResourceClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// resourceClaim must be a unmodified ResourceClaim API object that was retrieved from the Kubernetes API.
+// ExtractResourceClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceClaim(resourceClaim *resourcev1beta1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+	return ExtractResourceClaimFrom(resourceClaim, fieldManager, "")
+}
+
+// ExtractResourceClaimStatus extracts the applied configuration owned by fieldManager from
+// resourceClaim for the status subresource.
+// Experimental!
+func ExtractResourceClaimStatus(resourceClaim *resourcev1beta1.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+	return ExtractResourceClaimFrom(resourceClaim, fieldManager, "status")
+}
+
 func (b ResourceClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceclaimtemplate.go
@@ -46,29 +46,15 @@ func ResourceClaimTemplate(name, namespace string) *ResourceClaimTemplateApplyCo
 	return b
 }
 
-// ExtractResourceClaimTemplate extracts the applied configuration owned by fieldManager from
-// resourceClaimTemplate. If no managedFields are found in resourceClaimTemplate for fieldManager, a
-// ResourceClaimTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractResourceClaimTemplateFrom extracts the applied configuration owned by fieldManager from
+// resourceClaimTemplate for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // resourceClaimTemplate must be a unmodified ResourceClaimTemplate API object that was retrieved from the Kubernetes API.
-// ExtractResourceClaimTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractResourceClaimTemplateFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta1.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
-	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "")
-}
-
-// ExtractResourceClaimTemplateStatus is the same as ExtractResourceClaimTemplate except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceClaimTemplateStatus(resourceClaimTemplate *resourcev1beta1.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
-	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "status")
-}
-
-func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta1.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
+func ExtractResourceClaimTemplateFrom(resourceClaimTemplate *resourcev1beta1.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
 	b := &ResourceClaimTemplateApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaimTemplate, internal.Parser().Type("io.k8s.api.resource.v1beta1.ResourceClaimTemplate"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta1.Resourc
 	b.WithAPIVersion("resource.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractResourceClaimTemplate extracts the applied configuration owned by fieldManager from
+// resourceClaimTemplate. If no managedFields are found in resourceClaimTemplate for fieldManager, a
+// ResourceClaimTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// resourceClaimTemplate must be a unmodified ResourceClaimTemplate API object that was retrieved from the Kubernetes API.
+// ExtractResourceClaimTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta1.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
+	return ExtractResourceClaimTemplateFrom(resourceClaimTemplate, fieldManager, "")
+}
+
 func (b ResourceClaimTemplateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslice.go
@@ -45,6 +45,27 @@ func ResourceSlice(name string) *ResourceSliceApplyConfiguration {
 	return b
 }
 
+// ExtractResourceSliceFrom extracts the applied configuration owned by fieldManager from
+// resourceSlice for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// resourceSlice must be a unmodified ResourceSlice API object that was retrieved from the Kubernetes API.
+// ExtractResourceSliceFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceSliceFrom(resourceSlice *resourcev1beta1.ResourceSlice, fieldManager string, subresource string) (*ResourceSliceApplyConfiguration, error) {
+	b := &ResourceSliceApplyConfiguration{}
+	err := managedfields.ExtractInto(resourceSlice, internal.Parser().Type("io.k8s.api.resource.v1beta1.ResourceSlice"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(resourceSlice.Name)
+
+	b.WithKind("ResourceSlice")
+	b.WithAPIVersion("resource.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractResourceSlice extracts the applied configuration owned by fieldManager from
 // resourceSlice. If no managedFields are found in resourceSlice for fieldManager, a
 // ResourceSliceApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func ResourceSlice(name string) *ResourceSliceApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractResourceSlice(resourceSlice *resourcev1beta1.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
-	return extractResourceSlice(resourceSlice, fieldManager, "")
+	return ExtractResourceSliceFrom(resourceSlice, fieldManager, "")
 }
 
-// ExtractResourceSliceStatus is the same as ExtractResourceSlice except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceSliceStatus(resourceSlice *resourcev1beta1.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
-	return extractResourceSlice(resourceSlice, fieldManager, "status")
-}
-
-func extractResourceSlice(resourceSlice *resourcev1beta1.ResourceSlice, fieldManager string, subresource string) (*ResourceSliceApplyConfiguration, error) {
-	b := &ResourceSliceApplyConfiguration{}
-	err := managedfields.ExtractInto(resourceSlice, internal.Parser().Type("io.k8s.api.resource.v1beta1.ResourceSlice"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(resourceSlice.Name)
-
-	b.WithKind("ResourceSlice")
-	b.WithAPIVersion("resource.k8s.io/v1beta1")
-	return b, nil
-}
 func (b ResourceSliceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclass.go
@@ -45,6 +45,27 @@ func DeviceClass(name string) *DeviceClassApplyConfiguration {
 	return b
 }
 
+// ExtractDeviceClassFrom extracts the applied configuration owned by fieldManager from
+// deviceClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// deviceClass must be a unmodified DeviceClass API object that was retrieved from the Kubernetes API.
+// ExtractDeviceClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractDeviceClassFrom(deviceClass *resourcev1beta2.DeviceClass, fieldManager string, subresource string) (*DeviceClassApplyConfiguration, error) {
+	b := &DeviceClassApplyConfiguration{}
+	err := managedfields.ExtractInto(deviceClass, internal.Parser().Type("io.k8s.api.resource.v1beta2.DeviceClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(deviceClass.Name)
+
+	b.WithKind("DeviceClass")
+	b.WithAPIVersion("resource.k8s.io/v1beta2")
+	return b, nil
+}
+
 // ExtractDeviceClass extracts the applied configuration owned by fieldManager from
 // deviceClass. If no managedFields are found in deviceClass for fieldManager, a
 // DeviceClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func DeviceClass(name string) *DeviceClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractDeviceClass(deviceClass *resourcev1beta2.DeviceClass, fieldManager string) (*DeviceClassApplyConfiguration, error) {
-	return extractDeviceClass(deviceClass, fieldManager, "")
+	return ExtractDeviceClassFrom(deviceClass, fieldManager, "")
 }
 
-// ExtractDeviceClassStatus is the same as ExtractDeviceClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractDeviceClassStatus(deviceClass *resourcev1beta2.DeviceClass, fieldManager string) (*DeviceClassApplyConfiguration, error) {
-	return extractDeviceClass(deviceClass, fieldManager, "status")
-}
-
-func extractDeviceClass(deviceClass *resourcev1beta2.DeviceClass, fieldManager string, subresource string) (*DeviceClassApplyConfiguration, error) {
-	b := &DeviceClassApplyConfiguration{}
-	err := managedfields.ExtractInto(deviceClass, internal.Parser().Type("io.k8s.api.resource.v1beta2.DeviceClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(deviceClass.Name)
-
-	b.WithKind("DeviceClass")
-	b.WithAPIVersion("resource.k8s.io/v1beta2")
-	return b, nil
-}
 func (b DeviceClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaim.go
@@ -47,29 +47,15 @@ func ResourceClaim(name, namespace string) *ResourceClaimApplyConfiguration {
 	return b
 }
 
-// ExtractResourceClaim extracts the applied configuration owned by fieldManager from
-// resourceClaim. If no managedFields are found in resourceClaim for fieldManager, a
-// ResourceClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractResourceClaimFrom extracts the applied configuration owned by fieldManager from
+// resourceClaim for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // resourceClaim must be a unmodified ResourceClaim API object that was retrieved from the Kubernetes API.
-// ExtractResourceClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractResourceClaimFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaim(resourceClaim *resourcev1beta2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
-	return extractResourceClaim(resourceClaim, fieldManager, "")
-}
-
-// ExtractResourceClaimStatus is the same as ExtractResourceClaim except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceClaimStatus(resourceClaim *resourcev1beta2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
-	return extractResourceClaim(resourceClaim, fieldManager, "status")
-}
-
-func extractResourceClaim(resourceClaim *resourcev1beta2.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
+func ExtractResourceClaimFrom(resourceClaim *resourcev1beta2.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
 	b := &ResourceClaimApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaim, internal.Parser().Type("io.k8s.api.resource.v1beta2.ResourceClaim"), fieldManager, b, subresource)
 	if err != nil {
@@ -82,6 +68,29 @@ func extractResourceClaim(resourceClaim *resourcev1beta2.ResourceClaim, fieldMan
 	b.WithAPIVersion("resource.k8s.io/v1beta2")
 	return b, nil
 }
+
+// ExtractResourceClaim extracts the applied configuration owned by fieldManager from
+// resourceClaim. If no managedFields are found in resourceClaim for fieldManager, a
+// ResourceClaimApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// resourceClaim must be a unmodified ResourceClaim API object that was retrieved from the Kubernetes API.
+// ExtractResourceClaim provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceClaim(resourceClaim *resourcev1beta2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+	return ExtractResourceClaimFrom(resourceClaim, fieldManager, "")
+}
+
+// ExtractResourceClaimStatus extracts the applied configuration owned by fieldManager from
+// resourceClaim for the status subresource.
+// Experimental!
+func ExtractResourceClaimStatus(resourceClaim *resourcev1beta2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+	return ExtractResourceClaimFrom(resourceClaim, fieldManager, "status")
+}
+
 func (b ResourceClaimApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceclaimtemplate.go
@@ -46,29 +46,15 @@ func ResourceClaimTemplate(name, namespace string) *ResourceClaimTemplateApplyCo
 	return b
 }
 
-// ExtractResourceClaimTemplate extracts the applied configuration owned by fieldManager from
-// resourceClaimTemplate. If no managedFields are found in resourceClaimTemplate for fieldManager, a
-// ResourceClaimTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractResourceClaimTemplateFrom extracts the applied configuration owned by fieldManager from
+// resourceClaimTemplate for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // resourceClaimTemplate must be a unmodified ResourceClaimTemplate API object that was retrieved from the Kubernetes API.
-// ExtractResourceClaimTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractResourceClaimTemplateFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta2.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
-	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "")
-}
-
-// ExtractResourceClaimTemplateStatus is the same as ExtractResourceClaimTemplate except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractResourceClaimTemplateStatus(resourceClaimTemplate *resourcev1beta2.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
-	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "status")
-}
-
-func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta2.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
+func ExtractResourceClaimTemplateFrom(resourceClaimTemplate *resourcev1beta2.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
 	b := &ResourceClaimTemplateApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaimTemplate, internal.Parser().Type("io.k8s.api.resource.v1beta2.ResourceClaimTemplate"), fieldManager, b, subresource)
 	if err != nil {
@@ -81,6 +67,22 @@ func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta2.Resourc
 	b.WithAPIVersion("resource.k8s.io/v1beta2")
 	return b, nil
 }
+
+// ExtractResourceClaimTemplate extracts the applied configuration owned by fieldManager from
+// resourceClaimTemplate. If no managedFields are found in resourceClaimTemplate for fieldManager, a
+// ResourceClaimTemplateApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// resourceClaimTemplate must be a unmodified ResourceClaimTemplate API object that was retrieved from the Kubernetes API.
+// ExtractResourceClaimTemplate provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractResourceClaimTemplate(resourceClaimTemplate *resourcev1beta2.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
+	return ExtractResourceClaimTemplateFrom(resourceClaimTemplate, fieldManager, "")
+}
+
 func (b ResourceClaimTemplateApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
@@ -49,6 +49,27 @@ func PriorityClass(name string) *PriorityClassApplyConfiguration {
 	return b
 }
 
+// ExtractPriorityClassFrom extracts the applied configuration owned by fieldManager from
+// priorityClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// priorityClass must be a unmodified PriorityClass API object that was retrieved from the Kubernetes API.
+// ExtractPriorityClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPriorityClassFrom(priorityClass *schedulingv1.PriorityClass, fieldManager string, subresource string) (*PriorityClassApplyConfiguration, error) {
+	b := &PriorityClassApplyConfiguration{}
+	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1.PriorityClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(priorityClass.Name)
+
+	b.WithKind("PriorityClass")
+	b.WithAPIVersion("scheduling.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractPriorityClass extracts the applied configuration owned by fieldManager from
 // priorityClass. If no managedFields are found in priorityClass for fieldManager, a
 // PriorityClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -61,28 +82,9 @@ func PriorityClass(name string) *PriorityClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityClass(priorityClass *schedulingv1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
-	return extractPriorityClass(priorityClass, fieldManager, "")
+	return ExtractPriorityClassFrom(priorityClass, fieldManager, "")
 }
 
-// ExtractPriorityClassStatus is the same as ExtractPriorityClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPriorityClassStatus(priorityClass *schedulingv1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
-	return extractPriorityClass(priorityClass, fieldManager, "status")
-}
-
-func extractPriorityClass(priorityClass *schedulingv1.PriorityClass, fieldManager string, subresource string) (*PriorityClassApplyConfiguration, error) {
-	b := &PriorityClassApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1.PriorityClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(priorityClass.Name)
-
-	b.WithKind("PriorityClass")
-	b.WithAPIVersion("scheduling.k8s.io/v1")
-	return b, nil
-}
 func (b PriorityClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
@@ -49,6 +49,27 @@ func PriorityClass(name string) *PriorityClassApplyConfiguration {
 	return b
 }
 
+// ExtractPriorityClassFrom extracts the applied configuration owned by fieldManager from
+// priorityClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// priorityClass must be a unmodified PriorityClass API object that was retrieved from the Kubernetes API.
+// ExtractPriorityClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractPriorityClassFrom(priorityClass *schedulingv1beta1.PriorityClass, fieldManager string, subresource string) (*PriorityClassApplyConfiguration, error) {
+	b := &PriorityClassApplyConfiguration{}
+	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1beta1.PriorityClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(priorityClass.Name)
+
+	b.WithKind("PriorityClass")
+	b.WithAPIVersion("scheduling.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractPriorityClass extracts the applied configuration owned by fieldManager from
 // priorityClass. If no managedFields are found in priorityClass for fieldManager, a
 // PriorityClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -61,28 +82,9 @@ func PriorityClass(name string) *PriorityClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractPriorityClass(priorityClass *schedulingv1beta1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
-	return extractPriorityClass(priorityClass, fieldManager, "")
+	return ExtractPriorityClassFrom(priorityClass, fieldManager, "")
 }
 
-// ExtractPriorityClassStatus is the same as ExtractPriorityClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractPriorityClassStatus(priorityClass *schedulingv1beta1.PriorityClass, fieldManager string) (*PriorityClassApplyConfiguration, error) {
-	return extractPriorityClass(priorityClass, fieldManager, "status")
-}
-
-func extractPriorityClass(priorityClass *schedulingv1beta1.PriorityClass, fieldManager string, subresource string) (*PriorityClassApplyConfiguration, error) {
-	b := &PriorityClassApplyConfiguration{}
-	err := managedfields.ExtractInto(priorityClass, internal.Parser().Type("io.k8s.api.scheduling.v1beta1.PriorityClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(priorityClass.Name)
-
-	b.WithKind("PriorityClass")
-	b.WithAPIVersion("scheduling.k8s.io/v1beta1")
-	return b, nil
-}
 func (b PriorityClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
@@ -45,6 +45,27 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 	return b
 }
 
+// ExtractCSIDriverFrom extracts the applied configuration owned by fieldManager from
+// cSIDriver for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// cSIDriver must be a unmodified CSIDriver API object that was retrieved from the Kubernetes API.
+// ExtractCSIDriverFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCSIDriverFrom(cSIDriver *storagev1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
+	b := &CSIDriverApplyConfiguration{}
+	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1.CSIDriver"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(cSIDriver.Name)
+
+	b.WithKind("CSIDriver")
+	b.WithAPIVersion("storage.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractCSIDriver extracts the applied configuration owned by fieldManager from
 // cSIDriver. If no managedFields are found in cSIDriver for fieldManager, a
 // CSIDriverApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSIDriver(cSIDriver *storagev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
-	return extractCSIDriver(cSIDriver, fieldManager, "")
+	return ExtractCSIDriverFrom(cSIDriver, fieldManager, "")
 }
 
-// ExtractCSIDriverStatus is the same as ExtractCSIDriver except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCSIDriverStatus(cSIDriver *storagev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
-	return extractCSIDriver(cSIDriver, fieldManager, "status")
-}
-
-func extractCSIDriver(cSIDriver *storagev1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
-	b := &CSIDriverApplyConfiguration{}
-	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1.CSIDriver"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(cSIDriver.Name)
-
-	b.WithKind("CSIDriver")
-	b.WithAPIVersion("storage.k8s.io/v1")
-	return b, nil
-}
 func (b CSIDriverApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csistoragecapacity.go
@@ -50,29 +50,15 @@ func CSIStorageCapacity(name, namespace string) *CSIStorageCapacityApplyConfigur
 	return b
 }
 
-// ExtractCSIStorageCapacity extracts the applied configuration owned by fieldManager from
-// cSIStorageCapacity. If no managedFields are found in cSIStorageCapacity for fieldManager, a
-// CSIStorageCapacityApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractCSIStorageCapacityFrom extracts the applied configuration owned by fieldManager from
+// cSIStorageCapacity for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // cSIStorageCapacity must be a unmodified CSIStorageCapacity API object that was retrieved from the Kubernetes API.
-// ExtractCSIStorageCapacity provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractCSIStorageCapacityFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCSIStorageCapacity(cSIStorageCapacity *storagev1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
-	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "")
-}
-
-// ExtractCSIStorageCapacityStatus is the same as ExtractCSIStorageCapacity except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCSIStorageCapacityStatus(cSIStorageCapacity *storagev1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
-	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "status")
-}
-
-func extractCSIStorageCapacity(cSIStorageCapacity *storagev1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
+func ExtractCSIStorageCapacityFrom(cSIStorageCapacity *storagev1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
 	b := &CSIStorageCapacityApplyConfiguration{}
 	err := managedfields.ExtractInto(cSIStorageCapacity, internal.Parser().Type("io.k8s.api.storage.v1.CSIStorageCapacity"), fieldManager, b, subresource)
 	if err != nil {
@@ -85,6 +71,22 @@ func extractCSIStorageCapacity(cSIStorageCapacity *storagev1.CSIStorageCapacity,
 	b.WithAPIVersion("storage.k8s.io/v1")
 	return b, nil
 }
+
+// ExtractCSIStorageCapacity extracts the applied configuration owned by fieldManager from
+// cSIStorageCapacity. If no managedFields are found in cSIStorageCapacity for fieldManager, a
+// CSIStorageCapacityApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// cSIStorageCapacity must be a unmodified CSIStorageCapacity API object that was retrieved from the Kubernetes API.
+// ExtractCSIStorageCapacity provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCSIStorageCapacity(cSIStorageCapacity *storagev1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
+	return ExtractCSIStorageCapacityFrom(cSIStorageCapacity, fieldManager, "")
+}
+
 func (b CSIStorageCapacityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
@@ -53,6 +53,27 @@ func StorageClass(name string) *StorageClassApplyConfiguration {
 	return b
 }
 
+// ExtractStorageClassFrom extracts the applied configuration owned by fieldManager from
+// storageClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// storageClass must be a unmodified StorageClass API object that was retrieved from the Kubernetes API.
+// ExtractStorageClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractStorageClassFrom(storageClass *storagev1.StorageClass, fieldManager string, subresource string) (*StorageClassApplyConfiguration, error) {
+	b := &StorageClassApplyConfiguration{}
+	err := managedfields.ExtractInto(storageClass, internal.Parser().Type("io.k8s.api.storage.v1.StorageClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(storageClass.Name)
+
+	b.WithKind("StorageClass")
+	b.WithAPIVersion("storage.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractStorageClass extracts the applied configuration owned by fieldManager from
 // storageClass. If no managedFields are found in storageClass for fieldManager, a
 // StorageClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -65,28 +86,9 @@ func StorageClass(name string) *StorageClassApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStorageClass(storageClass *storagev1.StorageClass, fieldManager string) (*StorageClassApplyConfiguration, error) {
-	return extractStorageClass(storageClass, fieldManager, "")
+	return ExtractStorageClassFrom(storageClass, fieldManager, "")
 }
 
-// ExtractStorageClassStatus is the same as ExtractStorageClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractStorageClassStatus(storageClass *storagev1.StorageClass, fieldManager string) (*StorageClassApplyConfiguration, error) {
-	return extractStorageClass(storageClass, fieldManager, "status")
-}
-
-func extractStorageClass(storageClass *storagev1.StorageClass, fieldManager string, subresource string) (*StorageClassApplyConfiguration, error) {
-	b := &StorageClassApplyConfiguration{}
-	err := managedfields.ExtractInto(storageClass, internal.Parser().Type("io.k8s.api.storage.v1.StorageClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(storageClass.Name)
-
-	b.WithKind("StorageClass")
-	b.WithAPIVersion("storage.k8s.io/v1")
-	return b, nil
-}
 func (b StorageClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattributesclass.go
@@ -46,6 +46,27 @@ func VolumeAttributesClass(name string) *VolumeAttributesClassApplyConfiguration
 	return b
 }
 
+// ExtractVolumeAttributesClassFrom extracts the applied configuration owned by fieldManager from
+// volumeAttributesClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// volumeAttributesClass must be a unmodified VolumeAttributesClass API object that was retrieved from the Kubernetes API.
+// ExtractVolumeAttributesClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractVolumeAttributesClassFrom(volumeAttributesClass *storagev1.VolumeAttributesClass, fieldManager string, subresource string) (*VolumeAttributesClassApplyConfiguration, error) {
+	b := &VolumeAttributesClassApplyConfiguration{}
+	err := managedfields.ExtractInto(volumeAttributesClass, internal.Parser().Type("io.k8s.api.storage.v1.VolumeAttributesClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(volumeAttributesClass.Name)
+
+	b.WithKind("VolumeAttributesClass")
+	b.WithAPIVersion("storage.k8s.io/v1")
+	return b, nil
+}
+
 // ExtractVolumeAttributesClass extracts the applied configuration owned by fieldManager from
 // volumeAttributesClass. If no managedFields are found in volumeAttributesClass for fieldManager, a
 // VolumeAttributesClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,9 @@ func VolumeAttributesClass(name string) *VolumeAttributesClassApplyConfiguration
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttributesClass(volumeAttributesClass *storagev1.VolumeAttributesClass, fieldManager string) (*VolumeAttributesClassApplyConfiguration, error) {
-	return extractVolumeAttributesClass(volumeAttributesClass, fieldManager, "")
+	return ExtractVolumeAttributesClassFrom(volumeAttributesClass, fieldManager, "")
 }
 
-// ExtractVolumeAttributesClassStatus is the same as ExtractVolumeAttributesClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractVolumeAttributesClassStatus(volumeAttributesClass *storagev1.VolumeAttributesClass, fieldManager string) (*VolumeAttributesClassApplyConfiguration, error) {
-	return extractVolumeAttributesClass(volumeAttributesClass, fieldManager, "status")
-}
-
-func extractVolumeAttributesClass(volumeAttributesClass *storagev1.VolumeAttributesClass, fieldManager string, subresource string) (*VolumeAttributesClassApplyConfiguration, error) {
-	b := &VolumeAttributesClassApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttributesClass, internal.Parser().Type("io.k8s.api.storage.v1.VolumeAttributesClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(volumeAttributesClass.Name)
-
-	b.WithKind("VolumeAttributesClass")
-	b.WithAPIVersion("storage.k8s.io/v1")
-	return b, nil
-}
 func (b VolumeAttributesClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
@@ -50,29 +50,15 @@ func CSIStorageCapacity(name, namespace string) *CSIStorageCapacityApplyConfigur
 	return b
 }
 
-// ExtractCSIStorageCapacity extracts the applied configuration owned by fieldManager from
-// cSIStorageCapacity. If no managedFields are found in cSIStorageCapacity for fieldManager, a
-// CSIStorageCapacityApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractCSIStorageCapacityFrom extracts the applied configuration owned by fieldManager from
+// cSIStorageCapacity for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // cSIStorageCapacity must be a unmodified CSIStorageCapacity API object that was retrieved from the Kubernetes API.
-// ExtractCSIStorageCapacity provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractCSIStorageCapacityFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCSIStorageCapacity(cSIStorageCapacity *storagev1alpha1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
-	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "")
-}
-
-// ExtractCSIStorageCapacityStatus is the same as ExtractCSIStorageCapacity except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCSIStorageCapacityStatus(cSIStorageCapacity *storagev1alpha1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
-	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "status")
-}
-
-func extractCSIStorageCapacity(cSIStorageCapacity *storagev1alpha1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
+func ExtractCSIStorageCapacityFrom(cSIStorageCapacity *storagev1alpha1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
 	b := &CSIStorageCapacityApplyConfiguration{}
 	err := managedfields.ExtractInto(cSIStorageCapacity, internal.Parser().Type("io.k8s.api.storage.v1alpha1.CSIStorageCapacity"), fieldManager, b, subresource)
 	if err != nil {
@@ -85,6 +71,22 @@ func extractCSIStorageCapacity(cSIStorageCapacity *storagev1alpha1.CSIStorageCap
 	b.WithAPIVersion("storage.k8s.io/v1alpha1")
 	return b, nil
 }
+
+// ExtractCSIStorageCapacity extracts the applied configuration owned by fieldManager from
+// cSIStorageCapacity. If no managedFields are found in cSIStorageCapacity for fieldManager, a
+// CSIStorageCapacityApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// cSIStorageCapacity must be a unmodified CSIStorageCapacity API object that was retrieved from the Kubernetes API.
+// ExtractCSIStorageCapacity provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCSIStorageCapacity(cSIStorageCapacity *storagev1alpha1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
+	return ExtractCSIStorageCapacityFrom(cSIStorageCapacity, fieldManager, "")
+}
+
 func (b CSIStorageCapacityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
@@ -46,6 +46,27 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 	return b
 }
 
+// ExtractVolumeAttachmentFrom extracts the applied configuration owned by fieldManager from
+// volumeAttachment for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// volumeAttachment must be a unmodified VolumeAttachment API object that was retrieved from the Kubernetes API.
+// ExtractVolumeAttachmentFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractVolumeAttachmentFrom(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
+	b := &VolumeAttachmentApplyConfiguration{}
+	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1alpha1.VolumeAttachment"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(volumeAttachment.Name)
+
+	b.WithKind("VolumeAttachment")
+	b.WithAPIVersion("storage.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractVolumeAttachment extracts the applied configuration owned by fieldManager from
 // volumeAttachment. If no managedFields are found in volumeAttachment for fieldManager, a
 // VolumeAttachmentApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttachment(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
-	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
+	return ExtractVolumeAttachmentFrom(volumeAttachment, fieldManager, "")
 }
 
-// ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
-// that it extracts the status subresource applied configuration.
+// ExtractVolumeAttachmentStatus extracts the applied configuration owned by fieldManager from
+// volumeAttachment for the status subresource.
 // Experimental!
 func ExtractVolumeAttachmentStatus(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
-	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
+	return ExtractVolumeAttachmentFrom(volumeAttachment, fieldManager, "status")
 }
 
-func extractVolumeAttachment(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
-	b := &VolumeAttachmentApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1alpha1.VolumeAttachment"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(volumeAttachment.Name)
-
-	b.WithKind("VolumeAttachment")
-	b.WithAPIVersion("storage.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b VolumeAttachmentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattributesclass.go
@@ -46,6 +46,27 @@ func VolumeAttributesClass(name string) *VolumeAttributesClassApplyConfiguration
 	return b
 }
 
+// ExtractVolumeAttributesClassFrom extracts the applied configuration owned by fieldManager from
+// volumeAttributesClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// volumeAttributesClass must be a unmodified VolumeAttributesClass API object that was retrieved from the Kubernetes API.
+// ExtractVolumeAttributesClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractVolumeAttributesClassFrom(volumeAttributesClass *storagev1alpha1.VolumeAttributesClass, fieldManager string, subresource string) (*VolumeAttributesClassApplyConfiguration, error) {
+	b := &VolumeAttributesClassApplyConfiguration{}
+	err := managedfields.ExtractInto(volumeAttributesClass, internal.Parser().Type("io.k8s.api.storage.v1alpha1.VolumeAttributesClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(volumeAttributesClass.Name)
+
+	b.WithKind("VolumeAttributesClass")
+	b.WithAPIVersion("storage.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractVolumeAttributesClass extracts the applied configuration owned by fieldManager from
 // volumeAttributesClass. If no managedFields are found in volumeAttributesClass for fieldManager, a
 // VolumeAttributesClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,9 @@ func VolumeAttributesClass(name string) *VolumeAttributesClassApplyConfiguration
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttributesClass(volumeAttributesClass *storagev1alpha1.VolumeAttributesClass, fieldManager string) (*VolumeAttributesClassApplyConfiguration, error) {
-	return extractVolumeAttributesClass(volumeAttributesClass, fieldManager, "")
+	return ExtractVolumeAttributesClassFrom(volumeAttributesClass, fieldManager, "")
 }
 
-// ExtractVolumeAttributesClassStatus is the same as ExtractVolumeAttributesClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractVolumeAttributesClassStatus(volumeAttributesClass *storagev1alpha1.VolumeAttributesClass, fieldManager string) (*VolumeAttributesClassApplyConfiguration, error) {
-	return extractVolumeAttributesClass(volumeAttributesClass, fieldManager, "status")
-}
-
-func extractVolumeAttributesClass(volumeAttributesClass *storagev1alpha1.VolumeAttributesClass, fieldManager string, subresource string) (*VolumeAttributesClassApplyConfiguration, error) {
-	b := &VolumeAttributesClassApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttributesClass, internal.Parser().Type("io.k8s.api.storage.v1alpha1.VolumeAttributesClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(volumeAttributesClass.Name)
-
-	b.WithKind("VolumeAttributesClass")
-	b.WithAPIVersion("storage.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b VolumeAttributesClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
@@ -45,6 +45,27 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 	return b
 }
 
+// ExtractCSIDriverFrom extracts the applied configuration owned by fieldManager from
+// cSIDriver for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// cSIDriver must be a unmodified CSIDriver API object that was retrieved from the Kubernetes API.
+// ExtractCSIDriverFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCSIDriverFrom(cSIDriver *storagev1beta1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
+	b := &CSIDriverApplyConfiguration{}
+	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIDriver"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(cSIDriver.Name)
+
+	b.WithKind("CSIDriver")
+	b.WithAPIVersion("storage.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractCSIDriver extracts the applied configuration owned by fieldManager from
 // cSIDriver. If no managedFields are found in cSIDriver for fieldManager, a
 // CSIDriverApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSIDriver(cSIDriver *storagev1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
-	return extractCSIDriver(cSIDriver, fieldManager, "")
+	return ExtractCSIDriverFrom(cSIDriver, fieldManager, "")
 }
 
-// ExtractCSIDriverStatus is the same as ExtractCSIDriver except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCSIDriverStatus(cSIDriver *storagev1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
-	return extractCSIDriver(cSIDriver, fieldManager, "status")
-}
-
-func extractCSIDriver(cSIDriver *storagev1beta1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
-	b := &CSIDriverApplyConfiguration{}
-	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIDriver"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(cSIDriver.Name)
-
-	b.WithKind("CSIDriver")
-	b.WithAPIVersion("storage.k8s.io/v1beta1")
-	return b, nil
-}
 func (b CSIDriverApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
@@ -45,6 +45,27 @@ func CSINode(name string) *CSINodeApplyConfiguration {
 	return b
 }
 
+// ExtractCSINodeFrom extracts the applied configuration owned by fieldManager from
+// cSINode for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// cSINode must be a unmodified CSINode API object that was retrieved from the Kubernetes API.
+// ExtractCSINodeFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCSINodeFrom(cSINode *storagev1beta1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
+	b := &CSINodeApplyConfiguration{}
+	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSINode"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(cSINode.Name)
+
+	b.WithKind("CSINode")
+	b.WithAPIVersion("storage.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractCSINode extracts the applied configuration owned by fieldManager from
 // cSINode. If no managedFields are found in cSINode for fieldManager, a
 // CSINodeApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -57,28 +78,9 @@ func CSINode(name string) *CSINodeApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractCSINode(cSINode *storagev1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
-	return extractCSINode(cSINode, fieldManager, "")
+	return ExtractCSINodeFrom(cSINode, fieldManager, "")
 }
 
-// ExtractCSINodeStatus is the same as ExtractCSINode except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCSINodeStatus(cSINode *storagev1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
-	return extractCSINode(cSINode, fieldManager, "status")
-}
-
-func extractCSINode(cSINode *storagev1beta1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
-	b := &CSINodeApplyConfiguration{}
-	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSINode"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(cSINode.Name)
-
-	b.WithKind("CSINode")
-	b.WithAPIVersion("storage.k8s.io/v1beta1")
-	return b, nil
-}
 func (b CSINodeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
@@ -50,29 +50,15 @@ func CSIStorageCapacity(name, namespace string) *CSIStorageCapacityApplyConfigur
 	return b
 }
 
-// ExtractCSIStorageCapacity extracts the applied configuration owned by fieldManager from
-// cSIStorageCapacity. If no managedFields are found in cSIStorageCapacity for fieldManager, a
-// CSIStorageCapacityApplyConfiguration is returned with only the Name, Namespace (if applicable),
-// APIVersion and Kind populated. It is possible that no managed fields were found for because other
-// field managers have taken ownership of all the fields previously owned by fieldManager, or because
-// the fieldManager never owned fields any fields.
+// ExtractCSIStorageCapacityFrom extracts the applied configuration owned by fieldManager from
+// cSIStorageCapacity for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
 // cSIStorageCapacity must be a unmodified CSIStorageCapacity API object that was retrieved from the Kubernetes API.
-// ExtractCSIStorageCapacity provides a way to perform a extract/modify-in-place/apply workflow.
+// ExtractCSIStorageCapacityFrom provides a way to perform a extract/modify-in-place/apply workflow.
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCSIStorageCapacity(cSIStorageCapacity *storagev1beta1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
-	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "")
-}
-
-// ExtractCSIStorageCapacityStatus is the same as ExtractCSIStorageCapacity except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractCSIStorageCapacityStatus(cSIStorageCapacity *storagev1beta1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
-	return extractCSIStorageCapacity(cSIStorageCapacity, fieldManager, "status")
-}
-
-func extractCSIStorageCapacity(cSIStorageCapacity *storagev1beta1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
+func ExtractCSIStorageCapacityFrom(cSIStorageCapacity *storagev1beta1.CSIStorageCapacity, fieldManager string, subresource string) (*CSIStorageCapacityApplyConfiguration, error) {
 	b := &CSIStorageCapacityApplyConfiguration{}
 	err := managedfields.ExtractInto(cSIStorageCapacity, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIStorageCapacity"), fieldManager, b, subresource)
 	if err != nil {
@@ -85,6 +71,22 @@ func extractCSIStorageCapacity(cSIStorageCapacity *storagev1beta1.CSIStorageCapa
 	b.WithAPIVersion("storage.k8s.io/v1beta1")
 	return b, nil
 }
+
+// ExtractCSIStorageCapacity extracts the applied configuration owned by fieldManager from
+// cSIStorageCapacity. If no managedFields are found in cSIStorageCapacity for fieldManager, a
+// CSIStorageCapacityApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// cSIStorageCapacity must be a unmodified CSIStorageCapacity API object that was retrieved from the Kubernetes API.
+// ExtractCSIStorageCapacity provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractCSIStorageCapacity(cSIStorageCapacity *storagev1beta1.CSIStorageCapacity, fieldManager string) (*CSIStorageCapacityApplyConfiguration, error) {
+	return ExtractCSIStorageCapacityFrom(cSIStorageCapacity, fieldManager, "")
+}
+
 func (b CSIStorageCapacityApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
@@ -46,6 +46,27 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 	return b
 }
 
+// ExtractVolumeAttachmentFrom extracts the applied configuration owned by fieldManager from
+// volumeAttachment for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// volumeAttachment must be a unmodified VolumeAttachment API object that was retrieved from the Kubernetes API.
+// ExtractVolumeAttachmentFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractVolumeAttachmentFrom(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
+	b := &VolumeAttachmentApplyConfiguration{}
+	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1beta1.VolumeAttachment"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(volumeAttachment.Name)
+
+	b.WithKind("VolumeAttachment")
+	b.WithAPIVersion("storage.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractVolumeAttachment extracts the applied configuration owned by fieldManager from
 // volumeAttachment. If no managedFields are found in volumeAttachment for fieldManager, a
 // VolumeAttachmentApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttachment(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
-	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
+	return ExtractVolumeAttachmentFrom(volumeAttachment, fieldManager, "")
 }
 
-// ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
-// that it extracts the status subresource applied configuration.
+// ExtractVolumeAttachmentStatus extracts the applied configuration owned by fieldManager from
+// volumeAttachment for the status subresource.
 // Experimental!
 func ExtractVolumeAttachmentStatus(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
-	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
+	return ExtractVolumeAttachmentFrom(volumeAttachment, fieldManager, "status")
 }
 
-func extractVolumeAttachment(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
-	b := &VolumeAttachmentApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1beta1.VolumeAttachment"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(volumeAttachment.Name)
-
-	b.WithKind("VolumeAttachment")
-	b.WithAPIVersion("storage.k8s.io/v1beta1")
-	return b, nil
-}
 func (b VolumeAttachmentApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattributesclass.go
@@ -46,6 +46,27 @@ func VolumeAttributesClass(name string) *VolumeAttributesClassApplyConfiguration
 	return b
 }
 
+// ExtractVolumeAttributesClassFrom extracts the applied configuration owned by fieldManager from
+// volumeAttributesClass for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// volumeAttributesClass must be a unmodified VolumeAttributesClass API object that was retrieved from the Kubernetes API.
+// ExtractVolumeAttributesClassFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractVolumeAttributesClassFrom(volumeAttributesClass *storagev1beta1.VolumeAttributesClass, fieldManager string, subresource string) (*VolumeAttributesClassApplyConfiguration, error) {
+	b := &VolumeAttributesClassApplyConfiguration{}
+	err := managedfields.ExtractInto(volumeAttributesClass, internal.Parser().Type("io.k8s.api.storage.v1beta1.VolumeAttributesClass"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(volumeAttributesClass.Name)
+
+	b.WithKind("VolumeAttributesClass")
+	b.WithAPIVersion("storage.k8s.io/v1beta1")
+	return b, nil
+}
+
 // ExtractVolumeAttributesClass extracts the applied configuration owned by fieldManager from
 // volumeAttributesClass. If no managedFields are found in volumeAttributesClass for fieldManager, a
 // VolumeAttributesClassApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,9 @@ func VolumeAttributesClass(name string) *VolumeAttributesClassApplyConfiguration
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractVolumeAttributesClass(volumeAttributesClass *storagev1beta1.VolumeAttributesClass, fieldManager string) (*VolumeAttributesClassApplyConfiguration, error) {
-	return extractVolumeAttributesClass(volumeAttributesClass, fieldManager, "")
+	return ExtractVolumeAttributesClassFrom(volumeAttributesClass, fieldManager, "")
 }
 
-// ExtractVolumeAttributesClassStatus is the same as ExtractVolumeAttributesClass except
-// that it extracts the status subresource applied configuration.
-// Experimental!
-func ExtractVolumeAttributesClassStatus(volumeAttributesClass *storagev1beta1.VolumeAttributesClass, fieldManager string) (*VolumeAttributesClassApplyConfiguration, error) {
-	return extractVolumeAttributesClass(volumeAttributesClass, fieldManager, "status")
-}
-
-func extractVolumeAttributesClass(volumeAttributesClass *storagev1beta1.VolumeAttributesClass, fieldManager string, subresource string) (*VolumeAttributesClassApplyConfiguration, error) {
-	b := &VolumeAttributesClassApplyConfiguration{}
-	err := managedfields.ExtractInto(volumeAttributesClass, internal.Parser().Type("io.k8s.api.storage.v1beta1.VolumeAttributesClass"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(volumeAttributesClass.Name)
-
-	b.WithKind("VolumeAttributesClass")
-	b.WithAPIVersion("storage.k8s.io/v1beta1")
-	return b, nil
-}
 func (b VolumeAttributesClassApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigration.go
@@ -46,6 +46,27 @@ func StorageVersionMigration(name string) *StorageVersionMigrationApplyConfigura
 	return b
 }
 
+// ExtractStorageVersionMigrationFrom extracts the applied configuration owned by fieldManager from
+// storageVersionMigration for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// storageVersionMigration must be a unmodified StorageVersionMigration API object that was retrieved from the Kubernetes API.
+// ExtractStorageVersionMigrationFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+// Experimental!
+func ExtractStorageVersionMigrationFrom(storageVersionMigration *storagemigrationv1alpha1.StorageVersionMigration, fieldManager string, subresource string) (*StorageVersionMigrationApplyConfiguration, error) {
+	b := &StorageVersionMigrationApplyConfiguration{}
+	err := managedfields.ExtractInto(storageVersionMigration, internal.Parser().Type("io.k8s.api.storagemigration.v1alpha1.StorageVersionMigration"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(storageVersionMigration.Name)
+
+	b.WithKind("StorageVersionMigration")
+	b.WithAPIVersion("storagemigration.k8s.io/v1alpha1")
+	return b, nil
+}
+
 // ExtractStorageVersionMigration extracts the applied configuration owned by fieldManager from
 // storageVersionMigration. If no managedFields are found in storageVersionMigration for fieldManager, a
 // StorageVersionMigrationApplyConfiguration is returned with only the Name, Namespace (if applicable),
@@ -58,28 +79,16 @@ func StorageVersionMigration(name string) *StorageVersionMigrationApplyConfigura
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
 func ExtractStorageVersionMigration(storageVersionMigration *storagemigrationv1alpha1.StorageVersionMigration, fieldManager string) (*StorageVersionMigrationApplyConfiguration, error) {
-	return extractStorageVersionMigration(storageVersionMigration, fieldManager, "")
+	return ExtractStorageVersionMigrationFrom(storageVersionMigration, fieldManager, "")
 }
 
-// ExtractStorageVersionMigrationStatus is the same as ExtractStorageVersionMigration except
-// that it extracts the status subresource applied configuration.
+// ExtractStorageVersionMigrationStatus extracts the applied configuration owned by fieldManager from
+// storageVersionMigration for the status subresource.
 // Experimental!
 func ExtractStorageVersionMigrationStatus(storageVersionMigration *storagemigrationv1alpha1.StorageVersionMigration, fieldManager string) (*StorageVersionMigrationApplyConfiguration, error) {
-	return extractStorageVersionMigration(storageVersionMigration, fieldManager, "status")
+	return ExtractStorageVersionMigrationFrom(storageVersionMigration, fieldManager, "status")
 }
 
-func extractStorageVersionMigration(storageVersionMigration *storagemigrationv1alpha1.StorageVersionMigration, fieldManager string, subresource string) (*StorageVersionMigrationApplyConfiguration, error) {
-	b := &StorageVersionMigrationApplyConfiguration{}
-	err := managedfields.ExtractInto(storageVersionMigration, internal.Parser().Type("io.k8s.api.storagemigration.v1alpha1.StorageVersionMigration"), fieldManager, b, subresource)
-	if err != nil {
-		return nil, err
-	}
-	b.WithName(storageVersionMigration.Name)
-
-	b.WithKind("StorageVersionMigration")
-	b.WithAPIVersion("storagemigration.k8s.io/v1alpha1")
-	return b, nil
-}
 func (b StorageVersionMigrationApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttype.go
@@ -41,6 +41,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example-group.hyphens.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtype.go
@@ -42,6 +42,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example-group.hyphens.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttype.go
@@ -41,6 +41,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtype.go
@@ -42,6 +42,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/conflicting/v1/testtype.go
@@ -43,6 +43,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("conflicting.test.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttype.go
@@ -41,6 +41,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtype.go
@@ -42,6 +42,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtype.go
@@ -42,6 +42,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.test.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testsubresource.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testsubresource.go
@@ -37,6 +37,7 @@ func TestSubresource() *TestSubresourceApplyConfiguration {
 	b.WithAPIVersion("extensions.test.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestSubresourceApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/extensions/v1/testtype.go
@@ -42,6 +42,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("extensions.test.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/clustertesttype.go
@@ -41,6 +41,7 @@ func ClusterTestType(name string) *ClusterTestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b ClusterTestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/applyconfiguration/api/v1/testtype.go
@@ -42,6 +42,7 @@ func TestType(name, namespace string) *TestTypeApplyConfiguration {
 	b.WithAPIVersion("example.crd.code-generator.k8s.io/v1")
 	return b
 }
+
 func (b TestTypeApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/fischer.go
@@ -41,6 +41,7 @@ func Fischer(name string) *FischerApplyConfiguration {
 	b.WithAPIVersion("wardle.example.com/v1alpha1")
 	return b
 }
+
 func (b FischerApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
@@ -44,6 +44,7 @@ func Flunder(name, namespace string) *FlunderApplyConfiguration {
 	b.WithAPIVersion("wardle.example.com/v1alpha1")
 	return b
 }
+
 func (b FlunderApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
@@ -44,6 +44,7 @@ func Flunder(name, namespace string) *FlunderApplyConfiguration {
 	b.WithAPIVersion("wardle.example.com/v1beta1")
 	return b
 }
+
 func (b FlunderApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Extends applyconfiguration-gen to generate extract functions for all subresources, not just status.
- Makes `Extract${TYPE}From` public as a convenient escape hatch.
- Now checks if types actually have a status field and skips status extract function generation when absent (e.g., ControllerRevision).
- Also adds an empty line above the IsApplyConfiguration function.

#### Special notes for your reviewer:

Changing codegen logic: https://github.com/kubernetes/kubernetes/commit/c14427f37b84feb4b03d31cd12e933cc0357daf0
Generated pod extract functions: 
https://github.com/mrIncompetent/kubernetes/blob/03b8bf19742b2b219580de997d2b109694f667bd/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go#L58-L106

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
applyconfiguration-gen now generates extract functions for all subresources
```
