### PR TITLE
chore: remove uint64Ptr using ptr.To[int64] instead

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/utils/ptr"
 )
 
 func seccompLocalhostRef(profileName string) string {
@@ -323,8 +324,8 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 
 	resCfg := &cm.ResourceConfig{
 		Memory:    int64Ptr(335544320),
-		CPUShares: uint64Ptr(306),
-		CPUPeriod: uint64Ptr(100000),
+		CPUShares: ptr.To[uint64](306),
+		CPUPeriod: ptr.To[uint64](100000),
 		CPUQuota:  int64Ptr(30000),
 	}
 
@@ -357,8 +358,8 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 			},
 			expected: &cm.ResourceConfig{
 				Memory:    int64Ptr(335544320),
-				CPUShares: uint64Ptr(306),
-				CPUPeriod: uint64Ptr(100000),
+				CPUShares: ptr.To[uint64](306),
+				CPUPeriod: ptr.To[uint64](100000),
 				CPUQuota:  int64Ptr(30000),
 			},
 		},
@@ -388,8 +389,8 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 			},
 			expected: &cm.ResourceConfig{
 				Memory:    int64Ptr(268435456),
-				CPUShares: uint64Ptr(306),
-				CPUPeriod: uint64Ptr(100000),
+				CPUShares: ptr.To[uint64](306),
+				CPUPeriod: ptr.To[uint64](100000),
 				CPUQuota:  int64Ptr(30000),
 			},
 		},
@@ -419,8 +420,8 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 			},
 			expected: &cm.ResourceConfig{
 				Memory:    int64Ptr(335544320),
-				CPUShares: uint64Ptr(203),
-				CPUPeriod: uint64Ptr(100000),
+				CPUShares: ptr.To[uint64](203),
+				CPUPeriod: ptr.To[uint64](100000),
 				CPUQuota:  int64Ptr(20000),
 			},
 		},
@@ -428,7 +429,7 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 			name: "withoutCPUPeriod",
 			cfgInput: &cm.ResourceConfig{
 				Memory:    int64Ptr(335544320),
-				CPUShares: uint64Ptr(306),
+				CPUShares: ptr.To[uint64](306),
 			},
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
@@ -453,14 +454,14 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 			},
 			expected: &cm.ResourceConfig{
 				Memory:    int64Ptr(335544320),
-				CPUShares: uint64Ptr(203),
+				CPUShares: ptr.To[uint64](203),
 			},
 		},
 		{
 			name: "withoutCPUShares",
 			cfgInput: &cm.ResourceConfig{
 				Memory:    int64Ptr(335544320),
-				CPUPeriod: uint64Ptr(100000),
+				CPUPeriod: ptr.To[uint64](100000),
 				CPUQuota:  int64Ptr(30000),
 			},
 			pod: &v1.Pod{
@@ -486,7 +487,7 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 			},
 			expected: &cm.ResourceConfig{
 				Memory:    int64Ptr(335544320),
-				CPUPeriod: uint64Ptr(100000),
+				CPUPeriod: ptr.To[uint64](100000),
 				CPUQuota:  int64Ptr(20000),
 			},
 		},
@@ -517,8 +518,8 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 			},
 			expected: &cm.ResourceConfig{
 				Memory:    int64Ptr(268435456),
-				CPUShares: uint64Ptr(203),
-				CPUPeriod: uint64Ptr(100000),
+				CPUShares: ptr.To[uint64](203),
+				CPUPeriod: ptr.To[uint64](100000),
 				CPUQuota:  int64Ptr(20000),
 			},
 		},

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -46,10 +46,6 @@ func int64Ptr(i int64) *int64 {
 	return &i
 }
 
