### PR TITLE
Make actuated resources an internal detail of the KubeGenericRuntimeManager

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"encoding/json"
-
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +43,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -56,7 +53,6 @@ import (
 // podStatusManagerStateFile is the file name where status manager stores its state
 const (
 	allocatedPodsStateFile = "allocated_pods_state"
-	actuatedPodsStateFile  = "actuated_pods_state"
 
 	initialRetryDelay = 30 * time.Second
 	retryDelay        = 3 * time.Minute
@@ -81,13 +77,6 @@ type Manager interface {
 
 	// SetAllocatedResources checkpoints the resources allocated to a pod's containers.
 	SetAllocatedResources(allocatedPod *v1.Pod) error
-
-	// SetActuatedResources records the actuated resources of the given container (or the entire
-	// pod, if actuatedContainer is nil).
-	SetActuatedResources(allocatedPod *v1.Pod, actuatedContainer *v1.Container) error
-
-	// GetActuatedResources returns the stored actuated resources for the container, and whether they exist.
-	GetActuatedResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool)
 
 	// AddPodAdmitHandlers adds the admit handlers to the allocation manager.
 	// TODO: See if we can remove this and just add them in the allocation manager constructor.
@@ -123,15 +112,10 @@ type Manager interface {
 
 	// RetryPendingResizes retries all pending resizes.
 	RetryPendingResizes(trigger string)
-
-	// CheckPodResizeInProgress checks whether the actuated resizable resources differ from the allocated resources
-	// for any running containers.
-	CheckPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus)
 }
 
 type manager struct {
 	allocated state.State
-	actuated  state.State
 
 	admitHandlers           lifecycle.PodAdmitHandlers
 	containerRuntime        kubecontainer.Runtime
@@ -163,7 +147,6 @@ func NewManager(checkpointDirectory string,
 ) Manager {
 	return &manager{
 		allocated: newStateImpl(checkpointDirectory, allocatedPodsStateFile),
-		actuated:  newStateImpl(checkpointDirectory, actuatedPodsStateFile),
 
 		statusManager:           statusManager,
 		admitHandlers:           lifecycle.PodAdmitHandlers{},
@@ -177,17 +160,6 @@ func NewManager(checkpointDirectory string,
 		getPodByUID:    getPodByUID,
 		recorder:       recorder,
 	}
-}
-
-type containerAllocation struct {
-	Name      string                  `json:"name"`
-	Resources v1.ResourceRequirements `json:"resources,omitempty"`
-}
-
-type podResourceSummary struct {
-	//TODO: resources v1.ResourceRequirements, add pod-level resources here once resizing pod-level resources is supported
-	InitContainers []containerAllocation `json:"initContainers,omitempty"`
-	Containers     []containerAllocation `json:"containers,omitempty"`
 }
 
 func newStateImpl(checkpointDirectory, checkpointName string) state.State {
@@ -218,7 +190,6 @@ func NewInMemoryManager(nodeConfig cm.NodeConfig,
 ) Manager {
 	return &manager{
 		allocated: state.NewStateMemory(nil),
-		actuated:  state.NewStateMemory(nil),
 
 		statusManager:           statusManager,
 		admitHandlers:           lifecycle.PodAdmitHandlers{},
@@ -249,33 +220,6 @@ func (m *manager) Run(ctx context.Context) {
 			}
 		}
 	}()
-}
-
-// Gernerate pod resize completed event message
-func (m *manager) podResizeCompletionMsg(allocatedPod *v1.Pod) string {
-	podResizeSource := &podResourceSummary{}
-	podutil.VisitContainers(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers,
-		func(allocatedContainer *v1.Container, containerType podutil.ContainerType) bool {
-			allocation := containerAllocation{
-				Name:      allocatedContainer.Name,
-				Resources: allocatedContainer.Resources,
-			}
-			switch containerType {
-			case podutil.InitContainers:
-				podResizeSource.InitContainers = append(podResizeSource.InitContainers, allocation)
-			case podutil.Containers:
-				podResizeSource.Containers = append(podResizeSource.Containers, allocation)
-			}
-			return true
-		})
-
-	podResizeMsgDetailsJSON, err := json.Marshal(podResizeSource)
-	if err != nil {
-		klog.ErrorS(err, "Failed to serialize resource summary", "pod", format.Pod(allocatedPod))
-		return "Pod resize completed"
-	}
-	podResizeCompletedMsg := fmt.Sprintf("Pod resize completed: %s", string(podResizeMsgDetailsJSON))
-	return podResizeCompletedMsg
 }
 
 func (m *manager) RetryPendingResizes(trigger string) {
@@ -586,29 +530,10 @@ func (m *manager) RemovePod(uid types.UID) {
 		// If the deletion fails, it will be retried by RemoveOrphanedPods, so we can safely ignore the error.
 		klog.V(3).ErrorS(err, "Failed to delete pod allocation", "podUID", uid)
 	}
-
-	if err := m.actuated.RemovePod(uid); err != nil {
-		// If the deletion fails, it will be retried by RemoveOrphanedPods, so we can safely ignore the error.
-		klog.V(3).ErrorS(err, "Failed to delete pod allocation", "podUID", uid)
-	}
 }
 
 func (m *manager) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
 	m.allocated.RemoveOrphanedPods(remainingPods)
-	m.actuated.RemoveOrphanedPods(remainingPods)
-}
-
-func (m *manager) SetActuatedResources(allocatedPod *v1.Pod, actuatedContainer *v1.Container) error {
-	if actuatedContainer == nil {
-		alloc := allocationFromPod(allocatedPod)
-		return m.actuated.SetPodResourceInfo(allocatedPod.UID, alloc)
-	}
-
-	return m.actuated.SetContainerResources(allocatedPod.UID, actuatedContainer.Name, actuatedContainer.Resources)
-}
-
-func (m *manager) GetActuatedResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
-	return m.actuated.GetContainerResources(podUID, containerName)
 }
 
 func (m *manager) handlePodResourcesResize(pod *v1.Pod) (bool, error) {
@@ -763,49 +688,6 @@ func (m *manager) canResizePod(allocatedPods []*v1.Pod, pod *v1.Pod) (bool, stri
 	}
 
 	return true, "", ""
-}
-
-func (m *manager) CheckPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) {
-	// If a resize is in progress, make sure the cache has the correct state in case the Kubelet restarted.
-	if m.isPodResizeInProgress(allocatedPod, podStatus) {
-		// This is a no-op if the resize in progress condition is already set.
-		m.statusManager.SetPodResizeInProgressCondition(allocatedPod.UID, "", "", allocatedPod.Generation)
-	} else if m.statusManager.ClearPodResizeInProgressCondition(allocatedPod.UID) {
-		// (Allocated == Actual) => clear the resize in-progress status.
-		// Generate Pod resize completed event
-		podResizeCompletedEventMsg := m.podResizeCompletionMsg(allocatedPod)
-		if m.recorder != nil {
-			m.recorder.Eventf(allocatedPod, v1.EventTypeNormal, events.ResizeCompleted, podResizeCompletedEventMsg)
-		}
-	}
-}
-
-// isPodResizeInProgress checks whether the actuated resizable resources differ from the allocated resources
-// for any running containers. Specifically, the following differences are ignored:
-// - Non-resizable containers: non-restartable init containers, ephemeral containers
-// - Non-resizable resources: only CPU & memory are resizable
-// - Non-running containers: they will be sized correctly when (re)started
-func (m *manager) isPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
-	return !podutil.VisitContainers(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers,
-		func(allocatedContainer *v1.Container, containerType podutil.ContainerType) (shouldContinue bool) {
-			if !IsResizableContainer(allocatedContainer, containerType) {
-				return true
-			}
-
-			containerStatus := podStatus.FindContainerStatusByName(allocatedContainer.Name)
-			if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
-				// If the container isn't running, it doesn't need to be resized.
-				return true
-			}
-
-			actuatedResources, _ := m.GetActuatedResources(allocatedPod.UID, allocatedContainer.Name)
-			allocatedResources := allocatedContainer.Resources
-
-			return allocatedResources.Requests[v1.ResourceCPU].Equal(actuatedResources.Requests[v1.ResourceCPU]) &&
-				allocatedResources.Limits[v1.ResourceCPU].Equal(actuatedResources.Limits[v1.ResourceCPU]) &&
-				allocatedResources.Requests[v1.ResourceMemory].Equal(actuatedResources.Requests[v1.ResourceMemory]) &&
-				allocatedResources.Limits[v1.ResourceMemory].Equal(actuatedResources.Limits[v1.ResourceMemory])
-		})
 }
 
 func (m *manager) guaranteedPodResourceResizeRequired(pod *v1.Pod, resourceName v1.ResourceName) bool {

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -142,6 +142,11 @@ type Runtime interface {
 	// GetContainerSwapBehavior reports whether a container could be swappable.
 	// This is used to decide whether to handle InPlacePodVerticalScaling for containers.
 	GetContainerSwapBehavior(pod *v1.Pod, container *v1.Container) kubelettypes.SwapBehavior
+	// IsPodResizeInProgress checks whether the given pod is in the process of resizing
+	// (allocated resources != actuated resources).
+	IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *PodStatus) bool
+	// Temporarily expose actuated resources for incremental changes.
+	GetActuatedResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool)
 }
 
 // StreamingRuntime is the interface implemented by runtimes that handle the serving of the

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -138,15 +138,13 @@ type Runtime interface {
 	// ListPodSandboxMetrics retrieves the metrics for all pod sandboxes.
 	ListPodSandboxMetrics(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error)
 	// GetContainerStatus returns the status for the container.
-	GetContainerStatus(ctx context.Context, id ContainerID) (*Status, error)
+	GetContainerStatus(ctx context.Context, podUID types.UID, id ContainerID) (*Status, error)
 	// GetContainerSwapBehavior reports whether a container could be swappable.
 	// This is used to decide whether to handle InPlacePodVerticalScaling for containers.
 	GetContainerSwapBehavior(pod *v1.Pod, container *v1.Container) kubelettypes.SwapBehavior
 	// IsPodResizeInProgress checks whether the given pod is in the process of resizing
 	// (allocated resources != actuated resources).
 	IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *PodStatus) bool
