### PR TITLE
Make kubelet token cache UID-aware to prevent stale tokens after service account recreation

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1855,6 +1855,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
+	genericfeatures.TokenRequestServiceAccountUIDValidation: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/kubelet/token/token_manager.go
+++ b/pkg/kubelet/token/token_manager.go
@@ -206,5 +206,14 @@ func keyFunc(name, namespace string, tr *authenticationv1.TokenRequest) string {
 		ref = *tr.Spec.BoundObjectRef
 	}
 
-	return fmt.Sprintf("%q/%q/%#v/%#v/%#v", name, namespace, tr.Spec.Audiences, exp, ref)
+	var uid types.UID
+	if len(tr.UID) > 0 {
+		// If UID is set in the token request it is used as a precondition
+		// to ensure that the token request is for the same service account.
+		// This is useful to prevent stale tokens from being returned after a service account
+		// is deleted and recreated with the same name.
+		uid = tr.UID
+	}
+
+	return fmt.Sprintf("%q/%q/%#v/%#v/%#v/%q", name, namespace, tr.Spec.Audiences, exp, ref, uid)
 }

--- a/pkg/registry/core/serviceaccount/storage/token.go
+++ b/pkg/registry/core/serviceaccount/storage/token.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	authenticationtokenjwt "k8s.io/apiserver/pkg/authentication/token/jwt"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/rest"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/warning"
@@ -70,6 +71,7 @@ type TokenREST struct {
 
 var _ = rest.NamedCreater(&TokenREST{})
 var _ = rest.GroupVersionKindProvider(&TokenREST{})
+var _ = rest.SubresourceObjectMetaPreserver(&TokenREST{})
 
 var gvk = schema.GroupVersionKind{
 	Group:   authenticationapiv1.SchemeGroupVersion.Group,
@@ -103,6 +105,14 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 	}
 	svcacct := svcacctObj.(*api.ServiceAccount)
 
+	if len(req.UID) > 0 && req.UID != svcacct.UID {
+		if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.TokenRequestServiceAccountUIDValidation) {
+			return nil, errors.NewConflict(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, name, fmt.Errorf("the UID in the token request (%s) does not match the UID of the service account (%s)", req.UID, svcacct.UID))
+		} else {
+			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/token-request-uid-mismatch", fmt.Sprintf("the UID in the token request (%s) does not match the UID of the service account (%s)", req.UID, svcacct.UID))
+		}
+	}
+
 	// Default unset spec audiences to API server audiences based on server config
 	if len(req.Spec.Audiences) == 0 {
 		req.Spec.Audiences = r.auds
@@ -113,6 +123,11 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 	}
 	if len(req.Namespace) == 0 {
 		req.Namespace = svcacct.Namespace
+	}
+	if len(req.UID) == 0 {
+		req.UID = svcacct.UID
+	} else if req.UID != svcacct.UID {
+		warning.AddWarning(ctx, "", fmt.Sprintf("the UID in the token request (%s) does not match the UID of the service account (%s) but TokenRequestServiceAccountUIDValidation is not enabled. In the future, this will return a conflict error", req.UID, svcacct.UID))
 	}
 
 	// Save current time before building the token, to make sure the expiration
@@ -265,4 +280,10 @@ func newContext(ctx context.Context, resource, name, namespace string, gvk schem
 func (r *TokenREST) isKubeAudiences(tokenAudience []string) bool {
 	// tokenAudiences must be a strict subset of apiserver audiences
 	return r.audsSet.HasAll(tokenAudience...)
+}
+
+// PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate indicates that the
+// TokenRequest's UID should be preserved when creating subresources
+func (r *TokenREST) PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate() bool {
+	return true
 }

--- a/pkg/registry/core/serviceaccount/storage/token_test.go
+++ b/pkg/registry/core/serviceaccount/storage/token_test.go
@@ -28,10 +28,14 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/rest"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/apiserver/pkg/warning"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	authenticationapi "k8s.io/kubernetes/pkg/apis/authentication"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -184,6 +188,119 @@ func TestCreate_Token_WithExpiryCap(t *testing.T) {
 	}
 }
 
