### PR TITLE
chore: remove utilpointer usage in pkg/apis/autoscaling

### DIFF
--- a/pkg/apis/autoscaling/fuzzer/fuzzer.go
+++ b/pkg/apis/autoscaling/fuzzer/fuzzer.go
@@ -24,7 +24,7 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Funcs returns the fuzzer functions for the autoscaling api group.
@@ -41,7 +41,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 		},
 		func(s *autoscaling.HorizontalPodAutoscalerSpec, c randfill.Continue) {
 			c.FillNoCustom(s) // fuzz self without calling this function again
-			s.MinReplicas = pointer.Int32(c.Rand.Int31())
+			s.MinReplicas = ptr.To[int32](c.Rand.Int31())
 
 			randomQuantity := func() resource.Quantity {
 				var q resource.Quantity

--- a/pkg/apis/autoscaling/v1/defaults.go
+++ b/pkg/apis/autoscaling/v1/defaults.go
@@ -19,7 +19,7 @@ package v1
 import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -28,7 +28,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv1.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To[int32](1)
 	}
 
 	// NB: we apply a default for CPU utilization in conversion because

--- a/pkg/apis/autoscaling/v1/defaults_test.go
+++ b/pkg/apis/autoscaling/v1/defaults_test.go
@@ -29,7 +29,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultHPA(t *testing.T) {
@@ -46,7 +46,7 @@ func TestSetDefaultHPA(t *testing.T) {
 		{
 			hpa: autoscalingv1.HorizontalPodAutoscaler{
 				Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(3),
+					MinReplicas: ptr.To[int32](3),
 				},
 			},
 			expectReplicas: 3,

--- a/pkg/apis/autoscaling/v2/defaults.go
+++ b/pkg/apis/autoscaling/v2/defaults.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -70,7 +70,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv2.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To[int32](1)
 	}
 
 	if len(obj.Spec.Metrics) == 0 {

--- a/pkg/apis/autoscaling/v2/defaults_test.go
+++ b/pkg/apis/autoscaling/v2/defaults_test.go
@@ -35,7 +35,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v2"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestGenerateScaleDownRules(t *testing.T) {
@@ -69,13 +69,13 @@ func TestGenerateScaleDownRules(t *testing.T) {
 			rateDownPodsPeriodSeconds:    2,
 			rateDownPercent:              3,
 			rateDownPercentPeriodSeconds: 4,
-			stabilizationSeconds:         utilpointer.Int32(25),
+			stabilizationSeconds:         ptr.To[int32](25),
 			selectPolicy:                 &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -154,7 +154,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 100, PeriodSeconds: 15},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -163,13 +163,13 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			rateUpPodsPeriodSeconds:    2,
 			rateUpPercent:              3,
 			rateUpPercentPeriodSeconds: 4,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To[int32](25),
 			selectPolicy:               &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -180,7 +180,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MinChangePolicySelect),
 		},
 		{
@@ -190,29 +190,29 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 10},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
 			annotation:              "Pod policy and stabilization window are specified",
 			rateUpPodsPeriodSeconds: 2,
-			stabilizationSeconds:    utilpointer.Int32(25),
+			stabilizationSeconds:    ptr.To[int32](25),
 			rateUpPods:              4,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
 			annotation:                 "Percent policy and stabilization window are specified",
 			rateUpPercent:              7,
 			rateUpPercentPeriodSeconds: 60,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To[int32](25),
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 60},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 		},
 		{
@@ -223,7 +223,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 10},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MaxChangePolicySelect),
 			expectedTolerance:     &sampleTolerance,
 		},
@@ -281,7 +281,7 @@ func TestSetBehaviorDefaults(t *testing.T) {
 			annotation: "Behavior with stabilizationWindowSeconds and tolerance",
 			behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 				ScaleUp: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: utilpointer.Int32(100),
+					StabilizationWindowSeconds: ptr.To[int32](100),
 					Tolerance:                  &sampleTolerance,
 				},
 			},
@@ -293,7 +293,7 @@ func TestSetBehaviorDefaults(t *testing.T) {
 					},
 				},
 				ScaleUp: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: utilpointer.Int32(100),
