### PR TITLE
Support example in explain

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
@@ -236,5 +236,9 @@ func WithBuiltinTemplateFuncs(tmpl *template.Template) *template.Template {
 			}
 			return cur
 		},
+		"hasKey": func(dict map[string]any, key string) bool {
+			_, ok := dict[key]
+			return ok
+		},
 	})
 }

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -111,6 +111,7 @@ Takes dictionary as argument with keys:
             {{- /* TODO: The original explain would say RESOURCE instead of FIELD here under some circumstances */ -}}
             FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema "Document" $.Document) }}>{{"\n"}}
             {{- template "extractEnum" (dict "schema" $subschema "Document" $.Document "isLongView" true "limit" -1) -}}{{"\n"}}
+            {{- template "extractExample" (dict "schema" $subschema "Document" $.Document) -}}{{"\n"}}
             {{- "\n" -}}
         {{- end -}}
 
@@ -336,6 +337,31 @@ Takes dictionary as argument with keys:
                     {{- $element -}}
                 {{- end -}}
         {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /* Check if there is an example value and return it in this format:
+
+    EXAMPLE: main
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema
+    Document: openapi document
+*/ -}}
+{{- define "extractExample" -}}
+    {{- with $.schema -}}
+        {{- if hasKey . "example" -}}
+            {{- "EXAMPLE:" -}}
+            {{- "\n" -}}{{- "" | indent 4 -}}
+            {{- /* Use to reflect "" when we see empty string */ -}}
+            {{- $elementType := printf "%T" .example -}}
+            {{- /* Convert empty string to `""` for more clarification */ -}}
+            {{- if and (eq "string" $elementType) (eq .example "") -}}
+                {{- `""` -}}
+            {{- else -}}
+                {{- .example -}}
+            {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -762,6 +762,65 @@ func TestPlaintext(t *testing.T) {
 				checkEquals("ENUM:\n    Block\n    File\n    \"\""),
 			},
 		},
+		{
+			// show that extractExample can skip empty example field
+			Name:        "extractEmptyExample",
+			Subtemplate: "extractExample",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+				},
+			},
+			Checks: []check{
+				checkEquals(""),
+			},
+		},
+		{
+			// show that extractExample can extract example value
+			Name:        "extractExample",
+			Subtemplate: "extractExample",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"example":     "main",
+				},
+			},
+			Checks: []check{
+				checkEquals("EXAMPLE:\n    main"),
+			},
+		},
+		{
+			// show that extractExample can extract example value with empty string
+			Name:        "extractExampleEmptyString",
+			Subtemplate: "extractExample",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"example":     "",
+				},
+			},
+			Checks: []check{
+				checkEquals("EXAMPLE:\n    \"\""),
+			},
+		},
+		{
+			// show that extractExample can extract example value with numeric value
+			Name:        "extractExampleNumeric",
+			Subtemplate: "extractExample",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "integer",
+					"description": "a description that should not be printed",
+					"example":     42,
+				},
+			},
+			Checks: []check{
+				checkEquals("EXAMPLE:\n    42"),
+			},
+		},
 	}
 
 	tmpl, err := v2.WithBuiltinTemplateFuncs(template.New("")).Parse(plaintextSource)


### PR DESCRIPTION
fixes issue: https://github.com/kubernetes/kubectl/issues/1468


#### What type of PR is this?

  What type of PR is this?
  /kind feature

  What this PR does / why we need it:

  This PR enhances the kubectl explain command to display example values for CRD fields when they are defined in the OpenAPI schema. Previously, when
   users ran kubectl explain on CRD fields that had example values in their schema, these examples were not displayed, making it harder for users to
  understand the expected format and values for those fields.

  The implementation adds support for displaying example values in the same format as other field information, improving the user experience and
  documentation clarity for Custom Resource Definitions.

  Which issue(s) this PR is related to:

  Fixes [#1468](https://github.com/kubernetes/kubectl/issues/1468)

  Special notes for your reviewer:

  - The change only affects the OpenAPI v3 template system used by kubectl explain
  - Added comprehensive test coverage for the new functionality
  - The implementation handles edge cases like empty strings (displayed as "") and missing example fields
  - All existing tests continue to pass, ensuring no regression
  - The feature is backward compatible and only displays examples when they exist in the schema

  Does this PR introduce a user-facing change?

  kubectl explain now displays example values for CRD fields when they are defined in the OpenAPI schema, improving documentation and usability for
  Custom Resource Definitions.

  Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

  N/A

  ---
  Example of the new output:

  Before:
  FIELD: gitBranchName <string>

  DESCRIPTION:
      Git branch name that will be used for building your app.

  After:
  FIELD: gitBranchName <string>

  DESCRIPTION:
      Git branch name that will be used for building your app.

  EXAMPLE:
      main