### PR TITLE
Fix namespace not found

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -571,7 +571,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 				if err == nil {
 					_, err = client.CoreV1().Namespaces().Get(context.TODO(), o.Namespace, metav1.GetOptions{})
 					if apierrors.IsNotFound(err) {
-						fmt.Fprintf(o.ErrOut, "namespace %q not found\n", o.Namespace)
+						fmt.Fprintf(o.ErrOut, "Error from server (NotFound): namespaces %q not found\n", o.Namespace)
 						return utilerrors.NewAggregate(allErrs)
 					}
 				}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -566,6 +566,16 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		// if we wrote no output, and had no errors, and are not ignoring NotFound, be sure we output something
 		if allResourcesNamespaced {
+			if o.ExplicitNamespace {
+				client, err := f.KubernetesClientSet()
+				if err == nil {
+					_, err = client.CoreV1().Namespaces().Get(context.TODO(), o.Namespace, metav1.GetOptions{})
+					if apierrors.IsNotFound(err) {
+						fmt.Fprintf(o.ErrOut, "namespace %q not found\n", o.Namespace)
+						return utilerrors.NewAggregate(allErrs)
+					}
+				}
+			}
 			fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
 		} else {
 			fmt.Fprintln(o.ErrOut, "No resources found")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a misleading message in `kubectl get` when the specified namespace does not exist.  
Previously, it would say:  
`No resources found in <namespace> namespace`,  
even if the namespace didn’t exist.

With this change, it now correctly returns:  
`Error from server (NotFound): namespaces "<name>" not found`.

This improves clarity and avoids confusion for users.

#### Which issue(s) this PR is related to:
N/A – no GitHub issue, submitted directly

#### Special notes for your reviewer:
This is a user-facing UX improvement for kubectl to handle invalid namespace input more transparently.

#### Does this PR introduce a user-facing change?
```release-note
kubectl get now shows an error when the specified namespace does not exist,
instead of incorrectly showing "no resources found".
```

#### Terminal Output for your ref:
```
# Namespace list (no "rocket")
$ k get ns
NAME              STATUS   AGE
default           Active   39d
kube-node-lease   Active   39d
kube-public       Active   39d
kube-system       Active   39d
...

# Existing kubectl binary output:
$ k get po -n rocket
No resources found in rocket namespace.

# Patched kubectl binary output:
$ ./_output/bin/kubectl get po -n rocket
Error from server (NotFound): namespaces "rocket" not found
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
