### PR TITLE
chore: removed boolPtrFn helpers with ptr package implementation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/defaults_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/defaults_test.go
@@ -25,13 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 )
 
 func TestSetListOptionsDefaults(t *testing.T) {
-	boolPtrFn := func(b bool) *bool {
-		return &b
-	}
-
 	scenarios := []struct {
 		name                    string
 		watchListFeatureEnabled bool
@@ -47,8 +44,8 @@ func TestSetListOptionsDefaults(t *testing.T) {
 		{
 			name:                    "no-op, SendInitialEvents set",
 			watchListFeatureEnabled: true,
-			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: boolPtrFn(true)},
-			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: boolPtrFn(true)},
+			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: ptr.To(true)},
+			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: ptr.To(true)},
 		},
 		{
 			name:                    "no-op, ResourceVersionMatch set",
@@ -66,13 +63,13 @@ func TestSetListOptionsDefaults(t *testing.T) {
 			name:                    "defaults applied, match on empty RV",
 			watchListFeatureEnabled: true,
 			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true},
-			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: boolPtrFn(true), ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan},
+			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: ptr.To(true), ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan},
 		},
 		{
 			name:                    "defaults applied, match on RV=0",
 			watchListFeatureEnabled: true,
 			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, ResourceVersion: "0"},
-			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, ResourceVersion: "0", SendInitialEvents: boolPtrFn(true), ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan},
+			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, ResourceVersion: "0", SendInitialEvents: ptr.To(true), ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan},
 		},
 		{
 			name:        "no-op, match on empty RV but watch-list fg is off",
@@ -82,14 +79,14 @@ func TestSetListOptionsDefaults(t *testing.T) {
 		{
 			name:                    "no-op, match on empty RV but SendInitialEvents is on",
 			watchListFeatureEnabled: true,
-			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: boolPtrFn(true)},
-			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: boolPtrFn(true)},
+			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: ptr.To(true)},
+			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: ptr.To(true)},
 		},
 		{
 			name:                    "no-op, match on empty RV but SendInitialEvents is off",
 			watchListFeatureEnabled: true,
-			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: boolPtrFn(false)},
-			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: boolPtrFn(false)},
+			targetObj:               ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: ptr.To(false)},
+			expectedObj:             ListOptions{LabelSelector: labels.Everything(), FieldSelector: fields.Everything(), Watch: true, SendInitialEvents: ptr.To(false)},
 		},
 		{
 			name:                    "no-op, match on empty RV but ResourceVersionMatch set",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/validation/validation_test.go
@@ -21,13 +21,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateListOptions(t *testing.T) {
-	boolPtrFn := func(b bool) *bool {
-		return &b
-	}
-
 	cases := []struct {
 		name                    string
 		opts                    internalversion.ListOptions
@@ -65,7 +62,7 @@ func TestValidateListOptions(t *testing.T) {
 	}, {
 		name: "list-sendInitialEvents-forbidden",
 		opts: internalversion.ListOptions{
-			SendInitialEvents: boolPtrFn(true),
+			SendInitialEvents: ptr.To(true),
 		},
 		expectErrors: []string{"sendInitialEvents: Forbidden: sendInitialEvents is forbidden for list"},
 	}, {
@@ -77,7 +74,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "valid-watch-sendInitialEvents-on",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 			AllowWatchBookmarks:  true,
 		},
@@ -86,7 +83,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "valid-watch-sendInitialEvents-off",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(false),
+			SendInitialEvents:    ptr.To(false),
 			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 			AllowWatchBookmarks:  true,
 		},
@@ -102,14 +99,14 @@ func TestValidateListOptions(t *testing.T) {
 		name: "watch-sendInitialEvents-without-resourceversionmatch-forbidden",
 		opts: internalversion.ListOptions{
 			Watch:             true,
-			SendInitialEvents: boolPtrFn(true),
+			SendInitialEvents: ptr.To(true),
 		},
 		expectErrors: []string{"resourceVersionMatch: Forbidden: sendInitialEvents requires setting resourceVersionMatch to NotOlderThan", "sendInitialEvents: Forbidden: sendInitialEvents is forbidden for watch unless the WatchList feature gate is enabled"},
 	}, {
 		name: "watch-sendInitialEvents-with-exact-resourceversionmatch-forbidden",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: metav1.ResourceVersionMatchExact,
 			AllowWatchBookmarks:  true,
 		},
@@ -119,7 +116,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "watch-sendInitialEvents-on-with-empty-resourceversionmatch-forbidden",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: "",
 		},
 		expectErrors: []string{"resourceVersionMatch: Forbidden: sendInitialEvents requires setting resourceVersionMatch to NotOlderThan", "sendInitialEvents: Forbidden: sendInitialEvents is forbidden for watch unless the WatchList feature gate is enabled"},
@@ -127,7 +124,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "watch-sendInitialEvents-off-with-empty-resourceversionmatch-forbidden",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(false),
+			SendInitialEvents:    ptr.To(false),
 			ResourceVersionMatch: "",
 		},
 		expectErrors: []string{"resourceVersionMatch: Forbidden: sendInitialEvents requires setting resourceVersionMatch to NotOlderThan", "sendInitialEvents: Forbidden: sendInitialEvents is forbidden for watch unless the WatchList feature gate is enabled"},
@@ -135,7 +132,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "watch-sendInitialEvents-with-incorrect-resourceversionmatch-forbidden",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: "incorrect",
 			AllowWatchBookmarks:  true,
 		},
@@ -147,7 +144,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "watch-sendInitialEvents-no-allowWatchBookmark",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 		},
 		watchListFeatureEnabled: true,
@@ -155,7 +152,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "watch-sendInitialEvents-no-watchlist-fg-disabled",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 			AllowWatchBookmarks:  true,
 		},
@@ -164,7 +161,7 @@ func TestValidateListOptions(t *testing.T) {
 		name: "watch-sendInitialEvents-no-watchlist-fg-disabled",
 		opts: internalversion.ListOptions{
 			Watch:                true,
-			SendInitialEvents:    boolPtrFn(true),
+			SendInitialEvents:    ptr.To(true),
 			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 			AllowWatchBookmarks:  true,
 			Continue:             "123",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Replaces helper function 'boolPtrFn' with the "k8s.io/utils/ptr" implementations.

#### Which issue(s) this PR is related to:
Related to #132749

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
Replaces boolPtrFn helper functions with the "k8s.io/utils/ptr" implementation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
