### PR TITLE
chore: depr. pointer pkg replacement for component-base

### DIFF
--- a/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go
+++ b/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // RecommendedDefaultLeaderElectionConfiguration defaults a pointer to a
@@ -49,7 +49,7 @@ func RecommendedDefaultLeaderElectionConfiguration(obj *LeaderElectionConfigurat
 		obj.ResourceLock = EndpointsResourceLock
 	}
 	if obj.LeaderElect == nil {
-		obj.LeaderElect = utilpointer.BoolPtr(true)
+		obj.LeaderElect = ptr.To(true)
 	}
 }
 
@@ -85,7 +85,7 @@ func RecommendedDefaultClientConnectionConfiguration(obj *ClientConnectionConfig
 // run it in your wrapper struct of this type in its `SetDefaults_` method.
 func RecommendedDebuggingConfiguration(obj *DebuggingConfiguration) {
 	if obj.EnableProfiling == nil {
-		obj.EnableProfiling = utilpointer.BoolPtr(true) // profile debugging is cheap to have exposed and standard on kube binaries
+		obj.EnableProfiling = ptr.To(true) // profile debugging is cheap to have exposed and standard on kube binaries
 	}
 }
 

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -27,19 +27,19 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	dto "github.com/prometheus/client_model/go"
 	"k8s.io/component-base/metrics"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func samples2Histogram(samples []float64, upperBounds []float64) Histogram {
 	histogram := dto.Histogram{
 		SampleCount: uint64Ptr(0),
-		SampleSum:   pointer.Float64Ptr(0.0),
+		SampleSum:   ptr.To[float64](0.0),
 	}
 
 	for _, ub := range upperBounds {
 		histogram.Bucket = append(histogram.Bucket, &dto.Bucket{
 			CumulativeCount: uint64Ptr(0),
-			UpperBound:      pointer.Float64Ptr(ub),
+			UpperBound:      ptr.To[float64](ub),
 		})
 	}
 
@@ -161,7 +161,7 @@ func TestHistogramValidate(t *testing.T) {
 			h: Histogram{
 				&dto.Histogram{
 					SampleCount: uint64Ptr(1),
-					SampleSum:   pointer.Float64Ptr(0.0),
+					SampleSum:   ptr.To[float64](0.0),
 				},
 			},
 			err: fmt.Errorf("nil or empty histogram SampleSum"),
@@ -171,7 +171,7 @@ func TestHistogramValidate(t *testing.T) {
 			h: Histogram{
 				&dto.Histogram{
 					SampleCount: uint64Ptr(1),
-					SampleSum:   pointer.Float64Ptr(1.0),
+					SampleSum:   ptr.To[float64](1.0),
 					Bucket: []*dto.Bucket{
 						nil,
 					},
@@ -184,7 +184,7 @@ func TestHistogramValidate(t *testing.T) {
 			h: Histogram{
 				&dto.Histogram{
 					SampleCount: uint64Ptr(1),
-					SampleSum:   pointer.Float64Ptr(1.0),
+					SampleSum:   ptr.To[float64](1.0),
 					Bucket: []*dto.Bucket{
 						{},
 					},
@@ -197,9 +197,9 @@ func TestHistogramValidate(t *testing.T) {
 			h: Histogram{
 				&dto.Histogram{
 					SampleCount: uint64Ptr(1),
-					SampleSum:   pointer.Float64Ptr(1.0),
+					SampleSum:   ptr.To[float64](1.0),
 					Bucket: []*dto.Bucket{
-						{UpperBound: pointer.Float64Ptr(-1.0)},
+						{UpperBound: ptr.To[float64](-1.0)},
 					},
 				},
 			},
@@ -237,9 +237,9 @@ func TestLabelsMatch(t *testing.T) {
 	}{
 		{name: "metric labels and labelFilter have the same labels and values", metric: &dto.Metric{
 			Label: []*dto.LabelPair{
-				{Name: pointer.StringPtr("a"), Value: pointer.StringPtr("1")},
-				{Name: pointer.StringPtr("b"), Value: pointer.StringPtr("2")},
-				{Name: pointer.StringPtr("c"), Value: pointer.StringPtr("3")},
+				{Name: ptr.To("a"), Value: ptr.To("1")},
+				{Name: ptr.To("b"), Value: ptr.To("2")},
+				{Name: ptr.To("c"), Value: ptr.To("3")},
 			}}, labelFilter: map[string]string{
 			"a": "1",
 			"b": "2",
@@ -247,17 +247,17 @@ func TestLabelsMatch(t *testing.T) {
 		}, expectedMatch: true},
 		{name: "metric labels contain all labelFilter labels, and labelFilter is a subset of metric labels", metric: &dto.Metric{
 			Label: []*dto.LabelPair{
-				{Name: pointer.StringPtr("a"), Value: pointer.StringPtr("1")},
-				{Name: pointer.StringPtr("b"), Value: pointer.StringPtr("2")},
-				{Name: pointer.StringPtr("c"), Value: pointer.StringPtr("3")},
+				{Name: ptr.To("a"), Value: ptr.To("1")},
+				{Name: ptr.To("b"), Value: ptr.To("2")},
+				{Name: ptr.To("c"), Value: ptr.To("3")},
 			}}, labelFilter: map[string]string{
 			"a": "1",
 			"b": "2",
 		}, expectedMatch: true},
 		{name: "metric labels don't have all labelFilter labels and value", metric: &dto.Metric{
 			Label: []*dto.LabelPair{
-				{Name: pointer.StringPtr("a"), Value: pointer.StringPtr("1")},
-				{Name: pointer.StringPtr("b"), Value: pointer.StringPtr("2")},
+				{Name: ptr.To("a"), Value: ptr.To("1")},
+				{Name: ptr.To("b"), Value: ptr.To("2")},
 			}}, labelFilter: map[string]string{
 			"a": "1",
 			"b": "2",
@@ -265,9 +265,9 @@ func TestLabelsMatch(t *testing.T) {
 		}, expectedMatch: false},
 		{name: "The intersection of metric labels and labelFilter labels is empty", metric: &dto.Metric{
 			Label: []*dto.LabelPair{
-				{Name: pointer.StringPtr("aa"), Value: pointer.StringPtr("11")},
-				{Name: pointer.StringPtr("bb"), Value: pointer.StringPtr("22")},
-				{Name: pointer.StringPtr("cc"), Value: pointer.StringPtr("33")},
+				{Name: ptr.To("aa"), Value: ptr.To("11")},
+				{Name: ptr.To("bb"), Value: ptr.To("22")},
+				{Name: ptr.To("cc"), Value: ptr.To("33")},
 			}}, labelFilter: map[string]string{
 			"a": "1",
 			"b": "2",
@@ -275,9 +275,9 @@ func TestLabelsMatch(t *testing.T) {
 		}, expectedMatch: false},
 		{name: "metric labels have the same labels names but different values with labelFilter labels and value", metric: &dto.Metric{
 			Label: []*dto.LabelPair{
-				{Name: pointer.StringPtr("a"), Value: pointer.StringPtr("1")},
-				{Name: pointer.StringPtr("b"), Value: pointer.StringPtr("2")},
-				{Name: pointer.StringPtr("c"), Value: pointer.StringPtr("3")},
+				{Name: ptr.To("a"), Value: ptr.To("1")},
+				{Name: ptr.To("b"), Value: ptr.To("2")},
+				{Name: ptr.To("c"), Value: ptr.To("3")},
 			}}, labelFilter: map[string]string{
 			"a": "11",
 			"b": "2",
@@ -285,10 +285,10 @@ func TestLabelsMatch(t *testing.T) {
 		}, expectedMatch: false},
 		{name: "metric labels contain label name but different values with labelFilter labels and value", metric: &dto.Metric{
 			Label: []*dto.LabelPair{
-				{Name: pointer.StringPtr("a"), Value: pointer.StringPtr("1")},
-				{Name: pointer.StringPtr("b"), Value: pointer.StringPtr("2")},
-				{Name: pointer.StringPtr("c"), Value: pointer.StringPtr("33")},
-				{Name: pointer.StringPtr("d"), Value: pointer.StringPtr("4")},
+				{Name: ptr.To("a"), Value: ptr.To("1")},
+				{Name: ptr.To("b"), Value: ptr.To("2")},
+				{Name: ptr.To("c"), Value: ptr.To("33")},
+				{Name: ptr.To("d"), Value: ptr.To("4")},
 			}}, labelFilter: map[string]string{
 			"a": "1",
 			"b": "2",
@@ -302,8 +302,8 @@ func TestLabelsMatch(t *testing.T) {
 		}, expectedMatch: false},
 		{name: "metric labels is not empty and labelFilter is empty", metric: &dto.Metric{
 			Label: []*dto.LabelPair{
-				{Name: pointer.StringPtr("a"), Value: pointer.StringPtr("1")},
-				{Name: pointer.StringPtr("b"), Value: pointer.StringPtr("2")},
+				{Name: ptr.To("a"), Value: ptr.To("1")},
+				{Name: ptr.To("b"), Value: ptr.To("2")},
 			}}, labelFilter: map[string]string{}, expectedMatch: true},
 	}
 	for _, tt := range cases {
@@ -329,25 +329,25 @@ func TestHistogramVec_GetAggregatedSampleCount(t *testing.T) {
 		{
 			name: "zero case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: pointer.Float64Ptr(0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
 			},
 			want: 0,
 		},
 		{
 			name: "standard case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: pointer.Float64Ptr(2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: pointer.Float64Ptr(4.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(4), SampleSum: pointer.Float64Ptr(8.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(4), SampleSum: ptr.To[float64](8.0)}},
 			},
 			want: 7,
 		},
 		{
 			name: "mixed case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: pointer.Float64Ptr(2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: pointer.Float64Ptr(0.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: pointer.Float64Ptr(4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
 			},
 			want: 3,
 		},
@@ -375,25 +375,25 @@ func TestHistogramVec_GetAggregatedSampleSum(t *testing.T) {
 		{
 			name: "zero case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: pointer.Float64Ptr(0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
 			},
 			want: 0.0,
 		},
 		{
 			name: "standard case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: pointer.Float64Ptr(2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: pointer.Float64Ptr(4.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(4), SampleSum: pointer.Float64Ptr(8.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(4), SampleSum: ptr.To[float64](8.0)}},
 			},
 			want: 14.0,
 		},
 		{
 			name: "mixed case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: pointer.Float64Ptr(2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: pointer.Float64Ptr(0.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: pointer.Float64Ptr(4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
 			},
 			want: 6.0,
 		},
@@ -471,16 +471,16 @@ func TestHistogramVec_Validate(t *testing.T) {
 		{
 			name: "nil SampleCount",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: pointer.Float64Ptr(1.0)}},
-				&Histogram{&dto.Histogram{SampleSum: pointer.Float64Ptr(2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](1.0)}},
+				&Histogram{&dto.Histogram{SampleSum: ptr.To[float64](2.0)}},
 			},
 			want: fmt.Errorf("nil or empty histogram SampleCount"),
 		},
 		{
 			name: "valid HistogramVec",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: pointer.Float64Ptr(1.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: pointer.Float64Ptr(2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](1.0)}},
+				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](2.0)}},
 			},
 		},
 		{
@@ -488,19 +488,19 @@ func TestHistogramVec_Validate(t *testing.T) {
 			vec: HistogramVec{
 				&Histogram{&dto.Histogram{
 					SampleCount: uint64Ptr(4),
-					SampleSum:   pointer.Float64Ptr(10.0),
+					SampleSum:   ptr.To[float64](10.0),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(1), UpperBound: pointer.Float64Ptr(1)},
-						{CumulativeCount: uint64Ptr(2), UpperBound: pointer.Float64Ptr(2)},
-						{CumulativeCount: uint64Ptr(5), UpperBound: pointer.Float64Ptr(4)},
+						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](1)},
+						{CumulativeCount: uint64Ptr(2), UpperBound: ptr.To[float64](2)},
+						{CumulativeCount: uint64Ptr(5), UpperBound: ptr.To[float64](4)},
 					},
 				}},
 				&Histogram{&dto.Histogram{
 					SampleCount: uint64Ptr(3),
-					SampleSum:   pointer.Float64Ptr(8.0),
+					SampleSum:   ptr.To[float64](8.0),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(1), UpperBound: pointer.Float64Ptr(2)},
-						{CumulativeCount: uint64Ptr(3), UpperBound: pointer.Float64Ptr(4)},
+						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](2)},
+						{CumulativeCount: uint64Ptr(3), UpperBound: ptr.To[float64](4)},
 					},
 				}},
 			},
