### PR TITLE
Add egress selector support to JWT authenticator

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1849,6 +1849,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA and LockToDefault in 1.34, remove in 1.37
 	},
 
+	genericfeatures.StructuredAuthenticationConfigurationEgressSelector: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	genericfeatures.StructuredAuthorizationConfiguration: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -715,6 +715,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(
 			return err
 		}
 		authenticatorConfig.CustomDial = egressDialer
+		authenticatorConfig.EgressLookup = egressSelector.Lookup
 	}
 
 	// var openAPIV3SecuritySchemes spec3.SecuritySchemes

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -234,6 +234,7 @@ type Issuer struct {
 	CertificateAuthority string
 	Audiences            []string
 	AudienceMatchPolicy  AudienceMatchPolicyType
+	EgressSelectorType   EgressSelectorType
 }
 
 // AudienceMatchPolicyType is a set of valid values for Issuer.AudienceMatchPolicy
@@ -242,6 +243,14 @@ type AudienceMatchPolicyType string
 // Valid types for AudienceMatchPolicyType
 const (
 	AudienceMatchPolicyMatchAny AudienceMatchPolicyType = "MatchAny"
+)
+
+type EgressSelectorType string
+
+const (
+	EgressSelectorControlPlane EgressSelectorType = "controlplane"
+
+	EgressSelectorCluster EgressSelectorType = "cluster"
 )
 
 // ClaimValidationRule provides the configuration for a single claim validation rule.

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
@@ -185,6 +185,18 @@ type Issuer struct {
 	//   example: claimValidationRule[].expression: 'sets.equivalent(claims.aud, ["bar", "foo", "baz"])' to require an exact match.
 	// +optional
 	AudienceMatchPolicy AudienceMatchPolicyType `json:"audienceMatchPolicy,omitempty"`
+
+	// egressSelectorType is an indicator of which egress selection should be used for sending all traffic related
+	// to this issuer (discovery, JWKS, distributed claims, etc).  If unspecified, no custom dialer is used.
+	// When specified, the valid choices are "controlplane" and "cluster".  These correspond to the associated
+	// values in the --egress-selector-config-file.
+	//
+	// - controlplane: for traffic intended to go to the control plane.
+	//
+	// - cluster: for traffic intended to go to the system being managed by Kubernetes.
+	//
+	// +optional
+	EgressSelectorType EgressSelectorType `json:"egressSelectorType,omitempty"`
 }
 
 // AudienceMatchPolicyType is a set of valid values for issuer.audienceMatchPolicy
@@ -194,6 +206,17 @@ type AudienceMatchPolicyType string
 const (
 	// MatchAny means the "aud" claim in the presented JWT must match at least one of the entries in the "audiences" field.
 	AudienceMatchPolicyMatchAny AudienceMatchPolicyType = "MatchAny"
+)
+
+// EgressSelectorType is an indicator of which egress selection should be used for sending traffic.
+type EgressSelectorType string
+
+const (
+	// EgressSelectorControlPlane is the EgressSelectorType for traffic intended to go to the control plane.
+	EgressSelectorControlPlane EgressSelectorType = "controlplane"
+
+	// EgressSelectorCluster is the EgressSelectorType for traffic intended to go to the system being managed by Kubernetes.
+	EgressSelectorCluster EgressSelectorType = "cluster"
 )
 
 // ClaimValidationRule provides the configuration for a single claim validation rule.

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
@@ -682,6 +682,7 @@ func autoConvert_v1_Issuer_To_apiserver_Issuer(in *Issuer, out *apiserver.Issuer
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = apiserver.AudienceMatchPolicyType(in.AudienceMatchPolicy)
+	out.EgressSelectorType = apiserver.EgressSelectorType(in.EgressSelectorType)
 	return nil
 }
 