-func uint64Ptr(i uint64) *uint64 {
-	return &i
-}
-
 func TestIsInitContainerFailed(t *testing.T) {
 	tests := []struct {
 		status      *kubecontainer.Status
@@ -517,11 +513,11 @@ func TestMergeResourceConfig(t *testing.T) {
 	}{
 		{
 			name:   "merge all fields",
-			source: &cm.ResourceConfig{Memory: int64Ptr(1024), CPUShares: uint64Ptr(2)},
+			source: &cm.ResourceConfig{Memory: int64Ptr(1024), CPUShares: ptr.To[uint64](2)},
 			update: &cm.ResourceConfig{Memory: int64Ptr(2048), CPUQuota: int64Ptr(5000)},
 			expected: &cm.ResourceConfig{
 				Memory:    int64Ptr(2048),
-				CPUShares: uint64Ptr(2),
+				CPUShares: ptr.To[uint64](2),
 				CPUQuota:  int64Ptr(5000),
 			},
 		},
@@ -572,8 +568,8 @@ func TestMergeResourceConfig(t *testing.T) {
 func TestConvertResourceConfigToLinuxContainerResources(t *testing.T) {
 	resCfg := &cm.ResourceConfig{
 		Memory:        int64Ptr(2048),
-		CPUShares:     uint64Ptr(2),
-		CPUPeriod:     uint64Ptr(10000),
+		CPUShares:     ptr.To[uint64](2),
+		CPUPeriod:     ptr.To[uint64](10000),
 		CPUQuota:      int64Ptr(5000),
 		HugePageLimit: map[int64]int64{4096: 2048},
 		Unified:       map[string]string{"key1": "value1"},

--- a/pkg/kubelet/metrics/collectors/resource_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	summaryprovidertest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
+	"k8s.io/utils/ptr"
 )
 
 func TestCollectResourceMetrics(t *testing.T) {
@@ -73,15 +74,15 @@ func TestCollectResourceMetrics(t *testing.T) {
 				Node: statsapi.NodeStats{
 					CPU: &statsapi.CPUStats{
 						Time:                 testTime,
-						UsageCoreNanoSeconds: uint64Ptr(10000000000),
+						UsageCoreNanoSeconds: ptr.To[uint64](10000000000),
 					},
 					Memory: &statsapi.MemoryStats{
 						Time:            testTime,
-						WorkingSetBytes: uint64Ptr(1000),
+						WorkingSetBytes: ptr.To[uint64](1000),
 					},
 					Swap: &statsapi.SwapStats{
 						Time:           testTime,
-						SwapUsageBytes: uint64Ptr(500),
+						SwapUsageBytes: ptr.To[uint64](500),
 					},
 				},
 			},
@@ -143,15 +144,15 @@ func TestCollectResourceMetrics(t *testing.T) {
 								StartTime: metav1.NewTime(staticTimestamp.Add(-30 * time.Second)),
 								CPU: &statsapi.CPUStats{
 									Time:                 testTime,
-									UsageCoreNanoSeconds: uint64Ptr(10000000000),
+									UsageCoreNanoSeconds: ptr.To[uint64](10000000000),
 								},
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
-									WorkingSetBytes: uint64Ptr(1000),
+									WorkingSetBytes: ptr.To[uint64](1000),
 								},
 								Swap: &statsapi.SwapStats{
 									Time:           testTime,
-									SwapUsageBytes: uint64Ptr(1000),
+									SwapUsageBytes: ptr.To[uint64](1000),
 								},
 							},
 							{
@@ -159,11 +160,11 @@ func TestCollectResourceMetrics(t *testing.T) {
 								StartTime: metav1.NewTime(staticTimestamp.Add(-2 * time.Minute)),
 								CPU: &statsapi.CPUStats{
 									Time:                 testTime,
-									UsageCoreNanoSeconds: uint64Ptr(10000000000),
+									UsageCoreNanoSeconds: ptr.To[uint64](10000000000),
 								},
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
-									WorkingSetBytes: uint64Ptr(1000),
+									WorkingSetBytes: ptr.To[uint64](1000),
 								},
 							},
 						},
@@ -179,11 +180,11 @@ func TestCollectResourceMetrics(t *testing.T) {
 								StartTime: metav1.NewTime(staticTimestamp.Add(-10 * time.Minute)),
 								CPU: &statsapi.CPUStats{
 									Time:                 testTime,
-									UsageCoreNanoSeconds: uint64Ptr(10000000000),
+									UsageCoreNanoSeconds: ptr.To[uint64](10000000000),
 								},
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
-									WorkingSetBytes: uint64Ptr(1000),
+									WorkingSetBytes: ptr.To[uint64](1000),
 								},
 							},
 						},
@@ -233,11 +234,11 @@ func TestCollectResourceMetrics(t *testing.T) {
 								StartTime: metav1.NewTime(time.Unix(0, -1624396278302091597)),
 								CPU: &statsapi.CPUStats{
 									Time:                 testTime,
-									UsageCoreNanoSeconds: uint64Ptr(10000000000),
+									UsageCoreNanoSeconds: ptr.To[uint64](10000000000),
 								},
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
-									WorkingSetBytes: uint64Ptr(1000),
+									WorkingSetBytes: ptr.To[uint64](1000),
 								},
 							},
 						},
