### PR TITLE
chore: depr. pointer pkg replacement for pkg/apis (2/2)

### DIFF
--- a/pkg/apis/batch/fuzzer/fuzzer.go
+++ b/pkg/apis/batch/fuzzer/fuzzer.go
@@ -22,7 +22,7 @@ import (
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/randfill"
 )
 
@@ -45,20 +45,20 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			j.Completions = &completions
 			j.Parallelism = &parallelism
 			j.BackoffLimit = &backoffLimit
-			j.ManualSelector = pointer.Bool(c.Bool())
+			j.ManualSelector = ptr.To(c.Bool())
 			mode := batch.NonIndexedCompletion
 			if c.Bool() {
 				mode = batch.IndexedCompletion
-				j.BackoffLimitPerIndex = pointer.Int32(c.Rand.Int31())
-				j.MaxFailedIndexes = pointer.Int32(c.Rand.Int31())
+				j.BackoffLimitPerIndex = ptr.To[int32](c.Int31())
+				j.MaxFailedIndexes = ptr.To[int32](c.Int31())
 			}
 			if c.Bool() {
-				j.BackoffLimit = pointer.Int32(math.MaxInt32)
+				j.BackoffLimit = ptr.To[int32](math.MaxInt32)
 			}
 			j.CompletionMode = &mode
 			// We're fuzzing the internal JobSpec type, not the v1 type, so we don't
 			// need to fuzz the nil value.
-			j.Suspend = pointer.Bool(c.Bool())
+			j.Suspend = ptr.To(c.Bool())
 			podReplacementPolicy := batch.TerminatingOrFailed
 			if c.Bool() {
 				podReplacementPolicy = batch.Failed

--- a/pkg/apis/batch/v1beta1/defaults_test.go
+++ b/pkg/apis/batch/v1beta1/defaults_test.go
@@ -27,7 +27,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	. "k8s.io/kubernetes/pkg/apis/batch/v1beta1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultCronJob(t *testing.T) {
@@ -41,8 +41,8 @@ func TestSetDefaultCronJob(t *testing.T) {
 				Spec: batchv1beta1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1beta1.AllowConcurrent,
 					Suspend:                    newBool(false),
-					SuccessfulJobsHistoryLimit: utilpointer.Int32(3),
-					FailedJobsHistoryLimit:     utilpointer.Int32(1),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](3),
+					FailedJobsHistoryLimit:     ptr.To[int32](1),
 				},
 			},
 		},
@@ -51,16 +51,16 @@ func TestSetDefaultCronJob(t *testing.T) {
 				Spec: batchv1beta1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
 					Suspend:                    newBool(true),
-					SuccessfulJobsHistoryLimit: utilpointer.Int32(5),
-					FailedJobsHistoryLimit:     utilpointer.Int32(5),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](5),
+					FailedJobsHistoryLimit:     ptr.To[int32](5),
 				},
 			},
 			expected: &batchv1beta1.CronJob{
 				Spec: batchv1beta1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
 					Suspend:                    newBool(true),
-					SuccessfulJobsHistoryLimit: utilpointer.Int32(5),
-					FailedJobsHistoryLimit:     utilpointer.Int32(5),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](5),
+					FailedJobsHistoryLimit:     ptr.To[int32](5),
 				},
 			},
 		},

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/util/certificate/csr"
 	capi "k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -270,7 +270,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 					Usages:            validUsages,
 					Request:           newCSRPEM(t),
 					SignerName:        validSignerName,
