### PR TITLE
Compact watch cache based on last observed etcd compaction

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -187,7 +187,7 @@ func TestLists(t *testing.T) {
 					t.Parallel()
 					ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 					t.Cleanup(terminate)
-					storagetesting.RunTestList(ctx, t, cacher, increaseRV(server.V3Client.Client), compactStore(cacher, server.V3Client.Client), true, server.V3Client.Kubernetes.(*storagetesting.KubernetesRecorder))
+					storagetesting.RunTestList(ctx, t, cacher, compactStore(cacher, server.V3Client.Client), true, server.V3Client.Kubernetes.(*storagetesting.KubernetesRecorder))
 				})
 
 				t.Run("ConsistentList", func(t *testing.T) {
@@ -206,6 +206,14 @@ func TestLists(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestCompactRevision(t *testing.T) {
+	// Test requires store to observe extenal changes to compaction revision, requiring dedicated watch on compact key which is enabled by ListFromCacheSnapshot.
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, true)
+	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
+	t.Cleanup(terminate)
+	storagetesting.RunTestCompactRevision(ctx, t, cacher, increaseRV(server.V3Client.Client), compactStore(cacher, server.V3Client.Client))
 }
 
 func TestGetListRecursivePrefix(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
@@ -37,6 +38,7 @@ import (
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
+	"k8s.io/utils/clock"
 )
 
 var (
@@ -59,8 +61,11 @@ func newEtcdTestStorage(t testing.TB, prefix string) (*etcd3testing.EtcdTestServ
 	server, _ := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	versioner := storage.APIObjectVersioner{}
 	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
+	compactor := etcd3.NewCompactor(server.V3Client.Client, 0, clock.RealClock{}, nil)
+	t.Cleanup(compactor.Stop)
 	storage := etcd3.New(
 		server.V3Client,
+		compactor,
 		codec,
 		newPod,
 		newPodList,
@@ -131,10 +136,29 @@ func compactStore(c *CacheDelegator, client *clientv3.Client) storagetesting.Com
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := client.Compact(ctx, int64(rv)); err != nil {
-			t.Fatalf("Unable to compact, %v", err)
+		var currentVersion int64
+		currentVersion, _, _, err = etcd3.Compact(ctx, client, currentVersion, int64(rv))
+		if err != nil {
+			_, _, _, err = etcd3.Compact(ctx, client, currentVersion, int64(rv))
 		}
-		c.cacher.watchCache.Compact(int64(rv))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Wait for compaction to be observed.
+		if c.cacher.compactor != nil {
+			for {
+				select {
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				case <-time.After(100 * time.Millisecond):
+				}
+				compactedRev := c.storage.CompactRevision()
+				if compactedRev == int64(rv) {
+					break
+				}
+			}
+			c.cacher.compactor.compactIfNeeded()
+		}
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -137,6 +137,10 @@ func (d *dummyStorage) getRequestWatchProgressCounter() int {
 	return d.requestWatchProgressCounter
 }
 
+func (d *dummyStorage) CompactRevision() int64 {
+	return 0
+}
+
 type dummyWatch struct {
 	ch chan watch.Event
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/compactor.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/compactor.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apiserver/pkg/storage"
+
+	"k8s.io/utils/clock"
+)
+
+const (
+	// compactorPollPeriod determines period of reading compaction revision from storage.
+	compactorPollPeriod = 15 * time.Second
+)
+
+func newCompactor(store storage.Interface, wc *watchCache, clock clock.Clock) *compactor {
+	pr := &compactor{
+		clock: clock,
+		store: store,
+		wc:    wc,
+	}
+	return pr
+}
+
+type compactor struct {
+	clock clock.Clock
+	store storage.Interface
+	wc    *watchCache
+
+	lock            sync.Mutex
+	compactRevision int64
+}
+
+func (c *compactor) Run(stopCh <-chan struct{}) {
+	timer := c.clock.NewTimer(compactorPollPeriod)
+	defer timer.Stop()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-timer.C():
+			c.compactIfNeeded()
+			timer.Reset(compactorPollPeriod)
+		}
+	}
+}
+
+func (c *compactor) compactIfNeeded() {
+	rev := c.store.CompactRevision()
+	if rev == 0 {
+		return
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if rev <= c.compactRevision {
+		return
+	}
+	c.wc.Compact(rev)
+	c.compactRevision = rev
+}
+
+func (c *compactor) Revision() int64 {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.compactRevision
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -276,6 +276,13 @@ func (c *CacheDelegator) RequestWatchProgress(ctx context.Context) error {
 	return c.storage.RequestWatchProgress(ctx)
 }
 
+func (c *CacheDelegator) CompactRevision() int64 {
+	if c.cacher.compactor == nil {
+		return c.storage.CompactRevision()
+	}
+	return c.cacher.compactor.Revision()
+}
+
 func (c *CacheDelegator) Stop() {
 	c.stopOnce.Do(func() {
 		close(c.stopCh)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
@@ -37,7 +37,7 @@ func TestCompact(t *testing.T) {
 	client := testserver.RunEtcd(t, nil).Client
 	ctx := context.Background()
 	clock := testingclock.NewFakeClock(time.Now())
-	c := newCompactor(client, time.Minute, clock, nil)
+	c := NewCompactor(client, time.Minute, clock, nil)
 	t.Cleanup(c.Stop)
 	waitForClockWaiters(t, clock)
 
@@ -113,7 +113,7 @@ func assertNotCompacted(t *testing.T, ctx context.Context, client *clientv3.Clie
 func TestCompactIntervalZero(t *testing.T) {
 	client := testserver.RunEtcd(t, nil).Client
 	clock := testingclock.NewFakeClock(time.Now())
-	c := newCompactor(client, 0, clock, nil)
+	c := NewCompactor(client, 0, clock, nil)
 	t.Cleanup(c.Stop)
 
 	t.Log("Compact loop is disabled, no goroutine is waiting on clock")
@@ -162,7 +162,7 @@ func TestCompactConflict(t *testing.T) {
 
 	t.Log("First compact on time 0")
 	wantCompactRev := putResp.Header.Revision
-	curTime, curRev, compactRev, err := compact(ctx, client, 0, wantCompactRev)
+	curTime, curRev, compactRev, err := Compact(ctx, client, 0, wantCompactRev)
 	if err != nil {
 		t.Fatalf("compact failed: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestCompactConflict(t *testing.T) {
 	}
 
 	t.Log("Second compact on time 0")
-	curTime2, curRev2, compactRev2, err := compact(ctx, client, 0, wantCompactRev+1)
+	curTime2, curRev2, compactRev2, err := Compact(ctx, client, 0, wantCompactRev+1)
 	if err != nil {
 		t.Fatalf("compact failed: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestCompactConflict(t *testing.T) {
 	}
 
 	t.Log("Third compact on time 1")
-	curTime3, curRev3, compactRev3, err := compact(ctx, client, 1, wantCompactRev+1)
+	curTime3, curRev3, compactRev3, err := Compact(ctx, client, 1, wantCompactRev+1)
 	if err != nil {
 		t.Fatalf("compact failed: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -91,6 +91,7 @@ type store struct {
 	resourcePrefix string
 	newListFunc    func() runtime.Object
 	stats          *statsCache
+	compactor      Compactor
 }
 
 var _ storage.Interface = (*store)(nil)
@@ -141,7 +142,7 @@ func (a *abortOnFirstError) Aggregate(key string, err error) bool {
 func (a *abortOnFirstError) Err() error { return a.err }
 
 // New returns an etcd3 implementation of storage.Interface.
-func New(c *kubernetes.Client, codec runtime.Codec, newFunc, newListFunc func() runtime.Object, prefix, resourcePrefix string, groupResource schema.GroupResource, transformer value.Transformer, leaseManagerConfig LeaseManagerConfig, decoder Decoder, versioner storage.Versioner) *store {
+func New(c *kubernetes.Client, compactor Compactor, codec runtime.Codec, newFunc, newListFunc func() runtime.Object, prefix, resourcePrefix string, groupResource schema.GroupResource, transformer value.Transformer, leaseManagerConfig LeaseManagerConfig, decoder Decoder, versioner storage.Versioner) *store {
 	// for compatibility with etcd2 impl.
 	// no-op for default prefix of '/registry'.
 	// keeps compatibility with etcd2 impl for custom prefixes that don't start with '/'
@@ -183,6 +184,7 @@ func New(c *kubernetes.Client, codec runtime.Codec, newFunc, newListFunc func() 
 
 		resourcePrefix: resourcePrefix,
 		newListFunc:    newListFunc,
+		compactor:      compactor,
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
 		stats := newStatsCache(pathPrefix, s.getKeys)
@@ -197,6 +199,13 @@ func New(c *kubernetes.Client, codec runtime.Codec, newFunc, newListFunc func() 
 		etcdfeature.DefaultFeatureSupportChecker.CheckClient(c.Ctx(), c, storage.RequestWatchProgress)
 	}
 	return s
+}
+
+func (s *store) CompactRevision() int64 {
+	if s.compactor == nil {
+		return 0
+	}
+	return s.compactor.CompactRevision()
 }
 
 // Versioner implements storage.Interface.Versioner.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 )
 
 var scheme = runtime.NewScheme()
@@ -251,12 +253,19 @@ func TestTransformationFailure(t *testing.T) {
 
 func TestList(t *testing.T) {
 	ctx, store, client := testSetup(t)
-	storagetesting.RunTestList(ctx, t, store, increaseRV(client.Client), compactStorage(client.Client), false, client.Kubernetes.(*storagetesting.KubernetesRecorder))
+	storagetesting.RunTestList(ctx, t, store, compactStorage(store, client.Client), false, client.Kubernetes.(*storagetesting.KubernetesRecorder))
 }
 
 func TestConsistentList(t *testing.T) {
 	ctx, store, client := testSetup(t)
 	storagetesting.RunTestConsistentList(ctx, t, store, increaseRV(client.Client), false, true, false)
+}
+
+func TestCompactRevision(t *testing.T) {
+	// Test requires store to observe extenal changes to compaction revision, requiring dedicated watch on compact key which is enabled by ListFromCacheSnapshot.
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, true)
+	ctx, store, client := testSetup(t)
+	storagetesting.RunTestCompactRevision(ctx, t, store, increaseRV(client.Client), compactStorage(store, client.Client))
 }
 
 func checkStorageCallsInvariants(transformer *storagetesting.PrefixTransformer, recorder *storagetesting.KVRecorder) storagetesting.CallsValidation {
@@ -315,15 +324,34 @@ func TestNamespaceScopedList(t *testing.T) {
 	storagetesting.RunTestNamespaceScopedList(ctx, t, store)
 }
 
-func compactStorage(client *clientv3.Client) storagetesting.Compaction {
+func compactStorage(s *store, client *clientv3.Client) storagetesting.Compaction {
 	return func(ctx context.Context, t *testing.T, resourceVersion string) {
 		versioner := storage.APIObjectVersioner{}
 		rv, err := versioner.ParseResourceVersion(resourceVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err = client.Compact(ctx, int64(rv)); err != nil {
-			t.Fatalf("Unable to compact, %v", err)
+		var currentVersion int64
+		currentVersion, _, _, err = Compact(ctx, client, currentVersion, int64(rv))
+		if err != nil {
+			_, _, _, err = Compact(ctx, client, currentVersion, int64(rv))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Wait for compaction to be observed.
+		if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+			for {
+				select {
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				case <-time.After(100 * time.Millisecond):
+				}
+				compactedRev := s.CompactRevision()
+				if compactedRev == int64(rv) {
+					break
+				}
+			}
 		}
 	}
 }
@@ -338,7 +366,7 @@ func increaseRV(client *clientv3.Client) storagetesting.IncreaseRVFunc {
 
 func TestListInconsistentContinuation(t *testing.T) {
 	ctx, store, client := testSetup(t)
-	storagetesting.RunTestListInconsistentContinuation(ctx, t, store, compactStorage(client.Client))
+	storagetesting.RunTestListInconsistentContinuation(ctx, t, store, compactStorage(store, client.Client))
 }
 
 func TestListResourceVersionMatch(t *testing.T) {
@@ -587,8 +615,11 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, *store, *kub
 	}
 	client := setupOpts.client(t)
 	versioner := storage.APIObjectVersioner{}
+	compactor := NewCompactor(client.Client, 0, clock.RealClock{}, nil)
+	t.Cleanup(compactor.Stop)
 	store := New(
 		client,
+		compactor,
 		setupOpts.codec,
 		setupOpts.newFunc,
 		setupOpts.newListFunc,

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -63,7 +63,7 @@ func TestDeleteTriggerWatch(t *testing.T) {
 
 func TestWatchFromZero(t *testing.T) {
 	ctx, store, client := testSetup(t)
-	storagetesting.RunTestWatchFromZero(ctx, t, store, compactStorage(client.Client))
+	storagetesting.RunTestWatchFromZero(ctx, t, store, compactStorage(store, client.Client))
 }
 
 // TestWatchFromNonZero tests that

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -271,6 +271,11 @@ type Interface interface {
 	// SetKeysFunc allows to override the function used to get keys from storage.
 	// This allows to replace default function that fetches keys from storage with one using cache.
 	SetKeysFunc(KeysFunc)
+
+	// CompactRevision returns latest observed revision that was compacted.
+	// Without ListFromCacheSnapshot enabled only locally executed compaction will be observed.
+	// Returns 0 if no compaction was yet observed.
+	CompactRevision() int64
 }
 
 // KeysFunc is a function prototype to fetch keys from storage.

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -356,10 +356,11 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
 }
 
 type runningCompactor struct {
-	interval time.Duration
-	client   *clientv3.Client
-	cancel   DestroyFunc
-	refs     int
+	interval  time.Duration
+	client    *clientv3.Client
+	compactor etcd3.Compactor
+	cancel    DestroyFunc
+	refs      int
 }
 
 var (
@@ -374,19 +375,19 @@ var (
 // startCompactorOnce start one compactor per transport. If the interval get smaller on repeated calls, the
 // compactor is replaced. A destroy func is returned. If all destroy funcs with the same transport are called,
 // the compactor is stopped.
-func startCompactorOnce(c storagebackend.TransportConfig, interval time.Duration) (func(), error) {
+func startCompactorOnce(c storagebackend.TransportConfig, interval time.Duration) (etcd3.Compactor, func(), error) {
 	compactorsMu.Lock()
 	defer compactorsMu.Unlock()
 
 	if interval == 0 {
 		// short circuit, if the compaction request from apiserver is disabled
-		return func() {}, nil
+		return nil, func() {}, nil
 	}
 	key := fmt.Sprintf("%v", c) // gives: {[server1 server2] keyFile certFile caFile}
 	if compactor, foundBefore := compactors[key]; !foundBefore || compactor.interval > interval {
 		client, err := newETCD3Client(c)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		compactorClient := client.Client
 
@@ -401,13 +402,14 @@ func startCompactorOnce(c storagebackend.TransportConfig, interval time.Duration
 
 		compactor.interval = interval
 		compactor.client = compactorClient
-		c := etcd3.StartCompactor(compactorClient, interval)
+		c := etcd3.StartCompactorPerEndpoint(compactorClient, interval)
+		compactor.compactor = c
 		compactor.cancel = c.Stop
 	}
 
 	compactors[key].refs++
 
-	return func() {
+	return compactors[key].compactor, func() {
 		compactorsMu.Lock()
 		defer compactorsMu.Unlock()
 
@@ -422,7 +424,7 @@ func startCompactorOnce(c storagebackend.TransportConfig, interval time.Duration
 }
 
 func newETCD3Storage(c storagebackend.ConfigForResource, newFunc, newListFunc func() runtime.Object, resourcePrefix string) (storage.Interface, DestroyFunc, error) {
-	stopCompactor, err := startCompactorOnce(c.Transport, c.CompactionInterval)
+	compactor, stopCompactor, err := startCompactorOnce(c.Transport, c.CompactionInterval)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -453,7 +455,7 @@ func newETCD3Storage(c storagebackend.ConfigForResource, newFunc, newListFunc fu
 		transformer = etcd3.WithCorruptObjErrorHandlingTransformer(transformer)
 		decoder = etcd3.WithCorruptObjErrorHandlingDecoder(decoder)
 	}
-	store := etcd3.New(client, c.Codec, newFunc, newListFunc, c.Prefix, resourcePrefix, c.GroupResource, transformer, c.LeaseManagerConfig, decoder, versioner)
+	store := etcd3.New(client, compactor, c.Codec, newFunc, newListFunc, c.Prefix, resourcePrefix, c.GroupResource, transformer, c.LeaseManagerConfig, decoder, versioner)
 	var once sync.Once
 	destroyFunc := func() {
 		// we know that storage destroy funcs are called multiple times (due to reuse in subresources).


### PR DESCRIPTION
/kind feature

```release-note
Compact snapshots in watch cache based on etcd compaction
```

This PR adds a watch to the etcd compactor to monitor compaction done by other apiservers and adds a compactor to watch cache that every 15 seconds reads compaction revision from etcd compactor and compacts snapshots.

Ref https://github.com/kubernetes/enhancements/issues/4988

Note; after merging this PR we will be reverting https://github.com/kubernetes/test-infra/pull/34587 to re-enable conformance tests for compaction.
/assign @jpbetz 