### PR TITLE
chore: depr. pointer pkg replacement for apiext. pkg/registry

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy_test.go
@@ -31,13 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
-
-func strPtr(in string) *string {
-	return &in
-}
 
 func TestValidateAPIApproval(t *testing.T) {
 	okFn := func(t *testing.T, errors field.ErrorList) {
@@ -79,14 +74,14 @@ func TestValidateAPIApproval(t *testing.T) {
 			name:               "invalid annotation update",
 			group:              "sigs.k8s.io",
 			annotationValue:    "invalid",
-			oldAnnotationValue: strPtr("invalid"),
+			oldAnnotationValue: ptr.To("invalid"),
 			validateError:      okFn,
 		},
 		{
 			name:               "invalid annotation to missing",
 			group:              "sigs.k8s.io",
 			annotationValue:    "",
-			oldAnnotationValue: strPtr("invalid"),
+			oldAnnotationValue: ptr.To("invalid"),
 			validateError: func(t *testing.T, errors field.ErrorList) {
 				t.Helper()
 				if len(errors) == 0 {
@@ -101,7 +96,7 @@ func TestValidateAPIApproval(t *testing.T) {
 			name:               "missing to invalid annotation",
 			group:              "sigs.k8s.io",
 			annotationValue:    "invalid",
-			oldAnnotationValue: strPtr(""),
+			oldAnnotationValue: ptr.To(""),
 			validateError: func(t *testing.T, errors field.ErrorList) {
 				t.Helper()
 				if len(errors) == 0 {
@@ -130,7 +125,7 @@ func TestValidateAPIApproval(t *testing.T) {
 			name:               "missing annotation update",
 			group:              "sigs.k8s.io",
 			annotationValue:    "",
-			oldAnnotationValue: strPtr(""),
+			oldAnnotationValue: ptr.To(""),
 			validateError:      okFn,
 		},
 		{
@@ -158,7 +153,7 @@ func TestValidateAPIApproval(t *testing.T) {
 					Versions: []apiextensions.CustomResourceDefinitionVersion{{Name: "v1", Storage: true, Served: true}},
 					Names:    apiextensions.CustomResourceDefinitionNames{Plural: "foos", Singular: "foo", Kind: "Foo", ListKind: "FooList"},
 					Validation: &apiextensions.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object", XPreserveUnknownFields: pointer.BoolPtr(true)},
+						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object", XPreserveUnknownFields: ptr.To(true)},
 					},
 				},
 				Status: apiextensions.CustomResourceDefinitionStatus{
@@ -176,7 +171,7 @@ func TestValidateAPIApproval(t *testing.T) {
 						Versions: []apiextensions.CustomResourceDefinitionVersion{{Name: "v1", Storage: true, Served: true}},
 						Names:    apiextensions.CustomResourceDefinitionNames{Plural: "foos", Singular: "foo", Kind: "Foo", ListKind: "FooList"},
 						Validation: &apiextensions.CustomResourceValidation{
-							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object", XPreserveUnknownFields: pointer.BoolPtr(true)},
+							OpenAPIV3Schema: &apiextensions.JSONSchemaProps{Type: "object", XPreserveUnknownFields: ptr.To(true)},
 						},
 					},
 					Status: apiextensions.CustomResourceDefinitionStatus{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy_test.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

Beside the replacement of the deprecated package, I did also removed the helper function
```
func strPtr(in string) *string {
	return &in
}
```
with `ptr.To()`

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for apiextensions-apiserver pkg/registry.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
