### PR TITLE
chore: utilpointer removal in staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -414,8 +414,8 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 
 // WithDeprecatedPasswordFlag enables the username and password config flags
 func (f *ConfigFlags) WithDeprecatedPasswordFlag() *ConfigFlags {
-	f.Username = utilpointer.String("")
-	f.Password = utilpointer.String("")
+	f.Username = ptr.To("")
+	f.Password = ptr.To("")
 	return f
 }
 
@@ -451,22 +451,22 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 
 	return &ConfigFlags{
 		Insecure:   &insecure,
-		Timeout:    utilpointer.String("0"),
-		KubeConfig: utilpointer.String(""),
+		Timeout:    ptr.To("0"),
+		KubeConfig: ptr.To(""),
 
-		CacheDir:           utilpointer.String(getDefaultCacheDir()),
-		ClusterName:        utilpointer.String(""),
-		AuthInfoName:       utilpointer.String(""),
-		Context:            utilpointer.String(""),
-		Namespace:          utilpointer.String(""),
-		APIServer:          utilpointer.String(""),
-		TLSServerName:      utilpointer.String(""),
-		CertFile:           utilpointer.String(""),
-		KeyFile:            utilpointer.String(""),
-		CAFile:             utilpointer.String(""),
-		BearerToken:        utilpointer.String(""),
-		Impersonate:        utilpointer.String(""),
-		ImpersonateUID:     utilpointer.String(""),
+		CacheDir:           ptr.To(getDefaultCacheDir()),
+		ClusterName:        ptr.To(""),
+		AuthInfoName:       ptr.To(""),
+		Context:            ptr.To(""),
+		Namespace:          ptr.To(""),
+		APIServer:          ptr.To(""),
+		TLSServerName:      ptr.To(""),
+		CertFile:           ptr.To(""),
+		KeyFile:            ptr.To(""),
+		CAFile:             ptr.To(""),
+		BearerToken:        ptr.To(""),
+		Impersonate:        ptr.To(""),
+		ImpersonateUID:     ptr.To(""),
 		ImpersonateGroup:   &impersonateGroup,
 		DisableCompression: &disableCompression,
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086

#### Special notes for your reviewer:

Scoped utilpointer removal in staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
