### PR TITLE
add SuccessCriteriaMet status for kubectl get job

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1235,6 +1235,8 @@ func printJob(obj *batch.Job, options printers.GenerateOptions) ([]metav1.TableR
 		status = "Suspended"
 	} else if hasJobCondition(obj.Status.Conditions, batch.JobFailureTarget) {
 		status = "FailureTarget"
+	} else if hasJobCondition(obj.Status.Conditions, batch.JobSuccessCriteriaMet) {
+		status = "SuccessCriteriaMet"
 	} else {
 		status = "Running"
 	}

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -2842,6 +2842,29 @@ func TestPrintJob(t *testing.T) {
 			// Columns: Name, Status, Completions, Duration, Age
 			expected: []metav1.TableRow{{Cells: []interface{}{"job9", "Terminating", "0/1", "", "0s"}}},
 		},
+		{
+			job: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "job10",
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
+				},
+				Spec: batch.JobSpec{
+					Completions: nil,
+				},
+				Status: batch.JobStatus{
+					Succeeded: 0,
+					Conditions: []batch.JobCondition{
+						{
+							Type:   batch.JobSuccessCriteriaMet,
+							Status: api.ConditionTrue,
+						},
+					},
+				},
+			},
+			options: printers.GenerateOptions{},
+			// Columns: Name, Status, Completions, Duration, Age
+			expected: []metav1.TableRow{{Cells: []interface{}{"job10", "SuccessCriteriaMet", "0/1", "", "0s"}}},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
add SuccessCriteriaMet status for kubectl get job

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/132786

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
CLI: `kubectl get job` now displays the SuccessCriteriaMet status for the listed jobs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```

```
