### PR TITLE
chore: depr. pointer pkg replacement for test/e2e (1/2)

### DIFF
--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -45,7 +45,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	utilptr "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -320,7 +320,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 							{
 								ServiceAccountToken: &v1.ServiceAccountTokenProjection{
 									Path:              "token",
-									ExpirationSeconds: utilptr.Int64Ptr(60 * 60),
+									ExpirationSeconds: ptr.To[int64](60 * 60),
 								},
 							},
 						},
@@ -382,7 +382,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 							{
 								ServiceAccountToken: &v1.ServiceAccountTokenProjection{
 									Path:              "token",
-									ExpirationSeconds: utilptr.Int64Ptr(60 * 60),
+									ExpirationSeconds: ptr.To[int64](60 * 60),
 								},
 							},
 						},
@@ -781,7 +781,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		}))
 		framework.Logf("Got root ca configmap in namespace %q", f.Namespace.Name)
 
-		framework.ExpectNoError(f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, rootCAConfigMapName, metav1.DeleteOptions{GracePeriodSeconds: utilptr.Int64Ptr(0)}))
+		framework.ExpectNoError(f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, rootCAConfigMapName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}))
 		framework.Logf("Deleted root ca configmap in namespace %q", f.Namespace.Name)
 
 		framework.ExpectNoError(wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
@@ -843,13 +843,13 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: saName,
 			},
-			AutomountServiceAccountToken: utilptr.Bool(false),
+			AutomountServiceAccountToken: ptr.To(false),
 		}
 
 		ginkgo.By(fmt.Sprintf("Creating ServiceAccount %q ", saName))
 		createdServiceAccount, err := saClient.Create(ctx, initialServiceAccount, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
-		gomega.Expect(createdServiceAccount.AutomountServiceAccountToken).To(gomega.Equal(utilptr.Bool(false)), "Failed to set AutomountServiceAccountToken")
+		gomega.Expect(createdServiceAccount.AutomountServiceAccountToken).To(gomega.Equal(ptr.To(false)), "Failed to set AutomountServiceAccountToken")
 		framework.Logf("AutomountServiceAccountToken: %v", *createdServiceAccount.AutomountServiceAccountToken)
 
 		ginkgo.By(fmt.Sprintf("Updating ServiceAccount %q ", saName))
@@ -858,12 +858,12 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			updateServiceAccount, err := saClient.Get(ctx, saName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Unable to get ServiceAccount %q", saName)
-			updateServiceAccount.AutomountServiceAccountToken = utilptr.Bool(true)
+			updateServiceAccount.AutomountServiceAccountToken = ptr.To(true)
 			updatedServiceAccount, err = saClient.Update(ctx, updateServiceAccount, metav1.UpdateOptions{})
 			return err
 		})
 		framework.ExpectNoError(err, "Failed to update ServiceAccount")
-		gomega.Expect(updatedServiceAccount.AutomountServiceAccountToken).To(gomega.Equal(utilptr.Bool(true)), "Failed to set AutomountServiceAccountToken")
+		gomega.Expect(updatedServiceAccount.AutomountServiceAccountToken).To(gomega.Equal(ptr.To(true)), "Failed to set AutomountServiceAccountToken")
 		framework.Logf("AutomountServiceAccountToken: %v", *updatedServiceAccount.AutomountServiceAccountToken)
 	})
 

--- a/test/e2e/common/node/lease.go
+++ b/test/e2e/common/node/lease.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
@@ -79,11 +79,11 @@ var _ = SIGDescribe("Lease", func() {
 				Name: name,
 			},
 			Spec: coordinationv1.LeaseSpec{
-				HolderIdentity:       pointer.String("holder"),
-				LeaseDurationSeconds: pointer.Int32(30),
+				HolderIdentity:       ptr.To("holder"),
+				LeaseDurationSeconds: ptr.To[int32](30),
 				AcquireTime:          &metav1.MicroTime{Time: time.Time{}.Add(2 * time.Second)},
 				RenewTime:            &metav1.MicroTime{Time: time.Time{}.Add(5 * time.Second)},
-				LeaseTransitions:     pointer.Int32(0),
+				LeaseTransitions:     ptr.To[int32](0),
 			},
 		}
 
@@ -97,11 +97,11 @@ var _ = SIGDescribe("Lease", func() {
 		}
 
 		createdLease.Spec = coordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.String("holder2"),
-			LeaseDurationSeconds: pointer.Int32(30),
+			HolderIdentity:       ptr.To("holder2"),
+			LeaseDurationSeconds: ptr.To[int32](30),
 			AcquireTime:          &metav1.MicroTime{Time: time.Time{}.Add(20 * time.Second)},
 			RenewTime:            &metav1.MicroTime{Time: time.Time{}.Add(50 * time.Second)},
-			LeaseTransitions:     pointer.Int32(1),
+			LeaseTransitions:     ptr.To[int32](1),
 		}
 
 		_, err = leaseClient.Update(ctx, createdLease, metav1.UpdateOptions{})
