### PR TITLE
chore: depr. pointer pkg replacement for the reflector

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/client-go/tools/pager"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"k8s.io/utils/trace"
 )
 
@@ -749,7 +749,7 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 		options := metav1.ListOptions{
 			ResourceVersion:      lastKnownRV,
 			AllowWatchBookmarks:  true,
-			SendInitialEvents:    pointer.Bool(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 			TimeoutSeconds:       &timeoutSeconds,
 		}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
@@ -40,7 +40,7 @@ import (
 	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/klog/v2/ktesting"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestInitialEventsEndBookmarkTicker(t *testing.T) {
@@ -143,10 +143,10 @@ func TestWatchList(t *testing.T) {
 			closeAfterWatchEvents: 1,
 			expectedWatchRequests: 1,
 			expectedRequestOptions: []metav1.ListOptions{{
-				SendInitialEvents:    pointer.Bool(true),
+				SendInitialEvents:    ptr.To(true),
 				AllowWatchBookmarks:  true,
 				ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-				TimeoutSeconds:       pointer.Int64(1),
+				TimeoutSeconds:       ptr.To[int64](1),
 			}},
 		},
 		{
@@ -167,7 +167,7 @@ func TestWatchList(t *testing.T) {
 				{
 					AllowWatchBookmarks: true,
 					ResourceVersion:     "1",
-					TimeoutSeconds:      pointer.Int64(1),
+					TimeoutSeconds:      ptr.To[int64](1),
 				}},
 			expectedStoreContent: []v1.Pod{*makePod("p1", "1")},
 		},
@@ -190,10 +190,10 @@ func TestWatchList(t *testing.T) {
 			expectedStoreContent:  []v1.Pod{*makePod("p1", "1"), *makePod("p2", "2")},
 			expectedRequestOptions: []metav1.ListOptions{
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 				{
 					ResourceVersion: "0",
@@ -202,7 +202,7 @@ func TestWatchList(t *testing.T) {
 				{
 					AllowWatchBookmarks: true,
 					ResourceVersion:     "1",
-					TimeoutSeconds:      pointer.Int64(1),
+					TimeoutSeconds:      ptr.To[int64](1),
 				},
 			},
 		},
@@ -225,10 +225,10 @@ func TestWatchList(t *testing.T) {
 			expectedStoreContent:  []v1.Pod{*makePod("p1", "1"), *makePod("p2", "2")},
 			expectedRequestOptions: []metav1.ListOptions{
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 				{
 					ResourceVersion: "0",
@@ -237,7 +237,7 @@ func TestWatchList(t *testing.T) {
 				{
 					AllowWatchBookmarks: true,
 					ResourceVersion:     "1",
-					TimeoutSeconds:      pointer.Int64(1),
+					TimeoutSeconds:      ptr.To[int64](1),
 				},
 			},
 		},
@@ -256,10 +256,10 @@ func TestWatchList(t *testing.T) {
 			},
 			expectedWatchRequests: 1,
 			expectedRequestOptions: []metav1.ListOptions{{
-				SendInitialEvents:    pointer.Bool(true),
+				SendInitialEvents:    ptr.To(true),
 				AllowWatchBookmarks:  true,
 				ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-				TimeoutSeconds:       pointer.Int64(1),
+				TimeoutSeconds:       ptr.To[int64](1),
 			}},
 			expectedStoreContent: []v1.Pod{*makePod("p1", "1"), *makePod("p2", "2")},
 		},
@@ -271,7 +271,7 @@ func TestWatchList(t *testing.T) {
 				{Type: watch.Added, Object: makePod("p2", "2")},
 				{Type: watch.Modified, Object: func() runtime.Object {
 					p1 := makePod("p1", "3")
-					p1.Spec.ActiveDeadlineSeconds = pointer.Int64(12)
+					p1.Spec.ActiveDeadlineSeconds = ptr.To[int64](12)
 					return p1
 				}()},
 				{Type: watch.Added, Object: makePod("p3", "4")},
@@ -285,16 +285,16 @@ func TestWatchList(t *testing.T) {
 			},
 			expectedWatchRequests: 1,
 			expectedRequestOptions: []metav1.ListOptions{{
-				SendInitialEvents:    pointer.Bool(true),
+				SendInitialEvents:    ptr.To(true),
 				AllowWatchBookmarks:  true,
 				ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-				TimeoutSeconds:       pointer.Int64(1),
+				TimeoutSeconds:       ptr.To[int64](1),
 			}},
 			expectedStoreContent: []v1.Pod{
 				*makePod("p2", "2"),
 				func() v1.Pod {
 					p1 := *makePod("p1", "3")
-					p1.Spec.ActiveDeadlineSeconds = pointer.Int64(12)
+					p1.Spec.ActiveDeadlineSeconds = ptr.To[int64](12)
 					return p1
 				}(),
 			},
@@ -324,22 +324,22 @@ func TestWatchList(t *testing.T) {
 			expectedWatchRequests: 3,
 			expectedRequestOptions: []metav1.ListOptions{
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 			},
 			expectedStoreContent: []v1.Pod{*makePod("p1", "1")},
@@ -362,16 +362,16 @@ func TestWatchList(t *testing.T) {
 			expectedWatchRequests: 2,
 			expectedRequestOptions: []metav1.ListOptions{
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 			},
 			expectedStoreContent: []v1.Pod{*makePod("p1", "1")},
@@ -396,15 +396,15 @@ func TestWatchList(t *testing.T) {
 			expectedWatchRequests: 2,
 			expectedRequestOptions: []metav1.ListOptions{
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 				{
 					AllowWatchBookmarks: true,
 					ResourceVersion:     "3",
-					TimeoutSeconds:      pointer.Int64(1),
+					TimeoutSeconds:      ptr.To[int64](1),
 				},
 			},
 			expectedStoreContent: []v1.Pod{*makePod("p1", "1"), *makePod("p2", "2"), *makePod("p3", "3"), *makePod("p4", "4")},
@@ -435,15 +435,15 @@ func TestWatchList(t *testing.T) {
 			expectedWatchRequests: 2,
 			expectedRequestOptions: []metav1.ListOptions{
 				{
-					SendInitialEvents:    pointer.Bool(true),
+					SendInitialEvents:    ptr.To(true),
 					AllowWatchBookmarks:  true,
 					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-					TimeoutSeconds:       pointer.Int64(1),
+					TimeoutSeconds:       ptr.To[int64](1),
 				},
 				{
 					AllowWatchBookmarks: true,
 					ResourceVersion:     "3",
-					TimeoutSeconds:      pointer.Int64(1),
+					TimeoutSeconds:      ptr.To[int64](1),
 				},
 			},
 			expectedStoreContent: []v1.Pod{*makePod("p1", "1"), *makePod("p3", "3")},
@@ -464,10 +464,10 @@ func TestWatchList(t *testing.T) {
 			},
 			expectedWatchRequests: 1,
 			expectedRequestOptions: []metav1.ListOptions{{
-				SendInitialEvents:    pointer.Bool(true),
+				SendInitialEvents:    ptr.To(true),
 				AllowWatchBookmarks:  true,
 				ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-				TimeoutSeconds:       pointer.Int64(1),
+				TimeoutSeconds:       ptr.To[int64](1),
 			}},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/client-go/tools/cache/reflector.go
./staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the reflector.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
