### PR TITLE
chore: depr. pointer pkg replacement for the cloud-provider

### DIFF
--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/defaults.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/defaults.go
@@ -24,7 +24,7 @@ import (
 	nodeconfigv1alpha1 "k8s.io/cloud-provider/controllers/node/config/v1alpha1"
 	serviceconfigv1alpha1 "k8s.io/cloud-provider/controllers/service/config/v1alpha1"
 	cmconfigv1alpha1 "k8s.io/controller-manager/config/v1alpha1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -63,7 +63,7 @@ func SetDefaults_KubeCloudSharedConfiguration(obj *KubeCloudSharedConfiguration)
 		obj.ClusterName = "kubernetes"
 	}
 	if obj.ConfigureCloudRoutes == nil {
-		obj.ConfigureCloudRoutes = utilpointer.BoolPtr(true)
+		obj.ConfigureCloudRoutes = ptr.To(true)
 	}
 	if obj.RouteReconciliationPeriod == zero {
 		obj.RouteReconciliationPeriod = metav1.Duration{Duration: 10 * time.Second}

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -52,8 +52,7 @@ import (
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 	_ "k8s.io/controller-manager/pkg/features/register"
 	"k8s.io/klog/v2/ktesting"
-
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const region = "us-central"
@@ -250,7 +249,7 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 		expectPatchFinalizer: true,
 	}, {
 		desc:                 "service specifies loadBalancerClass",
-		service:              newService("with-external-balancer", v1.ServiceTypeLoadBalancer, tweakAddLBClass(utilpointer.String("custom-loadbalancer"))),
+		service:              newService("with-external-balancer", v1.ServiceTypeLoadBalancer, tweakAddLBClass(ptr.To("custom-loadbalancer"))),
 		expectOp:             deleteLoadBalancer,
 		expectCreateAttempt:  false,
 		expectPatchStatus:    false,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/cloud-provider/config/v1alpha1/defaults.go
./staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

NONE 

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the cloud-provider.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
