### PR TITLE
chore: remove strPtr usage with ptr.To

### DIFF
--- a/pkg/apis/certificates/v1beta1/defaults_test.go
+++ b/pkg/apis/certificates/v1beta1/defaults_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	capi "k8s.io/api/certificates/v1beta1"
+	"k8s.io/utils/ptr"
 )
 
 func TestIsKubeletServingCSR(t *testing.T) {
@@ -213,7 +214,6 @@ var (
 )
 
 func TestSetDefaults_CertificateSigningRequestSpec(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
 	tests := map[string]struct {
 		csr                capi.CertificateSigningRequestSpec
 		expectedSignerName string
@@ -230,14 +230,14 @@ func TestSetDefaults_CertificateSigningRequestSpec(t *testing.T) {
 			csr: capi.CertificateSigningRequestSpec{
 				Request:    csrWithOpts(kubeletServerPEMOptions),
 				Usages:     kubeletServerUsages,
-				SignerName: strPtr("example.com/not-kubelet-serving"),
+				SignerName: ptr.To("example.com/not-kubelet-serving"),
 			},
 			expectedSignerName: "example.com/not-kubelet-serving",
 		},
 		"defaults usages if not set": {
 			csr: capi.CertificateSigningRequestSpec{
 				Request:    csrWithOpts(kubeletServerPEMOptions),
-				SignerName: strPtr("example.com/test"),
+				SignerName: ptr.To("example.com/test"),
 			},
 			expectedSignerName: "example.com/test",
 			expectedUsages:     []capi.KeyUsage{capi.UsageDigitalSignature, capi.UsageKeyEncipherment},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -89,8 +89,6 @@ func (v validationMatch) contains(s string) validationMatch {
 	return v
 }
 
-func strPtr(s string) *string { return &s }
-
 // exampleCert was generated from crypto/tls/generate_cert.go with the following command:
 //
 //	go run generate_cert.go  --rsa-bits 2048 --host example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
@@ -386,7 +384,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 							Service: &apiextensions.ServiceReference{
 								Name:      "n",
 								Namespace: "ns",
@@ -436,7 +434,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr(""),
+							URL: ptr.To(""),
 						},
 					},
 					Validation: &apiextensions.CustomResourceValidation{
@@ -483,7 +481,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("None"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 					},
 					PreserveUnknownFields: ptr.To(false),
@@ -573,7 +571,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"invalid-version"},
 					},
@@ -620,7 +618,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"0v"},
 					},
@@ -668,7 +666,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"invalid-version", "v1beta1"},
 					},
@@ -713,7 +711,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"v1beta1", "v1beta1"},
 					},
@@ -887,7 +885,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"v1beta1"},
 					},
@@ -934,7 +932,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"v1beta1"},
 					},
@@ -979,7 +977,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"v1"},
 					},
@@ -1724,7 +1722,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 								Scale: &apiextensions.CustomResourceSubresourceScale{
 									SpecReplicasPath:   ".spec.replicas",
 									StatusReplicasPath: ".status.replicas",
-									LabelSelectorPath:  strPtr(".status.labelSelector"),
+									LabelSelectorPath:  ptr.To(".status.labelSelector"),
 								},
 							},
 						},
@@ -1737,7 +1735,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 								Scale: &apiextensions.CustomResourceSubresourceScale{
 									SpecReplicasPath:   ".spec.replicas",
 									StatusReplicasPath: ".status.replicas",
-									LabelSelectorPath:  strPtr(".spec.labelSelector"),
+									LabelSelectorPath:  ptr.To(".spec.labelSelector"),
 								},
 							},
 						},
@@ -1750,7 +1748,7 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 								Scale: &apiextensions.CustomResourceSubresourceScale{
 									SpecReplicasPath:   ".spec.replicas",
 									StatusReplicasPath: ".status.replicas",
-									LabelSelectorPath:  strPtr(".labelSelector"),
+									LabelSelectorPath:  ptr.To(".labelSelector"),
 								},
 							},
 						},
@@ -5200,7 +5198,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:      "array",
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
 										Type:       "object", // non-atomic
@@ -5233,7 +5231,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:      "array",
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
 										Type:       "object", // non-atomic
@@ -5293,7 +5291,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:      "array",
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
 										Type:       "object", // non-atomic
@@ -5480,7 +5478,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"invalid-version"},
 					},
