### PR TITLE
Fix data race in scheduling post start hook

### DIFF
--- a/pkg/registry/scheduling/rest/storage_scheduling.go
+++ b/pkg/registry/scheduling/rest/storage_scheduling.go
@@ -90,7 +90,8 @@ func AddSystemPriorityClasses() genericapiserver.PostStartHookFunc {
 				_, err := schedClientSet.PriorityClasses().Get(context.TODO(), pc.Name, metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err := schedClientSet.PriorityClasses().Create(context.TODO(), pc, metav1.CreateOptions{})
+						// create can mutate its input so we deep copy pc here since it is a global
+						_, err := schedClientSet.PriorityClasses().Create(context.TODO(), pc.DeepCopy(), metav1.CreateOptions{})
 						if err == nil || apierrors.IsAlreadyExists(err) {
 							klog.Infof("created PriorityClass %s with value %v", pc.Name, pc.Value)
 							continue


### PR DESCRIPTION
/kind bug

```release-note
NONE
```

```
==================
WARNING: DATA RACE
Read at 0x00010a07f370 by goroutine 70716:
  k8s.io/apimachinery/pkg/apis/meta/v1.(*TypeMeta).GroupVersionKind()
      k8s.io/apimachinery/pkg/apis/meta/v1/meta.go:126 +0x40
  k8s.io/apimachinery/pkg/runtime.WithVersionEncoder.Encode()
      k8s.io/apimachinery/pkg/runtime/helper.go:231 +0x13c
  k8s.io/apimachinery/pkg/runtime.(*WithVersionEncoder).Encode()
      <autogenerated>:1 +0x94
  k8s.io/apimachinery/pkg/runtime.Encode()
      k8s.io/apimachinery/pkg/runtime/codec.go:49 +0x90
  k8s.io/client-go/rest.(*Request).Body()
      k8s.io/client-go/rest/request.go:530 +0x584
  k8s.io/client-go/gentype.(*Client[go.shape.*uint8]).Create()
      k8s.io/client-go/gentype/type.go:212 +0x244
  k8s.io/client-go/kubernetes/typed/scheduling/v1.(*priorityClasses).Create()
      <autogenerated>:1 +0xf8
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1.1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:93 +0x218
  k8s.io/apimachinery/pkg/util/wait.Poll.ConditionFunc.WithContext.func1()
      k8s.io/apimachinery/pkg/util/wait/wait.go:113 +0x30
  k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:159 +0x94
  k8s.io/apimachinery/pkg/util/wait.waitForWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:212 +0x124
  k8s.io/apimachinery/pkg/util/wait.poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:260 +0xc0
  k8s.io/apimachinery/pkg/util/wait.PollWithContext()
      k8s.io/apimachinery/pkg/util/wait/poll.go:85 +0x84
  k8s.io/apimachinery/pkg/util/wait.Poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:66 +0x70
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:82 +0x94
  k8s.io/apiserver/pkg/server.runPostStartHook.func1()
      k8s.io/apiserver/pkg/server/hooks.go:200 +0x7c
  k8s.io/apiserver/pkg/server.runPostStartHook()
      k8s.io/apiserver/pkg/server/hooks.go:201 +0x84
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks.gowrap2()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x98

Previous write at 0x00010a07f370 by goroutine 70757:
  k8s.io/apimachinery/pkg/apis/meta/v1.(*TypeMeta).SetGroupVersionKind()
      k8s.io/apimachinery/pkg/apis/meta/v1/meta.go:121 +0x108
  k8s.io/apimachinery/pkg/runtime.WithVersionEncoder.Encode()
      k8s.io/apimachinery/pkg/runtime/helper.go:242 +0x260
  k8s.io/apimachinery/pkg/runtime.(*WithVersionEncoder).Encode()
      <autogenerated>:1 +0x94
  k8s.io/apimachinery/pkg/runtime.Encode()
      k8s.io/apimachinery/pkg/runtime/codec.go:49 +0x90
  k8s.io/client-go/rest.(*Request).Body()
      k8s.io/client-go/rest/request.go:530 +0x584
  k8s.io/client-go/gentype.(*Client[go.shape.*uint8]).Create()
      k8s.io/client-go/gentype/type.go:212 +0x244
  k8s.io/client-go/kubernetes/typed/scheduling/v1.(*priorityClasses).Create()
      <autogenerated>:1 +0xf8
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1.1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:93 +0x218
  k8s.io/apimachinery/pkg/util/wait.Poll.ConditionFunc.WithContext.func1()
      k8s.io/apimachinery/pkg/util/wait/wait.go:113 +0x30
  k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:159 +0x94
  k8s.io/apimachinery/pkg/util/wait.waitForWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:212 +0x124
  k8s.io/apimachinery/pkg/util/wait.poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:260 +0xc0
  k8s.io/apimachinery/pkg/util/wait.PollWithContext()
      k8s.io/apimachinery/pkg/util/wait/poll.go:85 +0x84
  k8s.io/apimachinery/pkg/util/wait.Poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:66 +0x70
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:82 +0x94
  k8s.io/apiserver/pkg/server.runPostStartHook.func1()
      k8s.io/apiserver/pkg/server/hooks.go:200 +0x7c
  k8s.io/apiserver/pkg/server.runPostStartHook()
      k8s.io/apiserver/pkg/server/hooks.go:201 +0x84
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks.gowrap2()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x98

Goroutine 70716 (running) created at:
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x10c
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.NonBlockingRunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:764 +0x198
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.RunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:602 +0x718
  k8s.io/kube-aggregator/pkg/apiserver.preparedAPIAggregator.Run()
      k8s.io/kube-aggregator/pkg/apiserver/apiserver.go:504 +0x130
  k8s.io/kubernetes/cmd/kube-apiserver/app/testing.StartTestServer.func3()
      k8s.io/kubernetes/cmd/kube-apiserver/app/testing/testserver.go:442 +0xb0

Goroutine 70757 (running) created at:
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x10c
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.NonBlockingRunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:764 +0x198
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.RunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:602 +0x718
  k8s.io/kube-aggregator/pkg/apiserver.preparedAPIAggregator.Run()
      k8s.io/kube-aggregator/pkg/apiserver/apiserver.go:504 +0x130
  k8s.io/kubernetes/cmd/kube-apiserver/app/testing.StartTestServer.func3()
      k8s.io/kubernetes/cmd/kube-apiserver/app/testing/testserver.go:442 +0xb0
==================
==================
WARNING: DATA RACE
Read at 0x00010a07f360 by goroutine 70716:
  k8s.io/apimachinery/pkg/apis/meta/v1.(*TypeMeta).GroupVersionKind()
      k8s.io/apimachinery/pkg/apis/meta/v1/meta.go:126 +0x58
  k8s.io/apimachinery/pkg/runtime.WithVersionEncoder.Encode()
      k8s.io/apimachinery/pkg/runtime/helper.go:231 +0x13c
  k8s.io/apimachinery/pkg/runtime.(*WithVersionEncoder).Encode()
      <autogenerated>:1 +0x94
  k8s.io/apimachinery/pkg/runtime.Encode()
      k8s.io/apimachinery/pkg/runtime/codec.go:49 +0x90
  k8s.io/client-go/rest.(*Request).Body()
      k8s.io/client-go/rest/request.go:530 +0x584
  k8s.io/client-go/gentype.(*Client[go.shape.*uint8]).Create()
      k8s.io/client-go/gentype/type.go:212 +0x244
  k8s.io/client-go/kubernetes/typed/scheduling/v1.(*priorityClasses).Create()
      <autogenerated>:1 +0xf8
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1.1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:93 +0x218
  k8s.io/apimachinery/pkg/util/wait.Poll.ConditionFunc.WithContext.func1()
      k8s.io/apimachinery/pkg/util/wait/wait.go:113 +0x30
  k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:159 +0x94
  k8s.io/apimachinery/pkg/util/wait.waitForWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:212 +0x124
  k8s.io/apimachinery/pkg/util/wait.poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:260 +0xc0
  k8s.io/apimachinery/pkg/util/wait.PollWithContext()
      k8s.io/apimachinery/pkg/util/wait/poll.go:85 +0x84
  k8s.io/apimachinery/pkg/util/wait.Poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:66 +0x70
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:82 +0x94
  k8s.io/apiserver/pkg/server.runPostStartHook.func1()
      k8s.io/apiserver/pkg/server/hooks.go:200 +0x7c
  k8s.io/apiserver/pkg/server.runPostStartHook()
      k8s.io/apiserver/pkg/server/hooks.go:201 +0x84
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks.gowrap2()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x98

Previous write at 0x00010a07f360 by goroutine 70757:
  k8s.io/apimachinery/pkg/apis/meta/v1.(*TypeMeta).SetGroupVersionKind()
      k8s.io/apimachinery/pkg/apis/meta/v1/meta.go:121 +0x144
  k8s.io/apimachinery/pkg/runtime.WithVersionEncoder.Encode()
      k8s.io/apimachinery/pkg/runtime/helper.go:242 +0x260
  k8s.io/apimachinery/pkg/runtime.(*WithVersionEncoder).Encode()
      <autogenerated>:1 +0x94
  k8s.io/apimachinery/pkg/runtime.Encode()
      k8s.io/apimachinery/pkg/runtime/codec.go:49 +0x90
  k8s.io/client-go/rest.(*Request).Body()
      k8s.io/client-go/rest/request.go:530 +0x584
  k8s.io/client-go/gentype.(*Client[go.shape.*uint8]).Create()
      k8s.io/client-go/gentype/type.go:212 +0x244
  k8s.io/client-go/kubernetes/typed/scheduling/v1.(*priorityClasses).Create()
      <autogenerated>:1 +0xf8
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1.1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:93 +0x218
  k8s.io/apimachinery/pkg/util/wait.Poll.ConditionFunc.WithContext.func1()
      k8s.io/apimachinery/pkg/util/wait/wait.go:113 +0x30
  k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:159 +0x94
  k8s.io/apimachinery/pkg/util/wait.waitForWithContext()
      k8s.io/apimachinery/pkg/util/wait/wait.go:212 +0x124
  k8s.io/apimachinery/pkg/util/wait.poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:260 +0xc0
  k8s.io/apimachinery/pkg/util/wait.PollWithContext()
      k8s.io/apimachinery/pkg/util/wait/poll.go:85 +0x84
  k8s.io/apimachinery/pkg/util/wait.Poll()
      k8s.io/apimachinery/pkg/util/wait/poll.go:66 +0x70
  k8s.io/kubernetes/pkg/registry/scheduling/rest.(*RESTStorageProvider).PostStartHook.RESTStorageProvider.PostStartHook.AddSystemPriorityClasses.func1()
      k8s.io/kubernetes/pkg/registry/scheduling/rest/storage_scheduling.go:82 +0x94
  k8s.io/apiserver/pkg/server.runPostStartHook.func1()
      k8s.io/apiserver/pkg/server/hooks.go:200 +0x7c
  k8s.io/apiserver/pkg/server.runPostStartHook()
      k8s.io/apiserver/pkg/server/hooks.go:201 +0x84
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks.gowrap2()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x98

Goroutine 70716 (running) created at:
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x10c
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.NonBlockingRunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:764 +0x198
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.RunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:602 +0x718
  k8s.io/kube-aggregator/pkg/apiserver.preparedAPIAggregator.Run()
      k8s.io/kube-aggregator/pkg/apiserver/apiserver.go:504 +0x130
  k8s.io/kubernetes/cmd/kube-apiserver/app/testing.StartTestServer.func3()
      k8s.io/kubernetes/cmd/kube-apiserver/app/testing/testserver.go:442 +0xb0

Goroutine 70757 (running) created at:
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks()
      k8s.io/apiserver/pkg/server/hooks.go:167 +0x10c
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.NonBlockingRunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:764 +0x198
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.RunWithContext()
      k8s.io/apiserver/pkg/server/genericapiserver.go:602 +0x718
  k8s.io/kube-aggregator/pkg/apiserver.preparedAPIAggregator.Run()
      k8s.io/kube-aggregator/pkg/apiserver/apiserver.go:504 +0x130
  k8s.io/kubernetes/cmd/kube-apiserver/app/testing.StartTestServer.func3()
      k8s.io/kubernetes/cmd/kube-apiserver/app/testing/testserver.go:442 +0xb0
==================
```
