### PR TITLE
client-go: event support label

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -51,6 +51,8 @@ func (r *noopRecorder) Eventf(object runtime.Object, eventtype, reason, messageF
 }
 func (r *noopRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 }
+func (r *noopRecorder) LabeledAnnotatedEventf(object runtime.Object, labels, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+}
 
 // getClaimPodName gets the name of the Pod associated with the Claim, or an empty string if this doesn't look matching.
 func getClaimPodName(set *apps.StatefulSet, claim *v1.PersistentVolumeClaim) string {

--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -417,6 +417,11 @@ func (f *FakeRecorder) AnnotatedEventf(obj runtime.Object, annotations map[strin
 	f.Eventf(obj, eventtype, reason, messageFmt, args...)
 }
 
+// LabeledAnnotatedEventf emits a fake formatted event to the fake recorder
+func (f *FakeRecorder) LabeledAnnotatedEventf(obj runtime.Object, labels, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.Eventf(obj, eventtype, reason, messageFmt, args...)
+}
+
 func (f *FakeRecorder) generateEvent(obj runtime.Object, timestamp metav1.Time, eventtype, reason, message string) {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -243,7 +243,12 @@ func (irecorder *innerEventRecorder) AnnotatedEventf(object runtime.Object, anno
 	if ref, ok := irecorder.shouldRecordEvent(object); ok {
 		irecorder.recorder.AnnotatedEventf(ref, annotations, eventtype, reason, messageFmt, args...)
 	}
+}
 
+func (irecorder *innerEventRecorder) LabeledAnnotatedEventf(object runtime.Object, labels, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	if ref, ok := irecorder.shouldRecordEvent(object); ok {
+		irecorder.recorder.LabeledAnnotatedEventf(ref, labels, annotations, eventtype, reason, messageFmt, args...)
+	}
 }
 
 // IsHostNetworkPod returns whether the host networking requested for the given Pod.

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -1187,6 +1187,10 @@ func (f *fakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[st
 	f.aEvents = append(f.aEvents, eventtype+":"+reason+":"+messageFmt)
 }
 
+func (f *fakeRecorder) LabeledAnnotatedEventf(object runtime.Object, labels, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.aEvents = append(f.aEvents, eventtype+":"+reason+":"+messageFmt)
+}
+
 func TestFilterEventRecorder(t *testing.T) {
 	recorder := &fakeRecorder{}
 	filtered := FilterEventRecorder(recorder)

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
@@ -46,6 +46,10 @@ func (r *mockRecorder) AnnotatedEventf(object runtime.Object, annotations map[st
 	r.events = append(r.events, fmt.Sprintf(messageFmt, args...))
 }
 
+func (r *mockRecorder) LabeledAnnotatedEventf(object runtime.Object, labels, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.events = append(r.events, fmt.Sprintf(messageFmt, args...))
+}
+
 const (
 	testNamespace = "test-namespace"
 	testName      = "test-name"

--- a/staging/src/k8s.io/client-go/tools/record/fake.go
+++ b/staging/src/k8s.io/client-go/tools/record/fake.go
@@ -51,24 +51,35 @@ func annotationsString(annotations map[string]string) string {
 		return " " + fmt.Sprint(annotations)
 	}
 }
+func labelsString(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	} else {
+		return " " + fmt.Sprint(labels)
+	}
+}
 
-func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+func (f *FakeRecorder) writeEvent(object runtime.Object, labels, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 	if f.Events != nil {
 		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
-			objectString(object, f.IncludeObject) + annotationsString(annotations)
+			objectString(object, f.IncludeObject) + annotationsString(annotations) + labelsString(labels)
 	}
 }
 
 func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
-	f.writeEvent(object, nil, eventtype, reason, "%s", message)
+	f.writeEvent(object, nil, nil, eventtype, reason, "%s", message)
 }
 
 func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
+	f.writeEvent(object, nil, nil, eventtype, reason, messageFmt, args...)
 }
 
 func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
+	f.writeEvent(object, nil, annotations, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) LabeledAnnotatedEventf(object runtime.Object, labels, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, labels, annotations, eventtype, reason, messageFmt, args...)
 }
 
 func (f *FakeRecorder) WithLogger(logger klog.Logger) EventRecorderLogger {


### PR DESCRIPTION
Support adding a label in the event.

```
Our scenario is similar to the spanid and traceid in distributed tracing. This way, a batch of events can be selected through the label, and then grouped.
```