### PR TITLE
chore: replace int64ptr with ptr.To

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -323,10 +323,10 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 	podOverheadMemory := resource.MustParse("64Mi")
 
 	resCfg := &cm.ResourceConfig{
-		Memory:    int64Ptr(335544320),
+		Memory:    ptr.To[int64](335544320),
 		CPUShares: ptr.To[uint64](306),
 		CPUPeriod: ptr.To[uint64](100000),
-		CPUQuota:  int64Ptr(30000),
+		CPUQuota:  ptr.To[int64](30000),
 	}
 
 	for _, tc := range []struct {
@@ -357,10 +357,10 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 				},
 			},
 			expected: &cm.ResourceConfig{
-				Memory:    int64Ptr(335544320),
+				Memory:    ptr.To[int64](335544320),
 				CPUShares: ptr.To[uint64](306),
 				CPUPeriod: ptr.To[uint64](100000),
-				CPUQuota:  int64Ptr(30000),
+				CPUQuota:  ptr.To[int64](30000),
 			},
 		},
 		{
@@ -388,10 +388,10 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 				},
 			},
 			expected: &cm.ResourceConfig{
-				Memory:    int64Ptr(268435456),
+				Memory:    ptr.To[int64](268435456),
 				CPUShares: ptr.To[uint64](306),
 				CPUPeriod: ptr.To[uint64](100000),
-				CPUQuota:  int64Ptr(30000),
+				CPUQuota:  ptr.To[int64](30000),
 			},
 		},
 		{
@@ -419,16 +419,16 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 				},
 			},
 			expected: &cm.ResourceConfig{
-				Memory:    int64Ptr(335544320),
+				Memory:    ptr.To[int64](335544320),
 				CPUShares: ptr.To[uint64](203),
 				CPUPeriod: ptr.To[uint64](100000),
-				CPUQuota:  int64Ptr(20000),
+				CPUQuota:  ptr.To[int64](20000),
 			},
 		},
 		{
 			name: "withoutCPUPeriod",
 			cfgInput: &cm.ResourceConfig{
-				Memory:    int64Ptr(335544320),
+				Memory:    ptr.To[int64](335544320),
 				CPUShares: ptr.To[uint64](306),
 			},
 			pod: &v1.Pod{
@@ -453,16 +453,16 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 				},
 			},
 			expected: &cm.ResourceConfig{
-				Memory:    int64Ptr(335544320),
+				Memory:    ptr.To[int64](335544320),
 				CPUShares: ptr.To[uint64](203),
 			},
 		},
 		{
 			name: "withoutCPUShares",
 			cfgInput: &cm.ResourceConfig{
-				Memory:    int64Ptr(335544320),
+				Memory:    ptr.To[int64](335544320),
 				CPUPeriod: ptr.To[uint64](100000),
-				CPUQuota:  int64Ptr(30000),
+				CPUQuota:  ptr.To[int64](30000),
 			},
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
@@ -486,9 +486,9 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 				},
 			},
 			expected: &cm.ResourceConfig{
-				Memory:    int64Ptr(335544320),
+				Memory:    ptr.To[int64](335544320),
 				CPUPeriod: ptr.To[uint64](100000),
-				CPUQuota:  int64Ptr(20000),
+				CPUQuota:  ptr.To[int64](20000),
 			},
 		},
 		{
@@ -517,10 +517,10 @@ func TestSubtractOverheadFromResourceConfig(t *testing.T) {
 				},
 			},
 			expected: &cm.ResourceConfig{
-				Memory:    int64Ptr(268435456),
+				Memory:    ptr.To[int64](268435456),
 				CPUShares: ptr.To[uint64](203),
 				CPUPeriod: ptr.To[uint64](100000),
-				CPUQuota:  int64Ptr(20000),
+				CPUQuota:  ptr.To[int64](20000),
 			},
 		},
 	} {

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -42,10 +42,6 @@ func (f podStatusProviderFunc) GetPodStatus(_ context.Context, uid types.UID, na
 	return f(uid, name, namespace)
 }
 
-func int64Ptr(i int64) *int64 {
-	return &i
-}
-
 func TestIsInitContainerFailed(t *testing.T) {
 	tests := []struct {
 		status      *kubecontainer.Status
@@ -148,7 +144,7 @@ func TestGetBackoffKey(t *testing.T) {
 			originalKey := GetBackoffKey(pod, &pod.Spec.Containers[0])
 
 			podCopy := pod.DeepCopy()
-			podCopy.Spec.ActiveDeadlineSeconds = int64Ptr(1)
+			podCopy.Spec.ActiveDeadlineSeconds = ptr.To[int64](1)
 			assert.Equal(t, originalKey, GetBackoffKey(podCopy, &podCopy.Spec.Containers[0]),
 				"Unrelated change should not change the key")
 
@@ -513,12 +509,12 @@ func TestMergeResourceConfig(t *testing.T) {
 	}{
 		{
 			name:   "merge all fields",
-			source: &cm.ResourceConfig{Memory: int64Ptr(1024), CPUShares: ptr.To[uint64](2)},
-			update: &cm.ResourceConfig{Memory: int64Ptr(2048), CPUQuota: int64Ptr(5000)},
+			source: &cm.ResourceConfig{Memory: ptr.To[int64](1024), CPUShares: ptr.To[uint64](2)},
+			update: &cm.ResourceConfig{Memory: ptr.To[int64](2048), CPUQuota: ptr.To[int64](5000)},
 			expected: &cm.ResourceConfig{
-				Memory:    int64Ptr(2048),
+				Memory:    ptr.To[int64](2048),
 				CPUShares: ptr.To[uint64](2),
-				CPUQuota:  int64Ptr(5000),
+				CPUQuota:  ptr.To[int64](5000),
 			},
 		},
 		{
@@ -533,25 +529,25 @@ func TestMergeResourceConfig(t *testing.T) {
 		{
 			name:   "update nil source",
 			source: nil,
-			update: &cm.ResourceConfig{Memory: int64Ptr(4096)},
+			update: &cm.ResourceConfig{Memory: ptr.To[int64](4096)},
 			expected: &cm.ResourceConfig{
-				Memory: int64Ptr(4096),
+				Memory: ptr.To[int64](4096),
 			},
 		},
 		{
 			name:   "update nil update",
-			source: &cm.ResourceConfig{Memory: int64Ptr(1024)},
+			source: &cm.ResourceConfig{Memory: ptr.To[int64](1024)},
 			update: nil,
 			expected: &cm.ResourceConfig{
-				Memory: int64Ptr(1024),
+				Memory: ptr.To[int64](1024),
 			},
 		},
 		{
 			name:   "update empty source",
 			source: &cm.ResourceConfig{},
-			update: &cm.ResourceConfig{Memory: int64Ptr(8192)},
+			update: &cm.ResourceConfig{Memory: ptr.To[int64](8192)},
 			expected: &cm.ResourceConfig{
-				Memory: int64Ptr(8192),
+				Memory: ptr.To[int64](8192),
 			},
 		},
 	}
@@ -567,10 +563,10 @@ func TestMergeResourceConfig(t *testing.T) {
 
 func TestConvertResourceConfigToLinuxContainerResources(t *testing.T) {
 	resCfg := &cm.ResourceConfig{
-		Memory:        int64Ptr(2048),
+		Memory:        ptr.To[int64](2048),
 		CPUShares:     ptr.To[uint64](2),
 		CPUPeriod:     ptr.To[uint64](10000),
-		CPUQuota:      int64Ptr(5000),
+		CPUQuota:      ptr.To[int64](5000),
 		HugePageLimit: map[int64]int64{4096: 2048},
 		Unified:       map[string]string{"key1": "value1"},
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -9642,7 +9642,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self == oldSelf"},
 									},
@@ -9668,7 +9668,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self == oldSelf"},
 									},
@@ -9691,7 +9691,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "array",
-							MaxItems:  int64ptr(10),
+							MaxItems:  ptr.To[int64](10),
 							XListType: ptr.To("atomic"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
@@ -9714,11 +9714,11 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "array",
-							MaxItems: int64ptr(10),
+							MaxItems: ptr.To[int64](10),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 								},
 							},
 							XValidations: apiextensions.ValidationRules{
@@ -9738,12 +9738,12 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "array",
-							MaxItems:  int64ptr(10),
+							MaxItems:  ptr.To[int64](10),
 							XListType: ptr.To("set"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self == oldSelf"},
 									},
@@ -9766,12 +9766,12 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "array",
-							MaxItems:  int64ptr(10),
+							MaxItems:  ptr.To[int64](10),
 							XListType: ptr.To("set"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 								},
 							},
 							XValidations: apiextensions.ValidationRules{
@@ -9801,7 +9801,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 									},
 									Required: []string{"name"},
 									Properties: map[string]apiextensions.JSONSchemaProps{
-										"name": {Type: "string", MaxLength: int64ptr(5)},
+										"name": {Type: "string", MaxLength: ptr.To[int64](5)},
 									},
 								},
 							},
@@ -9819,7 +9819,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:         "array",
-							MaxItems:     int64ptr(10),
+							MaxItems:     ptr.To[int64](10),
 							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"name"},
 							Items: &apiextensions.JSONSchemaPropsOrArray{
@@ -9827,7 +9827,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 									Type:     "object",
 									Required: []string{"name"},
 									Properties: map[string]apiextensions.JSONSchemaProps{
-										"name": {Type: "string", MaxLength: int64ptr(5)},
+										"name": {Type: "string", MaxLength: ptr.To[int64](5)},
 									},
 								},
 							},
@@ -9852,7 +9852,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self == oldSelf"},
 									},
@@ -9876,7 +9876,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self == oldSelf"},
 									},
