### PR TITLE
kubelet: add metrics related to image pull records

### DIFF
--- a/pkg/kubelet/images/pullmanager/metrics.go
+++ b/pkg/kubelet/images/pullmanager/metrics.go
@@ -52,7 +52,22 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-
+	inMemIntentsPercent = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      imageManagerSubsystem,
+			Name:           "inmemory_pullintents_usage_percent",
+			Help:           "The ImagePullIntents in-memory cache usage in percent.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	inMemPulledRecordsPercent = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      imageManagerSubsystem,
+			Name:           "inmemory_pulledrecords_usage_percent",
+			Help:           "The ImagePulledRecords in-memory cache usage in percent.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
 	mustPullChecksTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      imageManagerSubsystem,
@@ -67,6 +82,8 @@ var (
 func init() {
 	legacyregistry.MustRegister(fsPullIntentsSize)
 	legacyregistry.MustRegister(fsPulledRecordsSize)
+	legacyregistry.MustRegister(inMemIntentsPercent)
+	legacyregistry.MustRegister(inMemPulledRecordsPercent)
 	legacyregistry.MustRegister(mustPullChecksTotal)
 }
 

--- a/pkg/kubelet/images/pullmanager/metrics.go
+++ b/pkg/kubelet/images/pullmanager/metrics.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pullmanager
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
+)
+
+var (
+	fsPullIntentsSize = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      kubeletmetrics.KubeletSubsystem + "_imagemanager",
+			Name:           "ondisk_pullintents",
+			Help:           "Number of ImagePullIntents stored on disk.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	fsPulledRecordsSize = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      kubeletmetrics.KubeletSubsystem + "_imagemanager",
+			Name:           "ondisk_pulledrecords",
+			Help:           "Number of ImagePulledRecords stored on disk.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(fsPullIntentsSize)
+	legacyregistry.MustRegister(fsPulledRecordsSize)
+}
+
+// meteringRecordsAccessor wraps a PullRecordsAccessor that's capable of reporting its size
+// and updates its record metrics on write operations.
+type meteringRecordsAccessor struct {
+	sizeExposedPullRecordsAccessor
+	intentsSize       *metrics.Gauge
+	pulledRecordsSize *metrics.Gauge
+}
+
+type sizeExposedPullRecordsAccessor interface {
+	PullRecordsAccessor
+	intentsSize() (uint, error)
+	pulledRecordsSize() (uint, error)
+}
+
+func NewMeteringRecordsAccessor(pullRecordsAccessor sizeExposedPullRecordsAccessor, intentsSize, pulledRecordsSize *metrics.Gauge) *meteringRecordsAccessor {
+	return &meteringRecordsAccessor{
+		sizeExposedPullRecordsAccessor: pullRecordsAccessor,
+		intentsSize:                    intentsSize,
+		pulledRecordsSize:              pulledRecordsSize,
+	}
+}
+
+func (m *meteringRecordsAccessor) WriteImagePullIntent(image string) error {
+	if err := m.sizeExposedPullRecordsAccessor.WriteImagePullIntent(image); err != nil {
+		return err
+	}
+	m.recordIntentsSize()
+	return nil
+}
+
+func (m *meteringRecordsAccessor) DeleteImagePullIntent(image string) error {
+	if err := m.sizeExposedPullRecordsAccessor.DeleteImagePullIntent(image); err != nil {
+		return err
+	}
+	m.recordIntentsSize()
+	return nil
+}
+
+func (m *meteringRecordsAccessor) WriteImagePulledRecord(record *kubeletconfiginternal.ImagePulledRecord) error {
+	if err := m.sizeExposedPullRecordsAccessor.WriteImagePulledRecord(record); err != nil {
+		return err
+	}
+	m.recordPulledRecordsSize()
+	return nil
+}
+
+func (m *meteringRecordsAccessor) DeleteImagePulledRecord(imageRef string) error {
+	if err := m.sizeExposedPullRecordsAccessor.DeleteImagePulledRecord(imageRef); err != nil {
+		return err
+	}
+	m.recordPulledRecordsSize()
+	return nil
+}
+
+func (m *meteringRecordsAccessor) recordIntentsSize() {
+	intentsSize, err := m.sizeExposedPullRecordsAccessor.intentsSize()
+	if err != nil {
+		klog.V(4).ErrorS(err, "failed to read number of ImagePullIntents, can't update metric", "metricName", m.intentsSize.Name)
+		return
+	}
+	m.intentsSize.Set(float64(intentsSize))
+}
+
+func (m *meteringRecordsAccessor) recordPulledRecordsSize() {
+	pulledRecordsSize, err := m.sizeExposedPullRecordsAccessor.pulledRecordsSize()
+	if err != nil {
+		klog.V(4).ErrorS(err, "failed to read number of ImagePulledRecords, can't update metric", "metricName", m.pulledRecordsSize.Name)
+		return
+	}
+	m.pulledRecordsSize.Set(float64(pulledRecordsSize))
+}