-					ExpirationSeconds: pointer.Int32(-1),
+					ExpirationSeconds: ptr.To[int32](-1),
 				},
 			},
 			errs: field.ErrorList{
@@ -284,7 +284,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 					Usages:            validUsages,
 					Request:           newCSRPEM(t),
 					SignerName:        validSignerName,
-					ExpirationSeconds: pointer.Int32(0),
+					ExpirationSeconds: ptr.To[int32](0),
 				},
 			},
 			errs: field.ErrorList{
@@ -298,7 +298,7 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 					Usages:            validUsages,
 					Request:           newCSRPEM(t),
 					SignerName:        validSignerName,
-					ExpirationSeconds: pointer.Int32(1),
+					ExpirationSeconds: ptr.To[int32](1),
 				},
 			},
 			errs: field.ErrorList{

--- a/pkg/apis/discovery/v1/defaults_test.go
+++ b/pkg/apis/discovery/v1/defaults_test.go
@@ -25,7 +25,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/discovery/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultEndpointPort(t *testing.T) {
@@ -40,13 +40,13 @@ func TestSetDefaultEndpointPort(t *testing.T) {
 	}{
 		"should set appropriate defaults": {
 			original: &discovery.EndpointSlice{Ports: []discovery.EndpointPort{{
-				Port: utilpointer.Int32(80),
+				Port: ptr.To[int32](80),
 			}}},
 			expected: &discovery.EndpointSlice{
 				Ports: []discovery.EndpointPort{{
 					Name:     &emptyStr,
 					Protocol: &protoTCP,
-					Port:     utilpointer.Int32(80),
+					Port:     ptr.To[int32](80),
 				}},
 			},
 		},

--- a/pkg/apis/discovery/v1beta1/conversion_test.go
+++ b/pkg/apis/discovery/v1beta1/conversion_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/discovery/v1beta1"
 	"k8s.io/kubernetes/pkg/apis/discovery"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestEndpointZoneConverstion(t *testing.T) {
@@ -63,7 +63,7 @@ func TestEndpointZoneConverstion(t *testing.T) {
 				DeprecatedTopology: map[string]string{
 					"key1": "val1",
 				},
-				Zone: utilpointer.String("zone1"),
+				Zone: ptr.To("zone1"),
 			},
 		},
 		{
@@ -74,19 +74,19 @@ func TestEndpointZoneConverstion(t *testing.T) {
 				},
 			},
 			internal: discovery.Endpoint{
-				Zone: utilpointer.String("zone1"),
+				Zone: ptr.To("zone1"),
 			},
 		},
 		{
 			desc: "nodeName and topology[hostname] are populated with different values",
 			external: v1beta1.Endpoint{
-				NodeName: utilpointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				Topology: map[string]string{
 					corev1.LabelHostname: "node-2",
 				},
 			},
 			internal: discovery.Endpoint{
-				NodeName: utilpointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				DeprecatedTopology: map[string]string{
 					corev1.LabelHostname: "node-2",
 				},
@@ -95,13 +95,13 @@ func TestEndpointZoneConverstion(t *testing.T) {
 		{
 			desc: "nodeName and topology[hostname] are populated with same values",
 			external: v1beta1.Endpoint{
-				NodeName: utilpointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				Topology: map[string]string{
 					corev1.LabelHostname: "node-1",
 				},
 			},
 			internal: discovery.Endpoint{
-				NodeName: utilpointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			},
 		},
 		{
@@ -120,13 +120,13 @@ func TestEndpointZoneConverstion(t *testing.T) {
 		{
 			desc: "only nodeName is populated",
 			external: v1beta1.Endpoint{
-				NodeName: utilpointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 				Topology: map[string]string{
 					corev1.LabelHostname: "node-1",
 				},
 			},
 			internal: discovery.Endpoint{
-				NodeName: utilpointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			},
 		},
 	}

--- a/pkg/apis/discovery/v1beta1/defaults_test.go
+++ b/pkg/apis/discovery/v1beta1/defaults_test.go
@@ -25,7 +25,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/discovery/install"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultEndpointPort(t *testing.T) {
@@ -40,13 +40,13 @@ func TestSetDefaultEndpointPort(t *testing.T) {
 	}{
 		"should set appropriate defaults": {
 			original: &discovery.EndpointSlice{Ports: []discovery.EndpointPort{{
-				Port: utilpointer.Int32(80),
+				Port: ptr.To[int32](80),
 			}}},
 			expected: &discovery.EndpointSlice{
 				Ports: []discovery.EndpointPort{{
 					Name:     &emptyStr,
 					Protocol: &protoTCP,
-					Port:     utilpointer.Int32(80),
+					Port:     ptr.To[int32](80),
 				}},
 			},
 		},

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -33,7 +33,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
 	. "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetDefaultDaemonSetSpec(t *testing.T) {
@@ -82,7 +82,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: utilpointer.Int32(10),
+					RevisionHistoryLimit: ptr.To[int32](10),
 				},
 			},
 		},
@@ -95,7 +95,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 				},
 				Spec: extensionsv1beta1.DaemonSetSpec{
 					Template:             defaultTemplate,
-					RevisionHistoryLimit: utilpointer.Int32(1),
+					RevisionHistoryLimit: ptr.To[int32](1),
 				},
 			},
 			expected: &extensionsv1beta1.DaemonSet{
@@ -112,7 +112,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: utilpointer.Int32(1),
+					RevisionHistoryLimit: ptr.To[int32](1),
 				},
 			},
 		},
