### PR TITLE
chore: depr. pointer pkg replacement for pkg/apis (1/2)

### DIFF
--- a/pkg/apis/apiserverinternal/validation/validation_test.go
+++ b/pkg/apis/apiserverinternal/validation/validation_test.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/apiserverinternal"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateServerStorageVersion(t *testing.T) {
@@ -209,7 +209,7 @@ func TestValidateStorageVersionStatus(t *testing.T) {
 				EncodingVersion:   "v1alpha1",
 				DecodableVersions: []string{"v1alpha1", "v1"},
 			}},
-			CommonEncodingVersion: pointer.String("v1alpha1"),
+			CommonEncodingVersion: ptr.To("v1alpha1"),
 		},
 		expectedErr: "",
 	}, {
@@ -223,7 +223,7 @@ func TestValidateStorageVersionStatus(t *testing.T) {
 				EncodingVersion:   "v1beta1",
 				DecodableVersions: []string{"v1alpha1", "v1"},
 			}},
-			CommonEncodingVersion: pointer.String("v1alpha1"),
+			CommonEncodingVersion: ptr.To("v1alpha1"),
 		},
 		expectedErr: "storageVersions[1].apiServerID: Duplicate value: \"1\"",
 	}}

--- a/pkg/apis/core/v1/conversion_test.go
+++ b/pkg/apis/core/v1/conversion_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 	corefuzzer "k8s.io/kubernetes/pkg/apis/core/fuzzer"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	// ensure types are installed
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
@@ -252,7 +252,7 @@ func TestReplicationControllerConversion(t *testing.T) {
 				Namespace: "namespace",
 			},
 			Spec: v1.ReplicationControllerSpec{
-				Replicas:        utilpointer.Int32(1),
+				Replicas:        ptr.To[int32](1),
 				MinReadySeconds: 32,
 				Selector:        map[string]string{"foo": "bar", "bar": "foo"},
 				Template: &v1.PodTemplateSpec{
@@ -726,14 +726,14 @@ func TestConvert_v1_Pod_To_core_Pod(t *testing.T) {
 			args: args{
 				in: &v1.Pod{
 					Spec: v1.PodSpec{
-						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+						TerminationGracePeriodSeconds: ptr.To[int64](-1),
 					},
 				},
 				out: &core.Pod{},
 			},
 			wantOut: &core.Pod{
 				Spec: core.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64(1),
+					TerminationGracePeriodSeconds: ptr.To[int64](1),
 					SecurityContext:               &core.PodSecurityContext{},
 				},
 			},
@@ -766,14 +766,14 @@ func TestConvert_core_Pod_To_v1_Pod(t *testing.T) {
 			args: args{
 				in: &core.Pod{
 					Spec: core.PodSpec{
-						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+						TerminationGracePeriodSeconds: ptr.To[int64](-1),
 					},
 				},
 				out: &v1.Pod{},
 			},
 			wantOut: &v1.Pod{
 				Spec: v1.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64(1),
+					TerminationGracePeriodSeconds: ptr.To[int64](1),
 				},
 			},
 		},

--- a/pkg/apis/flowcontrol/v1beta1/defaults_test.go
+++ b/pkg/apis/flowcontrol/v1beta1/defaults_test.go
@@ -24,7 +24,7 @@ import (
 
 	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
@@ -45,8 +45,8 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 				Spec: flowcontrolv1beta1.PriorityLevelConfigurationSpec{
 					Type: flowcontrolv1beta1.PriorityLevelEnablementExempt,
 					Exempt: &flowcontrolv1beta1.ExemptPriorityLevelConfiguration{
-						NominalConcurrencyShares: pointer.Int32(0),
-						LendablePercent:          pointer.Int32(0),
+						NominalConcurrencyShares: ptr.To[int32](0),
+						LendablePercent:          ptr.To[int32](0),
 					},
 				},
 			},
@@ -69,7 +69,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta1.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta1.LimitedPriorityLevelConfiguration{
 						AssuredConcurrencyShares: 5,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta1.LimitResponse{
 							Type: flowcontrolv1beta1.LimitResponseTypeReject,
 						},

--- a/pkg/apis/flowcontrol/v1beta2/defaults_test.go
+++ b/pkg/apis/flowcontrol/v1beta2/defaults_test.go
@@ -24,7 +24,7 @@ import (
 
 	flowcontrolv1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
@@ -45,8 +45,8 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 				Spec: flowcontrolv1beta2.PriorityLevelConfigurationSpec{
 					Type: flowcontrolv1beta2.PriorityLevelEnablementExempt,
 					Exempt: &flowcontrolv1beta2.ExemptPriorityLevelConfiguration{
-						NominalConcurrencyShares: pointer.Int32(0),
-						LendablePercent:          pointer.Int32(0),
+						NominalConcurrencyShares: ptr.To[int32](0),
+						LendablePercent:          ptr.To[int32](0),
 					},
 				},
 			},
@@ -69,7 +69,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta2.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta2.LimitedPriorityLevelConfiguration{
 						AssuredConcurrencyShares: 5,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta2.LimitResponse{
 							Type: flowcontrolv1beta2.LimitResponseTypeReject,
 						},

--- a/pkg/apis/flowcontrol/v1beta3/defaults_test.go
+++ b/pkg/apis/flowcontrol/v1beta3/defaults_test.go
@@ -25,7 +25,7 @@ import (
 	flowcontrolv1beta3 "k8s.io/api/flowcontrol/v1beta3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
@@ -46,8 +46,8 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 				Spec: flowcontrolv1beta3.PriorityLevelConfigurationSpec{
 					Type: flowcontrolv1beta3.PriorityLevelEnablementExempt,
 					Exempt: &flowcontrolv1beta3.ExemptPriorityLevelConfiguration{
-						NominalConcurrencyShares: pointer.Int32(0),
-						LendablePercent:          pointer.Int32(0),
+						NominalConcurrencyShares: ptr.To[int32](0),
+						LendablePercent:          ptr.To[int32](0),
 					},
 				},
 			},
@@ -70,7 +70,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta3.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta3.LimitedPriorityLevelConfiguration{
 						NominalConcurrencyShares: 5,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta3.LimitResponse{
 							Type: flowcontrolv1beta3.LimitResponseTypeReject,
 						},
@@ -97,7 +97,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta3.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta3.LimitedPriorityLevelConfiguration{
 						NominalConcurrencyShares: 5,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta3.LimitResponse{
 							Type: flowcontrolv1beta3.LimitResponseTypeQueue,
 							Queuing: &flowcontrolv1beta3.QueuingConfiguration{
@@ -128,7 +128,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta3.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta3.LimitedPriorityLevelConfiguration{
 						NominalConcurrencyShares: PriorityLevelConfigurationDefaultNominalConcurrencyShares,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta3.LimitResponse{
 							Type: flowcontrolv1beta3.LimitResponseTypeReject,
 						},
@@ -164,7 +164,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta3.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta3.LimitedPriorityLevelConfiguration{
 						NominalConcurrencyShares: 0,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta3.LimitResponse{
 							Type: flowcontrolv1beta3.LimitResponseTypeReject,
 						},
@@ -200,7 +200,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta3.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta3.LimitedPriorityLevelConfiguration{
 						NominalConcurrencyShares: 0,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta3.LimitResponse{
 							Type: flowcontrolv1beta3.LimitResponseTypeReject,
 						},
@@ -236,7 +236,7 @@ func TestDefaultWithPriorityLevelConfiguration(t *testing.T) {
 					Type: flowcontrolv1beta3.PriorityLevelEnablementLimited,
 					Limited: &flowcontrolv1beta3.LimitedPriorityLevelConfiguration{
 						NominalConcurrencyShares: 1,
-						LendablePercent:          pointer.Int32(0),
+						LendablePercent:          ptr.To[int32](0),
 						LimitResponse: flowcontrolv1beta3.LimitResponse{
 							Type: flowcontrolv1beta3.LimitResponseTypeReject,
 						},

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol/internalbootstrap"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestFlowSchemaValidation(t *testing.T) {
@@ -746,15 +746,15 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 	badExemptSpec1 := flowcontrol.PriorityLevelConfigurationSpec{
 		Type: flowcontrol.PriorityLevelEnablementExempt,
 		Exempt: &flowcontrol.ExemptPriorityLevelConfiguration{
-			NominalConcurrencyShares: pointer.Int32(-1),
-			LendablePercent:          pointer.Int32(101),
+			NominalConcurrencyShares: ptr.To[int32](-1),
+			LendablePercent:          ptr.To[int32](101),
 		},
 	}
 	badExemptSpec2 := flowcontrol.PriorityLevelConfigurationSpec{
 		Type: flowcontrol.PriorityLevelEnablementExempt,
 		Exempt: &flowcontrol.ExemptPriorityLevelConfiguration{
-			NominalConcurrencyShares: pointer.Int32(-1),
-			LendablePercent:          pointer.Int32(-1),
+			NominalConcurrencyShares: ptr.To[int32](-1),
+			LendablePercent:          ptr.To[int32](-1),
 		},
 	}
 
@@ -773,8 +773,8 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 		return flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementExempt,
 			Exempt: &flowcontrol.ExemptPriorityLevelConfiguration{
-				NominalConcurrencyShares: pointer.Int32(*have.Spec.Exempt.NominalConcurrencyShares + 10),
-				LendablePercent:          pointer.Int32(*have.Spec.Exempt.LendablePercent + 10),
+				NominalConcurrencyShares: ptr.To[int32](*have.Spec.Exempt.NominalConcurrencyShares + 10),
+				LendablePercent:          ptr.To[int32](*have.Spec.Exempt.LendablePercent + 10),
 			},
 		}
 	}
@@ -809,8 +809,8 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 			Spec: flowcontrol.PriorityLevelConfigurationSpec{
 				Type: flowcontrol.PriorityLevelEnablementExempt,
 				Exempt: &flowcontrol.ExemptPriorityLevelConfiguration{
-					NominalConcurrencyShares: pointer.Int32(0),
-					LendablePercent:          pointer.Int32(0),
+					NominalConcurrencyShares: ptr.To[int32](0),
+					LendablePercent:          ptr.To[int32](0),
 				},
 			},
 		},
@@ -960,7 +960,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 				Type: flowcontrol.PriorityLevelEnablementLimited,
 				Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
 					NominalConcurrencyShares: 5,
-					LendablePercent:          pointer.Int32(0),
+					LendablePercent:          ptr.To[int32](0),
 					LimitResponse: flowcontrol.LimitResponse{
 						Type: flowcontrol.LimitResponseTypeReject,
 					}}},
@@ -1378,31 +1378,31 @@ func TestValidateLimitedPriorityLevelConfigurationWithBorrowing(t *testing.T) {
 		lendablePercent: nil,
 		errExpected:     nil,
 	}, {
-		lendablePercent: pointer.Int32(0),
+		lendablePercent: ptr.To[int32](0),
 		errExpected:     nil,
 	}, {
-		lendablePercent: pointer.Int32(100),
+		lendablePercent: ptr.To[int32](100),
 		errExpected:     nil,
 	}, {
-		lendablePercent: pointer.Int32(101),
+		lendablePercent: ptr.To[int32](101),
 		errExpected:     errLendablePercentFn(101),
 	}, {
-		lendablePercent: pointer.Int32(-1),
+		lendablePercent: ptr.To[int32](-1),
 		errExpected:     errLendablePercentFn(-1),
 	}, {
 		borrowingLimitPercent: nil,
 		errExpected:           nil,
 	}, {
-		borrowingLimitPercent: pointer.Int32(1),
+		borrowingLimitPercent: ptr.To[int32](1),
 		errExpected:           nil,
 	}, {
-		borrowingLimitPercent: pointer.Int32(100),
+		borrowingLimitPercent: ptr.To[int32](100),
 		errExpected:           nil,
 	}, {
-		borrowingLimitPercent: pointer.Int32(0),
+		borrowingLimitPercent: ptr.To[int32](0),
 		errExpected:           nil,
 	}, {
-		borrowingLimitPercent: pointer.Int32(-1),
+		borrowingLimitPercent: ptr.To[int32](-1),
 		errExpected:           errBorrowingLimitPercentFn(-1),
 	}}
 

--- a/pkg/apis/networking/fuzzer/fuzzer.go
+++ b/pkg/apis/networking/fuzzer/fuzzer.go
@@ -22,7 +22,7 @@ import (
 
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/apis/networking"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/randfill"
 )
 
@@ -73,7 +73,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			// default Parameters to Cluster
 			if p.Spec.Parameters == nil || p.Spec.Parameters.Scope == nil {
 				p.Spec.Parameters = &networking.IngressClassParametersReference{
-					Scope: utilpointer.String(networking.IngressClassParametersReferenceScopeCluster),
+					Scope: ptr.To(networking.IngressClassParametersReferenceScopeCluster),
 				}
 			}
 		},

--- a/pkg/apis/networking/v1/defaults.go
+++ b/pkg/apis/networking/v1/defaults.go
@@ -20,7 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -47,6 +47,6 @@ func SetDefaults_NetworkPolicy(obj *networkingv1.NetworkPolicy) {
 
 func SetDefaults_IngressClass(obj *networkingv1.IngressClass) {
 	if obj.Spec.Parameters != nil && obj.Spec.Parameters.Scope == nil {
-		obj.Spec.Parameters.Scope = utilpointer.String(networkingv1.IngressClassParametersReferenceScopeCluster)
+		obj.Spec.Parameters.Scope = ptr.To(networkingv1.IngressClassParametersReferenceScopeCluster)
 	}
 }

--- a/pkg/apis/networking/v1/defaults_test.go
+++ b/pkg/apis/networking/v1/defaults_test.go
@@ -28,7 +28,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	_ "k8s.io/kubernetes/pkg/apis/networking/install"
 	. "k8s.io/kubernetes/pkg/apis/networking/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultNetworkPolicy(t *testing.T) {
@@ -258,7 +258,7 @@ func TestSetDefaultsForIngressClassParametersReference(t *testing.T) {
 					Parameters: &networkingv1.IngressClassParametersReference{
 						Kind:  "k",
 						Name:  "n",
-						Scope: utilpointer.String(networkingv1.IngressClassParametersReferenceScopeCluster),
+						Scope: ptr.To(networkingv1.IngressClassParametersReferenceScopeCluster),
 					},
 				},
 			},
@@ -271,8 +271,8 @@ func TestSetDefaultsForIngressClassParametersReference(t *testing.T) {
 					Parameters: &networkingv1.IngressClassParametersReference{
 						Kind:      "k",
 						Name:      "n",
-						Scope:     utilpointer.String(networkingv1.IngressClassParametersReferenceScopeNamespace),
-						Namespace: utilpointer.String("foo-ns"),
+						Scope:     ptr.To(networkingv1.IngressClassParametersReferenceScopeNamespace),
+						Namespace: ptr.To("foo-ns"),
 					},
 				},
 			},
@@ -282,8 +282,8 @@ func TestSetDefaultsForIngressClassParametersReference(t *testing.T) {
 					Parameters: &networkingv1.IngressClassParametersReference{
 						Kind:      "k",
 						Name:      "n",
-						Scope:     utilpointer.String(networkingv1.IngressClassParametersReferenceScopeNamespace),
-						Namespace: utilpointer.String("foo-ns"),
+						Scope:     ptr.To(networkingv1.IngressClassParametersReferenceScopeNamespace),
+						Namespace: ptr.To("foo-ns"),
 					},
 				},
 			},

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -30,7 +30,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func makeValidNetworkPolicy() *networking.NetworkPolicy {
@@ -63,7 +63,7 @@ func makePort(proto *api.Protocol, port intstr.IntOrString, endPort int32) netwo
 		r.Port = &port
 	}
 	if endPort != 0 {
-		r.EndPort = utilpointer.Int32(endPort)
+		r.EndPort = ptr.To[int32](endPort)
 	}
 	return r
 }
@@ -778,7 +778,7 @@ func TestValidateIngress(t *testing.T) {
 							Backend: networking.IngressBackend{
 								Service: serviceNameBackend,
 								Resource: &api.TypedLocalObjectReference{
-									APIGroup: utilpointer.String("example.com"),
+									APIGroup: ptr.To("example.com"),
 									Kind:     "foo",
 									Name:     "bar",
 								},
@@ -801,7 +801,7 @@ func TestValidateIngress(t *testing.T) {
 							Backend: networking.IngressBackend{
 								Service: servicePortBackend,
 								Resource: &api.TypedLocalObjectReference{
-									APIGroup: utilpointer.String("example.com"),
+									APIGroup: ptr.To("example.com"),
 									Kind:     "foo",
 									Name:     "bar",
 								},
@@ -819,7 +819,7 @@ func TestValidateIngress(t *testing.T) {
 				ing.Spec.DefaultBackend = &networking.IngressBackend{
 					Service: serviceNameBackend,
 					Resource: &api.TypedLocalObjectReference{
-						APIGroup: utilpointer.String("example.com"),
+						APIGroup: ptr.To("example.com"),
 						Kind:     "foo",
 						Name:     "bar",
 					},
@@ -834,7 +834,7 @@ func TestValidateIngress(t *testing.T) {
 				ing.Spec.DefaultBackend = &networking.IngressBackend{
 					Service: servicePortBackend,
 					Resource: &api.TypedLocalObjectReference{
-						APIGroup: utilpointer.String("example.com"),
+						APIGroup: ptr.To("example.com"),
 						Kind:     "foo",
 						Name:     "bar",
 					},
@@ -999,7 +999,7 @@ func TestValidateIngressCreate(t *testing.T) {
 		Service: serviceBackend,
 	}
 	resourceBackend := &api.TypedLocalObjectReference{
-		APIGroup: utilpointer.String("example.com"),
+		APIGroup: ptr.To("example.com"),
 		Kind:     "foo",
 		Name:     "bar",
 	}
@@ -1021,7 +1021,7 @@ func TestValidateIngressCreate(t *testing.T) {
 	}{
 		"class field set": {
 			tweakIngress: func(ingress *networking.Ingress) {
-				ingress.Spec.IngressClassName = utilpointer.String("bar")
+				ingress.Spec.IngressClassName = ptr.To("bar")
 			},
 			expectedErrs: field.ErrorList{},
 		},
@@ -1033,14 +1033,14 @@ func TestValidateIngressCreate(t *testing.T) {
 		},
 		"class field and annotation set with same value": {
 			tweakIngress: func(ingress *networking.Ingress) {
-				ingress.Spec.IngressClassName = utilpointer.String("foo")
+				ingress.Spec.IngressClassName = ptr.To("foo")
 				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
 			expectedErrs: field.ErrorList{},
 		},
 		"class field and annotation set with different value": {
 			tweakIngress: func(ingress *networking.Ingress) {
-				ingress.Spec.IngressClassName = utilpointer.String("bar")
+				ingress.Spec.IngressClassName = ptr.To("bar")
 				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("annotations").Child(annotationIngressClass), "foo", "must match `ingressClassName` when both are specified")},
@@ -1183,7 +1183,7 @@ func TestValidateIngressUpdate(t *testing.T) {
 		Service: serviceBackend,
 	}
 	resourceBackend := &api.TypedLocalObjectReference{
-		APIGroup: utilpointer.String("example.com"),
+		APIGroup: ptr.To("example.com"),
 		Kind:     "foo",
 		Name:     "bar",
 	}
@@ -1204,7 +1204,7 @@ func TestValidateIngressUpdate(t *testing.T) {
 	}{
 		"class field set": {
 			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
-				newIngress.Spec.IngressClassName = utilpointer.String("bar")
+				newIngress.Spec.IngressClassName = ptr.To("bar")
 			},
 			expectedErrs: field.ErrorList{},
 		},
@@ -1216,7 +1216,7 @@ func TestValidateIngressUpdate(t *testing.T) {
 		},
 		"class field and annotation set": {
 			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
-				newIngress.Spec.IngressClassName = utilpointer.String("bar")
+				newIngress.Spec.IngressClassName = ptr.To("bar")
 				newIngress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
 			expectedErrs: field.ErrorList{},
@@ -1640,44 +1640,44 @@ func TestValidateIngressClass(t *testing.T) {
 		},
 		"valid name, valid controller, valid params": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(utilpointer.String("example.com"), "foo", "bar", utilpointer.String("Cluster"), nil)),
+				setParams(makeIngressClassParams(ptr.To("example.com"), "foo", "bar", ptr.To("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{},
 		},
 		"valid name, valid controller, invalid params (no kind)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(utilpointer.String("example.com"), "", "bar", utilpointer.String("Cluster"), nil)),
+				setParams(makeIngressClassParams(ptr.To("example.com"), "", "bar", ptr.To("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.kind"), "")},
 		},
 		"valid name, valid controller, invalid params (no name)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(utilpointer.String("example.com"), "foo", "", utilpointer.String("Cluster"), nil)),
+				setParams(makeIngressClassParams(ptr.To("example.com"), "foo", "", ptr.To("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.name"), "")},
 		},
 		"valid name, valid controller, invalid params (bad kind)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo/", "bar", utilpointer.String("Cluster"), nil)),
+				setParams(makeIngressClassParams(nil, "foo/", "bar", ptr.To("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec.parameters.kind"), "foo/", "may not contain '/'")},
 		},
 		"valid name, valid controller, invalid params (bad scope)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("bad-scope"), nil)),
+				setParams(makeIngressClassParams(nil, "foo", "bar", ptr.To("bad-scope"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.NotSupported(field.NewPath("spec.parameters.scope"),
 				"bad-scope", []string{"Cluster", "Namespace"})},
 		},
 		"valid name, valid controller, valid Namespace scope": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Namespace"), utilpointer.String("foo-ns"))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", ptr.To("Namespace"), ptr.To("foo-ns"))),
 			),
 			expectedErrs: field.ErrorList{},
 		},
 		"valid name, valid controller, valid scope, invalid namespace": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Namespace"), utilpointer.String("foo_ns"))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", ptr.To("Namespace"), ptr.To("foo_ns"))),
 			),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec.parameters.namespace"), "foo_ns",
 				"a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',"+
@@ -1686,13 +1686,13 @@ func TestValidateIngressClass(t *testing.T) {
 		},
 		"valid name, valid controller, valid Cluster scope": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Cluster"), nil)),
+				setParams(makeIngressClassParams(nil, "foo", "bar", ptr.To("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{},
 		},
 		"valid name, valid controller, invalid scope": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", nil, utilpointer.String("foo_ns"))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", nil, ptr.To("foo_ns"))),
 			),
 			expectedErrs: field.ErrorList{
 				field.Required(field.NewPath("spec.parameters.scope"), ""),
@@ -1700,21 +1700,21 @@ func TestValidateIngressClass(t *testing.T) {
 		},
 		"namespace not set when scope is Namespace": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Namespace"), nil)),
+				setParams(makeIngressClassParams(nil, "foo", "bar", ptr.To("Namespace"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.namespace"),
 				"`parameters.scope` is set to 'Namespace'")},
 		},
 		"namespace is forbidden when scope is Cluster": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Cluster"), utilpointer.String("foo-ns"))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", ptr.To("Cluster"), ptr.To("foo-ns"))),
 			),
 			expectedErrs: field.ErrorList{field.Forbidden(field.NewPath("spec.parameters.namespace"),
 				"`parameters.scope` is set to 'Cluster'")},
 		},
 		"empty namespace is forbidden when scope is Cluster": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Cluster"), utilpointer.String(""))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", ptr.To("Cluster"), ptr.To(""))),
 			),
 			expectedErrs: field.ErrorList{field.Forbidden(field.NewPath("spec.parameters.namespace"),
 				"`parameters.scope` is set to 'Cluster'")},
