### PR TITLE
Delete unnecessary mutex

### DIFF
--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -76,8 +76,6 @@ type GenericPLEG struct {
 	runningMu sync.Mutex
 	// Indicates relisting related parameters
 	relistDuration *RelistDuration
-	// Mutex to serialize updateCache called by relist vs UpdateCache interface
-	podCacheMutex sync.Mutex
 	// logger is used for contextual logging
 	logger klog.Logger
 	// watchConditions tracks pod watch conditions, guarded by watchConditionsLock
@@ -444,8 +442,6 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 		return nil, true, nil
 	}
 
-	g.podCacheMutex.Lock()
-	defer g.podCacheMutex.Unlock()
 	timestamp := g.clock.Now()
 
 	status, err := g.runtime.GetPodStatus(ctx, pod.ID, pod.Name, pod.Namespace)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This mutex was to serialize `updateCache` calls from `relist` and `UpdateCache`, but the latter was removed in https://github.com/kubernetes/kubernetes/pull/128518, so this is no longer necessary.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/assign @natasha41575 