@@ -124,7 +124,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: utilpointer.Int32(10),
+					RevisionHistoryLimit: ptr.To[int32](10),
 				},
 			},
 		},
@@ -138,7 +138,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: utilpointer.Int32(10),
+					RevisionHistoryLimit: ptr.To[int32](10),
 				},
 			},
 		},
@@ -180,7 +180,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			original: &extensionsv1beta1.Deployment{},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(1),
+					Replicas: ptr.To[int32](1),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
@@ -189,15 +189,15 @@ func TestSetDefaultDeployment(t *testing.T) {
 						},
 					},
 					Template:                defaultTemplate,
-					ProgressDeadlineSeconds: utilpointer.Int32(math.MaxInt32),
-					RevisionHistoryLimit:    utilpointer.Int32(math.MaxInt32),
+					ProgressDeadlineSeconds: ptr.To[int32](math.MaxInt32),
+					RevisionHistoryLimit:    ptr.To[int32](math.MaxInt32),
 				},
 			},
 		},
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
 							MaxSurge: &differentIntOrString,
@@ -207,7 +207,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
@@ -216,15 +216,15 @@ func TestSetDefaultDeployment(t *testing.T) {
 						},
 					},
 					Template:                defaultTemplate,
-					ProgressDeadlineSeconds: utilpointer.Int32(math.MaxInt32),
-					RevisionHistoryLimit:    utilpointer.Int32(math.MaxInt32),
+					ProgressDeadlineSeconds: ptr.To[int32](math.MaxInt32),
+					RevisionHistoryLimit:    ptr.To[int32](math.MaxInt32),
 				},
 			},
 		},
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(3),
+					Replicas: ptr.To[int32](3),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type:          extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: nil,
@@ -233,7 +233,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(3),
+					Replicas: ptr.To[int32](3),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
@@ -242,15 +242,15 @@ func TestSetDefaultDeployment(t *testing.T) {
 						},
 					},
 					Template:                defaultTemplate,
-					ProgressDeadlineSeconds: utilpointer.Int32(math.MaxInt32),
-					RevisionHistoryLimit:    utilpointer.Int32(math.MaxInt32),
+					ProgressDeadlineSeconds: ptr.To[int32](math.MaxInt32),
+					RevisionHistoryLimit:    ptr.To[int32](math.MaxInt32),
 				},
 			},
 		},
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
@@ -258,35 +258,35 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
 					Template:                defaultTemplate,
-					ProgressDeadlineSeconds: utilpointer.Int32(math.MaxInt32),
-					RevisionHistoryLimit:    utilpointer.Int32(math.MaxInt32),
+					ProgressDeadlineSeconds: ptr.To[int32](math.MaxInt32),
+					RevisionHistoryLimit:    ptr.To[int32](math.MaxInt32),
 				},
 			},
 		},
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: utilpointer.Int32(30),
+					ProgressDeadlineSeconds: ptr.To[int32](30),
 				},
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: utilpointer.Int32(5),
+					Replicas: ptr.To[int32](5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
 					Template:                defaultTemplate,
-					ProgressDeadlineSeconds: utilpointer.Int32(30),
-					RevisionHistoryLimit:    utilpointer.Int32(math.MaxInt32),
+					ProgressDeadlineSeconds: ptr.To[int32](30),
+					RevisionHistoryLimit:    ptr.To[int32](math.MaxInt32),
 				},
 			},
 		},