@@ -1765,7 +1765,7 @@ func TestValidateIngressClassUpdate(t *testing.T) {
 			newIngressClass: makeValidIngressClass("test123", "foo.co/bar",
 				setResourceVersion("2"),
 				setParams(
-					makeIngressClassParams(utilpointer.String("v1"), "ConfigMap", "foo", utilpointer.String("Namespace"), utilpointer.String("bar")),
+					makeIngressClassParams(ptr.To("v1"), "ConfigMap", "foo", ptr.To("Namespace"), ptr.To("bar")),
 				),
 			),
 			oldIngressClass: makeValidIngressClass("test123", "foo.co/bar"),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./pkg/apis/apiserverinternal/validation/validation_test.go
./pkg/apis/flowcontrol/v1beta3/defaults_test.go
./pkg/apis/flowcontrol/v1beta2/defaults_test.go
./pkg/apis/flowcontrol/v1beta1/defaults_test.go
./pkg/apis/flowcontrol/validation/validation_test.go
./pkg/apis/core/v1/conversion_test.go
./pkg/apis/networking/v1/defaults_test.go
./pkg/apis/networking/v1/defaults.go
./pkg/apis/networking/fuzzer/fuzzer.go
./pkg/apis/networking/validation/validation_test.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for pkg/apis (1/2).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