@@ -9903,7 +9903,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self == oldSelf"},
 									},
@@ -10045,7 +10045,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 											Type:     "object",
 											Required: []string{"key"},
 											Properties: map[string]apiextensions.JSONSchemaProps{
-												"key": {Type: "string", MaxLength: int64ptr(10)},
+												"key": {Type: "string", MaxLength: ptr.To[int64](10)},
 											},
 										},
 									},
@@ -10075,17 +10075,17 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "array",
-							MaxItems: int64ptr(10),
+							MaxItems: ptr.To[int64](10),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:          "object",
-									MaxProperties: int64ptr(10),
+									MaxProperties: ptr.To[int64](10),
 									AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
 										Schema: &apiextensions.JSONSchemaProps{
 											Type:     "object",
 											Required: []string{"key"},
 											Properties: map[string]apiextensions.JSONSchemaProps{
-												"key": {Type: "string", MaxLength: int64ptr(10)},
+												"key": {Type: "string", MaxLength: ptr.To[int64](10)},
 											},
 										},
 									},
@@ -10109,7 +10109,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:     "array",
-							MaxItems: int64ptr(4),
+							MaxItems: ptr.To[int64](4),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type: "object",
@@ -10160,11 +10160,11 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"list": {
 							Type:     "array",
-							MaxItems: int64Ptr(100000),
+							MaxItems: ptr.To[int64](100000),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64Ptr(5000),
+									MaxLength: ptr.To[int64](5000),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self.contains('keyword')"},
 									},
