### PR TITLE
test: add test coverage for latest.go and utils.go in pkg/scheduler

### DIFF
--- a/pkg/scheduler/apis/config/latest/latest_test.go
+++ b/pkg/scheduler/apis/config/latest/latest_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import (
+	"testing"
+)
+
+func TestDefault(t *testing.T) {
+	defaultIns, err := Default()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if defaultIns == nil {
+		t.Fatal("expected non-nil default configuration")
+	}
+	if defaultIns.APIVersion != "kubescheduler.config.k8s.io/v1" {
+		t.Errorf("expected default APIVersion 'kubescheduler.config.k8s.io/v1', got %s", defaultIns.APIVersion)
+	}
+}

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -776,3 +776,46 @@ func TestGetHostPorts(t *testing.T) {
 		})
 	}
 }
+
+func TestIsScalarResourceName(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceName v1.ResourceName
+		expected     bool
+	}{
+		{
+			name:         "extended resource",
+			resourceName: "example.com/gpu",
+			expected:     true,
+		},
+		{
+			name:         "hugepages resource",
+			resourceName: "hugepages-2Mi",
+			expected:     true,
+		},
+		{
+			name:         "prefixed native resource",
+			resourceName: "kubernetes.io/cpu",
+			expected:     true,
+		},
+		{
+			name:         "attachable volume resource",
+			resourceName: "attachable-volumes-aws-ebs",
+			expected:     true,
+		},
+		{
+			name:         "invalid resource name",
+			resourceName: "invalid-resource",
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsScalarResourceName(tt.resourceName)
+			if result != tt.expected {
+				t.Errorf("IsScalarResourceName(%q) = %v, expected as %v", tt.resourceName, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig scheduling
/priority backlog

#### What this PR does / why we need it:

Test coverage increase for scheduler package

#### Which issue(s) this PR is related to:

NONE

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
