### PR TITLE
fix kubelet TestPodResourceAllocationReset for windows

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -326,7 +326,7 @@ func newTestKubeletWithImageList(
 		func(pod *v1.Pod) { kubelet.HandlePodSyncs([]*v1.Pod{pod}) },
 		kubelet.GetActivePods,
 		kubelet.podManager.GetPodByUID,
-		config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }),
+		config.NewSourcesReady(func(_ sets.Set[string]) bool { return false }),
 	)
 	kubelet.allocationManager.SetContainerRuntime(fakeRuntime)
 	volumeStatsAggPeriod := time.Second * 10
@@ -2522,7 +2522,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
 				"3": state.PodResourceInfo{
 					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu800mMem800MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
+						cpu800mMem800MPodSpec.Containers[0].Name: cpu800mMem800MPodSpec.Containers[0].Resources,
 					},
 				},
 			},
@@ -2557,7 +2557,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
 				"6": state.PodResourceInfo{
 					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu800mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
+						cpu800mPodSpec.Containers[0].Name: cpu800mPodSpec.Containers[0].Resources,
 					},
 				},
 			},
@@ -2592,7 +2592,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
 				"9": state.PodResourceInfo{
 					ContainerResources: map[string]v1.ResourceRequirements{
-						mem800MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
+						mem800MPodSpec.Containers[0].Name: mem800MPodSpec.Containers[0].Resources,
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

Fix TestPodResourceAllocationReset for windows, which is [failing in the windows unit test job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/131612/pull-kubernetes-unit-windows-master/1943063695483473920). I think we can just skip it for windows, since IPPR is not supported for windows anyways. Pretty sure I broke this in https://github.com/kubernetes/kubernetes/pull/131612.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/assign @tallclair 

