### PR TITLE
chore: depr. pointer pkg replacement for apiext.-apiserver apiextensions

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
@@ -76,7 +76,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 				obj.Conversion.ConversionReviewVersions = []string{"v1beta1"}
 			}
 			if obj.PreserveUnknownFields == nil {
-				obj.PreserveUnknownFields = pointer.BoolPtr(true)
+				obj.PreserveUnknownFields = ptr.To(true)
 			}
 
 			// Move per-version schema, subresources, additionalPrinterColumns, selectableFields to the top-level.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion_test.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -504,7 +503,7 @@ func TestConversion(t *testing.T) {
 			In: &apiextensions.CustomResourceDefinition{
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Conversion: &apiextensions.CustomResourceConversion{
-						WebhookClientConfig: &apiextensions.WebhookClientConfig{URL: pointer.StringPtr("http://example.com")},
+						WebhookClientConfig: &apiextensions.WebhookClientConfig{URL: ptr.To("http://example.com")},
 					},
 				},
 			},
@@ -513,7 +512,7 @@ func TestConversion(t *testing.T) {
 				Spec: CustomResourceDefinitionSpec{
 					Conversion: &CustomResourceConversion{
 						Webhook: &WebhookConversion{
-							ClientConfig: &WebhookClientConfig{URL: pointer.StringPtr("http://example.com")},
+							ClientConfig: &WebhookClientConfig{URL: ptr.To("http://example.com")},
 						},
 					},
 				},
@@ -560,7 +559,7 @@ func TestConversion(t *testing.T) {
 				Spec: CustomResourceDefinitionSpec{
 					Conversion: &CustomResourceConversion{
 						Webhook: &WebhookConversion{
-							ClientConfig: &WebhookClientConfig{URL: pointer.StringPtr("http://example.com")},
+							ClientConfig: &WebhookClientConfig{URL: ptr.To("http://example.com")},
 						},
 					},
 				},
@@ -569,7 +568,7 @@ func TestConversion(t *testing.T) {
 			ExpectOut: &apiextensions.CustomResourceDefinition{
 				Spec: apiextensions.CustomResourceDefinitionSpec{
 					Conversion: &apiextensions.CustomResourceConversion{
-						WebhookClientConfig: &apiextensions.WebhookClientConfig{URL: pointer.StringPtr("http://example.com")},
+						WebhookClientConfig: &apiextensions.WebhookClientConfig{URL: ptr.To("http://example.com")},
 					},
 					PreserveUnknownFields: ptr.To(false),
 				},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -56,6 +56,6 @@ func SetDefaults_CustomResourceDefinitionSpec(obj *CustomResourceDefinitionSpec)
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = ptr.To[int32](443)
 	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults_test.go
@@ -23,7 +23,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaults(t *testing.T) {
@@ -65,7 +65,7 @@ func TestDefaults(t *testing.T) {
 						Strategy: WebhookConverter,
 						Webhook: &WebhookConversion{
 							ClientConfig: &WebhookClientConfig{
-								Service: &ServiceReference{Port: utilpointer.Int32Ptr(443)},
+								Service: &ServiceReference{Port: ptr.To[int32](443)},
 							},
 						},
 					},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -70,13 +70,13 @@ func SetDefaults_CustomResourceDefinitionSpec(obj *CustomResourceDefinitionSpec)
 		obj.Conversion.ConversionReviewVersions = []string{SchemeGroupVersion.Version}
 	}
 	if obj.PreserveUnknownFields == nil {
-		obj.PreserveUnknownFields = utilpointer.BoolPtr(true)
+		obj.PreserveUnknownFields = ptr.To(true)
 	}
 }
 
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = ptr.To[int32](443)
 	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults_test.go
@@ -23,7 +23,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaults(t *testing.T) {
@@ -41,7 +41,7 @@ func TestDefaults(t *testing.T) {
 				Spec: CustomResourceDefinitionSpec{
 					Scope:                 NamespaceScoped,
 					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
-					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 			},
 		},
@@ -56,7 +56,7 @@ func TestDefaults(t *testing.T) {
 							Service: &ServiceReference{},
 						},
 					},
-					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 			},
 			expected: &CustomResourceDefinition{
@@ -66,10 +66,10 @@ func TestDefaults(t *testing.T) {
 						Strategy:                 WebhookConverter,
 						ConversionReviewVersions: []string{"v1beta1"},
 						WebhookClientConfig: &WebhookClientConfig{
-							Service: &ServiceReference{Port: utilpointer.Int32Ptr(443)},
+							Service: &ServiceReference{Port: ptr.To[int32](443)},
 						},
 					},
-					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 			},
 		},
@@ -79,7 +79,7 @@ func TestDefaults(t *testing.T) {
 				Spec: CustomResourceDefinitionSpec{
 					Scope:                 NamespaceScoped,
 					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
-					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 					Versions: []CustomResourceDefinitionVersion{
 						{Name: "v1", Storage: false, Served: true},
 						{Name: "v2", Storage: true, Served: true},
@@ -91,7 +91,7 @@ func TestDefaults(t *testing.T) {
 				Spec: CustomResourceDefinitionSpec{
 					Scope:                 NamespaceScoped,
 					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
-					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 					Version:               "v1",
 					Versions: []CustomResourceDefinitionVersion{
 						{Name: "v1", Storage: false, Served: true},
@@ -110,7 +110,7 @@ func TestDefaults(t *testing.T) {
 				Spec: CustomResourceDefinitionSpec{
 					Scope:                 NamespaceScoped,
 					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
-					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 					Version:               "v1",
 				},
 			},
@@ -118,7 +118,7 @@ func TestDefaults(t *testing.T) {
 				Spec: CustomResourceDefinitionSpec{
 					Scope:                 NamespaceScoped,
 					Conversion:            &CustomResourceConversion{Strategy: NoneConverter},
-					PreserveUnknownFields: utilpointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 					Version:               "v1",
 					Versions: []CustomResourceDefinitionVersion{
 						{Name: "v1", Storage: true, Served: true},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apiserver/pkg/cel/library"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -148,7 +147,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {Type: "bogus"}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -198,7 +197,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -248,7 +247,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -399,7 +398,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -445,7 +444,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -487,7 +486,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							URL: strPtr("https://example.com/webhook"),
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -531,7 +530,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Strategy:                 apiextensions.ConversionStrategyType("None"),
 						ConversionReviewVersions: []string{"v1beta1"},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -583,7 +582,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -630,7 +629,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -678,7 +677,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -723,7 +722,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -766,7 +765,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -809,7 +808,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -944,7 +943,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version1"},
@@ -989,7 +988,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version1"},
@@ -1025,7 +1024,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("None"),
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1068,7 +1067,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("None"),
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1112,7 +1111,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("None"),
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1150,7 +1149,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("None"),
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1174,7 +1173,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Names: apiextensions.CustomResourceDefinitionNames{
 						Plural: "plural",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1223,7 +1222,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "value()*a",
 						ListKind: "value()*a",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1275,7 +1274,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "matching",
 						ListKind: "matching",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1332,7 +1331,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1376,7 +1375,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1420,7 +1419,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1443,7 +1442,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Version: "version",
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-							XPreserveUnknownFields: pointer.BoolPtr(false),
+							XPreserveUnknownFields: ptr.To(false),
 						},
 					},
 					Versions: []apiextensions.CustomResourceDefinitionVersion{
@@ -1460,7 +1459,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1499,7 +1498,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1543,7 +1542,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1587,7 +1586,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1627,7 +1626,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1668,7 +1667,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1690,7 +1689,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Validation:            &apiextensions.CustomResourceValidation{OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object"}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -1763,7 +1762,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -1804,7 +1803,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -1829,7 +1828,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type:                   "object",
-							XPreserveUnknownFields: pointer.BoolPtr(true),
+							XPreserveUnknownFields: ptr.To(true),
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"nil": {
 									Type:              "object",
@@ -1880,7 +1879,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 										"metadata": {
 											Type:                   "object",
 											XEmbeddedResource:      true,
-											XPreserveUnknownFields: pointer.BoolPtr(true),
+											XPreserveUnknownFields: ptr.To(true),
 										},
 										"apiVersion": {
 											Type: "string",
@@ -1888,7 +1887,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 												"foo": {
 													Type:                   "object",
 													XEmbeddedResource:      true,
-													XPreserveUnknownFields: pointer.BoolPtr(true),
+													XPreserveUnknownFields: ptr.To(true),
 												},
 											},
 										},
@@ -1898,7 +1897,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 												"foo": {
 													Type:                   "object",
 													XEmbeddedResource:      true,
-													XPreserveUnknownFields: pointer.BoolPtr(true),
+													XPreserveUnknownFields: ptr.To(true),
 												},
 											},
 										},
@@ -1935,11 +1934,11 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 					Validation: &apiextensions.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 							Type:                   "object",
-							XPreserveUnknownFields: pointer.BoolPtr(true),
+							XPreserveUnknownFields: ptr.To(true),
 							XValidations: apiextensions.ValidationRules{
 								{
 									Rule: "size(self.metadata.name) > 3",
@@ -1985,7 +1984,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -2022,7 +2021,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -2073,7 +2072,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -2180,7 +2179,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 											}),
 										},
 									},
-									XPreserveUnknownFields: pointer.BoolPtr(true),
+									XPreserveUnknownFields: ptr.To(true),
 								},
 								// x-kubernetes-embedded-resource: true
 								"embedded-fine": {
@@ -2203,7 +2202,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 								"embedded-preserve": {
 									Type:                   "object",
 									XEmbeddedResource:      true,
-									XPreserveUnknownFields: pointer.BoolPtr(true),
+									XPreserveUnknownFields: ptr.To(true),
 									Properties: map[string]apiextensions.JSONSchemaProps{
 										"foo": {
 											Type: "string",
@@ -2222,7 +2221,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 								"embedded-preserve-unpruned-objectmeta": {
 									Type:                   "object",
 									XEmbeddedResource:      true,
-									XPreserveUnknownFields: pointer.BoolPtr(true),
+									XPreserveUnknownFields: ptr.To(true),
 									Properties: map[string]apiextensions.JSONSchemaProps{
 										"foo": {
 											Type: "string",
@@ -2243,7 +2242,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -2288,7 +2287,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 								"embedded2": {
 									Type:                   "object",
 									XEmbeddedResource:      true,
-									XPreserveUnknownFields: pointer.BoolPtr(true),
+									XPreserveUnknownFields: ptr.To(true),
 									AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
 										Schema: &apiextensions.JSONSchemaProps{Type: "string"},
 									},
@@ -2296,7 +2295,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -2477,7 +2476,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"v1"},
@@ -2550,7 +2549,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"v1"},
@@ -2596,7 +2595,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"v1"},
@@ -2759,7 +2758,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 								"x-preserve-unknown-fields-unknown-field-object-defaults": {
 									Type:                   "object",
 									XEmbeddedResource:      true,
-									XPreserveUnknownFields: pointer.BoolPtr(true),
+									XPreserveUnknownFields: ptr.To(true),
 									Properties:             map[string]apiextensions.JSONSchemaProps{},
 									Default: jsonPtr(map[string]interface{}{
 										"apiVersion": "v1",
@@ -2779,7 +2778,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 										"embedded": {
 											Type:                   "object",
 											XEmbeddedResource:      true,
-											XPreserveUnknownFields: pointer.BoolPtr(true),
+											XPreserveUnknownFields: ptr.To(true),
 											Properties:             map[string]apiextensions.JSONSchemaProps{},
 										},
 									},
@@ -2803,7 +2802,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 										"embedded": {
 											Type:                   "object",
 											XEmbeddedResource:      true,
-											XPreserveUnknownFields: pointer.BoolPtr(true),
+											XPreserveUnknownFields: ptr.To(true),
 											Properties:             map[string]apiextensions.JSONSchemaProps{},
 										},
 									},
@@ -3919,7 +3918,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"v1"},
@@ -4116,7 +4115,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -4194,7 +4193,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -4499,7 +4498,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 							JSONPath: ".spec.longName",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5097,7 +5096,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5121,7 +5120,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {Type: "bogus"}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5151,7 +5150,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {Type: "bogus"}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5175,7 +5174,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {Type: "bogus2"}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5211,7 +5210,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5244,7 +5243,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5271,7 +5270,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5304,7 +5303,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5329,7 +5328,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {Type: "integer"}},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5348,7 +5347,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {}}, // untyped object
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5368,7 +5367,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
 					Versions:              []apiextensions.CustomResourceDefinitionVersion{{Name: "version", Served: true, Storage: true}},
 					Validation:            &apiextensions.CustomResourceValidation{},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5387,7 +5386,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {}}, // untyped object
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5419,7 +5418,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							},
 						}},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5445,7 +5444,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							},
 						}},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5490,7 +5489,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5531,7 +5530,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5576,7 +5575,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5617,7 +5616,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5664,7 +5663,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -5704,7 +5703,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6094,7 +6093,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6127,7 +6126,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6165,7 +6164,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6201,7 +6200,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6244,7 +6243,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6281,7 +6280,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6321,7 +6320,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6357,7 +6356,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind2",
 						ListKind: "listkind2",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6398,7 +6397,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind",
 						ListKind: "listkind",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6434,7 +6433,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "kind2",
 						ListKind: "listkind2",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					AcceptedNames: apiextensions.CustomResourceDefinitionNames{
@@ -6483,7 +6482,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6525,7 +6524,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6563,7 +6562,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6594,7 +6593,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6633,7 +6632,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6664,7 +6663,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 						Kind:     "Plural",
 						ListKind: "PluralList",
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6683,7 +6682,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Validation:            &apiextensions.CustomResourceValidation{OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object"}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6696,7 +6695,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Validation:            &apiextensions.CustomResourceValidation{OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object"}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6713,7 +6712,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Validation:            &apiextensions.CustomResourceValidation{OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object"}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6726,7 +6725,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Validation:            &apiextensions.CustomResourceValidation{OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object"}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6742,7 +6741,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Versions:              []apiextensions.CustomResourceDefinitionVersion{{Name: "version", Served: true, Storage: true}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6754,7 +6753,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Versions:              []apiextensions.CustomResourceDefinitionVersion{{Name: "version", Served: true, Storage: true}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6773,7 +6772,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6788,7 +6787,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6805,7 +6804,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Validation:            &apiextensions.CustomResourceValidation{OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object"}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6817,7 +6816,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Versions:              []apiextensions.CustomResourceDefinitionVersion{{Name: "version", Served: true, Storage: true}},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6838,7 +6837,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6853,7 +6852,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					},
 					Scope:                 apiextensions.NamespaceScoped,
 					Names:                 apiextensions.CustomResourceDefinitionNames{Plural: "plural", Singular: "singular", Kind: "Plural", ListKind: "PluralList"},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{StoredVersions: []string{"version"}},
 			},
@@ -6896,7 +6895,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6935,7 +6934,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(false),
+					PreserveUnknownFields: ptr.To(false),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6969,7 +6968,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -6999,7 +6998,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							},
 						},
 					},
-					PreserveUnknownFields: pointer.BoolPtr(true),
+					PreserveUnknownFields: ptr.To(true),
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
 					StoredVersions: []string{"version"},
@@ -7906,7 +7905,7 @@ func TestValidateCustomResourceDefinitionValidationRuleCompatibility(t *testing.
 								},
 								"array": {
 									Type:     "array",
-									MaxItems: pointer.Int64(1),
+									MaxItems: ptr.To[int64](1),
 									Items: &apiextensions.JSONSchemaPropsOrArray{
 										Schema: &apiextensions.JSONSchemaProps{
 											Type:         "string",
@@ -7917,7 +7916,7 @@ func TestValidateCustomResourceDefinitionValidationRuleCompatibility(t *testing.
 								},
 								"map": {
 									Type:          "object",
-									MaxProperties: pointer.Int64(1),
+									MaxProperties: ptr.To[int64](1),
 									AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
 										Schema: &apiextensions.JSONSchemaProps{
 											Type:         "string",
@@ -10721,11 +10720,11 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"f": {
 							Type:     "array",
-							MaxItems: pointer.Int64(5),
+							MaxItems: ptr.To[int64](5),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: pointer.Int64(5),
+									MaxLength: ptr.To[int64](5),
 								},
 							},
 							XValidations: apiextensions.ValidationRules{
@@ -11244,57 +11243,57 @@ func Test_validateDeprecationWarning(t *testing.T) {
 		{
 			name:       "not deprecated, empty warning",
 			deprecated: false,
-			warning:    pointer.StringPtr(""),
+			warning:    ptr.To(""),
 			want:       []string{"can only be set for deprecated versions"},
 		},
 		{
 			name:       "not deprecated, set warning",
 			deprecated: false,
-			warning:    pointer.StringPtr("foo"),
+			warning:    ptr.To("foo"),
 			want:       []string{"can only be set for deprecated versions"},
 		},
 
 		{
 			name:       "utf-8",
 			deprecated: true,
-			warning:    pointer.StringPtr("Iñtërnâtiônàlizætiøn,💝🐹🌇⛔"),
+			warning:    ptr.To("Iñtërnâtiônàlizætiøn,💝🐹🌇⛔"),
 			want:       nil,
 		},
 		{
 			name:       "long warning",
 			deprecated: true,
-			warning:    pointer.StringPtr(strings.Repeat("x", 256)),
+			warning:    ptr.To(strings.Repeat("x", 256)),
 			want:       nil,
 		},
 
 		{
 			name:       "too long warning",
 			deprecated: true,
-			warning:    pointer.StringPtr(strings.Repeat("x", 257)),
+			warning:    ptr.To(strings.Repeat("x", 257)),
 			want:       []string{"must be <= 256 characters long"},
 		},
 		{
 			name:       "newline",
 			deprecated: true,
-			warning:    pointer.StringPtr("Test message\nfoo"),
+			warning:    ptr.To("Test message\nfoo"),
 			want:       []string{"must only contain printable UTF-8 characters; non-printable character found at index 12"},
 		},
 		{
 			name:       "non-printable character",
 			deprecated: true,
-			warning:    pointer.StringPtr("Test message\u0008"),
+			warning:    ptr.To("Test message\u0008"),
 			want:       []string{"must only contain printable UTF-8 characters; non-printable character found at index 12"},
 		},
 		{
 			name:       "null character",
 			deprecated: true,
-			warning:    pointer.StringPtr("Test message\u0000"),
+			warning:    ptr.To("Test message\u0000"),
 			want:       []string{"must only contain printable UTF-8 characters; non-printable character found at index 12"},
 		},
 		{
 			name:       "non-utf-8",
 			deprecated: true,
-			warning:    pointer.StringPtr("Test message\xc5foo"),
+			warning:    ptr.To("Test message\xc5foo"),
 			want:       []string{"must only contain printable UTF-8 characters"},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults_test.go
./staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go
./staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion_test.go
./staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
./staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults_test.go
./staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults.go
./staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the apiextensions-apiserver apiextensions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
