### PR TITLE
chore: remove residual uint64ptr usage with k8s.io/util/ptr

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/cel_validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/cel_validation.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/cel"
+	"k8s.io/utils/ptr"
 )
 
 // unbounded uses nil to represent an unbounded cardinality value.
@@ -205,7 +206,7 @@ func (c *CELSchemaContext) childContext(child *apiextensions.JSONSchemaProps, ac
 	if maxElements == unbounded {
 		return result
 	}
-	result.MaxCardinality = uint64ptr(multiplyWithOverflowGuard(*c.MaxCardinality, *maxElements))
+	result.MaxCardinality = ptr.To[uint64](multiplyWithOverflowGuard(*c.MaxCardinality, *maxElements))
 	return result
 }
 
@@ -312,7 +313,7 @@ func extractMaxElements(schema *apiextensions.JSONSchemaProps) *uint64 {
 		}
 		// return 1 to indicate that all fields of an object exist at most one for
 		// each occurrence of the object they are fields of
-		return uint64ptr(1)
+		return ptr.To[uint64](1)
 	case "array":
 		if schema.MaxItems != nil {
 			maxItems := uint64(zeroIfNegative(*schema.MaxItems))
@@ -320,7 +321,7 @@ func extractMaxElements(schema *apiextensions.JSONSchemaProps) *uint64 {
 		}
 		return unbounded
 	default:
-		return uint64ptr(1)
+		return ptr.To[uint64](1)
 	}
 }
 
@@ -329,8 +330,4 @@ func zeroIfNegative(v int64) int64 {
 		return 0
 	}
 	return v
-}
-
-func uint64ptr(i uint64) *uint64 {
-	return &i
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -11348,14 +11348,14 @@ func TestCostInfo(t *testing.T) {
 			schema: []*apiextensions.JSONSchemaProps{
 				genObjectSchema(),
 			},
-			expectedMaxCardinality: uint64ptr(1),
+			expectedMaxCardinality: ptr.To[uint64](1),
 		},
 		{
 			name: "array",
 			schema: []*apiextensions.JSONSchemaProps{
 				withMaxItems(genArraySchema(), int64ptr(5)),
 			},
-			expectedMaxCardinality: uint64ptr(5),
+			expectedMaxCardinality: ptr.To[uint64](5),
 		},
 		{
 			name:                   "unbounded array",
@@ -11365,7 +11365,7 @@ func TestCostInfo(t *testing.T) {
 		{
 			name:                   "map",
 			schema:                 []*apiextensions.JSONSchemaProps{withMaxProperties(genMapSchema(), int64ptr(10))},
-			expectedMaxCardinality: uint64ptr(10),
+			expectedMaxCardinality: ptr.To[uint64](10),
 		},
 		{
 			name: "unbounded map",
@@ -11380,7 +11380,7 @@ func TestCostInfo(t *testing.T) {
 				withMaxProperties(genMapSchema(), int64ptr(5)),
 				withMaxItems(genArraySchema(), int64ptr(5)),
 			},
-			expectedMaxCardinality: uint64ptr(25),
+			expectedMaxCardinality: ptr.To[uint64](25),
 		},
 		{
 			name: "unbounded array inside bounded map",
@@ -11396,7 +11396,7 @@ func TestCostInfo(t *testing.T) {
 				withMaxItems(genArraySchema(), int64ptr(3)),
 				genObjectSchema(),
 			},
-			expectedMaxCardinality: uint64ptr(3),
+			expectedMaxCardinality: ptr.To[uint64](3),
 		},
 		{
 			name: "map inside object inside array",
@@ -11405,7 +11405,7 @@ func TestCostInfo(t *testing.T) {
 				genObjectSchema(),
 				withMaxProperties(genMapSchema(), int64ptr(4)),
 			},
-			expectedMaxCardinality: uint64ptr(8),
+			expectedMaxCardinality: ptr.To[uint64](8),
 		},
 		{
 			name: "integer overflow bounds check",
@@ -11413,7 +11413,7 @@ func TestCostInfo(t *testing.T) {
 				withMaxItems(genArraySchema(), int64ptr(math.MaxInt)),
 				withMaxItems(genArraySchema(), int64ptr(100)),
 			},
-			expectedMaxCardinality: uint64ptr(math.MaxUint),
+			expectedMaxCardinality: ptr.To[uint64](math.MaxUint),
 		},
 	}
 	for _, tt := range tests {

--- a/test/e2e/framework/debug/resource_usage_gatherer.go
+++ b/test/e2e/framework/debug/resource_usage_gatherer.go
@@ -41,6 +41,7 @@ import (
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	"k8s.io/utils/ptr"
 )
 
 // ResourceConstraint is a struct to hold constraints.
@@ -259,10 +260,10 @@ func getOneTimeResourceUsageOnNode(
 		return &ContainerResourceUsage{
 			Name:                    name,
 			Timestamp:               newStats.StartTime.Time,
-			CPUUsageInCores:         float64(removeUint64Ptr(newStats.CPU.UsageNanoCores)) / 1000000000,
-			MemoryUsageInBytes:      removeUint64Ptr(newStats.Memory.UsageBytes),
-			MemoryWorkingSetInBytes: removeUint64Ptr(newStats.Memory.WorkingSetBytes),
-			MemoryRSSInBytes:        removeUint64Ptr(newStats.Memory.RSSBytes),
+			CPUUsageInCores:         float64(ptr.Deref(newStats.CPU.UsageNanoCores, 0)) / 1000000000,
+			MemoryUsageInBytes:      ptr.Deref(newStats.Memory.UsageBytes, 0),
+			MemoryWorkingSetInBytes: ptr.Deref(newStats.Memory.WorkingSetBytes, 0),
+			MemoryRSSInBytes:        ptr.Deref(newStats.Memory.RSSBytes, 0),
 			CPUInterval:             0,
 		}
 	}
@@ -311,13 +312,6 @@ func getStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alp
 		return nil, err
 	}
 	return &summary, nil
-}
-
-func removeUint64Ptr(ptr *uint64) uint64 {
-	if ptr == nil {
-		return 0
-	}
-	return *ptr
 }
 
 func (w *resourceGatherWorker) gather(ctx context.Context, initialSleep time.Duration) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086 and https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
