### PR TITLE
kubeproxy metrics improve

### DIFF
--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -105,10 +105,10 @@ var (
 	// NetworkProgrammingQueueLatency tracks the time spent waiting in queue before obtaining the sync lock
 	NetworkProgrammingQueueLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
-			Subsystem: kubeProxySubsystem,
-			Name:      "network_programming_queue_duration_seconds",
-			Help:      "Network programming queue latency in seconds",
-			Buckets:   metrics.ExponentialBuckets(0.001, 2, 15),
+			Subsystem:      kubeProxySubsystem,
+			Name:           "network_programming_queue_duration_seconds",
+			Help:           "Network programming queue latency in seconds",
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"ip_family"},

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -49,7 +49,7 @@ var (
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_full_proxy_rules_duration_seconds",
 			Help:           "SyncProxyRules latency in seconds for full resyncs",
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 17),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"ip_family"},
@@ -61,7 +61,7 @@ var (
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_partial_proxy_rules_duration_seconds",
 			Help:           "SyncProxyRules latency in seconds for partial resyncs",
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 17),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"ip_family"},
@@ -95,8 +95,20 @@ var (
 				metrics.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
 				metrics.LinearBuckets(1, 1, 59),      // 1s, 2s, 3s, ... 59s
 				metrics.LinearBuckets(60, 5, 12),     // 60s, 65s, 70s, ... 115s
-				metrics.LinearBuckets(120, 30, 7),    // 2min, 2.5min, 3min, ..., 5min
+				metrics.LinearBuckets(120, 30, 17),   // 2min, 2.5min, 3min, ..., 10min
 			),
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"ip_family"},
+	)
+
+	// NetworkProgrammingQueueLatency tracks the time spent waiting in queue before obtaining the sync lock
+	NetworkProgrammingQueueLatency = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem: kubeProxySubsystem,
+			Name:      "network_programming_queue_duration_seconds",
+			Help:      "Network programming queue latency in seconds",
+			Buckets:   metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"ip_family"},
@@ -326,6 +338,7 @@ func RegisterMetrics(mode kubeproxyconfig.ProxyMode) {
 
 		// FIXME: winkernel does not implement these
 		legacyregistry.MustRegister(NetworkProgrammingLatency)
+		legacyregistry.MustRegister(NetworkProgrammingQueueLatency)
 		legacyregistry.MustRegister(SyncProxyRulesNoLocalEndpointsTotal)
 
 		switch mode {

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1861,8 +1861,10 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	for name, lastChangeTriggerTimes := range endpointUpdateResult.LastChangeTriggerTimes {
 		for _, lastChangeTriggerTime := range lastChangeTriggerTimes {
 			latency := metrics.SinceInSeconds(lastChangeTriggerTime)
+			queueLatency := metrics.SinceInSeconds(start) - metrics.SinceInSeconds(lastChangeTriggerTime)
 			metrics.NetworkProgrammingLatency.WithLabelValues(string(proxier.ipFamily)).Observe(latency)
-			proxier.logger.V(4).Info("Network programming", "endpoint", klog.KRef(name.Namespace, name.Name), "elapsed", latency)
+			metrics.NetworkProgrammingQueueLatency.WithLabelValues(string(proxier.ipFamily)).Observe(queueLatency)
+			proxier.logger.V(4).Info("Network programming", "endpoint", klog.KRef(name.Namespace, name.Name), "elapsed", latency, "queueLatency", queueLatency)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
Metrics improve
#### What this PR does / why we need it:
1. This PR extends metrics bucket range that in my scale test I observe the original limit has been breaching.
- `NetworkProgrammingLatency`: Increased largest bucket from 5min to 10min
- `SyncFullProxyRulesLatency`: Increased largest bucket from ~15s to ~1min (buckets: 15→17)
- `SyncPartialProxyRulesLatency`: Increased largest bucket from ~15s to ~1min (buckets: 15→17)

2. This PR adds new metrics `NetworkProgrammingQueueLatency`: New histogram metric tracking time spent waiting in queue before obtaining sync lock

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Yes, prometheus metrics change will be observed by user if enabled.

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