@@ -698,6 +699,7 @@ func autoConvert_apiserver_Issuer_To_v1_Issuer(in *apiserver.Issuer, out *Issuer
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = AudienceMatchPolicyType(in.AudienceMatchPolicy)
+	out.EgressSelectorType = EgressSelectorType(in.EgressSelectorType)
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -295,6 +295,18 @@ type Issuer struct {
 	//   example: claimValidationRule[].expression: 'sets.equivalent(claims.aud, ["bar", "foo", "baz"])' to require an exact match.
 	// +optional
 	AudienceMatchPolicy AudienceMatchPolicyType `json:"audienceMatchPolicy,omitempty"`
+
+	// egressSelectorType is an indicator of which egress selection should be used for sending all traffic related
+	// to this issuer (discovery, JWKS, distributed claims, etc).  If unspecified, no custom dialer is used.
+	// When specified, the valid choices are "controlplane" and "cluster".  These correspond to the associated
+	// values in the --egress-selector-config-file.
+	//
+	// - controlplane: for traffic intended to go to the control plane.
+	//
+	// - cluster: for traffic intended to go to the system being managed by Kubernetes.
+	//
+	// +optional
+	EgressSelectorType EgressSelectorType `json:"egressSelectorType,omitempty"`
 }
 
 // AudienceMatchPolicyType is a set of valid values for issuer.audienceMatchPolicy
@@ -304,6 +316,17 @@ type AudienceMatchPolicyType string
 const (
 	// MatchAny means the "aud" claim in the presented JWT must match at least one of the entries in the "audiences" field.
 	AudienceMatchPolicyMatchAny AudienceMatchPolicyType = "MatchAny"
+)
+
+// EgressSelectorType is an indicator of which egress selection should be used for sending traffic.
+type EgressSelectorType string
+
+const (
+	// EgressSelectorControlPlane is the EgressSelectorType for traffic intended to go to the control plane.
+	EgressSelectorControlPlane EgressSelectorType = "controlplane"
+
+	// EgressSelectorCluster is the EgressSelectorType for traffic intended to go to the system being managed by Kubernetes.
+	EgressSelectorCluster EgressSelectorType = "cluster"
 )
 
 // ClaimValidationRule provides the configuration for a single claim validation rule.

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -707,6 +707,7 @@ func autoConvert_v1alpha1_Issuer_To_apiserver_Issuer(in *Issuer, out *apiserver.
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = apiserver.AudienceMatchPolicyType(in.AudienceMatchPolicy)
+	out.EgressSelectorType = apiserver.EgressSelectorType(in.EgressSelectorType)
 	return nil
 }
 
@@ -723,6 +724,7 @@ func autoConvert_apiserver_Issuer_To_v1alpha1_Issuer(in *apiserver.Issuer, out *
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = AudienceMatchPolicyType(in.AudienceMatchPolicy)
+	out.EgressSelectorType = EgressSelectorType(in.EgressSelectorType)
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -266,6 +266,18 @@ type Issuer struct {
 	//   example: claimValidationRule[].expression: 'sets.equivalent(claims.aud, ["bar", "foo", "baz"])' to require an exact match.
 	// +optional
 	AudienceMatchPolicy AudienceMatchPolicyType `json:"audienceMatchPolicy,omitempty"`
+
+	// egressSelectorType is an indicator of which egress selection should be used for sending all traffic related
+	// to this issuer (discovery, JWKS, distributed claims, etc).  If unspecified, no custom dialer is used.
+	// When specified, the valid choices are "controlplane" and "cluster".  These correspond to the associated
+	// values in the --egress-selector-config-file.
+	//
+	// - controlplane: for traffic intended to go to the control plane.
+	//
+	// - cluster: for traffic intended to go to the system being managed by Kubernetes.
+	//
+	// +optional
+	EgressSelectorType EgressSelectorType `json:"egressSelectorType,omitempty"`
 }
 
 // AudienceMatchPolicyType is a set of valid values for issuer.audienceMatchPolicy
@@ -275,6 +287,17 @@ type AudienceMatchPolicyType string
 const (
 	// MatchAny means the "aud" claim in the presented JWT must match at least one of the entries in the "audiences" field.
 	AudienceMatchPolicyMatchAny AudienceMatchPolicyType = "MatchAny"
+)
+
+// EgressSelectorType is an indicator of which egress selection should be used for sending traffic.
+type EgressSelectorType string
+
+const (
+	// EgressSelectorControlPlane is the EgressSelectorType for traffic intended to go to the control plane.
+	EgressSelectorControlPlane EgressSelectorType = "controlplane"
+
+	// EgressSelectorCluster is the EgressSelectorType for traffic intended to go to the system being managed by Kubernetes.
+	EgressSelectorCluster EgressSelectorType = "cluster"
 )
 
 // ClaimValidationRule provides the configuration for a single claim validation rule.

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
@@ -643,6 +643,7 @@ func autoConvert_v1beta1_Issuer_To_apiserver_Issuer(in *Issuer, out *apiserver.I
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = apiserver.AudienceMatchPolicyType(in.AudienceMatchPolicy)
+	out.EgressSelectorType = apiserver.EgressSelectorType(in.EgressSelectorType)
 	return nil
 }
 
@@ -659,6 +660,7 @@ func autoConvert_apiserver_Issuer_To_v1beta1_Issuer(in *apiserver.Issuer, out *I
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = AudienceMatchPolicyType(in.AudienceMatchPolicy)
+	out.EgressSelectorType = EgressSelectorType(in.EgressSelectorType)
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -210,6 +210,12 @@ const (
 	// Enables Structured Authentication Configuration
 	StructuredAuthenticationConfiguration featuregate.Feature = "StructuredAuthenticationConfiguration"
 
+	// owner: @aramase, @enj, @nabokihms
+	// kep: https://kep.k8s.io/3331
+	//
+	// Enables Egress Selector in Structured Authentication Configuration
+	StructuredAuthenticationConfigurationEgressSelector featuregate.Feature = "StructuredAuthenticationConfigurationEgressSelector"
+
 	// owner: @palnabarun
 	// kep: https://kep.k8s.io/3221
 	//
@@ -403,6 +409,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA and LockToDefault in 1.34, remove in 1.37
+	},
+
+	StructuredAuthenticationConfigurationEgressSelector: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	StructuredAuthorizationConfiguration: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1573,6 +1573,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.34"
+- name: StructuredAuthenticationConfigurationEgressSelector
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: StructuredAuthorizationConfiguration
   versionedSpecs:
   - default: false

--- a/test/integration/apiserver/oidc/egress_test.go
+++ b/test/integration/apiserver/oidc/egress_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func runEgressProxy(t testing.TB, udsName string, ready chan<- struct{}) {
+	t.Helper()
+
+	l, err := net.Listen("unix", udsName)
+	if err != nil {
+		t.Errorf("unexpected UDS error: %v", err)
+		return
+	}
+
+	var called atomic.Bool
+	httpConnectProxy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ready" {
+			t.Log("egress proxy ready")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		called.Store(true)
+
+		if r.Method != http.MethodConnect {
+			http.Error(w, "this proxy only supports CONNECT passthrough", http.StatusMethodNotAllowed)
+			return
+		}
+
+		backendConn, err := (&net.Dialer{}).DialContext(r.Context(), "tcp", r.Host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = backendConn.Close() }()
+
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+			return
+		}
+
+		requestHijackedConn, _, err := hijacker.Hijack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = requestHijackedConn.Close() }()
+
+		// use t.Errorf for all errors after this Write since the client may think the connection is good
+		_, err = requestHijackedConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+		if err != nil {
+			t.Errorf("unexpected established error: %v", err)
+			return
+		}
+
+		writerComplete := make(chan struct{})
+		readerComplete := make(chan struct{})
+
+		go func() {
+			_, err := io.Copy(backendConn, requestHijackedConn)
+			if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+				t.Errorf("unexpected writer error: %v", err)
+			}
+			close(writerComplete)
+		}()
+
+		go func() {
+			_, err := io.Copy(requestHijackedConn, backendConn)
+			if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+				t.Errorf("unexpected reader error: %v", err)
+			}
+			close(readerComplete)
+		}()
+
+		// Wait for one half the connection to exit. Once it does,
+		// the defer will clean up the other half of the connection.
+		select {
+		case <-writerComplete:
+		case <-readerComplete:
+		}
+	})
+
+	server := http.Server{Handler: httpConnectProxy}
+
+	t.Cleanup(func() {
+		if !called.Load() {
+			t.Errorf("egress proxy was not called")
+		}
+
+		err := server.Shutdown(context.Background())
+		t.Logf("shutdown exit error: %v", err)
+	})
+
+	var once sync.Once
+	readyCheckClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", udsName)
+			},
+		},
+	}
+	go func() {
+		if err := wait.PollUntilContextCancel(t.Context(), time.Second, false, func(ctx context.Context) (bool, error) {
+			resp, err := readyCheckClient.Get("http://host.does.not.matter/ready")
+			if err != nil {
+				t.Logf("egress proxy error: %v", err)
+				return false, nil
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Logf("egress proxy unexpected status code: %v", resp.StatusCode)
+				return false, nil
+			}
+			once.Do(func() { close(ready) })
+			return true, nil
+		}); err != nil {
+			t.Errorf("egress proxy is not ready: %v", err)
+		}
+	}()
+
+	err = server.Serve(l)
+	t.Logf("egress exit error: %v", err)
+}


### PR DESCRIPTION
This change adds the `StructuredAuthenticationConfigurationEgressSelector` beta feature (default on).  When enabled, each JWT authenticator specified via the `AuthenticationConfiguration.jwt` array can optionally specify either the `controlplane` or `cluster` egress selector by setting the `issuer.egressSelectorType` field.  When unset, the prior behavior of using no egress selector is retained.

Egress selection is valuable when the persona configuring the JWT authenticator and the persona managing the control plane are different individuals.  This change allows the latter to protect control plane network services from unexpected connections.

/kind feature
/kind api-change
/assign aramase liggitt
/milestone v1.34

```release-note
JWT authenticators specified via the `AuthenticationConfiguration.jwt` array can now optionally specify either the `controlplane` or `cluster` egress selector by setting the `issuer.egressSelectorType` field.  When unset, the prior behavior of using no egress selector is retained.  The StructuredAuthenticationConfigurationEgressSelector beta feature (default on) must be enabled to use this functionality.
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3331
```