+					StabilizationWindowSeconds: ptr.To[int32](100),
 					SelectPolicy:               &maxPolicy,
 					Policies: []autoscalingv2.HPAScalingPolicy{
 						{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},
@@ -316,7 +316,7 @@ func TestSetBehaviorDefaults(t *testing.T) {
 					Policies:     policies,
 				},
 				ScaleUp: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: utilpointer.Int32(0),
+					StabilizationWindowSeconds: ptr.To[int32](0),
 					SelectPolicy:               &maxPolicy,
 					Policies: []autoscalingv2.HPAScalingPolicy{
 						{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},
@@ -355,7 +355,7 @@ func TestSetBehaviorDefaultsConfigurableToleranceEnabled(t *testing.T) {
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 				ScaleUp: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: utilpointer.Int32(100),
+					StabilizationWindowSeconds: ptr.To[int32](100),
 				},
 			},
 		},
@@ -371,7 +371,7 @@ func TestSetBehaviorDefaultsConfigurableToleranceEnabled(t *testing.T) {
 					},
 				},
 				ScaleUp: &autoscalingv2.HPAScalingRules{
-					StabilizationWindowSeconds: utilpointer.Int32(100),
+					StabilizationWindowSeconds: ptr.To[int32](100),
 					SelectPolicy:               &maxPolicy,
 					Policies: []autoscalingv2.HPAScalingPolicy{
 						{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},

--- a/pkg/apis/autoscaling/v2beta1/defaults.go
+++ b/pkg/apis/autoscaling/v2beta1/defaults.go
@@ -18,10 +18,10 @@ package v2beta1
 
 import (
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -30,7 +30,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv2beta1.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To[int32](1)
 	}
 
 	if len(obj.Spec.Metrics) == 0 {

--- a/pkg/apis/autoscaling/v2beta1/defaults_test.go
+++ b/pkg/apis/autoscaling/v2beta1/defaults_test.go
@@ -31,12 +31,12 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultHPA(t *testing.T) {
 	utilizationDefaultVal := int32(autoscaling.DefaultCPUUtilization)
-	defaultReplicas := utilpointer.Int32(1)
+	defaultReplicas := ptr.To[int32](1)
 	defaultTemplate := []autoscalingv2beta1.MetricSpec{
 		{
 			Type: autoscalingv2beta1.ResourceMetricSourceType,
@@ -67,13 +67,13 @@ func TestSetDefaultHPA(t *testing.T) {
 		{ // MinReplicas update
 			original: &autoscalingv2beta1.HorizontalPodAutoscaler{
 				Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(3),
+					MinReplicas: ptr.To[int32](3),
 					Metrics:     defaultTemplate,
 				},
 			},
 			expected: &autoscalingv2beta1.HorizontalPodAutoscaler{
 				Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
-					MinReplicas: utilpointer.Int32(3),
+					MinReplicas: ptr.To[int32](3),
 					Metrics:     defaultTemplate,
 				},
 			},

--- a/pkg/apis/autoscaling/v2beta2/defaults.go
+++ b/pkg/apis/autoscaling/v2beta2/defaults.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -71,7 +71,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_HorizontalPodAutoscaler(obj *autoscalingv2beta2.HorizontalPodAutoscaler) {
 	if obj.Spec.MinReplicas == nil {
-		obj.Spec.MinReplicas = pointer.Int32(1)
+		obj.Spec.MinReplicas = ptr.To[int32](1)
 	}
 
 	if len(obj.Spec.Metrics) == 0 {

--- a/pkg/apis/autoscaling/v2beta2/defaults_test.go
+++ b/pkg/apis/autoscaling/v2beta2/defaults_test.go
@@ -31,7 +31,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta2"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestGenerateScaleDownRules(t *testing.T) {
@@ -65,13 +65,13 @@ func TestGenerateScaleDownRules(t *testing.T) {
 			rateDownPodsPeriodSeconds:    2,
 			rateDownPercent:              3,
 			rateDownPercentPeriodSeconds: 4,
-			stabilizationSeconds:         utilpointer.Int32(25),
+			stabilizationSeconds:         ptr.To[int32](25),
 			selectPolicy:                 &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
@@ -147,7 +147,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 15},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 100, PeriodSeconds: 15},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
@@ -156,13 +156,13 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			rateUpPodsPeriodSeconds:    2,
 			rateUpPercent:              3,
 			rateUpPercentPeriodSeconds: 4,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To[int32](25),
 			selectPolicy:               &maxPolicy,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 3, PeriodSeconds: 4},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
@@ -173,7 +173,7 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 1, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MinPolicySelect),
 		},
 		{
@@ -183,29 +183,29 @@ func TestGenerateScaleUpRules(t *testing.T) {
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 10},
 			},
-			expectedStabilization: utilpointer.Int32(0),
+			expectedStabilization: ptr.To[int32](0),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
 			annotation:              "Pod policy and stabilization window are specified",
 			rateUpPodsPeriodSeconds: 2,
-			stabilizationSeconds:    utilpointer.Int32(25),
+			stabilizationSeconds:    ptr.To[int32](25),
 			rateUpPods:              4,
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PodsScalingPolicy, Value: 4, PeriodSeconds: 2},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 		{
 			annotation:                 "Percent policy and stabilization window are specified",
 			rateUpPercent:              7,
 			rateUpPercentPeriodSeconds: 60,
-			stabilizationSeconds:       utilpointer.Int32(25),
+			stabilizationSeconds:       ptr.To[int32](25),
 			expectedPolicies: []autoscalingv2.HPAScalingPolicy{
 				{Type: autoscalingv2.PercentScalingPolicy, Value: 7, PeriodSeconds: 60},
 			},
-			expectedStabilization: utilpointer.Int32(25),
+			expectedStabilization: ptr.To[int32](25),
 			expectedSelectPolicy:  string(autoscalingv2.MaxPolicySelect),
 		},
 	}

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -114,18 +113,18 @@ func TestValidateBehavior(t *testing.T) {
 		ScaleDown: nil,
 	}, {
 		ScaleUp: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(3600),
+			StabilizationWindowSeconds: ptr.To[int32](3600),
 			SelectPolicy:               &minPolicy,
 			Policies:                   simplePoliciesList,
 		},
 		ScaleDown: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(0),
+			StabilizationWindowSeconds: ptr.To[int32](0),
 			SelectPolicy:               &disabledPolicy,
 			Policies:                   simplePoliciesList,
 		},
 	}, {
 		ScaleUp: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(120),
+			StabilizationWindowSeconds: ptr.To[int32](120),
 			SelectPolicy:               &maxPolicy,
 			Policies: []autoscaling.HPAScalingPolicy{{
 				Type:          autoscaling.PodsScalingPolicy,
@@ -146,7 +145,7 @@ func TestValidateBehavior(t *testing.T) {
 			}},
 		},
 		ScaleDown: &autoscaling.HPAScalingRules{
-			StabilizationWindowSeconds: utilpointer.Int32(120),
+			StabilizationWindowSeconds: ptr.To[int32](120),
 			SelectPolicy:               &maxPolicy,
 			Policies: []autoscaling.HPAScalingPolicy{{
 				Type:          autoscaling.PodsScalingPolicy,
@@ -186,7 +185,7 @@ func TestValidateBehavior(t *testing.T) {
 	}, {
 		behavior: autoscaling.HorizontalPodAutoscalerBehavior{
 			ScaleUp: &autoscaling.HPAScalingRules{
-				StabilizationWindowSeconds: utilpointer.Int32(3601),
+				StabilizationWindowSeconds: ptr.To[int32](3601),
 				SelectPolicy:               &minPolicy,
 				Policies:                   simplePoliciesList,
 			},
@@ -278,7 +277,7 @@ func TestValidateBehavior(t *testing.T) {
 	}, {
 		behavior: autoscaling.HorizontalPodAutoscalerBehavior{
 			ScaleDown: &autoscaling.HPAScalingRules{
-				StabilizationWindowSeconds: utilpointer.Int32(3601),
+				StabilizationWindowSeconds: ptr.To[int32](3601),
 				SelectPolicy:               &minPolicy,
 				Policies:                   simplePoliciesList,
 			},
@@ -383,7 +382,7 @@ func prepareHPAWithBehavior(b autoscaling.HorizontalPodAutoscalerBehavior) autos
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ResourceMetricSourceType,
@@ -391,7 +390,7 @@ func prepareHPAWithBehavior(b autoscaling.HorizontalPodAutoscalerBehavior) autos
 					Name: api.ResourceCPU,
 					Target: autoscaling.MetricTarget{
 						Type:               autoscaling.UtilizationMetricType,
-						AverageUtilization: utilpointer.Int32(70),
+						AverageUtilization: ptr.To[int32](70),
 					},
 				},
 			}},
@@ -416,7 +415,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ResourceMetricSourceType,
@@ -424,7 +423,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Name: api.ResourceCPU,
 					Target: autoscaling.MetricTarget{
 						Type:               autoscaling.UtilizationMetricType,
-						AverageUtilization: utilpointer.Int32(70),
+						AverageUtilization: ptr.To[int32](70),
 					},
 				},
 			}},
@@ -439,7 +438,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 		},
 	}, {
@@ -452,7 +451,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ResourceMetricSourceType,
@@ -475,7 +474,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.PodsMetricSourceType,
@@ -500,7 +499,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ContainerResourceMetricSourceType,
@@ -509,7 +508,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Container: "test-container",
 					Target: autoscaling.MetricTarget{
 						Type:               autoscaling.UtilizationMetricType,
-						AverageUtilization: utilpointer.Int32(70),
+						AverageUtilization: ptr.To[int32](70),
 					},
 				},
 			}},
