### PR TITLE
Use object size to estimate list cost assigning 1 seat per 100KB

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -23,17 +23,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/cacher/delegator"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 )
 
-func newListWorkEstimator(countFn statsGetterFunc, config *WorkEstimatorConfig, maxSeatsFn maxSeatsFunc) WorkEstimatorFunc {
+const (
+	bytesPerSeat                     = 100_000
+	cacheWithStreamingMaxMemoryUsage = 1_000_000
+)
+
+func newListWorkEstimator(countFn statsGetterFunc, config *WorkEstimatorConfig, maxSeatsFn maxSeatsFunc) *listWorkEstimator {
 	estimator := &listWorkEstimator{
 		config:        config,
 		statsGetterFn: countFn,
 		maxSeatsFn:    maxSeatsFn,
 	}
-	return estimator.estimate
+	return estimator
 }
 
 type listWorkEstimator struct {
@@ -91,7 +99,6 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 	isListFromCache := requestInfo.Verb == "watch" || !listFromStorage
 
 	stats, err := e.statsGetterFn(key(requestInfo))
-	numStored := stats.ObjectCount
 	switch {
 	case err == ObjectCountStaleErr:
 		// object count going stale is indicative of degradation, so we should
@@ -119,7 +126,25 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 		klog.ErrorS(err, "Unexpected error from object count tracker")
 		return WorkEstimate{InitialSeats: maxSeats}
 	}
+	var seats uint64
+	if utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
+		seats = e.seatsBasedOnObjectSize(stats, listOptions, isListFromCache)
+	} else {
+		seats = e.seatsBasedOnObjectCount(stats, listOptions, isListFromCache)
+	}
 
+	// make sure we never return a seat of zero
+	if seats < minSeats {
+		seats = minSeats
+	}
+	if seats > maxSeats {
+		seats = maxSeats
+	}
+	return WorkEstimate{InitialSeats: seats}
+}
+
+func (e *listWorkEstimator) seatsBasedOnObjectCount(stats storage.Stats, listOptions metav1.ListOptions, isListFromCache bool) uint64 {
+	numStored := stats.ObjectCount
 	limit := numStored
 	if listOptions.Limit > 0 && listOptions.Limit < numStored {
 		limit = listOptions.Limit
@@ -142,16 +167,29 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 	// will be processed by the list request.
 	// we will come up with a different formula for the transformation function and/or
 	// fine tune this number in future iteratons.
-	seats := uint64(math.Ceil(float64(estimatedObjectsToBeProcessed) / e.config.ObjectsPerSeat))
+	return uint64(math.Ceil(float64(estimatedObjectsToBeProcessed) / e.config.ObjectsPerSeat))
+}
 
-	// make sure we never return a seat of zero
-	if seats < minSeats {
-		seats = minSeats
+func (e *listWorkEstimator) seatsBasedOnObjectSize(stats storage.Stats, listOptions metav1.ListOptions, isListFromCache bool) uint64 {
+	// Size not available, fallback to count based estimate
+	if stats.EstimatedAverageObjectSizeBytes <= 0 && stats.ObjectCount != 0 {
+		return e.seatsBasedOnObjectCount(stats, listOptions, isListFromCache)
 	}
-	if seats > maxSeats {
-		seats = maxSeats
+	limited := stats.ObjectCount
+	if listOptions.Limit > 0 && listOptions.Limit < limited {
+		limited = listOptions.Limit
 	}
-	return WorkEstimate{InitialSeats: seats}
+	objectsLoadedInMemory := limited
+	if !isListFromCache && (listOptions.FieldSelector != "" || listOptions.LabelSelector != "") {
+		objectsLoadedInMemory = max(limited, stats.ObjectCount/2)
+	}
+
+	memoryUsedAtOnce := objectsLoadedInMemory * stats.EstimatedAverageObjectSizeBytes
+	if isListFromCache {
+		// TODO: Identify if the resource is streamed
+		memoryUsedAtOnce = min(memoryUsedAtOnce, cacheWithStreamingMaxMemoryUsage)
+	}
+	return uint64(math.Ceil(float64(memoryUsedAtOnce) / bytesPerSeat))
 }
 
 func key(requestInfo *apirequest.RequestInfo) string {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+func TestListWorkEstimator(t *testing.T) {
+
+	defaultCfg := DefaultWorkEstimatorConfig()
+
+	tests := []struct {
+		name                      string
+		totalSize                 int64
+		objectCount               int64
+		request                   metav1.ListOptions
+		isListFromCache           bool
+		expectObjectCountEstimate uint64
+		expectObjectSizeEstimate  uint64
+	}{
+		{
+			name:                      "100KB resource, 100 objects, storage",
+			totalSize:                 100_000 - 1,
+			objectCount:               99,
+			isListFromCache:           false,
+			expectObjectCountEstimate: 2,
+			expectObjectSizeEstimate:  1,
+		},
+		{
+			name:                      "100KB resource, 10 objects, storage",
+			totalSize:                 100_000 - 1,
+			objectCount:               10,
+			isListFromCache:           false,
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  1,
+		},
+		{
+			name:                      "100KB resource, 99 objects, cache",
+			totalSize:                 100_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  1,
+		},
+		{
+			name:                      "100KB resource, 10 objects, cache",
+			totalSize:                 100_000 - 1,
+			objectCount:               10,
+			isListFromCache:           true,
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  1,
+		},
+		{
+			name:                      "1MB resource, 1000 objects, storage",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           false,
+			expectObjectCountEstimate: 20,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "1MB resource, 1000 objects, storage, limit 100",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 100},
+			expectObjectCountEstimate: 2,
+			expectObjectSizeEstimate:  1,
+		},
+		{
+			name:                      "1MB resource, 1000 objects, storage, limit 100, selector",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 100, LabelSelector: "a"},
+			expectObjectCountEstimate: 11,
+			expectObjectSizeEstimate:  5,
+		},
+		{
+			name:                      "1MB resource, 1000 objects, cache",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "1MB resource, 1000 objects, cache, limit 100",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			request:                   metav1.ListOptions{Limit: 100},
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  1,
+		},
+		{
+			name:                      "1MB resource, 1000 objects, cache, limit 100, selector",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			request:                   metav1.ListOptions{Limit: 100, LabelSelector: "a"},
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  1,
+		},
+		{
+			name:                      "1MB resource, 99 objects, storage",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           false,
+			expectObjectCountEstimate: 2,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "1MB resource, 99 objects, storage, limit 10",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 10},
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  2,
+		},
+		{
+			name:                      "1MB resource, 99 objects, storage, limit 10, selector",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 10, LabelSelector: "a"},
+			expectObjectCountEstimate: 2,
+			expectObjectSizeEstimate:  5,
+		},
+		{
+			name:                      "1MB resource, 99 objects, cache",
+			totalSize:                 1_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, store",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           false,
+			expectObjectCountEstimate: 20,
+			expectObjectSizeEstimate:  100,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, store, limit 100",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 100},
+			expectObjectCountEstimate: 2,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, store, limit 100, selector",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 100, LabelSelector: "a"},
+			expectObjectCountEstimate: 11,
+			expectObjectSizeEstimate:  50,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, cache",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, cache, limit 100",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			request:                   metav1.ListOptions{Limit: 100},
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, cache, limit 100, selector",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			request:                   metav1.ListOptions{Limit: 100, LabelSelector: "a"},
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 99 objects, store",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           false,
+			expectObjectCountEstimate: 2,
+			expectObjectSizeEstimate:  100,
+		},
+		{
+			name:                      "10MB resource, 99 objects, store, limit 10",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 10},
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  11,
+		},
+		{
+			name:                      "10MB resource, 99 objects, store, limit 10, selector",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           false,
+			request:                   metav1.ListOptions{Limit: 10, LabelSelector: "a"},
+			expectObjectCountEstimate: 2,
+			expectObjectSizeEstimate:  50,
+		},
+		{
+			name:                      "10MB resource, 99 objects, cache",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 99 objects, cache, limit 10",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			request:                   metav1.ListOptions{Limit: 10},
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 99 objects, cache, limit 10, selector",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			request:                   metav1.ListOptions{Limit: 10, LabelSelector: "a"},
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  10,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			estimator := newListWorkEstimator(nil, defaultCfg, nil)
+
+			stats := storage.Stats{ObjectCount: test.objectCount, EstimatedAverageObjectSizeBytes: test.totalSize / test.objectCount}
+
+			objectCountEstimate := estimator.seatsBasedOnObjectCount(stats, test.request, test.isListFromCache)
+			objectSizeEstimage := estimator.seatsBasedOnObjectSize(stats, test.request, test.isListFromCache)
+
+			if objectCountEstimate != test.expectObjectCountEstimate {
+				t.Errorf("Expected object count work estimate to match, expected: %d, but got: %d", test.expectObjectCountEstimate, objectCountEstimate)
+			}
+			if objectSizeEstimage != test.expectObjectSizeEstimate {
+				t.Errorf("Expected object size work estimate to match, expected: %d, but got: %d", test.expectObjectSizeEstimate, objectSizeEstimage)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width.go
@@ -76,7 +76,7 @@ func NewWorkEstimator(objectCountFn statsGetterFunc, watchCountFn watchCountGett
 	estimator := &workEstimator{
 		minimumSeats:          config.MinimumSeats,
 		maximumSeatsLimit:     config.MaximumSeatsLimit,
-		listWorkEstimator:     newListWorkEstimator(objectCountFn, config, maxSeatsFn),
+		listWorkEstimator:     newListWorkEstimator(objectCountFn, config, maxSeatsFn).estimate,
 		mutatingWorkEstimator: newMutatingWorkEstimator(watchCountFn, config, maxSeatsFn),
 	}
 	return estimator.estimate

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -88,7 +88,7 @@ func TestWorkEstimator(t *testing.T) {
 				"events.foo.bar": 699,
 			},
 			maxSeats:             10,
-			initialSeatsExpected: 8,
+			initialSeatsExpected: 4,
 		},
 		{
 			name:       "request verb is list, limit not set",
@@ -116,7 +116,7 @@ func TestWorkEstimator(t *testing.T) {
 				"events.foo.bar": 699,
 			},
 			maxSeats:             10,
-			initialSeatsExpected: 8,
+			initialSeatsExpected: 4,
 		},
 		{
 			name:       "request verb is list, no query parameters, count known",
@@ -130,7 +130,7 @@ func TestWorkEstimator(t *testing.T) {
 				"events.foo.bar": 399,
 			},
 			maxSeats:             10,
-			initialSeatsExpected: 8,
+			initialSeatsExpected: 4,
 		},
 		{
 			name:       "request verb is list, no query parameters, count not known",
@@ -156,7 +156,7 @@ func TestWorkEstimator(t *testing.T) {
 				"events.foo.bar": 699,
 			},
 			maxSeats:             10,
-			initialSeatsExpected: 8,
+			initialSeatsExpected: 4,
 		},
 		{
 			name:       "request verb is list, resource version is zero",
@@ -170,7 +170,7 @@ func TestWorkEstimator(t *testing.T) {
 				"events.foo.bar": 399,
 			},
 			maxSeats:             10,
-			initialSeatsExpected: 4,
+			initialSeatsExpected: 3,
 		},
 		{
 			name:       "request verb is list, resource version is zero, no limit",
@@ -197,7 +197,7 @@ func TestWorkEstimator(t *testing.T) {
 				"events.foo.bar": 699,
 			},
 			maxSeats:             10,
-			initialSeatsExpected: 8,
+			initialSeatsExpected: 4,
 		},
 		{
 			name:       "request verb is list, resource version match is NotOlderThan, limit not specified",
@@ -549,7 +549,7 @@ func TestWorkEstimator(t *testing.T) {
 				counts = map[string]int64{}
 			}
 			countsFn := func(key string) (storage.Stats, error) {
-				return storage.Stats{ObjectCount: counts[key]}, test.countErr
+				return storage.Stats{ObjectCount: counts[key], EstimatedAverageObjectSizeBytes: 1_000}, test.countErr
 			}
 			watchCountsFn := func(_ *apirequest.RequestInfo) int {
 				return test.watchCount


### PR DESCRIPTION
/kind feature

```release-note
Add SizeBasedListCostEstimate feature gate, enabled by default, changing method of assigning APF seats to LIST request. Assign one seat per 100KB of data loaded to memory at once to handle LIST request.
```

Ref https://github.com/kubernetes/kubernetes/issues/132233

/assing @jpbetz 