### PR TITLE
chore: depr. pointer pkg replacement for pkg/controller (1/2)

### DIFF
--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -55,7 +55,6 @@ import (
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/google/go-cmp/cmp"
@@ -83,7 +82,7 @@ func newReplicationController(replicas int) *v1.ReplicationController {
 			ResourceVersion: "18",
 		},
 		Spec: v1.ReplicationControllerSpec{
-			Replicas: pointer.Int32(int32(replicas)),
+			Replicas: ptr.To[int32](int32(replicas)),
 			Selector: map[string]string{"foo": "bar"},
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -145,7 +144,7 @@ func newReplicaSet(name string, replicas int, rsUuid types.UID) *apps.ReplicaSet
 			ResourceVersion: "18",
 		},
 		Spec: apps.ReplicaSetSpec{
-			Replicas: pointer.Int32(int32(replicas)),
+			Replicas: ptr.To[int32](int32(replicas)),
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
@@ -1223,7 +1223,7 @@ func TestControllerV2SyncCronJob(t *testing.T) {
 			jobPresentInCJActiveStatus: false,
 		},
 		"set lastsuccessfultime if successfulJobHistoryLimit is zero": {
-			successfulJobsHistoryLimit: pointer.Int32(0),
+			successfulJobsHistoryLimit: ptr.To[int32](0),
 			ranPreviously:              true,
 			schedule:                   onTheHour,
 			expectUpdateStatus:         true,
@@ -1231,7 +1231,7 @@ func TestControllerV2SyncCronJob(t *testing.T) {
 			jobPresentInCJActiveStatus: true,
 		},
 		"set lastsuccessfultime if successfulJobHistoryLimit is ten": {
-			successfulJobsHistoryLimit: pointer.Int32(10),
+			successfulJobsHistoryLimit: ptr.To[int32](10),
 			ranPreviously:              true,
 			schedule:                   onTheHour,
 			expectUpdateStatus:         true,
@@ -1787,7 +1787,7 @@ func TestControllerV2CleanupFinishedJobs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "foo-ns", Name: "fooer"},
 				Spec: batchv1.CronJobSpec{
 					Schedule:                   onTheHour,
-					SuccessfulJobsHistoryLimit: pointer.Int32(1),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](1),
 					JobTemplate: batchv1.JobTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"key": "value"}},
 					},
@@ -1799,7 +1799,7 @@ func TestControllerV2CleanupFinishedJobs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "foo-ns",
 						Name:            "finished-job-started-hour-ago",
-						OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: pointer.Bool(true)}},
+						OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: ptr.To(true)}},
 					},
 					Status: batchv1.JobStatus{StartTime: &metav1.Time{Time: justBeforeThePriorHour()}},
 				},
@@ -1807,7 +1807,7 @@ func TestControllerV2CleanupFinishedJobs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "foo-ns",
 						Name:            "finished-job-started-minute-ago",
-						OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: pointer.Bool(true)}},
+						OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: ptr.To(true)}},
 					},
 					Status: batchv1.JobStatus{StartTime: &metav1.Time{Time: justBeforeTheHour()}},
 				},
@@ -1822,7 +1822,7 @@ func TestControllerV2CleanupFinishedJobs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: "foo-ns", Name: "fooer"},
 				Spec: batchv1.CronJobSpec{
 					Schedule:                   onTheHour,
-					SuccessfulJobsHistoryLimit: pointer.Int32(2),
+					SuccessfulJobsHistoryLimit: ptr.To[int32](2),
 					JobTemplate: batchv1.JobTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"key": "value"}},
 					},
@@ -1834,7 +1834,7 @@ func TestControllerV2CleanupFinishedJobs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "foo-ns",
 						Name:            "finished-job-started-hour-ago",
-						OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: pointer.Bool(true)}},
+						OwnerReferences: []metav1.OwnerReference{{Name: "fooer", Controller: ptr.To(true)}},
 					},
 					Status: batchv1.JobStatus{StartTime: &metav1.Time{Time: justBeforeThePriorHour()}},
 				},