@@ -295,11 +296,11 @@ func TestCollectResourceMetrics(t *testing.T) {
 								StartTime: metav1.NewTime(staticTimestamp.Add(-10 * time.Minute)),
 								CPU: &statsapi.CPUStats{
 									Time:                 testTime,
-									UsageCoreNanoSeconds: uint64Ptr(10000000000),
+									UsageCoreNanoSeconds: ptr.To[uint64](10000000000),
 								},
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
-									WorkingSetBytes: uint64Ptr(1000),
+									WorkingSetBytes: ptr.To[uint64](1000),
 								},
 							},
 						},
@@ -337,15 +338,15 @@ func TestCollectResourceMetrics(t *testing.T) {
 						},
 						CPU: &statsapi.CPUStats{
 							Time:                 testTime,
-							UsageCoreNanoSeconds: uint64Ptr(10000000000),
+							UsageCoreNanoSeconds: ptr.To[uint64](10000000000),
 						},
 						Memory: &statsapi.MemoryStats{
 							Time:            testTime,
-							WorkingSetBytes: uint64Ptr(1000),
+							WorkingSetBytes: ptr.To[uint64](1000),
 						},
 						Swap: &statsapi.SwapStats{
 							Time:           testTime,
-							SwapUsageBytes: uint64Ptr(5000),
+							SwapUsageBytes: ptr.To[uint64](5000),
 						},
 					},
 				},
@@ -414,8 +415,4 @@ func TestCollectResourceMetrics(t *testing.T) {
 			}
 		})
 	}
-}
-
-func uint64Ptr(u uint64) *uint64 {
-	return &u
 }

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -659,8 +660,8 @@ func (p *criStatsProvider) makeContainerStats(
 		result.CPU.PSI = makePSIStats(stats.Cpu.Psi)
 	} else {
 		result.CPU.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.CPU.UsageCoreNanoSeconds = uint64Ptr(0)
-		result.CPU.UsageNanoCores = uint64Ptr(0)
+		result.CPU.UsageCoreNanoSeconds = ptr.To[uint64](0)
+		result.CPU.UsageNanoCores = ptr.To[uint64](0)
 	}
 	if stats.Memory != nil {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, stats.Memory.Timestamp))
