### PR TITLE
[FG:PodObservedGenerationTracking] Graduate PodObservedGenerationTracking to beta

### DIFF
--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -1259,62 +1259,98 @@ func TestDropDisabledPodStatusFields_ObservedGeneration(t *testing.T) {
 		name          string
 		podStatus     *api.PodStatus
 		oldPodStatus  *api.PodStatus
+		featureGateOn bool
 		wantPodStatus *api.PodStatus
 	}{
 		{
-			name:         "old=without, new=without",
-			oldPodStatus: podWithoutObservedGen(),
-			podStatus:    podWithoutObservedGen(),
-
+			name:          "old=without, new=without / feature gate off",
+			oldPodStatus:  podWithoutObservedGen(),
+			podStatus:     podWithoutObservedGen(),
+			featureGateOn: false,
 			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
-			name:         "old=without, new=with",
-			oldPodStatus: podWithoutObservedGen(),
-			podStatus:    podWithObservedGen(),
-
+			name:          "old=without, new=without / feature gate on",
+			oldPodStatus:  podWithoutObservedGen(),
+			podStatus:     podWithoutObservedGen(),
+			featureGateOn: true,
 			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
-			name:         "old=with, new=without",
-			oldPodStatus: podWithObservedGen(),
-			podStatus:    podWithoutObservedGen(),
-
+			name:          "old=without, new=with / feature gate off",
+			oldPodStatus:  podWithoutObservedGen(),
+			podStatus:     podWithObservedGen(),
+			featureGateOn: false,
 			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
-			name:         "old=with, new=with",
-			oldPodStatus: podWithObservedGen(),
-			podStatus:    podWithObservedGen(),
-
+			name:          "old=with, new=without / feature gate on",
+			oldPodStatus:  podWithObservedGen(),
+			podStatus:     podWithoutObservedGen(),
+			featureGateOn: true,
+			wantPodStatus: podWithoutObservedGen(),
+		},
+		{
+			name:          "old=with, new=with / feature gate off",
+			oldPodStatus:  podWithObservedGen(),
+			podStatus:     podWithObservedGen(),
+			featureGateOn: false,
 			wantPodStatus: podWithObservedGen(),
 		},
 		{
-			name:         "old=without, new=withInConditions",
-			oldPodStatus: podWithoutObservedGen(),
-			podStatus:    podWithObservedGenInConditions(),
-
+			name:          "old=with, new=with / feature gate on",
+			oldPodStatus:  podWithObservedGen(),
+			podStatus:     podWithObservedGen(),
+			featureGateOn: true,
+			wantPodStatus: podWithObservedGen(),
+		},
+		{
+			name:          "old=without, new=withInConditions / feature gate off",
+			oldPodStatus:  podWithoutObservedGen(),
+			podStatus:     podWithObservedGenInConditions(),
+			featureGateOn: false,
 			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
-			name:         "old=withInConditions, new=without",
-			oldPodStatus: podWithObservedGenInConditions(),
-			podStatus:    podWithoutObservedGen(),
-
+			name:          "old=without, new=withInConditions / feature gate on",
+			oldPodStatus:  podWithoutObservedGen(),
+			podStatus:     podWithObservedGenInConditions(),
+			featureGateOn: true,
+			wantPodStatus: podWithObservedGenInConditions(),
+		},
+		{
+			name:          "old=withInConditions, new=without / feature gate off",
+			oldPodStatus:  podWithObservedGenInConditions(),
+			podStatus:     podWithoutObservedGen(),
+			featureGateOn: false,
 			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
-			name:         "old=withInConditions, new=withInCondtions",
-			oldPodStatus: podWithObservedGenInConditions(),
-			podStatus:    podWithObservedGenInConditions(),
-
+			name:          "old=withInConditions, new=without / feature gate on",
+			oldPodStatus:  podWithObservedGenInConditions(),
+			podStatus:     podWithoutObservedGen(),
+			featureGateOn: true,
+			wantPodStatus: podWithoutObservedGen(),
+		},
+		{
+			name:          "old=withInConditions, new=withInCondtions / feature gate off",
+			oldPodStatus:  podWithObservedGenInConditions(),
+			podStatus:     podWithObservedGenInConditions(),
+			featureGateOn: false,
+			wantPodStatus: podWithObservedGenInConditions(),
+		},
+		{
+			name:          "old=withInConditions, new=withInCondtions / feature gate on",
+			oldPodStatus:  podWithObservedGenInConditions(),
+			podStatus:     podWithObservedGenInConditions(),
+			featureGateOn: true,
 			wantPodStatus: podWithObservedGenInConditions(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodObservedGenerationTracking, tt.featureGateOn)
 			dropDisabledPodStatusFields(tt.podStatus, tt.oldPodStatus, &api.PodSpec{}, &api.PodSpec{})
-
 			if !reflect.DeepEqual(tt.podStatus, tt.wantPodStatus) {
 				t.Errorf("dropDisabledStatusFields() = %v, want %v", tt.podStatus, tt.wantPodStatus)
 			}

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -1025,6 +1025,9 @@ func TestCalculatePodStatusObservedGeneration(t *testing.T) {
 					Generation: 5,
 				},
 			},
+			features: map[featuregate.Feature]bool{
+				features.PodObservedGenerationTracking: false,
+			},
 			expected: 0,
 		},
 		{
@@ -1048,6 +1051,9 @@ func TestCalculatePodStatusObservedGeneration(t *testing.T) {
 				Status: v1.PodStatus{
 					ObservedGeneration: 5,
 				},
+			},
+			features: map[featuregate.Feature]bool{
+				features.PodObservedGenerationTracking: false,
 			},
 			expected: 5,
 		},