@@ -10173,12 +10173,12 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 						},
 						"map": {
 							Type:          "object",
-							MaxProperties: int64Ptr(1000),
+							MaxProperties: ptr.To[int64](1000),
 							AdditionalProperties: &apiextensions.JSONSchemaPropsOrBool{
 								Allows: true,
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64Ptr(5000),
+									MaxLength: ptr.To[int64](5000),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: "self.contains('keyword')"},
 									},
@@ -10804,7 +10804,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: `self == oldSelf.orValue("")`, OptionalOldSelf: ptr.To(true)},
 									},
@@ -10830,7 +10830,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: `self == oldSelf.orValue("")`, OptionalOldSelf: ptr.To(true)},
 									},
@@ -10853,12 +10853,12 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "array",
-							MaxItems:  int64ptr(10),
+							MaxItems:  ptr.To[int64](10),
 							XListType: ptr.To("set"),
 							Items: &apiextensions.JSONSchemaPropsOrArray{
 								Schema: &apiextensions.JSONSchemaProps{
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: `self == oldSelf.orValue("")`, OptionalOldSelf: ptr.To(true)},
 									},
@@ -10885,7 +10885,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 							Properties: map[string]apiextensions.JSONSchemaProps{
 								"subfield": {
 									Type:      "string",
-									MaxLength: int64ptr(10),
+									MaxLength: ptr.To[int64](10),
 									XValidations: apiextensions.ValidationRules{
 										{Rule: `self == oldSelf.orValue("")`, OptionalOldSelf: ptr.To(true)},
 									},
@@ -10909,7 +10909,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "string",
-							MaxLength: int64ptr(10),
+							MaxLength: ptr.To[int64](10),
 							XValidations: apiextensions.ValidationRules{
 								{Rule: `self == "foo"`, OptionalOldSelf: ptr.To(true)},
 							},
@@ -10930,7 +10930,7 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"value": {
 							Type:      "string",
-							MaxLength: int64ptr(10),
+							MaxLength: ptr.To[int64](10),
 							XValidations: apiextensions.ValidationRules{
 								{Rule: `self == "foo"`, OptionalOldSelf: ptr.To(false)},
 							},
@@ -11140,11 +11140,11 @@ var validValidationSchema = &apiextensions.JSONSchemaProps{
 	ExclusiveMaximum: true,
 	Minimum:          float64Ptr(5),
 	ExclusiveMinimum: true,
-	MaxLength:        int64Ptr(10),
-	MinLength:        int64Ptr(5),
+	MaxLength:        ptr.To[int64](10),
+	MinLength:        ptr.To[int64](5),
 	Pattern:          "^[a-z]$",
-	MaxItems:         int64Ptr(10),
-	MinItems:         int64Ptr(5),
+	MaxItems:         ptr.To[int64](10),
+	MinItems:         ptr.To[int64](5),
 	MultipleOf:       float64Ptr(3),
 	Required:         []string{"spec", "status"},
 	Properties: map[string]apiextensions.JSONSchemaProps{
@@ -11176,11 +11176,11 @@ var validUnstructuralValidationSchema = &apiextensions.JSONSchemaProps{
 	ExclusiveMaximum: true,
 	Minimum:          float64Ptr(5),
 	ExclusiveMinimum: true,
-	MaxLength:        int64Ptr(10),
-	MinLength:        int64Ptr(5),
+	MaxLength:        ptr.To[int64](10),
+	MinLength:        ptr.To[int64](5),
 	Pattern:          "^[a-z]$",
-	MaxItems:         int64Ptr(10),
-	MinItems:         int64Ptr(5),
+	MaxItems:         ptr.To[int64](10),
+	MinItems:         ptr.To[int64](5),
 	MultipleOf:       float64Ptr(3),
 	Required:         []string{"spec", "status"},
 	Items: &apiextensions.JSONSchemaPropsOrArray{
@@ -11199,10 +11199,6 @@ var validUnstructuralValidationSchema = &apiextensions.JSONSchemaProps{
 }
 
 func float64Ptr(f float64) *float64 {
-	return &f
-}
-
-func int64Ptr(f int64) *int64 {
 	return &f
 }
 
@@ -11353,7 +11349,7 @@ func TestCostInfo(t *testing.T) {
 		{
 			name: "array",
 			schema: []*apiextensions.JSONSchemaProps{
-				withMaxItems(genArraySchema(), int64ptr(5)),
+				withMaxItems(genArraySchema(), ptr.To[int64](5)),
 			},
 			expectedMaxCardinality: ptr.To[uint64](5),
 		},
@@ -11364,7 +11360,7 @@ func TestCostInfo(t *testing.T) {
 		},
 		{
 			name:                   "map",
-			schema:                 []*apiextensions.JSONSchemaProps{withMaxProperties(genMapSchema(), int64ptr(10))},
+			schema:                 []*apiextensions.JSONSchemaProps{withMaxProperties(genMapSchema(), ptr.To[int64](10))},
 			expectedMaxCardinality: ptr.To[uint64](10),
 		},
 		{
@@ -11377,15 +11373,15 @@ func TestCostInfo(t *testing.T) {
 		{
 			name: "array inside map",
 			schema: []*apiextensions.JSONSchemaProps{
-				withMaxProperties(genMapSchema(), int64ptr(5)),
-				withMaxItems(genArraySchema(), int64ptr(5)),
+				withMaxProperties(genMapSchema(), ptr.To[int64](5)),
+				withMaxItems(genArraySchema(), ptr.To[int64](5)),
 			},
 			expectedMaxCardinality: ptr.To[uint64](25),
 		},
 		{
 			name: "unbounded array inside bounded map",
 			schema: []*apiextensions.JSONSchemaProps{
-				withMaxProperties(genMapSchema(), int64ptr(5)),
+				withMaxProperties(genMapSchema(), ptr.To[int64](5)),
 				genArraySchema(),
 			},
 			expectedMaxCardinality: nil,
@@ -11393,7 +11389,7 @@ func TestCostInfo(t *testing.T) {
 		{
 			name: "object inside array",
 			schema: []*apiextensions.JSONSchemaProps{
-				withMaxItems(genArraySchema(), int64ptr(3)),
+				withMaxItems(genArraySchema(), ptr.To[int64](3)),
 				genObjectSchema(),
 			},
 			expectedMaxCardinality: ptr.To[uint64](3),
@@ -11401,17 +11397,17 @@ func TestCostInfo(t *testing.T) {
 		{
 			name: "map inside object inside array",
 			schema: []*apiextensions.JSONSchemaProps{
-				withMaxItems(genArraySchema(), int64ptr(2)),
+				withMaxItems(genArraySchema(), ptr.To[int64](2)),
 				genObjectSchema(),
-				withMaxProperties(genMapSchema(), int64ptr(4)),
+				withMaxProperties(genMapSchema(), ptr.To[int64](4)),
 			},
 			expectedMaxCardinality: ptr.To[uint64](8),
 		},
 		{
 			name: "integer overflow bounds check",
 			schema: []*apiextensions.JSONSchemaProps{
-				withMaxItems(genArraySchema(), int64ptr(math.MaxInt)),
-				withMaxItems(genArraySchema(), int64ptr(100)),
+				withMaxItems(genArraySchema(), ptr.To[int64](math.MaxInt)),
+				withMaxItems(genArraySchema(), ptr.To[int64](100)),
 			},
 			expectedMaxCardinality: ptr.To[uint64](math.MaxUint),
 		},
@@ -11571,8 +11567,4 @@ func TestPerCRDEstimatedCost(t *testing.T) {
 			}
 		})
 	}
-}
-
-func int64ptr(i int64) *int64 {
-	return &i
 }

--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 )
@@ -135,7 +136,7 @@ func watchCRWithName(ctx context.Context, crdResourceClient dynamic.ResourceInte
 		ctx,
 		metav1.ListOptions{
 			FieldSelector:  "metadata.name=" + name,
-			TimeoutSeconds: int64ptr(600),
+			TimeoutSeconds: ptr.To[int64](600),
 		},
 	)
 }

--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -397,11 +397,6 @@ func watchConfigMaps(ctx context.Context, f *framework.Framework, resourceVersio
 	return c.CoreV1().ConfigMaps(ns).Watch(ctx, opts)
 }
 
-func int64ptr(i int) *int64 {
-	i64 := int64(i)
-	return &i64
-}
-
 func setConfigMapData(cm *v1.ConfigMap, key, value string) {
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132086 and https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
