### PR TITLE
chore: maxPtr utility removal with ptr.To

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas_test.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/utils/ptr"
 )
 
 func TestSchemaDeclType(t *testing.T) {
@@ -360,7 +361,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 		},
 		{
 			Name:        "arrayWithLength",
-			InputSchema: arraySchema("integer", "int64", maxPtr(10)),
+			InputSchema: arraySchema("integer", "int64", ptr.To[int64](10)),
 			// manually set by MaxItems
 			ExpectedMaxElements: 10,
 		},
@@ -371,7 +372,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 					Type: "string",
 				},
 				ValueValidation: &schema.ValueValidation{
-					MaxLength: maxPtr(20),
+					MaxLength: ptr.To[int64](20),
 				},
 			},
 			// manually set by MaxLength, but we expect a 4x multiplier compared to the original input
@@ -391,7 +392,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 				}},
 				ValueValidation: &schema.ValueValidation{
 					Format:        "string",
-					MaxProperties: maxPtr(15),
+					MaxProperties: ptr.To[int64](15),
 				},
 			},
 			// manually set by MaxProperties
@@ -493,7 +494,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 				},
 				ValueValidation: &schema.ValueValidation{
 					Format:    "byte",
-					MaxLength: maxPtr(20),
+					MaxLength: ptr.To[int64](20),
 				},
 			},
 			// note that unlike regular strings we don't have to take unicode into account,
@@ -557,10 +558,6 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 			}
 		})
 	}
-}
-
-func maxPtr(max int64) *int64 {
-	return &max
 }
 
 func genNestedSchema(depth int) *schema.Structural {

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/schemas_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/schemas_test.go
@@ -26,6 +26,7 @@ import (
 
 	apiservercel "k8s.io/apiserver/pkg/cel"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	"k8s.io/utils/ptr"
 )
 
 func TestSchemaDeclType(t *testing.T) {
@@ -229,10 +230,6 @@ func arraySchema(arrayType, format string, maxItems *int64) *spec.Schema {
 	}
 }
 
-func maxPtr(max int64) *int64 {
-	return &max
-}
-
 func TestEstimateMaxLengthJSON(t *testing.T) {
 	type maxLengthTest struct {
 		Name                string
@@ -311,7 +308,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 		},
 		{
 			Name:        "arrayWithLength",
-			InputSchema: arraySchema("integer", "int64", maxPtr(10)),
+			InputSchema: arraySchema("integer", "int64", ptr.To[int64](10)),
 			// manually set by MaxItems
 			ExpectedMaxElements: 10,
 		},
@@ -320,7 +317,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 			InputSchema: &spec.Schema{
 				SchemaProps: spec.SchemaProps{
 					Type:      []string{"string"},
-					MaxLength: maxPtr(20),
+					MaxLength: ptr.To[int64](20),
 				}},
 			// manually set by MaxLength, but we expect a 4x multiplier compared to the original input
 			// since OpenAPIv3 maxLength uses code points, but DeclType works with bytes
@@ -335,7 +332,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 						Schema: spec.StringProperty(),
 					},
 					Format:        "string",
-					MaxProperties: maxPtr(15),
+					MaxProperties: ptr.To[int64](15),
 				}},
 			// manually set by MaxProperties
 			ExpectedMaxElements: 15,
@@ -417,7 +414,7 @@ func TestEstimateMaxLengthJSON(t *testing.T) {
 				SchemaProps: spec.SchemaProps{
 					Type:      []string{"string"},
 					Format:    "byte",
-					MaxLength: maxPtr(20),
+					MaxLength: ptr.To[int64](20),
 				}},
 			// note that unlike regular strings we don't have to take unicode into account,
 			// so we expect the max length to be exactly equal to the user-supplied one


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/priority backlog

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE