### PR TITLE
chore: depr. pointer pkg replacement for test integration

### DIFF
--- a/test/integration/apiserver/cel/typeresolution_test.go
+++ b/test/integration/apiserver/cel/typeresolution_test.go
@@ -47,7 +47,7 @@ import (
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kube-openapi/pkg/validation/spec"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
@@ -412,7 +412,7 @@ func sampleReplicatedDeployment() *appsv1.Deployment {
 			Name: "demo-deployment",
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To[int32](2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "demo",
@@ -466,7 +466,7 @@ func installCRD(apiExtensionClient extclientset.Interface) (*apiextensionsv1.Cus
 					Storage: true,
 					Schema: &apiextensionsv1.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: pointer.Bool(true),
+							XPreserveUnknownFields: ptr.To(true),
 							Type:                   "object",
 							Properties: map[string]apiextensionsv1.JSONSchemaProps{
 								"spec": {

--- a/test/integration/apiserver/crd_regression_test.go
+++ b/test/integration/apiserver/crd_regression_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Regression test for https://issues.k8s.io/109099
@@ -72,7 +72,7 @@ func TestCRDExponentialRecursionBug(t *testing.T) {
 					Storage: true,
 					Schema: &apiextensionsv1.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							XPreserveUnknownFields: pointer.BoolPtr(true),
+							XPreserveUnknownFields: ptr.To(true),
 							Type:                   "object",
 							Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
 						},

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -48,7 +48,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/kubeconfig"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -238,8 +237,8 @@ func TestNodeAuthorizer(t *testing.T) {
 						{Name: "pvc", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc"}}},
 					},
 					ResourceClaims: []corev1.PodResourceClaim{
-						{Name: "namedclaim", ResourceClaimName: pointer.String("mynamedresourceclaim")},
-						{Name: "templateclaim", ResourceClaimTemplateName: pointer.String("myresourceclaimtemplate")},
+						{Name: "namedclaim", ResourceClaimName: ptr.To("mynamedresourceclaim")},
+						{Name: "templateclaim", ResourceClaimTemplateName: ptr.To("myresourceclaimtemplate")},
 					},
 				},
 			}, metav1.CreateOptions{})
@@ -384,8 +383,8 @@ func TestNodeAuthorizer(t *testing.T) {
 					Name: "node1",
 				},
 				Spec: coordination.LeaseSpec{
-					HolderIdentity:       pointer.String("node1"),
-					LeaseDurationSeconds: pointer.Int32(node1LeaseDurationSeconds),
+					HolderIdentity:       ptr.To("node1"),
+					LeaseDurationSeconds: ptr.To[int32](node1LeaseDurationSeconds),
 					RenewTime:            &metav1.MicroTime{Time: time.Now()},
 				},
 			}

--- a/test/integration/certificates/duration_test.go
+++ b/test/integration/certificates/duration_test.go
@@ -47,7 +47,7 @@ import (
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/controller/certificates/signer"
 	"k8s.io/kubernetes/test/integration/framework"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestCSRDuration(t *testing.T) {
@@ -135,50 +135,50 @@ func TestCSRDuration(t *testing.T) {
 		},
 		{
 			name:         "same duration set as certTTL",
-			duration:     pointer.Duration(24 * time.Hour),
+			duration:     ptr.To(24 * time.Hour),
 			wantDuration: 24 * time.Hour,
 			wantError:    "",
 		},
 		{
 			name:         "longer duration than certTTL",
-			duration:     pointer.Duration(48 * time.Hour),
+			duration:     ptr.To(48 * time.Hour),
 			wantDuration: 24 * time.Hour,
 			wantError:    "",
 		},
 		{
 			name:         "slightly shorter duration set",
-			duration:     pointer.Duration(20 * time.Hour),
+			duration:     ptr.To(20 * time.Hour),
 			wantDuration: 20 * time.Hour,
 			wantError:    "",
 		},
 		{
 			name:         "even shorter duration set",
-			duration:     pointer.Duration(10 * time.Hour),
+			duration:     ptr.To(10 * time.Hour),
 			wantDuration: 10 * time.Hour,
 			wantError:    "",
 		},
 		{
 			name:         "short duration set",
-			duration:     pointer.Duration(2 * time.Hour),
+			duration:     ptr.To(2 * time.Hour),
 			wantDuration: 2*time.Hour + 5*time.Minute,
 			wantError:    "",
 		},
 		{
 			name:         "very short duration set",
-			duration:     pointer.Duration(30 * time.Minute),
+			duration:     ptr.To(30 * time.Minute),
 			wantDuration: 30*time.Minute + 5*time.Minute,
 			wantError:    "",
 		},
 		{
 			name:         "shortest duration set",
-			duration:     pointer.Duration(10 * time.Minute),
+			duration:     ptr.To(10 * time.Minute),
 			wantDuration: 10*time.Minute + 5*time.Minute,
 			wantError:    "",
 		},
 		{
 			name:         "just too short duration set",
 			csrName:      "invalid-csr-001",
-			duration:     pointer.Duration(10*time.Minute - time.Second),
+			duration:     ptr.To(10*time.Minute - time.Second),
 			wantDuration: 0,
 			wantError: `cannot create certificate signing request: ` +
 				`CertificateSigningRequest.certificates.k8s.io "invalid-csr-001" is invalid: spec.expirationSeconds: Invalid value: 599: may not specify a duration less than 600 seconds (10 minutes)`,
@@ -186,7 +186,7 @@ func TestCSRDuration(t *testing.T) {
 		{
 			name:         "really too short duration set",
 			csrName:      "invalid-csr-002",
-			duration:     pointer.Duration(3 * time.Minute),
+			duration:     ptr.To(3 * time.Minute),
 			wantDuration: 0,
 			wantError: `cannot create certificate signing request: ` +
 				`CertificateSigningRequest.certificates.k8s.io "invalid-csr-002" is invalid: spec.expirationSeconds: Invalid value: 180: may not specify a duration less than 600 seconds (10 minutes)`,
@@ -194,7 +194,7 @@ func TestCSRDuration(t *testing.T) {
 		{
 			name:         "negative duration set",
 			csrName:      "invalid-csr-003",
-			duration:     pointer.Duration(-7 * time.Minute),
+			duration:     ptr.To(-7 * time.Minute),
 			wantDuration: 0,
 			wantError: `cannot create certificate signing request: ` +
 				`CertificateSigningRequest.certificates.k8s.io "invalid-csr-003" is invalid: spec.expirationSeconds: Invalid value: -420: may not specify a duration less than 600 seconds (10 minutes)`,

--- a/test/integration/controlplane/apiserver_identity_test.go
+++ b/test/integration/controlplane/apiserver_identity_test.go
@@ -40,7 +40,7 @@ import (
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 	"k8s.io/kubernetes/test/integration/framework"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -210,8 +210,8 @@ func newTestLease(acquireTime time.Time, namespace string) *coordinationv1.Lease
 			},
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.String(testLeaseName),
-			LeaseDurationSeconds: pointer.Int32(3600),
+			HolderIdentity:       ptr.To(testLeaseName),
+			LeaseDurationSeconds: ptr.To[int32](3600),
 			AcquireTime:          &metav1.MicroTime{Time: acquireTime},
 			RenewTime:            &metav1.MicroTime{Time: acquireTime},
 		},

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -53,7 +53,7 @@ import (
 	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -417,7 +417,7 @@ func (e *transformTest) createDeployment(name, namespace string) (*appsv1.Deploy
 			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To[int32](2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "nginx",

--- a/test/integration/endpointslice/endpointsliceterminating_test.go
+++ b/test/integration/endpointslice/endpointsliceterminating_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/endpointslice"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // TestEndpointSliceTerminating tests that terminating endpoints are included with the
@@ -65,9 +65,9 @@ func TestEndpointSliceTerminating(t *testing.T) {
 				{
 					Addresses: []string{"10.0.0.1"},
 					Conditions: discovery.EndpointConditions{
-						Ready:       utilpointer.BoolPtr(false),
-						Serving:     utilpointer.BoolPtr(true),
-						Terminating: utilpointer.BoolPtr(true),
+						Ready:       ptr.To(false),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(true),
 					},
 				},
 			},
@@ -93,9 +93,9 @@ func TestEndpointSliceTerminating(t *testing.T) {
 				{
 					Addresses: []string{"10.0.0.1"},
 					Conditions: discovery.EndpointConditions{
-						Ready:       utilpointer.BoolPtr(false),
-						Serving:     utilpointer.BoolPtr(false),
-						Terminating: utilpointer.BoolPtr(true),
+						Ready:       ptr.To(false),
+						Serving:     ptr.To(false),
+						Terminating: ptr.To(true),
 					},
 				},
 			},

--- a/test/integration/storageversion/gc_test.go
+++ b/test/integration/storageversion/gc_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/storageversiongc"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 	"k8s.io/kubernetes/test/integration/framework"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -99,7 +99,7 @@ func TestStorageVersionGarbageCollection(t *testing.T) {
 			t.Errorf("unexpected storage version entry id, expected %v, got: %v",
 				expectedID, sv.Status.StorageVersions[0].APIServerID)
 		}
-		assertCommonEncodingVersion(t, kubeclient, pointer.String(idToVersion(t, idA)))
+		assertCommonEncodingVersion(t, kubeclient, ptr.To(idToVersion(t, idA)))
 		if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(
 			context.TODO(), svName, metav1.DeleteOptions{}); err != nil {
 			t.Fatalf("failed to cleanup valid storage version: %v", err)
@@ -112,7 +112,7 @@ func TestStorageVersionGarbageCollection(t *testing.T) {
 		assertCommonEncodingVersion(t, kubeclient, nil)
 		deleteTestAPIServerIdentityLease(t, kubeclient, idA)
 		assertStorageVersionEntries(t, kubeclient, 1, idB)
-		assertCommonEncodingVersion(t, kubeclient, pointer.String(idToVersion(t, idB)))
+		assertCommonEncodingVersion(t, kubeclient, ptr.To(idToVersion(t, idB)))
 	})
 
 	t.Run("deleting an id should delete a storage version object that it owns entirely", func(t *testing.T) {
@@ -139,7 +139,7 @@ func createTestStorageVersion(t *testing.T, client kubernetes.Interface, ids ...
 	// every id is unique and creates a different version. We know we have a common encoding
 	// version when there is only one id. Pick it
 	if len(ids) == 1 {
-		sv.Status.CommonEncodingVersion = pointer.String(sv.Status.StorageVersions[0].EncodingVersion)
+		sv.Status.CommonEncodingVersion = ptr.To(sv.Status.StorageVersions[0].EncodingVersion)
 	}
 
 	createdSV, err := client.InternalV1alpha1().StorageVersions().Create(context.TODO(), sv, metav1.CreateOptions{})
@@ -180,8 +180,8 @@ func createTestAPIServerIdentityLease(t *testing.T, client kubernetes.Interface,
 			},
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.String(name),
-			LeaseDurationSeconds: pointer.Int32(3600),
+			HolderIdentity:       ptr.To(name),
+			LeaseDurationSeconds: ptr.To[int32](3600),
 			// create fresh leases
 			AcquireTime: &metav1.MicroTime{Time: time.Now()},
 			RenewTime:   &metav1.MicroTime{Time: time.Now()},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./test/integration/storageversion/gc_test.go
./test/integration/auth/node_test.go
./test/integration/certificates/duration_test.go
./test/integration/controlplane/transformation/transformation_test.go
./test/integration/controlplane/apiserver_identity_test.go
./test/integration/apiserver/crd_regression_test.go
./test/integration/apiserver/cel/typeresolution_test.go
./test/integration/endpointslice/endpointsliceterminating_test.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for ./test/integration
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