@@ -442,7 +442,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: extensionsv1beta1.ReplicaSet{
 				Spec: extensionsv1beta1.ReplicaSetSpec{
-					Replicas: utilpointer.Int32(0),
+					Replicas: ptr.To[int32](0),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -457,7 +457,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: extensionsv1beta1.ReplicaSet{
 				Spec: extensionsv1beta1.ReplicaSetSpec{
-					Replicas: utilpointer.Int32(3),
+					Replicas: ptr.To[int32](3),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -500,7 +500,7 @@ func TestDefaultRequestIsNotSetForReplicaSet(t *testing.T) {
 	}
 	rs := &extensionsv1beta1.ReplicaSet{
 		Spec: extensionsv1beta1.ReplicaSetSpec{
-			Replicas: utilpointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/apis/node/validation/validation_test.go
+++ b/pkg/apis/node/validation/validation_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/node"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -223,12 +223,12 @@ func TestValidateScheduling(t *testing.T) {
 				Key:               "valid",
 				Operator:          core.TolerationOpExists,
 				Effect:            core.TaintEffectNoExecute,
-				TolerationSeconds: utilpointer.Int64(5),
+				TolerationSeconds: ptr.To[int64](5),
 			}, {
 				Key:               "valid",
 				Operator:          core.TolerationOpExists,
 				Effect:            core.TaintEffectNoExecute,
-				TolerationSeconds: utilpointer.Int64(10),
+				TolerationSeconds: ptr.To[int64](10),
 			}},
 		},
 		expectErrs: 1,

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/resource"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -160,7 +159,7 @@ func TestValidateClaim(t *testing.T) {
 		"deletion-grace-period-seconds": {
 			claim: func() *resource.ResourceClaim {
 				claim := testClaim(goodName, goodNS, validClaimSpec)
-				claim.DeletionGracePeriodSeconds = pointer.Int64(10)
+				claim.DeletionGracePeriodSeconds = ptr.To[int64](10)
 				return claim
 			}(),
 		},

--- a/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func testClaimTemplate(name, namespace string, spec resource.ResourceClaimSpec) *resource.ResourceClaimTemplate {
@@ -98,7 +98,7 @@ func TestValidateClaimTemplate(t *testing.T) {
 		"deletion-grace-period-seconds": {
 			template: func() *resource.ResourceClaimTemplate {
 				template := testClaimTemplate(goodName, goodNS, validClaimSpec)
-				template.DeletionGracePeriodSeconds = pointer.Int64(10)
+				template.DeletionGracePeriodSeconds = ptr.To[int64](10)
 				return template
 			}(),
 		},

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -28,7 +28,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -237,7 +237,7 @@ func TestVolumeAttachmentValidation(t *testing.T) {
 			AttachError: &storage.VolumeError{
 				Time:      metav1.Time{},
 				Message:   "hello world",
-				ErrorCode: utilpointer.Int32(7),
+				ErrorCode: ptr.To[int32](7),
 			},
 			DetachError: &storage.VolumeError{
 				Time:    metav1.Time{},
@@ -334,12 +334,12 @@ func TestVolumeAttachmentValidation(t *testing.T) {
 				AttachError: &storage.VolumeError{
 					Time:      metav1.Time{},
 					Message:   "hello world",
-					ErrorCode: utilpointer.Int32(-1),
+					ErrorCode: ptr.To[int32](-1),
 				},
 				DetachError: &storage.VolumeError{
 					Time:      metav1.Time{},
 					Message:   "hello world",
-					ErrorCode: utilpointer.Int32(5),
+					ErrorCode: ptr.To[int32](5),
 				},
 			},
 		},
@@ -1035,7 +1035,7 @@ func TestCSINodeValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(0)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](0)},
 			}},
 		},
 	}, {
@@ -1046,7 +1046,7 @@ func TestCSINodeValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(1)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](1)},
 			}},
 		},
 	}, {
@@ -1241,7 +1241,7 @@ func TestCSINodeValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(-1)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](-1)},
 			}},
 		},
 	}, {
@@ -1282,7 +1282,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}},
 		},
 	}
