### PR TITLE
chore: depr. pointer pkg replacement for the kube-aggregator

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/defaults.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/defaults.go
@@ -18,7 +18,7 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -28,6 +28,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // SetDefaults_ServiceReference sets defaults for AuditSync Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = ptr.To[int32](443)
 	}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/defaults.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/defaults.go
@@ -18,7 +18,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -28,6 +28,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // SetDefaults_ServiceReference sets defaults for AuditSync Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = ptr.To[int32](443)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/defaults.go
./staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/defaults.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

NONE 

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the kube-aggregator apiregistration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
