### PR TITLE
Stabilize swap eviction priority test 

### DIFF
--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -570,6 +570,9 @@ type podEvictSpec struct {
 
 	evictionMaxPodGracePeriod int
 	evictionSoftGracePeriod   int
+
+	// Can be used in order to alter pod using runtime data
+	prePodCreationModificationFunc func(pod *v1.Pod)
 }
 
 // runEvictionTest sets up a testing environment given the provided pods, and checks a few things:
@@ -592,6 +595,9 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 			ginkgo.By("setting up pods to be used by tests")
 			pods := []*v1.Pod{}
 			for _, spec := range testSpecs {
+				if spec.prePodCreationModificationFunc != nil {
+					spec.prePodCreationModificationFunc(spec.pod)
+				}
 				pods = append(pods, spec.pod)
 			}
 			e2epod.NewPodClient(f).CreateBatch(ctx, pods)
@@ -941,14 +947,12 @@ func logDiskMetrics(ctx context.Context) {
 	}
 }
 
-func logMemoryMetrics(ctx context.Context) {
-	summary, err := getNodeSummary(ctx)
-	if err != nil {
-		framework.Logf("Error getting summary: %v", err)
-		return
-	}
+func logMemoryMetricsWithSummary(ctx context.Context, summary *kubeletstatsv1alpha1.Summary) {
 	if summary.Node.Memory != nil && summary.Node.Memory.WorkingSetBytes != nil && summary.Node.Memory.AvailableBytes != nil {
 		framework.Logf("Node.Memory.WorkingSetBytes: %d, Node.Memory.AvailableBytes: %d", *summary.Node.Memory.WorkingSetBytes, *summary.Node.Memory.AvailableBytes)
+	}
+	if summary.Node.Swap != nil && summary.Node.Swap.SwapUsageBytes != nil && summary.Node.Swap.SwapAvailableBytes != nil {
+		framework.Logf("summary.Node.Swap.SwapUsageBytes: %d, summary.Node.Swap.SwapAvailableBytes: %d", *summary.Node.Swap.SwapUsageBytes, *summary.Node.Swap.SwapAvailableBytes)
 	}
 	for _, sysContainer := range summary.Node.SystemContainers {
 		if sysContainer.Name == kubeletstatsv1alpha1.SystemContainerPods && sysContainer.Memory != nil && sysContainer.Memory.WorkingSetBytes != nil && sysContainer.Memory.AvailableBytes != nil {
@@ -960,9 +964,29 @@ func logMemoryMetrics(ctx context.Context) {
 		for _, container := range pod.Containers {
 			if container.Memory != nil && container.Memory.WorkingSetBytes != nil {
 				framework.Logf("--- summary Container: %s WorkingSetBytes: %d", container.Name, *container.Memory.WorkingSetBytes)
+				if container.Memory.UsageBytes != nil {
+					framework.Logf("--- summary Container: %s UsageBytes: %d", container.Name, *container.Memory.UsageBytes)
+				}
+			}
+			if container.Swap != nil {
+				if container.Swap.SwapUsageBytes != nil {
+					framework.Logf("--- summary Container: %s SwapUsageBytes: %d", container.Name, *container.Swap.SwapUsageBytes)
+				}
+				if container.Swap.SwapAvailableBytes != nil {
+					framework.Logf("--- summary Container: %s SwapAvailableBytes: %d", container.Name, *container.Swap.SwapAvailableBytes)
+				}
 			}
 		}
 	}
+}
+
+func logMemoryMetrics(ctx context.Context) {
+	summary, err := getNodeSummary(ctx)
+	if err != nil {
+		framework.Logf("Error getting summary: %v", err)
+		return
+	}
+	logMemoryMetricsWithSummary(ctx, summary)
 }
 
 func logPidMetrics(ctx context.Context) {


### PR DESCRIPTION
/kind failing-test
/sig node

#### What this PR does / why we need it:
This is a follow-up to https://github.com/kubernetes/test-infra/pull/35062 which edits the swap-conformance lane so it would run memory eviction tests.

Whenever swap is provisioned on the node, the kernel might be able to reclaim much more memory, hence it is harder to get the node to become memory pressured, as expected as part of the eviction tests.

This results in the test [failing](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-swap-conformance-ubuntu-serial/1940286967258288128) over the following error:
```
{ failed [FAILED] Timed out after 600.000s.
Expected
    <*errors.errorString | 0xc000b60640>: 
    NodeCondition: MemoryPressure not encountered
    {
        s: "NodeCondition: MemoryPressure not encountered",
    }
to be nil
In [It] at: k8s.io/kubernetes/test/e2e_node/eviction_test.go:608 @ 07/02/25 06:30:20.951
}
```

This PR:
* Slightly refactors the eviction tests, so that run specs would support defining a function that would alter the pod before creation.
* Stabilizes the `PriorityMemoryEvictionOrdering` test by adding another container that slowly allocates the same amount as the swap capacity to help bring the node into memory pressure.

#### Special notes for your reviewer:
This problem was already hunting us in the past as part of https://github.com/kubernetes/test-infra/pull/34558.

Periodic lanes can be seen here:
- https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-fedora-serial
- https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-ubuntu-serial

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
