### PR TITLE
WIP: DRA metrics: promotion to beta

### DIFF
--- a/pkg/controller/resourceclaim/metrics/metrics.go
+++ b/pkg/controller/resourceclaim/metrics/metrics.go
@@ -34,7 +34,7 @@ var (
 			Subsystem:      ResourceClaimSubsystem,
 			Name:           "create_attempts_total",
 			Help:           "Number of ResourceClaims creation requests",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		})
 	// ResourceClaimCreateFailures tracks the number of unsuccessful
 	// ResourceClaims().Create calls
@@ -43,7 +43,7 @@ var (
 			Subsystem:      ResourceClaimSubsystem,
 			Name:           "create_failures_total",
 			Help:           "Number of ResourceClaims creation request failures",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		})
 	// NumResourceClaims tracks the current number of ResourceClaims.
 	NumResourceClaims = metrics.NewGauge(
@@ -51,7 +51,7 @@ var (
 			Subsystem:      ResourceClaimSubsystem,
 			Name:           "resource_claims",
 			Help:           "Number of ResourceClaims",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		})
 	// NumAllocatedResourceClaims tracks the current number of allocated ResourceClaims.
 	NumAllocatedResourceClaims = metrics.NewGauge(
@@ -59,7 +59,7 @@ var (
 			Subsystem:      ResourceClaimSubsystem,
 			Name:           "allocated_resource_claims",
 			Help:           "Number of allocated ResourceClaims",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		})
 )
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -1011,7 +1011,7 @@ var (
 			Name:           DRAOperationsDurationKey,
 			Help:           "Latency histogram in seconds for the duration of handling all ResourceClaims referenced by a pod when the pod starts or stops. Identified by the name of the operation (PrepareResources or UnprepareResources) and separated by the success of the operation. The number of failed operations is provided through the histogram's overall count.",
 			Buckets:        DRADurationBuckets,
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"operation_name", "is_error"},
 	)
@@ -1023,7 +1023,7 @@ var (
 			Name:           DRAGRPCOperationsDurationKey,
 			Help:           "Duration in seconds of the DRA gRPC operations",
 			Buckets:        DRADurationBuckets,
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"driver_name", "method_name", "grpc_status_code"},
 	)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -179,6 +179,59 @@
   help: The count of disabled metrics.
   type: Counter
   stabilityLevel: BETA
+- name: grpc_operations_duration_seconds
+  subsystem: dra
+  help: Duration in seconds of the DRA gRPC operations
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - driver_name
+  - grpc_status_code
+  - method_name
+  buckets:
+  - 0.1
+  - 0.1534127404634391
+  - 0.23535468936502524
+  - 0.36106407876409946
+  - 0.5539182980610752
+  - 0.849781240983936
+  - 1.303672689737678
+  - 1.9999999999999993
+  - 3.0682548092687805
+  - 4.7070937873005025
+  - 7.221281575281985
+  - 11.078365961221499
+  - 16.995624819678714
+  - 26.07345379475354
+  - 39.99999999999997
+- name: operations_duration_seconds
+  subsystem: dra
+  help: Latency histogram in seconds for the duration of handling all ResourceClaims
+    referenced by a pod when the pod starts or stops. Identified by the name of the
+    operation (PrepareResources or UnprepareResources) and separated by the success
+    of the operation. The number of failed operations is provided through the histogram's
+    overall count.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - is_error
+  - operation_name
+  buckets:
+  - 0.1
+  - 0.1534127404634391
+  - 0.23535468936502524
+  - 0.36106407876409946
+  - 0.5539182980610752
+  - 0.849781240983936
+  - 1.303672689737678
+  - 1.9999999999999993
+  - 3.0682548092687805
+  - 4.7070937873005025
+  - 7.221281575281985
+  - 11.078365961221499
+  - 16.995624819678714
+  - 26.07345379475354
+  - 39.99999999999997
 - name: hidden_metrics_total
   help: The count of hidden metrics.
   type: Counter
@@ -212,6 +265,26 @@
   labels:
   - deprecated_version
   - stability_level
+- name: allocated_resource_claims
+  subsystem: resourceclaim_controller
+  help: Number of allocated ResourceClaims
+  type: Gauge
+  stabilityLevel: BETA
+- name: create_attempts_total
+  subsystem: resourceclaim_controller
+  help: Number of ResourceClaims creation requests
+  type: Counter
+  stabilityLevel: BETA
+- name: create_failures_total
+  subsystem: resourceclaim_controller
+  help: Number of ResourceClaims creation request failures
+  type: Counter
+  stabilityLevel: BETA
+- name: resource_claims
+  subsystem: resourceclaim_controller
+  help: Number of ResourceClaims
+  type: Gauge
+  stabilityLevel: BETA
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

These metrics have been part of the initial DRA beta in 1.32. While feedback on these metrics has been limited, they seem useful and there's no reason to expect further changes to them.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/132141
KEP: https://github.com/kubernetes/enhancements/issues/4381

#### Special notes for your reviewer:

Discussed in https://github.com/kubernetes/enhancements/pull/5333#discussion_r2103936676

#### Does this PR introduce a user-facing change?

```release-note
DRA: several metrics are now beta.
```