@@ -524,7 +523,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ContainerResourceMetricSourceType,
@@ -548,7 +547,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ObjectMetricSourceType,
@@ -577,7 +576,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ExternalMetricSourceType,
@@ -603,7 +602,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(1),
+			MinReplicas: ptr.To[int32](1),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ExternalMetricSourceType,
@@ -634,7 +633,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -642,7 +641,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -654,7 +653,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -663,7 +662,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -675,7 +674,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "..", Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -683,7 +682,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -695,7 +694,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "..", Name: "myrc"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -704,7 +703,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -716,7 +715,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -724,7 +723,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -736,7 +735,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -745,7 +744,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -757,7 +756,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController", Name: ".."},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -765,7 +764,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -777,7 +776,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController", Name: ".."},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -786,7 +785,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -801,7 +800,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{},
-				MinReplicas:    utilpointer.Int32(-1),
+				MinReplicas:    ptr.To[int32](-1),
 				MaxReplicas:    5,
 			},
 		},
@@ -814,7 +813,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{},
-				MinReplicas:    utilpointer.Int32(7),
+				MinReplicas:    ptr.To[int32](7),
 				MaxReplicas:    5,
 			},
 		},
@@ -827,7 +826,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -835,7 +834,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 							AverageValue:       resource.NewMilliQuantity(300, resource.DecimalSI),
 						},
 					},
