### PR TITLE
chore: depr. pointer pkg replacement for the csr

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/staging/src/k8s.io/client-go/util/certificate/csr/csr.go
@@ -39,7 +39,7 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // RequestCertificate will either use an existing (if this process has run
@@ -102,7 +102,7 @@ func RequestCertificateWithContext(ctx context.Context, client clientset.Interfa
 }
 
 func DurationToExpirationSeconds(duration time.Duration) *int32 {
-	return pointer.Int32(int32(duration / time.Second))
+	return ptr.To(int32(duration / time.Second))
 }
 
 func ExpirationSecondsToDuration(expirationSeconds int32) time.Duration {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/client-go/util/certificate/csr/csr.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the csr.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
