### PR TITLE
Refactor and cleanup scheduling queues for consistency, logging, and documentation

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -180,7 +180,7 @@ type PriorityQueue struct {
 	activeQ  activeQueuer
 	backoffQ backoffQueuer
 	// unschedulableEntities holds pods and pod groups that have been tried and determined unschedulable.
-	unschedulableEntities *unschedulableEntities
+	unschedulableEntities unschedulableEntitiesQueuer
 	// pendingPodGroupPods stores all pending pods that wait for their corresponding pod group to be requeued.
 	pendingPodGroupPods *pendingPodGroupMemberPods
 
@@ -728,13 +728,14 @@ func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, entity framework.Queue
 	}
 
 	if entity.Gated() {
-		if p.unschedulableEntities.get(entity) == nil {
-			logger.V(5).Info("Entity moved to an internal scheduling queue, because it is gated", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", unschedulableQ)
+		if p.unschedulableEntities.has(entity) {
+			p.unschedulableEntities.update(entity, gatedBefore)
+		} else {
+			p.unschedulableEntities.add(logger, entity, event)
 		}
 		// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
 		// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
 		entity.SetWasFlushedFromUnschedulable(false)
-		p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event)
 		// Entity not moved to activeQ.
 		return false
 	}
@@ -758,13 +759,14 @@ func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, entity framework.Queu
 	if p.isPopFromBackoffQEnabled {
 		p.runPreEnqueuePlugins(context.Background(), entity)
 		if entity.Gated() {
-			if uInfo := p.unschedulableEntities.get(entity); uInfo == nil {
-				logger.V(5).Info("Entity moved to an internal scheduling queue, because it is gated", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", unschedulableQ)
+			if p.unschedulableEntities.has(entity) {
+				p.unschedulableEntities.update(entity, gatedBefore)
+			} else {
+				p.unschedulableEntities.add(logger, entity, event)
 			}
 			// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
 			// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
 			entity.SetWasFlushedFromUnschedulable(false)
-			p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event)
 			return false
 		}
 	}
@@ -833,7 +835,7 @@ func (p *PriorityQueue) deleteFromAnyQueue(entityLookup framework.QueuedEntityIn
 	if entity := p.backoffQ.delete(entityLookup); entity != nil {
 		return entity, queueAfterBackoff
 	}
-	if entity := p.unschedulableEntities.get(entityLookup); entity != nil {
+	if entity, ok := p.unschedulableEntities.get(entityLookup); ok {
 		p.unschedulableEntities.delete(entity, entity.Gated())
 		return entity, queueSkip
 	}
@@ -898,7 +900,9 @@ func (p *PriorityQueue) activate(logger klog.Logger, entityLookup framework.Queu
 	var entity framework.QueuedEntityInfo
 	var movesFromBackoffQ bool
 	// Verify if the entity is present in unschedulableEntities or backoffQ.
-	if entity = p.unschedulableEntities.get(entityLookup); entity == nil {
+	if existing, ok := p.unschedulableEntities.get(entityLookup); ok {
+		entity = existing
+	} else {
 		// Entity may be present in the backoffQ. Try to delete the entity from the backoffQ now
 		// to make sure it won't be popped from the backoffQ just before moving it to the activeQ.
 		if entity = p.backoffQ.delete(entityLookup); entity == nil {
@@ -978,7 +982,7 @@ func (p *PriorityQueue) AddUnschedulablePodIfNotPresent(logger klog.Logger, pInf
 	}()
 
 	pod := pInfo.Pod
-	if p.unschedulableEntities.get(pInfo) != nil {
+	if p.unschedulableEntities.has(pInfo) {
 		return fmt.Errorf("Pod %v is already present in unschedulable queue", klog.KObj(pod))
 	}
 
@@ -1029,7 +1033,7 @@ func (p *PriorityQueue) AddUnschedulablePodIfNotPresent(logger klog.Logger, pInf
 
 	// In this case, we try to requeue this Pod to activeQ/backoffQ.
 	queue := p.requeueEntityWithQueueingStrategy(logger, pInfo, schedulingHint, framework.ScheduleAttemptFailure)
-	logger.V(3).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", podSchedulingCycle, "hint", schedulingHint, "unschedulable plugins", rejectorPlugins)
+	logger.V(5).Info("Pod requeue decision after scheduling attempt", "pod", klog.KObj(pod), "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", podSchedulingCycle, "hint", schedulingHint, "unschedulable plugins", rejectorPlugins)
 	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 		// When the Pod is moved to activeQ, need to let p.cond know so that the Pod will be pop()ed out.
 		p.activeQ.broadcast()
@@ -1057,7 +1061,7 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	if p.unschedulableEntities.get(pgInfo) != nil {
+	if p.unschedulableEntities.has(pgInfo) {
 		return fmt.Errorf("pod group %v is already present in unschedulable queue", klog.KObj(pgInfo))
 	}
 
@@ -1117,7 +1121,7 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 			queue = activeQ
 		}
 	}
-	logger.V(3).Info("Pod group moved to an internal scheduling queue", "podGroup", klog.KObj(pgInfo), "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", schedulingCycle, "unschedulable plugins", rejectorPlugins)
+	logger.V(5).Info("Pod group requeue decision after scheduling attempt", "podGroup", klog.KObj(pgInfo), "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", schedulingCycle, "unschedulable plugins", rejectorPlugins)
 	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 		// When the Pod group is moved to activeQ, need to let p.cond know so that the Pod will be pop()ed out.
 		p.activeQ.broadcast()
@@ -1150,7 +1154,7 @@ func (p *PriorityQueue) flushUnschedulableEntitiesLeftover(logger klog.Logger) {
 
 	var entitiesToMove []framework.QueuedEntityInfo
 	currentTime := p.clock.Now()
-	for _, entity := range p.unschedulableEntities.entityInfoMap {
+	p.unschedulableEntities.forEach(func(entity framework.QueuedEntityInfo) {
 		lastScheduleTime := entity.GetTimestamp()
 		if flushTime := entity.GetFlushTimestamp(); flushTime.After(lastScheduleTime) {
 			lastScheduleTime = flushTime
@@ -1161,7 +1165,7 @@ func (p *PriorityQueue) flushUnschedulableEntitiesLeftover(logger klog.Logger) {
 			entity.SetFlushTimestamp(currentTime)
 			entitiesToMove = append(entitiesToMove, entity)
 		}
-	}
+	})
 
 	if len(entitiesToMove) > 0 {
 		p.moveEntitiesToActiveOrBackoffQueue(logger, entitiesToMove, framework.EventUnschedulableTimeout, nil, nil)
@@ -1244,7 +1248,7 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 	}
 
 	// If the pod is in the unschedulable queue, updating it may make it schedulable.
-	if entity := p.unschedulableEntities.get(entityLookup); entity != nil {
+	if entity, ok := p.unschedulableEntities.get(entityLookup); ok {
 		pInfo, err := entity.Update(newPod)
 		if err != nil {
 			logger.Error(err, "Failed to update pod in an entity", "type", entity.Type(), "entity", klog.KObj(entity), "pod", klog.KObj(newPod))
@@ -1267,7 +1271,7 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 			hint := p.isEntityWorthRequeuing(logger, entity, evt, oldPod, newPod)
 			queue := p.requeueEntityWithQueueingStrategy(logger, entity, hint, evt.Label())
 			if queue != unschedulableQ {
-				logger.V(5).Info("Entity moved to an internal scheduling queue because the Pod is updated", "type", entity.Type(), "entity", entityRef, "pod", klog.KObj(newPod), "event", evt.Label(), "queue", queue)
+				logger.V(5).Info("Pod update triggered entity requeue", "type", entity.Type(), "entity", entityRef, "pod", klog.KObj(newPod), "event", evt.Label(), "queue", queue)
 			}
 			if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 				p.activeQ.broadcast()
@@ -1369,7 +1373,7 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 	}
 
 	// Check unschedulableEntities
-	if entity := p.unschedulableEntities.get(pInfoLookup); entity != nil {
+	if entity, ok := p.unschedulableEntities.get(pInfoLookup); ok {
 		p.unschedulableEntities.delete(pInfoLookup, entity.Gated())
 		// Drop metric for deleted pod.
 		decreaseUnschedulableReasonMetric(entity)
@@ -1388,8 +1392,8 @@ func (p *PriorityQueue) moveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 		return
 	}
 
-	unschedulableEntities := make([]framework.QueuedEntityInfo, 0, len(p.unschedulableEntities.entityInfoMap))
-	for _, entity := range p.unschedulableEntities.entityInfoMap {
+	unschedulableEntities := make([]framework.QueuedEntityInfo, 0, p.unschedulableEntities.len())
+	p.unschedulableEntities.forEach(func(entity framework.QueuedEntityInfo) {
 		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
 			if preCheck == nil || preCheck(pInfo.Pod) {
 				unschedulableEntities = append(unschedulableEntities, entity)
@@ -1397,7 +1401,7 @@ func (p *PriorityQueue) moveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 			}
 			return true
 		})
-	}
+	})
 	p.moveEntitiesToActiveOrBackoffQueue(logger, unschedulableEntities, event, oldObj, newObj)
 }
 
@@ -1418,7 +1422,11 @@ func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 func (p *PriorityQueue) requeueEntityWithQueueingStrategy(logger klog.Logger, entity framework.QueuedEntityInfo, strategy queueingStrategy, event string) string {
 	if strategy == queueSkip {
 		// Current Gate status is required for already exisiting entities. For new entities, this parameter is ignored/unused by addPod/addPodGroup.
-		p.unschedulableEntities.addOrUpdate(entity, entity.Gated(), event)
+		if p.unschedulableEntities.has(entity) {
+			p.unschedulableEntities.update(entity, entity.Gated())
+		} else {
+			p.unschedulableEntities.add(logger, entity, event)
+		}
 		return unschedulableQ
 	}
 
@@ -1497,14 +1505,7 @@ func (p *PriorityQueue) PodsInBackoffQ() []*v1.Pod {
 func (p *PriorityQueue) UnschedulablePods() []*v1.Pod {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
-	var result []*v1.Pod
-	for _, entity := range p.unschedulableEntities.entityInfoMap {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
-			result = append(result, pInfo.Pod)
-			return true
-		})
-	}
-	return result
+	return p.unschedulableEntities.listPods()
 }
 
 // PendingPodGroupPods returns all the pending pods waiting for their pod groups.
@@ -1579,14 +1580,9 @@ func (p *PriorityQueue) PendingPods() ([]*v1.Pod, string) {
 	backoffQPods := p.PodsInBackoffQ()
 	backoffQLen := len(backoffQPods)
 	result = append(result, backoffQPods...)
-	unschedulablePodsLen := 0
-	for _, entity := range p.unschedulableEntities.entityInfoMap {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
-			result = append(result, pInfo.Pod)
-			unschedulablePodsLen++
-			return true
-		})
-	}
+	unschedulablePods := p.unschedulableEntities.listPods()
+	unschedulablePodsLen := len(unschedulablePods)
+	result = append(result, unschedulablePods...)
 	if !p.isGenericWorkloadEnabled {
 		return result, fmt.Sprintf(pendingPodsSummary, activeQLen, backoffQLen, unschedulablePodsLen)
 	}
@@ -1631,10 +1627,7 @@ func (p *PriorityQueue) getEntityFromAnyQueue(unlockedActiveQ unlockedActiveQueu
 	if ok {
 		return existing
 	}
-	if existing = p.unschedulableEntities.get(entityLookup); existing != nil {
-		if existing.Gated() {
-			return existing
-		}
+	if existing, ok = p.unschedulableEntities.get(entityLookup); ok {
 		return existing
 	}
 	return nil

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -117,8 +117,7 @@ func setQueuedPodInfoGated(queuedPodInfo *framework.QueuedPodInfo, gatingPlugin 
 }
 
 func getUnschedulablePod(p *PriorityQueue, pod *v1.Pod) *v1.Pod {
-	pInfo := p.unschedulableEntities.get(newQueuedPodInfoForLookup(pod))
-	if pInfo != nil {
+	if pInfo, ok := p.unschedulableEntities.get(newQueuedPodInfoForLookup(pod)); ok {
 		return pInfo.(*framework.QueuedPodInfo).Pod
 	}
 	return nil
@@ -238,8 +237,8 @@ func TestPriorityQueue_AddNominatedGatedPod(t *testing.T) {
 	q.Add(ctx, gatedPod)
 
 	// Verify the pod is gated
-	pInfo := q.unschedulableEntities.get(newQueuedPodInfoForLookup(gatedPod))
-	if pInfo == nil || !pInfo.Gated() {
+	pInfo, ok := q.unschedulableEntities.get(newQueuedPodInfoForLookup(gatedPod))
+	if !ok || !pInfo.Gated() {
 		t.Fatalf("Expected pod to be gated in unschedulableEntities")
 	}
 
@@ -1433,7 +1432,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 			// Add high priority entity to the errorBackoffQ
 			q.backoffQ.add(logger, errorBackoffEntity, framework.EventUnscheduledPodAdd.Label())
 			// Add entity to the unschedulableEntities
-			q.unschedulableEntities.addOrUpdate(unschedEntity, false, framework.EventUnscheduledPodAdd.Label())
+			q.unschedulableEntities.add(klog.Background(), unschedEntity, framework.EventUnscheduledPodAdd.Label())
 
 			var gotPods []string
 			for i := 0; i < len(tt.wantPods)+1; i++ {
@@ -1552,7 +1551,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 				pInfo := q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, queuePlugin)
 				// needs to increment to make the pod backing off
 				pInfo.UnschedulableCount++
-				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.add(klog.Background(), pInfo, framework.EventUnscheduledPodAdd.Label())
 				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
 				updatedPod.Annotations["foo"] = "test"
 				return medPriorityPodInfo.Pod, updatedPod
@@ -1565,7 +1564,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 				pInfo := q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, queuePlugin)
 				// needs to increment to make the pod backing off
 				pInfo.UnschedulableCount++
-				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.add(klog.Background(), pInfo, framework.EventUnscheduledPodAdd.Label())
 				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
 				updatedPod.Annotations["foo"] = "test1"
 				// Move clock by podMaxBackoffDuration, so that pods in the unschedulableEntities would pass the backing off,
@@ -1578,7 +1577,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 			name:  "when updating a pod in unschedulableEntities, if the scheduling hint returns QueueSkip, it remains in unschedulableEntities",
 			wantQ: unschedulableQ,
 			prepareFunc: func(tCtx ktesting.TContext, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
-				q.unschedulableEntities.addOrUpdate(q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, skipPlugin), false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.add(klog.Background(), q.newQueuedPodInfo(tCtx, medPriorityPodInfo.Pod, skipPlugin), framework.EventUnscheduledPodAdd.Label())
 				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
 				updatedPod.Annotations["foo"] = "test1"
 				return medPriorityPodInfo.Pod, updatedPod
@@ -1635,7 +1634,7 @@ func TestPriorityQueue_Update(t *testing.T) {
 				pInfo = pInfoFromActive.(*framework.QueuedPodInfo)
 			}
 
-			if pInfoFromUnsched := q.unschedulableEntities.get(newQueuedPodInfoForLookup(newPod)); pInfoFromUnsched != nil {
+			if pInfoFromUnsched, ok := q.unschedulableEntities.get(newQueuedPodInfoForLookup(newPod)); ok {
 				if tt.wantQ != unschedulableQ {
 					t.Errorf("expected pod %s to not be queued to unschedulableEntities, but it was", newPod.Name)
 				}
@@ -1846,14 +1845,14 @@ func TestPriorityQueue_Delete(t *testing.T) {
 			// Verification
 			for _, pod := range tt.expectedAbsentPods {
 				pInfoLookup := newQueuedPodInfoForLookup(pod)
-				if q.activeQ.has(pInfoLookup) || q.backoffQ.has(pInfoLookup) || q.unschedulableEntities.get(pInfoLookup) != nil {
+				if q.activeQ.has(pInfoLookup) || q.backoffQ.has(pInfoLookup) || q.unschedulableEntities.has(pInfoLookup) {
 					t.Errorf("Expected pod %v to be absent, but it is present", pod.Name)
 				}
 			}
 
 			for _, pod := range tt.expectedPresentPods {
 				pInfoLookup := newQueuedPodInfoForLookup(pod)
-				if !q.activeQ.has(pInfoLookup) && !q.backoffQ.has(pInfoLookup) && q.unschedulableEntities.get(pInfoLookup) == nil {
+				if !q.activeQ.has(pInfoLookup) && !q.backoffQ.has(pInfoLookup) && !q.unschedulableEntities.has(pInfoLookup) {
 					t.Errorf("Expected pod %v to be present, but it is absent", pod.Name)
 				}
 			}
@@ -1952,7 +1951,7 @@ func TestPriorityQueue_Activate(t *testing.T) {
 			}
 
 			for _, qPodInfo := range tt.qPodInfoInUnschedulableEntities {
-				q.unschedulableEntities.addOrUpdate(qPodInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.add(klog.Background(), qPodInfo, framework.EventUnscheduledPodAdd.Label())
 			}
 
 			for _, qPodInfo := range tt.qPodInfoInBackoffQ {
@@ -2165,8 +2164,8 @@ func TestPriorityQueue_moveToActiveQ(t *testing.T) {
 				if got != tt.wantSuccess {
 					t.Errorf("Unexpected result: want %v, but got %v", tt.wantSuccess, got)
 				}
-				if tt.wantUnschedulablePods != len(q.unschedulableEntities.entityInfoMap) {
-					t.Errorf("Unexpected unschedulableEntities: want %v, but got %v", tt.wantUnschedulablePods, len(q.unschedulableEntities.entityInfoMap))
+				if tt.wantUnschedulablePods != q.unschedulableEntities.len() {
+					t.Errorf("Unexpected unschedulableEntities: want %v, but got %v", tt.wantUnschedulablePods, q.unschedulableEntities.len())
 				}
 
 				// Simulate an update event.
@@ -2174,8 +2173,8 @@ func TestPriorityQueue_moveToActiveQ(t *testing.T) {
 				metav1.SetMetaDataAnnotation(&clone.ObjectMeta, "foo", "")
 				q.Update(ctx, tt.pod, clone)
 				// Ensure the pod is still located in unschedulableEntities.
-				if tt.wantUnschedulablePods != len(q.unschedulableEntities.entityInfoMap) {
-					t.Errorf("Unexpected unschedulableEntities: want %v, but got %v", tt.wantUnschedulablePods, len(q.unschedulableEntities.entityInfoMap))
+				if tt.wantUnschedulablePods != q.unschedulableEntities.len() {
+					t.Errorf("Unexpected unschedulableEntities: want %v, but got %v", tt.wantUnschedulablePods, q.unschedulableEntities.len())
 				}
 			})
 		}
@@ -2266,14 +2265,14 @@ func TestPriorityQueue_moveToBackoffQ(t *testing.T) {
 					if !q.backoffQ.has(pInfo) {
 						t.Errorf("Expected pod to be in backoffQ, but it isn't")
 					}
-					if q.unschedulableEntities.get(pInfo) != nil {
+					if q.unschedulableEntities.has(pInfo) {
 						t.Errorf("Expected pod not to be in unschedulableEntities, but it is")
 					}
 				} else {
 					if q.backoffQ.has(pInfo) {
 						t.Errorf("Expected pod not to be in backoffQ, but it is")
 					}
-					if q.unschedulableEntities.get(pInfo) == nil {
+					if !q.unschedulableEntities.has(pInfo) {
 						t.Errorf("Expected pod to be in unschedulableEntities, but it isn't")
 					}
 				}
@@ -2560,7 +2559,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.
 			} else {
 				// The pod was already moved to unschedulableEntities because it's gated.
 				// Update it with the test's configured podInfo to ensure custom test fields are set.
-				q.unschedulableEntities.addOrUpdate(test.podInfo, test.podInfo.Gated(), "test-setup")
+				q.unschedulableEntities.update(test.podInfo, test.podInfo.Gated())
 			}
 			cl.Step(test.duration)
 
@@ -2578,7 +2577,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.
 				t.Fatalf("expected pod to be queued to activeQ, but it was not")
 			}
 
-			if q.unschedulableEntities.get(test.podInfo) == nil && test.expectedQ == unschedulableQ {
+			if !q.unschedulableEntities.has(test.podInfo) && test.expectedQ == unschedulableQ {
 				t.Fatalf("expected pod to be queued to unschedulableEntities, but it was not")
 			}
 		})
@@ -2723,7 +2722,7 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
 	// hpp1 will go to backoffQ because no failure plugin is associated with it.
 	// All plugins other than hpp1 are enqueued to the unschedulable Pod pool.
 	for _, pod := range []*v1.Pod{unschedulablePodInfo.Pod, highPriorityPodInfo.Pod, hpp2} {
-		if q.unschedulableEntities.get(newQueuedPodInfoForLookup(pod)) == nil {
+		if !q.unschedulableEntities.has(newQueuedPodInfoForLookup(pod)) {
 			t.Errorf("Expected %v in the unschedulableEntities", pod.Name)
 		}
 	}
@@ -2747,9 +2746,9 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
 		t.Errorf("Expected 0 item to be in backoffQ, but got: %v", q.backoffQ.len())
 	}
 	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID)
-	if len(q.unschedulableEntities.entityInfoMap) != 1 {
+	if q.unschedulableEntities.len() != 1 {
 		// hpp2 won't be moved regardless of its backoff timer.
-		t.Errorf("Expected 1 item to be in unschedulableEntities, but got: %v", len(q.unschedulableEntities.entityInfoMap))
+		t.Errorf("Expected 1 item to be in unschedulableEntities, but got: %v", q.unschedulableEntities.len())
 	}
 }
 
@@ -3462,8 +3461,8 @@ func TestFlushUnschedulableEntitiesLeftoverSetsFlag(t *testing.T) {
 	}
 
 	// Verify flag is cleared when pod returns to queue
-	internalPInfo := q.unschedulableEntities.get(newQueuedPodInfoForLookup(pod))
-	if internalPInfo == nil {
+	internalPInfo, ok := q.unschedulableEntities.get(newQueuedPodInfoForLookup(pod))
+	if !ok {
 		t.Fatalf("pod should be in unschedulableEntities")
 	}
 	if internalPInfo.(*framework.QueuedPodInfo).WasFlushedFromUnschedulable {
@@ -3658,7 +3657,7 @@ func TestGatedPodFlushFrequency(t *testing.T) {
 			}
 
 			// Add gated pod directly to unschedulableEntities
-			q.unschedulableEntities.addOrUpdate(tt.entityInfo, false, "test-setup")
+			q.unschedulableEntities.add(klog.Background(), tt.entityInfo, "test-setup")
 
 			// Step clock past the flush duration and trigger flush
 			// T=5:01
@@ -3872,7 +3871,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			if isInBackoffQ := q.backoffQ.has(pgInfo); isInBackoffQ != test.expectedInBackoffQ {
 				tCtx.Errorf("Expected pod group to be in backoffQ: %v, got %v", test.expectedInBackoffQ, isInBackoffQ)
 			}
-			if isInUnschedulable := q.unschedulableEntities.get(pgInfo) != nil; isInUnschedulable != test.expectedInUnschedulableEntities {
+			if isInUnschedulable := q.unschedulableEntities.has(pgInfo); isInUnschedulable != test.expectedInUnschedulableEntities {
 				tCtx.Errorf("Expected pod group to be in unschedulableEntities: %v, got %v", test.expectedInUnschedulableEntities, isInUnschedulable)
 			}
 			if q.pendingPodGroupPods.len() != 0 {
@@ -4048,7 +4047,7 @@ var (
 			// needs to increment it to make it backoff
 			pInfo.UnschedulableCount++
 		}
-		queue.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+		queue.unschedulableEntities.add(klog.Background(), pInfo, framework.EventUnscheduledPodAdd.Label())
 	}
 	deletePod = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		queue.Delete(tCtx.Logger(), pInfo.Pod)
@@ -5397,7 +5396,8 @@ func Test_queuedPodInfo_gatedSetUponCreationAndUnsetUponUpdate(t *testing.T) {
 	gatedPod := st.MakePod().SchedulingGates([]string{"hello world"}).Obj()
 	q.Add(ctx, gatedPod)
 
-	if !q.unschedulableEntities.get(newQueuedPodInfoForLookup(gatedPod)).Gated() {
+	entity, ok := q.unschedulableEntities.get(newQueuedPodInfoForLookup(gatedPod))
+	if !ok || !entity.Gated() {
 		t.Error("Expected pod to be gated")
 	}
 
@@ -5435,7 +5435,7 @@ func TestPriorityQueue_GetPod(t *testing.T) {
 	q := NewTestQueue(ctx, newDefaultQueueSort())
 	q.activeQ.add(logger, newQueuedPodInfoForLookup(activeQPod), framework.EventUnscheduledPodAdd.Label())
 	q.backoffQ.add(logger, newQueuedPodInfoForLookup(backoffQPod), framework.EventUnscheduledPodAdd.Label())
-	q.unschedulableEntities.addOrUpdate(newQueuedPodInfoForLookup(unschedPod), false, framework.EventUnscheduledPodAdd.Label())
+	q.unschedulableEntities.add(klog.Background(), newQueuedPodInfoForLookup(unschedPod), framework.EventUnscheduledPodAdd.Label())
 
 	tests := []struct {
 		name        string
@@ -5818,7 +5818,7 @@ func TestPriorityQueue_UpdateRecomputesSignature(t *testing.T) {
 			name: "pod in unschedulableEntities",
 			prepareFunc: func(tCtx ktesting.TContext, q *PriorityQueue) {
 				pInfo := q.newQueuedPodInfo(tCtx, pod1)
-				q.unschedulableEntities.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+				q.unschedulableEntities.add(klog.Background(), pInfo, framework.EventUnscheduledPodAdd.Label())
 			},
 		},
 		{
@@ -5993,13 +5993,13 @@ func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQue
 	case stateUnschedulable:
 		entity := q.activeQ.delete(pgLookup)
 		if entity != nil {
-			q.unschedulableEntities.addOrUpdate(entity, false, framework.EventUnscheduledPodAdd.Label())
+			q.unschedulableEntities.add(klog.Background(), entity, framework.EventUnscheduledPodAdd.Label())
 		}
 	case stateGated:
 		entity := q.activeQ.delete(pgLookup)
 		if entity != nil {
 			entity.SetGatingPlugin("preEnqueuePlugin", []fwk.ClusterEvent{pvAdd})
-			q.unschedulableEntities.addOrUpdate(entity, false, framework.EventUnscheduledPodAdd.Label())
+			q.unschedulableEntities.add(klog.Background(), entity, framework.EventUnscheduledPodAdd.Label())
 		}
 	}
 }
@@ -6158,8 +6158,7 @@ func TestAddPodGroupMember(t *testing.T) {
 				entity, _ = q.backoffQ.get(pgLookup)
 			}
 
-			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
-			inUnschedulable := unschedulableEntity != nil
+			unschedulableEntity, inUnschedulable := q.unschedulableEntities.get(pgLookup)
 			if inUnschedulable != tt.expectedInUnschedulable {
 				t.Errorf("Expected incoming pod in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
 			}
@@ -6351,8 +6350,7 @@ func TestDeletePodGroupMember(t *testing.T) {
 				entity, _ = q.backoffQ.get(pgLookup)
 			}
 
-			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
-			inUnschedulable := unschedulableEntity != nil
+			unschedulableEntity, inUnschedulable := q.unschedulableEntities.get(pgLookup)
 			if inUnschedulable != tt.expectedInUnschedulable {
 				t.Errorf("Expected target pod group in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
 			}
@@ -6581,8 +6579,7 @@ func TestUpdatePodGroupMember(t *testing.T) {
 				entity, _ = q.backoffQ.get(pgLookup)
 			}
 
-			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
-			inUnschedulable := unschedulableEntity != nil
+			unschedulableEntity, inUnschedulable := q.unschedulableEntities.get(pgLookup)
 			if inUnschedulable != tt.expectedInUnschedulable {
 				t.Errorf("Expected target pod group in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
 			}
@@ -6735,8 +6732,7 @@ func TestActivatePodGroupMember(t *testing.T) {
 				t.Errorf("Expected target pod group not to be present in backoffQ")
 			}
 
-			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
-			inUnschedulable := unschedulableEntity != nil
+			unschedulableEntity, inUnschedulable := q.unschedulableEntities.get(pgLookup)
 			if inUnschedulable != tt.expectedInUnschedulable {
 				t.Errorf("Expected target pod group in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
 			}
@@ -6905,8 +6901,7 @@ func TestMoveAllToActiveOrBackoffQueuePodGroupMember(t *testing.T) {
 				t.Errorf("Expected target pod group not to be present in backoffQ")
 			}
 
-			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
-			inUnschedulable := unschedulableEntity != nil
+			unschedulableEntity, inUnschedulable := q.unschedulableEntities.get(pgLookup)
 			if inUnschedulable != tt.expectedInUnschedulable {
 				t.Errorf("Expected target pod group in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
 			}
@@ -7035,7 +7030,7 @@ func TestFlushBackoffQCompletedPodGroupMember(t *testing.T) {
 				entity, _ = q.backoffQ.get(pgLookup)
 			}
 
-			if q.unschedulableEntities.get(pgLookup) != nil {
+			if q.unschedulableEntities.has(pgLookup) {
 				t.Errorf("Expected target pod group not to be present in unschedulableEntities")
 			}
 
@@ -7134,8 +7129,7 @@ func TestFlushUnschedulableEntitiesLeftoverPodGroupMember(t *testing.T) {
 				t.Errorf("Expected target pod group not to be present in backoffQ")
 			}
 
-			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
-			inUnschedulable := unschedulableEntity != nil
+			unschedulableEntity, inUnschedulable := q.unschedulableEntities.get(pgLookup)
 			if inUnschedulable != tt.expectedInUnschedulable {
 				t.Errorf("Expected target pod group in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
 			}
@@ -7314,8 +7308,7 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 				entity, _ = q.backoffQ.get(pgLookup)
 			}
 
-			unschedulableEntity := q.unschedulableEntities.get(pgLookup)
-			inUnschedulable := unschedulableEntity != nil
+			unschedulableEntity, inUnschedulable := q.unschedulableEntities.get(pgLookup)
 			if inUnschedulable != tt.expectedInUnschedulable {
 				t.Errorf("Expected pod group in unschedulableEntities: %v, got %v", tt.expectedInUnschedulable, inUnschedulable)
 			}

--- a/pkg/scheduler/backend/queue/unschedulable_entities.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities.go
@@ -17,9 +17,33 @@ limitations under the License.
 package queue
 
 import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
+
+// unschedulableEntitiesQueuer is a wrapper for unschedulableEntities related operations.
+type unschedulableEntitiesQueuer interface {
+	// add adds an entity to the unschedulable queue.
+	// The event should show which event triggered the addition and is used for the metric recording.
+	add(logger klog.Logger, entity framework.QueuedEntityInfo, event string)
+	// update updates an entity in the unschedulable queue.
+	update(entity framework.QueuedEntityInfo, gatedBefore bool)
+	// delete removes an entity from the unschedulable queue.
+	// The `gated` parameter is used to figure out which metric should be decreased.
+	delete(entity framework.QueuedEntityInfo, gated bool)
+	// get returns the matching entity from the unschedulable queue.
+	get(entity framework.QueuedEntityInfo) (framework.QueuedEntityInfo, bool)
+	// has returns true if the matching entity exists in the unschedulable queue.
+	has(entity framework.QueuedEntityInfo) bool
+	// forEach calls fn for each entity in the unschedulable queue.
+	forEach(fn func(framework.QueuedEntityInfo))
+	// listPods returns all pods in the unschedulable queue.
+	listPods() []*v1.Pod
+	// len returns the number of entities in the unschedulable queue.
+	len() int
+}
 
 // unschedulableEntities holds pods and pod groups that cannot be scheduled.
 type unschedulableEntities struct {
@@ -60,23 +84,29 @@ func (u *unschedulableEntities) updateMetricsOnStateChange(gatedBefore, isGated 
 	}
 }
 
-// addOrUpdate adds an entity to the unschedulable entityInfoMap.
+// add adds an entity to the unschedulable entityInfoMap.
 // The event should show which event triggered the addition and is used for the metric recording.
-func (u *unschedulableEntities) addOrUpdate(entity framework.QueuedEntityInfo, gatedBefore bool, event string) {
+func (u *unschedulableEntities) add(logger klog.Logger, entity framework.QueuedEntityInfo, event string) {
+	entityKey := u.keyFunc(entity)
+	if entity.Gated() {
+		u.gatedRecorder.Add(entity.Size())
+	} else {
+		u.unschedulableRecorder.Add(entity.Size())
+	}
+	if metrics.SchedulerQueueIncomingPods != nil {
+		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Add(float64(entity.Size()))
+	}
+	logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", unschedulableQ)
+	u.entityInfoMap[entityKey] = entity
+}
+
+// update updates an entity in the unschedulable entityInfoMap.
+func (u *unschedulableEntities) update(entity framework.QueuedEntityInfo, gatedBefore bool) {
 	entityKey := u.keyFunc(entity)
 	if _, exists := u.entityInfoMap[entityKey]; exists {
 		u.updateMetricsOnStateChange(gatedBefore, entity.Gated(), entity.Size())
-	} else {
-		if entity.Gated() {
-			u.gatedRecorder.Add(entity.Size())
-		} else {
-			u.unschedulableRecorder.Add(entity.Size())
-		}
-		if metrics.SchedulerQueueIncomingPods != nil {
-			metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Add(float64(entity.Size()))
-		}
+		u.entityInfoMap[entityKey] = entity
 	}
-	u.entityInfoMap[entityKey] = entity
 }
 
 // delete deletes an entity from the unschedulable entityInfoMap.
@@ -95,17 +125,40 @@ func (u *unschedulableEntities) delete(entity framework.QueuedEntityInfo, gated 
 
 // get returns the QueuedEntityInfo if an entity with the same key is found in the map.
 // It returns nil otherwise.
-func (u *unschedulableEntities) get(entity framework.QueuedEntityInfo) framework.QueuedEntityInfo {
+func (u *unschedulableEntities) get(entity framework.QueuedEntityInfo) (framework.QueuedEntityInfo, bool) {
 	entityKey := u.keyFunc(entity)
 	if entity, exists := u.entityInfoMap[entityKey]; exists {
-		return entity
+		return entity, true
 	}
-	return nil
+	return nil, false
 }
 
-// clear removes all the entries from the unschedulable entityInfoMap.
-func (u *unschedulableEntities) clear() {
-	u.entityInfoMap = make(map[string]framework.QueuedEntityInfo)
-	u.unschedulableRecorder.Clear()
-	u.gatedRecorder.Clear()
+// has returns true if the matching entity exists in the unschedulable entityInfoMap.
+func (u *unschedulableEntities) has(entity framework.QueuedEntityInfo) bool {
+	_, exists := u.get(entity)
+	return exists
+}
+
+// forEach calls fn for each entity in the unschedulable queue.
+func (u *unschedulableEntities) forEach(fn func(framework.QueuedEntityInfo)) {
+	for _, entity := range u.entityInfoMap {
+		fn(entity)
+	}
+}
+
+// listPods returns all pods in the unschedulable queue.
+func (u *unschedulableEntities) listPods() []*v1.Pod {
+	var result []*v1.Pod
+	for _, entity := range u.entityInfoMap {
+		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+			result = append(result, pInfo.Pod)
+			return true
+		})
+	}
+	return result
+}
+
+// len returns the number of entities in the unschedulable queue.
+func (u *unschedulableEntities) len() int {
+	return len(u.entityInfoMap)
 }

--- a/pkg/scheduler/backend/queue/unschedulable_entities_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -62,7 +63,6 @@ func TestUnschedulableEntities(t *testing.T) {
 		add    action = "adding"
 		update action = "updating"
 		delete action = "deleting"
-		clear  action = "clearing"
 	)
 
 	type step struct {
@@ -73,16 +73,13 @@ func TestUnschedulableEntities(t *testing.T) {
 
 	var actionToOperation = map[action]func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, gatedBefore bool){
 		add: func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, _ bool) {
-			ue.addOrUpdate(pInfo, false, framework.EventUnscheduledPodAdd.Label())
+			ue.add(klog.Background(), pInfo, framework.EventUnscheduledPodAdd.Label())
 		},
 		update: func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, gatedBefore bool) {
-			ue.addOrUpdate(pInfo, gatedBefore, framework.EventUnscheduledPodUpdate.Label())
+			ue.update(pInfo, gatedBefore)
 		},
 		delete: func(ue *unschedulableEntities, pInfo *framework.QueuedPodInfo, gatedBefore bool) {
 			ue.delete(pInfo, gatedBefore)
-		},
-		clear: func(ue *unschedulableEntities, _ *framework.QueuedPodInfo, _ bool) {
-			ue.clear()
 		},
 	}
 
@@ -96,8 +93,8 @@ func TestUnschedulableEntities(t *testing.T) {
 	}
 
 	gated := func(p *v1.Pod, ue *unschedulableEntities) bool {
-		pInfo := ue.get(newQueuedPodInfoForLookup(p))
-		return pInfo != nil && pInfo.Gated()
+		pInfo, ok := ue.get(newQueuedPodInfoForLookup(p))
+		return ok && pInfo.Gated()
 	}
 
 	makePodInfo := func(p *v1.Pod, gated bool) *framework.QueuedPodInfo {
@@ -135,7 +132,6 @@ func TestUnschedulableEntities(t *testing.T) {
 						makePodInfo(pods[0], false),
 						makePodInfo(pods[1], false),
 						makePodInfo(pods[2], false),
-						makePodInfo(pods[2], false),
 						makePodInfo(pods[3], false),
 					},
 					expectedPods: []*framework.QueuedPodInfo{
@@ -147,9 +143,9 @@ func TestUnschedulableEntities(t *testing.T) {
 				},
 				{
 					action: update,
-					pods:   []*framework.QueuedPodInfo{makePodInfo(pods[0], false)},
+					pods:   []*framework.QueuedPodInfo{makePodInfo(pods[0], true)},
 					expectedPods: []*framework.QueuedPodInfo{
-						makePodInfo(pods[0], false),
+						makePodInfo(pods[0], true),
 						makePodInfo(pods[1], false),
 						makePodInfo(pods[2], false),
 						makePodInfo(pods[3], false),
@@ -228,12 +224,6 @@ func TestUnschedulableEntities(t *testing.T) {
 
 				assertMetrics(step.expectedPods, string(step.action))
 			}
-
-			ue.clear()
-			if len(ue.entityInfoMap) != 0 {
-				t.Errorf("Expected the map to be empty, but has %v elements.", len(ue.entityInfoMap))
-			}
-			assertMetrics([]*framework.QueuedPodInfo{}, string(clear))
 		})
 	}
 }
@@ -255,8 +245,8 @@ func TestUnschedulablePodGroups_Unified(t *testing.T) {
 		},
 	}
 
-	ue.addOrUpdate(pgInfo, false, "test")
-	if ue.get(pgInfo) == nil {
+	ue.add(klog.Background(), pgInfo, "test")
+	if !ue.has(pgInfo) {
 		t.Errorf("Expected pod group to be present")
 	}
 	if unschedulableRecorder.value() != 1 {
@@ -264,7 +254,7 @@ func TestUnschedulablePodGroups_Unified(t *testing.T) {
 	}
 
 	ue.delete(pgInfo, false)
-	if ue.get(pgInfo) != nil {
+	if ue.has(pgInfo) {
 		t.Errorf("Expected pod group to be deleted")
 	}
 	if unschedulableRecorder.value() != 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

1. Refactor `unschedulablePods` into `unschedulablePodsQueuer` interface
   - Provides clearly separated methods: `add`, `update`, `delete`, `get`, `has`, `list`, `listPod`, `len`, and `clear`.
2. Moves `"Pod moved to an internal scheduling queue"` logging into queue `add` methods to ensure consistency.
3. Adds interface comments to `activeQueuer` and `SchedulingQueue`.

#### Which issue(s) this PR is related to:

#130977

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
