### PR TITLE
kube-controller-manager: Extend --controllers usage string to contain required feature gates

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/certificates/approver"
@@ -233,8 +232,8 @@ func newPodCertificateRequestCleanerControllerDescriptor() *ControllerDescriptor
 	return &ControllerDescriptor{
 		name:        names.PodCertificateRequestCleanerController,
 		constructor: newPodCertificateRequestCleanerController,
-		requiredFeatureGates: []featuregate.Feature{
-			features.PodCertificateRequest,
+		requiredFeatureGates: []string{
+			string(features.PodCertificateRequest),
 		},
 	}
 }
@@ -288,9 +287,11 @@ func newRootCACertificatePublisherController(ctx context.Context, controllerCont
 
 func newKubeAPIServerSignerClusterTrustBundledPublisherDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
-		name:                 names.KubeAPIServerClusterTrustBundlePublisherController,
-		constructor:          newKubeAPIServerSignerClusterTrustBundledPublisherController,
-		requiredFeatureGates: []featuregate.Feature{features.ClusterTrustBundle},
+		name:        names.KubeAPIServerClusterTrustBundlePublisherController,
+		constructor: newKubeAPIServerSignerClusterTrustBundledPublisherController,
+		requiredFeatureGates: []string{
+			string(features.ClusterTrustBundle),
+		},
 	}
 }
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -156,6 +156,9 @@ controller, and serviceaccounts controller.`,
 		},
 	}
 
+	// Format controllers list so that it contains the associated feature gates.
+	s.Generic.ControllerListFormatter = newControllerListFormatter(NewControllerDescriptors())
+
 	fs := cmd.Flags()
 	namedFlagSets := s.Flags(KnownControllers(), ControllersDisabledByDefault(), ControllerAliases())
 	s.ParsedFlags = &namedFlagSets

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/metadata"
 	restclient "k8s.io/client-go/rest"
 	cpnames "k8s.io/cloud-provider/names"
-	"k8s.io/component-base/featuregate"
 	"k8s.io/controller-manager/controller"
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog/v2"
@@ -221,8 +220,8 @@ func newTaintEvictionControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:        names.TaintEvictionController,
 		constructor: newTaintEvictionController,
-		requiredFeatureGates: []featuregate.Feature{
-			features.SeparateTaintEvictionController,
+		requiredFeatureGates: []string{
+			string(features.SeparateTaintEvictionController),
 		},
 	}
 }
@@ -252,10 +251,10 @@ func newDeviceTaintEvictionControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:        names.DeviceTaintEvictionController,
 		constructor: newDeviceTaintEvictionController,
-		requiredFeatureGates: []featuregate.Feature{
+		requiredFeatureGates: []string{
 			// TODO update app.TestFeatureGatedControllersShouldNotDefineAliases when removing these feature gates.
-			features.DynamicResourceAllocation,
-			features.DRADeviceTaints,
+			string(features.DynamicResourceAllocation),
+			string(features.DRADeviceTaints),
 		},
 	}
 }
@@ -467,8 +466,8 @@ func newResourceClaimControllerDescriptor() *ControllerDescriptor {
 		name:        names.ResourceClaimController,
 		aliases:     []string{"resource-claim-controller"},
 		constructor: newResourceClaimController,
-		requiredFeatureGates: []featuregate.Feature{
-			features.DynamicResourceAllocation, // TODO update app.TestFeatureGatedControllersShouldNotDefineAliases when removing this feature
+		requiredFeatureGates: []string{
+			string(features.DynamicResourceAllocation), // TODO update app.TestFeatureGatedControllersShouldNotDefineAliases when removing this feature
 		},
 	}
 }
@@ -874,8 +873,8 @@ func newVolumeAttributesClassProtectionControllerDescriptor() *ControllerDescrip
 	return &ControllerDescriptor{
 		name:        names.VolumeAttributesClassProtectionController,
 		constructor: newVolumeAttributesClassProtectionController,
-		requiredFeatureGates: []featuregate.Feature{
-			features.VolumeAttributesClass,
+		requiredFeatureGates: []string{
+			string(features.VolumeAttributesClass),
 		},
 	}
 }
@@ -1080,9 +1079,9 @@ func newStorageVersionGarbageCollectorControllerDescriptor() *ControllerDescript
 		name:        names.StorageVersionGarbageCollectorController,
 		aliases:     []string{"storage-version-gc"},
 		constructor: newStorageVersionGarbageCollectorController,
-		requiredFeatureGates: []featuregate.Feature{
-			genericfeatures.APIServerIdentity,
-			genericfeatures.StorageVersionAPI,
+		requiredFeatureGates: []string{
+			string(genericfeatures.APIServerIdentity),
+			string(genericfeatures.StorageVersionAPI),
 		},
 	}
 }
@@ -1107,8 +1106,8 @@ func newSELinuxWarningControllerDescriptor() *ControllerDescriptor {
 		name:                names.SELinuxWarningController,
 		constructor:         newSELinuxWarningController,
 		isDisabledByDefault: true,
-		requiredFeatureGates: []featuregate.Feature{
-			features.SELinuxChangePolicy,
+		requiredFeatureGates: []string{
+			string(features.SELinuxChangePolicy),
 		},
 	}
 }

--- a/cmd/kube-controller-manager/app/networking.go
+++ b/cmd/kube-controller-manager/app/networking.go
@@ -22,7 +22,6 @@ package app
 import (
 	"context"
 
-	"k8s.io/component-base/featuregate"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/servicecidrs"
 	"k8s.io/kubernetes/pkg/features"
@@ -32,8 +31,8 @@ func newServiceCIDRsControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:        names.ServiceCIDRController,
 		constructor: newServiceCIDRsController,
-		requiredFeatureGates: []featuregate.Feature{
-			features.MultiCIDRServiceAllocator,
+		requiredFeatureGates: []string{
+			string(features.MultiCIDRServiceAllocator),
 		},
 	}
 }

--- a/cmd/kube-controller-manager/app/options.go
+++ b/cmd/kube-controller-manager/app/options.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+func newControllerListFormatter(descriptors map[string]*ControllerDescriptor) func([]string) string {
+	return func(controllers []string) string {
+		var out strings.Builder
+		out.WriteString("\n")
+		for _, name := range controllers {
+			// In case there is no descriptor for the controller, just write the name.
+			// This should never happen in practice, but better not to panic.
+			desc, ok := descriptors[name]
+			if !ok {
+				fmt.Fprintf(&out, "%s\n", name)
+				continue
+			}
+
+			gates := desc.GetRequiredFeatureGates()
+			if len(gates) == 0 {
+				fmt.Fprintf(&out, "%s\n", name)
+			} else {
+				fmt.Fprintf(&out, "%s (requires feature gates: %s)\n", name, strings.Join(gates, ", "))
+			}
+		}
+		return out.String()
+	}
+}

--- a/cmd/kube-controller-manager/app/options_test.go
+++ b/cmd/kube-controller-manager/app/options_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOptions_ControllerListFormatter(t *testing.T) {
+	testcases := []struct {
+		name        string
+		descriptors map[string]*ControllerDescriptor
+		controllers []string
+		expected    string
+	}{
+		{
+			name:        "unknown controller name",
+			descriptors: nil,
+			controllers: []string{"controller"},
+			expected:    "\ncontroller\n",
+		},
+		{
+			name: "without feature gates",
+			descriptors: map[string]*ControllerDescriptor{
+				"controller_A": {},
+				"controller_B": {},
+			},
+			controllers: []string{"controller_A", "controller_B"},
+			expected:    "\ncontroller_A\ncontroller_B\n",
+		},
+		{
+			name: "with feature gates",
+			descriptors: map[string]*ControllerDescriptor{
+				"controller_A": {},
+				"controller_B": {
+					requiredFeatureGates: []string{
+						"F1",
+						"F2",
+					},
+				},
+				"controller_C": {},
+			},
+			controllers: []string{"controller_A", "controller_B"},
+			expected:    "\ncontroller_A\ncontroller_B (requires feature gates: F1, F2)\n",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newControllerListFormatter(tc.descriptors)(tc.controllers)
+			if got != tc.expected {
+				t.Error("unexpected output:\n", cmp.Diff(tc.expected, got))
+			}
+		})
+	}
+}
+
+func TestCommand_ControllerListFormatter(t *testing.T) {
+	// This test makes sure the formatter is actually set properly.
+	// This can break, though, when no feature gate is actually required.
+	cmd := NewControllerManagerCommand()
+	usage := cmd.Flags().Lookup("controllers").Usage
+	if !strings.Contains(usage, "(requires feature gates:") {
+		t.Error("unexpected usage:\n", usage)
+	}
+}

--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -24,7 +24,6 @@ import (
 	pluginvalidatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/component-base/featuregate"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/validatingadmissionpolicystatus"
 	"k8s.io/kubernetes/pkg/generated/openapi"
@@ -32,9 +31,8 @@ import (
 
 func newValidatingAdmissionPolicyStatusControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
-		name:                 names.ValidatingAdmissionPolicyStatusController,
-		constructor:          newValidatingAdmissionPolicyStatusController,
-		requiredFeatureGates: []featuregate.Feature{},
+		name:        names.ValidatingAdmissionPolicyStatusController,
+		constructor: newValidatingAdmissionPolicyStatusController,
 	}
 }
 

--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -284,9 +284,9 @@ func svmSetup(ctx context.Context, t *testing.T) *svmTest {
 
 	kcm := kubecontrollermanagertesting.StartTestServerOrDie(ctx, []string{
 		"--kubeconfig=" + kubeConfigFile,
-		"--controllers=garbagecollector,svm",     // these are the only controllers needed for this test
-		"--use-service-account-credentials=true", // exercise RBAC of SVM controller
-		"--leader-elect=false",                   // KCM leader election calls os.Exit when it ends, so it is easier to just turn it off altogether
+		"--controllers=garbagecollector,storage-version-migrator-controller", // these are the only controllers needed for this test
+		"--use-service-account-credentials=true",                             // exercise RBAC of SVM controller
+		"--leader-elect=false",                                               // KCM leader election calls os.Exit when it ends, so it is easier to just turn it off altogether
 	})
 
 	clientSet, err := clientset.NewForConfig(server.ClientConfig)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Print the feature gates required for each controller.
This makes it easy for the user to see what feature gates need to be enabled for particular controllers.

The updated usage output:

```
     --controllers strings                                                                                                                                                         
                A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'.
                
                All controllers: 
                bootstrap-signer-controller
                certificatesigningrequest-approving-controller
                certificatesigningrequest-cleaner-controller
                certificatesigningrequest-signing-controller
                cloud-node-lifecycle-controller
                clusterrole-aggregation-controller
                cronjob-controller
                daemonset-controller
                deployment-controller
                device-taint-eviction-controller (requires feature gates: DRADeviceTaints, DynamicResourceAllocation)
                disruption-controller
                endpoints-controller
                endpointslice-controller
                endpointslice-mirroring-controller
                ephemeral-volume-controller
                garbage-collector-controller
                horizontal-pod-autoscaler-controller
                job-controller
                kube-apiserver-serving-clustertrustbundle-publisher-controller (requires feature gates: ClusterTrustBundle)
                legacy-serviceaccount-token-cleaner-controller
                namespace-controller
                node-ipam-controller
                node-lifecycle-controller
                node-route-controller
                persistentvolume-attach-detach-controller
                persistentvolume-binder-controller
                persistentvolume-expander-controller
                persistentvolume-protection-controller
                persistentvolumeclaim-protection-controller
                pod-garbage-collector-controller
                podcertificaterequest-cleaner-controller (requires feature gates: PodCertificateRequest)
                replicaset-controller
                replicationcontroller-controller
                resourceclaim-controller (requires feature gates: DynamicResourceAllocation)
                resourcequota-controller
                root-ca-certificate-publisher-controller
                selinux-warning-controller (requires feature gates: SELinuxChangePolicy)
                service-cidr-controller (requires feature gates: MultiCIDRServiceAllocator)
                service-lb-controller
                serviceaccount-controller
                serviceaccount-token-controller
                statefulset-controller
                storage-version-migrator-controller (requires feature gates: InOrderInformers, InformerResourceVersion, StorageVersionMigrator)
                storageversion-garbage-collector-controller (requires feature gates: APIServerIdentity, StorageVersionAPI)
                taint-eviction-controller (requires feature gates: SeparateTaintEvictionController)
                token-cleaner-controller
                ttl-after-finished-controller
                ttl-controller
                validatingadmissionpolicy-status-controller
                volumeattributesclass-protection-controller (requires feature gates: VolumeAttributesClass)
                
                Disabled-by-default controllers: 
                bootstrap-signer-controller
                selinux-warning-controller (requires feature gates: SELinuxChangePolicy)
                token-cleaner-controller
                 (default [*])

```
#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

1) Feel free to propose a nicer formatting.
2) To make sure the output is correct for KCM, I made sure all controller descriptors contain correct information. I had to fix a few controllers, which were checking gates manually instead of using the descriptor.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Extended `kube-controller-manager` usage help for the `--controllers` command line option, to print the names of associated feature gates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
