### PR TITLE
Fix volume limit e2e test cleanup

### DIFF
--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -130,6 +130,54 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 		dDriver = driver.(storageframework.DynamicPVTestDriver)
 	})
 
+	cleanupTest := func(ctx context.Context, timeout time.Duration) error {
+		var cleanupErrors []string
+		for _, podName := range l.podNames {
+			framework.Logf("Deleting pod %s", podName)
+			err := l.cs.CoreV1().Pods(l.ns.Name).Delete(ctx, podName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				cleanupErrors = append(cleanupErrors, fmt.Sprintf("failed to delete pod %s: %s", podName, err))
+			}
+		}
+		for _, pvcName := range l.pvcNames {
+			framework.Logf("Deleting PVC %s", pvcName)
+			err := l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Delete(ctx, pvcName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				cleanupErrors = append(cleanupErrors, fmt.Sprintf("failed to delete PVC %s: %s", pvcName, err))
+			}
+		}
+		// Wait for the PVs to be deleted. It includes also pod and PVC deletion because of PVC protection.
+		// We use PVs to make sure that the test does not leave orphan PVs when a CSI driver is destroyed
+		// just after the test ends.
+		err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+			existing := 0
+			for _, pvName := range l.pvNames.UnsortedList() {
+				_, err := l.cs.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+				if err == nil {
+					existing++
+				} else {
+					if apierrors.IsNotFound(err) {
+						l.pvNames.Delete(pvName)
+					} else {
+						framework.Logf("Failed to get PV %s: %s", pvName, err)
+					}
+				}
+			}
+			if existing > 0 {
+				framework.Logf("Waiting for %d PVs to be deleted", existing)
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Sprintf("timed out waiting for PVs to be deleted: %s", err))
+		}
+		if len(cleanupErrors) != 0 {
+			return errors.New("test cleanup failed: " + strings.Join(cleanupErrors, "; "))
+		}
+		return nil
+	}
+
 	// This checks that CSIMaxVolumeLimitChecker works as expected.
 	// A randomly chosen node should be able to handle as many CSI volumes as
 	// it claims to handle in CSINode.Spec.Drivers[x].Allocatable.
@@ -169,7 +217,7 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 
 		l.resource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, testVolumeSizeRange)
 		ginkgo.DeferCleanup(l.resource.CleanupResource)
-		ginkgo.DeferCleanup(cleanupTest, l.cs, l.ns.Name, l.podNames, l.pvcNames, l.pvNames, testSlowMultiplier*f.Timeouts.PVDelete)
+		ginkgo.DeferCleanup(cleanupTest, testSlowMultiplier*f.Timeouts.PVDelete)
 
 		selection := e2epod.NodeSelection{Name: nodeName}
 
@@ -277,52 +325,6 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 			}
 		}
 	})
-}
-
-func cleanupTest(ctx context.Context, cs clientset.Interface, ns string, podNames, pvcNames []string, pvNames sets.Set[string], timeout time.Duration) error {
-	var cleanupErrors []string
-	for _, podName := range podNames {
-		err := cs.CoreV1().Pods(ns).Delete(ctx, podName, metav1.DeleteOptions{})
-		if err != nil {
-			cleanupErrors = append(cleanupErrors, fmt.Sprintf("failed to delete pod %s: %s", podName, err))
-		}
-	}
-	for _, pvcName := range pvcNames {
-		err := cs.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, pvcName, metav1.DeleteOptions{})
-		if !apierrors.IsNotFound(err) {
-			cleanupErrors = append(cleanupErrors, fmt.Sprintf("failed to delete PVC %s: %s", pvcName, err))
-		}
-	}
-	// Wait for the PVs to be deleted. It includes also pod and PVC deletion because of PVC protection.
-	// We use PVs to make sure that the test does not leave orphan PVs when a CSI driver is destroyed
-	// just after the test ends.
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
-		existing := 0
-		for _, pvName := range pvNames.UnsortedList() {
-			_, err := cs.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
-			if err == nil {
-				existing++
-			} else {
-				if apierrors.IsNotFound(err) {
-					pvNames.Delete(pvName)
-				} else {
-					framework.Logf("Failed to get PV %s: %s", pvName, err)
-				}
-			}
-		}
-		if existing > 0 {
-			framework.Logf("Waiting for %d PVs to be deleted", existing)
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		cleanupErrors = append(cleanupErrors, fmt.Sprintf("timed out waiting for PVs to be deleted: %s", err))
-	}
-	if len(cleanupErrors) != 0 {
-		return errors.New("test cleanup failed: " + strings.Join(cleanupErrors, "; "))
-	}
-	return nil
 }
 
 // waitForAllPVCsBound waits until the given PVCs are all bound. It then returns the bound PVC names as a set.


### PR DESCRIPTION
Pass the local test state to `cleanupTest()` as a pointer. It is mostly empty at the point of calling  `DeferCleanup(cleanupTest, ...)`, so using `ginkgo.DeferCleanup(cleanupTest, ..., l.podNames, ...)` just passes empty `podNames` to the cleanup and the test pods are not deleted.
`l.podNames` gets populated later and the cleanup must use the updated one.

And now that the cleanup actually does something, fix the error handling in it.

As result, the test deletes all test pods while csi-driver-hostpath is still installed and the pods can be actually deleted. 

#### What type of PR is this?
/kind bug
/kind failing-test
Fixes: #132673

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```release-note
Fixed e2e test "[Driver: csi-hostpath] [Testpattern: Dynamic PV (filesystem volmode)] volumeLimits should support volume limits]" not to leak Pods and namespaces.
```
