### PR TITLE
customresource: support graceful delete by updating delete options

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -401,6 +401,25 @@ func (a customResourceStrategy) MatchCustomResourceDefinitionStorage(label label
 	}
 }
 
+// CheckGracefulDelete updates the delete option with the desired grace value
+func (a customResourceStrategy) CheckGracefulDelete(ctx context.Context, obj runtime.Object, options *metav1.DeleteOptions) bool {
+	if options == nil || options.GracePeriodSeconds == nil {
+		return false
+	}
+
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return false
+	}
+
+	// Only support graceful deletion if the object has finalizers
+	if len(metaObj.GetFinalizers()) == 0 {
+		return false
+	}
+
+	return true
+}
+
 // OpenAPIv3 type/maxLength/maxItems/MaxProperties/required/enum violation/wrong type field validation failures are viewed as blocking err for CEL validation
 func hasBlockingErr(errs field.ErrorList) (bool, *field.Error) {
 	for _, err := range errs {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/grace_period_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/grace_period_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGracePeriodOnCustomResource(t *testing.T) {
+	tearDown, apiExtensionClient, dynamicClient, err := fixtures.StartDefaultServerWithClients(t)
+	require.NoError(t, err)
+	defer tearDown()
+
+	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	require.NoError(t, err)
+
+	gvrList := fixtures.GetGroupVersionResourcesOfCustomResource(noxuDefinition)
+	gvr := gvrList[0]
+	noxuClient := dynamicClient.Resource(gvr).Namespace("default")
+
+	name := "foo123"
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvr.GroupVersion().String(),
+			"kind":       "WishIHadChosenNoxu",
+			"metadata": map[string]interface{}{
+				"name":       name,
+				"finalizers": []interface{}{"noxu.example.com/finalizer"},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err = noxuClient.Create(ctx, instance, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	gracePeriod := int64(30)
+	err = noxuClient.Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriod,
+	})
+	require.NoError(t, err)
+
+	time.Sleep(300 * time.Millisecond)
+
+	got, err := noxuClient.Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, got.GetDeletionGracePeriodSeconds())
+	require.Equal(t, gracePeriod, *got.GetDeletionGracePeriodSeconds())
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug  
/kind feature  
/kind api-change  

---

### What this PR does / why we need it

This PR updates the `customResourceStrategy` to support graceful deletion of Custom Resources by introducing the `CheckGracefulDelete` method. This method ensures that when a `--grace-period` flag is provided (or 
`DeleteOptions.GracePeriodSeconds` is set), it correctly updates the metadata of the resource during deletion.

The lack of this functionality previously caused the `gracePeriodSeconds` to be ignored for Custom Resources, leading to unexpected behavior—particularly for controllers or operators relying on finalizers and graceful shutdown logic.

Additionally, this PR introduces an integration test to verify the correct update and persistence of the grace period on custom resource deletion.

---

### Which issue(s) this PR is related to:

- Rebase of [#60744](https://github.com/kubernetes/kubernetes/pull/60744)  
- Partially fixes [#56567](https://github.com/kubernetes/kubernetes/issues/56567)

---

### Special notes for your reviewer:

This change touches the internal strategy for CRDs and may affect behavior for controllers using finalizers with custom delete logic. Please verify compatibility with existing finalizer-based cleanup mechanisms.

---

### Does this PR introduce a user-facing change?

```release-note
Custom Resources now honor the --grace-period flag, updating their 
deletion metadata with the specified grace period.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
