### PR TITLE
chore: refactored fuzzer to remove depr. obj.Version for obj.Versions

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
@@ -46,20 +46,14 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			if len(obj.Names.ListKind) == 0 && len(obj.Names.Kind) > 0 {
 				obj.Names.ListKind = obj.Names.Kind + "List"
 			}
-			if len(obj.Versions) == 0 && len(obj.Version) == 0 {
-				// internal object must have a version to roundtrip all fields
-				obj.Version = "v1"
-			}
-			if len(obj.Versions) == 0 && len(obj.Version) != 0 {
+			if len(obj.Versions) == 0 {
 				obj.Versions = []apiextensions.CustomResourceDefinitionVersion{
 					{
-						Name:    obj.Version,
+						Name:    "v1",
 						Served:  true,
 						Storage: true,
 					},
 				}
-			} else if len(obj.Versions) != 0 {
-				obj.Version = obj.Versions[0].Name
 			}
 			if len(obj.AdditionalPrinterColumns) == 0 {
 				obj.AdditionalPrinterColumns = []apiextensions.CustomResourceColumnDefinition{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated field 'obj.Version' with 'obj.Versions'.
This includes also a small refactor, since we no longer have 'obj.Version'.

#### Which issue(s) this PR is related to:

Related to #132729 
This PR does not close the mentioned issue, since there are several more 'Version' deprecations in our codebase.

#### Special notes for your reviewer:

This was my first idea of replacing the deprecated field, and a refactored code.
Any suggestion/improvements/tips are welcome! 👍 

#### Does this PR introduce a user-facing change?

```release-note
Replaced the deprecated Version field, with Versions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
