### PR TITLE
golangci-lint: exclude naming convention check for swagger docs

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -102,6 +102,12 @@ linters:
           - revive
         text: "(ST1003: should not use underscores in Go names; func ([cC]onvert_.*_To_.*|[sS]etDefaults_)|exported: exported function (Convert|SetDefaults)_.* should be of the form)"
 
+      # The generated swagger docs also don't follow the naming convention.
+      - linters:
+          - staticcheck
+        text: "ST1003: should not use underscores in Go names"
+        path: types_swagger_doc_generated.go$
+
       - path: (.+)\.go$
         # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
         text: ineffective break statement. Did you mean to break out of the outer loop

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -102,6 +102,12 @@ linters:
           - revive
         text: "(ST1003: should not use underscores in Go names; func ([cC]onvert_.*_To_.*|[sS]etDefaults_)|exported: exported function (Convert|SetDefaults)_.* should be of the form)"
 
+      # The generated swagger docs also don't follow the naming convention.
+      - linters:
+          - staticcheck
+        text: "ST1003: should not use underscores in Go names"
+        path: types_swagger_doc_generated.go$
+
       # TODO(https://github.com/kubernetes/kubernetes/issues/131475): Remove these excluded directories and fix findings. Due to large amount of findings in different components
       # with different owners it's hard to fix everything in a single pr. This will therefore be done in multiple prs.
       - path: (pkg/volume/*|test/*|azure/*|pkg/cmd/wait*|request/bearertoken/*|metrics/*|filters/*)

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -102,6 +102,12 @@ linters:
           - revive
         text: "(ST1003: should not use underscores in Go names; func ([cC]onvert_.*_To_.*|[sS]etDefaults_)|exported: exported function (Convert|SetDefaults)_.* should be of the form)"
 
+      # The generated swagger docs also don't follow the naming convention.
+      - linters:
+          - staticcheck
+        text: "ST1003: should not use underscores in Go names"
+        path: types_swagger_doc_generated.go$
+
       {{- if .Hints}}
 
       - path: (.+)\.go$


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/priority important-soon

#### What this PR does / why we need it:

This started to show up now as linter hints at the start of the 1.34 cycle in all PRs which modify the API. We don't want to enforce that convention in that generated code, so suppressing it.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/132706
https://github.com/kubernetes/kubernetes/pull/132626

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
