### PR TITLE
remove utilpointer usage in pkg/quota/v1/evaluator/core/services_test.go

### DIFF
--- a/pkg/quota/v1/evaluator/core/services_test.go
+++ b/pkg/quota/v1/evaluator/core/services_test.go
@@ -26,7 +26,7 @@ import (
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestServiceEvaluatorMatchesResources(t *testing.T) {
@@ -173,7 +173,7 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 							Port: 27444,
 						},
 					},
-					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+					AllocateLoadBalancerNodePorts: ptr.To(false),
 				},
 			},
 			usage: corev1.ResourceList{
@@ -219,7 +219,7 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 							Port: 27444,
 						},
 					},
-					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(true),
+					AllocateLoadBalancerNodePorts: ptr.To(true),
 				},
 			},
 			usage: corev1.ResourceList{
@@ -243,7 +243,7 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 							NodePort: 32002,
 						},
 					},
-					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+					AllocateLoadBalancerNodePorts: ptr.To(false),
 				},
 			},
 			usage: corev1.ResourceList{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086

#### Special notes for your reviewer:

Scoped utilpointer removal in pkg/quota/v1/evaluator/core/services_test.go

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
