### PR TITLE
Automated cherry pick of #132502: Fix flake caused by invalid detection of active policies in VAP integration tests

### DIFF
--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -65,6 +65,8 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
 // Short term fix to refresh the policy source cache faster for tests
@@ -3004,8 +3006,17 @@ func secondaryAuthorizationServiceAccountClient(t *testing.T, adminClient *clien
 
 func withWaitReadyConstraintAndExpression(policy *admissionregistrationv1.ValidatingAdmissionPolicy) *admissionregistrationv1.ValidatingAdmissionPolicy {
 	policy = policy.DeepCopy()
+
+	testMarkerName := fmt.Sprintf("test-marker-%s", utilrand.String(utilvalidation.DNS1123SubdomainMaxLength-len("test-marker-")))
+	annotations := policy.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["test-marker-name"] = testMarkerName
+	policy.SetAnnotations(annotations)
+
 	policy.Spec.MatchConstraints.ResourceRules = append(policy.Spec.MatchConstraints.ResourceRules, admissionregistrationv1.NamedRuleWithOperations{
-		ResourceNames: []string{"test-marker"},
+		ResourceNames: []string{testMarkerName},
 		RuleWithOperations: admissionregistrationv1.RuleWithOperations{
 			Operations: []admissionregistrationv1.OperationType{
 				"UPDATE",
@@ -3024,7 +3035,7 @@ func withWaitReadyConstraintAndExpression(policy *admissionregistrationv1.Valida
 		},
 	})
 	policy.Spec.Validations = append([]admissionregistrationv1.Validation{{
-		Expression: "object.metadata.name != 'test-marker'",
+		Expression: fmt.Sprintf("object.metadata.name != '%s'", testMarkerName),
 		Message:    "marker denied; policy is ready",
 	}}, policy.Spec.Validations...)
 	return policy
@@ -3039,14 +3050,23 @@ func createAndWaitReadyNamespaced(t *testing.T, client clientset.Interface, bind
 }
 
 func createAndWaitReadyNamespacedWithWarnHandler(t *testing.T, client clientset.Interface, binding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, matchLabels map[string]string, ns string, handler *warningHandler) error {
-	marker := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "test-marker", Namespace: ns, Labels: matchLabels}}
+	policy, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(context.TODO(), binding.Spec.PolicyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	testMarkerName := "test-marker"
+	if testMarkerNameAnnotation, ok := policy.GetAnnotations()["test-marker-name"]; ok {
+		testMarkerName = testMarkerNameAnnotation
+	}
+
+	marker := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: testMarkerName, Namespace: ns, Labels: matchLabels}}
 	defer func() {
 		err := client.CoreV1().Endpoints(ns).Delete(context.TODO(), marker.Name, metav1.DeleteOptions{})
 		if err != nil {
 			t.Logf("error deleting marker: %v", err)
 		}
 	}()
-	marker, err := client.CoreV1().Endpoints(ns).Create(context.TODO(), marker, metav1.CreateOptions{})
+	marker, err = client.CoreV1().Endpoints(ns).Create(context.TODO(), marker, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -3059,6 +3059,7 @@ func createAndWaitReadyNamespacedWithWarnHandler(t *testing.T, client clientset.
 		testMarkerName = testMarkerNameAnnotation
 	}
 
+	//nolint:staticcheck // SA1019 skip linter to allow cherrypick.
 	marker := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: testMarkerName, Namespace: ns, Labels: matchLabels}}
 	defer func() {
 		err := client.CoreV1().Endpoints(ns).Delete(context.TODO(), marker.Name, metav1.DeleteOptions{})


### PR DESCRIPTION
Cherry pick of #132502 on release-1.33.

To fix: https://github.com/kubernetes/kubernetes/issues/132735

#132502: Fix flake caused by invalid detection of active policies in VAP integration tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```