--- a/pkg/controller/daemon/util/daemonset_util_test.go
+++ b/pkg/controller/daemon/util/daemonset_util_test.go
@@ -27,7 +27,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func newPod(podName string, nodeName string, label map[string]string) *v1.Pod {
@@ -51,8 +51,8 @@ func newPod(podName string, nodeName string, label map[string]string) *v1.Pod {
 }
 
 func TestIsPodUpdated(t *testing.T) {
-	templateGeneration := pointer.Int64(12345)
-	badGeneration := pointer.Int64(12350)
+	templateGeneration := ptr.To[int64](12345)
+	badGeneration := ptr.To[int64](12350)
 	hash := "55555"
 	labels := map[string]string{extensions.DaemonSetTemplateGenerationKey: fmt.Sprint(*templateGeneration), extensions.DefaultDaemonSetUniqueLabelKey: hash}
 	labelsNoHash := map[string]string{extensions.DaemonSetTemplateGenerationKey: fmt.Sprint(*templateGeneration)}
@@ -148,8 +148,8 @@ func TestCreatePodTemplate(t *testing.T) {
 		hash               string
 		expectUniqueLabel  bool
 	}{
-		{pointer.Int64(1), "", false},
-		{pointer.Int64(2), "3242341807", true},
+		{ptr.To[int64](1), "", false},
+		{ptr.To[int64](2), "3242341807", true},
 	}
 	for _, test := range tests {
 		podTemplateSpec := v1.PodTemplateSpec{}

--- a/pkg/controller/endpointslicemirroring/utils_test.go
+++ b/pkg/controller/endpointslicemirroring/utils_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestNewEndpointSlice(t *testing.T) {
@@ -193,7 +193,7 @@ func TestAddressToEndpoint(t *testing.T) {
 	epAddress := v1.EndpointAddress{
 		IP:       "10.1.2.3",
 		Hostname: "foo",
-		NodeName: pointer.String("node-abc"),
+		NodeName: ptr.To("node-abc"),
 		TargetRef: &v1.ObjectReference{
 			APIVersion: "v1",
 			Kind:       "Pod",
@@ -204,9 +204,9 @@ func TestAddressToEndpoint(t *testing.T) {
 	ready := true
 	expectedEndpoint := discovery.Endpoint{
 		Addresses: []string{"10.1.2.3"},
-		Hostname:  pointer.String("foo"),
+		Hostname:  ptr.To("foo"),
 		Conditions: discovery.EndpointConditions{
-			Ready: pointer.BoolPtr(true),
+			Ready: ptr.To(true),
 		},
 		TargetRef: &v1.ObjectReference{
 			APIVersion: "v1",
@@ -214,7 +214,7 @@ func TestAddressToEndpoint(t *testing.T) {
 			Namespace:  "default",
 			Name:       "foo",
 		},
-		NodeName: pointer.String("node-abc"),
+		NodeName: ptr.To("node-abc"),
 	}
 
 	ep, addrType := addressToEndpoint(epAddress, ready)

--- a/pkg/controller/garbagecollector/config/v1alpha1/defaults.go
+++ b/pkg/controller/garbagecollector/config/v1alpha1/defaults.go
@@ -18,7 +18,7 @@ package v1alpha1
 
 import (
 	kubectrlmgrconfigv1alpha1 "k8s.io/kube-controller-manager/config/v1alpha1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // RecommendedDefaultGarbageCollectorControllerConfiguration defaults a pointer to a
@@ -32,7 +32,7 @@ import (
 // run it in your wrapper struct of this type in its `SetDefaults_` method.
 func RecommendedDefaultGarbageCollectorControllerConfiguration(obj *kubectrlmgrconfigv1alpha1.GarbageCollectorControllerConfiguration) {
 	if obj.EnableGarbageCollector == nil {
-		obj.EnableGarbageCollector = pointer.Bool(true)
+		obj.EnableGarbageCollector = ptr.To(true)
 	}
 	if obj.ConcurrentGCSyncs == 0 {
 		obj.ConcurrentGCSyncs = 20

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -38,7 +38,7 @@ import (
 
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/controller/garbagecollector/metaonly"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -499,7 +499,7 @@ func TestAbsentOwnerCache(t *testing.T) {
 			Name:       "rc1",
 			UID:        "1",
 			APIVersion: "v1",
-			Controller: pointer.Bool(true),
+			Controller: ptr.To(true),
 		},
 	})
 	rc1Pod2 := getPod("rc1Pod2", []metav1.OwnerReference{
@@ -508,7 +508,7 @@ func TestAbsentOwnerCache(t *testing.T) {
 			Name:       "rc1",
 			UID:        "1",
 			APIVersion: "v1",
-			Controller: pointer.Bool(false),
+			Controller: ptr.To(false),
 		},
 	})
 	rc2Pod1 := getPod("rc2Pod1", []metav1.OwnerReference{

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/testutil"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func alwaysReady() bool { return true }
@@ -687,7 +687,7 @@ func TestGCInspectingPatchedPodBeforeDeletion(t *testing.T) {
 			},
 			expectedDeleteAction: &clienttesting.DeleteActionImpl{
 				Name:          "testPod",
-				DeleteOptions: metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)},
+				DeleteOptions: metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)},
 			},
 		},
 	}

--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2/ktesting"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func setupController(ctx context.Context, clientset kubernetes.Interface) {
@@ -53,7 +53,7 @@ func newKubeApiserverLease(name, holderIdentity string) *coordinationv1.Lease {
 			},
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: utilpointer.StringPtr(holderIdentity),
+			HolderIdentity: ptr.To(holderIdentity),
 		},
 	}
 }
@@ -89,7 +89,7 @@ func Test_StorageVersionUpdatedWithAllEncodingVersionsEqualOnLeaseDeletion(t *te
 					DecodableVersions: []string{"v2"},
 				},
 			},
-			CommonEncodingVersion: utilpointer.String("v1"),
+			CommonEncodingVersion: ptr.To("v1"),
 		},
 	}
 
@@ -174,7 +174,7 @@ func Test_StorageVersionUpdatedWithDifferentEncodingVersionsOnLeaseDeletion(t *t
 					DecodableVersions: []string{"v2"},
 				},
 			},
