### PR TITLE
Add feature gate enable test for KubeletPodResourcesGet

### DIFF
--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -1022,7 +1022,7 @@ var _ = SIGDescribe("POD Resources", framework.WithSerial(), feature.PodResource
 						})
 
 						framework.Logf("Get result: %v, err: %v", res, err)
-						gomega.Expect(err).ToNot(gomega.HaveOccurred(), "expected Get to succeed with the feature gate enabled")
+						framework.ExpectNoError(err, "Expected Get to succeed with the feature gate enabled")
 						gomega.Expect(res.PodResources.Name).To(gomega.Equal(pod.Name))
 						gomega.Expect(res.PodResources.Containers).To(gomega.HaveLen(1), "expected one container")
 						container := res.PodResources.Containers[0]

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -1024,6 +1024,12 @@ var _ = SIGDescribe("POD Resources", framework.WithSerial(), feature.PodResource
 						framework.Logf("Get result: %v, err: %v", res, err)
 						gomega.Expect(err).ToNot(gomega.HaveOccurred(), "expected Get to succeed with the feature gate enabled")
 						gomega.Expect(res.PodResources.Name).To(gomega.Equal(pod.Name))
+						gomega.Expect(res.PodResources.Containers).To(gomega.HaveLen(1), "expected one container")
+						container := res.PodResources.Containers[0]
+						gomega.Expect(container.Name).To(gomega.Equal(pd.cntName), "expected container name match")
+						gomega.Expect(container.CpuIds).ToNot(gomega.BeEmpty(), "expected CPU IDs to be reported")
+						gomega.Expect(len(container.CpuIds)).To(gomega.Equal(pd.CpuRequestExclusive()), "expected one exclusive CPU")
+						gomega.Expect(container.Devices).To(gomega.BeEmpty(), "expected no devices")
 					})
 				})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add an explicit gingko.context  to check when KubeletPodResourcesGet feature gate is enabled, it returns a valid Get() response.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Addressing e2e test fixes for KEP-3695 discussed here https://github.com/kubernetes/kubernetes/pull/132345#issuecomment-2987352753 


#### Does this PR introduce a user-facing change?
None


