### PR TITLE
deflake storage tests: changing the name of non-namespaced items like ClusterRole with driver namespace as suffix

### DIFF
--- a/test/e2e/storage/utils/create.go
+++ b/test/e2e/storage/utils/create.go
@@ -274,8 +274,11 @@ var factories = map[What]ItemFactory{
 
 // PatchName makes the name of some item unique by appending the
 // generated unique name.
-func PatchName(f *framework.Framework, item *string) {
-	if *item != "" {
+func PatchName(f *framework.Framework, driverNamespace *v1.Namespace, item *string) {
+	if *item != "" && driverNamespace != nil {
+		*item = *item + "-" + driverNamespace.GetName()
+	}
+	if *item != "" && f.Namespace != nil {
 		*item = *item + "-" + f.UniqueName
 	}
 }
@@ -304,28 +307,28 @@ func patchItemRecursively(f *framework.Framework, driverNamespace *v1.Namespace,
 		// All those names are exempt from renaming. That list could be populated by querying
 		// and get extended by tests.
 		if item.Name != "e2e-test-privileged-psp" {
-			PatchName(f, &item.Name)
+			PatchName(f, driverNamespace, &item.Name)
 		}
 	case *rbacv1.ClusterRole:
-		PatchName(f, &item.Name)
+		PatchName(f, driverNamespace, &item.Name)
 	case *rbacv1.Role:
 		PatchNamespace(f, driverNamespace, &item.Namespace)
 		// Roles are namespaced, but because for RoleRef above we don't
 		// know whether the referenced role is a ClusterRole or Role
 		// and therefore always renames, we have to do the same here.
-		PatchName(f, &item.Name)
+		PatchName(f, driverNamespace, &item.Name)
 	case *storagev1.StorageClass:
-		PatchName(f, &item.Name)
+		PatchName(f, driverNamespace, &item.Name)
 	case *storagev1beta1.VolumeAttributesClass:
-		PatchName(f, &item.Name)
+		PatchName(f, driverNamespace, &item.Name)
 	case *storagev1.CSIDriver:
-		PatchName(f, &item.Name)
+		PatchName(f, driverNamespace, &item.Name)
 	case *v1.ServiceAccount:
 		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
 	case *v1.Secret:
 		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
 	case *rbacv1.ClusterRoleBinding:
-		PatchName(f, &item.Name)
+		PatchName(f, driverNamespace, &item.Name)
 		for i := range item.Subjects {
 			if err := patchItemRecursively(f, driverNamespace, &item.Subjects[i]); err != nil {
 				return fmt.Errorf("%T: %w", f, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#129369 want to fix https://github.com/kubernetes/kubernetes/issues/118037 but it cause [another flaky test](https://github.com/kubernetes/kubernetes/pull/129369#discussion_r2179688314) when the test has a bad cleanup

so we can not remove the driver namespace before test namespace. 

we need to change the generation policy of all non-namespaced resource for driver manifests. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
