### PR TITLE
chore: depr. pointer pkg replacement for pkg/controller (2/2)

### DIFF
--- a/pkg/api/service/testing/make.go
+++ b/pkg/api/service/testing/make.go
@@ -19,7 +19,7 @@ package testing
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -83,7 +83,7 @@ func SetTypeNodePort(svc *api.Service) {
 func SetTypeLoadBalancer(svc *api.Service) {
 	svc.Spec.Type = api.ServiceTypeLoadBalancer
 	svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyCluster
-	svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+	svc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 	svc.Spec.ExternalName = ""
 	internalTrafficPolicy := api.ServiceInternalTrafficPolicyCluster
 	svc.Spec.InternalTrafficPolicy = &internalTrafficPolicy
@@ -193,7 +193,7 @@ func SetExternalTrafficPolicy(policy api.ServiceExternalTrafficPolicy) Tweak {
 // SetAllocateLoadBalancerNodePorts sets the allocate LB node port field.
 func SetAllocateLoadBalancerNodePorts(val bool) Tweak {
 	return func(svc *api.Service) {
-		svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(val)
+		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To(val)
 	}
 }
 

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -53,7 +53,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	clocktesting "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 type pdbStates map[string]policy.PodDisruptionBudget
@@ -509,7 +509,7 @@ func TestIntegerMaxUnavailableWithScaling(t *testing.T) {
 	ps.VerifyPdbStatus(t, pdbName, 0, 1, 5, 7, map[string]metav1.Time{})
 
 	// Update scale of ReplicaSet and check PDB
-	rs.Spec.Replicas = pointer.Int32(5)
+	rs.Spec.Replicas = ptr.To[int32](5)
 	update(t, dc.rsStore, rs)
 
 	dc.sync(ctx, pdbName)
@@ -535,7 +535,7 @@ func TestPercentageMaxUnavailableWithScaling(t *testing.T) {
 	ps.VerifyPdbStatus(t, pdbName, 0, 1, 4, 7, map[string]metav1.Time{})
 
 	// Update scale of ReplicaSet and check PDB
-	rs.Spec.Replicas = pointer.Int32(3)
+	rs.Spec.Replicas = ptr.To[int32](3)
 	update(t, dc.rsStore, rs)
 
 	dc.sync(ctx, pdbName)

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -47,7 +47,7 @@ import (
 	controllerpkg "k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	utilnet "k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var alwaysReady = func() bool { return true }
@@ -2185,7 +2185,7 @@ func TestSyncServiceOverCapacity(t *testing.T) {
 		expectedAnnotation:  true,
 	}, {
 		name:                "annotation removed below capacity",
-		startingAnnotation:  pointer.String("truncated"),
+		startingAnnotation:  ptr.To("truncated"),
 		numExisting:         maxCapacity - 1,
 		numDesired:          maxCapacity - 1,
 		numDesiredNotReady:  0,
@@ -2194,7 +2194,7 @@ func TestSyncServiceOverCapacity(t *testing.T) {
 		expectedAnnotation:  false,
 	}, {
 		name:                "annotation was set to warning previously, annotation removed at capacity",
-		startingAnnotation:  pointer.String("warning"),
+		startingAnnotation:  ptr.To("warning"),
 		numExisting:         maxCapacity,
 		numDesired:          maxCapacity,
 		numDesiredNotReady:  0,
@@ -2203,7 +2203,7 @@ func TestSyncServiceOverCapacity(t *testing.T) {
 		expectedAnnotation:  false,
 	}, {
 		name:                "annotation was set to warning previously but still over capacity",
-		startingAnnotation:  pointer.String("warning"),
+		startingAnnotation:  ptr.To("warning"),
 		numExisting:         maxCapacity + 1,
 		numDesired:          maxCapacity + 1,
 		numDesiredNotReady:  0,
@@ -2212,7 +2212,7 @@ func TestSyncServiceOverCapacity(t *testing.T) {
 		expectedAnnotation:  true,
 	}, {
 		name:                "annotation removed at capacity",
-		startingAnnotation:  pointer.String("truncated"),
+		startingAnnotation:  ptr.To("truncated"),
 		numExisting:         maxCapacity,
 		numDesired:          maxCapacity,
 		numDesiredNotReady:  0,
@@ -2221,7 +2221,7 @@ func TestSyncServiceOverCapacity(t *testing.T) {
 		expectedAnnotation:  false,
 	}, {
 		name:                "no endpoints change, annotation value corrected",
-		startingAnnotation:  pointer.String("invalid"),
+		startingAnnotation:  ptr.To("invalid"),
 		numExisting:         maxCapacity + 1,
 		numDesired:          maxCapacity + 1,
 		numDesiredNotReady:  0,
@@ -2384,7 +2384,7 @@ func TestTruncateEndpoints(t *testing.T) {
 }
 
 func TestEndpointPortFromServicePort(t *testing.T) {
-	http := pointer.String("http")
+	http := ptr.To("http")
 	testCases := map[string]struct {
 		serviceAppProtocol           *string
 		expectedEndpointsAppProtocol *string

--- a/pkg/controller/endpointslicemirroring/reconciler_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_test.go
@@ -33,7 +33,7 @@ import (
 	endpointsv1 "k8s.io/kubernetes/pkg/api/v1/endpoints"
 	"k8s.io/kubernetes/pkg/controller/endpointslicemirroring/metrics"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const defaultMaxEndpointsPerSubset = int32(1000)
@@ -87,7 +87,7 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -106,7 +106,7 @@ func TestReconcile(t *testing.T) {
 				Addresses: []corev1.EndpointAddress{{
 					IP:       "10.0.0.1",
 					Hostname: "pod-1",
-					NodeName: pointer.String("node-1"),
+					NodeName: ptr.To("node-1"),
 				}},
 			},
 			{
@@ -118,7 +118,7 @@ func TestReconcile(t *testing.T) {
 				Addresses: []corev1.EndpointAddress{{
 					IP:       "10.0.0.2",
 					Hostname: "pod-2",
-					NodeName: pointer.String("node-1"),
+					NodeName: ptr.To("node-1"),
 				}},
 			},
 		},
@@ -138,7 +138,7 @@ func TestReconcile(t *testing.T) {
 				Addresses: []corev1.EndpointAddress{{
 					IP:       "10.0.0.1",
 					Hostname: "pod-1",
-					NodeName: pointer.String("node-1"),
+					NodeName: ptr.To("node-1"),
 				}},
 			},
 			{
@@ -150,7 +150,7 @@ func TestReconcile(t *testing.T) {
 				Addresses: []corev1.EndpointAddress{{
 					IP:       "10.0.0.1",
 					Hostname: "pod-1",
-					NodeName: pointer.String("node-1"),
+					NodeName: ptr.To("node-1"),
 				}},
 			},
 		},
@@ -170,7 +170,7 @@ func TestReconcile(t *testing.T) {
 				Addresses: []corev1.EndpointAddress{{
 					IP:       "10.0.0.1",
 					Hostname: "pod-1",
-					NodeName: pointer.String("node-1"),
+					NodeName: ptr.To("node-1"),
 				}},
 			},
 			{
@@ -182,7 +182,7 @@ func TestReconcile(t *testing.T) {
 				Addresses: []corev1.EndpointAddress{{
 					IP:       "10.0.0.2",
 					Hostname: "pod-2",
-					NodeName: pointer.String("node-1"),
+					NodeName: ptr.To("node-1"),
 				}},
 			},
 		},
@@ -201,7 +201,7 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}},
 		}},
 		endpointsDeletionPending: true,
@@ -237,14 +237,14 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}},
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.0.0.1"},
-				Hostname:   pointer.String("pod-1"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Hostname:   ptr.To("pod-1"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedNumSlices:     1,
@@ -278,14 +278,14 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}},
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.0.0.1"},
-				Hostname:   pointer.String("pod-1"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Hostname:   ptr.To("pod-1"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedNumSlices:     1,
@@ -310,14 +310,14 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}},
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.0.0.1"},
-				Hostname:   pointer.String("pod-1"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Hostname:   ptr.To("pod-1"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedNumSlices:     1,
@@ -343,14 +343,14 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}},
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.0.0.1"},
-				Hostname:   pointer.String("pod-1"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Hostname:   ptr.To("pod-1"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedNumSlices:     1,
@@ -370,11 +370,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -396,11 +396,11 @@ func TestReconcile(t *testing.T) {
 			NotReadyAddresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -422,20 +422,20 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.1.1.1",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.1.1.2",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 			NotReadyAddresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -457,11 +457,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -476,15 +476,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.1.1",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.1.2",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "10.0.1.3",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -506,11 +506,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -525,15 +525,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.1.1",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.1.2",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "10.0.1.3",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{{
@@ -542,12 +542,12 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}, {
-				Name:     pointer.String("https"),
-				Port:     pointer.Int32(443),
+				Name:     ptr.To("https"),
+				Port:     ptr.To[int32](443),
 				Protocol: &protoUDP,
 			}},
 		}},
@@ -569,11 +569,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -588,15 +588,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.1.1",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.1.2",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "10.0.1.3",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{{
@@ -605,20 +605,20 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}, {
-				Name:     pointer.String("https"),
-				Port:     pointer.Int32(443),
+				Name:     ptr.To("https"),
+				Port:     ptr.To[int32](443),
 				Protocol: &protoUDP,
 			}},
 			Endpoints: []discovery.Endpoint{{
 				Addresses: []string{"10.0.0.2"},
-				Hostname:  pointer.String("pod-2"),
+				Hostname:  ptr.To("pod-2"),
 			}, {
 				Addresses: []string{"10.0.0.1", "10.0.0.3"},
-				Hostname:  pointer.String("pod-1"),
+				Hostname:  ptr.To("pod-1"),
 			}},
 		}},
 		expectedNumSlices:     2,
@@ -639,11 +639,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -658,15 +658,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.1.1",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.1.2",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "10.0.1.3",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{{
@@ -675,24 +675,24 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}, {
-				Name:     pointer.String("https"),
-				Port:     pointer.Int32(443),
+				Name:     ptr.To("https"),
+				Port:     ptr.To[int32](443),
 				Protocol: &protoUDP,
 			}},
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.0.0.1"},
-				Hostname:   pointer.String("pod-1"),
-				NodeName:   pointer.String("node-1"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Hostname:   ptr.To("pod-1"),
+				NodeName:   ptr.To("node-1"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}, {
 				Addresses:  []string{"10.0.0.2"},
-				Hostname:   pointer.String("pod-2"),
-				NodeName:   pointer.String("node-2"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Hostname:   ptr.To("pod-2"),
+				NodeName:   ptr.To("node-2"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedNumSlices:     2,
@@ -713,11 +713,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "2001:db8:2222:3333:4444:5555:6666:7777",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -732,15 +732,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.1.1",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.1.2",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "2001:db8:3333:4444:5555:6666:7777:8888",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -762,11 +762,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "2001:db8:1111:3333:4444:5555:6666:7777",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "2001:db8:2222:3333:4444:5555:6666:7777",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -781,15 +781,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "2001:db8:3333:3333:4444:5555:6666:7777",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "2001:db8:4444:3333:4444:5555:6666:7777",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "2001:db8:5555:3333:4444:5555:6666:7777",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -811,11 +811,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "2001:db8:1111:3333:4444:5555:6666:7777",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "this-is-not-an-ip",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -830,15 +830,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "this-is-also-not-an-ip",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "2001:db8:4444:3333:4444:5555:6666:7777",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "2001:db8:5555:3333:4444:5555:6666:7777",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -860,11 +860,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "this-is-not-an-ip1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "this-is-not-an-ip12",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -879,15 +879,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "this-is-not-an-ip11",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "this-is-not-an-ip12",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "this-is-not-an-ip3",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -909,11 +909,11 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.0.1",
 				Hostname: "pod-1",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.0.2",
 				Hostname: "pod-2",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}},
 		}, {
 			Ports: []corev1.EndpointPort{{
@@ -928,15 +928,15 @@ func TestReconcile(t *testing.T) {
 			Addresses: []corev1.EndpointAddress{{
 				IP:       "10.0.1.1",
 				Hostname: "pod-11",
-				NodeName: pointer.String("node-1"),
+				NodeName: ptr.To("node-1"),
 			}, {
 				IP:       "10.0.1.2",
 				Hostname: "pod-12",
-				NodeName: pointer.String("node-2"),
+				NodeName: ptr.To("node-2"),
 			}, {
 				IP:       "10.0.1.3",
 				Hostname: "pod-13",
-				NodeName: pointer.String("node-3"),
+				NodeName: ptr.To("node-3"),
 			}},
 		}},
 		existingEndpointSlices: []*discovery.EndpointSlice{},
@@ -1044,14 +1044,14 @@ func TestReconcile(t *testing.T) {
 			},
 			AddressType: discovery.AddressTypeIPv4,
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
-				Port:     pointer.Int32(80),
+				Name:     ptr.To("http"),
+				Port:     ptr.To[int32](80),
 				Protocol: &protoTCP,
 			}},
 			Endpoints: []discovery.Endpoint{{
 				Addresses:  []string{"10.0.0.1"},
-				Hostname:   pointer.String("pod-1"),
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+				Hostname:   ptr.To("pod-1"),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 			}},
 		}},
 		expectedNumSlices:     1,

--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestRealHistory_ListControllerRevisions(t *testing.T) {
@@ -1650,7 +1650,7 @@ func newStatefulSet(replicas int, name string, uid types.UID, labels map[string]
 				MatchLabels:      nil,
 				MatchExpressions: testMatchExpressions,
 			},
-			Replicas: pointer.Int32(int32(replicas)),
+			Replicas: ptr.To[int32](int32(replicas)),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -48,7 +48,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/node"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -95,7 +95,7 @@ func createNodeLease(nodeName string, renewTime metav1.MicroTime) *coordv1.Lease
 			Namespace: v1.NamespaceNodeLease,
 		},
 		Spec: coordv1.LeaseSpec{
-			HolderIdentity: pointer.String(nodeName),
+			HolderIdentity: ptr.To(nodeName),
 			RenewTime:      &renewTime,
 		},
 	}

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -54,7 +54,7 @@ import (
 	. "k8s.io/kubernetes/pkg/controller/testutil"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -105,7 +105,7 @@ func newReplicaSet(replicas int, selectorMap map[string]string) *apps.ReplicaSet
 			ResourceVersion: "18",
 		},
 		Spec: apps.ReplicaSetSpec{
-			Replicas: pointer.Int32(int32(replicas)),
+			Replicas: ptr.To[int32](int32(replicas)),
 			Selector: &metav1.LabelSelector{MatchLabels: selectorMap},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
@@ -21,7 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectrlmgrconfigv1alpha1 "k8s.io/kube-controller-manager/config/v1alpha1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // RecommendedDefaultPersistentVolumeBinderControllerConfiguration defaults a pointer to a
@@ -53,10 +53,10 @@ func RecommendedDefaultPersistentVolumeBinderControllerConfiguration(obj *kubect
 // this defaulting method run it in your wrapper struct of this type in its `SetDefaults_` method.
 func RecommendedDefaultVolumeConfiguration(obj *kubectrlmgrconfigv1alpha1.VolumeConfiguration) {
 	if obj.EnableHostPathProvisioning == nil {
-		obj.EnableHostPathProvisioning = pointer.Bool(false)
+		obj.EnableHostPathProvisioning = ptr.To(false)
 	}
 	if obj.EnableDynamicProvisioning == nil {
-		obj.EnableDynamicProvisioning = pointer.Bool(true)
+		obj.EnableDynamicProvisioning = ptr.To(true)
 	}
 	if obj.FlexVolumePluginDir == "" {
 		obj.FlexVolumePluginDir = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"

--- a/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
+++ b/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Test_Controller validates the garbage collection logic for the apiserverleasegc controller.
@@ -48,8 +48,8 @@ func Test_Controller(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To("kube-apiserver-12345"),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now()},
 				},
 			},
@@ -66,8 +66,8 @@ func Test_Controller(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To("kube-apiserver-12345"),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-time.Minute)},
 				},
 			},
@@ -84,8 +84,8 @@ func Test_Controller(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To("kube-apiserver-12345"),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-time.Minute)},
 				},
 			},
@@ -102,8 +102,8 @@ func Test_Controller(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
-					LeaseDurationSeconds: pointer.Int32Ptr(10),
+					HolderIdentity:       ptr.To("kube-apiserver-12345"),
+					LeaseDurationSeconds: ptr.To[int32](10),
 					RenewTime:            nil,
 				},
 			},