@@ -670,7 +671,7 @@ func (p *criStatsProvider) makeContainerStats(
 		result.Memory.PSI = makePSIStats(stats.Memory.Psi)
 	} else {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.Memory.WorkingSetBytes = uint64Ptr(0)
+		result.Memory.WorkingSetBytes = ptr.To[uint64](0)
 	}
 	if stats.Swap != nil {
 		result.Swap.Time = metav1.NewTime(time.Unix(0, stats.Swap.Timestamp))
@@ -682,8 +683,8 @@ func (p *criStatsProvider) makeContainerStats(
 		}
 	} else {
 		result.Swap.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.Swap.SwapUsageBytes = uint64Ptr(0)
-		result.Swap.SwapAvailableBytes = uint64Ptr(0)
+		result.Swap.SwapUsageBytes = ptr.To[uint64](0)
+		result.Swap.SwapAvailableBytes = ptr.To[uint64](0)
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
 		result.IO = &statsapi.IOStats{}
@@ -747,8 +748,8 @@ func (p *criStatsProvider) makeContainerCPUAndMemoryStats(
 		Memory:    &statsapi.MemoryStats{},
 		Swap: &statsapi.SwapStats{
 			Time:               metav1.NewTime(time.Unix(0, time.Now().UnixNano())),
-			SwapUsageBytes:     uint64Ptr(0),
-			SwapAvailableBytes: uint64Ptr(0),
+			SwapUsageBytes:     ptr.To[uint64](0),
+			SwapAvailableBytes: ptr.To[uint64](0),
 		},
 		// UserDefinedMetrics is not supported by CRI.
 	}
@@ -765,8 +766,8 @@ func (p *criStatsProvider) makeContainerCPUAndMemoryStats(
 		result.CPU.PSI = makePSIStats(stats.Cpu.Psi)
 	} else {
 		result.CPU.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.CPU.UsageCoreNanoSeconds = uint64Ptr(0)
-		result.CPU.UsageNanoCores = uint64Ptr(0)
+		result.CPU.UsageCoreNanoSeconds = ptr.To[uint64](0)
+		result.CPU.UsageNanoCores = ptr.To[uint64](0)
 	}
 	if stats.Memory != nil {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, stats.Memory.Timestamp))
@@ -776,7 +777,7 @@ func (p *criStatsProvider) makeContainerCPUAndMemoryStats(
 		result.Memory.PSI = makePSIStats(stats.Memory.Psi)
 	} else {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.Memory.WorkingSetBytes = uint64Ptr(0)
+		result.Memory.WorkingSetBytes = ptr.To[uint64](0)
 	}
 	if stats.Swap != nil {
 		result.Swap.Time = metav1.NewTime(time.Unix(0, stats.Swap.Timestamp))

--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -31,6 +31,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"k8s.io/utils/ptr"
 )
 
 // windowsNetworkStatsProvider creates an interface that allows for testing the logic without needing to create a container
@@ -131,8 +132,8 @@ func (p *criStatsProvider) makeWinContainerStats(
 		}
 	} else {
 		result.CPU.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.CPU.UsageCoreNanoSeconds = uint64Ptr(0)
-		result.CPU.UsageNanoCores = uint64Ptr(0)
+		result.CPU.UsageCoreNanoSeconds = ptr.To[uint64](0)
+		result.CPU.UsageNanoCores = ptr.To[uint64](0)
 	}
 	if stats.Memory != nil {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, stats.Memory.Timestamp))
@@ -147,9 +148,9 @@ func (p *criStatsProvider) makeWinContainerStats(
 		}
 	} else {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.Memory.WorkingSetBytes = uint64Ptr(0)
-		result.Memory.AvailableBytes = uint64Ptr(0)
-		result.Memory.PageFaults = uint64Ptr(0)
+		result.Memory.WorkingSetBytes = ptr.To[uint64](0)
+		result.Memory.AvailableBytes = ptr.To[uint64](0)
+		result.Memory.PageFaults = ptr.To[uint64](0)
 	}
 	if stats.WritableLayer != nil {
 		result.Rootfs.Time = metav1.NewTime(time.Unix(0, stats.WritableLayer.Timestamp))

--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
+	"k8s.io/utils/ptr"
 )
 
 // defaultNetworkInterfaceName is used for collectng network stats.
