### PR TITLE
Fix kube_codegen.sh to correctly resolve GOBIN via go env

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -117,7 +117,10 @@ function kube::codegen::gen_helpers() {
         GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
-    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+    gobin="$(go env GOBIN)"
+    if [[ -z "${gobin}" ]]; then
+        gobin="$(go env GOPATH)/bin"
+    fi
 
     # Deepcopy
     #
@@ -368,7 +371,10 @@ function kube::codegen::gen_openapi() {
         GO111MODULE=on go install $(printf "k8s.io/kube-openapi/cmd/%s " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
-    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+    gobin="$(go env GOBIN)"
+    if [[ -z "${gobin}" ]]; then
+        gobin="$(go env GOPATH)/bin"
+    fi
 
     local input_pkgs=( "${extra_pkgs[@]:+"${extra_pkgs[@]}"}")
     while read -r dir; do
@@ -601,7 +607,10 @@ function kube::codegen::gen_client() {
         GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
-    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+    gobin="$(go env GOBIN)"
+    if [[ -z "${gobin}" ]]; then
+        gobin="$(go env GOPATH)/bin"
+    fi
 
     local group_versions=()
     local input_pkgs=()
@@ -773,7 +782,10 @@ function kube::codegen::gen_register() {
         GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
-    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+    gobin="$(go env GOBIN)"
+    if [[ -z "${gobin}" ]]; then
+        gobin="$(go env GOPATH)/bin"
+    fi
 
     # Register
     #


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery
/priority important-soon

#### What this PR does / why we need it:

Fixes incorrect resolution of the Go binary installation directory (`GOBIN`) in `kube_codegen.sh`.  
The script now uses `go env GOBIN` to detect the correct binary directory, ensuring code-generator tools are found even when `GOBIN` is set via `go env -w`.  
This resolves failures when binaries are not installed in `$GOPATH/bin` and improves compatibility with modern Go workflows.

#### Which issue(s) this PR is related to:

Fixes #132377

#### Does this PR introduce a user-facing change?

```release-note
NONE
```