### PR TITLE
chore: depr. pointer pkg replacement for apiext. integration

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/deprecation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/deprecation_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var deprecationFixture = &apiextensionsv1.CustomResourceDefinition{
@@ -45,7 +45,7 @@ var deprecationFixture = &apiextensionsv1.CustomResourceDefinition{
 				Name:               "v1alpha2",
 				Served:             true,
 				Deprecated:         true,
-				DeprecationWarning: pointer.StringPtr("custom deprecation warning"),
+				DeprecationWarning: ptr.To("custom deprecation warning"),
 				Schema:             &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"}},
 			},
 			{

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +35,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -47,7 +46,7 @@ const (
 func AllowAllSchema() *apiextensionsv1.CustomResourceValidation {
 	return &apiextensionsv1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			XPreserveUnknownFields: pointer.BoolPtr(true),
+			XPreserveUnknownFields: ptr.To(true),
 			Type:                   "object",
 		},
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -122,7 +122,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 				"embedded": {
 					Type:                   "object",
 					XEmbeddedResource:      true,
-					XPreserveUnknownFields: pointer.BoolPtr(true),
+					XPreserveUnknownFields: ptr.To(true),
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/apiextensions-apiserver/test/integration/deprecation_test.go
./staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
./staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the apiextensions-apiservers integration tests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
