### PR TITLE
chore: depr. pointer pkg replacement for test/e2e (2/2)

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -52,7 +52,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 	samplev1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -362,7 +362,7 @@ func SetUpSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclien
 			Service: &apiregistrationv1.ServiceReference{
 				Namespace: n.namespace,
 				Name:      "sample-api",
-				Port:      pointer.Int32(aggregatorServicePort),
+				Port:      ptr.To[int32](aggregatorServicePort),
 			},
 			Group:                apiServiceGroupName,
 			Version:              apiServiceVersion,

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/kubernetes/test/utils/format"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/test/integration"
@@ -147,8 +147,8 @@ var _ = SIGDescribe("CustomResourceConversionWebhook [Privileged:ClusterAdmin]",
 						Service: &apiextensionsv1.ServiceReference{
 							Namespace: f.Namespace.Name,
 							Name:      serviceCRDName,
-							Path:      pointer.String("/crdconvert"),
-							Port:      pointer.Int32(servicePort),
+							Path:      ptr.To("/crdconvert"),
+							Port:      ptr.To[int32](servicePort),
 						},
 					},
 					ConversionReviewVersions: []string{"v1", "v1beta1"},
@@ -182,8 +182,8 @@ var _ = SIGDescribe("CustomResourceConversionWebhook [Privileged:ClusterAdmin]",
 						Service: &apiextensionsv1.ServiceReference{
 							Namespace: f.Namespace.Name,
 							Name:      serviceCRDName,
-							Path:      pointer.String("/crdconvert"),
-							Port:      pointer.Int32(servicePort),
+							Path:      ptr.To("/crdconvert"),
+							Port:      ptr.To[int32](servicePort),
 						},
 					},
 					ConversionReviewVersions: []string{"v1", "v1beta1"},

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -31,7 +31,7 @@ import (
 
 	"k8s.io/apiserver/pkg/cel/environment"
 	openapiutil "k8s.io/kube-openapi/pkg/util"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -552,7 +552,7 @@ func setupCRDAndVerifySchemaWithOptions(f *framework.Framework, schema, expect [
 			} else {
 				version.Schema = &apiextensionsv1.CustomResourceValidation{
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: pointer.BoolPtr(true),
+						XPreserveUnknownFields: ptr.To(true),
 						Type:                   "object",
 					},
 				}

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -55,7 +55,6 @@ import (
 	"k8s.io/kubernetes/test/utils/format"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
@@ -2360,7 +2359,7 @@ func newTestReplicationControllerForQuota(name, image string, replicas int32) *v
 			Name: name,
 		},
 		Spec: v1.ReplicationControllerSpec{
-			Replicas: pointer.Int32(replicas),
+			Replicas: ptr.To[int32](replicas),
 			Selector: map[string]string{
 				"name": name,
 			},

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -370,17 +370,17 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		policyIgnore := admissionregistrationv1.Ignore
 
 		ginkgo.By("Setting timeout (1s) shorter than webhook latency (5s)")
-		slowWebhookCleanup := registerSlowWebhook(ctx, f, markersNamespaceName, f.UniqueName, certCtx, &policyFail, pointer.Int32(1), servicePort)
+		slowWebhookCleanup := registerSlowWebhook(ctx, f, markersNamespaceName, f.UniqueName, certCtx, &policyFail, ptr.To[int32](1), servicePort)
 		testSlowWebhookTimeoutFailEarly(ctx, f)
 		slowWebhookCleanup(ctx)
 
 		ginkgo.By("Having no error when timeout is shorter than webhook latency and failure policy is ignore")
-		slowWebhookCleanup = registerSlowWebhook(ctx, f, markersNamespaceName, f.UniqueName, certCtx, &policyIgnore, pointer.Int32(1), servicePort)
+		slowWebhookCleanup = registerSlowWebhook(ctx, f, markersNamespaceName, f.UniqueName, certCtx, &policyIgnore, ptr.To[int32](1), servicePort)
 		testSlowWebhookTimeoutNoError(ctx, f)
 		slowWebhookCleanup(ctx)
 
 		ginkgo.By("Having no error when timeout is longer than webhook latency")
-		slowWebhookCleanup = registerSlowWebhook(ctx, f, markersNamespaceName, f.UniqueName, certCtx, &policyFail, pointer.Int32(10), servicePort)
+		slowWebhookCleanup = registerSlowWebhook(ctx, f, markersNamespaceName, f.UniqueName, certCtx, &policyFail, ptr.To[int32](10), servicePort)
 		testSlowWebhookTimeoutNoError(ctx, f)
 		slowWebhookCleanup(ctx)
 
@@ -953,7 +953,7 @@ func newValidatingWebhookWithMatchConditions(
 						Namespace: f.Namespace.Name,
 						Name:      serviceName,
 						Path:      strPtr("/always-deny"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -998,7 +998,7 @@ func newMutatingWebhookWithMatchConditions(
 						Namespace: f.Namespace.Name,
 						Name:      serviceName,
 						Path:      strPtr("/mutating-configmaps"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -1217,7 +1217,7 @@ func registerWebhookForAttachingPod(ctx context.Context, f *framework.Framework,
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/pods/attach"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -1307,7 +1307,7 @@ func registerMutatingWebhookForPod(ctx context.Context, f *framework.Framework, 
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/mutating-pods"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -1496,7 +1496,7 @@ func failingWebhook(namespace, name string, servicePort int32) admissionregistra
 				Namespace: namespace,
 				Name:      serviceName,
 				Path:      strPtr("/configmaps"),
-				Port:      pointer.Int32(servicePort),
+				Port:      ptr.To[int32](servicePort),
 			},
 			// Without CA bundle, the call to webhook always fails
 			CABundle: nil,
@@ -1603,7 +1603,7 @@ func registerValidatingWebhookForWebhookConfigurations(ctx context.Context, f *f
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/always-deny"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -1661,7 +1661,7 @@ func registerMutatingWebhookForWebhookConfigurations(ctx context.Context, f *fra
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/add-label"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -1721,7 +1721,7 @@ func testWebhooksForWebhookConfigurations(ctx context.Context, f *framework.Fram
 						// but because the failure policy is ignore, it will
 						// have no effect on admission requests.
 						Path: strPtr(""),
-						Port: pointer.Int32(servicePort),
+						Port: ptr.To[int32](servicePort),
 					},
 					CABundle: nil,
 				},
@@ -1777,7 +1777,7 @@ func testWebhooksForWebhookConfigurations(ctx context.Context, f *framework.Fram
 						// but because the failure policy is ignore, it will
 						// have no effect on admission requests.
 						Path: strPtr(""),
-						Port: pointer.Int32(servicePort),
+						Port: ptr.To[int32](servicePort),
 					},
 					CABundle: nil,
 				},
@@ -2005,7 +2005,7 @@ func registerWebhookForCustomResource(ctx context.Context, f *framework.Framewor
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/custom-resource"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -2054,7 +2054,7 @@ func registerMutatingWebhookForCustomResource(ctx context.Context, f *framework.
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/mutating-custom-resource"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -2080,7 +2080,7 @@ func registerMutatingWebhookForCustomResource(ctx context.Context, f *framework.
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/mutating-custom-resource"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -2311,7 +2311,7 @@ func registerValidatingWebhookForCRD(ctx context.Context, f *framework.Framework
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/crd"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -2345,7 +2345,7 @@ func testCRDDenyWebhook(ctx context.Context, f *framework.Framework) {
 			Storage: true,
 			Schema: &apiextensionsv1.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-					XPreserveUnknownFields: pointer.BoolPtr(true),
+					XPreserveUnknownFields: ptr.To(true),
 					Type:                   "object",
 				},
 			},
@@ -2436,7 +2436,7 @@ func registerSlowWebhook(ctx context.Context, f *framework.Framework, markersNam
 						Namespace: namespace,
 						Name:      serviceName,
 						Path:      strPtr("/always-allow-delay-5s"),
-						Port:      pointer.Int32(servicePort),
+						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
 				},
@@ -2507,7 +2507,7 @@ func createAdmissionWebhookMultiVersionTestCRDWithV1Storage(f *framework.Framewo
 				Storage: true,
 				Schema: &apiextensionsv1.CustomResourceValidation{
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: pointer.BoolPtr(true),
+						XPreserveUnknownFields: ptr.To(true),
 						Type:                   "object",
 					},
 				},
@@ -2518,7 +2518,7 @@ func createAdmissionWebhookMultiVersionTestCRDWithV1Storage(f *framework.Framewo
 				Storage: false,
 				Schema: &apiextensionsv1.CustomResourceValidation{
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-						XPreserveUnknownFields: pointer.BoolPtr(true),
+						XPreserveUnknownFields: ptr.To(true),
 						Type:                   "object",
 					},
 				},
@@ -2585,7 +2585,7 @@ func newDenyPodWebhookFixture(f *framework.Framework, certCtx *certContext, serv
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
 				Path:      strPtr("/pods"),
-				Port:      pointer.Int32(servicePort),
+				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
 		},
@@ -2626,7 +2626,7 @@ func newDenyConfigMapWebhookFixture(f *framework.Framework, certCtx *certContext
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
 				Path:      strPtr("/configmaps"),
-				Port:      pointer.Int32(servicePort),
+				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
 		},
@@ -2652,7 +2652,7 @@ func newMutateConfigMapWebhookFixture(f *framework.Framework, certCtx *certConte
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
 				Path:      strPtr("/mutating-configmaps"),
-				Port:      pointer.Int32(servicePort),
+				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
 		},
@@ -2726,7 +2726,7 @@ func newValidatingIsReadyWebhookFixture(f *framework.Framework, certCtx *certCon
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
 				Path:      strPtr("/always-deny"),
-				Port:      pointer.Int32(servicePort),
+				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
 		},
@@ -2765,7 +2765,7 @@ func newMutatingIsReadyWebhookFixture(f *framework.Framework, certCtx *certConte
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
 				Path:      strPtr("/always-deny"),
-				Port:      pointer.Int32(servicePort),
+				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
 		},

--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -41,7 +41,7 @@ import (
 	e2edaemonset "k8s.io/kubernetes/test/e2e/framework/daemonset"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -173,7 +173,7 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 		framework.Logf("%s has been patched", patchedControllerRevision.Name)
 
 		ginkgo.By("Create a new ControllerRevision")
-		ds.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(1)
+		ds.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To[int64](1)
 		newHash, newName := hashAndNameForDaemonSet(ds)
 		newRevision := &appsv1.ControllerRevision{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -50,7 +50,6 @@ import (
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
 	"k8s.io/kubernetes/test/e2e/scheduling"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
@@ -271,7 +270,7 @@ var _ = SIGDescribe("Job", func() {
 
 		ginkgo.By("Creating a job with suspend=true")
 		job := e2ejob.NewTestJob("succeed", "suspend-true-to-false", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
-		job.Spec.Suspend = pointer.BoolPtr(true)
+		job.Spec.Suspend = ptr.To(true)
 		job, err := e2ejob.CreateJob(ctx, f.ClientSet, f.Namespace.Name, job)
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
@@ -287,7 +286,7 @@ var _ = SIGDescribe("Job", func() {
 		ginkgo.By("Updating the job with suspend=false")
 		job, err = f.ClientSet.BatchV1().Jobs(f.Namespace.Name).Get(ctx, job.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get job in namespace: %s", f.Namespace.Name)
-		job.Spec.Suspend = pointer.BoolPtr(false)
+		job.Spec.Suspend = ptr.To(false)
 		job, err = e2ejob.UpdateJob(ctx, f.ClientSet, f.Namespace.Name, job)
 		framework.ExpectNoError(err, "failed to update job in namespace: %s", f.Namespace.Name)
 
@@ -303,7 +302,7 @@ var _ = SIGDescribe("Job", func() {
 
 		ginkgo.By("Creating a job with suspend=false")
 		job := e2ejob.NewTestJob("notTerminate", "suspend-false-to-true", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
-		job.Spec.Suspend = pointer.Bool(false)
+		job.Spec.Suspend = ptr.To(false)
 		job, err := e2ejob.CreateJob(ctx, f.ClientSet, f.Namespace.Name, job)
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
@@ -315,7 +314,7 @@ var _ = SIGDescribe("Job", func() {
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			job, err = e2ejob.GetJob(ctx, f.ClientSet, f.Namespace.Name, job.Name)
 			framework.ExpectNoError(err, "unable to get job %s in namespace %s", job.Name, f.Namespace.Name)
-			job.Spec.Suspend = pointer.Bool(true)
+			job.Spec.Suspend = ptr.To(true)
 			updatedJob, err := e2ejob.UpdateJob(ctx, f.ClientSet, f.Namespace.Name, job)
 			if err == nil {
 				job = updatedJob
@@ -1180,7 +1179,7 @@ done`}
 		ginkgo.By("Creating a suspended job")
 		job := e2ejob.NewTestJob("succeed", jobName, v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job.Labels = label
-		job.Spec.Suspend = pointer.BoolPtr(true)
+		job.Spec.Suspend = ptr.To(true)
 		job, err = e2ejob.CreateJob(ctx, f.ClientSet, ns, job)
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", ns)
 
@@ -1210,7 +1209,7 @@ done`}
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			patchedJob, err = jobClient.Get(ctx, jobName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Unable to get job %s", jobName)
-			patchedJob.Spec.Suspend = pointer.BoolPtr(false)
+			patchedJob.Spec.Suspend = ptr.To(false)
 			if patchedJob.Annotations == nil {
 				patchedJob.Annotations = map[string]string{}
 			}

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -48,7 +48,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var _ = SIGDescribe("ReplicationController", func() {
@@ -461,7 +461,7 @@ func newRC(rsName string, replicas int32, rcPodLabels map[string]string, imageNa
 			Name: rsName,
 		},
 		Spec: v1.ReplicationControllerSpec{
-			Replicas: pointer.Int32(replicas),
+			Replicas: ptr.To[int32](replicas),
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: rcPodLabels,

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -60,7 +60,6 @@ import (
 	e2estatefulset "k8s.io/kubernetes/test/e2e/framework/statefulset"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -345,7 +344,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: func() *appsv1.RollingUpdateStatefulSetStrategy {
 					return &appsv1.RollingUpdateStatefulSetStrategy{
-						Partition: pointer.Int32(3),
+						Partition: ptr.To[int32](3),
 					}
 				}(),
 			}
@@ -400,7 +399,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: func() *appsv1.RollingUpdateStatefulSetStrategy {
 					return &appsv1.RollingUpdateStatefulSetStrategy{
-						Partition: pointer.Int32(2),
+						Partition: ptr.To[int32](2),
 					}
 				}(),
 			}
@@ -409,7 +408,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					Type: appsv1.RollingUpdateStatefulSetStrategyType,
 					RollingUpdate: func() *appsv1.RollingUpdateStatefulSetStrategy {
 						return &appsv1.RollingUpdateStatefulSetStrategy{
-							Partition: pointer.Int32(2),
+							Partition: ptr.To[int32](2),
 						}
 					}(),
 				}
@@ -2295,7 +2294,7 @@ func deletingPodForRollingUpdatePartitionTest(ctx context.Context, f *framework.
 		Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		RollingUpdate: func() *appsv1.RollingUpdateStatefulSetStrategy {
 			return &appsv1.RollingUpdateStatefulSetStrategy{
-				Partition: pointer.Int32(1),
+				Partition: ptr.To[int32](1),
 			}
 		}(),
 	}

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -84,7 +84,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 	uexec "k8s.io/utils/exec"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -1237,7 +1237,7 @@ metadata:
 					framework.Failf("failed to unmarshal schema: %v", err)
 				}
 				// Allow for arbitrary-extra properties.
-				props.XPreserveUnknownFields = pointer.BoolPtr(true)
+				props.XPreserveUnknownFields = ptr.To(true)
 				for i := range crd.Spec.Versions {
 					crd.Spec.Versions[i].Schema = &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: props}
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./test/e2e/kubectl/kubectl.go
./test/e2e/apps/controller_revision.go
./test/e2e/apps/rc.go
./test/e2e/apps/statefulset.go
./test/e2e/apps/job.go
./test/e2e/apimachinery/webhook.go
./test/e2e/apimachinery/crd_conversion_webhook.go
./test/e2e/apimachinery/aggregator.go
./test/e2e/apimachinery/resource_quota.go
./test/e2e/apimachinery/crd_publish_openapi.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for ./test/e2e.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