-	// Temporarily expose actuated resources for incremental changes.
-	GetActuatedResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool)
 }
 
 // StreamingRuntime is the interface implemented by runtimes that handle the serving of the

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -531,7 +531,7 @@ func (f *FakeContainerCommandRunner) RunInContainer(_ context.Context, container
 	return []byte(f.Stdout), f.Err
 }
 
-func (f *FakeRuntime) GetContainerStatus(_ context.Context, _ kubecontainer.ContainerID) (status *kubecontainer.Status, err error) {
+func (f *FakeRuntime) GetContainerStatus(_ context.Context, _ types.UID, _ kubecontainer.ContainerID) (status *kubecontainer.Status, err error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -548,8 +548,4 @@ func (f *FakeRuntime) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Contai
 
 func (f *FakeRuntime) IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
 	return false
-}
-
-func (f *FakeRuntime) GetActuatedResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
-	return v1.ResourceRequirements{}, false
 }

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -545,3 +545,11 @@ func (f *FakeRuntime) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Contai
 	}
 	return kubetypes.NoSwap
 }
+
+func (f *FakeRuntime) IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
+	return false
+}
+
+func (f *FakeRuntime) GetActuatedResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
+	return v1.ResourceRequirements{}, false
+}

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -353,72 +353,6 @@ func (_c *MockRuntime_GeneratePodStatus_Call) RunAndReturn(run func(event *v1.Co
 	return _c
 }
 
-// GetActuatedResources provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GetActuatedResources(podUID types.UID, containerName string) (v10.ResourceRequirements, bool) {
-	ret := _mock.Called(podUID, containerName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetActuatedResources")
-	}
-
-	var r0 v10.ResourceRequirements
-	var r1 bool
-	if returnFunc, ok := ret.Get(0).(func(types.UID, string) (v10.ResourceRequirements, bool)); ok {
-		return returnFunc(podUID, containerName)
-	}
-	if returnFunc, ok := ret.Get(0).(func(types.UID, string) v10.ResourceRequirements); ok {
-		r0 = returnFunc(podUID, containerName)
-	} else {
-		r0 = ret.Get(0).(v10.ResourceRequirements)
-	}
-	if returnFunc, ok := ret.Get(1).(func(types.UID, string) bool); ok {
-		r1 = returnFunc(podUID, containerName)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-	return r0, r1
-}
-
-// MockRuntime_GetActuatedResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActuatedResources'
-type MockRuntime_GetActuatedResources_Call struct {
-	*mock.Call
-}
-
-// GetActuatedResources is a helper method to define mock.On call
-//   - podUID types.UID
-//   - containerName string
-func (_e *MockRuntime_Expecter) GetActuatedResources(podUID interface{}, containerName interface{}) *MockRuntime_GetActuatedResources_Call {
-	return &MockRuntime_GetActuatedResources_Call{Call: _e.mock.On("GetActuatedResources", podUID, containerName)}
-}
-
-func (_c *MockRuntime_GetActuatedResources_Call) Run(run func(podUID types.UID, containerName string)) *MockRuntime_GetActuatedResources_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 types.UID
-		if args[0] != nil {
-			arg0 = args[0].(types.UID)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockRuntime_GetActuatedResources_Call) Return(resourceRequirements v10.ResourceRequirements, b bool) *MockRuntime_GetActuatedResources_Call {
-	_c.Call.Return(resourceRequirements, b)
-	return _c
-}
-
-func (_c *MockRuntime_GetActuatedResources_Call) RunAndReturn(run func(podUID types.UID, containerName string) (v10.ResourceRequirements, bool)) *MockRuntime_GetActuatedResources_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetContainerLogs provides a mock function for the type MockRuntime
 func (_mock *MockRuntime) GetContainerLogs(ctx context.Context, pod *v10.Pod, containerID container.ContainerID, logOptions *v10.PodLogOptions, stdout io.Writer, stderr io.Writer) error {
 	ret := _mock.Called(ctx, pod, containerID, logOptions, stdout, stderr)
@@ -501,8 +435,8 @@ func (_c *MockRuntime_GetContainerLogs_Call) RunAndReturn(run func(ctx context.C
 }
 
 // GetContainerStatus provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GetContainerStatus(ctx context.Context, id container.ContainerID) (*container.Status, error) {
-	ret := _mock.Called(ctx, id)
+func (_mock *MockRuntime) GetContainerStatus(ctx context.Context, podUID types.UID, id container.ContainerID) (*container.Status, error) {
+	ret := _mock.Called(ctx, podUID, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetContainerStatus")
@@ -510,18 +444,18 @@ func (_mock *MockRuntime) GetContainerStatus(ctx context.Context, id container.C
 
 	var r0 *container.Status
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, container.ContainerID) (*container.Status, error)); ok {
-		return returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID, container.ContainerID) (*container.Status, error)); ok {
+		return returnFunc(ctx, podUID, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, container.ContainerID) *container.Status); ok {
-		r0 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID, container.ContainerID) *container.Status); ok {
+		r0 = returnFunc(ctx, podUID, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*container.Status)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, container.ContainerID) error); ok {
-		r1 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, types.UID, container.ContainerID) error); ok {
+		r1 = returnFunc(ctx, podUID, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -535,24 +469,30 @@ type MockRuntime_GetContainerStatus_Call struct {
 
 // GetContainerStatus is a helper method to define mock.On call
 //   - ctx context.Context
+//   - podUID types.UID
 //   - id container.ContainerID
-func (_e *MockRuntime_Expecter) GetContainerStatus(ctx interface{}, id interface{}) *MockRuntime_GetContainerStatus_Call {
-	return &MockRuntime_GetContainerStatus_Call{Call: _e.mock.On("GetContainerStatus", ctx, id)}
+func (_e *MockRuntime_Expecter) GetContainerStatus(ctx interface{}, podUID interface{}, id interface{}) *MockRuntime_GetContainerStatus_Call {
+	return &MockRuntime_GetContainerStatus_Call{Call: _e.mock.On("GetContainerStatus", ctx, podUID, id)}
 }
 
-func (_c *MockRuntime_GetContainerStatus_Call) Run(run func(ctx context.Context, id container.ContainerID)) *MockRuntime_GetContainerStatus_Call {
+func (_c *MockRuntime_GetContainerStatus_Call) Run(run func(ctx context.Context, podUID types.UID, id container.ContainerID)) *MockRuntime_GetContainerStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 container.ContainerID
+		var arg1 types.UID
 		if args[1] != nil {
-			arg1 = args[1].(container.ContainerID)
+			arg1 = args[1].(types.UID)
+		}
+		var arg2 container.ContainerID
+		if args[2] != nil {
+			arg2 = args[2].(container.ContainerID)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -563,7 +503,7 @@ func (_c *MockRuntime_GetContainerStatus_Call) Return(status *container.Status, 
 	return _c
 }
 
-func (_c *MockRuntime_GetContainerStatus_Call) RunAndReturn(run func(ctx context.Context, id container.ContainerID) (*container.Status, error)) *MockRuntime_GetContainerStatus_Call {
+func (_c *MockRuntime_GetContainerStatus_Call) RunAndReturn(run func(ctx context.Context, podUID types.UID, id container.ContainerID) (*container.Status, error)) *MockRuntime_GetContainerStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -27,12 +27,12 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	v10 "k8s.io/api/core/v1"
-	types0 "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/kubelet/types"
+	types0 "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // NewMockRuntime creates a new instance of MockRuntime. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -353,6 +353,72 @@ func (_c *MockRuntime_GeneratePodStatus_Call) RunAndReturn(run func(event *v1.Co
 	return _c
 }
 
+// GetActuatedResources provides a mock function for the type MockRuntime
+func (_mock *MockRuntime) GetActuatedResources(podUID types.UID, containerName string) (v10.ResourceRequirements, bool) {
+	ret := _mock.Called(podUID, containerName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetActuatedResources")
+	}
+
+	var r0 v10.ResourceRequirements
+	var r1 bool
+	if returnFunc, ok := ret.Get(0).(func(types.UID, string) (v10.ResourceRequirements, bool)); ok {
+		return returnFunc(podUID, containerName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(types.UID, string) v10.ResourceRequirements); ok {
+		r0 = returnFunc(podUID, containerName)
+	} else {
+		r0 = ret.Get(0).(v10.ResourceRequirements)
+	}
+	if returnFunc, ok := ret.Get(1).(func(types.UID, string) bool); ok {
+		r1 = returnFunc(podUID, containerName)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+	return r0, r1
+}
+
+// MockRuntime_GetActuatedResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActuatedResources'
+type MockRuntime_GetActuatedResources_Call struct {
+	*mock.Call
+}
+
+// GetActuatedResources is a helper method to define mock.On call
+//   - podUID types.UID
+//   - containerName string
+func (_e *MockRuntime_Expecter) GetActuatedResources(podUID interface{}, containerName interface{}) *MockRuntime_GetActuatedResources_Call {
+	return &MockRuntime_GetActuatedResources_Call{Call: _e.mock.On("GetActuatedResources", podUID, containerName)}
+}
+
+func (_c *MockRuntime_GetActuatedResources_Call) Run(run func(podUID types.UID, containerName string)) *MockRuntime_GetActuatedResources_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 types.UID
+		if args[0] != nil {
+			arg0 = args[0].(types.UID)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRuntime_GetActuatedResources_Call) Return(resourceRequirements v10.ResourceRequirements, b bool) *MockRuntime_GetActuatedResources_Call {
+	_c.Call.Return(resourceRequirements, b)
+	return _c
+}
+
+func (_c *MockRuntime_GetActuatedResources_Call) RunAndReturn(run func(podUID types.UID, containerName string) (v10.ResourceRequirements, bool)) *MockRuntime_GetActuatedResources_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetContainerLogs provides a mock function for the type MockRuntime
 func (_mock *MockRuntime) GetContainerLogs(ctx context.Context, pod *v10.Pod, containerID container.ContainerID, logOptions *v10.PodLogOptions, stdout io.Writer, stderr io.Writer) error {
 	ret := _mock.Called(ctx, pod, containerID, logOptions, stdout, stderr)
@@ -503,18 +569,18 @@ func (_c *MockRuntime_GetContainerStatus_Call) RunAndReturn(run func(ctx context
 }
 
 // GetContainerSwapBehavior provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GetContainerSwapBehavior(pod *v10.Pod, container1 *v10.Container) types.SwapBehavior {
+func (_mock *MockRuntime) GetContainerSwapBehavior(pod *v10.Pod, container1 *v10.Container) types0.SwapBehavior {
 	ret := _mock.Called(pod, container1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetContainerSwapBehavior")
 	}
 
-	var r0 types.SwapBehavior
-	if returnFunc, ok := ret.Get(0).(func(*v10.Pod, *v10.Container) types.SwapBehavior); ok {
+	var r0 types0.SwapBehavior
+	if returnFunc, ok := ret.Get(0).(func(*v10.Pod, *v10.Container) types0.SwapBehavior); ok {
 		r0 = returnFunc(pod, container1)
 	} else {
-		r0 = ret.Get(0).(types.SwapBehavior)
+		r0 = ret.Get(0).(types0.SwapBehavior)
 	}
 	return r0
 }
@@ -549,12 +615,12 @@ func (_c *MockRuntime_GetContainerSwapBehavior_Call) Run(run func(pod *v10.Pod, 
 	return _c
 }
 
-func (_c *MockRuntime_GetContainerSwapBehavior_Call) Return(swapBehavior types.SwapBehavior) *MockRuntime_GetContainerSwapBehavior_Call {
+func (_c *MockRuntime_GetContainerSwapBehavior_Call) Return(swapBehavior types0.SwapBehavior) *MockRuntime_GetContainerSwapBehavior_Call {
 	_c.Call.Return(swapBehavior)
 	return _c
 }
 
-func (_c *MockRuntime_GetContainerSwapBehavior_Call) RunAndReturn(run func(pod *v10.Pod, container1 *v10.Container) types.SwapBehavior) *MockRuntime_GetContainerSwapBehavior_Call {
+func (_c *MockRuntime_GetContainerSwapBehavior_Call) RunAndReturn(run func(pod *v10.Pod, container1 *v10.Container) types0.SwapBehavior) *MockRuntime_GetContainerSwapBehavior_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -692,7 +758,7 @@ func (_c *MockRuntime_GetImageSize_Call) RunAndReturn(run func(ctx context.Conte
 }
 
 // GetPodStatus provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GetPodStatus(ctx context.Context, uid types0.UID, name string, namespace string) (*container.PodStatus, error) {
+func (_mock *MockRuntime) GetPodStatus(ctx context.Context, uid types.UID, name string, namespace string) (*container.PodStatus, error) {
 	ret := _mock.Called(ctx, uid, name, namespace)
 
 	if len(ret) == 0 {
@@ -701,17 +767,17 @@ func (_mock *MockRuntime) GetPodStatus(ctx context.Context, uid types0.UID, name
 
 	var r0 *container.PodStatus
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, types0.UID, string, string) (*container.PodStatus, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID, string, string) (*container.PodStatus, error)); ok {
 		return returnFunc(ctx, uid, name, namespace)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, types0.UID, string, string) *container.PodStatus); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, types.UID, string, string) *container.PodStatus); ok {
 		r0 = returnFunc(ctx, uid, name, namespace)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*container.PodStatus)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, types0.UID, string, string) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, types.UID, string, string) error); ok {
 		r1 = returnFunc(ctx, uid, name, namespace)
 	} else {
 		r1 = ret.Error(1)
@@ -726,22 +792,22 @@ type MockRuntime_GetPodStatus_Call struct {
 
 // GetPodStatus is a helper method to define mock.On call
 //   - ctx context.Context
-//   - uid types0.UID
+//   - uid types.UID
 //   - name string
 //   - namespace string
 func (_e *MockRuntime_Expecter) GetPodStatus(ctx interface{}, uid interface{}, name interface{}, namespace interface{}) *MockRuntime_GetPodStatus_Call {
 	return &MockRuntime_GetPodStatus_Call{Call: _e.mock.On("GetPodStatus", ctx, uid, name, namespace)}
 }
 
-func (_c *MockRuntime_GetPodStatus_Call) Run(run func(ctx context.Context, uid types0.UID, name string, namespace string)) *MockRuntime_GetPodStatus_Call {
+func (_c *MockRuntime_GetPodStatus_Call) Run(run func(ctx context.Context, uid types.UID, name string, namespace string)) *MockRuntime_GetPodStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 types0.UID
+		var arg1 types.UID
 		if args[1] != nil {
-			arg1 = args[1].(types0.UID)
+			arg1 = args[1].(types.UID)
 		}
 		var arg2 string
 		if args[2] != nil {
@@ -766,7 +832,7 @@ func (_c *MockRuntime_GetPodStatus_Call) Return(podStatus *container.PodStatus, 
 	return _c
 }
 
-func (_c *MockRuntime_GetPodStatus_Call) RunAndReturn(run func(ctx context.Context, uid types0.UID, name string, namespace string) (*container.PodStatus, error)) *MockRuntime_GetPodStatus_Call {
+func (_c *MockRuntime_GetPodStatus_Call) RunAndReturn(run func(ctx context.Context, uid types.UID, name string, namespace string) (*container.PodStatus, error)) *MockRuntime_GetPodStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -959,6 +1025,63 @@ func (_c *MockRuntime_ImageStats_Call) Return(imageStats *container.ImageStats, 
 }
 
 func (_c *MockRuntime_ImageStats_Call) RunAndReturn(run func(ctx context.Context) (*container.ImageStats, error)) *MockRuntime_ImageStats_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsPodResizeInProgress provides a mock function for the type MockRuntime
+func (_mock *MockRuntime) IsPodResizeInProgress(allocatedPod *v10.Pod, podStatus *container.PodStatus) bool {
+	ret := _mock.Called(allocatedPod, podStatus)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsPodResizeInProgress")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(*v10.Pod, *container.PodStatus) bool); ok {
+		r0 = returnFunc(allocatedPod, podStatus)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// MockRuntime_IsPodResizeInProgress_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPodResizeInProgress'
+type MockRuntime_IsPodResizeInProgress_Call struct {
+	*mock.Call
+}
+
+// IsPodResizeInProgress is a helper method to define mock.On call
+//   - allocatedPod *v10.Pod
+//   - podStatus *container.PodStatus
+func (_e *MockRuntime_Expecter) IsPodResizeInProgress(allocatedPod interface{}, podStatus interface{}) *MockRuntime_IsPodResizeInProgress_Call {
+	return &MockRuntime_IsPodResizeInProgress_Call{Call: _e.mock.On("IsPodResizeInProgress", allocatedPod, podStatus)}
+}
+
+func (_c *MockRuntime_IsPodResizeInProgress_Call) Run(run func(allocatedPod *v10.Pod, podStatus *container.PodStatus)) *MockRuntime_IsPodResizeInProgress_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *v10.Pod
+		if args[0] != nil {
+			arg0 = args[0].(*v10.Pod)
+		}
+		var arg1 *container.PodStatus
+		if args[1] != nil {
+			arg1 = args[1].(*container.PodStatus)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRuntime_IsPodResizeInProgress_Call) Return(b bool) *MockRuntime_IsPodResizeInProgress_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *MockRuntime_IsPodResizeInProgress_Call) RunAndReturn(run func(allocatedPod *v10.Pod, podStatus *container.PodStatus) bool) *MockRuntime_IsPodResizeInProgress_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/events/resize.go
+++ b/pkg/kubelet/events/resize.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
+)
+
+// PodResizeCompletedMsg gernerates the pod resize completed event message.
+func PodResizeCompletedMsg(allocatedPod *v1.Pod) string {
+	type containerAllocation struct {
+		Name      string                  `json:"name"`
+		Resources v1.ResourceRequirements `json:"resources,omitempty"`
+	}
+	type podResourceSummary struct {
+		//TODO: resources v1.ResourceRequirements, add pod-level resources here once resizing pod-level resources is supported
+		InitContainers []containerAllocation `json:"initContainers,omitempty"`
+		Containers     []containerAllocation `json:"containers,omitempty"`
+	}
+
+	podResizeSource := &podResourceSummary{}
+
+	for container, containerType := range podutil.ContainerIter(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers) {
+		allocation := containerAllocation{
+			Name:      container.Name,
+			Resources: container.Resources,
+		}
+		switch containerType {
+		case podutil.InitContainers:
+			podResizeSource.InitContainers = append(podResizeSource.InitContainers, allocation)
+		case podutil.Containers:
+			podResizeSource.Containers = append(podResizeSource.Containers, allocation)
+		}
+	}
+
+	podResizeMsgDetailsJSON, err := json.Marshal(podResizeSource)
+	if err != nil {
+		klog.ErrorS(err, "Failed to serialize resource summary", "pod", format.Pod(allocatedPod))
+		return "Pod resize completed"
+	}
+	podResizeCompletedMsg := fmt.Sprintf("Pod resize completed: %s", string(podResizeMsgDetailsJSON))
+	return podResizeCompletedMsg
+}

--- a/pkg/kubelet/events/resize_test.go
+++ b/pkg/kubelet/events/resize_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestPodResizeCompletedMsg(t *testing.T) {
+	type testResources struct {
+		cpuReq, cpuLim, memReq, memLim int64
+	}
+	type testContainer struct {
+		allocated               testResources
+		nonSidecarInit, sidecar bool
+		isRunning               bool
+	}
+
+	tests := []struct {
+		name                        string
+		containers                  []testContainer
+		expectPodResizeCompletedMsg string
+	}{{
+		name: "simple running container",
+		containers: []testContainer{{
+			allocated: testResources{100, 100, 100, 100},
+			isRunning: true,
+		}},
+		expectPodResizeCompletedMsg: `Pod resize completed: {"containers":[{"name":"c0","resources":{"limits":{"cpu":"100m","memory":"100"},"requests":{"cpu":"100m","memory":"100"}}}]}`,
+	}, {
+		name: "several containers",
+		containers: []testContainer{{
+			allocated: testResources{cpuReq: 100, cpuLim: 200},
+			sidecar:   true,
+			isRunning: true,
+		}, {
+			allocated: testResources{memReq: 100, memLim: 200},
+			isRunning: true,
+		}, {
+			allocated: testResources{cpuReq: 200, memReq: 100},
+			isRunning: true,
+		}},
+		expectPodResizeCompletedMsg: `Pod resize completed: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}]}`,
+	}, {
+		name: "best-effort pod",
+		containers: []testContainer{{
+			allocated: testResources{},
+			isRunning: true,
+		}},
+		expectPodResizeCompletedMsg: `Pod resize completed: {"containers":[{"name":"c0","resources":{}}]}`,
+	}}
+
+	mkRequirements := func(r testResources) v1.ResourceRequirements {
+		res := v1.ResourceRequirements{
+			Requests: v1.ResourceList{},
+			Limits:   v1.ResourceList{},
+		}
+		if r.cpuReq != 0 {
+			res.Requests[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuReq, resource.DecimalSI)
+		}
+		if r.cpuLim != 0 {
+			res.Limits[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuLim, resource.DecimalSI)
+		}
+		if r.memReq != 0 {
+			res.Requests[v1.ResourceMemory] = *resource.NewQuantity(r.memReq, resource.DecimalSI)
+		}
+		if r.memLim != 0 {
+			res.Limits[v1.ResourceMemory] = *resource.NewQuantity(r.memLim, resource.DecimalSI)
+		}
+		return res
+	}
+	mkContainer := func(index int, c testContainer) v1.Container {
+		container := v1.Container{
+			Name:      fmt.Sprintf("c%d", index),
+			Resources: mkRequirements(c.allocated),
+		}
+		if c.sidecar {
+			container.RestartPolicy = ptr.To(v1.ContainerRestartPolicyAlways)
+		}
+		return container
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					UID:  "12345",
+				},
+			}
+
+			for i, c := range test.containers {
+				// Add the container to the pod
+				container := mkContainer(i, c)
+				if c.nonSidecarInit || c.sidecar {
+					pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
+				} else {
+					pod.Spec.Containers = append(pod.Spec.Containers, container)
+				}
+			}
+
+			// Verify pod resize completed event is emitted
+			msg := PodResizeCompletedMsg(pod)
+			assert.Equal(t, test.expectPodResizeCompletedMsg, msg)
+		})
+	}
+}

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -328,7 +328,7 @@ func (im *realImageGCManager) handleImageVolumes(ctx context.Context, imagesInUs
 		return nil
 	}
 
-	status, err := im.runtime.GetContainerStatus(ctx, container.ID)
+	status, err := im.runtime.GetContainerStatus(ctx, pod.ID, container.ID)
 	if err != nil {
 		return fmt.Errorf("get container status: %w", err)
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -790,7 +790,6 @@ func NewMainKubelet(ctx context.Context,
 		kubeDeps.ContainerManager,
 		klet.containerLogManager,
 		klet.runtimeClassManager,
-		klet.allocationManager,
 		seccompDefault,
 		kubeCfg.MemorySwap.SwapBehavior,
 		kubeDeps.ContainerManager.GetNodeAllocatableAbsolute,
@@ -1943,8 +1942,16 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Check whether a resize is in progress so we can set the PodResizeInProgressCondition accordingly.
-		kl.allocationManager.CheckPodResizeInProgress(pod, podStatus)
-		// TODO(#132851): There is a race condition here, where the goroutine in the
+		if kl.containerRuntime.IsPodResizeInProgress(pod, podStatus) {
+			kl.statusManager.SetPodResizeInProgressCondition(pod.UID, "", "", pod.Generation)
+		} else if kl.statusManager.ClearPodResizeInProgressCondition(pod.UID) {
+			// (Allocated == Actual) => clear the resize in-progress status.
+			if kl.recorder != nil {
+				msg := events.PodResizeCompletedMsg(pod)
+				kl.recorder.Eventf(pod, v1.EventTypeNormal, events.ResizeCompleted, msg)
+			}
+		}
+		// TODO(natasha41575): There is a race condition here, where the goroutine in the
 		// allocation manager may allocate a new resize and unconditionally set the
 		// PodResizeInProgressCondition before we set the status below.
 	}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2224,12 +2224,10 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			} else {
 				preserveOldResourcesValue(v1.ResourceCPU, oldStatus.Resources.Requests, resources.Requests)
 			}
-			// TODO(tallclair,vinaykul,InPlacePodVerticalScaling): Investigate defaulting to actuated resources instead of allocated resources above
-			if _, exists := resources.Requests[v1.ResourceMemory]; exists {
-				// Get memory requests from actuated resources
-				if actuatedResources, found := kl.containerRuntime.GetActuatedResources(pod.UID, allocatedContainer.Name); found {
-					resources.Requests[v1.ResourceMemory] = *actuatedResources.Requests.Memory()
-				}
+			if cStatus.Resources != nil && cStatus.Resources.MemoryRequest != nil {
+				resources.Requests[v1.ResourceMemory] = cStatus.Resources.MemoryRequest.DeepCopy()
+			} else {
+				preserveOldResourcesValue(v1.ResourceMemory, oldStatus.Resources.Requests, resources.Requests)
 			}
 		}
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2227,7 +2227,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			// TODO(tallclair,vinaykul,InPlacePodVerticalScaling): Investigate defaulting to actuated resources instead of allocated resources above
 			if _, exists := resources.Requests[v1.ResourceMemory]; exists {
 				// Get memory requests from actuated resources
-				if actuatedResources, found := kl.allocationManager.GetActuatedResources(pod.UID, allocatedContainer.Name); found {
+				if actuatedResources, found := kl.containerRuntime.GetActuatedResources(pod.UID, allocatedContainer.Name); found {
 					resources.Requests[v1.ResourceMemory] = *actuatedResources.Requests.Memory()
 				}
 			}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3437,7 +3437,6 @@ func TestSyncPodSpans(t *testing.T) {
 		kubelet.containerManager,
 		kubelet.containerLogManager,
 		kubelet.runtimeClassManager,
-		kubelet.allocationManager,
 		false,
 		kubeCfg.MemorySwap.SwapBehavior,
 		kubelet.containerManager.GetNodeAllocatableAbsolute,

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/component-base/logs/logreduction"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	"k8s.io/kubernetes/pkg/credentialprovider"
-	"k8s.io/kubernetes/pkg/kubelet/allocation"
+	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/images"
@@ -119,7 +119,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 		logManager:             logManager,
 		memoryThrottlingFactor: 0.9,
 		podLogsDirectory:       fakePodLogsDirectory,
-		allocationManager:      allocation.NewInMemoryManager(cm.NodeConfig{}, nil, nil, nil, nil, nil, nil),
+		actuatedState:          state.NewStateMemory(nil),
 	}
 
 	// Initialize swap controller availability check (always false for tests)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -53,6 +53,7 @@ import (
 	"k8s.io/kubernetes/pkg/credentialprovider/plugin"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/allocation"
+	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -86,6 +87,8 @@ const (
 	identicalErrorDelay = 1 * time.Minute
 	// OpenTelemetry instrumentation scope name
 	instrumentationScope = "k8s.io/kubernetes/pkg/kubelet/kuberuntime"
+
+	actuatedPodsStateFile = "actuated_pods_state"
 )
 
 var (
@@ -159,8 +162,8 @@ type kubeGenericRuntimeManager struct {
 	// Manage RuntimeClass resources.
 	runtimeClassManager *runtimeclass.Manager
 
-	// Manager allocated & actuated resources.
-	allocationManager allocation.Manager
+	// actuatedState tracks actuated resources.
+	actuatedState state.State
 
 	// Cache last per-container error message to reduce log spam
 	logReduction *logreduction.LogReduction
@@ -227,7 +230,6 @@ func NewKubeGenericRuntimeManager(
 	containerManager cm.ContainerManager,
 	logManager logs.ContainerLogManager,
 	runtimeClassManager *runtimeclass.Manager,
-	allocationManager allocation.Manager,
 	seccompDefault bool,
 	memorySwapBehavior string,
 	getNodeAllocatable func() v1.ResourceList,
@@ -260,7 +262,6 @@ func NewKubeGenericRuntimeManager(
 		internalLifecycle:      containerManager.InternalContainerLifecycle(),
 		logManager:             logManager,
 		runtimeClassManager:    runtimeClassManager,
-		allocationManager:      allocationManager,
 		logReduction:           logreduction.NewLogReduction(identicalErrorDelay),
 		seccompDefault:         seccompDefault,
 		memorySwapBehavior:     memorySwapBehavior,
@@ -354,6 +355,11 @@ func NewKubeGenericRuntimeManager(
 		},
 		versionCacheTTL,
 	)
+
+	kubeRuntimeManager.actuatedState, err = state.NewStateCheckpoint(rootDirectory, actuatedPodsStateFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize actuated state checkpoint: %w", err)
+	}
 
 	return kubeRuntimeManager, imageGCHooks, nil
 }
@@ -634,7 +640,7 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(ctx context.Context, 
 		return true
 	}
 
-	actuatedResources, found := m.allocationManager.GetActuatedResources(pod.UID, container.Name)
+	actuatedResources, found := m.actuatedState.GetContainerResources(pod.UID, container.Name)
 	if !found {
 		logger.Error(nil, "Missing actuated resource record", "pod", klog.KObj(pod), "container", container.Name)
 		// Proceed with the zero-value actuated resources. For restart NotRequired, this may
@@ -1816,6 +1822,13 @@ func (m *kubeGenericRuntimeManager) GetContainerStatus(ctx context.Context, id k
 
 // GarbageCollect removes dead containers using the specified container gc policy.
 func (m *kubeGenericRuntimeManager) GarbageCollect(ctx context.Context, gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
+	// Remove terminated pods from the actuated state.
+	for uid := range m.actuatedState.GetPodResourceInfoMap() {
+		if m.podStateProvider.ShouldPodContentBeRemoved(uid) {
+			m.actuatedState.RemovePod(uid)
+		}
+	}
+
 	return m.containerGC.GarbageCollect(ctx, gcPolicy, allSourcesReady, evictNonDeletedPods)
 }
 
@@ -1844,4 +1857,47 @@ func (m *kubeGenericRuntimeManager) ListMetricDescriptors(ctx context.Context) (
 
 func (m *kubeGenericRuntimeManager) ListPodSandboxMetrics(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error) {
 	return m.runtimeService.ListPodSandboxMetrics(ctx)
+}
+
+func (m *kubeGenericRuntimeManager) GetActuatedResources(podUID kubetypes.UID, containerName string) (v1.ResourceRequirements, bool) {
+	return m.actuatedState.GetContainerResources(podUID, containerName)
+}
+
+// isPodResizeInProgress checks whether the actuated resizable resources differ from the allocated resources
+// for any running containers. Specifically, the following differences are ignored:
+// - Non-resizable containers: non-restartable init containers, ephemeral containers
+// - Non-resizable resources: only CPU & memory are resizable
+// - Non-running containers: they will be sized correctly when (re)started
+func (m *kubeGenericRuntimeManager) IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
+	return !podutil.VisitContainers(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers,
+		func(allocatedContainer *v1.Container, containerType podutil.ContainerType) (shouldContinue bool) {
+			if !isResizableContainer(allocatedContainer, containerType) {
+				return true
+			}
+
+			containerStatus := podStatus.FindContainerStatusByName(allocatedContainer.Name)
+			if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
+				// If the container isn't running, it doesn't need to be resized.
+				return true
+			}
+
+			actuatedResources, _ := m.GetActuatedResources(allocatedPod.UID, allocatedContainer.Name)
+			allocatedResources := allocatedContainer.Resources
+
+			return allocatedResources.Requests[v1.ResourceCPU].Equal(actuatedResources.Requests[v1.ResourceCPU]) &&
+				allocatedResources.Limits[v1.ResourceCPU].Equal(actuatedResources.Limits[v1.ResourceCPU]) &&
+				allocatedResources.Requests[v1.ResourceMemory].Equal(actuatedResources.Requests[v1.ResourceMemory]) &&
+				allocatedResources.Limits[v1.ResourceMemory].Equal(actuatedResources.Limits[v1.ResourceMemory])
+		})
+}
+
+func isResizableContainer(container *v1.Container, containerType podutil.ContainerType) bool {
+	switch containerType {
+	case podutil.InitContainers:
+		return podutil.IsRestartableInitContainer(container)
+	case podutil.Containers:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2754,7 +2754,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 			if test.setupFn != nil {
 				test.setupFn(pod)
 			}
-			t.Cleanup(func() { m.actuatedState.RemovePod(pod.UID) })
+			t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
 
 			for idx := range pod.Spec.Containers {
 				// compute hash
@@ -3919,11 +3919,11 @@ func TestIsPodResizeInProgress(t *testing.T) {
 					actuatedContainer.Resources = mkRequirements(*c.actuated)
 					require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
 
-					fetched, found := m.GetActuatedResources(pod.UID, container.Name)
+					fetched, found := m.actuatedState.GetContainerResources(pod.UID, container.Name)
 					require.True(t, found)
 					assert.Equal(t, actuatedContainer.Resources, fetched)
 				} else {
-					_, found := m.GetActuatedResources(pod.UID, container.Name)
+					_, found := m.actuatedState.GetContainerResources(pod.UID, container.Name)
 					require.False(t, found)
 				}
 			}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2336,7 +2336,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	setupActuatedResources := func(pod *v1.Pod, container *v1.Container, actuatedResources v1.ResourceRequirements) {
 		actuatedContainer := container.DeepCopy()
 		actuatedContainer.Resources = actuatedResources
-		require.NoError(t, m.allocationManager.SetActuatedResources(pod, actuatedContainer))
+		require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
 	}
 
 	for desc, test := range map[string]struct {
@@ -2754,7 +2754,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 			if test.setupFn != nil {
 				test.setupFn(pod)
 			}
-			t.Cleanup(func() { m.allocationManager.RemovePod(pod.UID) })
+			t.Cleanup(func() { m.actuatedState.RemovePod(pod.UID) })
 
 			for idx := range pod.Spec.Containers {
 				// compute hash
@@ -3287,7 +3287,7 @@ func TestDoPodResizeAction(t *testing.T) {
 	metrics.PodResizeDurationMilliseconds.Reset()
 }
 
-func TestCheckPodResize(t *testing.T) {
+func TestValidatePodResizeAction(t *testing.T) {
 	if goruntime.GOOS != "linux" {
 		t.Skip("unsupported OS")
 	}
@@ -3661,6 +3661,275 @@ func TestIncrementImageVolumeMetrics(t *testing.T) {
 			); err != nil {
 				t.Error(err)
 			}
+		})
+	}
+}
+
+func TestIsPodResizeInProgress(t *testing.T) {
+	type testResources struct {
+		cpuReq, cpuLim, memReq, memLim int64
+	}
+	type testContainer struct {
+		allocated               testResources
+		actuated                *testResources
+		nonSidecarInit, sidecar bool
+		isRunning               bool
+		unstarted               bool // Whether the container is missing from the pod status
+	}
+
+	tests := []struct {
+		name            string
+		containers      []testContainer
+		expectHasResize bool
+	}{{
+		name: "simple running container",
+		containers: []testContainer{{
+			allocated: testResources{100, 100, 100, 100},
+			actuated:  &testResources{100, 100, 100, 100},
+			isRunning: true,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "simple unstarted container",
+		containers: []testContainer{{
+			allocated: testResources{100, 100, 100, 100},
+			unstarted: true,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "simple resized container/cpu req",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{150, 200, 100, 200},
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}, {
+		name: "simple resized container/cpu limit",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 300, 100, 200},
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}, {
+		name: "simple resized container/mem req",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 200, 150, 200},
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}, {
+		name: "simple resized container/cpu+mem req",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{150, 200, 150, 200},
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}, {
+		name: "simple resized container/mem limit",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 200, 100, 300},
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}, {
+		name: "terminated resized container",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{200, 200, 100, 200},
+			isRunning: false,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "non-sidecar init container",
+		containers: []testContainer{{
+			allocated:      testResources{100, 200, 100, 200},
+			nonSidecarInit: true,
+			isRunning:      true,
+		}, {
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 200, 100, 200},
+			isRunning: true,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "non-resized sidecar",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 200, 100, 200},
+			sidecar:   true,
+			isRunning: true,
+		}, {
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 200, 100, 200},
+			isRunning: true,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "resized sidecar",
+		containers: []testContainer{{
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{200, 200, 100, 200},
+			sidecar:   true,
+			isRunning: true,
+		}, {
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 200, 100, 200},
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}, {
+		name: "several containers and a resize",
+		containers: []testContainer{{
+			allocated:      testResources{100, 200, 100, 200},
+			nonSidecarInit: true,
+			isRunning:      true,
+		}, {
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{100, 200, 100, 200},
+			isRunning: true,
+		}, {
+			allocated: testResources{100, 200, 100, 200},
+			unstarted: true,
+		}, {
+			allocated: testResources{100, 200, 100, 200},
+			actuated:  &testResources{200, 200, 100, 200}, // Resized
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}, {
+		name: "several containers",
+		containers: []testContainer{{
+			allocated: testResources{cpuReq: 100, cpuLim: 200},
+			actuated:  &testResources{cpuReq: 100, cpuLim: 200},
+			sidecar:   true,
+			isRunning: true,
+		}, {
+			allocated: testResources{memReq: 100, memLim: 200},
+			actuated:  &testResources{memReq: 100, memLim: 200},
+			isRunning: true,
+		}, {
+			allocated: testResources{cpuReq: 200, memReq: 100},
+			actuated:  &testResources{cpuReq: 200, memReq: 100},
+			isRunning: true,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "best-effort pod",
+		containers: []testContainer{{
+			allocated: testResources{},
+			actuated:  &testResources{},
+			isRunning: true,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "burstable pod/not resizing",
+		containers: []testContainer{{
+			allocated: testResources{cpuReq: 100},
+			actuated:  &testResources{cpuReq: 100},
+			isRunning: true,
+		}},
+		expectHasResize: false,
+	}, {
+		name: "burstable pod/resized",
+		containers: []testContainer{{
+			allocated: testResources{cpuReq: 100},
+			actuated:  &testResources{cpuReq: 500},
+			isRunning: true,
+		}},
+		expectHasResize: true,
+	}}
+
+	mkRequirements := func(r testResources) v1.ResourceRequirements {
+		res := v1.ResourceRequirements{
+			Requests: v1.ResourceList{},
+			Limits:   v1.ResourceList{},
+		}
+		if r.cpuReq != 0 {
+			res.Requests[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuReq, resource.DecimalSI)
+		}
+		if r.cpuLim != 0 {
+			res.Limits[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuLim, resource.DecimalSI)
+		}
+		if r.memReq != 0 {
+			res.Requests[v1.ResourceMemory] = *resource.NewQuantity(r.memReq, resource.DecimalSI)
+		}
+		if r.memLim != 0 {
+			res.Limits[v1.ResourceMemory] = *resource.NewQuantity(r.memLim, resource.DecimalSI)
+		}
+		return res
+	}
+	mkContainer := func(index int, c testContainer) v1.Container {
+		container := v1.Container{
+			Name:      fmt.Sprintf("c%d", index),
+			Resources: mkRequirements(c.allocated),
+		}
+		if c.sidecar {
+			container.RestartPolicy = ptr.To(v1.ContainerRestartPolicyAlways)
+		}
+		return container
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			_, _, m, err := createTestRuntimeManager(tCtx)
+			require.NoError(t, err)
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					UID:  "12345",
+				},
+			}
+			podStatus := &kubecontainer.PodStatus{
+				ID:   pod.UID,
+				Name: pod.Name,
+			}
+
+			for i, c := range test.containers {
+				// Add the container to the pod
+				container := mkContainer(i, c)
+				if c.nonSidecarInit || c.sidecar {
+					pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
+				} else {
+					pod.Spec.Containers = append(pod.Spec.Containers, container)
+				}
+
+				// Add the container to the pod status, if it's started.
+				if !test.containers[i].unstarted {
+					cs := kubecontainer.Status{
+						Name: container.Name,
+					}
+					if test.containers[i].isRunning {
+						cs.State = kubecontainer.ContainerStateRunning
+					} else {
+						cs.State = kubecontainer.ContainerStateExited
+					}
+					podStatus.ContainerStatuses = append(podStatus.ContainerStatuses, &cs)
+				}
+
+				// Register the actuated container (if needed)
+				if c.actuated != nil {
+					actuatedContainer := container.DeepCopy()
+					actuatedContainer.Resources = mkRequirements(*c.actuated)
+					require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
+
+					fetched, found := m.GetActuatedResources(pod.UID, container.Name)
+					require.True(t, found)
+					assert.Equal(t, actuatedContainer.Resources, fetched)
+				} else {
+					_, found := m.GetActuatedResources(pod.UID, container.Name)
+					require.False(t, found)
+				}
+			}
+
+			resizeInProgress := m.IsPodResizeInProgress(pod, podStatus)
+			assert.Equal(t, test.expectHasResize, resizeInProgress)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This started as a cleanup to reduce some interdependencies between components and reduce the responsibilities & complexity of the allocation.Manager, but I also ended up changing the way we retry pending resizes after successfully resizing a pod.

This is broken into 3 commits:

1. Move actuated resources state to kuberuntime.Manager - straightforward refactoring: move the actuated state into the runtime manager component, and expose it with a temporary `GetActuatedResources` method.
2. Populate memory requests from actuated resources at pod status generation time - eliminate a dependency on actuated resources when generating the pod status
3. ~~Retry pending resizes if a status update leads to aggregate requests shrinking - This is the more significant change, discussed below.~~ (moved to https://github.com/kubernetes/kubernetes/pull/133045)

Previously, we were overwriting the PodStatus.Resources with the actuated resources when retrying pending resizes. Doing so was necessary since the pod from the pod manager might not have synced the updated status yet when resizes are retried. The problems with this approach include:
- Actuated resources can differ from actual resources (which is why we added actuated resources originally)
- We're using a different view of the pod for resizing than for scheduling and pod admission

The solution is to wait until the pod status with the updated resources has synced to the pod manager (which happens through HandlePodReconcile). We don't want to retry the resizes on every single pod status update, so I only triggered the retry when the aggregate requests decrease.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-longterm