### PR TITLE
Increase docker image load timeout

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -444,7 +444,7 @@ function try-load-docker-image {
 
   # Deliberately word split load_image_command
   # shellcheck disable=SC2086
-  until timeout 30 ${load_image_command} "${img}"; do
+  until timeout 300 ${load_image_command} "${img}"; do
     if [[ "${attempt_num}" == "${max_attempts}" ]]; then
       echo "Fail to load docker image file ${img} using ${load_image_command} after ${max_attempts} retries. Exit!!"
       exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Increase the timeout for docker image load. Containerd 2.0 has a performance degradation in image loading time https://github.com/containerd/containerd/issues/11726. This caused image loading to timeout for smaller shared-core machines like e2-micro (12.5% of core time). Increasing the timeout to help mitigate against this issue.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/132853

#### Special notes for your reviewer:

Might also be related to containerd 2.0 issue: https://github.com/containerd/containerd/issues/11726

#### Does this PR introduce a user-facing change?

```release-note
Increases the container image load timeout threshold on GCE from 30s to 300s.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

