### PR TITLE
chore: depr. pointer pkg replacement for apiext. pkg/cntroller

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints"
 	"k8s.io/kube-openapi/pkg/validation/spec"
-	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -479,7 +478,7 @@ func TestBuildOpenAPIV2(t *testing.T) {
 				}
 			}
 			if tt.preserveUnknownFields != nil && *tt.preserveUnknownFields {
-				validation.OpenAPIV3Schema.XPreserveUnknownFields = utilpointer.BoolPtr(true)
+				validation.OpenAPIV3Schema.XPreserveUnknownFields = ptr.To(true)
 			}
 
 			// TODO: mostly copied from the test above. reuse code to cleanup
@@ -589,7 +588,7 @@ func TestBuildOpenAPIV3(t *testing.T) {
 				}
 			}
 			if tt.preserveUnknownFields != nil && *tt.preserveUnknownFields {
-				validation.OpenAPIV3Schema.XPreserveUnknownFields = utilpointer.BoolPtr(true)
+				validation.OpenAPIV3Schema.XPreserveUnknownFields = ptr.To(true)
 			}
 
 			got, err := BuildOpenAPIV3(&apiextensionsv1.CustomResourceDefinition{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
@@ -35,7 +35,7 @@ import (
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/kube-openapi/pkg/util/proto"
 	"k8s.io/kube-openapi/pkg/validation/spec"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func Test_ConvertJSONSchemaPropsToOpenAPIv2Schema(t *testing.T) {
@@ -646,7 +646,7 @@ func Test_ConvertJSONSchemaPropsToOpenAPIv2SchemaByType(t *testing.T) {
 		{
 			name: "preserve-unknown-fields in arrays",
 			in: &apiextensions.JSONSchemaProps{
-				XPreserveUnknownFields: pointer.BoolPtr(true),
+				XPreserveUnknownFields: ptr.To(true),
 				Type:                   "array",
 				Items: &apiextensions.JSONSchemaPropsOrArray{Schema: &apiextensions.JSONSchemaProps{
 					Type: "string",
@@ -657,7 +657,7 @@ func Test_ConvertJSONSchemaPropsToOpenAPIv2SchemaByType(t *testing.T) {
 		{
 			name: "preserve-unknown-fields in objects",
 			in: &apiextensions.JSONSchemaProps{
-				XPreserveUnknownFields: pointer.BoolPtr(true),
+				XPreserveUnknownFields: ptr.To(true),
 				Type:                   "object",
 				Properties: map[string]apiextensions.JSONSchemaProps{
 					"foo": {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
./staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for apiextensions-apiserver pkg/controller.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), 

```docs
NONE
```
