### PR TITLE
chore: depr. pointer pkg replacement for test/e2e and utils

### DIFF
--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -45,10 +45,10 @@ import (
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	testutils "k8s.io/kubernetes/test/utils"
-	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -949,7 +949,7 @@ func CreateCustomResourceDefinition(ctx context.Context, c crdclientset.Interfac
 					Scale: &apiextensionsv1.CustomResourceSubresourceScale{
 						SpecReplicasPath:   ".spec.replicas",
 						StatusReplicasPath: ".status.replicas",
-						LabelSelectorPath:  utilpointer.String(".status.selector"),
+						LabelSelectorPath:  ptr.To(".status.selector"),
 					},
 				},
 			}},

--- a/test/e2e/framework/node/runtimeclass/runtimeclass.go
+++ b/test/e2e/framework/node/runtimeclass/runtimeclass.go
@@ -27,7 +27,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -50,7 +50,7 @@ func NewRuntimeClassPod(runtimeClassName string) *v1.Pod {
 				Command: []string{"true"},
 			}},
 			RestartPolicy:                v1.RestartPolicyNever,
-			AutomountServiceAccountToken: utilpointer.BoolPtr(false),
+			AutomountServiceAccountToken: ptr.To(false),
 		},
 	}
 }

--- a/test/e2e/framework/pod/utils.go
+++ b/test/e2e/framework/pod/utils.go
@@ -27,7 +27,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	psaapi "k8s.io/pod-security-admission/api"
 	psapolicy "k8s.io/pod-security-admission/policy"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // This command runs an infinite loop, sleeping for 1 second in each iteration.
@@ -92,7 +92,7 @@ func GetDefaultNonRootUser() *int64 {
 	if framework.NodeOSDistroIs("windows") {
 		return nil
 	}
-	return pointer.Int64(DefaultNonRootUser)
+	return ptr.To[int64](DefaultNonRootUser)
 }
 
 // GeneratePodSecurityContext generates the corresponding pod security context with the given inputs
