### PR TITLE
Fix IntOrString cost estimation when schema has a MaxLength constraint

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
@@ -1872,6 +1872,18 @@ func TestCostEstimation(t *testing.T) {
 			setMaxElements:   1000,
 			expectedSetCost:  401,
 		},
+		{
+			name: "IntOrString type with quantity rule",
+			schemaGenerator: func(max *int64) *schema.Structural {
+				intOrString := intOrStringType()
+				intOrString = withRule(intOrString, "isQuantity(self)")
+				intOrString = withMaxLength(intOrString, max)
+				return &intOrString
+			},
+			expectedCalcCost: 314574,
+			setMaxElements:   20,
+			expectedSetCost:  9,
+		},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This updates the way that the maximum size of an IntOrString is calculated in the CEL cost estimator to take into account an openapi maxlength constraint.

I was working with someone on a field like:
```
// request is the minimum amount of the resource required (e.g. "2Mi", "1Gi").
	// This field is optional.
	// When limit is specified, request cannot be greater than limit.
	// +optional
	Request resource.Quantity `json:"request,omitempty"`
```

We then started adding some CEL rules, for example,
```
	// +kubebuilder:validation:XValidation:rule="isQuantity(self) && quantity(self).isGreaterThan(quantity('0'))",message="request must be a positive, non-zero quantity"
```
The API server started to complain of high validation costs. Typically this is because the unbounded string length results in a high `MaxElements` in the cost estimates.

The usual fix would be to add a maximum length, for example:
```
	// +kubebuilder:validation:MaxLength=20
```
But this doesn't work initially because of the way controller-gen is applying different parts of the schema, adding 
```
	// +kubebuilder:validation:XIntOrString
```
Allows it to produce the following schema:
```
request:
  anyOf:
  - type: integer
  - type: string
  description: |-
    request is the minimum amount of the resource required (e.g. "2Mi", "1Gi").
    This field is optional.
    When limit is specified, request cannot be greater than limit.
  maxLength: 20 // This is the only part we've added on top of the default schema that controller tools produced
  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
  x-kubernetes-int-or-string: true
  x-kubernetes-validations:
  - message: request must be a non-negative quantity
    rule: isQuantity(self) && quantity(self).isGreaterThan(quantity('0'))
```

We then noticed that the cost estimates were still particularly high. It turns out, that the logic handling any `XIntOrString` field isn't correctly observing the `MaxLength`.

As far as I can tell, the above is a valid schema and the API server appears to accept this schema, and enforce the maximum string length (note int64 has a maximum length of 19 so the integer max length should be covered by this case too, though CELs cost estimates for integers doesn't set a max elements AFAICT)

This PR updates the logic to take into account the max length and resolves our issue.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix runtime cost estimation for x-int-or-string custom resource schemas with maximum lengths
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
