### PR TITLE
chore: depr. pointer pkg replacement for psa tests

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/test/fixtures.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/pod-security-admission/api"
 	"k8s.io/pod-security-admission/policy"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // minimalValidPods holds minimal valid OS neutral pods per-level per-version.
@@ -70,7 +70,7 @@ func init() {
 
 	// 1.0+: baseline + runAsNonRoot=true
 	restricted_1_0 := tweak(baseline_1_0, func(p *corev1.Pod) {
-		p.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(true)}
+		p.Spec.SecurityContext = &corev1.PodSecurityContext{RunAsNonRoot: ptr.To(true)}
 	})
 	minimalValidPods[api.LevelRestricted][api.MajorMinorVersion(1, 0)] = restricted_1_0
 	minimalValidLinuxPods[api.LevelRestricted][api.MajorMinorVersion(1, 0)] = addLinux(restricted_1_0)
@@ -78,8 +78,8 @@ func init() {
 
 	// 1.8+: allowPrivilegeEscalation=false
 	restricted_1_8 := tweak(restricted_1_0, func(p *corev1.Pod) {
-		p.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: pointer.BoolPtr(false)}
-		p.Spec.InitContainers[0].SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: pointer.BoolPtr(false)}
+		p.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)}
+		p.Spec.InitContainers[0].SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)}
 	})
 	minimalValidPods[api.LevelRestricted][api.MajorMinorVersion(1, 8)] = restricted_1_8
 	minimalValidLinuxPods[api.LevelRestricted][api.MajorMinorVersion(1, 8)] = addLinux(restricted_1_8)

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_allowPrivilegeEscalation.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_allowPrivilegeEscalation.go
@@ -19,7 +19,7 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 /*
@@ -44,11 +44,11 @@ func init() {
 			return []*corev1.Pod{
 				// explicit true
 				tweak(p, func(p *corev1.Pod) {
-					p.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = pointer.BoolPtr(true)
+					p.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = ptr.To(true)
 				}),
 				// ensure initContainers are checked
 				tweak(p, func(p *corev1.Pod) {
-					p.Spec.InitContainers[0].SecurityContext.AllowPrivilegeEscalation = pointer.BoolPtr(true)
+					p.Spec.InitContainers[0].SecurityContext.AllowPrivilegeEscalation = ptr.To(true)
 				}),
 				// nil AllowPrivilegeEscalation
 				tweak(p, func(p *corev1.Pod) { p.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = nil }),

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_privileged.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_privileged.go
@@ -19,7 +19,7 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 /*
@@ -38,8 +38,8 @@ func init() {
 			return []*corev1.Pod{
 				// privileged explicitly set to false
 				tweak(p, func(p *corev1.Pod) {
-					p.Spec.Containers[0].SecurityContext.Privileged = pointer.BoolPtr(false)
-					p.Spec.InitContainers[0].SecurityContext.Privileged = pointer.BoolPtr(false)
+					p.Spec.Containers[0].SecurityContext.Privileged = ptr.To(false)
+					p.Spec.InitContainers[0].SecurityContext.Privileged = ptr.To(false)
 				}),
 			}
 		},
@@ -48,12 +48,12 @@ func init() {
 			return []*corev1.Pod{
 				// privileged set to true in container
 				tweak(p, func(p *corev1.Pod) {
-					p.Spec.Containers[0].SecurityContext.Privileged = pointer.BoolPtr(true)
+					p.Spec.Containers[0].SecurityContext.Privileged = ptr.To(true)
 					p.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = nil
 				}),
 				// privileged set to true in init container
 				tweak(p, func(p *corev1.Pod) {
-					p.Spec.InitContainers[0].SecurityContext.Privileged = pointer.BoolPtr(true)
+					p.Spec.InitContainers[0].SecurityContext.Privileged = ptr.To(true)
 					p.Spec.InitContainers[0].SecurityContext.AllowPrivilegeEscalation = nil
 				}),
 			}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_runAsNonRoot.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_runAsNonRoot.go
@@ -19,7 +19,7 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 /*
@@ -42,15 +42,15 @@ func init() {
 			return []*corev1.Pod{
 				// set at pod level
 				tweak(p, func(p *corev1.Pod) {
-					p.Spec.SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
+					p.Spec.SecurityContext.RunAsNonRoot = ptr.To(true)
 					p.Spec.Containers[0].SecurityContext.RunAsNonRoot = nil
 					p.Spec.InitContainers[0].SecurityContext.RunAsNonRoot = nil
 				}),
 				// set on all containers
 				tweak(p, func(p *corev1.Pod) {
 					p.Spec.SecurityContext.RunAsNonRoot = nil
-					p.Spec.Containers[0].SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
-					p.Spec.InitContainers[0].SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
+					p.Spec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(true)
+					p.Spec.InitContainers[0].SecurityContext.RunAsNonRoot = ptr.To(true)
 				}),
 			}
 		},
@@ -64,10 +64,10 @@ func init() {
 					p.Spec.InitContainers[0].SecurityContext.RunAsNonRoot = nil
 				}),
 				// explicit false on pod
-				tweak(p, func(p *corev1.Pod) { p.Spec.SecurityContext.RunAsNonRoot = pointer.BoolPtr(false) }),
+				tweak(p, func(p *corev1.Pod) { p.Spec.SecurityContext.RunAsNonRoot = ptr.To(false) }),
 				// explicit false on containers
-				tweak(p, func(p *corev1.Pod) { p.Spec.Containers[0].SecurityContext.RunAsNonRoot = pointer.BoolPtr(false) }),
-				tweak(p, func(p *corev1.Pod) { p.Spec.InitContainers[0].SecurityContext.RunAsNonRoot = pointer.BoolPtr(false) }),
+				tweak(p, func(p *corev1.Pod) { p.Spec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(false) }),
+				tweak(p, func(p *corev1.Pod) { p.Spec.InitContainers[0].SecurityContext.RunAsNonRoot = ptr.To(false) }),
 			}
 		},
 	}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_runAsUser.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_runAsUser.go
@@ -19,7 +19,7 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 /*
@@ -41,9 +41,9 @@ func init() {
 			p = ensureSecurityContext(p)
 			return []*corev1.Pod{
 				tweak(p, func(p *corev1.Pod) {
-					p.Spec.SecurityContext.RunAsUser = pointer.Int64Ptr(1000)
-					p.Spec.Containers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(1000)
-					p.Spec.InitContainers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(1000)
+					p.Spec.SecurityContext.RunAsUser = ptr.To[int64](1000)
+					p.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To[int64](1000)
+					p.Spec.InitContainers[0].SecurityContext.RunAsUser = ptr.To[int64](1000)
 				}),
 			}
 		},
@@ -51,10 +51,10 @@ func init() {
 			p = ensureSecurityContext(p)
 			return []*corev1.Pod{
 				// explicit 0 on pod
-				tweak(p, func(p *corev1.Pod) { p.Spec.SecurityContext.RunAsUser = pointer.Int64Ptr(0) }),
+				tweak(p, func(p *corev1.Pod) { p.Spec.SecurityContext.RunAsUser = ptr.To[int64](0) }),
 				// explicit 0 on containers
-				tweak(p, func(p *corev1.Pod) { p.Spec.Containers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(0) }),
-				tweak(p, func(p *corev1.Pod) { p.Spec.InitContainers[0].SecurityContext.RunAsUser = pointer.Int64Ptr(0) }),
+				tweak(p, func(p *corev1.Pod) { p.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To[int64](0) }),
+				tweak(p, func(p *corev1.Pod) { p.Spec.InitContainers[0].SecurityContext.RunAsUser = ptr.To[int64](0) }),
 			}
 		},
 	}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_windowsHostProcess.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_windowsHostProcess.go
@@ -19,7 +19,7 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 /*
@@ -59,15 +59,15 @@ func init() {
 					// HostNetwork is required to be true for HostProcess pods.
 					// Set to true here so we pass API validation and get to admission checks.
 					p.Spec.HostNetwork = true
-					p.Spec.SecurityContext.WindowsOptions.HostProcess = pointer.BoolPtr(true)
+					p.Spec.SecurityContext.WindowsOptions.HostProcess = ptr.To(true)
 				}),
 				// true for containers
 				tweak(p, func(p *corev1.Pod) {
 					// HostNetwork is required to be true for HostProcess pods.
 					// Set to true here so we pass API validation and get to admission checks.
 					p.Spec.HostNetwork = true
-					p.Spec.Containers[0].SecurityContext.WindowsOptions.HostProcess = pointer.BoolPtr(true)
-					p.Spec.InitContainers[0].SecurityContext.WindowsOptions.HostProcess = pointer.BoolPtr(true)
+					p.Spec.Containers[0].SecurityContext.WindowsOptions.HostProcess = ptr.To(true)
+					p.Spec.InitContainers[0].SecurityContext.WindowsOptions.HostProcess = ptr.To(true)
 				}),
 			}
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/pod-security-admission/test/fixtures_runAsUser.go
./staging/src/k8s.io/pod-security-admission/test/fixtures_allowPrivilegeEscalation.go
./staging/src/k8s.io/pod-security-admission/test/fixtures_privileged.go
./staging/src/k8s.io/pod-security-admission/test/fixtures_runAsNonRoot.go
./staging/src/k8s.io/pod-security-admission/test/fixtures.go
./staging/src/k8s.io/pod-security-admission/test/fixtures_windowsHostProcess.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for pod-security-admission tests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
