### PR TITLE
Fix TestProgressNotify for etcd v3.6.2

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -106,9 +106,9 @@ func TestWatchInitializationSignal(t *testing.T) {
 func TestProgressNotify(t *testing.T) {
 	clusterConfig := testserver.NewTestConfig(t)
 	clusterConfig.WatchProgressNotifyInterval = time.Second
-	ctx, store, _ := testSetup(t, withClientConfig(clusterConfig))
+	ctx, store, client := testSetup(t, withClientConfig(clusterConfig))
 
-	storagetesting.RunOptionalTestProgressNotify(ctx, t, store)
+	storagetesting.RunOptionalTestProgressNotify(ctx, t, store, increaseRV(client.Client))
 }
 
 func TestWatchWithUnsafeDelete(t *testing.T) {


### PR DESCRIPTION
/kind failing-test

```release-note
NONE
```

Fixes https://github.com/kubernetes/kubernetes/issues/132908