### PR TITLE
Enable running cache inconsistency detection by default

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1790,6 +1790,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
 	},
 
+	genericfeatures.DetectCacheInconsistency: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	genericfeatures.KMSv1: {
 		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
 		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Deprecated},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -114,6 +114,12 @@ const (
 	// Enables coordinated leader election in the API server
 	CoordinatedLeaderElection featuregate.Feature = "CoordinatedLeaderElection"
 
+	// owner: @serathius
+	// kep: https://kep.k8s.io/4988
+	//
+	// Enabled cache inconsistency detection.
+	DetectCacheInconsistency featuregate.Feature = "DetectCacheInconsistency"
+
 	// owner: @aramase
 	// kep: https://kep.k8s.io/3299
 	// deprecated: v1.28
@@ -334,6 +340,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	CoordinatedLeaderElection: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
+	},
+
+	DetectCacheInconsistency: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KMSv1: {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1131,6 +1131,15 @@ func (c *Cacher) isStopped() bool {
 	return c.stopped
 }
 
+func (c *Cacher) Compact(resourceVersion string) error {
+	rv, err := c.versioner.ParseResourceVersion(resourceVersion)
+	if err != nil {
+		return err
+	}
+	c.watchCache.Compact(rv)
+	return nil
+}
+
 // Stop implements the graceful termination.
 func (c *Cacher) Stop() {
 	c.stopLock.Lock()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -218,10 +218,17 @@ func (d *dummyStorage) GetCurrentResourceVersion(ctx context.Context) (uint64, e
 type dummyCacher struct {
 	dummyStorage
 	ready bool
+
+	lastCompactedResourceVersion string
 }
 
 func (d *dummyCacher) Ready() bool {
 	return d.ready
+}
+
+func (d *dummyCacher) Compact(resourceVersion string) error {
+	d.lastCompactedResourceVersion = resourceVersion
+	return nil
 }
 
 func TestShouldDelegateList(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/compactor.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/compactor.go
@@ -72,7 +72,7 @@ func (c *compactor) compactIfNeeded() {
 	if rev <= c.compactRevision {
 		return
 	}
-	c.wc.Compact(rev)
+	c.wc.Compact(uint64(rev))
 	c.compactRevision = rev
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -49,13 +49,13 @@ var (
 	// 5 minutes were proposed to match the default compaction period. It's magnitute higher than
 	// List latency SLO (30 seconds) and timeout (1 minute).
 	ConsistencyCheckPeriod = 5 * time.Minute
-	// ConsistencyCheckerEnabled enables the consistency checking mechanism for cache.
+	// panicOnCacheInconsistency enables the consistency checking mechanism for cache.
 	// Based on KUBE_WATCHCACHE_CONSISTENCY_CHECKER environment variable.
-	ConsistencyCheckerEnabled = false
+	panicOnCacheInconsistency = false
 )
 
 func init() {
-	ConsistencyCheckerEnabled, _ = strconv.ParseBool(os.Getenv("KUBE_WATCHCACHE_CONSISTENCY_CHECKER"))
+	panicOnCacheInconsistency, _ = strconv.ParseBool(os.Getenv("KUBE_WATCHCACHE_CONSISTENCY_CHECKER"))
 }
 
 func NewCacheDelegator(cacher *Cacher, storage storage.Interface) *CacheDelegator {
@@ -64,7 +64,7 @@ func NewCacheDelegator(cacher *Cacher, storage storage.Interface) *CacheDelegato
 		storage: storage,
 		stopCh:  make(chan struct{}),
 	}
-	if ConsistencyCheckerEnabled {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DetectCacheInconsistency) || panicOnCacheInconsistency {
 		d.checker = newConsistencyChecker(cacher.resourcePrefix, cacher.groupResource, cacher.newListFunc, cacher, storage)
 		d.wg.Add(1)
 		go func() {
@@ -290,7 +290,7 @@ func (c *CacheDelegator) Stop() {
 	c.wg.Wait()
 }
 
-func newConsistencyChecker(resourcePrefix string, groupResource schema.GroupResource, newListFunc func() runtime.Object, cacher getListerReady, etcd getLister) *consistencyChecker {
+func newConsistencyChecker(resourcePrefix string, groupResource schema.GroupResource, newListFunc func() runtime.Object, cacher cacher, etcd getLister) *consistencyChecker {
 	return &consistencyChecker{
 		groupResource:  groupResource,
 		resourcePrefix: resourcePrefix,
@@ -305,13 +305,14 @@ type consistencyChecker struct {
 	groupResource  schema.GroupResource
 	newListFunc    func() runtime.Object
 
-	cacher getListerReady
+	cacher cacher
 	etcd   getLister
 }
 
-type getListerReady interface {
+type cacher interface {
 	getLister
 	Ready() bool
+	Compact(string) error
 }
 
 type getLister interface {
@@ -319,12 +320,13 @@ type getLister interface {
 }
 
 func (c consistencyChecker) startChecking(stopCh <-chan struct{}) {
+	klog.V(3).InfoS("Cache consistency check start", "group", c.groupResource.Group, "resource", c.groupResource.Resource)
 	err := wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), ConsistencyCheckPeriod, false, func(ctx context.Context) (done bool, err error) {
 		c.check(ctx)
 		return false, nil
 	})
 	if err != nil {
-		klog.InfoS("Cache consistency check exiting", "group", c.groupResource.Group, "resource", c.groupResource.Resource, "err", err)
+		klog.V(3).InfoS("Cache consistency check exiting", "group", c.groupResource.Group, "resource", c.groupResource.Resource, "err", err)
 	}
 }
 
@@ -338,11 +340,16 @@ func (c *consistencyChecker) check(ctx context.Context) {
 	if digests.CacheDigest == digests.EtcdDigest {
 		klog.V(3).InfoS("Cache consistency check passed", "group", c.groupResource.Group, "resource", c.groupResource.Resource, "resourceVersion", digests.ResourceVersion, "digest", digests.CacheDigest)
 		metrics.StorageConsistencyCheckTotal.WithLabelValues(c.groupResource.Group, c.groupResource.Resource, "success").Inc()
-	} else {
-		klog.ErrorS(nil, "Cache consistency check failed", "group", c.groupResource.Group, "resource", c.groupResource.Resource, "resourceVersion", digests.ResourceVersion, "etcdDigest", digests.EtcdDigest, "cacheDigest", digests.CacheDigest)
-		metrics.StorageConsistencyCheckTotal.WithLabelValues(c.groupResource.Group, c.groupResource.Resource, "failure").Inc()
-		// Panic on internal consistency checking enabled only by environment variable. R
+		return
+	}
+	klog.ErrorS(nil, "Cache consistency check failed", "group", c.groupResource.Group, "resource", c.groupResource.Resource, "resourceVersion", digests.ResourceVersion, "etcdDigest", digests.EtcdDigest, "cacheDigest", digests.CacheDigest)
+	metrics.StorageConsistencyCheckTotal.WithLabelValues(c.groupResource.Group, c.groupResource.Resource, "failure").Inc()
+	if panicOnCacheInconsistency {
 		panic(fmt.Sprintf("Cache consistency check failed, group: %q, resource: %q, resourceVersion: %q, etcdDigest: %q, cacheDigest: %q", c.groupResource.Group, c.groupResource.Resource, digests.ResourceVersion, digests.EtcdDigest, digests.CacheDigest))
+	}
+	err = c.cacher.Compact(digests.ResourceVersion)
+	if err != nil {
+		klog.ErrorS(err, "Failed to compact cache", "group", c.groupResource.Group, "resource", c.groupResource.Resource, "resourceVersion", digests.ResourceVersion)
 	}
 }
 
@@ -350,26 +357,19 @@ func (c *consistencyChecker) calculateDigests(ctx context.Context) (*storageDige
 	if !c.cacher.Ready() {
 		return nil, fmt.Errorf("cache is not ready")
 	}
-	cacheDigest, resourceVersion, err := c.calculateStoreDigest(ctx, c.cacher, storage.ListOptions{
-		Recursive:            true,
-		ResourceVersion:      "0",
-		Predicate:            storage.Everything,
-		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
-	})
+	cacheDigest, cacheResourceVersion, err := c.calculateStoreDigest(ctx, c.cacher, "0", 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed calculating cache digest: %w", err)
 	}
-	etcdDigest, _, err := c.calculateStoreDigest(ctx, c.etcd, storage.ListOptions{
-		Recursive:            true,
-		ResourceVersion:      resourceVersion,
-		Predicate:            storage.Everything,
-		ResourceVersionMatch: metav1.ResourceVersionMatchExact,
-	})
+	etcdDigest, etcdResourceVersion, err := c.calculateStoreDigest(ctx, c.etcd, cacheResourceVersion, storageWatchListPageSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed calculating etcd digest: %w", err)
 	}
+	if cacheResourceVersion != etcdResourceVersion {
+		return nil, fmt.Errorf("etcd returned different resource version then expected, cache: %q, etcd: %q", cacheResourceVersion, etcdResourceVersion)
+	}
 	return &storageDigest{
-		ResourceVersion: resourceVersion,
+		ResourceVersion: cacheResourceVersion,
 		CacheDigest:     cacheDigest,
 		EtcdDigest:      etcdDigest,
 	}, nil
@@ -381,27 +381,48 @@ type storageDigest struct {
 	EtcdDigest      string
 }
 
-func (c *consistencyChecker) calculateStoreDigest(ctx context.Context, store getLister, opts storage.ListOptions) (digest, rv string, err error) {
-	// TODO: Implement pagination
-	resp := c.newListFunc()
-	err = store.GetList(ctx, c.resourcePrefix, opts, resp)
-	if err != nil {
-		return "", "", err
+func (c *consistencyChecker) calculateStoreDigest(ctx context.Context, store getLister, resourceVersion string, limit int64) (digest, rv string, err error) {
+	opts := storage.ListOptions{
+		Recursive:       true,
+		Predicate:       storage.Everything,
+		ResourceVersion: resourceVersion,
 	}
-	digest, err = listDigest(resp)
-	if err != nil {
-		return "", "", err
+	opts.Predicate.Limit = limit
+	if resourceVersion == "0" {
+		opts.ResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
+	} else {
+		opts.ResourceVersionMatch = metav1.ResourceVersionMatchExact
 	}
-	list, err := meta.ListAccessor(resp)
-	if err != nil {
-		return "", "", err
+	h := fnv.New64()
+	for {
+		resp := c.newListFunc()
+		err = store.GetList(ctx, c.resourcePrefix, opts, resp)
+		if err != nil {
+			return "", "", err
+		}
+		err = addListToDigest(h, resp)
+		if err != nil {
+			return "", "", err
+		}
+		list, err := meta.ListAccessor(resp)
+		if err != nil {
+			return "", "", err
+		}
+		if resourceVersion == "0" {
+			resourceVersion = list.GetResourceVersion()
+		}
+		continueToken := list.GetContinue()
+		if continueToken == "" {
+			return fmt.Sprintf("%x", h.Sum64()), resourceVersion, nil
+		}
+		opts.Predicate.Continue = continueToken
+		opts.ResourceVersion = ""
+		opts.ResourceVersionMatch = ""
 	}
-	return digest, list.GetResourceVersion(), nil
 }
 
-func listDigest(list runtime.Object) (string, error) {
-	h := fnv.New64()
-	err := meta.EachListItem(list, func(obj runtime.Object) error {
+func addListToDigest(h hash.Hash64, list runtime.Object) error {
+	return meta.EachListItem(list, func(obj runtime.Object) error {
 		objectMeta, err := meta.Accessor(obj)
 		if err != nil {
 			return err
@@ -412,10 +433,6 @@ func listDigest(list runtime.Object) (string, error) {
 		}
 		return nil
 	})
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", h.Sum64()), nil
 }
 
 func addObjectToDigest(h hash.Hash64, objectMeta metav1.Object) error {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator_test.go
@@ -18,16 +18,20 @@ package cacher
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/apis/example"
 	"k8s.io/apiserver/pkg/storage"
 )
 
-func TestCalculateDigest(t *testing.T) {
+func TestConsistencyCheckerDigest(t *testing.T) {
 	newListFunc := func() runtime.Object { return &example.PodList{} }
 	testCases := []struct {
 		desc            string
@@ -36,9 +40,10 @@ func TestCalculateDigest(t *testing.T) {
 		cacherItems     []example.Pod
 		etcdItems       []example.Pod
 
-		expectListKey string
-		expectDigest  storageDigest
-		expectErr     bool
+		expectListKey                  string
+		expectDigest                   storageDigest
+		expectErr                      bool
+		expectCompactedResourceVersion string
 	}{
 		{
 			desc:            "not ready",
@@ -87,6 +92,7 @@ func TestCalculateDigest(t *testing.T) {
 				CacheDigest:     "4ae4e750bd825b17",
 				EtcdDigest:      "f940a60af965b03",
 			},
+			expectCompactedResourceVersion: "2",
 		},
 		{
 			desc:            "name changes digest",
@@ -103,10 +109,11 @@ func TestCalculateDigest(t *testing.T) {
 				CacheDigest:     "c9120494e4c1897d",
 				EtcdDigest:      "c9156494e4c46274",
 			},
+			expectCompactedResourceVersion: "2",
 		},
 		{
 			desc:            "resourceVersion changes digest",
-			resourceVersion: "2",
+			resourceVersion: "4",
 			cacherReady:     true,
 			cacherItems: []example.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod", ResourceVersion: "3"}},
@@ -115,10 +122,11 @@ func TestCalculateDigest(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod", ResourceVersion: "4"}},
 			},
 			expectDigest: storageDigest{
-				ResourceVersion: "2",
+				ResourceVersion: "4",
 				CacheDigest:     "86bf3a5e80d1c5ca",
 				EtcdDigest:      "86bf3a5e80d1c5cd",
 			},
+			expectCompactedResourceVersion: "4",
 		},
 		{
 			desc:            "watch missed write event",
@@ -136,6 +144,7 @@ func TestCalculateDigest(t *testing.T) {
 				CacheDigest:     "1859bac707c2cb2b",
 				EtcdDigest:      "11d147fc800df0e0",
 			},
+			expectCompactedResourceVersion: "3",
 		},
 	}
 
@@ -189,6 +198,108 @@ func TestCalculateDigest(t *testing.T) {
 			if *digest != tc.expectDigest {
 				t.Errorf("Expect: %+v Got: %+v", &tc.expectDigest, *digest)
 			}
+
+			checker.check(context.Background())
+			if cacher.lastCompactedResourceVersion != tc.expectCompactedResourceVersion {
+				t.Errorf("Expect: %+v Got: %+v", tc.expectCompactedResourceVersion, cacher.lastCompactedResourceVersion)
+			}
 		})
+	}
+}
+
+func TestConsistencyCheckerListOpts(t *testing.T) {
+	newListFunc := func() runtime.Object { return &example.PodList{} }
+
+	resourceVersion := "50"
+	etcdOpts := []storage.ListOptions{}
+	etcd := &dummyStorage{
+		getListFn: func(_ context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+			etcdOpts = append(etcdOpts, opts)
+			podList := listObj.(*example.PodList)
+			podList.ResourceVersion = resourceVersion
+			return nil
+		},
+	}
+	cacherOpts := []storage.ListOptions{}
+	cacher := &dummyCacher{
+		ready: true,
+		dummyStorage: dummyStorage{
+			getListFn: func(_ context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+				cacherOpts = append(cacherOpts, opts)
+				podList := listObj.(*example.PodList)
+				podList.ResourceVersion = resourceVersion
+				return nil
+			},
+		},
+	}
+	checker := newConsistencyChecker("", schema.GroupResource{}, newListFunc, cacher, etcd)
+	_, err := checker.calculateDigests(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCacherOpts := []storage.ListOptions{
+		{
+			ResourceVersion:      "0",
+			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+			Predicate:            storage.Everything,
+			Recursive:            true,
+		},
+	}
+	if diff := cmp.Diff(cacherOpts, wantCacherOpts); diff != "" {
+		t.Errorf("unexpected list opts (-want +got):\n%s", diff)
+	}
+	wantEtcdOpts := []storage.ListOptions{
+		{
+			ResourceVersion:      resourceVersion,
+			ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+			Predicate: storage.SelectionPredicate{
+				Label: labels.Everything(),
+				Field: fields.Everything(),
+				Limit: storageWatchListPageSize,
+			},
+			Recursive: true,
+		},
+	}
+	if diff := cmp.Diff(etcdOpts, wantEtcdOpts); diff != "" {
+		t.Errorf("unexpected list opts (-want +got):\n%s", diff)
+	}
+}
+
+func TestConsistencyCheckerDigestMatches(t *testing.T) {
+	ctx, store, terminate := testSetup(t)
+	t.Cleanup(terminate)
+
+	var out example.Pod
+	resourceVersion := ""
+	t.Logf("Create %d pods to ensure pagination", storageWatchListPageSize+1)
+	for i := 0; i < int(storageWatchListPageSize)+1; i++ {
+		pod := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: fmt.Sprintf("%d", i)}}
+		err := store.Create(ctx, computePodKey(pod), pod, &out, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resourceVersion = out.ResourceVersion
+	}
+
+	t.Log("Execute list to ensure cache is up to date")
+	outList := &example.PodList{}
+	err := store.cacher.GetList(ctx, "/pods", storage.ListOptions{ResourceVersion: resourceVersion, Recursive: true, Predicate: storage.Everything, ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan}, outList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outList.Items) != int(storageWatchListPageSize)+1 {
+		t.Errorf("Expect to get %d pods, got %d", storageWatchListPageSize+1, len(outList.Items))
+	}
+
+	checker := newConsistencyChecker("/pods", schema.GroupResource{}, store.cacher.newListFunc, store.cacher, store.storage)
+	digest, err := checker.calculateDigests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest.CacheDigest != digest.EtcdDigest {
+		t.Errorf("Expect digests to match, cache: %s etcd: %q", digest.CacheDigest, digest.EtcdDigest)
+	}
+	if digest.ResourceVersion != resourceVersion {
+		t.Errorf("Expect resourceVersion to equal: %q, got %q", resourceVersion, digest.ResourceVersion)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -183,7 +183,7 @@ var (
 			Namespace:      namespace,
 			Name:           "storage_consistency_checks_total",
 			Help:           "Counter for status of consistency checks between etcd and watch cache",
-			StabilityLevel: compbasemetrics.INTERNAL,
+			StabilityLevel: compbasemetrics.ALPHA,
 		}, []string{"group", "resource", "status"})
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -936,9 +936,9 @@ func (w *watchCache) getIntervalFromStoreLocked(key string, matchesSingle bool) 
 	return ci, nil
 }
 
-func (w *watchCache) Compact(rev int64) {
+func (w *watchCache) Compact(rev uint64) {
 	if w.snapshots == nil {
 		return
 	}
-	w.snapshots.RemoveLess(uint64(rev))
+	w.snapshots.RemoveLess(rev)
 }

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -389,6 +389,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.33"
+- name: DetectCacheInconsistency
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: DevicePluginCDIDevices
   versionedSpecs:
   - default: false


### PR DESCRIPTION
/kind feature

```release-note
Add DetectCacheInconsistency feature gate that allows apiserver to periodically compare consistency between cache and etcd. Inconsistency is reported to `apiserver_storage_consistency_checks_total` metric and results in cache snapshots being purged.
```

Design agreed on in https://github.com/kubernetes/enhancements/pull/5355

Ref https://github.com/kubernetes/enhancements/issues/4988

/assign @jpbetz @deads2k 