### PR TITLE
Drop experimental flags from etcd

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	utilsnet "k8s.io/utils/net"
@@ -240,9 +241,6 @@ func getEtcdCommand(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.A
 	}
 	defaultArguments := []kubeadmapi.Arg{
 		{Name: "name", Value: nodeName},
-		// TODO: start using --initial-corrupt-check once the graduated flag is available,
-		// https://github.com/kubernetes/kubeadm/issues/2676
-		{Name: "experimental-initial-corrupt-check", Value: "true"},
 		{Name: "listen-client-urls", Value: fmt.Sprintf("%s,%s", etcdutil.GetClientURLByIP(etcdLocalhostAddress), etcdutil.GetClientURL(endpoint))},
 		{Name: "advertise-client-urls", Value: etcdutil.GetClientURL(endpoint)},
 		{Name: "listen-peer-urls", Value: etcdutil.GetPeerURL(endpoint)},
@@ -258,7 +256,20 @@ func getEtcdCommand(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.A
 		{Name: "peer-client-cert-auth", Value: "true"},
 		{Name: "snapshot-count", Value: "10000"},
 		{Name: "listen-metrics-urls", Value: fmt.Sprintf("http://%s", net.JoinHostPort(etcdLocalhostAddress, strconv.Itoa(kubeadmconstants.EtcdMetricsPort)))},
-		{Name: "experimental-watch-progress-notify-interval", Value: "5s"},
+	}
+
+	if len(cfg.KubernetesVersion) > 0 && version.MustParseSemantic(cfg.KubernetesVersion).Minor() >= 34 {
+		// Arguments used by Etcd 3.6.0+.
+		// TODO: Start always using these once kubeadm only supports etcd >= 3.6.0 for all its supported k8s versions.
+		defaultArguments = append(defaultArguments, []kubeadmapi.Arg{
+			{Name: "feature-gates", Value: "InitialCorruptCheck=true"},
+			{Name: "watch-progress-notify-interval", Value: "5s"},
+		}...)
+	} else {
+		defaultArguments = append(defaultArguments, []kubeadmapi.Arg{
+			{Name: "experimental-initial-corrupt-check", Value: "true"},
+			{Name: "experimental-watch-progress-notify-interval", Value: "5s"},
+		}...)
 	}
 
 	if len(initialCluster) == 0 {

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -107,8 +107,7 @@ spec:
     - --cert-file=etcd/server.crt
     - --client-cert-auth=true
     - --data-dir=%s/etcd
-    - --experimental-initial-corrupt-check=true
-    - --experimental-watch-progress-notify-interval=5s
+    - --feature-gates=InitialCorruptCheck=true
     - --initial-advertise-peer-urls=https://:2380
     - --initial-cluster==https://:2380
     - --key-file=etcd/server.key
@@ -122,6 +121,7 @@ spec:
     - --peer-trusted-ca-file=etcd/ca.crt
     - --snapshot-count=10000
     - --trusted-ca-file=etcd/ca.crt
+    - --watch-progress-notify-interval=5s
     image: /etcd:%s
     imagePullPolicy: IfNotPresent
     livenessProbe:
@@ -283,6 +283,7 @@ func TestGetEtcdCommand(t *testing.T) {
 	var tests = []struct {
 		name             string
 		advertiseAddress string
+		k8sVersion       string
 		nodeName         string
 		extraArgs        []kubeadmapi.Arg
 		initialCluster   []etcdutil.Member
@@ -405,6 +406,34 @@ func TestGetEtcdCommand(t *testing.T) {
 				fmt.Sprintf("--initial-cluster=foo=https://[2001:db8::3]:%d", kubeadmconstants.EtcdListenPeerPort),
 			},
 		},
+		{
+			name:             "New etcd (3.6.0+) flags",
+			advertiseAddress: "1.2.3.4",
+			k8sVersion:       "1.34.0",
+			nodeName:         "bar",
+			expected: []string{
+				"etcd",
+				"--name=bar",
+				"--feature-gates=InitialCorruptCheck=true",
+				"--watch-progress-notify-interval=5s",
+				fmt.Sprintf("--listen-client-urls=https://127.0.0.1:%d,https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort, kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-metrics-urls=http://127.0.0.1:%d", kubeadmconstants.EtcdMetricsPort),
+				fmt.Sprintf("--advertise-client-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--initial-advertise-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				"--data-dir=/var/lib/etcd",
+				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),
+				"--key-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerKeyName),
+				"--trusted-ca-file=" + filepath.FromSlash(kubeadmconstants.EtcdCACertName),
+				"--client-cert-auth=true",
+				"--peer-cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdPeerCertName),
+				"--peer-key-file=" + filepath.FromSlash(kubeadmconstants.EtcdPeerKeyName),
+				"--peer-trusted-ca-file=" + filepath.FromSlash(kubeadmconstants.EtcdCACertName),
+				"--snapshot-count=10000",
+				"--peer-client-cert-auth=true",
+				fmt.Sprintf("--initial-cluster=bar=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+			},
+		},
 	}
 
 	for _, rt := range tests {
@@ -413,6 +442,7 @@ func TestGetEtcdCommand(t *testing.T) {
 				AdvertiseAddress: rt.advertiseAddress,
 			}
 			cfg := &kubeadmapi.ClusterConfiguration{
+				KubernetesVersion: rt.k8sVersion,
 				Etcd: kubeadmapi.Etcd{
 					Local: &kubeadmapi.LocalEtcd{
 						DataDir:   "/var/lib/etcd",


### PR DESCRIPTION
They were deprecated in etcd 3.6.0 and were removed in 3.7.0: https://github.com/etcd-io/etcd/pull/19959

1. `--experimental-initial-corrupt-check` was removed and is now a feature gate set with `--feature-gates=InitialCorruptCheck=true` in https://github.com/etcd-io/etcd/pull/18478
2. `--experimental-watch-progress-notify-interval` was removed and is now called `--watch-progress-notify-interval` without `experimental-` prefix: https://github.com/etcd-io/etcd/pull/19248 

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Stops using flags deprecated in Etcd 3.6.0 and allows to use Etcd 3.7.0.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubeadm/issues/2676

#### Special notes for your reviewer:

Tested using kind with etcd v3.6.1 and main branch images.

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: instead of passing the etcd flag --experimental-initial-corrupt-check, set the InitialCorruptCheck=true etcd feature gate, and instead of passing the --experimental-watch-progress-notify-interval flag, pass its graduated variant --watch-progress-notify-interval.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
