### PR TITLE
Promote PSI metrics feature to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -430,7 +430,6 @@ const (
 	// KubeletPSI enables Kubelet to surface PSI metrics
 	// owner: @roycaihw
 	// kep: https://kep.k8s.io/4205
-	// alpha: v1.33
 	KubeletPSI featuregate.Feature = "KubeletPSI"
 
 	// owner: @moshe010
@@ -1271,6 +1270,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	KubeletPSI: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KubeletPodResourcesDynamicResources: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -733,6 +733,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.33"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: KubeletRegistrationGetOnExistsOnly
   versionedSpecs:
   - default: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Promote the KubeletPSI feature gate to beta.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/4205

#### Special notes for your reviewer:
Beta graduation requirements: 
- [x] Extend e2e test coverage
  - [x] Current test coverage
    - [x] [E2E test](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/summary_test.go): PSI data surfaced in node summary API 
    - [x] Unit tests: `pkg/kubelet/stats`, `pkg/kubelet/server/stats`
    - [x] [Presubmits](https://testgrid.k8s.io/sig-node-presubmits#pr-node-kubelet-containerd-kubelet-psi)
    - [x] [Prow job](https://github.com/kubernetes/test-infra/blob/0ff1ad0fce4ccf8f817913e35c055de8b164f008/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml#L563) 
  - [x] [Increased test coverage](https://github.com/kubernetes/kubernetes/pull/132824)
- [x] Allowing time for feedback: no outstanding [issue reported](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue%20state%3Aopen%20(%22Pressure%20Stall%20Information%22%20OR%20%22psi%22))
- [x] Performance testing to verify
  - [x] Verification enabling PSI on nodes doesn't introduce excessive CPU or memory usage in the kernel
  - [x] PSI metrics collection doesn't introduce excessive CPU or memory usage increase in the kubelet
  - [x] [Performance test report](https://docs.google.com/document/d/1hBc-mNpC8hNMoN70jsRtbr5sdLM6F2foWWtWdJiJzic/edit?usp=sharing)
  - [x] [Performance test script](https://drive.google.com/file/d/17Eg-2ZnAT849mXLaDdE-imLdso_49ttX/view?usp=drive_link) and [data analysis script](https://drive.google.com/file/d/1outLH51pt31z3nNpgaG5-TQgICYOrrDx/view?usp=drive_link)
  - [x] [Raw data](https://drive.google.com/drive/folders/1t2rVNpeMyqZc5LH60T97OfHTmY2Xd0tg?usp=drive_link)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promoted Linux node pressure stall information (PSI) metrics to beta.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4205-psi-metric
- [Usage]: https://kubernetes.io/docs/reference/instrumentation/node-metrics/#psi
```

/sig node
/priority important-soon