### PR TITLE
Expose compaction revision from compactor

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
@@ -33,36 +34,95 @@ const (
 
 var (
 	endpointsMapMu sync.Mutex
-	endpointsMap   map[string]struct{}
+	endpointsMap   map[string]*compactor
 )
 
 func init() {
-	endpointsMap = make(map[string]struct{})
+	endpointsMap = make(map[string]*compactor)
 }
 
 // StartCompactor starts a compactor in the background to compact old version of keys that's not needed.
 // By default, we save the most recent 5 minutes data and compact versions > 5minutes ago.
 // It should be enough for slow watchers and to tolerate burst.
 // TODO: We might keep a longer history (12h) in the future once storage API can take advantage of past version of keys.
-func StartCompactor(ctx context.Context, client *clientv3.Client, compactInterval time.Duration) {
+func StartCompactor(client *clientv3.Client, compactInterval time.Duration) *compactor {
 	endpointsMapMu.Lock()
 	defer endpointsMapMu.Unlock()
 
 	// In one process, we can have only one compactor for one cluster.
 	// Currently we rely on endpoints to differentiate clusters.
 	for _, ep := range client.Endpoints() {
-		if _, ok := endpointsMap[ep]; ok {
+		if c, ok := endpointsMap[ep]; ok {
 			klog.V(4).Infof("compactor already exists for endpoints %v", client.Endpoints())
-			return
+			return c
 		}
 	}
+	c := newCompactor(client, compactInterval, clock.RealClock{}, func() {
+		endpointsMapMu.Lock()
+		defer endpointsMapMu.Unlock()
+		for _, ep := range client.Endpoints() {
+			delete(endpointsMap, ep)
+		}
+	})
 	for _, ep := range client.Endpoints() {
-		endpointsMap[ep] = struct{}{}
+		endpointsMap[ep] = c
 	}
+	return c
+}
 
-	if compactInterval != 0 {
-		go compactor(ctx, client, clock.RealClock{}, compactInterval)
+func newCompactor(client *clientv3.Client, compactInterval time.Duration, clock clock.Clock, onClose func()) *compactor {
+	c := &compactor{
+		client:   client,
+		interval: compactInterval,
+		stop:     make(chan struct{}),
+		clock:    clock,
+		onClose:  onClose,
 	}
+	if compactInterval != 0 {
+		c.wg.Add(1)
+		go func() {
+			defer c.wg.Done()
+			c.runCompactLoop(c.stop)
+		}()
+	}
+	return c
+}
+
+type compactor struct {
+	client  *clientv3.Client
+	wg      sync.WaitGroup
+	clock   clock.Clock
+	onClose func()
+
+	stopOnce sync.Once
+	stop     chan struct{}
+
+	mux             sync.Mutex
+	compactRevision int64
+	interval        time.Duration
+}
+
+func (c *compactor) Stop() {
+	// Prevent integration tests stopping compactor twice.
+	c.stopOnce.Do(func() {
+		if c.onClose != nil {
+			c.onClose()
+		}
+		close(c.stop)
+		c.wg.Wait()
+	})
+}
+
+func (c *compactor) CompactRevision() int64 {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	return c.compactRevision
+}
+
+func (c *compactor) SetCompactRevision(rev int64) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	c.compactRevision = rev
 }
 
 // compactor periodically compacts historical versions of keys in etcd.
@@ -70,7 +130,7 @@ func StartCompactor(ctx context.Context, client *clientv3.Client, compactInterva
 // In other words, after compaction, it will only contain keys set during last interval.
 // Any API call for the older versions of keys will return error.
 // Interval is the time interval between each compaction. The first compaction happens after "interval".
-func compactor(ctx context.Context, client *clientv3.Client, clock clock.Clock, interval time.Duration) {
+func (c *compactor) runCompactLoop(stopCh chan struct{}) {
 	// Technical definitions:
 	// We have a special key in etcd defined as *compactRevKey*.
 	// compactRevKey's value will be set to the string of last compacted revision.
@@ -110,20 +170,25 @@ func compactor(ctx context.Context, client *clientv3.Client, clock clock.Clock, 
 	// - What happened under heavy load scenarios? Initially, each apiserver will do only one compaction
 	//   every 5 minutes. This is very unlikely affecting or affected w.r.t. server load.
 
+	ctx := wait.ContextForChannel(stopCh)
 	var compactTime int64
 	var rev int64
+	var compactRev int64
 	var err error
 	for {
 		select {
-		case <-clock.After(interval):
+		case <-c.clock.After(c.interval):
 		case <-ctx.Done():
 			return
 		}
 
-		compactTime, rev, err = compact(ctx, client, compactTime, rev)
+		compactTime, rev, compactRev, err = compact(ctx, c.client, compactTime, rev)
 		if err != nil {
-			klog.Errorf("etcd: endpoint (%v) compact failed: %v", client.Endpoints(), err)
+			klog.Errorf("etcd: endpoint (%v) compact failed: %v", c.client.Endpoints(), err)
 			continue
+		}
+		if compactRev != 0 {
+			c.SetCompactRevision(compactRev)
 		}
 	}
 }
@@ -131,33 +196,37 @@ func compactor(ctx context.Context, client *clientv3.Client, clock clock.Clock, 
 // compact compacts etcd store and returns current rev.
 // It will return the current compact time and global revision if no error occurred.
 // Note that CAS fail will not incur any error.
-func compact(ctx context.Context, client *clientv3.Client, t, rev int64) (int64, int64, error) {
+func compact(ctx context.Context, client *clientv3.Client, expectVersion, rev int64) (currentVersion, currentRev, compactRev int64, err error) {
 	resp, err := client.KV.Txn(ctx).If(
-		clientv3.Compare(clientv3.Version(compactRevKey), "=", t),
+		clientv3.Compare(clientv3.Version(compactRevKey), "=", expectVersion),
 	).Then(
 		clientv3.OpPut(compactRevKey, strconv.FormatInt(rev, 10)), // Expect side effect: increment Version
 	).Else(
 		clientv3.OpGet(compactRevKey),
 	).Commit()
 	if err != nil {
-		return t, rev, err
+		return expectVersion, rev, 0, err
 	}
 
-	curRev := resp.Header.Revision
+	currentRev = resp.Header.Revision
 
 	if !resp.Succeeded {
-		curTime := resp.Responses[0].GetResponseRange().Kvs[0].Version
-		return curTime, curRev, nil
+		currentVersion = resp.Responses[0].GetResponseRange().Kvs[0].Version
+		compactRev, err = strconv.ParseInt(string(resp.Responses[0].GetResponseRange().Kvs[0].Value), 10, 64)
+		if err != nil {
+			return currentVersion, currentRev, 0, nil
+		}
+		return currentVersion, currentRev, compactRev, nil
 	}
-	curTime := t + 1
+	currentVersion = expectVersion + 1
 
 	if rev == 0 {
 		// We don't compact on bootstrap.
-		return curTime, curRev, nil
+		return currentVersion, currentRev, 0, nil
 	}
 	if _, err = client.Compact(ctx, rev); err != nil {
-		return curTime, curRev, err
+		return currentVersion, currentRev, 0, err
 	}
 	klog.V(4).Infof("etcd: compacted rev (%d), endpoints (%v)", rev, client.Endpoints())
-	return curTime, curRev, nil
+	return currentVersion, currentRev, rev, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
@@ -18,43 +18,107 @@ package etcd3
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	etcdrpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+const (
+	waitDelay   = time.Millisecond
+	waitTimeout = 100 * waitDelay
 )
 
 func TestCompact(t *testing.T) {
 	client := testserver.RunEtcd(t, nil).Client
 	ctx := context.Background()
+	clock := testingclock.NewFakeClock(time.Now())
+	wg := sync.WaitGroup{}
+	defer wg.Wait()
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		compactor(ctx, client, clock, time.Minute)
+	}()
+	waitForClockWaiters(t, clock)
+
+	t.Log("First compaction cycle saves revision before first write")
+	clock.Step(time.Minute)
+	waitForClockWaiters(t, clock)
+
+	t.Log("First write")
 	putResp, err := client.Put(ctx, "/somekey", "data")
 	if err != nil {
 		t.Fatalf("Put failed: %v", err)
 	}
+	assertNotCompacted(t, ctx, client, putResp.Header.Revision)
 
+	t.Log("Second compaction cycle compacts before first write")
+	clock.Step(time.Minute)
+	waitForClockWaiters(t, clock)
+	assertNotCompacted(t, ctx, client, putResp.Header.Revision)
+
+	t.Log("Create second revision")
 	putResp1, err := client.Put(ctx, "/somekey", "data2")
 	if err != nil {
 		t.Fatalf("Put failed: %v", err)
 	}
+	assertNotCompacted(t, ctx, client, putResp1.Header.Revision)
 
-	_, _, err = compact(ctx, client, 0, putResp1.Header.Revision)
-	if err != nil {
-		t.Fatalf("compact failed: %v", err)
-	}
+	t.Log("Third compaction cycle compacts revision after first write")
+	clock.Step(time.Minute)
+	waitForClockWaiters(t, clock)
+	assertCompacted(t, ctx, client, putResp.Header.Revision)
 
-	obj, err := client.Get(ctx, "/somekey", clientv3.WithRev(putResp.Header.Revision))
+	assertNotCompacted(t, ctx, client, putResp1.Header.Revision)
+
+	t.Log("Fourth compaction cycle compacts second write")
+	clock.Step(time.Minute)
+	waitForClockWaiters(t, clock)
+	assertCompacted(t, ctx, client, putResp.Header.Revision)
+	assertCompacted(t, ctx, client, putResp1.Header.Revision)
+}
+
+func assertCompacted(t *testing.T, ctx context.Context, client *clientv3.Client, rev int64) {
+	t.Helper()
+	_, err := client.Get(ctx, "/somekey", clientv3.WithRev(rev))
 	if err != etcdrpc.ErrCompacted {
-		t.Errorf("Expecting ErrCompacted, but get=%v err=%v", obj, err)
+		t.Errorf("Expecting rev %d compacted, but err=%v", rev, err)
 	}
 }
 
-// TestCompactConflict tests that two compactors (Let's use C1, C2) are trying to compact etcd cluster with the same
+func assertNotCompacted(t *testing.T, ctx context.Context, client *clientv3.Client, rev int64) {
+	t.Helper()
+	_, err := client.Get(ctx, "/somekey", clientv3.WithRev(rev))
+	if err != nil {
+		t.Errorf("Get on rev %d failed: %v", rev, err)
+	}
+}
+
+func waitForClockWaiters(t *testing.T, clock *testingclock.FakeClock) {
+	t.Helper()
+	for start := time.Now(); time.Since(start) < waitTimeout; {
+		if clock.HasWaiters() {
+			return
+		}
+		time.Sleep(waitDelay)
+	}
+	t.Fatal("No waiters")
+}
+
+// TestCompactConflict tests that multiple compactors are trying to compact etcd cluster with the same
 // logical time.
-// - C1 compacts first. It will succeed.
-// - C2 compacts after. It will fail. But it will get latest logical time, which should be larger by one.
+// - C1 compacts on time 0. It will succeed.
+// - C2 compacts on time 0. It will fail as this time was compacted. But it will get latest logical time, which should be larger by one.
+// - C3 compacts on time 1. It will succeed
 func TestCompactConflict(t *testing.T) {
 	client := testserver.RunEtcd(t, nil).Client
 	ctx := context.Background()
@@ -64,21 +128,48 @@ func TestCompactConflict(t *testing.T) {
 		t.Fatalf("Put failed: %v", err)
 	}
 
-	// Compact first. It would do the compaction and return compact time which is incremented by 1.
-	curTime, _, err := compact(ctx, client, 0, putResp.Header.Revision)
+	t.Log("First compact on time 0")
+	wantCompactRev := putResp.Header.Revision
+	curTime, curRev, err := compact(ctx, client, 0, wantCompactRev)
 	if err != nil {
 		t.Fatalf("compact failed: %v", err)
 	}
+	t.Log("Current time should increase by 1")
 	if curTime != 1 {
 		t.Errorf("Expect current logical time = 1, get = %v", curTime)
 	}
+	t.Log("Current revision should increase by 1")
+	wantCurrentRev := putResp.Header.Revision + 1
+	if curRev != wantCurrentRev {
+		t.Errorf("Expect current revision = %d, get = %d", wantCurrentRev, curRev)
+	}
 
-	// Compact again with the same parameters. It won't do compaction but return the latest compact time.
-	curTime2, _, err := compact(ctx, client, 0, putResp.Header.Revision)
+	t.Log("Second compact on time 0")
+	curTime2, curRev2, err := compact(ctx, client, 0, wantCompactRev+1)
 	if err != nil {
 		t.Fatalf("compact failed: %v", err)
 	}
+	t.Log("Should return same time as from the first compacty")
 	if curTime != curTime2 {
 		t.Errorf("Unexpected curTime (%v) != curTime2 (%v)", curTime, curTime2)
+	}
+	t.Log("Current revision should stay the same")
+	if curRev2 != wantCurrentRev {
+		t.Errorf("Expect current revision = %d, get = %d", wantCurrentRev, curRev2)
+	}
+
+	t.Log("Third compact on time 1")
+	curTime3, curRev3, err := compact(ctx, client, 1, wantCompactRev+1)
+	if err != nil {
+		t.Fatalf("compact failed: %v", err)
+	}
+	t.Log("Current time should increase by 1")
+	if curTime3 != 2 {
+		t.Errorf("Expect current logical time = 2, get = %v", curTime3)
+	}
+	t.Log("Current revision should increase by 1")
+	wantCurrentRev += 1
+	if curRev3 != wantCurrentRev {
+		t.Errorf("Expect current revision = %d, get = %d", wantCurrentRev, curRev3)
 	}
 }


### PR DESCRIPTION
/kind feature

Ref https://github.com/kubernetes/enhancements/issues/4988

To implement watch cache compaction we need to have a way to expose compacted revision from storage. Compaction is not executed by storage, but by compactor a independent goroutine that is shared between storages. 

Proposal: Use the compactor goroutine, rewrite it to struct and store in it latest compacted revision. 
We need a dedicated struct as in future we plan to also watch compaction key to observe compactions executed by other apiservers. Using a compactor ensures that we will only open one watch per etcd endpoint.

Problem, current code of compactor is a huge mess. It does 2 layer caching and reference counting. We need to cleanup this logic. 

The PR has 2 commits, first improves the tests to ensure we don't break anything, second allows to be returned from `StartCompactor` function so caller can read the last compact revision.

```release-note
NONE
```

/cc @liggitt