@@ -115,11 +115,11 @@ var _ = SIGDescribe("Lease", func() {
 
 		patchedLease := readLease.DeepCopy()
 		patchedLease.Spec = coordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.String("holder3"),
-			LeaseDurationSeconds: pointer.Int32(60),
+			HolderIdentity:       ptr.To("holder3"),
+			LeaseDurationSeconds: ptr.To[int32](60),
 			AcquireTime:          &metav1.MicroTime{Time: time.Time{}.Add(50 * time.Second)},
 			RenewTime:            &metav1.MicroTime{Time: time.Time{}.Add(70 * time.Second)},
-			LeaseTransitions:     pointer.Int32(2),
+			LeaseTransitions:     ptr.To[int32](2),
 		}
 		patchBytes, err := getPatchBytes(readLease, patchedLease)
 		framework.ExpectNoError(err, "creating patch failed")
@@ -140,11 +140,11 @@ var _ = SIGDescribe("Lease", func() {
 				Labels: map[string]string{"deletecollection": "true"},
 			},
 			Spec: coordinationv1.LeaseSpec{
-				HolderIdentity:       pointer.String("holder"),
-				LeaseDurationSeconds: pointer.Int32(30),
+				HolderIdentity:       ptr.To("holder"),
+				LeaseDurationSeconds: ptr.To[int32](30),
 				AcquireTime:          &metav1.MicroTime{Time: time.Time{}.Add(2 * time.Second)},
 				RenewTime:            &metav1.MicroTime{Time: time.Time{}.Add(5 * time.Second)},
-				LeaseTransitions:     pointer.Int32(0),
+				LeaseTransitions:     ptr.To[int32](0),
 			},
 		}
 		_, err = leaseClient.Create(ctx, lease2, metav1.CreateOptions{})

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -55,7 +55,7 @@ import (
 	e2ewebsocket "k8s.io/kubernetes/test/e2e/framework/websocket"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -1094,7 +1094,7 @@ var _ = SIGDescribe("Pods", func() {
 				Labels: label,
 			},
 			Spec: v1.PodSpec{
-				TerminationGracePeriodSeconds: pointer.Int64(1),
+				TerminationGracePeriodSeconds: ptr.To[int64](1),
 				Containers: []v1.Container{
 					{
 						Name:  "agnhost",

--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -40,7 +40,6 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
@@ -460,7 +459,7 @@ var _ = SIGDescribe("Security Context", func() {
 							Name:    podName,
 							Command: []string{"id", "-u"}, // Print UID and exit
 							SecurityContext: &v1.SecurityContext{
-								RunAsNonRoot: pointer.BoolPtr(true),
+								RunAsNonRoot: ptr.To(true),
 								RunAsUser:    userid,
 							},
 						},
@@ -473,7 +472,7 @@ var _ = SIGDescribe("Security Context", func() {
 			// creates a pod with RunAsUser, which is not supported on Windows.
 			e2eskipper.SkipIfNodeOSDistroIs("windows")
 			name := "explicit-nonroot-uid"
-			pod := makeNonRootPod(name, rootImage, pointer.Int64Ptr(nonRootTestUserID))
+			pod := makeNonRootPod(name, rootImage, ptr.To[int64](nonRootTestUserID))
 			podClient.Create(ctx, pod)
 
 			podClient.WaitForSuccess(ctx, name, framework.PodStartTimeout)
@@ -483,7 +482,7 @@ var _ = SIGDescribe("Security Context", func() {
 			// creates a pod with RunAsUser, which is not supported on Windows.
 			e2eskipper.SkipIfNodeOSDistroIs("windows")
 			name := "explicit-root-uid"
-			pod := makeNonRootPod(name, nonRootImage, pointer.Int64Ptr(0))
+			pod := makeNonRootPod(name, nonRootImage, ptr.To[int64](0))
 			pod = podClient.Create(ctx, pod)
 
 			ev, err := podClient.WaitForErrorEventOrSuccess(ctx, pod)

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/network/common"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -602,8 +602,8 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		ginkgo.By("creating")
 		eps1 := epsTemplate.DeepCopy()
 		eps1.Ports = []discoveryv1.EndpointPort{{
-			Name:     pointer.String("port80"),
-			Port:     pointer.Int32(8090),
+			Name:     ptr.To("port80"),
+			Port:     ptr.To[int32](8090),
 			Protocol: &tcpProtocol,
 		}}
 
@@ -611,8 +611,8 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		framework.ExpectNoError(err)
 		eps2 := epsTemplate.DeepCopy()
 		eps2.Ports = []discoveryv1.EndpointPort{{
-			Name:     pointer.String("port81"),
-			Port:     pointer.Int32(9090),
+			Name:     ptr.To("port81"),
+			Port:     ptr.To[int32](9090),
 			Protocol: &tcpProtocol,
 		}}
 
@@ -707,8 +707,8 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 			},
 		}
 		eps1.Ports = []discoveryv1.EndpointPort{{
-			Name:     pointer.String("port80"),
-			Port:     pointer.Int32(8090),
+			Name:     ptr.To("port80"),
+			Port:     ptr.To[int32](8090),
 			Protocol: &tcpProtocol,
 		}}
 
@@ -722,8 +722,8 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 			},
 		}
 		eps2.Ports = []discoveryv1.EndpointPort{{
-			Name:     pointer.String("port81"),
-			Port:     pointer.Int32(8090),
+			Name:     ptr.To("port81"),
+			Port:     ptr.To[int32](8090),
 			Protocol: &tcpProtocol,
 		}}
 		_, err = f.ClientSet.DiscoveryV1().EndpointSlices(ns).Create(context.TODO(), eps2, metav1.CreateOptions{})

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	admissionapi "k8s.io/pod-security-admission/api"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -178,11 +178,11 @@ var _ = common.SIGDescribe("IngressClass", feature.Ingress, func() {
 			Spec: networkingv1.IngressClassSpec{
 				Controller: "example.com/controller",
 				Parameters: &networkingv1.IngressClassParametersReference{
-					Scope:     utilpointer.String("Namespace"),
-					Namespace: utilpointer.String("foo-ns"),
+					Scope:     ptr.To("Namespace"),
+					Namespace: ptr.To("foo-ns"),
 					Kind:      "fookind",
 					Name:      "fooname",
-					APIGroup:  utilpointer.String("example.com"),
+					APIGroup:  ptr.To("example.com"),
 				},
 			},
 		}

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -48,7 +48,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -370,7 +370,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 							},
 						},
 					},
-					TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+					TerminationGracePeriodSeconds: ptr.To[int64](-1),
 				},
 			}
 
@@ -394,7 +394,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 				pod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err, "failed to query for pod")
 				ginkgo.By("updating the pod to have a negative TerminationGracePeriodSeconds")
-				pod.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(-1)
+				pod.Spec.TerminationGracePeriodSeconds = ptr.To[int64](-1)
 				_, err = podClient.PodInterface.Update(ctx, pod, metav1.UpdateOptions{})
 				return err
 			})