--- a/pkg/kubelet/images/pullmanager/metrics_test.go
+++ b/pkg/kubelet/images/pullmanager/metrics_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pullmanager
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/metrics/legacyregistry"
+	metricstestutil "k8s.io/component-base/metrics/testutil"
+	"k8s.io/kubernetes/pkg/kubelet/apis/config"
+)
+
+func TestFSPullRecordsMetrics(t *testing.T) {
+	tempDir := t.TempDir()
+	legacyregistry.Reset()
+	defer legacyregistry.Reset()
+
+	fsAccessor, err := NewFSPullRecordsAccessor(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmpIntents(t, 0)
+	require.NoError(t, fsAccessor.WriteImagePullIntent("test-image:latest"))
+	cmpIntents(t, 1)
+
+	// Test that writing the same record does not increase the count
+	require.NoError(t, fsAccessor.WriteImagePullIntent("test-image:latest"))
+	require.NoError(t, fsAccessor.WriteImagePullIntent("test-image:latest"))
+	cmpIntents(t, 1)
+
+	// Test adding more records
+	require.NoError(t, fsAccessor.WriteImagePullIntent("test-image:v1"))
+	require.NoError(t, fsAccessor.WriteImagePullIntent("test-image:v1.1"))
+	cmpIntents(t, 3)
+
+	cmpPulledRecords(t, 0)
+	require.NoError(t, fsAccessor.WriteImagePulledRecord(&config.ImagePulledRecord{
+		ImageRef:        "test-image-latest-ref",
+		LastUpdatedTime: metav1.NewTime(time.Now()),
+	}))
+	cmpPulledRecords(t, 1)
+
+	// Test that writing the same record does not increase the count
+	require.NoError(t, fsAccessor.WriteImagePulledRecord(&config.ImagePulledRecord{
+		ImageRef:        "test-image-latest-ref",
+		LastUpdatedTime: metav1.NewTime(time.Now()),
+	}))
+	require.NoError(t, fsAccessor.WriteImagePulledRecord(&config.ImagePulledRecord{
+		ImageRef:        "test-image-latest-ref",
+		LastUpdatedTime: metav1.NewTime(time.Now()),
+	}))
+	cmpPulledRecords(t, 1)
+
+	// Test adding more records
+	require.NoError(t, fsAccessor.WriteImagePulledRecord(&config.ImagePulledRecord{
+		ImageRef:        "test-image-v1-ref",
+		LastUpdatedTime: metav1.NewTime(time.Now()),
+	}))
+	require.NoError(t, fsAccessor.WriteImagePulledRecord(&config.ImagePulledRecord{
+		ImageRef:        "test-image-v1.1-ref",
+		LastUpdatedTime: metav1.NewTime(time.Now()),
+	}))
+	require.NoError(t, fsAccessor.WriteImagePulledRecord(&config.ImagePulledRecord{
+		ImageRef:        "test-image-v1.2-ref",
+		LastUpdatedTime: metav1.NewTime(time.Now()),
+	}))
+	cmpPulledRecords(t, 4)
+
+	cmpIntents(t, 3) // double-check that intents count is not affected
+
+	// Test deletions
+	require.NoError(t, fsAccessor.DeleteImagePullIntent("test-image:latest"))
+	cmpIntents(t, 2)
+
+	require.NoError(t, fsAccessor.DeleteImagePullIntent("test-image:latest"))
+	require.NoError(t, fsAccessor.DeleteImagePullIntent("test-image:latest"))
+	cmpIntents(t, 2)
+
+	require.NoError(t, fsAccessor.DeleteImagePullIntent("test-image:v1"))
+	require.NoError(t, fsAccessor.DeleteImagePullIntent("test-image:v1.1"))
+	cmpIntents(t, 0)
+
+	cmpPulledRecords(t, 4) // double-check that pulled records count is not affected
+
+	// Test image pulled record deletions
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-v1.1-ref"))
+	cmpPulledRecords(t, 3)
+
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-v1.1-ref"))
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-v1.1-ref"))
+	cmpPulledRecords(t, 3)
+
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-v1.2-ref"))
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-v1-ref"))
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-latest-ref"))
+	cmpPulledRecords(t, 0)
+
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-v1-ref"))
+	require.NoError(t, fsAccessor.DeleteImagePulledRecord("test-image-latest-ref"))
+	cmpPulledRecords(t, 0)
+}
+
+func cmpIntents(t *testing.T, expected uint) {
+	t.Helper()
+	const metricFormat = `
+# HELP kubelet_imagemanager_ondisk_pullintents [ALPHA] Number of ImagePullIntents stored on disk.
+# TYPE kubelet_imagemanager_ondisk_pullintents gauge
+kubelet_imagemanager_ondisk_pullintents %d
+`
+
+	err := metricstestutil.GatherAndCompare(
+		legacyregistry.DefaultGatherer, strings.NewReader(fmt.Sprintf(metricFormat, expected)), "kubelet_imagemanager_ondisk_pullintents",
+	)
+	if err != nil {
+		t.Errorf("failed to gather metrics: %v", err)
+	}
+}
+func cmpPulledRecords(t *testing.T, expected uint) {
+	t.Helper()
+	const metricFormat = `
+# HELP kubelet_imagemanager_ondisk_pulledrecords [ALPHA] Number of ImagePulledRecords stored on disk.
+# TYPE kubelet_imagemanager_ondisk_pulledrecords gauge
+kubelet_imagemanager_ondisk_pulledrecords %d
+`
+
+	err := metricstestutil.GatherAndCompare(
+		legacyregistry.DefaultGatherer, strings.NewReader(fmt.Sprintf(metricFormat, expected)), "kubelet_imagemanager_ondisk_pulledrecords",
+	)
+	if err != nil {
+		t.Errorf("failed to gather metrics: %v", err)
+	}
+}

--- a/pkg/kubelet/images/pullmanager/testdata/pulled/sha256-e766e4624f9bc4d3847d6c5b470d9d5362cc8d0c250bd9572daf95278e044263
+++ b/pkg/kubelet/images/pullmanager/testdata/pulled/sha256-e766e4624f9bc4d3847d6c5b470d9d5362cc8d0c250bd9572daf95278e044263
@@ -1,0 +1,1 @@
+{"kind":"ImagePulledRecord","apiVersion":"kubelet.config.k8s.io/v1alpha1","lastUpdatedTime":"2024-10-21T12:26:40Z","imageRef":"testbrokenrecord":"credentialMapping":{"docker.io/testing/broken":{"kubernetesSecrets":[{"uid":"testsecretuid","namespace":"default","name":"pull-secret","credentialHash":"testsecrethash"}]}}

--- a/pkg/kubelet/images/pullmanager/testdata/pulled/sha256-f4058727984875eb66ddbf289f7013096d4cbaa167e591fbcb2e447e36391c1f
+++ b/pkg/kubelet/images/pullmanager/testdata/pulled/sha256-f4058727984875eb66ddbf289f7013096d4cbaa167e591fbcb2e447e36391c1f
@@ -1,0 +1,1 @@
+{"kind":"ImagePulledRecord","apiVersion":"kubelet.config.k8s.io/v1alpha1","lastUpdatedTime":"2024-10-21T12:26:40Z","imageRef":"policyallowed","credentialMapping":{"docker.io/testing/policyexempt":{"kubernetesSecrets":[{"uid":"testsecretuid","namespace":"secretns","name":"pull-secret","credentialHash":"testsecrethash"}]}}}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds metrics describing the size of image pull records cache and for the total number of MustAttemptImagePull invocations and their results.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/2535

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New metrics are introduced related to Ensure Secret Pulled Images KEP:
    - kubelet_imagemanager_ondisk_pullintents - the number of pull intent records currently kept on disk
    - kubelet_imagemanager_ondisk_pulledrecords - the number of image pulled records currently kept on disk
    - kubelet_imagemanager_image_mustpull_checks_total{result} - the number for how many times an image was checked against the pull records and the results of those checks
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2535
```

/sig auth
/sig node
