### PR TITLE
Fix help for set selector

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
@@ -74,7 +74,7 @@ var (
 	selectorExample = templates.Examples(`
         # Set the labels and selector before creating a deployment/service pair
         kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run=client | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
-        kubectl create deployment my-dep -o yaml --dry-run=client | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -`)
+        kubectl create deployment my-dep --image=nginx -o yaml --dry-run=client | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -`)
 )
 
 // NewSelectorOptions returns an initialized SelectorOptions instance


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The example in the help for `kubectl set selector` does not work:
```bash
$ kubectl set selector --help 
...
Examples:
  # Set the labels and selector before creating a deployment/service pair
  kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run=client | kubectl set selector --local -f
- 'environment=qa' -o yaml | kubectl create -f -
  kubectl create deployment my-dep -o yaml --dry-run=client | kubectl label --local -f - environment=qa -o yaml |
kubectl create -f -

$ kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run=client | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
service/my-svc created
$ kubectl create deployment my-dep -o yaml --dry-run=client | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -
error: required flag(s) "image" not set
error: no objects passed to create
```
The example is fixed as part of this PR.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
The minimal fix for the problem would be to set the `--image` flag for the creation of the deployment:
```bash
kubectl create deployment my-dep --image=nginx -o yaml --dry-run=client | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -
```
But I also exchanged the `create deployment` with `run`. This works fine as well but reduces the complexity of the second command a lot and would put more emphasis on the actual `set selector` command. But if that change might be too much, I could alter the PR to only add the `--image` flag.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
