### PR TITLE
chore: removing redundant type conversion

### DIFF
--- a/pkg/apis/batch/fuzzer/fuzzer.go
+++ b/pkg/apis/batch/fuzzer/fuzzer.go
@@ -39,9 +39,9 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 		},
 		func(j *batch.JobSpec, c randfill.Continue) {
 			c.FillNoCustom(j) // fuzz self without calling this function again
-			completions := int32(c.Rand.Int31())
-			parallelism := int32(c.Rand.Int31())
-			backoffLimit := int32(c.Rand.Int31())
+			completions := c.Int31()
+			parallelism := c.Int31()
+			backoffLimit := c.Int31()
 			j.Completions = &completions
 			j.Parallelism = &parallelism
 			j.BackoffLimit = &backoffLimit
@@ -75,9 +75,9 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			sds := int64(c.Uint64())
 			sj.StartingDeadlineSeconds = &sds
 			sj.Schedule = c.String(0)
-			successfulJobsHistoryLimit := int32(c.Rand.Int31())
+			successfulJobsHistoryLimit := c.Int31()
 			sj.SuccessfulJobsHistoryLimit = &successfulJobsHistoryLimit
-			failedJobsHistoryLimit := int32(c.Rand.Int31())
+			failedJobsHistoryLimit := c.Int31()
 			sj.FailedJobsHistoryLimit = &failedJobsHistoryLimit
 		},
 		func(cp *batch.ConcurrencyPolicy, c randfill.Continue) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Removes redundant type conversion within the apis/batch/fuzzer.

#### Which issue(s) this PR is related to:

Fixes #132790 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