@@ -528,20 +528,20 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			wantVec: HistogramVec{
 				&Histogram{&dto.Histogram{
 					SampleCount: uint64Ptr(1),
-					SampleSum:   pointer.Float64Ptr(1.5),
+					SampleSum:   ptr.To[float64](1.5),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(0), UpperBound: pointer.Float64Ptr(0.5)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: pointer.Float64Ptr(2.0)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: pointer.Float64Ptr(5.0)},
+						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](0.5)},
+						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](2.0)},
+						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](5.0)},
 					},
 				}},
 				&Histogram{&dto.Histogram{
 					SampleCount: uint64Ptr(1),
-					SampleSum:   pointer.Float64Ptr(2.5),
+					SampleSum:   ptr.To[float64](2.5),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(0), UpperBound: pointer.Float64Ptr(0.5)},
-						{CumulativeCount: uint64Ptr(0), UpperBound: pointer.Float64Ptr(2.0)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: pointer.Float64Ptr(5.0)},
+						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](0.5)},
+						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](2.0)},
+						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](5.0)},
 					},
 				}},
 			},
@@ -552,11 +552,11 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			wantVec: HistogramVec{
 				&Histogram{&dto.Histogram{
 					SampleCount: uint64Ptr(1),
-					SampleSum:   pointer.Float64Ptr(2.5),
+					SampleSum:   ptr.To[float64](2.5),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(0), UpperBound: pointer.Float64Ptr(0.5)},
-						{CumulativeCount: uint64Ptr(0), UpperBound: pointer.Float64Ptr(2.0)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: pointer.Float64Ptr(5.0)},
+						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](0.5)},
+						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](2.0)},
+						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](5.0)},
 					},
 				}},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
./staging/src/k8s.io/component-base/config/v1alpha1/defaults.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for the component-base.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
