### PR TITLE
Fixes scheduler nil panic due to empty init container request&limit

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -430,7 +430,12 @@ func maxResourceList(list, newList v1.ResourceList) {
 // max returns the result of max(a, b...) for each named resource and is only used if we can't
 // accumulate into an existing resource list
 func max(a v1.ResourceList, b ...v1.ResourceList) v1.ResourceList {
-	result := a.DeepCopy()
+	var result v1.ResourceList
+	if a != nil {
+		result = a.DeepCopy()
+	} else {
+		result = v1.ResourceList{}
+	}
 	for _, other := range b {
 		maxResourceList(result, other)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

This PR fixes a nil panic issue in kube-scheduler which caused leader loss in a cluster:

```
E0701 15:53:40.193220      11 runtime_faststr_swiss.go:265] "Observed a panic" panic="assignment to entry in nil map" panicGoValue="\"assignment to entry in nil map\"" stacktrace=<
	goroutine 367 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2e55568, 0xc000d5a2a0}, {0x25b3900, 0x463a5c0})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x2e55568, 0xc000d5a270}, {0x25b3900, 0x463a5c0}, {0x0, 0x0, 0xc0009b0880?})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x116
	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithLogger({{0x2e5df30?, 0xc00051eac0?}, 0xc0009b08c8?}, {0x0, 0x0, 0x0})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:91 +0x115
	panic({0x25b3900?, 0x463a5c0?})
		runtime/panic.go:792 +0x132
	k8s.io/component-helpers/resource.maxResourceList(0x0, 0x1f400000?)
		k8s.io/component-helpers/resource/helpers.go:399 +0x2ba
	k8s.io/component-helpers/resource.max(0xc0009b12b8?, {0xc000748c88, 0x2, 0x1f400000?})
		k8s.io/component-helpers/resource/helpers.go:409 +0x5e
	k8s.io/component-helpers/resource.determineContainerReqs(0xc000d5a210?, 0xc0009b1378?, 0xc000ae9bb0?)
		k8s.io/component-helpers/resource/helpers.go:231 +0x175
	k8s.io/component-helpers/resource.AggregateContainerRequests(0xc000b7b688, {0x0, 0x1, 0x0, 0x0, 0x0, 0x1})
		k8s.io/component-helpers/resource/helpers.go:163 +0x265
	k8s.io/component-helpers/resource.PodRequests(0xc000b7b688, {0x0, 0x1, 0x0, 0x0, 0x0, 0x1})
		k8s.io/component-helpers/resource/helpers.go:123 +0x76
	k8s.io/kubernetes/pkg/scheduler/framework.(*PodInfo).calculateResource(0xc0002fbf10)
		k8s.io/kubernetes/pkg/scheduler/framework/types.go:1135 +0xfe
	k8s.io/kubernetes/pkg/scheduler/framework.(*NodeInfo).update(0xc000b3b710, 0xc0002fbf10, 0x1)
		k8s.io/kubernetes/pkg/scheduler/framework/types.go:1058 +0x3d
	k8s.io/kubernetes/pkg/scheduler/framework.(*NodeInfo).AddPodInfo(0xc000b3b710, 0xc0002fbf10)
		k8s.io/kubernetes/pkg/scheduler/framework/types.go:989 +0x206
	k8s.io/kubernetes/pkg/scheduler/framework.(*NodeInfo).AddPod(0xc000b3b710, 0xc000b7b688)
		k8s.io/kubernetes/pkg/scheduler/framework/types.go:997 +0x45
	k8s.io/kubernetes/pkg/scheduler/backend/cache.(*cacheImpl).addPod(0xc0008484e0, {{0x2e5df30?, 0xc00051eac0?}, 0x25463c0?}, 0xc000b7b688, 0x0)
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a 1.33 regression that can cause a nil panic in kube-scheduler when aggregating resource requests across container's spec and status.
```