### PR TITLE
chore: first depr. pointer pkg replacement for apiserver (1/2)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview_test.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 	"k8s.io/apiserver/pkg/authentication/user"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestVerifyAdmissionResponse(t *testing.T) {
@@ -535,7 +535,7 @@ func TestCreateAdmissionObjects(t *testing.T) {
 						},
 						Object:    runtime.RawExtension{Object: versionedObj},
 						OldObject: runtime.RawExtension{Object: versionedObjOld},
-						DryRun:    utilpointer.BoolPtr(false),
+						DryRun:    ptr.To(false),
 						Options:   runtime.RawExtension{Object: &metav1.UpdateOptions{FieldManager: "foo"}},
 					},
 				}
@@ -578,7 +578,7 @@ func TestCreateAdmissionObjects(t *testing.T) {
 						},
 						Object:    runtime.RawExtension{Object: versionedObj},
 						OldObject: runtime.RawExtension{Object: versionedObjOld},
-						DryRun:    utilpointer.BoolPtr(false),
+						DryRun:    ptr.To(false),
 						Options:   runtime.RawExtension{Object: &metav1.UpdateOptions{FieldManager: "foo"}},
 					},
 				}

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -36,7 +36,7 @@ import (
 	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 	authorizationcel "k8s.io/apiserver/pkg/authorization/cel"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateAuthenticationConfiguration(t *testing.T) {
@@ -69,7 +69,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "sub",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -87,7 +87,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "sub",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -114,7 +114,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "sub",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -133,7 +133,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "sub",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -153,7 +153,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "claim",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -183,7 +183,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "claim",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -208,7 +208,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						},
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -234,7 +234,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "sub",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 						UserValidationRules: []api.UserValidationRule{
@@ -264,7 +264,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "sub",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -653,7 +653,7 @@ func TestValidateAuthenticationConfiguration(t *testing.T) {
 						ClaimMappings: api.ClaimMappings{
 							Username: api.PrefixedClaimOrExpression{
 								Claim:  "sub",
-								Prefix: pointer.String("prefix"),
+								Prefix: ptr.To("prefix"),
 							},
 						},
 					},
@@ -1137,7 +1137,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Expression: "claims.username",
-					Prefix:     pointer.String("prefix"),
+					Prefix:     ptr.To("prefix"),
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
@@ -1170,7 +1170,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Groups: api.PrefixedClaimOrExpression{
 					Claim:      "claim",
@@ -1185,11 +1185,11 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Groups: api.PrefixedClaimOrExpression{
 					Expression: "claims.groups",
-					Prefix:     pointer.String("prefix"),
+					Prefix:     ptr.To("prefix"),
 				},
 			},
 			structuredAuthnFeatureEnabled: true,
@@ -1200,7 +1200,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Groups: api.PrefixedClaimOrExpression{
 					Claim: "claim",
@@ -1214,7 +1214,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Groups: api.PrefixedClaimOrExpression{
 					Expression: "foo.bar",
@@ -1230,7 +1230,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				UID: api.ClaimOrExpression{
 					Claim:      "claim",
@@ -1245,7 +1245,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				UID: api.ClaimOrExpression{
 					Expression: "foo.bar",
@@ -1261,7 +1261,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Extra: []api.ExtraMapping{
 					{Key: "", ValueExpression: "claims.extra"},
@@ -1275,7 +1275,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Extra: []api.ExtraMapping{
 					{Key: "example.org/foo", ValueExpression: ""},
@@ -1289,7 +1289,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Extra: []api.ExtraMapping{
 					{Key: "example.org/foo", ValueExpression: "foo.bar"},
@@ -1317,7 +1317,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Groups: api.PrefixedClaimOrExpression{
 					Expression: "foo.bar",
@@ -1333,7 +1333,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				UID: api.ClaimOrExpression{
 					Expression: "foo.bar",
@@ -1349,7 +1349,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				UID: api.ClaimOrExpression{
 					Claim: "claim",
@@ -1363,7 +1363,7 @@ func TestValidateClaimMappings(t *testing.T) {
 			in: api.ClaimMappings{
 				Username: api.PrefixedClaimOrExpression{
 					Claim:  "claim",
-					Prefix: pointer.String("prefix"),
+					Prefix: ptr.To("prefix"),
 				},
 				Extra: []api.ExtraMapping{
 					{Key: "example.org/foo", ValueExpression: "claims.extra"},

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -80,7 +79,7 @@ func TestDeleteResourceAuditLogRequestObject(t *testing.T) {
 
 	policy := metav1.DeletePropagationBackground
 	deleteOption := &metav1.DeleteOptions{
-		GracePeriodSeconds: pointer.Int64Ptr(30),
+		GracePeriodSeconds: ptr.To[int64](30),
 		PropagationPolicy:  &policy,
 	}
 
@@ -102,7 +101,7 @@ func TestDeleteResourceAuditLogRequestObject(t *testing.T) {
 		{
 			name: "meta built-in Codec encode v1.DeleteOptions",
 			object: &metav1.DeleteOptions{
-				GracePeriodSeconds: pointer.Int64Ptr(30),
+				GracePeriodSeconds: ptr.To[int64](30),
 				PropagationPolicy:  &policy,
 			},
 			gv:         metav1.SchemeGroupVersion,
@@ -112,7 +111,7 @@ func TestDeleteResourceAuditLogRequestObject(t *testing.T) {
 		{
 			name: "fake corev1 registered codec encode v1 DeleteOptions",
 			object: &metav1.DeleteOptions{
-				GracePeriodSeconds: pointer.Int64Ptr(30),
+				GracePeriodSeconds: ptr.To[int64](30),
 				PropagationPolicy:  &policy,
 			},
 			gv:         metav1.SchemeGroupVersion,

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // utilities for loading JOSE keys.
@@ -388,7 +388,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -419,7 +419,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -447,7 +447,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "email",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -479,7 +479,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "email",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -510,7 +510,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "email",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -541,7 +541,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "email",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -572,11 +572,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -609,11 +609,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -666,11 +666,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -724,11 +724,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -778,11 +778,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -826,11 +826,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -880,11 +880,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "rabbits",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -937,11 +937,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -992,11 +992,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1049,11 +1049,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1109,11 +1109,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1147,11 +1147,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1204,11 +1204,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1248,11 +1248,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1283,11 +1283,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1317,11 +1317,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -1364,11 +1364,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -1403,11 +1403,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -1443,7 +1443,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -1472,7 +1472,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -1501,7 +1501,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -1532,7 +1532,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1565,7 +1565,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1598,7 +1598,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1631,7 +1631,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1662,7 +1662,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -1701,7 +1701,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -1737,7 +1737,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -1766,7 +1766,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("oidc:"),
+							Prefix: ptr.To("oidc:"),
 						},
 					},
 				},
@@ -1797,11 +1797,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("oidc:"),
+							Prefix: ptr.To("oidc:"),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String("groups:"),
+							Prefix: ptr.To("groups:"),
 						},
 					},
 				},
@@ -1834,11 +1834,11 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("oidc:"),
+							Prefix: ptr.To("oidc:"),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String("groups:"),
+							Prefix: ptr.To("groups:"),
 						},
 					},
 				},
@@ -1891,7 +1891,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -1921,7 +1921,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1953,7 +1953,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -1986,7 +1986,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -2007,7 +2007,7 @@ func TestToken(t *testing.T) {
 					},
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -2029,7 +2029,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -2052,7 +2052,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -2077,7 +2077,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -2101,7 +2101,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -2121,7 +2121,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "email",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -2152,7 +2152,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("prefix:"),
+							Prefix: ptr.To("prefix:"),
 						},
 					},
 				},
@@ -2181,7 +2181,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("system:"),
+							Prefix: ptr.To("system:"),
 						},
 					},
 					UserValidationRules: []apiserver.UserValidationRule{
@@ -2219,7 +2219,7 @@ func TestToken(t *testing.T) {
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Claim:  "groups",
-							Prefix: pointer.String("system:"),
+							Prefix: ptr.To("system:"),
 						},
 					},
 					UserValidationRules: []apiserver.UserValidationRule{
@@ -2255,7 +2255,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -2290,7 +2290,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -2328,7 +2328,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -2369,7 +2369,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 					ClaimValidationRules: []apiserver.ClaimValidationRule{
@@ -3092,7 +3092,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String("oidc:"),
+							Prefix: ptr.To("oidc:"),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Expression: `(claims.roles.split(",") + claims.other_roles.split(",")).map(role, "groups:" + role)`,
@@ -3673,7 +3673,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 						Groups: apiserver.PrefixedClaimOrExpression{
 							Expression: "claims.groups",
@@ -3758,7 +3758,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -3795,7 +3795,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -3832,7 +3832,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -3869,7 +3869,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},
@@ -3906,7 +3906,7 @@ func TestToken(t *testing.T) {
 					ClaimMappings: apiserver.ClaimMappings{
 						Username: apiserver.PrefixedClaimOrExpression{
 							Claim:  "username",
-							Prefix: pointer.String(""),
+							Prefix: ptr.To(""),
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
./staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
./staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
./staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview_test.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaces deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the apiserver (1/2).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

-->
```docs
NONE
```