@@ -1097,6 +1103,9 @@ func TestCalculatePodConditionObservedGeneration(t *testing.T) {
 					}},
 				},
 			},
+			features: map[featuregate.Feature]bool{
+				features.PodObservedGenerationTracking: false,
+			},
 			expected: 0,
 		},
 		{
@@ -1128,6 +1137,9 @@ func TestCalculatePodConditionObservedGeneration(t *testing.T) {
 						ObservedGeneration: 5,
 					}},
 				},
+			},
+			features: map[featuregate.Feature]bool{
+				features.PodObservedGenerationTracking: false,
 			},
 			expected: 5,
 		},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1425,6 +1425,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	PodObservedGenerationTracking: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	PodReadyToStartContainersCondition: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1061,6 +1061,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.33"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: PodReadyToStartContainersCondition
   versionedSpecs:
   - default: false

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -658,8 +658,9 @@ func TestStalePodDisruption(t *testing.T) {
 			podPhase: v1.PodRunning,
 			wantConditions: []v1.PodCondition{
 				{
-					Type:   v1.DisruptionTarget,
-					Status: v1.ConditionFalse,
+					Type:               v1.DisruptionTarget,
+					Status:             v1.ConditionFalse,
+					ObservedGeneration: 1,
 				},
 			},
 		},

--- a/test/integration/podgc/podgc_test.go
+++ b/test/integration/podgc/podgc_test.go
@@ -49,10 +49,11 @@ func TestPodGcOrphanedPodsWithFinalizer(t *testing.T) {
 			phase:     v1.PodPending,
 			wantPhase: v1.PodFailed,
 			wantDisruptionTarget: &v1.PodCondition{
-				Type:    v1.DisruptionTarget,
-				Status:  v1.ConditionTrue,
-				Reason:  "DeletionByPodGC",
-				Message: "PodGC: node no longer exists",
+				Type:               v1.DisruptionTarget,
+				Status:             v1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             "DeletionByPodGC",
+				Message:            "PodGC: node no longer exists",
 			},
 		},
 		"succeeded pod": {
@@ -302,10 +303,11 @@ func TestPodGcForPodsWithDuplicatedFieldKeys(t *testing.T) {
 				},
 			},
 			wantDisruptionTarget: &v1.PodCondition{
-				Type:    v1.DisruptionTarget,
-				Status:  v1.ConditionTrue,
-				Reason:  "DeletionByPodGC",
-				Message: "PodGC: node no longer exists",
+				Type:               v1.DisruptionTarget,
+				Status:             v1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             "DeletionByPodGC",
+				Message:            "PodGC: node no longer exists",
 			},
 		},
 		"Orphan pod with duplicated ports; scenario from https://issues.k8s.io/113482": {
@@ -335,10 +337,11 @@ func TestPodGcForPodsWithDuplicatedFieldKeys(t *testing.T) {
 				},
 			},
 			wantDisruptionTarget: &v1.PodCondition{
-				Type:    v1.DisruptionTarget,
-				Status:  v1.ConditionTrue,
-				Reason:  "DeletionByPodGC",
-				Message: "PodGC: node no longer exists",
+				Type:               v1.DisruptionTarget,
+				Status:             v1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             "DeletionByPodGC",
+				Message:            "PodGC: node no longer exists",
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Graduate `PodObservedGenerationTracking` feature to beta / on by default.

#### Special notes for your reviewer:

PRs that we wanted for this for 1.34: 
- https://github.com/kubernetes/kubernetes/pull/131157
- https://github.com/kubernetes/kubernetes/pull/132198
- https://github.com/kubernetes/kubernetes/pull/132535

A couple are still under review though they should be close. Not sure if the convention is to wait for everything to merge before flipping the switch?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Graduate `PodObservedGenerationTracking` feature to beta and have it on by default. This feature means that the top level `status.observedGeneration` and `status.conditions[].observedGeneration` fields in pods will now be populated to reflect the `metadata.generation` of the podspec at the time that the status or condition is being reported. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/5067
```
