### PR TITLE
fix: revert TestPatchResourceTimeout addition for flaky avoidance

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -726,14 +726,6 @@ func (p *patcher) patchResource(ctx context.Context, scope *RequestScope) (runti
 		}
 		return result, err
 	})
-
-	// In case of a timeout error, the goroutine handling the request is still running.
-	// https://github.com/kubernetes/kubernetes/blob/d2c12afa4593e50a187075157d38748292b02733/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/finisher/finisher.go#L127-L146
-	// We cannot reliably read the variable (data race!) and have to assume that
-	// the object was not created.
-	if errors.IsTimeout(err) {
-		return result, false, err
-	}
 	return result, wasCreated, err
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -323,25 +323,6 @@ func TestPatchCustomResource(t *testing.T) {
 	}
 }
 
-type testTimeoutPatcher struct {
-	t *testing.T
-}
-
-func (p *testTimeoutPatcher) New() runtime.Object {
-	return &example.Pod{}
-}
-
-func (p *testTimeoutPatcher) Update(ctx context.Context, _ string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	// Block until the context is canceled to simulate a timeout scenario.
-	<-ctx.Done()
-	return nil, false, ctx.Err()
-}
-
-func (p *testTimeoutPatcher) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	p.t.Fatal("unexpected call to testPatcher.Get")
-	return nil, errors.New("unexpected call to testPatcher.Get")
-}
-
 type testPatcher struct {
 	t *testing.T
 
@@ -451,9 +432,6 @@ type patchTestCase struct {
 	expectedError string
 	// if set, indicates the number of times patching was expected to be attempted
 	expectedTries int
-
-	// isTimeout for this test case
-	isTimeout bool
 }
 
 func (tc *patchTestCase) Run(t *testing.T) {
@@ -586,16 +564,8 @@ func (tc *patchTestCase) Run(t *testing.T) {
 				FieldManager: "test-manager",
 			},
 		}
-		var timeout time.Duration
-		if tc.isTimeout {
-			// Simulate timeout by using a zero-duration timeout and the timeout patcher
-			// replace testPatcher with the timeout simulator
-			timeout = 0
-			p.restPatcher = &testTimeoutPatcher{t: t}
-		} else {
-			timeout = time.Second
-		}
-		ctx, cancel := context.WithTimeout(ctx, timeout)
+
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		resultObj, _, err := p.patchResource(ctx, &RequestScope{
 			FieldManager: fieldmanager,
 		})
@@ -705,20 +675,6 @@ func TestPatchResourceNumberConversion(t *testing.T) {
 	setTcPod(tc.updatePod, name, namespace, uid, "2", examplev1.SchemeGroupVersion.String(), &thirty, "anywhere")
 
 	setTcPod(tc.expectedPod, name, namespace, uid, "2", "", &thirty, "anywhere")
-
-	tc.Run(t)
-}
-
-func TestPatchResourceTimeout(t *testing.T) {
-	tc := &patchTestCase{
-		name:          "TestPatchResourceTimeout",
-		startingPod:   &example.Pod{},
-		changedPod:    &example.Pod{},
-		updatePod:     &example.Pod{},
-		expectedPod:   nil,
-		isTimeout:     true,
-		expectedError: "Timeout: request did not complete within requested timeout - context deadline exceeded",
-	}
 
 	tc.Run(t)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This test is flaky as reported in https://github.com/kubernetes/kubernetes/issues/132712, which was just added in PR https://github.com/kubernetes/kubernetes/pull/132049

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/132712

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