@@ -120,7 +120,7 @@ func Test_Controller(t *testing.T) {
 					},
 				},
 				Spec: coordinationv1.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr("kube-apiserver-12345"),
+					HolderIdentity:       ptr.To("kube-apiserver-12345"),
 					LeaseDurationSeconds: nil,
 					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now().Add(-time.Minute)},
 				},

--- a/pkg/quota/v1/evaluator/core/services_test.go
+++ b/pkg/quota/v1/evaluator/core/services_test.go
@@ -26,7 +26,7 @@ import (
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestServiceEvaluatorMatchesResources(t *testing.T) {
@@ -173,7 +173,7 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 							Port: 27444,
 						},
 					},
-					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+					AllocateLoadBalancerNodePorts: ptr.To(false),
 				},
 			},
 			usage: corev1.ResourceList{
@@ -219,7 +219,7 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 							Port: 27444,
 						},
 					},
-					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(true),
+					AllocateLoadBalancerNodePorts: ptr.To(true),
 				},
 			},
 			usage: corev1.ResourceList{
@@ -243,7 +243,7 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 							NodePort: 32002,
 						},
 					},
-					AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+					AllocateLoadBalancerNodePorts: ptr.To(false),
 				},
 			},
 			usage: corev1.ResourceList{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for:
./pkg/controller/endpointslicemirroring/reconciler_test.go
./pkg/controller/endpoint/endpoints_controller_test.go
./pkg/controller/history/controller_history_test.go
./pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
./pkg/controller/replicaset/replica_set_test.go
./pkg/controller/disruption/disruption_test.go
./pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
./pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
./pkg/api/service/testing/make.go
./pkg/quota/v1/evaluator/core/services_test.go

#### Which issue(s) this PR is related to:
Related to #132086 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaced deprecated package 'k8s.io/utils/pointer' with 'k8s.io/utils/ptr' for pkg/controller (2/2).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