@@ -119,11 +119,11 @@ func GenerateContainerSecurityContext(level psaapi.Level) *v1.SecurityContext {
 	switch level {
 	case psaapi.LevelBaseline:
 		return &v1.SecurityContext{
-			Privileged: pointer.Bool(false),
+			Privileged: ptr.To(false),
 		}
 	case psaapi.LevelPrivileged:
 		return &v1.SecurityContext{
-			Privileged: pointer.Bool(true),
+			Privileged: ptr.To(true),
 		}
 	case psaapi.LevelRestricted:
 		return GetRestrictedContainerSecurityContext()
@@ -154,14 +154,14 @@ const DefaultNonRootUserName = "ContainerUser"
 // Tests that require a specific user ID should override this.
 func GetRestrictedPodSecurityContext() *v1.PodSecurityContext {
 	psc := &v1.PodSecurityContext{
-		RunAsNonRoot:   pointer.Bool(true),
+		RunAsNonRoot:   ptr.To(true),
 		RunAsUser:      GetDefaultNonRootUser(),
 		SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault},
 	}
 
 	if framework.NodeOSDistroIs("windows") {
 		psc.WindowsOptions = &v1.WindowsSecurityContextOptions{}
-		psc.WindowsOptions.RunAsUserName = pointer.String(DefaultNonRootUserName)
+		psc.WindowsOptions.RunAsUserName = ptr.To(DefaultNonRootUserName)
 	}
 
 	return psc
@@ -170,7 +170,7 @@ func GetRestrictedPodSecurityContext() *v1.PodSecurityContext {
 // GetRestrictedContainerSecurityContext returns a minimal restricted container security context.
 func GetRestrictedContainerSecurityContext() *v1.SecurityContext {
 	return &v1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.Bool(false),
+		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities:             &v1.Capabilities{Drop: []v1.Capability{"ALL"}},
 	}
 }
@@ -194,7 +194,7 @@ func MixinRestrictedPodSecurity(pod *v1.Pod) error {
 		pod.Spec.SecurityContext = GetRestrictedPodSecurityContext()
 	} else {
 		if pod.Spec.SecurityContext.RunAsNonRoot == nil {
-			pod.Spec.SecurityContext.RunAsNonRoot = pointer.Bool(true)
+			pod.Spec.SecurityContext.RunAsNonRoot = ptr.To(true)
 		}
 		if pod.Spec.SecurityContext.RunAsUser == nil {
 			pod.Spec.SecurityContext.RunAsUser = GetDefaultNonRootUser()
@@ -204,7 +204,7 @@ func MixinRestrictedPodSecurity(pod *v1.Pod) error {
 		}
 		if framework.NodeOSDistroIs("windows") && pod.Spec.SecurityContext.WindowsOptions == nil {
 			pod.Spec.SecurityContext.WindowsOptions = &v1.WindowsSecurityContextOptions{}
-			pod.Spec.SecurityContext.WindowsOptions.RunAsUserName = pointer.String(DefaultNonRootUserName)
+			pod.Spec.SecurityContext.WindowsOptions.RunAsUserName = ptr.To(DefaultNonRootUserName)
 		}
 	}
 	for i := range pod.Spec.Containers {
@@ -234,7 +234,7 @@ func mixinRestrictedContainerSecurityContext(container *v1.Container) {
 		container.SecurityContext = GetRestrictedContainerSecurityContext()
 	} else {
 		if container.SecurityContext.AllowPrivilegeEscalation == nil {
-			container.SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
+			container.SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
 		}
 		if container.SecurityContext.Capabilities == nil {
 			container.SecurityContext.Capabilities = &v1.Capabilities{}

--- a/test/e2e/framework/pod/utils_test.go
+++ b/test/e2e/framework/pod/utils_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestMixinRestrictedPodSecurity(t *testing.T) {
@@ -83,7 +83,7 @@ func TestMixinRestrictedPodSecurity(t *testing.T) {
 				Name:  "pause",
 				Image: "pause",
 				SecurityContext: &v1.SecurityContext{
-					Privileged: pointer.Bool(true),
+					Privileged: ptr.To(true),
 				},
 			}},
 		},

--- a/test/e2e/framework/rc/rc_utils.go
+++ b/test/e2e/framework/rc/rc_utils.go
@@ -31,7 +31,7 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
 	testutils "k8s.io/kubernetes/test/utils"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // ByNameContainer returns a ReplicationController with specified name and container
@@ -52,7 +52,7 @@ func ByNameContainer(name string, replicas int32, labels map[string]string, c v1
 			Name: name,
 		},
 		Spec: v1.ReplicationControllerSpec{
-			Replicas: pointer.Int32(replicas),
+			Replicas: ptr.To[int32](replicas),
 			Selector: labels,
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/framework/statefulset/fixtures.go
+++ b/test/e2e/framework/statefulset/fixtures.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // NewStatefulSet creates a new Webserver StatefulSet for testing. The StatefulSet is named name, is in namespace ns,
@@ -71,7 +71,7 @@ func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			Replicas: pointer.Int32(replicas),
+			Replicas: ptr.To[int32](replicas),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,

--- a/test/utils/crd/crd_util.go
+++ b/test/utils/crd/crd_util.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	crdclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -157,7 +157,7 @@ func CreateTestCRD(f *framework.Framework, opts ...Option) (*TestCrd, error) {
 				Storage: true,
 				Schema: &apiextensionsv1.CustomResourceValidation{
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: pointer.BoolPtr(true),
+						XPreserveUnknownFields: ptr.To(true),
 						Type:                   "object",
 					},
 				},

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -44,7 +44,7 @@ import (
 	scaleclient "k8s.io/client-go/scale"
 	"k8s.io/client-go/util/workqueue"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/klog/v2"
 )
@@ -302,7 +302,7 @@ func (config *DeploymentConfig) create() error {
 			Name: config.Name,
 		},
 		Spec: apps.DeploymentSpec{
-			Replicas: pointer.Int32(int32(config.Replicas)),
+			Replicas: ptr.To[int32](int32(config.Replicas)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": config.Name,
@@ -373,7 +373,7 @@ func (config *ReplicaSetConfig) create() error {
 			Name: config.Name,
 		},
 		Spec: apps.ReplicaSetSpec{
-			Replicas: pointer.Int32(int32(config.Replicas)),
+			Replicas: ptr.To[int32](int32(config.Replicas)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"name": config.Name,
@@ -445,7 +445,7 @@ func (config *RCConfig) create() error {
 			Name: config.Name,
 		},
 		Spec: v1.ReplicationControllerSpec{
-			Replicas: pointer.Int32(int32(config.Replicas)),
+			Replicas: ptr.To[int32](int32(config.Replicas)),
 			Selector: map[string]string{
 				"name": config.Name,
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./test/utils/crd/crd_util.go
./test/utils/runners.go
./test/e2e/framework/pod/utils_test.go
./test/e2e/framework/pod/utils.go
./test/e2e/framework/statefulset/fixtures.go
./test/e2e/framework/node/runtimeclass/runtimeclass.go
./test/e2e/framework/autoscaling/autoscaling_utils.go
./test/e2e/framework/rc/rc_utils.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for ./test/e2e and ./test/utils.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
