### PR TITLE
DRA API: implement ResourceClaim strategy for DRADeviceTaints

### DIFF
--- a/pkg/api/resourceclaimspec/util.go
+++ b/pkg/api/resourceclaimspec/util.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceclaimspec
+
+import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/apis/resource"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// DropDisabledFields removes disabled fields from the spec unless they were in
+// use there before.
+//
+// Theoretically some features could be in use in an old ResourceClaim status
+// and not in use in the spec. This can only occur in a spec update, which is
+// currently prevented because the entire spec is immutable. Even if it was
+// allowed, preventing adding disabled fields to the spec is the right thing to
+// do regardless of what may have ended up in the status earlier.
+func DropDisabledFields(new, old *resource.ResourceClaimSpec) {
+	dropDisabledDRAPrioritizedListFields(new, old)
+	dropDisabledDRADeviceTaintsFields(new, old) // Intentionally after dropDisabledDRAPrioritizedListFields to avoid iterating over FirstAvailable slice which needs to be dropped.
+	dropDisabledDRAAdminAccessFields(new, old)
+	dropDisabledDRAResourceClaimConsumableCapacityFields(new, old)
+}
+
+func dropDisabledDRADeviceTaintsFields(new, old *resource.ResourceClaimSpec) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaints) ||
+		draDeviceTaintsInUse(old) {
+		return
+	}
+
+	for i, req := range new.Devices.Requests {
+		if exactly := req.Exactly; exactly != nil {
+			exactly.Tolerations = nil
+		}
+		for e := range req.FirstAvailable {
+			new.Devices.Requests[i].FirstAvailable[e].Tolerations = nil
+		}
+	}
+}
+
+func draDeviceTaintsInUse(spec *resource.ResourceClaimSpec) bool {
+	if spec == nil {
+		return false
+	}
+
+	for _, req := range spec.Devices.Requests {
+		if exactly := req.Exactly; exactly != nil && len(exactly.Tolerations) > 0 {
+			return true
+		}
+		for _, sub := range req.FirstAvailable {
+			if len(sub.Tolerations) > 0 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func dropDisabledDRAPrioritizedListFields(new, old *resource.ResourceClaimSpec) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList) {
+		return
+	}
+	if draPrioritizedListFeatureInUse(old) {
+		return
+	}
+
+	for i := range new.Devices.Requests {
+		new.Devices.Requests[i].FirstAvailable = nil
+	}
+}
+
+func draPrioritizedListFeatureInUse(spec *resource.ResourceClaimSpec) bool {
+	if spec == nil {
+		return false
+	}
+
+	for _, request := range spec.Devices.Requests {
+		if len(request.FirstAvailable) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func dropDisabledDRAAdminAccessFields(new, old *resource.ResourceClaimSpec) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess) ||
+		DRAAdminAccessFeatureInUse(old) {
+		// No need to drop anything.
+		return
+	}
+
+	for i := range new.Devices.Requests {
+		if new.Devices.Requests[i].Exactly != nil {
+			new.Devices.Requests[i].Exactly.AdminAccess = nil
+		}
+	}
+}
+
+// DRAAdminAccessFeatureInUse checks whether the feature is in use in the spec.
+func DRAAdminAccessFeatureInUse(spec *resource.ResourceClaimSpec) bool {
+	if spec == nil {
+		return false
+	}
+
+	for _, request := range spec.Devices.Requests {
+		if request.Exactly != nil && request.Exactly.AdminAccess != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func dropDisabledDRAResourceClaimConsumableCapacityFields(new, old *resource.ResourceClaimSpec) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity) ||
+		DRAConsumableCapacityFeatureInUse(old) {
+		// No need to drop anything.
+		return
+	}
+
+	for _, constaint := range new.Devices.Constraints {
+		constaint.DistinctAttribute = nil
+	}
+
+	for i := range new.Devices.Requests {
+		if new.Devices.Requests[i].Exactly != nil {
+			new.Devices.Requests[i].Exactly.Capacity = nil
+		}
+		request := new.Devices.Requests[i]
+		for j := range request.FirstAvailable {
+			new.Devices.Requests[i].FirstAvailable[j].Capacity = nil
+		}
+	}
+}
+
+// DRAConsumableCapacityFeatureInUse checks whether the feature is in use in the spec.
+func DRAConsumableCapacityFeatureInUse(spec *resource.ResourceClaimSpec) bool {
+	if spec == nil {
+		return false
+	}
+
+	for _, constaint := range spec.Devices.Constraints {
+		if constaint.DistinctAttribute != nil {
+			return true
+		}
+	}
+
+	for _, request := range spec.Devices.Requests {
+		if request.Exactly != nil && request.Exactly.Capacity != nil {
+			return true
+		}
+		for _, subRequest := range request.FirstAvailable {
+			if subRequest.Capacity != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -239,6 +239,7 @@ func toSelectableFields(claim *resource.ResourceClaim) fields.Set {
 // dropDisabledFields removes fields which are covered by a feature gate.
 func dropDisabledFields(newClaim, oldClaim *resource.ResourceClaim) {
 	dropDisabledDRAPrioritizedListFields(newClaim, oldClaim)
+	dropDisabledDRADeviceTaintsFields(newClaim, oldClaim) // Intentionally after dropDisabledDRAPrioritizedListFields to avoid iterating over FirstAvailable slice which needs to be dropped.
 	dropDisabledDRAAdminAccessFields(newClaim, oldClaim)
 	dropDisabledDRAResourceClaimDeviceStatusFields(newClaim, oldClaim)
 	dropDisabledDRADeviceBindingConditionsFields(newClaim, oldClaim)
@@ -323,6 +324,41 @@ func draAdminAccessFeatureInUse(claim *resource.ResourceClaim) bool {
 	return false
 }
 
+func dropDisabledDRADeviceTaintsFields(newClaim, oldClaim *resource.ResourceClaim) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaints) ||
+		draDeviceTaintsInUse(oldClaim) {
+		return
+	}
+
+	for i, req := range newClaim.Spec.Devices.Requests {
+		if exactly := req.Exactly; exactly != nil {
+			exactly.Tolerations = nil
+		}
+		for e := range req.FirstAvailable {
+			newClaim.Spec.Devices.Requests[i].FirstAvailable[e].Tolerations = nil
+		}
+	}
+}
+
+func draDeviceTaintsInUse(claim *resource.ResourceClaim) bool {
+	if claim == nil {
+		return false
+	}
+
+	for _, req := range claim.Spec.Devices.Requests {
+		if exactly := req.Exactly; exactly != nil && len(exactly.Tolerations) > 0 {
+			return true
+		}
+		for _, sub := range req.FirstAvailable {
+			if len(sub.Tolerations) > 0 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func isDRAResourceClaimDeviceStatusInUse(claim *resource.ResourceClaim) bool {
 	return claim != nil && len(claim.Status.Devices) > 0
 }
@@ -381,8 +417,6 @@ func dropDeallocatedStatusDevices(newClaim, oldClaim *resource.ResourceClaim) {
 		newClaim.Status.Devices = nil
 	}
 }
-
-// TODO: add tests after partitionable devices is merged (code conflict!)
 
 // dropDisabledDRADeviceBindingConditionsFields removes fields which are covered by a feature gate.
 func dropDisabledDRADeviceBindingConditionsFields(newClaim, oldClaim *resource.ResourceClaim) {

--- a/pkg/registry/resource/resourceclaimtemplate/strategy.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy.go
@@ -26,12 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage/names"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/api/resourceclaimspec"
 	"k8s.io/kubernetes/pkg/apis/resource"
 	"k8s.io/kubernetes/pkg/apis/resource/validation"
-	"k8s.io/kubernetes/pkg/features"
 	resourceutils "k8s.io/kubernetes/pkg/registry/resource"
 )
 
@@ -112,151 +111,9 @@ func toSelectableFields(template *resource.ResourceClaimTemplate) fields.Set {
 }
 
 func dropDisabledFields(newClaimTemplate, oldClaimTemplate *resource.ResourceClaimTemplate) {
-	dropDisabledDRAPrioritizedListFields(newClaimTemplate, oldClaimTemplate)
-	dropDisabledDRADeviceTaintsFields(newClaimTemplate, oldClaimTemplate) // Intentionally after dropDisabledDRAPrioritizedListFields to avoid iterating over FirstAvailable slice which needs to be dropped.
-	dropDisabledDRAAdminAccessFields(newClaimTemplate, oldClaimTemplate)
-	dropDisabledDRAResourceClaimConsumableCapacityFields(newClaimTemplate, oldClaimTemplate)
-}
-
-func dropDisabledDRADeviceTaintsFields(newClaimTemplate, oldClaimTemplate *resource.ResourceClaimTemplate) {
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaints) ||
-		draDeviceTaintsInUse(oldClaimTemplate) {
-		return
+	var oldClaimSpec *resource.ResourceClaimSpec
+	if oldClaimTemplate != nil {
+		oldClaimSpec = &oldClaimTemplate.Spec.Spec
 	}
-
-	for i, req := range newClaimTemplate.Spec.Spec.Devices.Requests {
-		if exactly := req.Exactly; exactly != nil {
-			exactly.Tolerations = nil
-		}
-		for e := range req.FirstAvailable {
-			newClaimTemplate.Spec.Spec.Devices.Requests[i].FirstAvailable[e].Tolerations = nil
-		}
-	}
-}
-
-func draDeviceTaintsInUse(claimTemplate *resource.ResourceClaimTemplate) bool {
-	if claimTemplate == nil {
-		return false
-	}
-
-	for _, req := range claimTemplate.Spec.Spec.Devices.Requests {
-		if exactly := req.Exactly; exactly != nil && len(exactly.Tolerations) > 0 {
-			return true
-		}
-		for _, sub := range req.FirstAvailable {
-			if len(sub.Tolerations) > 0 {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func dropDisabledDRAPrioritizedListFields(newClaimTemplate, oldClaimTemplate *resource.ResourceClaimTemplate) {
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList) {
-		return
-	}
-	if draPrioritizedListFeatureInUse(oldClaimTemplate) {
-		return
-	}
-
-	for i := range newClaimTemplate.Spec.Spec.Devices.Requests {
-		newClaimTemplate.Spec.Spec.Devices.Requests[i].FirstAvailable = nil
-	}
-}
-
-func draPrioritizedListFeatureInUse(claimTemplate *resource.ResourceClaimTemplate) bool {
-	if claimTemplate == nil {
-		return false
-	}
-
-	for _, request := range claimTemplate.Spec.Spec.Devices.Requests {
-		if len(request.FirstAvailable) > 0 {
-			return true
-		}
-	}
-
-	return false
-}
-
-func dropDisabledDRAAdminAccessFields(newClaimTemplate, oldClaimTemplate *resource.ResourceClaimTemplate) {
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess) {
-		// No need to drop anything.
-		return
-	}
-	if draAdminAccessFeatureInUse(oldClaimTemplate) {
-		// If anything was set in the past, then fields must not get
-		// dropped on potentially unrelated updates.
-		return
-	}
-
-	for i := range newClaimTemplate.Spec.Spec.Devices.Requests {
-		if newClaimTemplate.Spec.Spec.Devices.Requests[i].Exactly != nil {
-			newClaimTemplate.Spec.Spec.Devices.Requests[i].Exactly.AdminAccess = nil
-		}
-	}
-}
-
-func draAdminAccessFeatureInUse(claimTemplate *resource.ResourceClaimTemplate) bool {
-	if claimTemplate == nil {
-		return false
-	}
-
-	for _, request := range claimTemplate.Spec.Spec.Devices.Requests {
-		if request.Exactly != nil && request.Exactly.AdminAccess != nil {
-			return true
-		}
-	}
-
-	return false
-}
-
-func draConsumableCapacityFeatureInUse(claimTemplate *resource.ResourceClaimTemplate) bool {
-	if claimTemplate == nil {
-		return false
-	}
-
-	for _, constaint := range claimTemplate.Spec.Spec.Devices.Constraints {
-		if constaint.DistinctAttribute != nil {
-			return true
-		}
-	}
-
-	for _, request := range claimTemplate.Spec.Spec.Devices.Requests {
-		if request.Exactly != nil && request.Exactly.Capacity != nil {
-			return true
-		}
-		for _, subRequest := range request.FirstAvailable {
-			if subRequest.Capacity != nil {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// dropDisabledDRAResourceClaimConsumableCapacityFields drops any new feature field
-// from the newClaimTemplate if they were not used in the oldClaimTemplate.
-func dropDisabledDRAResourceClaimConsumableCapacityFields(newClaimTemplate, oldClaimTemplate *resource.ResourceClaimTemplate) {
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity) ||
-		draConsumableCapacityFeatureInUse(oldClaimTemplate) {
-		// No need to drop anything.
-		return
-	}
-
-	for _, constaint := range newClaimTemplate.Spec.Spec.Devices.Constraints {
-		constaint.DistinctAttribute = nil
-	}
-
-	for i := range newClaimTemplate.Spec.Spec.Devices.Requests {
-		if newClaimTemplate.Spec.Spec.Devices.Requests[i].Exactly != nil {
-			newClaimTemplate.Spec.Spec.Devices.Requests[i].Exactly.Capacity = nil
-		}
-		request := newClaimTemplate.Spec.Spec.Devices.Requests[i]
-		for j := range request.FirstAvailable {
-			newClaimTemplate.Spec.Spec.Devices.Requests[i].FirstAvailable[j].Capacity = nil
-		}
-	}
+	resourceclaimspec.DropDisabledFields(&newClaimTemplate.Spec.Spec, oldClaimSpec)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Dropping the disabled "Tolerations" field in the ResourceClaim API was missing.

This wasn't possible at the time of implementing the Device Taints API, at least not completely, because it depended on prioritized list being merged first, to cover the "FirstAvailable" field introduced together with that feature.

That the device taints PR got merged despite this gap was an oversight. The confusing TODO probably didn't help: the entire implementation was missing (or got lost due to a bad merge conflict resolution, not sure anymore) and it referenced the wrong other feature (partitionable devices doesn't affect ResourceClaim).

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5055

#### Special notes for your reviewer:

This allowed clients to set the field when it should have been dropped. It simply had no effect. Clients can keep updating such objects because of the "feature in use" check, as long as the spec remains immutable.

#### Does this PR introduce a user-facing change?

```release-note
DRA API: the "tolerations" field in exact and sub requests now gets dropped properly when the DRADeviceTaints API is disabled.
```
