### PR TITLE
local-up-cluster: cleanup, support automated upgrade/downgrade testing

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -26,6 +26,11 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # CA in /var/run/kubernetes.
 # Usage: `hack/local-up-cluster.sh`.
 
+# Dump config at KUBE_VERBOSE >= 2.
+if (( KUBE_VERBOSE >= 2 )); then
+  set -x
+fi
+
 DOCKER_OPTS=${DOCKER_OPTS:-""}
 export DOCKER=(docker "${DOCKER_OPTS[@]}")
 DOCKER_ROOT=${DOCKER_ROOT:-""}
@@ -155,6 +160,11 @@ AUDIT_POLICY_FILE=${AUDIT_POLICY_FILE:-""}
 # dmesg command PID for cleanup
 DMESG_PID=${DMESG_PID:-""}
 
+# Stop logging commands again at KUBE_VERBOSE <= 4.
+if (( KUBE_VERBOSE <= 4 )); then
+  set +x
+fi
+
 # Stop right away if the build fails
 set -e
 
@@ -230,6 +240,10 @@ fi
 # Shut down anyway if there's an error.
 set +e
 
+if (( KUBE_VERBOSE >= 2 )); then
+  set -x
+fi
+
 API_PORT=${API_PORT:-0}
 API_SECURE_PORT=${API_SECURE_PORT:-6443}
 
@@ -275,6 +289,10 @@ REUSE_CERTS=${REUSE_CERTS:-false}
 # Ensure CERT_DIR is created for auto-generated crt/key and kubeconfig
 mkdir -p "${CERT_DIR}" &>/dev/null || sudo mkdir -p "${CERT_DIR}"
 CONTROLPLANE_SUDO=$(test -w "${CERT_DIR}" || echo "sudo -E")
