### PR TITLE
DRA E2E: serialize costly test

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1124,7 +1124,9 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), framework.With
 			driver.WithKubelet = withKubelet
 			b := newBuilder(f, driver)
 
-			f.It("supports sharing a claim sequentially", f.WithSlow(), func(ctx context.Context) {
+			// This test needs the entire test cluster for itself, therefore it is marked as serial.
+			// Running it in parallel happened to cause resource issues.
+			f.It("supports sharing a claim sequentially", f.WithSlow(), f.WithSerial(), func(ctx context.Context) {
 				var objects []klog.KMetadata
 				objects = append(objects, b.externalClaim())
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

After enabling more tests in 00dd610c93e7f40f498c6825141cd07330058064, periodic ci-kind-dra-all became unstable, with random flakes at the time when the "supports sharing a claim sequentially". Probably the cluster became overwhelmed by the number of pods which wanted to run in parallel. Running this tests in the serial phase of a Ginkgo run should fix this.

#### Which issue(s) this PR is related to:

- okay: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kind-dra-all/1940074564826435584

Failing:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kind-dra-all/1940165162669445120
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kind-dra-all/1940255760818638848
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kind-dra-all/1940346358753923072

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