@@ -46,8 +47,8 @@ func cadvisorInfoToCPUandMemoryStats(info *cadvisorapiv2.ContainerInfo) (*statsa
 	var memoryStats *statsapi.MemoryStats
 	cpuStats = &statsapi.CPUStats{
 		Time:                 metav1.NewTime(cstat.Timestamp),
-		UsageNanoCores:       uint64Ptr(0),
-		UsageCoreNanoSeconds: uint64Ptr(0),
+		UsageNanoCores:       ptr.To[uint64](0),
+		UsageCoreNanoSeconds: ptr.To[uint64](0),
 	}
 	if info.Spec.HasCpu {
 		if cstat.CpuInst != nil {
@@ -82,7 +83,7 @@ func cadvisorInfoToCPUandMemoryStats(info *cadvisorapiv2.ContainerInfo) (*statsa
 	} else {
 		memoryStats = &statsapi.MemoryStats{
 			Time:            metav1.NewTime(cstat.Timestamp),
-			WorkingSetBytes: uint64Ptr(0),
+			WorkingSetBytes: ptr.To[uint64](0),
 		}
 	}
 	return cpuStats, memoryStats
@@ -177,7 +178,7 @@ func cadvisorInfoToProcessStats(info *cadvisorapiv2.ContainerInfo) *statsapi.Pro
 		return nil
 	}
 	num := cstat.Processes.ProcessCount
-	return &statsapi.ProcessStats{ProcessCount: uint64Ptr(num)}
+	return &statsapi.ProcessStats{ProcessCount: ptr.To[uint64](num)}
 }
 
 func mergeProcessStats(first *statsapi.ProcessStats, second *statsapi.ProcessStats) *statsapi.ProcessStats {
@@ -202,7 +203,7 @@ func mergeProcessStats(first *statsapi.ProcessStats, second *statsapi.ProcessSta
 		secondProcessCount = *second.ProcessCount
 	}
 
-	return &statsapi.ProcessStats{ProcessCount: uint64Ptr(firstProcessCount + secondProcessCount)}
+	return &statsapi.ProcessStats{ProcessCount: ptr.To[uint64](firstProcessCount + secondProcessCount)}
 }
 
 // cadvisorInfoToNetworkStats returns the statsapi.NetworkStats converted from
@@ -428,10 +429,6 @@ func getUint64Value(value *uint64) uint64 {
 	}
 
 	return *value
-}
-
-func uint64Ptr(i uint64) *uint64 {
-	return &i
 }
 
 func calcEphemeralStorage(containers []statsapi.ContainerStats, volumes []statsapi.VolumeStats, rootFsInfo *cadvisorapiv2.FsInfo,

--- a/pkg/kubelet/stats/provider_test.go
+++ b/pkg/kubelet/stats/provider_test.go
@@ -40,6 +40,7 @@ import (
 	kubepodtest "k8s.io/kubernetes/pkg/kubelet/pod/testing"
 	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -174,7 +175,7 @@ func TestRootFsStats(t *testing.T) {
 
 func TestHasDedicatedImageFs(t *testing.T) {
 	ctx := context.Background()
-	imageStatsExpected := &statsapi.FsStats{AvailableBytes: uint64Ptr(1)}
+	imageStatsExpected := &statsapi.FsStats{AvailableBytes: ptr.To[uint64](1)}
 
 	for desc, test := range map[string]struct {
 		rootfsDevice     string
@@ -200,8 +201,8 @@ func TestHasDedicatedImageFs(t *testing.T) {
 			rootfsDevice:     "root/device",
 			imagefsDevice:    "root/device",
 			dedicated:        true,
-			imageFsStats:     &statsapi.FsStats{AvailableBytes: uint64Ptr(1)},
-			containerFsStats: &statsapi.FsStats{AvailableBytes: uint64Ptr(2)},
+			imageFsStats:     &statsapi.FsStats{AvailableBytes: ptr.To[uint64](1)},
+			containerFsStats: &statsapi.FsStats{AvailableBytes: ptr.To[uint64](2)},
 		},
 	} {
 		t.Logf("TestCase %q", desc)

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -292,10 +292,6 @@ func GetHistogramVecFromGatherer(gatherer metrics.Gatherer, metricName string, l
 	return vec, nil
 }
 
-func uint64Ptr(u uint64) *uint64 {
-	return &u
-}
-
 // Bucket of a histogram
 type bucket struct {
 	upperBound float64

--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics_test.go
@@ -32,13 +32,13 @@ import (
 
 func samples2Histogram(samples []float64, upperBounds []float64) Histogram {
 	histogram := dto.Histogram{
-		SampleCount: uint64Ptr(0),
+		SampleCount: ptr.To[uint64](0),
 		SampleSum:   ptr.To[float64](0.0),
 	}
 
 	for _, ub := range upperBounds {
 		histogram.Bucket = append(histogram.Bucket, &dto.Bucket{
-			CumulativeCount: uint64Ptr(0),
+			CumulativeCount: ptr.To[uint64](0),
 			UpperBound:      ptr.To[float64](ub),
 		})
 	}
@@ -142,7 +142,7 @@ func TestHistogramValidate(t *testing.T) {
 			name: "empty SampleCount",
 			h: Histogram{
 				&dto.Histogram{
-					SampleCount: uint64Ptr(0),
+					SampleCount: ptr.To[uint64](0),
 				},
 			},
 			err: fmt.Errorf("nil or empty histogram SampleCount"),
@@ -151,7 +151,7 @@ func TestHistogramValidate(t *testing.T) {
 			name: "nil SampleSum",
 			h: Histogram{
 				&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 				},
 			},
 			err: fmt.Errorf("nil or empty histogram SampleSum"),
@@ -160,7 +160,7 @@ func TestHistogramValidate(t *testing.T) {
 			name: "empty SampleSum",
 			h: Histogram{
 				&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 					SampleSum:   ptr.To[float64](0.0),
 				},
 			},
@@ -170,7 +170,7 @@ func TestHistogramValidate(t *testing.T) {
 			name: "nil bucket",
 			h: Histogram{
 				&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 					SampleSum:   ptr.To[float64](1.0),
 					Bucket: []*dto.Bucket{
 						nil,
@@ -183,7 +183,7 @@ func TestHistogramValidate(t *testing.T) {
 			name: "nil bucket UpperBound",
 			h: Histogram{
 				&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 					SampleSum:   ptr.To[float64](1.0),
 					Bucket: []*dto.Bucket{
 						{},
@@ -196,7 +196,7 @@ func TestHistogramValidate(t *testing.T) {
 			name: "negative bucket UpperBound",
 			h: Histogram{
 				&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 					SampleSum:   ptr.To[float64](1.0),
 					Bucket: []*dto.Bucket{
 						{UpperBound: ptr.To[float64](-1.0)},
@@ -329,25 +329,25 @@ func TestHistogramVec_GetAggregatedSampleCount(t *testing.T) {
 		{
 			name: "zero case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](0), SampleSum: ptr.To[float64](0.0)}},
 			},
 			want: 0,
 		},
 		{
 			name: "standard case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(4), SampleSum: ptr.To[float64](8.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](2), SampleSum: ptr.To[float64](4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](4), SampleSum: ptr.To[float64](8.0)}},
 			},
 			want: 7,
 		},
 		{
 			name: "mixed case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](0), SampleSum: ptr.To[float64](0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](2), SampleSum: ptr.To[float64](4.0)}},
 			},
 			want: 3,
 		},
@@ -375,25 +375,25 @@ func TestHistogramVec_GetAggregatedSampleSum(t *testing.T) {
 		{
 			name: "zero case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](0), SampleSum: ptr.To[float64](0.0)}},
 			},
 			want: 0.0,
 		},
 		{
 			name: "standard case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(4), SampleSum: ptr.To[float64](8.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](2), SampleSum: ptr.To[float64](4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](4), SampleSum: ptr.To[float64](8.0)}},
 			},
 			want: 14.0,
 		},
 		{
 			name: "mixed case",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](2.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(0), SampleSum: ptr.To[float64](0.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](4.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](1), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](0), SampleSum: ptr.To[float64](0.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](2), SampleSum: ptr.To[float64](4.0)}},
 			},
 			want: 6.0,
 		},
@@ -471,7 +471,7 @@ func TestHistogramVec_Validate(t *testing.T) {
 		{
 			name: "nil SampleCount",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](1.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](1), SampleSum: ptr.To[float64](1.0)}},
 				&Histogram{&dto.Histogram{SampleSum: ptr.To[float64](2.0)}},
 			},
 			want: fmt.Errorf("nil or empty histogram SampleCount"),
@@ -479,28 +479,28 @@ func TestHistogramVec_Validate(t *testing.T) {
 		{
 			name: "valid HistogramVec",
 			vec: HistogramVec{
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(1), SampleSum: ptr.To[float64](1.0)}},
-				&Histogram{&dto.Histogram{SampleCount: uint64Ptr(2), SampleSum: ptr.To[float64](2.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](1), SampleSum: ptr.To[float64](1.0)}},
+				&Histogram{&dto.Histogram{SampleCount: ptr.To[uint64](2), SampleSum: ptr.To[float64](2.0)}},
 			},
 		},
 		{
 			name: "different bucket size",
 			vec: HistogramVec{
 				&Histogram{&dto.Histogram{
-					SampleCount: uint64Ptr(4),
+					SampleCount: ptr.To[uint64](4),
 					SampleSum:   ptr.To[float64](10.0),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](1)},
-						{CumulativeCount: uint64Ptr(2), UpperBound: ptr.To[float64](2)},
-						{CumulativeCount: uint64Ptr(5), UpperBound: ptr.To[float64](4)},
+						{CumulativeCount: ptr.To[uint64](1), UpperBound: ptr.To[float64](1)},
+						{CumulativeCount: ptr.To[uint64](2), UpperBound: ptr.To[float64](2)},
+						{CumulativeCount: ptr.To[uint64](5), UpperBound: ptr.To[float64](4)},
 					},
 				}},
 				&Histogram{&dto.Histogram{
-					SampleCount: uint64Ptr(3),
+					SampleCount: ptr.To[uint64](3),
 					SampleSum:   ptr.To[float64](8.0),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](2)},
-						{CumulativeCount: uint64Ptr(3), UpperBound: ptr.To[float64](4)},
+						{CumulativeCount: ptr.To[uint64](1), UpperBound: ptr.To[float64](2)},
+						{CumulativeCount: ptr.To[uint64](3), UpperBound: ptr.To[float64](4)},
 					},
 				}},
 			},
@@ -527,21 +527,21 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			lvMap: map[string]string{"label1": "value1-0"},
 			wantVec: HistogramVec{
 				&Histogram{&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 					SampleSum:   ptr.To[float64](1.5),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](0.5)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](2.0)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](5.0)},
+						{CumulativeCount: ptr.To[uint64](0), UpperBound: ptr.To[float64](0.5)},
+						{CumulativeCount: ptr.To[uint64](1), UpperBound: ptr.To[float64](2.0)},
+						{CumulativeCount: ptr.To[uint64](1), UpperBound: ptr.To[float64](5.0)},
 					},
 				}},
 				&Histogram{&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 					SampleSum:   ptr.To[float64](2.5),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](0.5)},