+
+if (( KUBE_VERBOSE <= 4 )); then
+  set +x
+fi
 
 function test_apiserver_off {
     # For the common local scenario, fail fast if server is already running.

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1369,9 +1369,7 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   # kubekins has a special directory for docker root
   DOCKER_ROOT="/docker-graph"
 
-  # to use docker installed containerd as kubelet container runtime
-  # we need to enable cri and install cni
-  # install cni for docker in docker
+  # to use containerd as kubelet container runtime we need to install cni
   install_cni 
 
   # If we are running in a cgroups v2 environment
@@ -1396,6 +1394,23 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   docker version
   containerd --version
   runc --version
+
+  # configure and start containerd
+  echo "configuring containerd"
+  containerd config default > /etc/containerd/config.toml
+  sed -ie 's|root = "/var/lib/containerd"|root = "/docker-graph/containerd/daemon"|' /etc/containerd/config.toml
+  sed -ie 's|state = "/run/containerd"|state = "/var/run/docker/containerd/daemon"|' /etc/containerd/config.toml
+  sed -ie 's|enable_cdi = false|enable_cdi = true|' /etc/containerd/config.toml
+
+  echo "starting containerd"
+  containerd_endpoint="${CONTAINER_RUNTIME_ENDPOINT#unix://}"
+  start-stop-daemon --start --background --pidfile /var/run/containerd.pid --output ${LOG_DIR}/containerd.log \
+          --exec /usr/bin/containerd -- --address "${containerd_endpoint}"
+  kube::util::wait_for_success 60 2 "ctr --address ${containerd_endpoint} images list"
+  if [ $? == "1" ]; then
+    echo "time out on waiting for containerd to start"
+    exit 1
+  fi
 
   echo "starting docker"
   service docker start

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1359,6 +1359,13 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   export PATH="${KUBE_ROOT}/third_party/etcd:${PATH}"
   KUBE_FASTBUILD=true make ginkgo cross
 
+  log_dir="${LOG_DIR}"
+  if [[ -n "${ARTIFACTS}" ]]; then
+    # Store logs in the artifacts directory so that they are
+    # available in the prow web UI.
+    log_dir="${ARTIFACTS}"
+  fi
+
   echo "install additional packages"
   apt-get update
   apt-get install -y conntrack dnsutils nftables ripgrep sudo tree vim
@@ -1385,7 +1392,7 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --debug\"" >> /etc/default/docker
 
   # let's log it where we can grab it later
-  echo "DOCKER_LOGFILE=${LOG_DIR}/docker.log" >> /etc/default/docker
+  echo "DOCKER_LOGFILE=${log_dir}/docker.log" >> /etc/default/docker
 
   echo "stopping docker"
   service docker stop
@@ -1404,7 +1411,7 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
 
   echo "starting containerd"
   containerd_endpoint="${CONTAINER_RUNTIME_ENDPOINT#unix://}"
-  start-stop-daemon --start --background --pidfile /var/run/containerd.pid --output ${LOG_DIR}/containerd.log \
+  start-stop-daemon --start --background --pidfile /var/run/containerd.pid --output "${log_dir}/containerd.log" \
           --exec /usr/bin/containerd -- --address "${containerd_endpoint}"
   kube::util::wait_for_success 60 2 "ctr --address ${containerd_endpoint} images list"
   if [ $? == "1" ]; then

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -823,31 +823,6 @@ function wait_node_ready(){
   fi
 }
 
-function refresh_docker_containerd_runc {
-  apt update
-  apt-get install ca-certificates curl gnupg ripgrep tree vim
-  install -m 0755 -d /etc/apt/keyrings
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-  chmod a+r /etc/apt/keyrings/docker.gpg
-
-  # shellcheck disable=SC2027 disable=SC2046
-  echo \
-    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-    tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-  apt-get update
-  apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
-  groupadd docker
-  usermod -aG docker "$USER"
-
-  if ! grep -q "cri-containerd" "/lib/systemd/system/docker.service"; then
-    sed -i "s/ExecStart=\(.*\)/ExecStart=\1 --cri-containerd/" /lib/systemd/system/docker.service
-  fi
-
-  apt install -y conntrack vim htop ripgrep dnsutils tree ripgrep build-essential
-}
-
 function wait_coredns_available(){
   if [[ -n "${DRY_RUN}" ]]; then
     return
@@ -1286,22 +1261,6 @@ function parse_eviction {
   done
 }
 
-function update_packages {
-  apt-get update && apt-get install -y sudo
-  apt-get remove -y systemd
-
-  # Do not update docker / containerd / runc
-  sed -i 's/\(.*\)docker\(.*\)/#\1docker\2/' /etc/apt/sources.list
-
-  # jump through hoops to avoid removing docker/containerd
-  # when installing nftables and kmod, as those docker/containerd
-  # packages depend on iptables
-  dpkg -r --force-depends iptables && \
-  apt -y --fix-broken install && \
-  apt -y install nftables kmod && \
-  apt -y install iptables
-}
-
 function tolerate_cgroups_v2 {
   # https://github.com/moby/moby/blob/be220af9fb36e9baa9a75bbc41f784260aa6f96e/hack/dind#L28-L38
   # cgroup v2: enable nesting
@@ -1400,8 +1359,9 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   export PATH="${KUBE_ROOT}/third_party/etcd:${PATH}"
   KUBE_FASTBUILD=true make ginkgo cross
 
-  # install things we need that are missing from the kubekins image
-  update_packages
+  echo "install additional packages"
+  apt-get update
+  apt-get install -y conntrack dnsutils nftables ripgrep sudo tree vim
 
   # configure shared mounts to prevent failure in DIND scenarios
   mount --make-rshared /
@@ -1431,9 +1391,6 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
 
   echo "stopping docker"
   service docker stop
-
-  # bump up things
-  refresh_docker_containerd_runc
 
   # check if the new stuff is there
   docker version

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -22,7 +22,7 @@ fi
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # This script builds and runs a local kubernetes cluster. You may need to run
-# this as root to allow kubelet to open docker's socket, and to write the test
+# this as root to allow kubelet to open containerd's socket, and to write the test
 # CA in /var/run/kubernetes.
 # Usage: `hack/local-up-cluster.sh`.
 
@@ -31,9 +31,6 @@ if (( KUBE_VERBOSE >= 2 )); then
   set -x
 fi
 
-DOCKER_OPTS=${DOCKER_OPTS:-""}
-export DOCKER=(docker "${DOCKER_OPTS[@]}")
-DOCKER_ROOT=${DOCKER_ROOT:-""}
 ALLOW_PRIVILEGED=${ALLOW_PRIVILEGED:-""}
 RUNTIME_CONFIG=${RUNTIME_CONFIG:-""}
 KUBELET_AUTHORIZATION_WEBHOOK=${KUBELET_AUTHORIZATION_WEBHOOK:-""}
@@ -1304,7 +1301,7 @@ function install_cni {
         \) \
         -delete
 
-  # containerd 1.4.12 installed by docker in kubekins supports CNI version 0.4.0
+  # containerd in kubekins supports CNI version 0.4.0
   echo "Configuring cni"
   sudo mkdir -p "$CNI_CONFIG_DIR"
   cat << EOF | sudo tee "$CNI_CONFIG_DIR"/10-containerd-net.conflist
@@ -1373,9 +1370,6 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   # configure shared mounts to prevent failure in DIND scenarios
   mount --make-rshared /
 
-  # kubekins has a special directory for docker root
-  DOCKER_ROOT="/docker-graph"
-
   # to use containerd as kubelet container runtime we need to install cni
   install_cni 
 
@@ -1383,22 +1377,10 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
   # we need to enable nesting
   tolerate_cgroups_v2
 
-  # enable cri for docker in docker
-  echo "enable cri"
-  # shellcheck disable=SC2129
-  echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --cri-containerd\"" >> /etc/default/docker
-
-  # enable debug
-  echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --debug\"" >> /etc/default/docker
-
-  # let's log it where we can grab it later
-  echo "DOCKER_LOGFILE=${log_dir}/docker.log" >> /etc/default/docker
-
   echo "stopping docker"
   service docker stop
 
-  # check if the new stuff is there
-  docker version
+  # output version info
   containerd --version
   runc --version
 
@@ -1418,9 +1400,6 @@ if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
     echo "time out on waiting for containerd to start"
     exit 1
   fi
-
-  echo "starting docker"
-  service docker start
 fi
 
 # validate that etcd is: not running, in path, and has minimum required version.

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -183,6 +183,8 @@ function usage {
             echo "           CPUMANAGER_RECONCILE_PERIOD=\"5s\" \\"
             echo "           KUBELET_FLAGS=\"--kube-reserved=cpu=1,memory=2Gi,ephemeral-storage=1Gi --system-reserved=cpu=1,memory=2Gi,ephemeral-storage=1Gi\" \\"
             echo "           hack/local-up-cluster.sh (build a local copy of the source with full-pcpus-only CPU Management policy)"
+            echo ""
+            echo "-d         dry-run: prepare for running commands, then show their command lines instead of running them"
 }
 
 # This function guesses where the existing cached binary build is for the `-O`
@@ -198,9 +200,14 @@ function guess_built_binary_path {
 
 ### Allow user to supply the source directory.
 GO_OUT=${GO_OUT:-}
-while getopts "ho:O" OPTION
+DRY_RUN=
+while getopts "dho:O" OPTION
 do
     case ${OPTION} in
+        d)
+            echo "skipping running commands"
+            DRY_RUN=1
+            ;;
         o)
             echo "skipping build"
             GO_OUT="${OPTARG}"
@@ -223,6 +230,28 @@ do
             ;;
     esac
 done
+
+# run executes the command specified by its parameters if DRY_RUN is empty,
+# otherwise it prints them.
+#
+# The first parameter must be the name of the Kubernetes components.
+# It is only used when printing the command in dry-run mode.
+# The second parameter is a log file for the command. It may be empty.
+function run {
+    local what="$1"
+    local log="$2"
+    shift
+    shift
+    if [[ -z "${DRY_RUN}" ]]; then
+        if [[ -z "${log}" ]]; then
+            "${@}"
+        else
+            "${@}" >"${log}" 2>&1
+        fi
+    else
+        echo "RUN ${what}: ${*}"
+    fi
+}
 
 if [ -z "${GO_OUT}" ]; then
     binaries_to_build="cmd/kubectl cmd/kube-apiserver cmd/kube-controller-manager cmd/cloud-controller-manager cmd/kube-scheduler"
@@ -626,9 +655,13 @@ EOF
       AUDIT_POLICY_FILE="${TMP_DIR}/kube-audit-policy-file"
     fi
 
+    # Create admin config. Works without the apiserver, so do it early to enable debug access to the apiserver while it starts.
+    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" admin
+    ${CONTROLPLANE_SUDO} chown "${USER}" "${CERT_DIR}/client-admin.key" # make readable for kubectl
+
     APISERVER_LOG=${LOG_DIR}/kube-apiserver.log
     # shellcheck disable=SC2086
-    ${CONTROLPLANE_SUDO} "${GO_OUT}/kube-apiserver" "${authorizer_args[@]}" "${priv_arg}" ${runtime_config} \
+    run kube-apiserver "${APISERVER_LOG}" ${CONTROLPLANE_SUDO} "${GO_OUT}/kube-apiserver" "${authorizer_args[@]}" "${priv_arg}" ${runtime_config} \
       "${advertise_address}" \
       "${node_port_range}" \
       --v="${LOG_LEVEL}" \
@@ -668,33 +701,33 @@ EOF
       --requestheader-allowed-names=system:auth-proxy \
       --proxy-client-cert-file="${CERT_DIR}/client-auth-proxy.crt" \
       --proxy-client-key-file="${CERT_DIR}/client-auth-proxy.key" \
-      --cors-allowed-origins="${API_CORS_ALLOWED_ORIGINS}" >"${APISERVER_LOG}" 2>&1 &
+      --cors-allowed-origins="${API_CORS_ALLOWED_ORIGINS}" &
     APISERVER_PID=$!
 
-    # Create kubeconfigs for all components, using client certs
-    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" admin
-    ${CONTROLPLANE_SUDO} chown "${USER}" "${CERT_DIR}/client-admin.key" # make readable for kubectl
+    if [[ -z "${DRY_RUN}" ]]; then
+        # Wait for kube-apiserver to come up before launching the rest of the components.
+        echo "Waiting for apiserver to come up"
+        kube::util::wait_for_url "https://${API_HOST_IP}:${API_SECURE_PORT}/healthz" "apiserver: " 1 "${WAIT_FOR_URL_API_SERVER}" "${MAX_TIME_FOR_URL_API_SERVER}" \
+            || { echo "check apiserver logs: ${APISERVER_LOG}" ; exit 1 ; }
+    fi
 
-    # Wait for kube-apiserver to come up before launching the rest of the components.
-    echo "Waiting for apiserver to come up"
-    kube::util::wait_for_url "https://${API_HOST_IP}:${API_SECURE_PORT}/healthz" "apiserver: " 1 "${WAIT_FOR_URL_API_SERVER}" "${MAX_TIME_FOR_URL_API_SERVER}" \
-        || { echo "check apiserver logs: ${APISERVER_LOG}" ; exit 1 ; }
-
+    # Create kubeconfigs for all components, using client certs. This needs a running apiserver.
     kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" controller
     kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" scheduler
 
     if [[ -z "${AUTH_ARGS}" ]]; then
         AUTH_ARGS="--client-key=${CERT_DIR}/client-admin.key --client-certificate=${CERT_DIR}/client-admin.crt"
     fi
+
     # Grant apiserver permission to speak to the kubelet
-    ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" create clusterrolebinding kube-apiserver-kubelet-admin --clusterrole=system:kubelet-api-admin --user=kube-apiserver
+    run kubectl "" "${KUBECTL}" --kubeconfig "${CERT_DIR}/admin.kubeconfig" create clusterrolebinding kube-apiserver-kubelet-admin --clusterrole=system:kubelet-api-admin --user=kube-apiserver
 
     # Grant kubelets permission to request client certificates
-    ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" create clusterrolebinding kubelet-csr --clusterrole=system:certificates.k8s.io:certificatesigningrequests:selfnodeclient --group=system:nodes
+    run kubectl "" "${KUBECTL}" --kubeconfig "${CERT_DIR}/admin.kubeconfig" create clusterrolebinding kubelet-csr --clusterrole=system:certificates.k8s.io:certificatesigningrequests:selfnodeclient --group=system:nodes
 
     ${CONTROLPLANE_SUDO} cp "${CERT_DIR}/admin.kubeconfig" "${CERT_DIR}/admin-kube-aggregator.kubeconfig"
     ${CONTROLPLANE_SUDO} chown -R "$(whoami)" "${CERT_DIR}"
-    ${KUBECTL} config set-cluster local-up-cluster --kubeconfig="${CERT_DIR}/admin-kube-aggregator.kubeconfig" --server="https://${API_HOST_IP}:31090"
+    run kubectl "" "${KUBECTL}" config set-cluster local-up-cluster --kubeconfig="${CERT_DIR}/admin-kube-aggregator.kubeconfig" --server="https://${API_HOST_IP}:31090"
     echo "use 'kubectl --kubeconfig=${CERT_DIR}/admin-kube-aggregator.kubeconfig' to use the aggregated API server"
 
 }
@@ -709,7 +742,8 @@ function start_controller_manager {
     fi
 
     CTLRMGR_LOG=${LOG_DIR}/kube-controller-manager.log
-    ${CONTROLPLANE_SUDO} "${GO_OUT}/kube-controller-manager" \
+    # shellcheck disable=SC2086
+    run kube-controller-manager "${CTLRMGR_LOG}" ${CONTROLPLANE_SUDO} "${GO_OUT}/kube-controller-manager" \
       --v="${LOG_LEVEL}" \
       --vmodule="${LOG_SPEC}" \
       --service-account-private-key-file="${SERVICE_ACCOUNT_KEY}" \
@@ -747,7 +781,7 @@ function start_cloud_controller_manager {
 
     CLOUD_CTLRMGR_LOG=${LOG_DIR}/cloud-controller-manager.log
     # shellcheck disable=SC2086
-    ${CONTROLPLANE_SUDO} "${EXTERNAL_CLOUD_PROVIDER_BINARY:-"${GO_OUT}/cloud-controller-manager"}" \
+    run cloud-controller-manager ${CONTROLPLANE_SUDO} "${EXTERNAL_CLOUD_PROVIDER_BINARY:-"${GO_OUT}/cloud-controller-manager"}" \
       ${CLOUD_CTLRMGR_FLAGS} \
       --v="${LOG_LEVEL}" \
       --vmodule="${LOG_SPEC}" \
@@ -763,6 +797,12 @@ function start_cloud_controller_manager {
 }
 
 function wait_node_ready(){
+  if [[ -n "${DRY_RUN}" ]]; then
+    return
+  fi
+
+  echo "wait kubelet ready"
+
   # check the nodes information after kubelet daemon start
   local nodes_stats="${KUBECTL} --kubeconfig '${CERT_DIR}/admin.kubeconfig' get nodes"
   local node_name=$HOSTNAME_OVERRIDE
@@ -809,6 +849,10 @@ function refresh_docker_containerd_runc {
 }
 
 function wait_coredns_available(){
+  if [[ -n "${DRY_RUN}" ]]; then
+    return
+  fi
+
   local interval_time=2
   local coredns_wait_time=300
 
@@ -1001,12 +1045,12 @@ EOF
     } >>"${TMP_DIR}"/kubelet.yaml
 
     # shellcheck disable=SC2024
-    sudo -E "${GO_OUT}/kubelet" "${all_kubelet_flags[@]}" \
-      --config="${TMP_DIR}"/kubelet.yaml >"${KUBELET_LOG}" 2>&1 &
+    run kubelet "${KUBELET_LOG}" sudo -E "${GO_OUT}/kubelet" "${all_kubelet_flags[@]}" \
+      --config="${TMP_DIR}"/kubelet.yaml &
     KUBELET_PID=$!
 
     # Quick check that kubelet is running.
-    if [ -n "${KUBELET_PID}" ] && ps -p ${KUBELET_PID} > /dev/null; then
+    if [ -n "${DRY_RUN}" ] || ( [ -n "${KUBELET_PID}" ] && ps -p ${KUBELET_PID} > /dev/null ); then
       echo "kubelet ( ${KUBELET_PID} ) is running."
     else
       cat "${KUBELET_LOG}" ; exit 1
@@ -1018,7 +1062,6 @@ function start_kubeproxy {
 
     if [[ "${START_MODE}" != *"nokubelet"* ]]; then
       # wait for kubelet collect node information
-      echo "wait kubelet ready"
       wait_node_ready
     fi
 
@@ -1049,7 +1092,7 @@ EOF
     # Probably not necessary...
     #
     # shellcheck disable=SC2024
-    sudo "${GO_OUT}/kube-proxy" \
+    run kube-proxy "${PROXY_LOG}" sudo "${GO_OUT}/kube-proxy" \
       --v="${LOG_LEVEL}" \
       --config="${TMP_DIR}"/kube-proxy.yaml \
       --healthz-port="${PROXY_HEALTHZ_PORT}" \
@@ -1071,57 +1114,58 @@ clientConnection:
 leaderElection:
   leaderElect: ${LEADER_ELECT}
 EOF
-    ${CONTROLPLANE_SUDO} "${GO_OUT}/kube-scheduler" \
+    # shellcheck disable=SC2086
+    run kube-scheduler "${SCHEDULER_LOG}" ${CONTROLPLANE_SUDO} "${GO_OUT}/kube-scheduler" \
       --v="${LOG_LEVEL}" \
       --config="${TMP_DIR}"/kube-scheduler.yaml \
       --feature-gates="${FEATURE_GATES}" \
       --emulated-version="${EMULATED_VERSION}" \
       --authentication-kubeconfig "${CERT_DIR}"/scheduler.kubeconfig \
       --authorization-kubeconfig "${CERT_DIR}"/scheduler.kubeconfig \
-      --master="https://${API_HOST}:${API_SECURE_PORT}" >"${SCHEDULER_LOG}" 2>&1 &
+      --secure-port="${SCHEDULER_SECURE_PORT}" \
+      --bind-address="${API_BIND_ADDR}" \
+      --master="https://${API_HOST}:${API_SECURE_PORT}" &
     SCHEDULER_PID=$!
 }
 
 function start_dns_addon {
     if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
-        cp "${KUBE_ROOT}/cluster/addons/dns/${DNS_ADDON}/${DNS_ADDON}.yaml.in" dns.yaml
-        ${SED} -i -e "s/dns_domain/${DNS_DOMAIN}/g" dns.yaml
-        ${SED} -i -e "s/dns_server/${DNS_SERVER_IP}/g" dns.yaml
-        ${SED} -i -e "s/dns_memory_limit/${DNS_MEMORY_LIMIT}/g" dns.yaml
+        cp "${KUBE_ROOT}/cluster/addons/dns/${DNS_ADDON}/${DNS_ADDON}.yaml.in" "${TMP_DIR}/dns.yaml"
+        ${SED} -i -e "s/dns_domain/${DNS_DOMAIN}/g" "${TMP_DIR}/dns.yaml"
+        ${SED} -i -e "s/dns_server/${DNS_SERVER_IP}/g" "${TMP_DIR}/dns.yaml"
+        ${SED} -i -e "s/dns_memory_limit/${DNS_MEMORY_LIMIT}/g" "${TMP_DIR}/dns.yaml"
         # TODO update to dns role once we have one.
         # use kubectl to create dns addon
-        if ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system apply -f dns.yaml ; then
+        if run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system apply -f "${TMP_DIR}/dns.yaml" ; then
             echo "${DNS_ADDON} addon successfully deployed."
         else
 		echo "Something is wrong with your DNS input"
-		cat dns.yaml
+		cat "${TMP_DIR}/dns.yaml"
 		exit 1
         fi
-        rm dns.yaml
     fi
 }
 
 function start_nodelocaldns {
-  cp "${KUBE_ROOT}/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml" nodelocaldns.yaml
+  cp "${KUBE_ROOT}/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml" "${TMP_DIR}/nodelocaldns.yaml"
   # eventually all the __PILLAR__ stuff will be gone, but theyre still in nodelocaldns for backward compat.
-  ${SED} -i -e "s/__PILLAR__DNS__DOMAIN__/${DNS_DOMAIN}/g" nodelocaldns.yaml
-  ${SED} -i -e "s/__PILLAR__DNS__SERVER__/${DNS_SERVER_IP}/g" nodelocaldns.yaml
-  ${SED} -i -e "s/__PILLAR__LOCAL__DNS__/${LOCAL_DNS_IP}/g" nodelocaldns.yaml
+  ${SED} -i -e "s/__PILLAR__DNS__DOMAIN__/${DNS_DOMAIN}/g" "${TMP_DIR}/nodelocaldns.yaml"
+  ${SED} -i -e "s/__PILLAR__DNS__SERVER__/${DNS_SERVER_IP}/g" "${TMP_DIR}/nodelocaldns.yaml"
+  ${SED} -i -e "s/__PILLAR__LOCAL__DNS__/${LOCAL_DNS_IP}/g" "${TMP_DIR}/nodelocaldns.yaml"
 
   # use kubectl to create nodelocaldns addon
-  ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system apply -f nodelocaldns.yaml
+  run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system apply -f "${TMP_DIR}/nodelocaldns.yaml"
   echo "NodeLocalDNS addon successfully deployed."
-  rm nodelocaldns.yaml
 }
 
 function start_csi_snapshotter {
     if [[ "${ENABLE_CSI_SNAPSHOTTER}" = true ]]; then
         echo "Creating Kubernetes-CSI snapshotter"
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml"
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml"
+        run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
+        run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
+        run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
+        run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml"
+        run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml"
 
         echo "Kubernetes-CSI snapshotter successfully deployed."
     fi
@@ -1136,13 +1180,17 @@ function create_storage_class {
 
     if [ -e "${CLASS_FILE}" ]; then
         echo "Create default storage class for ${CLOUD_PROVIDER}"
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${CLASS_FILE}"
+        run kubectl "" "${KUBECTL}" --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${CLASS_FILE}"
     else
         echo "No storage class available for ${CLOUD_PROVIDER}."
     fi
 }
 
 function print_success {
+if [[ -n "${DRY_RUN}" ]]; then
+  return
+fi
+
 if [[ "${START_MODE}" != "kubeletonly" ]]; then
   if [[ "${ENABLE_DAEMON}" = false ]]; then
     echo "Local Kubernetes cluster is running. Press Ctrl-C to shut it down."
@@ -1484,13 +1532,19 @@ fi
 
 print_success
 
-if [[ "${ENABLE_DAEMON}" = false ]]; then
+if [[ -n "${DRY_RUN}" ]]; then
+  # Ensure that "run" output has been flushed. This waits for anything which might have been started.
+  # shellcheck disable=SC2086
+  wait ${APISERVER_PID-} ${CTLRMGR_PID-} ${CLOUD_CTLRMGR_PID-} ${KUBELET_PID-} ${PROXY_PID-} ${SCHEDULER_PID-}
+  echo "Local etcd is running. Run commands. Press Ctrl-C to shut it down."
+  sleep infinity
+elif [[ "${ENABLE_DAEMON}" = false ]]; then
   while true; do sleep 1; healthcheck; done
 fi
 
 if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
-  ${KUBECTL} config set-cluster local --server=https://localhost:6443 --certificate-authority=/var/run/kubernetes/server-ca.crt
-  ${KUBECTL} config set-credentials myself --client-key=/var/run/kubernetes/client-admin.key --client-certificate=/var/run/kubernetes/client-admin.crt
-  ${KUBECTL} config set-context local --cluster=local --user=myself
-  ${KUBECTL} config use-context local
+  run kubectl "" "${KUBECTL}" config set-cluster local --server=https://localhost:6443 --certificate-authority=/var/run/kubernetes/server-ca.crt
+  run kubectl "" "${KUBECTL}" config set-credentials myself --client-key=/var/run/kubernetes/client-admin.key --client-certificate=/var/run/kubernetes/client-admin.crt
+  run kubectl "" "${KUBECTL}" config set-context local --cluster=local --user=myself
+  run kubectl "" "${KUBECTL}" config use-context local
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The primary  purpose was to enable the usage if local-cluster-up.sh as "backend" for automated upgrade/downgrade: by printing commands in "dry run" mode, the caller can execute them and restart individual commands.

Making that work in the CI turned into a simplification of the script by getting rid of unnecessary historic cruft. That makes merging these changes worthwhile by themselves, just as the "dry run" mode might also be useful for debugging the script.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/132295

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @dims