### PR TITLE
Show simple values in validation rule failures

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -494,7 +494,9 @@ func (s *Validator) validateExpressions(ctx context.Context, fldPath *field.Path
 		}
 
 		value := obj
-		if sts.Type == "object" || sts.Type == "array" {
+		if ok {
+			value = field.OmitValueType{}
+		} else if sts.Type == "object" || sts.Type == "array" {
 			value = sts.Type
 		}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -451,42 +451,49 @@ func (s *Validator) validateExpressions(ctx context.Context, fldPath *field.Path
 			}
 			continue
 		}
-		if evalResult != types.True {
-			currentFldPath := fldPath
-			if len(compiled.NormalizedRuleFieldPath) > 0 {
-				currentFldPath = currentFldPath.Child(compiled.NormalizedRuleFieldPath)
-			}
 
-			addErr := func(e *field.Error) {
-				if !compiled.UsesOldSelf && correlation.shouldRatchetError() {
-					warning.AddWarning(ctx, "", e.Error())
-				} else {
-					errs = append(errs, e)
-				}
-			}
+		if evalResult == types.True {
+			continue
+		}
 
-			if compiled.MessageExpression != nil {
-				messageExpression, newRemainingBudget, msgErr := evalMessageExpression(ctx, compiled.MessageExpression, rule.MessageExpression, activation, remainingBudget)
-				if msgErr != nil {
-					if msgErr.Type == cel.ErrorTypeInternal {
-						addErr(field.InternalError(currentFldPath, msgErr))
-						return errs, -1
-					} else if msgErr.Type == cel.ErrorTypeInvalid {
-						addErr(field.Invalid(currentFldPath, sts.Type, msgErr.Error()))
-						return errs, -1
-					} else {
-						klog.V(2).ErrorS(msgErr, "messageExpression evaluation failed")
-						addErr(fieldErrorForReason(currentFldPath, sts.Type, ruleMessageOrDefault(rule), rule.Reason))
-						remainingBudget = newRemainingBudget
-					}
-				} else {
-					addErr(fieldErrorForReason(currentFldPath, sts.Type, messageExpression, rule.Reason))
-					remainingBudget = newRemainingBudget
-				}
+		// Prepare a field error describing why the expression evaluated to False.
+		// Its detail may come from another expression that might fail to evaluate or exceed the budget.
+
+		currentFldPath := fldPath
+		if len(compiled.NormalizedRuleFieldPath) > 0 {
+			currentFldPath = currentFldPath.Child(compiled.NormalizedRuleFieldPath)
+		}
+
+		addErr := func(e *field.Error) {
+			if !compiled.UsesOldSelf && correlation.shouldRatchetError() {
+				warning.AddWarning(ctx, "", e.Error())
 			} else {
-				addErr(fieldErrorForReason(currentFldPath, sts.Type, ruleMessageOrDefault(rule), rule.Reason))
+				errs = append(errs, e)
 			}
 		}
+
+		detail, ok := "", false
+		if compiled.MessageExpression != nil {
+			messageExpression, newRemainingBudget, msgErr := evalMessageExpression(ctx, compiled.MessageExpression, rule.MessageExpression, activation, remainingBudget)
+			if msgErr == nil {
+				detail, ok = messageExpression, true
+				remainingBudget = newRemainingBudget
+			} else if msgErr.Type == cel.ErrorTypeInternal {
+				addErr(field.InternalError(currentFldPath, msgErr))
+				return errs, -1
+			} else if msgErr.Type == cel.ErrorTypeInvalid {
+				addErr(field.Invalid(currentFldPath, sts.Type, msgErr.Error()))
+				return errs, -1
+			} else {
+				klog.V(2).ErrorS(msgErr, "messageExpression evaluation failed")
+				remainingBudget = newRemainingBudget
+			}
+		}
+		if !ok {
+			detail = ruleMessageOrDefault(rule)
+		}
+
+		addErr(fieldErrorForReason(currentFldPath, sts.Type, detail, rule.Reason))
 	}
 	return errs, remainingBudget
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -493,7 +493,12 @@ func (s *Validator) validateExpressions(ctx context.Context, fldPath *field.Path
 			detail = ruleMessageOrDefault(rule)
 		}
 
-		addErr(fieldErrorForReason(currentFldPath, sts.Type, detail, rule.Reason))
+		value := obj
+		if sts.Type == "object" || sts.Type == "array" {
+			value = sts.Type
+		}
+
+		addErr(fieldErrorForReason(currentFldPath, value, detail, rule.Reason))
 	}
 	return errs, remainingBudget
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -2696,8 +2696,8 @@ func TestValidationExpressionsAtSchemaLevels(t *testing.T) {
 				},
 			},
 			errors: []string{
-				`root.myProperty[key]: Invalid value: "string": must be value2 or not value`,
-				`root.myProperty[key2]: Invalid value: "string": len must be 5`,
+				`root.myProperty[key]: Invalid value: "value": must be value2 or not value`,
+				`root.myProperty[key2]: Invalid value: "value2": len must be 5`,
 			},
 			schema: &schema.Structural{
 				Generic: schema.Generic{
@@ -2742,8 +2742,8 @@ func TestValidationExpressionsAtSchemaLevels(t *testing.T) {
 				"key2": "value2",
 			},
 			errors: []string{
-				`root.key: Invalid value: "string": must be value2 or not value`,
-				`root.key2: Invalid value: "string": len must be 5`,
+				`root.key: Invalid value: "value": must be value2 or not value`,
+				`root.key2: Invalid value: "value2": len must be 5`,
 			},
 			schema: &schema.Structural{
 				Generic: schema.Generic{
@@ -3924,7 +3924,7 @@ func TestRatcheting(t *testing.T) {
 						type: string
 						x-kubernetes-validations:
 						- rule: self == "bar"
-						  message: "gotta be baz"
+						  message: "gotta be bar"
 				`),
 			oldObj: mustUnstructured(`
 				foo: baz
@@ -3933,7 +3933,7 @@ func TestRatcheting(t *testing.T) {
 				foo: baz
 			`),
 			warnings: []string{
-				`root.foo: Invalid value: "string": gotta be baz`,
+				`root.foo: Invalid value: "baz": gotta be bar`,
 			},
 		},
 		{
@@ -3960,7 +3960,7 @@ func TestRatcheting(t *testing.T) {
 				- bar: bar
 			`),
 			warnings: []string{
-				`root[0].bar: Invalid value: "string": gotta be baz`,
+				`root[0].bar: Invalid value: "bar": gotta be baz`,
 			},
 		},
 		{
@@ -3986,7 +3986,7 @@ func TestRatcheting(t *testing.T) {
 				- 2
 			`),
 			warnings: []string{
-				`root[1]: Invalid value: "number": gotta be odd`,
+				`root[1]: Invalid value: 2: gotta be odd`,
 			},
 		},
 		{
@@ -4020,7 +4020,7 @@ func TestRatcheting(t *testing.T) {
 				- 2
 			`),
 			warnings: []string{
-				`root.setArray[2]: Invalid value: "number": gotta be odd`,
+				`root.setArray[2]: Invalid value: 2: gotta be odd`,
 			},
 		},
 		{
@@ -4055,8 +4055,8 @@ func TestRatcheting(t *testing.T) {
 				  value: baz
 			`),
 			warnings: []string{
-				`root[0].value: Invalid value: "string": gotta be baz`,
-				`root[1].value: Invalid value: "string": gotta be baz`,
+				`root[0].value: Invalid value: "notbaz": gotta be baz`,
+				`root[1].value: Invalid value: "notbaz": gotta be baz`,
 			},
 		},
 		{
@@ -4089,7 +4089,7 @@ func TestRatcheting(t *testing.T) {
 				  value: notbaz
 			`),
 			warnings: []string{
-				`root[1].value: Invalid value: "string": gotta be baz`,
+				`root[1].value: Invalid value: "notbaz": gotta be baz`,
 			},
 		},
 		{
@@ -4131,8 +4131,8 @@ func TestRatcheting(t *testing.T) {
 						bar: notbaz
 			`),
 			warnings: []string{
-				`root.mapField.foo: Invalid value: "string": gotta be baz`,
-				`root.mapField.mapField.bar: Invalid value: "string": gotta be nested baz`,
+				`root.mapField.foo: Invalid value: "notbaz": gotta be baz`,
+				`root.mapField.mapField.bar: Invalid value: "notbaz": gotta be nested baz`,
 			},
 		},
 		{
@@ -4182,11 +4182,11 @@ func TestRatcheting(t *testing.T) {
 			`),
 			errors: []string{
 				// Didn't get ratcheted because we changed its value from baz to notbaz
-				`root.mapField.foo: Invalid value: "string": gotta be baz`,
+				`root.mapField.foo: Invalid value: "notbaz": gotta be baz`,
 			},
 			warnings: []string{
 				// Ratcheted because its value remained the same, even though it is invalid
-				`root.mapField.mapField.bar: Invalid value: "string": gotta be baz`,
+				`root.mapField.mapField.bar: Invalid value: "notbaz": gotta be baz`,
 			},
 		},
 		{
@@ -4219,7 +4219,7 @@ func TestRatcheting(t *testing.T) {
 				- bar: bar
 			`),
 			warnings: []string{
-				`root.atomicArray[0].bar: Invalid value: "string": gotta be baz`,
+				`root.atomicArray[0].bar: Invalid value: "bar": gotta be baz`,
 			},
 		},
 		{
@@ -4247,7 +4247,7 @@ func TestRatcheting(t *testing.T) {
 				- bar: baz
 			`),
 			errors: []string{
-				`root[0].bar: Invalid value: "string": gotta be baz`,
+				`root[0].bar: Invalid value: "bar": gotta be baz`,
 			},
 		},
 		{
@@ -4268,7 +4268,7 @@ func TestRatcheting(t *testing.T) {
 				foo: bar
 			`),
 			errors: []string{
-				`root.foo: Invalid value: "string": gotta be baz`,
+				`root.foo: Invalid value: "bar": gotta be baz`,
 			},
 		},
 		{
@@ -4351,8 +4351,8 @@ func TestRatcheting(t *testing.T) {
 				kind: Baz
 			`),
 			errors: []string{
-				`root.apiVersion: Invalid value: "string": failed rule: self == "v1"`,
-				`root.kind: Invalid value: "string": failed rule: self == "Pod"`,
+				`root.apiVersion: Invalid value: "v2": failed rule: self == "v1"`,
+				`root.kind: Invalid value: "Baz": failed rule: self == "Pod"`,
 			},
 		},
 		{
@@ -4420,12 +4420,12 @@ func TestRatcheting(t *testing.T) {
 				  otherField: newValue3
 			`),
 			warnings: []string{
-				`root.subField.apiVersion: Invalid value: "string": failed rule: self == "v1"`,
-				`root.subField.kind: Invalid value: "string": failed rule: self == "Pod"`,
-				`root.list[0].apiVersion: Invalid value: "string": failed rule: self == "v1"`,
-				`root.list[0].kind: Invalid value: "string": failed rule: self == "Pod"`,
-				`root.list[1].apiVersion: Invalid value: "string": failed rule: self == "v1"`,
-				`root.list[1].kind: Invalid value: "string": failed rule: self == "Pod"`,
+				`root.subField.apiVersion: Invalid value: "v2": failed rule: self == "v1"`,
+				`root.subField.kind: Invalid value: "Baz": failed rule: self == "Pod"`,
+				`root.list[0].apiVersion: Invalid value: "v2": failed rule: self == "v1"`,
+				`root.list[0].kind: Invalid value: "Baz": failed rule: self == "Pod"`,
+				`root.list[1].apiVersion: Invalid value: "v3": failed rule: self == "v1"`,
+				`root.list[1].kind: Invalid value: "Bar": failed rule: self == "Pod"`,
 			},
 		},
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation_test.go
@@ -463,7 +463,7 @@ func TestValidateCustomResource(t *testing.T) {
 					object:    map[string]interface{}{"field": "y"},
 					oldObject: map[string]interface{}{"field": "x"},
 					expectErrs: []string{
-						`field: Invalid value: "string": failed rule: self == oldSelf`,
+						`field: Invalid value: "y": failed rule: self == oldSelf`,
 					}},
 			},
 		},
@@ -511,7 +511,7 @@ func TestValidateCustomResource(t *testing.T) {
 					object:    map[string]interface{}{"field": []interface{}{map[string]interface{}{"k1": "a", "k2": "b", "v1": 0.9}}},
 					oldObject: map[string]interface{}{"field": []interface{}{map[string]interface{}{"k1": "a", "k2": "b", "v1": 1.0}}},
 					expectErrs: []string{
-						`field[0].v1: Invalid value: "number": failed rule: self >= oldSelf`,
+						`field[0].v1: Invalid value: 0.9: failed rule: self >= oldSelf`,
 					}},
 			},
 		},
@@ -550,7 +550,7 @@ func TestValidateCustomResource(t *testing.T) {
 				{
 					object: map[string]interface{}{"field": []interface{}{map[string]interface{}{"x": "y"}}},
 					expectErrs: []string{
-						`field[0].x: Invalid value: "string": failed rule: self == 'x'`,
+						`field[0].x: Invalid value: "y": failed rule: self == 'x'`,
 					}},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This improves the messages returned to the user when CEL validation rules fail. Simple values (numbers, booleans, and strings) are included in the message rather than the field type.

#### Which issue(s) this PR is related to:

Fixes #132528

#### Special notes for your reviewer:

This is split into three atomic commits for review. The third commit is for the third item in [this comment](https://github.com/kubernetes/kubernetes/issues/132528#issuecomment-3005414029) and affects no existing tests:

> 3. possibly omit the value when outputting errors from custom messageExpressions

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: improve the validation error message shown for custom resources with CEL validation rules to include the value that failed validation
```
