### PR TITLE
ci: integration test speedup with IO related perf flakeness bypass

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -24,10 +24,6 @@ set -o xtrace
 # TODO: make test-integration should handle this automatically
 source ./hack/install-etcd.sh
 
-# TODO: drop KUBE_INTEGRATION_TEST_MAX_CONCURRENCY later when we've figured out 
-# stabilizing the tests / CI Setting this to a hardcoded value is fragile.
-export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
-
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export LOG_LEVEL=4

--- a/hack/jenkins/test-integration-dockerized.sh
+++ b/hack/jenkins/test-integration-dockerized.sh
@@ -26,8 +26,5 @@ set -o xtrace
 source ./hack/install-etcd.sh
 
 set -x;
-# TODO: drop KUBE_INTEGRATION_TEST_MAX_CONCURRENCY later when we've figured out 
-# stabilizing the tests / CI Setting this to a hardcoded value is fragile.
-export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
 
 make test-integration KUBE_KEEP_VERBOSE_TEST_OUTPUT=y LOG_LEVEL=4


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig testing
/sig scheduling
/priority important-longterm

#### What this PR does / why we need it:

Integration test is often taking well over an hour even with 8 cores and 20Gi assigned in prow. It used to be more like 30m or less.

#### Which issue(s) this PR is related to:

[integration tests are painfully slow #126202](https://github.com/kubernetes/kubernetes/issues/126202)

[Tracking Issue: Presubmit Performance #130762](https://github.com/kubernetes/kubernetes/issues/130762)

https://github.com/kubernetes/kubernetes/pull/130758#issuecomment-3060810578

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
