### PR TITLE
Don't log irrelevant zone hints message on no endpoints

### DIFF
--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -42,6 +42,11 @@ import (
 // Serving-Terminating endpoints (independently for Cluster and Local) if no Ready
 // endpoints are available.
 func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeName string, nodeLabels map[string]string) (clusterEndpoints, localEndpoints, allReachableEndpoints []Endpoint, hasAnyEndpoints bool) {
+	if len(endpoints) == 0 {
+		// If there are no endpoints, we have nothing to categorize
+		return
+	}
+
 	var topologyMode string
 	var useServingTerminatingEndpoints bool
 

--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -153,6 +153,12 @@ func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeName str
 //     hinted for this node's zone, then it returns "PreferSameZone".
 //   - Otherwise it returns "" (meaning, no topology / default traffic distribution).
 func topologyModeFromHints(svcInfo ServicePort, endpoints []Endpoint, nodeName, zone string) string {
+	if len(endpoints) == 0 {
+		// The code below assumes at least 1 endpoint; if there are no endpoints,
+		// there are no hints.
+		return ""
+	}
+
 	hasEndpointForNode := false
 	allEndpointsHaveNodeHints := true
 	hasEndpointForZone := false

--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -390,6 +390,13 @@ func TestCategorizeEndpoints(t *testing.T) {
 		clusterEndpoints: nil,
 		localEndpoints:   sets.New[string]("10.0.0.1:80"),
 		allEndpoints:     sets.New[string]("10.0.0.1:80"),
+	}, {
+		name:             "empty cluster endpoints when no service endpoints exist",
+		serviceInfo:      &BaseServicePortInfo{},
+		endpoints:        nil,
+		clusterEndpoints: sets.New[string](),
+		localEndpoints:   nil,
+		allEndpoints:     nil,
 	}}
 
 	for _, tc := range testCases {

--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -391,10 +391,10 @@ func TestCategorizeEndpoints(t *testing.T) {
 		localEndpoints:   sets.New[string]("10.0.0.1:80"),
 		allEndpoints:     sets.New[string]("10.0.0.1:80"),
 	}, {
-		name:             "empty cluster endpoints when no service endpoints exist",
+		name:             "empty endpoints when no service endpoints exist",
 		serviceInfo:      &BaseServicePortInfo{},
 		endpoints:        nil,
-		clusterEndpoints: sets.New[string](),
+		clusterEndpoints: nil,
 		localEndpoints:   nil,
 		allEndpoints:     nil,
 	}}
@@ -405,7 +405,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 
 			clusterEndpoints, localEndpoints, allEndpoints, hasAnyEndpoints := CategorizeEndpoints(tc.endpoints, tc.serviceInfo, tc.nodeName, tc.nodeLabels)
 
-			if tc.clusterEndpoints == nil && clusterEndpoints != nil {
+			if len(tc.clusterEndpoints) == 0 && len(clusterEndpoints) != 0 {
 				t.Errorf("expected no cluster endpoints but got %v", clusterEndpoints)
 			} else {
 				err := checkExpectedEndpoints(tc.clusterEndpoints, clusterEndpoints)
@@ -414,7 +414,7 @@ func TestCategorizeEndpoints(t *testing.T) {
 				}
 			}
 
-			if tc.localEndpoints == nil && localEndpoints != nil {
+			if len(tc.localEndpoints) == 0 && len(localEndpoints) != 0 {
 				t.Errorf("expected no local endpoints but got %v", localEndpoints)
 			} else {
 				err := checkExpectedEndpoints(tc.localEndpoints, localEndpoints)
@@ -424,9 +424,9 @@ func TestCategorizeEndpoints(t *testing.T) {
 			}
 
 			var expectedAllEndpoints sets.Set[string]
-			if tc.clusterEndpoints != nil && tc.localEndpoints == nil {
+			if len(tc.clusterEndpoints) != 0 && len(tc.localEndpoints) == 0 {
 				expectedAllEndpoints = tc.clusterEndpoints
-			} else if tc.localEndpoints != nil && tc.clusterEndpoints == nil {
+			} else if len(tc.localEndpoints) != 0 && len(tc.clusterEndpoints) == 0 {
 				expectedAllEndpoints = tc.localEndpoints
 			} else {
 				expectedAllEndpoints = tc.allEndpoints


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

See https://github.com/kubernetes/kubernetes/issues/132678 - kube-proxy is currently logging erroneous messages about ignoring topology hints when an endpointslice is empty. This short circuits the function and returns the default traffic distribution if there are no endpoints.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/132678

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes 1.33 regression with spammy log messages
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
