### PR TITLE
chore: remove utilpointer usage in admission packages

### DIFF
--- a/plugin/pkg/admission/network/defaultingressclass/admission_test.go
+++ b/plugin/pkg/admission/network/defaultingressclass/admission_test.go
@@ -31,7 +31,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/controller"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestAdmission(t *testing.T) {
@@ -134,30 +134,30 @@ func TestAdmission(t *testing.T) {
 			classes:         []*networkingv1.IngressClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			classField:      nil,
 			classAnnotation: nil,
-			expectedClass:   utilpointer.String(defaultClass1.Name),
+			expectedClass:   ptr.To(defaultClass1.Name),
 			expectedError:   nil,
 		},
 		{
 			name:            "one default, no modification of Ingress with class field=''",
 			classes:         []*networkingv1.IngressClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
-			classField:      utilpointer.String(""),
+			classField:      ptr.To(""),
 			classAnnotation: nil,
-			expectedClass:   utilpointer.String(""),
+			expectedClass:   ptr.To(""),
 			expectedError:   nil,
 		},
 		{
 			name:            "one default, no modification of Ingress with class field='foo'",
 			classes:         []*networkingv1.IngressClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
-			classField:      utilpointer.String("foo"),
+			classField:      ptr.To("foo"),
 			classAnnotation: nil,
-			expectedClass:   utilpointer.String("foo"),
+			expectedClass:   ptr.To("foo"),
 			expectedError:   nil,
 		},
 		{
 			name:            "one default, no modification of Ingress with class annotation='foo'",
 			classes:         []*networkingv1.IngressClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			classField:      nil,
-			classAnnotation: utilpointer.String("foo"),
+			classAnnotation: ptr.To("foo"),
 			expectedClass:   nil,
 			expectedError:   nil,
 		},
@@ -166,15 +166,15 @@ func TestAdmission(t *testing.T) {
 			classes:         []*networkingv1.IngressClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			classField:      nil,
 			classAnnotation: nil,
-			expectedClass:   utilpointer.String(defaultClass1.Name),
+			expectedClass:   ptr.To(defaultClass1.Name),
 			expectedError:   nil,
 		},
 		{
 			name:            "two defaults, no modification with Ingress with class field=''",
 			classes:         []*networkingv1.IngressClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
-			classField:      utilpointer.String(""),
+			classField:      ptr.To(""),
 			classAnnotation: nil,
-			expectedClass:   utilpointer.String(""),
+			expectedClass:   ptr.To(""),
 			expectedError:   nil,
 		},
 		{
@@ -182,7 +182,7 @@ func TestAdmission(t *testing.T) {
 			classes:         []*networkingv1.IngressClass{defaultClassWithCreateTime1, defaultClassWithCreateTime2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			classField:      nil,
 			classAnnotation: nil,
-			expectedClass:   utilpointer.String(defaultClassWithCreateTime1.Name),
+			expectedClass:   ptr.To(defaultClassWithCreateTime1.Name),
 			expectedError:   nil,
 		},
 	}

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -38,7 +38,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/serviceaccount"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -485,7 +485,7 @@ func (s *Plugin) mountServiceAccountToken(serviceAccount *corev1.ServiceAccount,
 func TokenVolumeSource() *api.ProjectedVolumeSource {
 	return &api.ProjectedVolumeSource{
 		// explicitly set default value, see #104464
-		DefaultMode: pointer.Int32(corev1.ProjectedVolumeSourceDefaultMode),
+		DefaultMode: ptr.To[int32](corev1.ProjectedVolumeSourceDefaultMode),
 		Sources: []api.VolumeProjection{
 			{
 				ServiceAccountToken: &api.ServiceAccountTokenProjection{

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -35,7 +35,7 @@ import (
 	v1defaults "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/controller"
 	kubelet "k8s.io/kubernetes/pkg/kubelet/types"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestIgnoresNonCreate(t *testing.T) {
@@ -200,7 +200,7 @@ func TestAssignsDefaultServiceAccountAndBoundTokenWithNoSecretTokens(t *testing.
 					{ConfigMap: &api.ConfigMapProjection{LocalObjectReference: api.LocalObjectReference{Name: "kube-root-ca.crt"}, Items: []api.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}}}},
 					{DownwardAPI: &api.DownwardAPIProjection{Items: []api.DownwardAPIVolumeFile{{Path: "namespace", FieldRef: &api.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"}}}}},
 				},
-				DefaultMode: utilpointer.Int32(0644),
+				DefaultMode: ptr.To[int32](0644),
 			},
 		},
 	}}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086

#### Special notes for your reviewer:

Scoped utilpointer removal in files related to admission package

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
