### PR TITLE
Move unschedulablePods struct to a separate file

### DIFF
--- a/pkg/scheduler/backend/queue/unschedulable_pods.go
+++ b/pkg/scheduler/backend/queue/unschedulable_pods.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+)
+
+// unschedulablePods holds pods that cannot be scheduled.
+type unschedulablePods struct {
+	// podInfoMap is a map key by a pod's full-name and the value is a pointer to the QueuedPodInfo.
+	podInfoMap map[string]*framework.QueuedPodInfo
+	keyFunc    func(*v1.Pod) string
+	// unschedulableRecorder/gatedRecorder updates the counter when elements of an unschedulablePods
+	// get added or removed, and it does nothing if it's nil.
+	unschedulableRecorder, gatedRecorder metrics.MetricRecorder
+}
+
+// newUnschedulablePods initializes a new object of unschedulablePods.
+func newUnschedulablePods(unschedulableRecorder, gatedRecorder metrics.MetricRecorder) *unschedulablePods {
+	return &unschedulablePods{
+		podInfoMap:            make(map[string]*framework.QueuedPodInfo),
+		keyFunc:               util.GetPodFullName,
+		unschedulableRecorder: unschedulableRecorder,
+		gatedRecorder:         gatedRecorder,
+	}
+}
+
+// addOrUpdate adds a pod to the unschedulable podInfoMap.
+// The event should show which event triggered the addition and is used for the metric recording.
+func (u *unschedulablePods) addOrUpdate(pInfo *framework.QueuedPodInfo, event string) {
+	podID := u.keyFunc(pInfo.Pod)
+	if _, exists := u.podInfoMap[podID]; !exists {
+		if pInfo.Gated() && u.gatedRecorder != nil {
+			u.gatedRecorder.Inc()
+		} else if !pInfo.Gated() && u.unschedulableRecorder != nil {
+			u.unschedulableRecorder.Inc()
+		}
+		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Inc()
+	}
+	u.podInfoMap[podID] = pInfo
+}
+
+// delete deletes a pod from the unschedulable podInfoMap.
+// The `gated` parameter is used to figure out which metric should be decreased.
+func (u *unschedulablePods) delete(pod *v1.Pod, gated bool) {
+	podID := u.keyFunc(pod)
+	if _, exists := u.podInfoMap[podID]; exists {
+		if gated && u.gatedRecorder != nil {
+			u.gatedRecorder.Dec()
+		} else if !gated && u.unschedulableRecorder != nil {
+			u.unschedulableRecorder.Dec()
+		}
+	}
+	delete(u.podInfoMap, podID)
+}
+
+// get returns the QueuedPodInfo if a pod with the same key as the key of the given "pod"
+// is found in the map. It returns nil otherwise.
+func (u *unschedulablePods) get(pod *v1.Pod) *framework.QueuedPodInfo {
+	podKey := u.keyFunc(pod)
+	if pInfo, exists := u.podInfoMap[podKey]; exists {
+		return pInfo
+	}
+	return nil
+}
+
+// clear removes all the entries from the unschedulable podInfoMap.
+func (u *unschedulablePods) clear() {
+	u.podInfoMap = make(map[string]*framework.QueuedPodInfo)
+	if u.unschedulableRecorder != nil {
+		u.unschedulableRecorder.Clear()
+	}
+	if u.gatedRecorder != nil {
+		u.gatedRecorder.Clear()
+	}
+}

