### PR TITLE
Provide accurate information whether list will be delegated to list work estimator

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1675,7 +1675,7 @@ func (e *Store) startObservingCount(period time.Duration, objectCountTracker flo
 
 		metrics.UpdateObjectCount(e.DefaultQualifiedResource, stats.ObjectCount)
 		if objectCountTracker != nil {
-			objectCountTracker.Set(resourceName, stats)
+			objectCountTracker.Set(resourceName, flowcontrolrequest.StatsDelegator{Stats: stats, ShouldDelegateList: e.Storage.Storage.ShouldDelegateList})
 		}
 	}, period, resourceCountPollPeriodJitter, true, stopCh)
 	return func() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -131,6 +131,10 @@ func (d *dummyStorage) RequestWatchProgress(ctx context.Context) error {
 	return nil
 }
 
+func (d *dummyStorage) ShouldDelegateList(storage.ListOptions) (bool, error) {
+	return false, nil
+}
+
 func (d *dummyStorage) getRequestWatchProgressCounter() int {
 	d.RLock()
 	defer d.RUnlock()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -238,6 +238,14 @@ func (c *CacheDelegator) GetList(ctx context.Context, key string, opts storage.L
 	return nil
 }
 
+func (c *CacheDelegator) ShouldDelegateList(opts storage.ListOptions) (bool, error) {
+	result, err := delegator.ShouldDelegateList(opts, c.cacher)
+	if err != nil {
+		return false, err
+	}
+	return result.ShouldDelegate, nil
+}
+
 func shouldDelegateListOnNotReadyCache(opts storage.ListOptions) bool {
 	pred := opts.Predicate
 	noLabelSelector := pred.Label == nil || pred.Label.Empty()

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -644,6 +644,10 @@ func (s *store) Stats(ctx context.Context) (stats storage.Stats, err error) {
 	}, nil
 }
 
+func (s *store) ShouldDelegateList(opts storage.ListOptions) (bool, error) {
+	return true, nil
+}
+
 func (s *store) SetKeysFunc(keys storage.KeysFunc) {
 	if s.stats != nil {
 		s.stats.SetKeysFunc(keys)

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -276,6 +276,7 @@ type Interface interface {
 	// Without ListFromCacheSnapshot enabled only locally executed compaction will be observed.
 	// Returns 0 if no compaction was yet observed.
 	CompactRevision() int64
+	ShouldDelegateList(opts ListOptions) (bool, error)
 }
 
 // KeysFunc is a function prototype to fetch keys from storage.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
@@ -76,7 +76,7 @@ func TestStorageObjectCountTracker(t *testing.T) {
 			key := "foo.bar.resource"
 			now := time.Now()
 			fakeClock.SetTime(now.Add(-test.lastUpdated))
-			tracker.Set(key, storage.Stats{ObjectCount: test.count})
+			tracker.Set(key, StatsDelegator{Stats: storage.Stats{ObjectCount: test.count}})
 
 			fakeClock.SetTime(now)
 			stats, err := tracker.Get(key)
@@ -102,19 +102,19 @@ func TestStorageObjectCountTrackerWithPrune(t *testing.T) {
 
 	now := time.Now()
 	fakeClock.SetTime(now.Add(-61 * time.Minute))
-	tracker.Set("k1", storage.Stats{ObjectCount: 61})
+	tracker.Set("k1", StatsDelegator{Stats: storage.Stats{ObjectCount: 61}})
 	fakeClock.SetTime(now.Add(-60 * time.Minute))
-	tracker.Set("k2", storage.Stats{ObjectCount: 60})
+	tracker.Set("k2", StatsDelegator{Stats: storage.Stats{ObjectCount: 60}})
 	// we are going to prune keys that are stale for >= 1h
 	// so the above keys are expected to be pruned and the
 	// key below should not be pruned.
 	mostRecent := now.Add(-59 * time.Minute)
 	fakeClock.SetTime(mostRecent)
-	tracker.Set("k3", storage.Stats{ObjectCount: 59})
+	tracker.Set("k3", StatsDelegator{Stats: storage.Stats{ObjectCount: 59}})
 	expected := map[string]*timestampedStats{
 		"k3": {
-			Stats:         storage.Stats{ObjectCount: 59},
-			lastUpdatedAt: mostRecent,
+			StatsDelegator: StatsDelegator{Stats: storage.Stats{ObjectCount: 59}},
+			lastUpdatedAt:  mostRecent,
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -23,7 +23,6 @@ import (
 
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
-	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"k8s.io/klog/v2"
@@ -59,7 +58,7 @@ func (we *WorkEstimate) MaxSeats() int {
 
 // statsGetterFunc represents a function that gets the total
 // number of objects for a given resource.
-type statsGetterFunc func(string) (storage.Stats, error)
+type statsGetterFunc func(string) (StatsDelegator, error)
 
 // watchCountGetterFunc represents a function that gets the total
 // number of watchers potentially interested in a given request.


### PR DESCRIPTION
/kind feature

```release-note
Priority and Fairness will estimate List cost based on more accurate information whether request is handled by cache or etcd. 
```

Currently APF has no access to storage layer to know whether List is handled by cache or not, it just assumes that watch cache is always enabled for resource.

This PR pipes delegator function through existing stats pipeline. This is not a long term solution, but ensures that there are no bugs with registration/deregistration of CRDs.

ref https://github.com/kubernetes/kubernetes/issues/132233

/cc @deads2k @MikeSpreitzer @jpbetz 