@@ -1299,7 +1299,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}},
 		},
 	}, {
@@ -1324,12 +1324,12 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}, {
 				Name:         "io.kubernetes.storage.csi.driver-3",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(30)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](30)},
 			}},
 		},
 	}, {
@@ -1344,7 +1344,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.new-driver",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(30)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](30)},
 			}},
 		},
 	}}
@@ -1367,7 +1367,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}},
 		},
 	}, {
@@ -1382,7 +1382,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}},
 		},
 	}, {
@@ -1393,12 +1393,12 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-1",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(10)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](10)},
 			}, {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}},
 		},
 	}, {
@@ -1413,7 +1413,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(21)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](21)},
 			}},
 		},
 	}, {
@@ -1467,7 +1467,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(21)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](21)},
 			}},
 		},
 	}}
@@ -1484,7 +1484,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}},
 		},
 	}, {
@@ -1499,7 +1499,7 @@ func TestCSINodeUpdateValidation(t *testing.T) {
 				Name:         "io.kubernetes.storage.csi.driver-2",
 				NodeID:       nodeID,
 				TopologyKeys: []string{"company.com/zone2"},
-				Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32(20)},
+				Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 			}},
 		},
 	}}
@@ -2153,7 +2153,7 @@ func TestCSIServiceAccountToken(t *testing.T) {
 		csiDriver: &storage.CSIDriver{
 			ObjectMeta: metav1.ObjectMeta{Name: driverName},
 			Spec: storage.CSIDriverSpec{
-				TokenRequests:     []storage.TokenRequest{{Audience: gcp, ExpirationSeconds: utilpointer.Int64(10)}},
+				TokenRequests:     []storage.TokenRequest{{Audience: gcp, ExpirationSeconds: ptr.To[int64](10)}},
 				RequiresRepublish: &notRequiresRepublish,
 			},
 		},
@@ -2163,7 +2163,7 @@ func TestCSIServiceAccountToken(t *testing.T) {
 		csiDriver: &storage.CSIDriver{
 			ObjectMeta: metav1.ObjectMeta{Name: driverName},
 			Spec: storage.CSIDriverSpec{
-				TokenRequests:     []storage.TokenRequest{{Audience: gcp, ExpirationSeconds: utilpointer.Int64(1<<32 + 1)}},
+				TokenRequests:     []storage.TokenRequest{{Audience: gcp, ExpirationSeconds: ptr.To[int64](1<<32 + 1)}},
 				RequiresRepublish: &notRequiresRepublish,
 			},
 		},
@@ -2213,7 +2213,7 @@ func TestCSIDriverValidationSELinuxMountEnabledDisabled(t *testing.T) {
 	}, {
 		name:              "feature enabled, non-nil value",
 		featureEnabled:    true,
-		seLinuxMountValue: utilpointer.Bool(true),
+		seLinuxMountValue: ptr.To(true),
 		expectError:       false,
 	}, {
 		name:              "feature disabled, nil value",
@@ -2223,7 +2223,7 @@ func TestCSIDriverValidationSELinuxMountEnabledDisabled(t *testing.T) {
 	}, {
 		name:              "feature disabled, non-nil value",
 		featureEnabled:    false,
-		seLinuxMountValue: utilpointer.Bool(true),
+		seLinuxMountValue: ptr.To(true),
 		expectError:       false,
 	}}
 	for _, test := range tests {
@@ -2232,10 +2232,10 @@ func TestCSIDriverValidationSELinuxMountEnabledDisabled(t *testing.T) {
 			csiDriver := &storage.CSIDriver{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: storage.CSIDriverSpec{
-					AttachRequired:    utilpointer.Bool(true),
-					PodInfoOnMount:    utilpointer.Bool(true),
-					RequiresRepublish: utilpointer.Bool(true),
-					StorageCapacity:   utilpointer.Bool(true),
+					AttachRequired:    ptr.To(true),
+					PodInfoOnMount:    ptr.To(true),
+					RequiresRepublish: ptr.To(true),
+					StorageCapacity:   ptr.To(true),
 					SELinuxMount:      test.seLinuxMountValue,
 				},
 			}
@@ -2265,18 +2265,18 @@ func TestCSIDriverValidationSELinuxMountEnabledDisabled(t *testing.T) {
 		name:           "feature enabled, nil->set",
 		featureEnabled: true,
 		oldValue:       nil,
-		newValue:       utilpointer.Bool(true),
+		newValue:       ptr.To(true),
 		expectError:    false,
 	}, {
 		name:           "feature enabled, set->set",
 		featureEnabled: true,
-		oldValue:       utilpointer.Bool(true),
-		newValue:       utilpointer.Bool(true),
+		oldValue:       ptr.To(true),
+		newValue:       ptr.To(true),
 		expectError:    false,
 	}, {
 		name:           "feature enabled, set->nil",
 		featureEnabled: true,
-		oldValue:       utilpointer.Bool(true),
+		oldValue:       ptr.To(true),
 		newValue:       nil,
 		expectError:    true, // populated by defaulting and required when feature is enabled
 	}, {
@@ -2289,18 +2289,18 @@ func TestCSIDriverValidationSELinuxMountEnabledDisabled(t *testing.T) {
 		name:           "feature disabled, nil->set",
 		featureEnabled: false,
 		oldValue:       nil,
-		newValue:       utilpointer.Bool(true),
+		newValue:       ptr.To(true),
 		expectError:    false,
 	}, {
 		name:           "feature disabled, set->set",
 		featureEnabled: false,
-		oldValue:       utilpointer.Bool(true),
-		newValue:       utilpointer.Bool(true),
+		oldValue:       ptr.To(true),
+		newValue:       ptr.To(true),
 		expectError:    false,
 	}, {
 		name:           "feature disabled, set->nil",
 		featureEnabled: false,
-		oldValue:       utilpointer.Bool(true),
+		oldValue:       ptr.To(true),
 		newValue:       nil,
 		expectError:    false,
 	}}
@@ -2310,10 +2310,10 @@ func TestCSIDriverValidationSELinuxMountEnabledDisabled(t *testing.T) {
 			oldCSIDriver := &storage.CSIDriver{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 				Spec: storage.CSIDriverSpec{
-					AttachRequired:    utilpointer.Bool(true),
-					PodInfoOnMount:    utilpointer.Bool(true),
-					RequiresRepublish: utilpointer.Bool(true),
-					StorageCapacity:   utilpointer.Bool(true),
+					AttachRequired:    ptr.To(true),
+					PodInfoOnMount:    ptr.To(true),
+					RequiresRepublish: ptr.To(true),
+					StorageCapacity:   ptr.To(true),
 					SELinuxMount:      test.oldValue,
 				},
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./pkg/apis/discovery/v1/defaults_test.go
./pkg/apis/discovery/v1beta1/defaults_test.go
./pkg/apis/discovery/v1beta1/conversion_test.go
./pkg/apis/certificates/validation/validation_test.go
./pkg/apis/storage/validation/validation_test.go
./pkg/apis/extensions/v1beta1/defaults_test.go
./pkg/apis/batch/fuzzer/fuzzer.go
./pkg/apis/batch/v1beta1/defaults_test.go
./pkg/apis/node/validation/validation_test.go
./pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
./pkg/apis/resource/validation/validation_resourceclaim_test.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
The linter suggested to remove the redundant type in:
./pkg/apis/batch/fuzzer/fuzzer.go

```
-j.BackoffLimitPerIndex = pointer.Int32(c.Rand.Int31())
-j.MaxFailedIndexes = pointer.Int32(c.Rand.Int31())
+j.BackoffLimitPerIndex = ptr.To[int32](c.Int31())
+j.MaxFailedIndexes = ptr.To[int32](c.Int31())
```

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for pkg/apis (2/2).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
