### PR TITLE
Add apiserver_resource_size_estimate_bytes metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1668,18 +1668,18 @@ func (e *Store) startObservingCount(period time.Duration, objectCountTracker flo
 	stopCh := make(chan struct{})
 	go wait.JitterUntil(func() {
 		stats, err := e.Storage.Stats(ctx)
+		metrics.UpdateStoreStats(e.DefaultQualifiedResource, stats, err)
 		if err != nil {
 			klog.V(5).InfoS("Failed to update storage count metric", "err", err)
-			stats.ObjectCount = -1
+			return
 		}
 
-		metrics.UpdateObjectCount(e.DefaultQualifiedResource, stats.ObjectCount)
 		if objectCountTracker != nil {
 			objectCountTracker.Set(resourceName, stats)
 		}
 	}, period, resourceCountPollPeriodJitter, true, stopCh)
 	return func() {
-		metrics.DeleteObjectCount(e.DefaultQualifiedResource)
+		metrics.DeleteStoreStats(e.DefaultQualifiedResource)
 		close(stopCh)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
 )
@@ -226,33 +227,64 @@ func TestStorageSizeCollector(t *testing.T) {
 
 }
 
-func TestUpdateObjectCount(t *testing.T) {
+func TestUpdateStoreStats(t *testing.T) {
 	registry := metrics.NewKubeRegistry()
 	registry.Register(objectCounts)
-	testedMetrics := "apiserver_storage_objects"
+	registry.MustRegister(resourceSizeEstimate)
 
 	testCases := []struct {
 		desc     string
 		resource schema.GroupResource
-		count    int64
+		stats    storage.Stats
+		err      error
 		want     string
 	}{
 		{
-			desc:     "successful fetch",
+			desc:     "successful object count",
 			resource: schema.GroupResource{Group: "foo", Resource: "bar"},
-			count:    10,
-			want: `# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
+			stats:    storage.Stats{ObjectCount: 10},
+			want: `# HELP apiserver_resource_size_estimate_bytes [ALPHA] Estimated size of stored objects in database. Estimate is based on sum of last observed sizes of serialized objects. In case of a fetching error, the value will be -1.
+# TYPE apiserver_resource_size_estimate_bytes gauge
+apiserver_resource_size_estimate_bytes{group="foo",resource="bar"} -1
+# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
 # TYPE apiserver_storage_objects gauge
 apiserver_storage_objects{resource="bar.foo"} 10
 `,
 		},
 		{
+			desc:     "successful object count and size",
+			resource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			stats:    storage.Stats{ObjectCount: 10, EstimatedAverageObjectSizeBytes: 10},
+			want: `# HELP apiserver_resource_size_estimate_bytes [ALPHA] Estimated size of stored objects in database. Estimate is based on sum of last observed sizes of serialized objects. In case of a fetching error, the value will be -1.
+# TYPE apiserver_resource_size_estimate_bytes gauge
+apiserver_resource_size_estimate_bytes{group="foo",resource="bar"} 100
+# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
+# TYPE apiserver_storage_objects gauge
+apiserver_storage_objects{resource="bar.foo"} 10
+`,
+		},
+		{
+			desc:     "empty object count",
+			resource: schema.GroupResource{Group: "foo", Resource: "bar"},
+			stats:    storage.Stats{ObjectCount: 0, EstimatedAverageObjectSizeBytes: 0},
+			want: `# HELP apiserver_resource_size_estimate_bytes [ALPHA] Estimated size of stored objects in database. Estimate is based on sum of last observed sizes of serialized objects. In case of a fetching error, the value will be -1.
+# TYPE apiserver_resource_size_estimate_bytes gauge
+apiserver_resource_size_estimate_bytes{group="foo",resource="bar"} 0
+# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
+# TYPE apiserver_storage_objects gauge
+apiserver_storage_objects{resource="bar.foo"} 0
+`,
+		},
+		{
 			desc:     "failed fetch",
 			resource: schema.GroupResource{Group: "foo", Resource: "bar"},
-			count:    -1,
+			err:      errors.New("dummy"),
 			want: `# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
 # TYPE apiserver_storage_objects gauge
 apiserver_storage_objects{resource="bar.foo"} -1
+# HELP apiserver_resource_size_estimate_bytes [ALPHA] Estimated size of stored objects in database. Estimate is based on sum of last observed sizes of serialized objects. In case of a fetching error, the value will be -1.
+# TYPE apiserver_resource_size_estimate_bytes gauge
+apiserver_resource_size_estimate_bytes{group="foo",resource="bar"} -1
 `,
 		},
 	}
@@ -260,46 +292,53 @@ apiserver_storage_objects{resource="bar.foo"} -1
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			defer registry.Reset()
-			UpdateObjectCount(test.resource, test.count)
-			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), testedMetrics); err != nil {
+			UpdateStoreStats(test.resource, test.stats, test.err)
+			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), "apiserver_storage_objects", "apiserver_resource_size_estimate_bytes"); err != nil {
 				t.Fatal(err)
 			}
 		})
 	}
 }
 
-func TestDeleteObjectCount(t *testing.T) {
+func TestDeleteStoreStats(t *testing.T) {
 	registry := metrics.NewKubeRegistry()
 	registry.MustRegister(objectCounts)
-	testedMetrics := "apiserver_storage_objects"
+	registry.MustRegister(resourceSizeEstimate)
 
-	UpdateObjectCount(schema.GroupResource{Group: "foo1", Resource: "bar1"}, int64(10))
-	UpdateObjectCount(schema.GroupResource{Group: "foo2", Resource: "bar2"}, int64(20))
+	UpdateStoreStats(schema.GroupResource{Group: "foo1", Resource: "bar1"}, storage.Stats{ObjectCount: 10}, nil)
+	UpdateStoreStats(schema.GroupResource{Group: "foo2", Resource: "bar2"}, storage.Stats{ObjectCount: 20, EstimatedAverageObjectSizeBytes: 10}, nil)
 
-	expectedMetrics := `# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
+	expectedMetrics := `# HELP apiserver_resource_size_estimate_bytes [ALPHA] Estimated size of stored objects in database. Estimate is based on sum of last observed sizes of serialized objects. In case of a fetching error, the value will be -1.
+# TYPE apiserver_resource_size_estimate_bytes gauge
+apiserver_resource_size_estimate_bytes{group="foo1",resource="bar1"} -1
+apiserver_resource_size_estimate_bytes{group="foo2",resource="bar2"} 200
+# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
 # TYPE apiserver_storage_objects gauge
 apiserver_storage_objects{resource="bar1.foo1"} 10
 apiserver_storage_objects{resource="bar2.foo2"} 20
 `
-	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), testedMetrics); err != nil {
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), "apiserver_storage_objects", "apiserver_resource_size_estimate_bytes"); err != nil {
 		t.Fatal(err)
 	}
 
-	DeleteObjectCount(schema.GroupResource{Group: "foo1", Resource: "bar1"})
+	DeleteStoreStats(schema.GroupResource{Group: "foo1", Resource: "bar1"})
 
-	expectedMetrics = `# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
+	expectedMetrics = `# HELP apiserver_resource_size_estimate_bytes [ALPHA] Estimated size of stored objects in database. Estimate is based on sum of last observed sizes of serialized objects. In case of a fetching error, the value will be -1.
+# TYPE apiserver_resource_size_estimate_bytes gauge
+apiserver_resource_size_estimate_bytes{group="foo2",resource="bar2"} 200
+# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
 # TYPE apiserver_storage_objects gauge
 apiserver_storage_objects{resource="bar2.foo2"} 20
 `
-	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), testedMetrics); err != nil {
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), "apiserver_storage_objects", "apiserver_resource_size_estimate_bytes"); err != nil {
 		t.Fatal(err)
 	}
 
-	DeleteObjectCount(schema.GroupResource{Group: "foo2", Resource: "bar2"})
+	DeleteStoreStats(schema.GroupResource{Group: "foo2", Resource: "bar2"})
 	expectedMetrics = `# HELP apiserver_storage_objects [STABLE] Number of stored objects at the time of last check split by kind. In case of a fetching error, the value will be -1.
 # TYPE apiserver_storage_objects gauge
 `
-	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), testedMetrics); err != nil {
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), "apiserver_storage_objects", "apiserver_resource_size_estimate_bytes"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker.go
@@ -97,17 +97,6 @@ type objectCountTracker struct {
 }
 
 func (t *objectCountTracker) Set(groupResource string, stats storage.Stats) {
-	if stats.ObjectCount <= -1 {
-		// a value of -1 indicates that the 'Count' call failed to contact
-		// the storage layer, in most cases this error can be transient.
-		// we will continue to work with the count that is in the cache
-		// up to a certain threshold defined by staleTolerationThreshold.
-		// in case this becomes a non transient error then the count for
-		// the given resource will will eventually be removed from
-		// the cache by the pruner.
-		return
-	}
-
 	now := t.clock.Now()
 
 	// lock for writing

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/object_count_tracker_test.go
@@ -30,18 +30,14 @@ func TestStorageObjectCountTracker(t *testing.T) {
 	tests := []struct {
 		name          string
 		lastUpdated   time.Duration
+		skipSetting   bool
 		count         int64
 		errExpected   error
 		countExpected int64
 	}{
 		{
 			name:        "object count not tracked for given resource",
-			count:       -2,
-			errExpected: ObjectCountNotFoundErr,
-		},
-		{
-			name:        "transient failure",
-			count:       -1,
+			skipSetting: true,
 			errExpected: ObjectCountNotFoundErr,
 		},
 		{
@@ -76,7 +72,9 @@ func TestStorageObjectCountTracker(t *testing.T) {
 			key := "foo.bar.resource"
 			now := time.Now()
 			fakeClock.SetTime(now.Add(-test.lastUpdated))
-			tracker.Set(key, storage.Stats{ObjectCount: test.count})
+			if !test.skipSetting {
+				tracker.Set(key, storage.Stats{ObjectCount: test.count})
+			}
 
 			fakeClock.SetTime(now)
 			stats, err := tracker.Get(key)


### PR DESCRIPTION
/kind feature

Side effect of https://github.com/kubernetes/kubernetes/issues/132233 effort. Estimating resource size was implemented in https://github.com/kubernetes/kubernetes/pull/132355

```release-note
Add apiserver_resource_size_estimate_bytes metric to apiserver
```

/sig instrumentation
/cc @richabanker @dgrisonnet @jpbetz @deads2k 

It's a beautiful view:
```
# HELP apiserver_resource_size_estimate_bytes [ALPHA] Estimated size of stored objects in database. Estimate is based on last observed size
of serialized objects. In case of a fetching error, the value will be -1.
# TYPE apiserver_resource_size_estimate_bytes gauge
apiserver_resource_size_estimate_bytes{group="",resource="configmaps"} 22946
apiserver_resource_size_estimate_bytes{group="",resource="endpoints"} 1308
apiserver_resource_size_estimate_bytes{group="",resource="namespaces"} 2016
apiserver_resource_size_estimate_bytes{group="",resource="nodes"} 3547
apiserver_resource_size_estimate_bytes{group="",resource="pods"} 49959
apiserver_resource_size_estimate_bytes{group="",resource="secrets"} 100880
apiserver_resource_size_estimate_bytes{group="",resource="serviceaccounts"} 5852
apiserver_resource_size_estimate_bytes{group="",resource="services"} 1780
apiserver_resource_size_estimate_bytes{group="apiregistration.k8s.io",resource="apiservices"} 17620
apiserver_resource_size_estimate_bytes{group="apps",resource="controllerrevisions"} 4324
apiserver_resource_size_estimate_bytes{group="apps",resource="daemonsets"} 6162
apiserver_resource_size_estimate_bytes{group="apps",resource="deployments"} 8734
apiserver_resource_size_estimate_bytes{group="apps",resource="replicasets"} 6990
apiserver_resource_size_estimate_bytes{group="certificates.k8s.io",resource="certificatesigningrequests"} 2372
apiserver_resource_size_estimate_bytes{group="coordination.k8s.io",resource="leases"} 1972
apiserver_resource_size_estimate_bytes{group="discovery.k8s.io",resource="endpointslices"} 1738
apiserver_resource_size_estimate_bytes{group="flowcontrol.apiserver.k8s.io",resource="flowschemas"} 11396
apiserver_resource_size_estimate_bytes{group="flowcontrol.apiserver.k8s.io",resource="prioritylevelconfigurations"} 4912
apiserver_resource_size_estimate_bytes{group="networking.k8s.io",resource="ipaddresses"} 1066
apiserver_resource_size_estimate_bytes{group="networking.k8s.io",resource="servicecidrs"} 951
apiserver_resource_size_estimate_bytes{group="rbac.authorization.k8s.io",resource="clusterrolebindings"} 35224
apiserver_resource_size_estimate_bytes{group="rbac.authorization.k8s.io",resource="clusterroles"} 57890
apiserver_resource_size_estimate_bytes{group="rbac.authorization.k8s.io",resource="rolebindings"} 7536
apiserver_resource_size_estimate_bytes{group="rbac.authorization.k8s.io",resource="roles"} 6144
apiserver_resource_size_estimate_bytes{group="scheduling.k8s.io",resource="priorityclasses"} 782
apiserver_resource_size_estimate_bytes{group="storage.k8s.io",resource="csinodes"} 666
apiserver_resource_size_estimate_bytes{group="storage.k8s.io",resource="storageclasses"} 841
```
