### PR TITLE
chore: depr. pointer pkg replacement for cli-runtime

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -33,7 +33,7 @@
   - k8s.io/cli-runtime/pkg/printers
   - k8s.io/cli-runtime/pkg/resource
   - k8s.io/cli-runtime/pkg/kustomize
-  - k8s.io/utils/pointer
+  - k8s.io/utils/ptr
 
 - baseImportPath: "./staging/src/k8s.io/apimachinery"
   allowedImports:

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -414,8 +414,8 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 
 // WithDeprecatedPasswordFlag enables the username and password config flags
 func (f *ConfigFlags) WithDeprecatedPasswordFlag() *ConfigFlags {
-	f.Username = utilpointer.String("")
-	f.Password = utilpointer.String("")
+	f.Username = ptr.To("")
+	f.Password = ptr.To("")
 	return f
 }
 
@@ -451,22 +451,22 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 
 	return &ConfigFlags{
 		Insecure:   &insecure,
-		Timeout:    utilpointer.String("0"),
-		KubeConfig: utilpointer.String(""),
+		Timeout:    ptr.To("0"),
+		KubeConfig: ptr.To(""),
 
-		CacheDir:           utilpointer.String(getDefaultCacheDir()),
-		ClusterName:        utilpointer.String(""),
-		AuthInfoName:       utilpointer.String(""),
-		Context:            utilpointer.String(""),
-		Namespace:          utilpointer.String(""),
-		APIServer:          utilpointer.String(""),
-		TLSServerName:      utilpointer.String(""),
-		CertFile:           utilpointer.String(""),
-		KeyFile:            utilpointer.String(""),
-		CAFile:             utilpointer.String(""),
-		BearerToken:        utilpointer.String(""),
-		Impersonate:        utilpointer.String(""),
-		ImpersonateUID:     utilpointer.String(""),
+		CacheDir:           ptr.To(getDefaultCacheDir()),
+		ClusterName:        ptr.To(""),
+		AuthInfoName:       ptr.To(""),
+		Context:            ptr.To(""),
+		Namespace:          ptr.To(""),
+		APIServer:          ptr.To(""),
+		TLSServerName:      ptr.To(""),
+		CertFile:           ptr.To(""),
+		KeyFile:            ptr.To(""),
+		CAFile:             ptr.To(""),
+		BearerToken:        ptr.To(""),
+		Impersonate:        ptr.To(""),
+		ImpersonateUID:     ptr.To(""),
 		ImpersonateGroup:   &impersonateGroup,
 		DisableCompression: &disableCompression,
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the cli-runtime.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
