### PR TITLE
chore: remove utilpointer usage in test/integration/service/loadbancer_test.go

### DIFF
--- a/test/integration/service/loadbalancer_test.go
+++ b/test/integration/service/loadbalancer_test.go
@@ -38,7 +38,6 @@ import (
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/utils/net"
-	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -62,7 +61,7 @@ func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.Bool(false),
+			AllocateLoadBalancerNodePorts: ptr.To(false),
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
@@ -121,7 +120,7 @@ func Test_ServiceUpdateLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 	}
 
 	service.Spec.Type = corev1.ServiceTypeLoadBalancer
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+	service.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
@@ -152,7 +151,7 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.Bool(true),
+			AllocateLoadBalancerNodePorts: ptr.To(true),
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
@@ -171,7 +170,7 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 		t.Error("expected node ports but found none")
 	}
 
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+	service.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
@@ -202,7 +201,7 @@ func Test_ServiceLoadBalancerDisableAllocatedNodePort(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.Bool(true),
+			AllocateLoadBalancerNodePorts: ptr.To(true),
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
@@ -221,7 +220,7 @@ func Test_ServiceLoadBalancerDisableAllocatedNodePort(t *testing.T) {
 		t.Error("expected node ports but found none")
 	}
 
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+	service.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 	service.Spec.Ports[0].NodePort = 0
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
@@ -253,7 +252,7 @@ func Test_ServiceLoadBalancerDisableAllocatedNodePorts(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.Bool(true),
+			AllocateLoadBalancerNodePorts: ptr.To(true),
 			Ports: []corev1.ServicePort{{
 				Name: "np-1",
 				Port: int32(80),
@@ -276,7 +275,7 @@ func Test_ServiceLoadBalancerDisableAllocatedNodePorts(t *testing.T) {
 		t.Error("expected node ports but found none")
 	}
 
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+	service.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 	service.Spec.Ports[0].NodePort = 0
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
@@ -311,7 +310,7 @@ func Test_ServiceLoadBalancerDisableAllocatedNodePortsByPatch(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.Bool(true),
+			AllocateLoadBalancerNodePorts: ptr.To(true),
 			Ports: []corev1.ServicePort{{
 				Name: "np-1",
 				Port: int32(80),
@@ -335,7 +334,7 @@ func Test_ServiceLoadBalancerDisableAllocatedNodePortsByPatch(t *testing.T) {
 	}
 
 	clone := service.DeepCopy()
-	clone.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
+	clone.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 	clone.Spec.Ports[0].NodePort = 0
 
 	oldData, err := json.Marshal(service)
@@ -384,7 +383,7 @@ func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.Bool(false),
+			AllocateLoadBalancerNodePorts: ptr.To(false),
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
@@ -403,7 +402,7 @@ func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
 		t.Error("not expected node ports but found one")
 	}
 
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+	service.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
@@ -454,7 +453,7 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
-			LoadBalancerClass: utilpointer.String("test.com/test"),
+			LoadBalancerClass: ptr.To("test.com/test"),
 		},
 	}
 
@@ -500,7 +499,7 @@ func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
-			LoadBalancerClass: utilpointer.String("test.com/test"),
+			LoadBalancerClass: ptr.To("test.com/test"),
 		},
 	}
 
@@ -509,7 +508,7 @@ func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
-	service.Spec.LoadBalancerClass = utilpointer.String("test.com/update")
+	service.Spec.LoadBalancerClass = ptr.To("test.com/update")
 	_, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatal("Error: updating test service load balancer class should throw error, field is immutable")
@@ -559,7 +558,7 @@ func Test_UpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
-	service.Spec.LoadBalancerClass = utilpointer.String("test.com/test")
+	service.Spec.LoadBalancerClass = ptr.To("test.com/test")
 	_, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatal("Error: updating test service load balancer class should throw error, field is immutable")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086

#### Special notes for your reviewer:

Scoped utilpointer removal in test/integration/service/loadbancer_test.go

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE

```release-note
NONE
```