--- a/pkg/scheduler/backend/queue/unschedulable_pods_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_pods_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+)
+
+func TestUnschedulablePods(t *testing.T) {
+	var pods = []*v1.Pod{
+		st.MakePod().Name("p0").Namespace("ns1").Annotation("annot1", "val1").NominatedNodeName("node1").Obj(),
+		st.MakePod().Name("p1").Namespace("ns1").Annotation("annot", "val").Obj(),
+		st.MakePod().Name("p2").Namespace("ns2").Annotation("annot2", "val2").Annotation("annot3", "val3").NominatedNodeName("node3").Obj(),
+		st.MakePod().Name("p3").Namespace("ns4").Annotation("annot2", "val2").Annotation("annot3", "val3").NominatedNodeName("node1").Obj(),
+	}
+	var updatedPods = make([]*v1.Pod, len(pods))
+	updatedPods[0] = pods[0].DeepCopy()
+	updatedPods[1] = pods[1].DeepCopy()
+	updatedPods[3] = pods[3].DeepCopy()
+
+	tests := []struct {
+		name                   string
+		podsToAdd              []*v1.Pod
+		expectedMapAfterAdd    map[string]*framework.QueuedPodInfo
+		podsToUpdate           []*v1.Pod
+		expectedMapAfterUpdate map[string]*framework.QueuedPodInfo
+		podsToDelete           []*v1.Pod
+		expectedMapAfterDelete map[string]*framework.QueuedPodInfo
+	}{
+		{
+			name:      "create, update, delete subset of pods",
+			podsToAdd: []*v1.Pod{pods[0], pods[1], pods[2], pods[3]},
+			expectedMapAfterAdd: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, pods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, pods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToUpdate: []*v1.Pod{updatedPods[0]},
+			expectedMapAfterUpdate: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, updatedPods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, pods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToDelete: []*v1.Pod{pods[0], pods[1]},
+			expectedMapAfterDelete: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+		},
+		{
+			name:      "create, update, delete all",
+			podsToAdd: []*v1.Pod{pods[0], pods[3]},
+			expectedMapAfterAdd: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, pods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToUpdate: []*v1.Pod{updatedPods[3]},
+			expectedMapAfterUpdate: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, pods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, updatedPods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToDelete:           []*v1.Pod{pods[0], pods[3]},
+			expectedMapAfterDelete: map[string]*framework.QueuedPodInfo{},
+		},
+		{
+			name:      "delete non-existing and existing pods",
+			podsToAdd: []*v1.Pod{pods[1], pods[2]},
+			expectedMapAfterAdd: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, pods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToUpdate: []*v1.Pod{updatedPods[1]},
+			expectedMapAfterUpdate: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, updatedPods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToDelete: []*v1.Pod{pods[2], pods[3]},
+			expectedMapAfterDelete: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, updatedPods[1]), UnschedulablePlugins: sets.New[string]()},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			upm := newUnschedulablePods(nil, nil)
+			for _, p := range test.podsToAdd {
+				upm.addOrUpdate(newQueuedPodInfoForLookup(p), framework.EventUnscheduledPodAdd.Label())
+			}
+			if diff := cmp.Diff(test.expectedMapAfterAdd, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected map after adding pods(-want, +got):\n%s", diff)
+			}
+
+			if len(test.podsToUpdate) > 0 {
+				for _, p := range test.podsToUpdate {
+					upm.addOrUpdate(newQueuedPodInfoForLookup(p), framework.EventUnscheduledPodUpdate.Label())
+				}
+				if diff := cmp.Diff(test.expectedMapAfterUpdate, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+					t.Errorf("Unexpected map after updating pods (-want, +got):\n%s", diff)
+				}
+			}
+			for _, p := range test.podsToDelete {
+				upm.delete(p, false)
+			}
+			if diff := cmp.Diff(test.expectedMapAfterDelete, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected map after deleting pods (-want, +got):\n%s", diff)
+			}
+			upm.clear()
+			if len(upm.podInfoMap) != 0 {
+				t.Errorf("Expected the map to be empty, but has %v elements.", len(upm.podInfoMap))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce a separate test file for unschedulablePods
Remove unschedulablePods test functions from scheduling queues test file

#### What type of PR is this?

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:
Improvement in `scheduling_queue` code, separate unschedulablePods into a new file
#### Which issue(s) this PR is related to:

#130977 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NO
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