@@ -851,7 +850,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -860,7 +859,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 							AverageValue:       resource.NewMilliQuantity(300, resource.DecimalSI),
 						},
 					},
@@ -873,14 +872,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
 					Resource: &autoscaling.ResourceMetricSource{
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -892,7 +891,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -900,7 +899,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -912,7 +911,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -921,7 +920,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(70),
+							AverageUtilization: ptr.To[int32](70),
 						},
 					},
 				}},
@@ -933,7 +932,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -941,7 +940,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To[int32](-10),
 						},
 					},
 				}},
@@ -953,7 +952,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -962,7 +961,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To[int32](-10),
 						},
 					},
 				}},
@@ -974,7 +973,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -982,7 +981,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To[int32](-10),
 						},
 					},
 				}},
@@ -994,7 +993,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -1003,7 +1002,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "---***",
 						Target: autoscaling.MetricTarget{
 							Type:               autoscaling.UtilizationMetricType,
-							AverageUtilization: utilpointer.Int32(-10),
+							AverageUtilization: ptr.To[int32](-10),
 						},
 					},
 				}},
@@ -1015,7 +1014,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ResourceMetricSourceType,
@@ -1034,7 +1033,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ContainerResourceMetricSourceType,
@@ -1054,7 +1053,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.PodsMetricSourceType,
@@ -1074,7 +1073,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.PodsMetricSourceType,
@@ -1095,7 +1094,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ObjectMetricSourceType,
@@ -1120,7 +1119,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ObjectMetricSourceType,
@@ -1145,7 +1144,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ObjectMetricSourceType,
@@ -1168,7 +1167,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ExternalMetricSourceType,
@@ -1190,7 +1189,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 			Spec: autoscaling.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
+				MinReplicas:    ptr.To[int32](1),
 				MaxReplicas:    5,
 				Metrics: []autoscaling.MetricSpec{{
 					Type: autoscaling.ExternalMetricSourceType,
@@ -1215,7 +1214,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1237,7 +1236,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1260,7 +1259,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1283,7 +1282,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1307,7 +1306,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1330,7 +1329,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1352,7 +1351,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ExternalMetricSourceType,
@@ -1371,7 +1370,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{},
@@ -1384,7 +1383,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.MetricSourceType("InvalidType"),
@@ -1397,7 +1396,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{{
 						Type: autoscaling.ResourceMetricSourceType,
@@ -1493,7 +1492,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
+					MinReplicas:    ptr.To[int32](1),
 					MaxReplicas:    5, Metrics: []autoscaling.MetricSpec{spec},
 				},
 			}, hpaSpecValidationOpts)
@@ -1525,7 +1524,7 @@ func prepareMinReplicasCases(t *testing.T, minReplicas int32) []autoscaling.Hori
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(minReplicas),
+			MinReplicas: ptr.To[int32](minReplicas),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ObjectMetricSourceType,
@@ -1555,7 +1554,7 @@ func prepareMinReplicasCases(t *testing.T, minReplicas int32) []autoscaling.Hori
 				Kind: "ReplicationController",
 				Name: "myrc",
 			},
