### PR TITLE
chore: depr. pointer pkg replacement for controller-manager

### DIFF
--- a/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
+++ b/staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -200,7 +200,7 @@ func (ts *tokenSourceImpl) Token() (*oauth2.Token, error) {
 
 		tr, inErr := ts.coreClient.ServiceAccounts(ts.namespace).CreateToken(context.TODO(), ts.serviceAccountName, &v1authenticationapi.TokenRequest{
 			Spec: v1authenticationapi.TokenRequestSpec{
-				ExpirationSeconds: utilpointer.Int64Ptr(ts.expirationSeconds),
+				ExpirationSeconds: ptr.To[int64](ts.expirationSeconds),
 			},
 		}, metav1.CreateOptions{})
 		if inErr != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/controller-manager/pkg/clientbuilder/client_builder_dynamic.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the controller-manager.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