+func TestTokenRequest_ServiceAccountUIDValidation(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		featureGateEnabled      bool
+		serviceAccountUID       types.UID
+		requestUID              types.UID
+		expectError             string
+		expectedRecordedWarning string
+		expectAuditAnnotations  map[string]string
+		expectedResultUID       types.UID
+	}{
+		{
+			name:               "feature gate enabled - matching UID",
+			featureGateEnabled: true,
+			serviceAccountUID:  "correct-sa-uid-123",
+			requestUID:         "correct-sa-uid-123",
+			expectedResultUID:  "correct-sa-uid-123",
+		},
+		{
+			name:               "feature gate enabled - mismatched UID",
+			featureGateEnabled: true,
+			serviceAccountUID:  "correct-sa-uid-123",
+			requestUID:         "wrong-sa-uid-456",
+			expectError:        `Operation cannot be fulfilled on TokenRequest.authentication.k8s.io "test-sa": the UID in the token request (wrong-sa-uid-456) does not match the UID of the service account (correct-sa-uid-123)`,
+		},
+		{
+			name:                    "feature gate disabled - mismatched UID",
+			featureGateEnabled:      false,
+			serviceAccountUID:       "correct-sa-uid-123",
+			requestUID:              "wrong-sa-uid-456",
+			expectedResultUID:       "wrong-sa-uid-456", // No validation, so request UID is used as-is (backwards compatibility)
+			expectedRecordedWarning: "the UID in the token request (wrong-sa-uid-456) does not match the UID of the service account (correct-sa-uid-123) but TokenRequestServiceAccountUIDValidation is not enabled. In the future, this will return a conflict error",
+			expectAuditAnnotations: map[string]string{
+				"authentication.k8s.io/token-request-uid-mismatch": "the UID in the token request (wrong-sa-uid-456) does not match the UID of the service account (correct-sa-uid-123)",
+			},
+		},
+		{
+			name:               "empty request UID",
+			featureGateEnabled: false,
+			serviceAccountUID:  "correct-sa-uid-123",
+			requestUID:         "",
+			expectedResultUID:  "correct-sa-uid-123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.TokenRequestServiceAccountUIDValidation, tc.featureGateEnabled)
+
+			serviceAccount := validNewServiceAccount("test-sa")
+			serviceAccount.UID = tc.serviceAccountUID
+
+			serviceAccountGetter := &objectGetter{obj: serviceAccount}
+			aud := authenticator.Audiences{"test-audience"}
+
+			storage, server := newTokenStorage(t, testTokenGenerator{"fake"}, aud, panicGetter{}, panicGetter{}, nil)
+			defer server.Terminate(t)
+			defer storage.DestroyFunc()
+
+			storage.Token.svcaccts = serviceAccountGetter
+
+			dc := dummyRecorder{agent: "", text: ""}
+			ctx := context.Background()
+			ctx = request.WithNamespace(warning.WithWarningRecorder(ctx, &dc), serviceAccount.Namespace)
+			// create an audit context to allow recording audit information
+			ctx = audit.WithAuditContext(ctx)
+
+			tokenReq := &authenticationapi.TokenRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceAccount.Name,
+					Namespace: serviceAccount.Namespace,
+					UID:       tc.requestUID,
+				},
+				Spec: authenticationapi.TokenRequestSpec{
+					Audiences:         aud,
+					ExpirationSeconds: 3600, // 1 hour
+				},
+			}
+
+			out, err := storage.Token.Create(ctx, serviceAccount.Name, tokenReq, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+
+			if len(tc.expectError) > 0 {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if err.Error() != tc.expectError {
+					t.Errorf("expected error %q, got %q", tc.expectError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got: %v", err)
+				}
+				result := out.(*authenticationapi.TokenRequest)
+				if result.UID != tc.expectedResultUID {
+					t.Errorf("expected result UID %q, got %q", tc.expectedResultUID, result.UID)
+				}
+			}
+
+			if len(tc.expectedRecordedWarning) > 0 && tc.expectedRecordedWarning != dc.getWarning() {
+				t.Errorf("expected recorded warning %q, got %q", tc.expectedRecordedWarning, dc.getWarning())
+			}
+
+			auditContext := audit.AuditContextFrom(ctx)
+			for key, expectedValue := range tc.expectAuditAnnotations {
+				actualValue, ok := auditContext.GetEventAnnotation(key)
+				if !ok || actualValue != expectedValue {
+					t.Errorf("expected audit annotation %q with value %q, got %v", key, expectedValue, actualValue)
+				}
+			}
+		})
+	}
+}
+
 type objectGetter struct {
 	obj runtime.Object
 	err error
@@ -209,3 +326,19 @@ func (f testTokenGenerator) GenerateToken(ctx context.Context, claims *jwt.Claim
 }
 
 var _ token.TokenGenerator = testTokenGenerator{}
+
+type dummyRecorder struct {
+	agent string
+	text  string
+}
+
+func (r *dummyRecorder) AddWarning(agent, text string) {
+	r.agent = agent
+	r.text = text
+}
+
+func (r *dummyRecorder) getWarning() string {
+	return r.text
+}
+
+var _ warning.Recorder = &dummyRecorder{}

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -216,6 +216,16 @@ const (
 	// Enables Structured Authorization Configuration
 	StructuredAuthorizationConfiguration featuregate.Feature = "StructuredAuthorizationConfiguration"
 
+	// owner: @aramase
+	//
+	// Enables validation of service account UID in TokenRequest API.
+	//
+	// This feature gate is used to ensure that the UID provided in the TokenRequest
+	// matches the UID of the service account for which the token is being requested.
+	// It helps prevent misuse of the TokenRequest API by ensuring that tokens are only
+	// issued for the correct service account.
+	TokenRequestServiceAccountUIDValidation featuregate.Feature = "TokenRequestServiceAccountUIDValidation"
+
 	// owner: @enj
 	//
 	// Enables http2 DOS mitigations for unauthenticated clients.
@@ -409,6 +419,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	},
+
+	TokenRequestServiceAccountUIDValidation: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	UnauthenticatedHTTP2DOSMitigation: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1603,6 +1603,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.32"
+- name: TokenRequestServiceAccountUIDValidation
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: TopologyAwareHints
   versionedSpecs:
   - default: false


### PR DESCRIPTION
Fixes an issue where the kubelet token cache could return stale tokens when a service account is deleted and recreated with the same name. The cache was keyed only by namespace and service account name, causing it to return expired tokens for the new service account.

fixes https://github.com/kubernetes/kubernetes/issues/132802

```release-note
Fix kubelet token cache returning stale tokens when service accounts are recreated with the same name. The token cache is now UID-aware and the new `TokenRequestServiceAccountUIDValidation` feature gate (Beta, enabled by default) validates the TokenRequest UID when set matches the service account UID.
```

```docs
TODO
```

/kind bug
/triage accepted
/sig auth
/milestone v1.34