-			MinReplicas: utilpointer.Int32(minReplicas),
+			MinReplicas: ptr.To[int32](minReplicas),
 			MaxReplicas: 5,
 			Metrics: []autoscaling.MetricSpec{{
 				Type: autoscaling.ExternalMetricSourceType,
@@ -1600,7 +1599,7 @@ func TestValidateHorizontalPodAutoscalerScaleToZeroDisabled(t *testing.T) {
 	nonZeroMinReplicasCases := prepareMinReplicasCases(t, 1)
 
 	for _, successCase := range nonZeroMinReplicasCases {
-		successCase.Spec.MinReplicas = utilpointer.Int32(1)
+		successCase.Spec.MinReplicas = ptr.To[int32](1)
 		if errs := ValidateHorizontalPodAutoscaler(&successCase, hpaSpecValidationOpts); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
@@ -1711,14 +1710,14 @@ func TestValidateHorizontalPodAutoscalerConfigurableToleranceEnabled(t *testing.
 		},
 		{
 			rule: autoscaling.HPAScalingRules{
-				StabilizationWindowSeconds: utilpointer.Int32(60),
+				StabilizationWindowSeconds: ptr.To[int32](60),
 			},
 			msg: "at least one Policy",
 		},
 		{
 			rule: autoscaling.HPAScalingRules{
 				Tolerance:                  resource.NewMilliQuantity(1, resource.DecimalSI),
-				StabilizationWindowSeconds: utilpointer.Int32(60),
+				StabilizationWindowSeconds: ptr.To[int32](60),
 			},
 			msg: "at least one Policy",
 		},
@@ -1755,7 +1754,7 @@ func TestValidateHorizontalPodAutoscalerConfigurableToleranceDisabled(t *testing
 			Policies:     policiesList,
 		},
 		{
-			StabilizationWindowSeconds: utilpointer.Int32(60),
+			StabilizationWindowSeconds: ptr.To[int32](60),
 			Policies:                   policiesList,
 		},
 	}
@@ -1779,7 +1778,7 @@ func TestValidateHorizontalPodAutoscalerConfigurableToleranceDisabled(t *testing
 		},
 		{
 			rule: autoscaling.HPAScalingRules{
-				StabilizationWindowSeconds: utilpointer.Int32(60),
+				StabilizationWindowSeconds: ptr.To[int32](60),
 			},
 			msg: "at least one Policy",
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086

#### Special notes for your reviewer:

Scoped utilpointer removal in pkg/apis/autoscaling

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE

```release-note
NONE
```