@@ -5521,7 +5519,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"invalid-version_0, invalid-version"},
 					},
@@ -5566,7 +5564,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"invalid-version"},
 					},
@@ -5607,7 +5605,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"v1beta1", "invalid-version"},
 					},
@@ -5654,7 +5652,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 						ConversionReviewVersions: []string{"invalid-version"},
 					},
@@ -5695,7 +5693,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 					Conversion: &apiextensions.CustomResourceConversion{
 						Strategy: apiextensions.ConversionStrategyType("Webhook"),
 						WebhookClientConfig: &apiextensions.WebhookClientConfig{
-							URL: strPtr("https://example.com/webhook"),
+							URL: ptr.To("https://example.com/webhook"),
 						},
 					},
 					Validation: &apiextensions.CustomResourceValidation{
@@ -7022,7 +7020,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7052,7 +7050,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7086,7 +7084,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7117,7 +7115,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7153,7 +7151,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7185,7 +7183,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7221,7 +7219,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7252,7 +7250,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7290,7 +7288,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7322,7 +7320,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7358,7 +7356,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7389,7 +7387,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:         "array",
-								XListType:    strPtr("map"),
+								XListType:    ptr.To("map"),
 								XListMapKeys: []string{"key"},
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
@@ -7427,7 +7425,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:      "array",
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
 										Type:     "string",
@@ -7452,7 +7450,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:      "array",
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
 										Type:     "string",
@@ -7481,7 +7479,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"foo": {
 								Type:      "array",
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
 										Type: "string",
@@ -7505,7 +7503,7 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 							Type: "object",
 							Properties: map[string]apiextensions.JSONSchemaProps{"bar": {
 								Type:      "array",
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 								Items: &apiextensions.JSONSchemaPropsOrArray{
 									Schema: &apiextensions.JSONSchemaProps{
 										Type:     "string",
@@ -8158,7 +8156,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "object",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8169,7 +8167,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			name: "unset type with list type extension set",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8181,7 +8179,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("invalid"),
+					XListType: ptr.To("invalid"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8193,7 +8191,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("set"),
+					XListType:    ptr.To("set"),
 					XListMapKeys: []string{"key"},
 				},
 			},
@@ -8217,7 +8215,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("map"),
+					XListType: ptr.To("map"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8230,7 +8228,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 				},
 			},
@@ -8243,7 +8241,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						JSONSchemas: []apiextensions.JSONSchemaProps{
@@ -8266,7 +8264,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8284,7 +8282,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8302,7 +8300,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8325,7 +8323,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key", "key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8348,7 +8346,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"keyA", "keyB"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8371,7 +8369,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("atomic"),
+					XListType: ptr.To("atomic"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type: "string",
@@ -8385,7 +8383,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("atomic"),
+					XListType: ptr.To("atomic"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type:       "object",
@@ -8400,7 +8398,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type: "string",
@@ -8414,11 +8412,11 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type:     "object",
-							XMapType: strPtr("atomic"),
+							XMapType: ptr.To("atomic"),
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"foo": {Type: "string"},
 							},
@@ -8432,11 +8430,11 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type:     "object",
-							XMapType: strPtr("granular"),
+							XMapType: ptr.To("granular"),
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"foo": {Type: "string"},
 							},
@@ -8454,7 +8452,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type: "object",
@@ -8475,11 +8473,11 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type:      "array",
-							XListType: strPtr("atomic"),
+							XListType: ptr.To("atomic"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type: "string",
@@ -8495,7 +8493,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type: "array",
@@ -8514,11 +8512,11 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Type:      "array",
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type: "string",
@@ -8538,7 +8536,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:     "array",
-					XMapType: strPtr("granular"),
+					XMapType: ptr.To("granular"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8549,7 +8547,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			name: "unset type with map type extension (granular)",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					XMapType: strPtr("granular"),
+					XMapType: ptr.To("granular"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8561,7 +8559,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:     "array",
-					XMapType: strPtr("atomic"),
+					XMapType: ptr.To("atomic"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8572,7 +8570,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			name: "unset type with map type extension (atomic)",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					XMapType: strPtr("atomic"),
+					XMapType: ptr.To("atomic"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8584,7 +8582,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:     "object",
-					XMapType: strPtr("badMapType"),
+					XMapType: ptr.To("badMapType"),
 				},
 			},
 			expectedErrors: []validationMatch{
@@ -8596,7 +8594,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:     "object",
-					XMapType: strPtr("granular"),
+					XMapType: ptr.To("granular"),
 				},
 			},
 		},
@@ -8605,7 +8603,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:     "object",
-					XMapType: strPtr("atomic"),
+					XMapType: ptr.To("atomic"),
 				},
 			},
 		},
@@ -8614,7 +8612,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8640,7 +8638,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8664,7 +8662,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8689,7 +8687,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8717,7 +8715,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"key"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8745,7 +8743,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:         "array",
-					XListType:    strPtr("map"),
+					XListType:    ptr.To("map"),
 					XListMapKeys: []string{"a"},
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
@@ -8782,7 +8780,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Nullable: true,
@@ -8802,7 +8800,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type:      "array",
-					XListType: strPtr("set"),
+					XListType: ptr.To("set"),
 					Items: &apiextensions.JSONSchemaPropsOrArray{
 						Schema: &apiextensions.JSONSchemaProps{
 							Nullable: false,
@@ -9640,7 +9638,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "array",
-							XListType: strPtr("atomic"),
+							XListType: ptr.To("atomic"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
@@ -9694,7 +9692,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						"value": {
 							Type:      "array",
 							MaxItems:  int64ptr(10),
-							XListType: strPtr("atomic"),
+							XListType: ptr.To("atomic"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type: "string",
@@ -9741,7 +9739,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						"value": {
 							Type:      "array",
 							MaxItems:  int64ptr(10),
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
@@ -9769,7 +9767,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						"value": {
 							Type:      "array",
 							MaxItems:  int64ptr(10),
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
@@ -9793,7 +9791,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:         "array",
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"name"},
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
@@ -9822,7 +9820,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						"value": {
 							Type:         "array",
 							MaxItems:     int64ptr(10),
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"name"},
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
@@ -9850,7 +9848,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "object",
-							XMapType: strPtr("granular"),
+							XMapType: ptr.To("granular"),
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type:      "string",
@@ -9874,7 +9872,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "object",
-							XMapType: strPtr("future"),
+							XMapType: ptr.To("future"),
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type:      "string",
@@ -9925,7 +9923,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "object",
-							XMapType: strPtr("granular"),
+							XMapType: ptr.To("granular"),
 							XValidations: apiextensions.ValidationRules{
 								{Rule: "self == oldSelf"},
 							},
@@ -9960,7 +9958,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "object",
-							XMapType: strPtr("atomic"),
+							XMapType: ptr.To("atomic"),
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type: "object",
@@ -9983,7 +9981,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "object",
-							XMapType: strPtr("atomic"),
+							XMapType: ptr.To("atomic"),
 							XValidations: apiextensions.ValidationRules{
 								{Rule: "self == oldSelf"},
 							},
@@ -10802,7 +10800,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "array",
-							XListType: strPtr("atomic"),
+							XListType: ptr.To("atomic"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
@@ -10856,7 +10854,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						"value": {
 							Type:      "array",
 							MaxItems:  int64ptr(10),
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
@@ -10883,7 +10881,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "object",
-							XMapType: strPtr("future"),
+							XMapType: ptr.To("future"),
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type:      "string",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/listtype/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/listtype/validation_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateListSetsAndMaps(t *testing.T) {
@@ -68,7 +69,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 				Properties: map[string]schema.Structural{
 					"array": {
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Generic: schema.Generic{
 							Type: "array",
@@ -88,7 +89,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 				Properties: map[string]schema.Structural{
 					"array": {
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Generic: schema.Generic{
 							Type: "array",
@@ -111,7 +112,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 				Properties: map[string]schema.Structural{
 					"array": {
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Generic: schema.Generic{
 							Type: "array",
@@ -131,7 +132,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 				Properties: map[string]schema.Structural{
 					"array": {
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Generic: schema.Generic{
 							Type: "array",
@@ -181,7 +182,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							Type: "array",
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Items: &schema.Structural{
 							Generic: schema.Generic{
@@ -209,7 +210,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							Type: "array",
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Items: &schema.Structural{
 							Generic: schema.Generic{
@@ -244,7 +245,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 								Type: "array",
 							},
 							Extensions: schema.Extensions{
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 							},
 							Items: &schema.Structural{
 								Generic: schema.Generic{
@@ -277,14 +278,14 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							Type: "array",
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Items: &schema.Structural{
 							Generic: schema.Generic{
 								Type: "array",
 							},
 							Extensions: schema.Extensions{
-								XListType: strPtr("set"),
+								XListType: ptr.To("set"),
 							},
 						},
 					},
@@ -325,7 +326,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"integers": {
@@ -338,7 +339,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"booleans": {
@@ -351,7 +352,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"float64": {
@@ -364,7 +365,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"nil": {
@@ -377,7 +378,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"empty maps": {
@@ -397,7 +398,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"map values": {
@@ -417,7 +418,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"nil values": {
@@ -438,7 +439,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"array": {
@@ -456,7 +457,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"nil array": {
@@ -475,7 +476,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 					"multiple duplicates": {
@@ -495,7 +496,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 					},
 				},
@@ -528,7 +529,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							Type: "array",
 						},
 						Extensions: schema.Extensions{
-							XListType: strPtr("set"),
+							XListType: ptr.To("set"),
 						},
 						Items: &schema.Structural{
 							Generic: schema.Generic{
@@ -583,7 +584,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -597,7 +598,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -611,7 +612,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -625,7 +626,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -640,7 +641,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -659,7 +660,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -680,7 +681,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -701,7 +702,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a", "b"},
 						},
 					},
@@ -722,7 +723,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a", "b"},
 						},
 					},
@@ -744,7 +745,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -776,7 +777,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -808,7 +809,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -845,7 +846,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a", "b"},
 						},
 					},
@@ -867,7 +868,7 @@ func TestValidateListSetsAndMaps(t *testing.T) {
 							},
 						},
 						Extensions: schema.Extensions{
-							XListType:    strPtr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"a"},
 						},
 					},
@@ -936,5 +937,3 @@ func duplicate(path ...string) validationMatch {
 func invalid(path ...string) validationMatch {
 	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeInvalid}
 }
-
-func strPtr(s string) *string { return &s }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
 )
 
 func TestForProperValidationErrors(t *testing.T) {
@@ -841,7 +842,7 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 				t.Fatalf("unexpected non-error: uniqueItems cannot be set to true")
 			}
 
-			validationSchema.OpenAPIV3Schema.Ref = strPtr("#/definition/zeta")
+			validationSchema.OpenAPIV3Schema.Ref = ptr.To("#/definition/zeta")
 			validationSchema.OpenAPIV3Schema.Properties["zeta"] = apiextensionsv1.JSONSchemaProps{
 				Type:        "array",
 				UniqueItems: false,
@@ -1613,10 +1614,6 @@ func toValidationJSON(yml string) string {
 
 func float64Ptr(f float64) *float64 {
 	return &f
-}
-
-func strPtr(str string) *string {
-	return &str
 }
 
 func TestNonStructuralSchemaConditionForCRDV1(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
@@ -27,11 +27,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/apis/apiserver"
+	"k8s.io/utils/ptr"
 )
-
-func strptr(s string) *string {
-	return &s
-}
 
 func TestReadEgressSelectorConfiguration(t *testing.T) {
 	testcases := []struct {
@@ -46,14 +43,14 @@ func TestReadEgressSelectorConfiguration(t *testing.T) {
 			createFile:     true,
 			contents:       ``,
 			expectedResult: nil,
-			expectedError:  strptr("invalid service configuration object \"\""),
+			expectedError:  ptr.To("invalid service configuration object \"\""),
 		},
 		{
 			name:           "absent",
 			createFile:     false,
 			contents:       ``,
 			expectedResult: nil,
-			expectedError:  strptr("errors.errorString{s:\"unable to read egress selector configuration"),
+			expectedError:  ptr.To("errors.errorString{s:\"unable to read egress selector configuration"),
 		},
 		{
 			name:       "unknown field causes error",
@@ -69,7 +66,7 @@ egressSelections:
     bar: "baz"
 `,
 			expectedResult: nil,
-			expectedError:  strptr("runtime.strictDecodingError"),
+			expectedError:  ptr.To("runtime.strictDecodingError"),
 		},
 		{
 			name:       "duplicate field causes error",
@@ -85,7 +82,7 @@ egressSelections:
     proxyProtocol: "Indirect"
 `,
 			expectedResult: nil,
-			expectedError:  strptr("runtime.strictDecodingError"),
+			expectedError:  ptr.To("runtime.strictDecodingError"),
 		},
 		{
 			name:       "v1beta1",
@@ -303,7 +300,7 @@ spec:
               mountPath: /etc/srv/kubernetes/pki/konnectivity-agent
 `,
 			expectedResult: nil,
-			expectedError:  strptr("invalid service configuration object \"DaemonSet\""),
+			expectedError:  ptr.To("invalid service configuration object \"DaemonSet\""),
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	tracingapi "k8s.io/component-base/tracing/api/v1"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -31,10 +32,6 @@ var (
 	ipAddress    = "127.0.0.1:4317"
 	samplingRate = int32(12345)
 )
-
-func strptr(s string) *string {
-	return &s
-}
 
 func TestValidateTracingOptions(t *testing.T) {
 	testcases := []struct {
@@ -95,7 +92,7 @@ func TestReadTracingConfiguration(t *testing.T) {
 			createFile:     false,
 			contents:       ``,
 			expectedResult: nil,
-			expectedError:  strptr("unable to read tracing configuration from \"test-tracing-config-absent\": open test-tracing-config-absent: no such file or directory"),
+			expectedError:  ptr.To("unable to read tracing configuration from \"test-tracing-config-absent\": open test-tracing-config-absent: no such file or directory"),
 		},
 		{
 			name:       "duplicate field error; strict validation",
@@ -108,7 +105,7 @@ endpoint: localhost:4318
 samplingRatePerMillion: 12345
 `,
 			expectedResult: nil,
-			expectedError:  strptr("unable to decode tracing configuration data: strict decoding error"),
+			expectedError:  ptr.To("unable to decode tracing configuration data: strict decoding error"),
 		},
 		{
 			name:       "unknown field error; strict validation",
@@ -121,7 +118,7 @@ endpoint: localhost:4318
 samplingRatePerMillion: 12345
 `,
 			expectedResult: nil,
-			expectedError:  strptr("unable to decode tracing configuration data: strict decoding error"),
+			expectedError:  ptr.To("unable to decode tracing configuration data: strict decoding error"),
 		},
 		{
 			name:       "v1alpha1",
@@ -173,7 +170,7 @@ spec:
           name: agent
 `,
 			expectedResult: nil,
-			expectedError:  strptr("unable to decode tracing configuration data: no kind \"DaemonSet\" is registered for version \"apps/v1\" in scheme"),
+			expectedError:  ptr.To("unable to decode tracing configuration data: no kind \"DaemonSet\" is registered for version \"apps/v1\" in scheme"),
 		},
 	}
 

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/ptr"
-
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -49,6 +47,7 @@ import (
 	"k8s.io/kubernetes/test/utils/crd"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -952,7 +951,7 @@ func newValidatingWebhookWithMatchConditions(
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: f.Namespace.Name,
 						Name:      serviceName,
-						Path:      strPtr("/always-deny"),
+						Path:      ptr.To("/always-deny"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -997,7 +996,7 @@ func newMutatingWebhookWithMatchConditions(
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: f.Namespace.Name,
 						Name:      serviceName,
-						Path:      strPtr("/mutating-configmaps"),
+						Path:      ptr.To("/mutating-configmaps"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -1152,8 +1151,6 @@ func deployWebhookAndService(ctx context.Context, f *framework.Framework, image 
 	framework.ExpectNoError(err, "waiting for service %s/%s have %d endpoint", namespace, serviceName, 1)
 }
 
-func strPtr(s string) *string { return &s }
-
 func registerWebhook(ctx context.Context, f *framework.Framework, markersNamespaceName string, configName string, certCtx *certContext, servicePort int32) {
 	client := f.ClientSet
 	ginkgo.By("Registering the webhook via the AdmissionRegistration API")
@@ -1216,7 +1213,7 @@ func registerWebhookForAttachingPod(ctx context.Context, f *framework.Framework,
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/pods/attach"),
+						Path:      ptr.To("/pods/attach"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -1306,7 +1303,7 @@ func registerMutatingWebhookForPod(ctx context.Context, f *framework.Framework, 
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/mutating-pods"),
+						Path:      ptr.To("/mutating-pods"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -1495,7 +1492,7 @@ func failingWebhook(namespace, name string, servicePort int32) admissionregistra
 			Service: &admissionregistrationv1.ServiceReference{
 				Namespace: namespace,
 				Name:      serviceName,
-				Path:      strPtr("/configmaps"),
+				Path:      ptr.To("/configmaps"),
 				Port:      ptr.To[int32](servicePort),
 			},
 			// Without CA bundle, the call to webhook always fails
@@ -1602,7 +1599,7 @@ func registerValidatingWebhookForWebhookConfigurations(ctx context.Context, f *f
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/always-deny"),
+						Path:      ptr.To("/always-deny"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -1660,7 +1657,7 @@ func registerMutatingWebhookForWebhookConfigurations(ctx context.Context, f *fra
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/add-label"),
+						Path:      ptr.To("/add-label"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -1720,7 +1717,7 @@ func testWebhooksForWebhookConfigurations(ctx context.Context, f *framework.Fram
 						// so the call to this webhook will always fail,
 						// but because the failure policy is ignore, it will
 						// have no effect on admission requests.
-						Path: strPtr(""),
+						Path: ptr.To(""),
 						Port: ptr.To[int32](servicePort),
 					},
 					CABundle: nil,
@@ -1776,7 +1773,7 @@ func testWebhooksForWebhookConfigurations(ctx context.Context, f *framework.Fram
 						// so the call to this webhook will always fail,
 						// but because the failure policy is ignore, it will
 						// have no effect on admission requests.
-						Path: strPtr(""),
+						Path: ptr.To(""),
 						Port: ptr.To[int32](servicePort),
 					},
 					CABundle: nil,
@@ -2004,7 +2001,7 @@ func registerWebhookForCustomResource(ctx context.Context, f *framework.Framewor
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/custom-resource"),
+						Path:      ptr.To("/custom-resource"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -2053,7 +2050,7 @@ func registerMutatingWebhookForCustomResource(ctx context.Context, f *framework.
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/mutating-custom-resource"),
+						Path:      ptr.To("/mutating-custom-resource"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -2079,7 +2076,7 @@ func registerMutatingWebhookForCustomResource(ctx context.Context, f *framework.
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/mutating-custom-resource"),
+						Path:      ptr.To("/mutating-custom-resource"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -2310,7 +2307,7 @@ func registerValidatingWebhookForCRD(ctx context.Context, f *framework.Framework
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/crd"),
+						Path:      ptr.To("/crd"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -2435,7 +2432,7 @@ func registerSlowWebhook(ctx context.Context, f *framework.Framework, markersNam
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/always-allow-delay-5s"),
+						Path:      ptr.To("/always-allow-delay-5s"),
 						Port:      ptr.To[int32](servicePort),
 					},
 					CABundle: certCtx.signingCert,
@@ -2584,7 +2581,7 @@ func newDenyPodWebhookFixture(f *framework.Framework, certCtx *certContext, serv
 			Service: &admissionregistrationv1.ServiceReference{
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
-				Path:      strPtr("/pods"),
+				Path:      ptr.To("/pods"),
 				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
@@ -2625,7 +2622,7 @@ func newDenyConfigMapWebhookFixture(f *framework.Framework, certCtx *certContext
 			Service: &admissionregistrationv1.ServiceReference{
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
-				Path:      strPtr("/configmaps"),
+				Path:      ptr.To("/configmaps"),
 				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
@@ -2651,7 +2648,7 @@ func newMutateConfigMapWebhookFixture(f *framework.Framework, certCtx *certConte
 			Service: &admissionregistrationv1.ServiceReference{
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
-				Path:      strPtr("/mutating-configmaps"),
+				Path:      ptr.To("/mutating-configmaps"),
 				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
@@ -2725,7 +2722,7 @@ func newValidatingIsReadyWebhookFixture(f *framework.Framework, certCtx *certCon
 			Service: &admissionregistrationv1.ServiceReference{
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
-				Path:      strPtr("/always-deny"),
+				Path:      ptr.To("/always-deny"),
 				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,
@@ -2764,7 +2761,7 @@ func newMutatingIsReadyWebhookFixture(f *framework.Framework, certCtx *certConte
 			Service: &admissionregistrationv1.ServiceReference{
 				Namespace: f.Namespace.Name,
 				Name:      serviceName,
-				Path:      strPtr("/always-deny"),
+				Path:      ptr.To("/always-deny"),
 				Port:      ptr.To[int32](servicePort),
 			},
 			CABundle: certCtx.signingCert,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086 and https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