-						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](2.0)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](5.0)},
+						{CumulativeCount: ptr.To[uint64](0), UpperBound: ptr.To[float64](0.5)},
+						{CumulativeCount: ptr.To[uint64](0), UpperBound: ptr.To[float64](2.0)},
+						{CumulativeCount: ptr.To[uint64](1), UpperBound: ptr.To[float64](5.0)},
 					},
 				}},
 			},
@@ -551,12 +551,12 @@ func TestGetHistogramVecFromGatherer(t *testing.T) {
 			lvMap: map[string]string{"label1": "value1-0", "label2": "value2-1"},
 			wantVec: HistogramVec{
 				&Histogram{&dto.Histogram{
-					SampleCount: uint64Ptr(1),
+					SampleCount: ptr.To[uint64](1),
 					SampleSum:   ptr.To[float64](2.5),
 					Bucket: []*dto.Bucket{
-						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](0.5)},
-						{CumulativeCount: uint64Ptr(0), UpperBound: ptr.To[float64](2.0)},
-						{CumulativeCount: uint64Ptr(1), UpperBound: ptr.To[float64](5.0)},
+						{CumulativeCount: ptr.To[uint64](0), UpperBound: ptr.To[float64](0.5)},
+						{CumulativeCount: ptr.To[uint64](0), UpperBound: ptr.To[float64](2.0)},
+						{CumulativeCount: ptr.To[uint64](1), UpperBound: ptr.To[float64](5.0)},
 					},
 				}},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086 and https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
