### PR TITLE
chore: depr. pointer pkg replacement for psa policy

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_allowPrivilegeEscalation_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_allowPrivilegeEscalation_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestAllowPrivilegeEscalation_1_25(t *testing.T) {
@@ -37,8 +37,8 @@ func TestAllowPrivilegeEscalation_1_25(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "a"},
 					{Name: "b", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: nil}},
-					{Name: "c", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(true)}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(false)}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)}},
 				}}},
 			expectReason: `allowPrivilegeEscalation != false`,
 			expectDetail: `containers "a", "b", "c" must set securityContext.allowPrivilegeEscalation=false`,
@@ -95,8 +95,8 @@ func TestAllowPrivilegeEscalation_1_8(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "a"},
 					{Name: "b", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: nil}},
-					{Name: "c", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(true)}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(false)}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(true)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: ptr.To(false)}},
 				}}},
 			expectReason: `allowPrivilegeEscalation != false`,
 			expectDetail: `containers "a", "b", "c" must set securityContext.allowPrivilegeEscalation=false`,

--- a/staging/src/k8s.io/pod-security-admission/policy/check_privileged_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_privileged_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestPrivileged(t *testing.T) {
@@ -36,9 +36,9 @@ func TestPrivileged(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
-					{Name: "c", SecurityContext: &corev1.SecurityContext{Privileged: utilpointer.Bool(false)}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{Privileged: utilpointer.Bool(true)}},
-					{Name: "e", SecurityContext: &corev1.SecurityContext{Privileged: utilpointer.Bool(true)}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{Privileged: ptr.To(false)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{Privileged: ptr.To(true)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{Privileged: ptr.To(true)}},
 				},
 			}},
 			expectReason: `privileged`,

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestRunAsNonRoot(t *testing.T) {
@@ -45,7 +45,7 @@ func TestRunAsNonRoot(t *testing.T) {
 		{
 			name: "pod runAsNonRoot=false",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: utilpointer.Bool(false)},
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: ptr.To(false)},
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 				},
@@ -56,14 +56,14 @@ func TestRunAsNonRoot(t *testing.T) {
 		{
 			name: "containers runAsNonRoot=false",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: utilpointer.Bool(true)},
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: ptr.To(true)},
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
-					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(false)}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(false)}},
-					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
-					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr.To(false)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr.To(false)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr.To(true)}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr.To(true)}},
 				},
 			}},
 			expectReason: `runAsNonRoot != true`,
@@ -75,8 +75,8 @@ func TestRunAsNonRoot(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
-					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr.To(true)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr.To(true)}},
 				},
 			}},
 			expectReason: `runAsNonRoot != true`,
@@ -85,7 +85,7 @@ func TestRunAsNonRoot(t *testing.T) {
 		{
 			name: "UserNamespacesPodSecurityStandards enabled without HostUsers",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				HostUsers: utilpointer.Bool(false),
+				HostUsers: ptr.To(false),
 			}},
 			expectAllowed:  true,
 			relaxForUserNS: true,
@@ -96,7 +96,7 @@ func TestRunAsNonRoot(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "a"},
 				},
-				HostUsers: utilpointer.Bool(true),
+				HostUsers: ptr.To(true),
 			}},
 			expectReason:   `runAsNonRoot != true`,
 			expectDetail:   `pod or container "a" must set securityContext.runAsNonRoot=true`,

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestRunAsUser(t *testing.T) {
@@ -35,7 +35,7 @@ func TestRunAsUser(t *testing.T) {
 		{
 			name: "pod runAsUser=0",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(0)},
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: ptr.To[int64](0)},
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 				},
@@ -46,7 +46,7 @@ func TestRunAsUser(t *testing.T) {
 		{
 			name: "pod runAsUser=non-zero",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(1000)},
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: ptr.To[int64](1000)},
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 				},
@@ -66,14 +66,14 @@ func TestRunAsUser(t *testing.T) {
 		{
 			name: "containers runAsUser=0",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(1000)},
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: ptr.To[int64](1000)},
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
-					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(0)}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(0)}},
-					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(1)}},
-					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(1)}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](0)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](0)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](1)}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](1)}},
 				},
 			}},
 			expectReason: `runAsUser=0`,
@@ -83,10 +83,10 @@ func TestRunAsUser(t *testing.T) {
 			name: "containers runAsUser=non-zero",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(1)}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(2)}},
-					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(3)}},
-					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsUser: utilpointer.Int64(4)}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](1)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](2)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](3)}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](4)}},
 				},
 			}},
 			expectAllowed: true,
@@ -94,7 +94,7 @@ func TestRunAsUser(t *testing.T) {
 		{
 			name: "UserNamespacesPodSecurityStandards enabled without HostUsers",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				HostUsers: utilpointer.Bool(false),
+				HostUsers: ptr.To(false),
 			}},
 			expectAllowed:  true,
 			relaxForUserNS: true,
@@ -102,11 +102,11 @@ func TestRunAsUser(t *testing.T) {
 		{
 			name: "UserNamespacesPodSecurityStandards enabled with HostUsers",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(0)},
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: ptr.To[int64](0)},
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 				},
-				HostUsers: utilpointer.Bool(true),
+				HostUsers: ptr.To(true),
 			}},
 			expectAllowed:  false,
 			expectReason:   `runAsUser=0`,

--- a/staging/src/k8s.io/pod-security-admission/policy/check_windowsHostProcess_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_windowsHostProcess_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestWindowsHostProcess(t *testing.T) {
@@ -34,15 +34,15 @@ func TestWindowsHostProcess(t *testing.T) {
 			name: "host process",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
-					WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(true)},
+					WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: ptr.To(true)},
 				},
 				Containers: []corev1.Container{
 					{Name: "a", SecurityContext: nil},
 					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
 					{Name: "c", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{}}},
-					{Name: "d", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(false)}}},
-					{Name: "e", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(true)}}},
-					{Name: "f", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(true)}}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: ptr.To(false)}}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: ptr.To(true)}}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: ptr.To(true)}}},
 				},
 			}},
 			expectReason: `hostProcess`,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/pod-security-admission/policy/check_allowPrivilegeEscalation_test.go
./staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
./staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot_test.go
./staging/src/k8s.io/pod-security-admission/policy/check_privileged_test.go
./staging/src/k8s.io/pod-security-admission/policy/check_windowsHostProcess_test.go

#### Which issue(s) this PR is related to:

Related to #132086 

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the pod-security-admission policy.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