@@ -573,7 +573,7 @@ var _ = SIGDescribe("Pods Extended (pod generation)", feature.PodObservedGenerat
 			pod.ObjectMeta.Labels = map[string]string{
 				"time": value,
 			}
-			pod.Spec.ActiveDeadlineSeconds = utilpointer.Int64(5000)
+			pod.Spec.ActiveDeadlineSeconds = ptr.To[int64](5000)
 
 			ginkgo.By("submitting the pod to kubernetes")
 			pod = podClient.CreateSync(ctx, pod)

--- a/test/e2e/storage/csimock/csi_service_account_token.go
+++ b/test/e2e/storage/csimock/csi_service_account_token.go
@@ -26,7 +26,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
-	utilptr "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
@@ -56,7 +56,7 @@ var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
 			{
 				desc:                  "token should be plumbed down when csiServiceAccountTokenEnabled=true",
 				deployCSIDriverObject: true,
-				tokenRequests:         []storagev1.TokenRequest{{ExpirationSeconds: utilptr.Int64Ptr(60 * 10)}},
+				tokenRequests:         []storagev1.TokenRequest{{ExpirationSeconds: ptr.To[int64](60 * 10)}},
 			},
 		}
 		for _, test := range tests {

--- a/test/e2e/storage/testsuites/fsgroupchangepolicy.go
+++ b/test/e2e/storage/testsuites/fsgroupchangepolicy.go
@@ -31,7 +31,7 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -241,7 +241,7 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 				NS:                     f.Namespace.Name,
 				NodeSelection:          l.config.ClientNodeSelection,
 				PVCs:                   []*v1.PersistentVolumeClaim{l.resource.Pvc},
-				FsGroup:                utilpointer.Int64Ptr(int64(test.initialPodFsGroup)),
+				FsGroup:                ptr.To[int64](int64(test.initialPodFsGroup)),
 				PodFSGroupChangePolicy: &policy,
 			}
 			// Create initial pod and create files in root and sub-directory and verify ownership.
@@ -262,7 +262,7 @@ func (s *fsGroupChangePolicyTestSuite) DefineTests(driver storageframework.TestD
 			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))
 
 			// Create a second pod with existing volume and verify the contents ownership.
-			podConfig.FsGroup = utilpointer.Int64Ptr(int64(test.secondPodFsGroup))
+			podConfig.FsGroup = ptr.To[int64](int64(test.secondPodFsGroup))
 			pod = createPodAndVerifyContentGid(ctx, l.config.Framework, &podConfig, false /* createInitialFiles */, strconv.Itoa(test.finalExpectedRootDirFileOwnership), strconv.Itoa(test.finalExpectedSubDirFileOwnership))
 			ginkgo.By(fmt.Sprintf("Deleting Pod %s/%s", pod.Namespace, pod.Name))
 			framework.ExpectNoError(e2epod.DeletePodWithWait(ctx, f.ClientSet, pod))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./test/e2e/auth/service_accounts.go
./test/e2e/network/endpointslice.go
./test/e2e/network/ingressclass.go
./test/e2e/storage/csimock/csi_service_account_token.go
./test/e2e/storage/testsuites/fsgroupchangepolicy.go
./test/e2e/common/node/security_context.go
./test/e2e/common/node/pods.go
./test/e2e/common/node/lease.go
./test/e2e/node/pods.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for ./test/e2e.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
