### PR TITLE
chore: replace int32Ptr usage with ptr.To

### DIFF
--- a/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	//
 	// Uncomment to load all auth plugins
 	// _ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -67,7 +68,7 @@ func main() {
 			Name: "demo-deployment",
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(2),
+			Replicas: ptr.To[int32](2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "demo",
@@ -130,7 +131,7 @@ func main() {
 			panic(fmt.Errorf("Failed to get latest version of Deployment: %v", getErr))
 		}
 
-		result.Spec.Replicas = int32Ptr(1)                           // reduce replica count
+		result.Spec.Replicas = ptr.To[int32](1)                      // reduce replica count
 		result.Spec.Template.Spec.Containers[0].Image = "nginx:1.13" // change nginx version
 		_, updateErr := deploymentsClient.Update(context.TODO(), result, metav1.UpdateOptions{})
 		return updateErr
@@ -174,5 +175,3 @@ func prompt() {
 	}
 	fmt.Println()
 }
-
-func int32Ptr(i int32) *int32 { return &i }

--- a/staging/src/k8s.io/sample-controller/controller_test.go
+++ b/staging/src/k8s.io/sample-controller/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/ptr"
 
 	samplecontroller "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	"k8s.io/sample-controller/pkg/generated/clientset/versioned/fake"
@@ -247,7 +248,7 @@ func getRef(foo *samplecontroller.Foo, t *testing.T) cache.ObjectName {
 
 func TestCreatesDeployment(t *testing.T) {
 	f := newFixture(t)
-	foo := newFoo("test", int32Ptr(1))
+	foo := newFoo("test", ptr.To[int32](1))
 	_, ctx := ktesting.NewTestContext(t)
 
 	f.fooLister = append(f.fooLister, foo)
@@ -262,7 +263,7 @@ func TestCreatesDeployment(t *testing.T) {
 
 func TestDoNothing(t *testing.T) {
 	f := newFixture(t)
-	foo := newFoo("test", int32Ptr(1))
+	foo := newFoo("test", ptr.To[int32](1))
 	_, ctx := ktesting.NewTestContext(t)
 
 	d := newDeployment(foo)
@@ -278,13 +279,13 @@ func TestDoNothing(t *testing.T) {
 
 func TestUpdateDeployment(t *testing.T) {
 	f := newFixture(t)
-	foo := newFoo("test", int32Ptr(1))
+	foo := newFoo("test", ptr.To[int32](1))
 	_, ctx := ktesting.NewTestContext(t)
 
 	d := newDeployment(foo)
 
 	// Update replicas
-	foo.Spec.Replicas = int32Ptr(2)
+	foo.Spec.Replicas = ptr.To[int32](2)
 	expDeployment := newDeployment(foo)
 
 	f.fooLister = append(f.fooLister, foo)
@@ -299,7 +300,7 @@ func TestUpdateDeployment(t *testing.T) {
 
 func TestNotControlledByUs(t *testing.T) {
 	f := newFixture(t)
-	foo := newFoo("test", int32Ptr(1))
+	foo := newFoo("test", ptr.To[int32](1))
 	_, ctx := ktesting.NewTestContext(t)
 
 	d := newDeployment(foo)
@@ -313,5 +314,3 @@ func TestNotControlledByUs(t *testing.T) {
 
 	f.runExpectError(ctx, getRef(foo, t))
 }
-
-func int32Ptr(i int32) *int32 { return &i }

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
 
 require (
@@ -53,7 +54,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
 	k8s.io/kube-openapi v0.0.0-20250628140032-d90c4fd18f59 // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -1597,7 +1597,7 @@ func TestGetSubresourcesAsTables(t *testing.T) {
 						Name: "replicationcontroller-1",
 					},
 					Spec: v1.ReplicationControllerSpec{
-						Replicas: int32Ptr(2),
+						Replicas: ptr.To[int32](2),
 						Selector: map[string]string{
 							"label": "test-label",
 						},
@@ -1632,7 +1632,7 @@ func TestGetSubresourcesAsTables(t *testing.T) {
 						Name: "replicationcontroller-2",
 					},
 					Spec: v1.ReplicationControllerSpec{
-						Replicas: int32Ptr(2),
+						Replicas: ptr.To[int32](2),
 						Selector: map[string]string{
 							"label": "test-label",
 						},
@@ -3676,10 +3676,6 @@ func assertManagedFields(t *testing.T, obj *unstructured.Unstructured) {
 	if len(obj.GetManagedFields()) == 0 {
 		t.Errorf("unexpected empty managed fields in object: %v", obj)
 	}
-}
-
-func int32Ptr(i int32) *int32 {
-	return &i
 }
 
 // TestDefaultStorageEncoding verifies that the storage encoding for all built-in resources is


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