-			CommonEncodingVersion: utilpointer.String("v1"),
+			CommonEncodingVersion: ptr.To("v1"),
 		},
 	}
 
@@ -255,7 +255,7 @@ func Test_StorageVersionContainsInvalidLeaseID(t *testing.T) {
 					DecodableVersions: []string{"v1"},
 				},
 			},
-			CommonEncodingVersion: utilpointer.String("v1"),
+			CommonEncodingVersion: ptr.To("v1"),
 		},
 	}
 

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller_test.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func newJob(completionTime, failedTime metav1.Time, ttl *int32) *batchv1.Job {
@@ -88,7 +88,7 @@ func TestTimeLeft(t *testing.T) {
 	}{
 		{
 			name:         "Error case: Job unfinished",
-			ttl:          pointer.Int32(100),
+			ttl:          ptr.To[int32](100),
 			since:        &now.Time,
 			expectErr:    true,
 			expectErrStr: "should not be cleaned up",
@@ -103,25 +103,25 @@ func TestTimeLeft(t *testing.T) {
 		{
 			name:             "Job completed now, 0s TTL",
 			completionTime:   now,
-			ttl:              pointer.Int32(0),
+			ttl:              ptr.To[int32](0),
 			since:            &now.Time,
-			expectedTimeLeft: pointer.Duration(0 * time.Second),
+			expectedTimeLeft: ptr.To(0 * time.Second),
 			expectedExpireAt: now.Time,
 		},
 		{
 			name:             "Job completed now, 10s TTL",
 			completionTime:   now,
-			ttl:              pointer.Int32(10),
+			ttl:              ptr.To[int32](10),
 			since:            &now.Time,
-			expectedTimeLeft: pointer.Duration(10 * time.Second),
+			expectedTimeLeft: ptr.To(10 * time.Second),
 			expectedExpireAt: now.Add(10 * time.Second),
 		},
 		{
 			name:             "Job completed 10s ago, 15s TTL",
 			completionTime:   metav1.NewTime(now.Add(-10 * time.Second)),
-			ttl:              pointer.Int32(15),
+			ttl:              ptr.To[int32](15),
 			since:            &now.Time,
-			expectedTimeLeft: pointer.Duration(5 * time.Second),
+			expectedTimeLeft: ptr.To(5 * time.Second),
 			expectedExpireAt: now.Add(5 * time.Second),
 		},
 		{
@@ -134,25 +134,25 @@ func TestTimeLeft(t *testing.T) {
 		{
 			name:             "Job failed now, 0s TTL",
 			failedTime:       now,
-			ttl:              pointer.Int32(0),
+			ttl:              ptr.To[int32](0),
 			since:            &now.Time,
-			expectedTimeLeft: pointer.Duration(0 * time.Second),
+			expectedTimeLeft: ptr.To(0 * time.Second),
 			expectedExpireAt: now.Time,
 		},
 		{
 			name:             "Job failed now, 10s TTL",
 			failedTime:       now,
-			ttl:              pointer.Int32(10),
+			ttl:              ptr.To[int32](10),
 			since:            &now.Time,
-			expectedTimeLeft: pointer.Duration(10 * time.Second),
+			expectedTimeLeft: ptr.To(10 * time.Second),
 			expectedExpireAt: now.Add(10 * time.Second),
 		},
 		{
 			name:             "Job failed 10s ago, 15s TTL",
 			failedTime:       metav1.NewTime(now.Add(-10 * time.Second)),
-			ttl:              pointer.Int32(15),
+			ttl:              ptr.To[int32](15),
 			since:            &now.Time,
-			expectedTimeLeft: pointer.Duration(5 * time.Second),
+			expectedTimeLeft: ptr.To(5 * time.Second),
 			expectedExpireAt: now.Add(5 * time.Second),
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./pkg/controller/garbagecollector/config/v1alpha1/defaults.go
./pkg/controller/garbagecollector/garbagecollector_test.go
./pkg/controller/controller_utils_test.go
./pkg/controller/ttlafterfinished/ttlafterfinished_controller_test.go
./pkg/controller/podgc/gc_controller_test.go
./pkg/controller/cronjob/cronjob_controllerv2_test.go
./pkg/controller/daemon/util/daemonset_util_test.go
./pkg/controller/storageversiongc/gc_controller_test.go
./pkg/controller/endpointslicemirroring/utils_test.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for pkg/controller (1/2).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
