### PR TITLE
Reject pod when attachment limit is exceeded

### DIFF
--- a/pkg/controller/volume/attachdetach/testing/plugin.go
+++ b/pkg/controller/volume/attachdetach/testing/plugin.go
@@ -105,7 +105,7 @@ func (plugin *TestPlugin) NewUnmounter(name string, podUID types.UID) (volume.Un
 	return nil, nil
 }
 
-func (plugin *TestPlugin) VerifyExhaustedResource(spec *volume.Spec, nodeName types.NodeName) {}
+func (plugin *TestPlugin) VerifyExhaustedResource(spec *volume.Spec) {}
 
 func (plugin *TestPlugin) ConstructVolumeSpec(volumeName, mountPath string) (volume.ReconstructedVolume, error) {
 	fakeVolume := &v1.Volume{

--- a/pkg/controller/volume/attachdetach/testing/plugin.go
+++ b/pkg/controller/volume/attachdetach/testing/plugin.go
@@ -105,7 +105,9 @@ func (plugin *TestPlugin) NewUnmounter(name string, podUID types.UID) (volume.Un
 	return nil, nil
 }
 
-func (plugin *TestPlugin) VerifyExhaustedResource(spec *volume.Spec) {}
+func (plugin *TestPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+	return false
+}
 
 func (plugin *TestPlugin) ConstructVolumeSpec(volumeName, mountPath string) (volume.ReconstructedVolume, error) {
 	fakeVolume := &v1.Volume{

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2011,7 +2011,9 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Wait for volumes to attach/mount
 	if err := kl.volumeManager.WaitForAttachAndMount(ctx, pod); err != nil {
 		if errors.Is(err, volumemanager.ErrVolumeAttachLimitExceeded) {
-			kl.rejectPod(pod, "VolumeAttachmentLimitExceeded", "Node has insufficient volume attachment capacity")
+			reasonStr := "VolumeAttachmentLimitExceeded"
+			kl.rejectPod(pod, reasonStr, "Node has insufficient volume attachment capacity")
+			recordAdmissionRejection(reasonStr)
 			return true, fmt.Errorf("Pod rejected due to insufficient volume attachment capacity")
 		}
 		if !wait.Interrupted(err) {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2013,9 +2013,9 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	if err := kl.volumeManager.WaitForAttachAndMount(ctx, pod); err != nil {
 		var volumeAttachLimitErr *volumemanager.VolumeAttachLimitExceededError
 		if errors.As(err, &volumeAttachLimitErr) {
-			kl.rejectPod(pod, volumemanager.VolumeAttachmentLimitExceededReason, "Node has insufficient volume attachment capacity")
+			kl.rejectPod(pod, volumemanager.VolumeAttachmentLimitExceededReason, volumeAttachLimitErr.Error())
 			recordAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
-			return true, volumeAttachLimitErr
+			return true, nil
 		}
 		if !wait.Interrupted(err) {
 			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to attach or mount volumes: %v", err)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2014,7 +2014,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 			reasonStr := "VolumeAttachmentLimitExceeded"
 			kl.rejectPod(pod, reasonStr, "Node has insufficient volume attachment capacity")
 			recordAdmissionRejection(reasonStr)
-			return true, fmt.Errorf("Pod rejected due to insufficient volume attachment capacity")
+			return true, fmt.Errorf("pod rejected due to insufficient volume attachment capacity")
 		}
 		if !wait.Interrupted(err) {
 			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to attach or mount volumes: %v", err)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -253,6 +253,7 @@ var (
 		sysctl.ForbiddenReason,
 		topologymanager.ErrorTopologyAffinity,
 		nodeshutdown.NodeShutdownNotAdmittedReason,
+		volumemanager.VolumeAttachmentLimitExceededReason,
 	)
 
 	// This is exposed for unit tests.
@@ -2012,9 +2013,8 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	if err := kl.volumeManager.WaitForAttachAndMount(ctx, pod); err != nil {
 		var volumeAttachLimitErr *volumemanager.VolumeAttachLimitExceededError
 		if errors.As(err, &volumeAttachLimitErr) {
-			reasonStr := "VolumeAttachmentLimitExceeded"
-			kl.rejectPod(pod, reasonStr, "Node has insufficient volume attachment capacity")
-			recordAdmissionRejection(reasonStr)
+			kl.rejectPod(pod, volumemanager.VolumeAttachmentLimitExceededReason, "Node has insufficient volume attachment capacity")
+			recordAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
 			return true, volumeAttachLimitErr
 		}
 		if !wait.Interrupted(err) {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3212,6 +3212,15 @@ func TestRecordAdmissionRejection(t *testing.T) {
 			`,
 		},
 		{
+			name:   "VolumeAttachmentLimitExceeded",
+			reason: kubeletvolume.VolumeAttachmentLimitExceededReason,
+			wants: `
+				# HELP kubelet_admission_rejections_total [ALPHA] Cumulative number pod admission rejections by the Kubelet.
+				# TYPE kubelet_admission_rejections_total counter
+				kubelet_admission_rejections_total{reason="VolumeAttachmentLimitExceeded"} 1
+			`,
+		},
+		{
 			name:   "PodOSSelectorNodeLabelDoesNotMatch",
 			reason: lifecycle.PodOSSelectorNodeLabelDoesNotMatch,
 			wants: `

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -86,6 +86,10 @@ const (
 	// operation is waiting it only blocks other operations on the same device,
 	// other devices are not affected.
 	waitForAttachTimeout = 10 * time.Minute
+
+	// VolumeAttachmentLimitExceededReason is the reason for rejecting a pod
+	// when the node has reached its volume attachment limit.
+	VolumeAttachmentLimitExceededReason = "VolumeAttachmentLimitExceeded"
 )
 
 // VolumeManager runs a set of asynchronous loops that figure out which volumes

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -31,10 +31,13 @@ import (
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	utiltesting "k8s.io/client-go/util/testing"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/volume"
@@ -239,6 +242,91 @@ func TestWaitForAttachAndMountError(t *testing.T) {
 		"unattached volumes=[vol02 vol2], failed to process volumes=[vol03 vol3]") {
 		t.Errorf("Unexpected error info: %v", err)
 	}
+}
+
+func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MutableCSINodeAllocatableCount, true)
+
+	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	podManager := kubepod.NewBasicPodManager()
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "abc",
+			Namespace: "nsA",
+			UID:       "1234",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "container1",
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "vol1",
+							MountPath: "/vol1",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "vol1",
+					VolumeSource: v1.VolumeSource{
+						RBD: &v1.RBDVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(pod)
+
+	attachablePlug := &volumetest.FakeVolumePlugin{
+		PluginName: "fake",
+		CanSupportFn: func(spec *volume.Spec) bool {
+			return (spec.PersistentVolume != nil && spec.PersistentVolume.Spec.RBD != nil) ||
+				(spec.Volume != nil && spec.Volume.RBD != nil)
+		},
+		VerifyExhaustedEnabled: true,
+	}
+
+	plugMgr := &volume.VolumePluginMgr{}
+	fakeVolumeHost := volumetest.NewFakeKubeletVolumeHost(t, tmpDir, kubeClient, nil)
+	plugMgr.InitPlugins([]volume.VolumePlugin{attachablePlug}, nil, fakeVolumeHost)
+
+	manager := NewVolumeManager(
+		true,
+		testHostname,
+		podManager,
+		&fakePodStateProvider{},
+		kubeClient,
+		plugMgr,
+		mount.NewFakeMounter(nil),
+		hostutil.NewFakeHostUtil(nil),
+		"",
+		&record.FakeRecorder{},
+		volumetest.NewBlockVolumePathHandler())
+
+	tCtx := ktesting.Init(t)
+	t.Cleanup(func() { tCtx.Cancel("test has completed") })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	go manager.Run(tCtx, sourcesReady)
+	podManager.SetPods([]*v1.Pod{pod})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	err = manager.WaitForAttachAndMount(ctx, pod)
+
+	require.Error(t, err, "Expected an error but got none")
+
+	var attachErr *VolumeAttachLimitExceededError
+	require.ErrorAs(t, err, &attachErr, "Error should be of type VolumeAttachLimitExceededError")
+	require.Equal(t, []string{"vol1"}, attachErr.UnmountedVolumes, "UnmountedVolumes mismatch")
+	require.Equal(t, []string{"vol1"}, attachErr.UnattachedVolumes, "UnattachedVolumes mismatch")
+	require.Empty(t, attachErr.VolumesNotInDSW, "VolumesNotInDSW should be empty")
+	require.ErrorIs(t, attachErr.OriginalError, context.DeadlineExceeded, "OriginalError should be context.DeadlineExceeded")
 }
 
 func TestInitialPendingVolumesForPodAndGetVolumesInUse(t *testing.T) {

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -249,7 +249,12 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	tmpDir, err := utiltesting.MkTmpdir("volumeManagerTest")
 	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("Failed to remove temporary directory %s: %v", tmpDir, err)
+		}
+	})
 
 	podManager := kubepod.NewBasicPodManager()
 
@@ -294,7 +299,9 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 
 	plugMgr := &volume.VolumePluginMgr{}
 	fakeVolumeHost := volumetest.NewFakeKubeletVolumeHost(t, tmpDir, kubeClient, nil)
-	plugMgr.InitPlugins([]volume.VolumePlugin{attachablePlug}, nil, fakeVolumeHost)
+	if err := plugMgr.InitPlugins([]volume.VolumePlugin{attachablePlug}, nil, fakeVolumeHost); err != nil {
+		t.Fatalf("Failed to initialize volume plugins: %v", err)
+	}
 
 	manager := NewVolumeManager(
 		true,

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -75,7 +75,9 @@ func (attacher *fcAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName ty
 	return volumesAttachedCheck, nil
 }
 
-func (plugin *fcPlugin) VerifyExhaustedResource(spec *volume.Spec, nodeName types.NodeName) {}
+func (plugin *fcPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+	return false
+}
 
 func (attacher *fcAttacher) WaitForAttach(spec *volume.Spec, devicePath string, _ *v1.Pod, timeout time.Duration) (string, error) {
 	mounter, err := volumeSpecToMounter(spec, attacher.host)

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -101,7 +101,9 @@ func (plugin *flexVolumePlugin) Init(host volume.VolumeHost) error {
 	return nil
 }
 
-func (plugin *flexVolumePlugin) VerifyExhaustedResource(spec *volume.Spec, nodeName types.NodeName) {}
+func (plugin *flexVolumePlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+	return false
+}
 
 func (plugin *flexVolumePlugin) getExecutable() string {
 	parts := strings.Split(plugin.driverName, "/")

--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -54,7 +54,9 @@ func (plugin *iscsiPlugin) NewAttacher() (volume.Attacher, error) {
 	}, nil
 }
 
-func (plugin *iscsiPlugin) VerifyExhaustedResource(spec *volume.Spec, nodeName types.NodeName) {}
+func (plugin *iscsiPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+	return false
+}
 
 func (plugin *iscsiPlugin) NewDeviceMounter() (volume.DeviceMounter, error) {
 	return plugin.NewAttacher()

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -230,7 +230,7 @@ type AttachableVolumePlugin interface {
 	NewDetacher() (Detacher, error)
 	// CanAttach tests if provided volume spec is attachable
 	CanAttach(spec *Spec) (bool, error)
-	VerifyExhaustedResource(spec *Spec, nodeName types.NodeName)
+	VerifyExhaustedResource(spec *Spec) bool
 }
 
 // DeviceMountableVolumePlugin is an extended interface of VolumePlugin and is used

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -191,6 +191,7 @@ type FakeVolumePlugin struct {
 	SupportsSELinux        bool
 	DisableNodeExpansion   bool
 	CanSupportFn           func(*volume.Spec) bool
+	VerifyExhaustedEnabled bool
 
 	// default to false which means it is attachable by default
 	NonAttachable bool
@@ -438,7 +439,7 @@ func (plugin *FakeVolumePlugin) CanAttach(spec *volume.Spec) (bool, error) {
 }
 
 func (plugin *FakeVolumePlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
-	return false
+	return plugin.VerifyExhaustedEnabled
 }
 
 func (plugin *FakeVolumePlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -437,7 +437,9 @@ func (plugin *FakeVolumePlugin) CanAttach(spec *volume.Spec) (bool, error) {
 	return !plugin.NonAttachable, nil
 }
 
-func (plugin *FakeVolumePlugin) VerifyExhaustedResource(spec *volume.Spec, nodeName types.NodeName) {}
+func (plugin *FakeVolumePlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+	return false
+}
 
 func (plugin *FakeVolumePlugin) CanDeviceMount(spec *volume.Spec) (bool, error) {
 	return true, nil
@@ -619,7 +621,8 @@ func (f *FakeAttachableVolumePlugin) CanAttach(spec *volume.Spec) (bool, error) 
 	return true, nil
 }
 
-func (f *FakeAttachableVolumePlugin) VerifyExhaustedResource(spec *volume.Spec, nodeName types.NodeName) {
+func (f *FakeAttachableVolumePlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
+	return false
 }
 
 var _ volume.VolumePlugin = &FakeAttachableVolumePlugin{}

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -1477,13 +1477,6 @@ func (og *operationGenerator) GenerateVerifyControllerAttachedVolumeFunc(
 			}
 		}
 
-		// Volume is not attached - check if this is due to resource exhaustion before returning the error
-		if utilfeature.DefaultFeatureGate.Enabled(features.MutableCSINodeAllocatableCount) {
-			if attachablePlugin, pluginErr := og.volumePluginMgr.FindAttachablePluginBySpec(volumeToMount.VolumeSpec); pluginErr == nil && attachablePlugin != nil {
-				attachablePlugin.VerifyExhaustedResource(volumeToMount.VolumeSpec, nodeName)
-			}
-		}
-
 		// Volume not attached, return error. Caller will log and retry.
 		eventErr, detailedErr := volumeToMount.GenerateError("Volume not attached according to node status", nil)
 		return volumetypes.NewOperationContext(eventErr, detailedErr, migrated)

--- a/test/e2e/storage/csimock/mutable_csinode_allocatable.go
+++ b/test/e2e/storage/csimock/mutable_csinode_allocatable.go
@@ -18,20 +18,29 @@ package csimock
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/onsi/ginkgo/v2"
 
+	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	"k8s.io/kubernetes/test/e2e/storage/drivers"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -50,67 +59,161 @@ var _ = utils.SIGDescribe("MutableCSINodeAllocatableCount", framework.WithFeatur
 	f := framework.NewDefaultFramework("mutable-allocatable-mock")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
-	var (
-		driver     drivers.MockCSITestDriver
-		cfg        *storageframework.PerTestConfig
-		clientSet  clientset.Interface
-		nodeName   string
-		driverName string
-	)
+	ginkgo.Describe("Dynamic Allocatable Count", func() {
+		var (
+			driver     drivers.MockCSITestDriver
+			cfg        *storageframework.PerTestConfig
+			clientSet  clientset.Interface
+			nodeName   string
+			driverName string
+		)
 
-	ginkgo.BeforeEach(func(ctx context.Context) {
-		var calls int32
-		hook := drivers.Hooks{
-			Post: func(_ context.Context, method string, _ interface{}, reply interface{}, err error) (interface{}, error) {
-				if strings.Contains(method, "NodeGetInfo") {
-					if r, ok := reply.(*csipbv1.NodeGetInfoResponse); ok && err == nil {
-						if atomic.AddInt32(&calls, 1) == 1 {
-							r.MaxVolumesPerNode = initialMaxVolumesPerNode
-						} else {
-							r.MaxVolumesPerNode = updatedMaxVolumesPerNode
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			var calls int32
+			hook := drivers.Hooks{
+				Post: func(_ context.Context, method string, _ interface{}, reply interface{}, err error) (interface{}, error) {
+					if strings.Contains(method, "NodeGetInfo") {
+						if r, ok := reply.(*csipbv1.NodeGetInfoResponse); ok && err == nil {
+							if atomic.AddInt32(&calls, 1) == 1 {
+								r.MaxVolumesPerNode = initialMaxVolumesPerNode
+							} else {
+								r.MaxVolumesPerNode = updatedMaxVolumesPerNode
+							}
+							framework.Logf("NodeGetInfo called, setting MaxVolumesPerNode to %d", r.MaxVolumesPerNode)
+							return r, nil
 						}
-						framework.Logf("NodeGetInfo called, setting MaxVolumesPerNode to %d", r.MaxVolumesPerNode)
-						return r, nil
 					}
-				}
-				return reply, err
-			},
-		}
-
-		opts := drivers.CSIMockDriverOpts{
-			Embedded:       true,
-			RegisterDriver: true,
-			Hooks:          hook,
-		}
-		driver = drivers.InitMockCSIDriver(opts)
-		cfg = driver.PrepareTest(ctx, f)
-
-		clientSet = f.ClientSet
-		driverName = cfg.GetUniqueDriverName()
-		nodeName = cfg.ClientNodeSelection.Name
-
-		updateCSIDriverWithNodeAllocatableUpdatePeriodSeconds(ctx, clientSet, driverName, updatePeriodSeconds)
-
-		err := drivers.WaitForCSIDriverRegistrationOnNode(ctx, nodeName, driverName, clientSet)
-		framework.ExpectNoError(err)
-	})
-
-	f.It("should observe dynamic changes in CSINode allocatable count", func(ctx context.Context) {
-		framework.Logf("Testing dynamic changes in CSINode allocatable count")
-		initVal, err := readCSINodeLimit(ctx, clientSet, nodeName, driverName)
-		framework.ExpectNoError(err)
-		framework.Logf("Initial MaxVolumesPerNode limit: %d", initVal)
-
-		err = wait.PollUntilContextTimeout(ctx, time.Duration(updatePeriodSeconds), timeout, true, func(ctx context.Context) (bool, error) {
-			cur, err := readCSINodeLimit(ctx, clientSet, nodeName, driverName)
-			if err != nil {
-				return false, nil
+					return reply, err
+				},
 			}
-			return int64(cur) == updatedMaxVolumesPerNode, nil
+
+			opts := drivers.CSIMockDriverOpts{
+				Embedded:       true,
+				RegisterDriver: true,
+				Hooks:          hook,
+			}
+			driver = drivers.InitMockCSIDriver(opts)
+			cfg = driver.PrepareTest(ctx, f)
+
+			clientSet = f.ClientSet
+			driverName = cfg.GetUniqueDriverName()
+			nodeName = cfg.ClientNodeSelection.Name
+
+			updateCSIDriverWithNodeAllocatableUpdatePeriodSeconds(ctx, clientSet, driverName, updatePeriodSeconds)
+
+			err := drivers.WaitForCSIDriverRegistrationOnNode(ctx, nodeName, driverName, clientSet)
+			framework.ExpectNoError(err)
 		})
 
-		framework.ExpectNoError(err, "CSINode allocatable count was not updated to %d in time", updatedMaxVolumesPerNode)
-		framework.Logf("SUCCESS: MaxVolumesPerNode updated limit %d", updatedMaxVolumesPerNode)
+		f.It("should observe dynamic changes in CSINode allocatable count", func(ctx context.Context) {
+			framework.Logf("Testing dynamic changes in CSINode allocatable count")
+			initVal, err := readCSINodeLimit(ctx, clientSet, nodeName, driverName)
+			framework.ExpectNoError(err)
+			framework.Logf("Initial MaxVolumesPerNode limit: %d", initVal)
+
+			err = wait.PollUntilContextTimeout(ctx, time.Duration(updatePeriodSeconds), timeout, true, func(ctx context.Context) (bool, error) {
+				cur, err := readCSINodeLimit(ctx, clientSet, nodeName, driverName)
+				if err != nil {
+					return false, nil
+				}
+				return int64(cur) == updatedMaxVolumesPerNode, nil
+			})
+
+			framework.ExpectNoError(err, "CSINode allocatable count was not updated to %d in time", updatedMaxVolumesPerNode)
+			framework.Logf("SUCCESS: MaxVolumesPerNode updated limit %d", updatedMaxVolumesPerNode)
+		})
+	})
+
+	ginkgo.Describe("Attach Limit Exceeded", func() {
+		var (
+			driver     drivers.MockCSITestDriver
+			cfg        *storageframework.PerTestConfig
+			clientSet  clientset.Interface
+			nodeName   string
+			driverName string
+			m          *mockDriverSetup
+		)
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			hook := drivers.Hooks{
+				Post: func(_ context.Context, method string, _ interface{}, reply interface{}, err error) (interface{}, error) {
+					if strings.Contains(method, "ControllerPublishVolume") && err == nil {
+						return nil, status.Error(codes.ResourceExhausted, "attachment limit exceeded")
+					}
+					return reply, err
+				},
+			}
+
+			opts := drivers.CSIMockDriverOpts{
+				Embedded:       true,
+				RegisterDriver: true,
+				Hooks:          hook,
+			}
+			driver = drivers.InitMockCSIDriver(opts)
+			cfg = driver.PrepareTest(ctx, f)
+
+			clientSet = f.ClientSet
+			driverName = cfg.GetUniqueDriverName()
+			nodeName = cfg.ClientNodeSelection.Name
+
+			m = newMockDriverSetup(f)
+			m.cs = clientSet
+			m.driver = driver
+			m.config = cfg
+			m.provisioner = driverName
+
+			updateCSIDriverWithNodeAllocatableUpdatePeriodSeconds(ctx, clientSet, driverName, updatePeriodSeconds)
+
+			err := drivers.WaitForCSIDriverRegistrationOnNode(ctx, nodeName, driverName, clientSet)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			m.cleanup(ctx)
+		})
+
+		f.It("should transition pod to failed state when attachment limit exceeded", func(ctx context.Context) {
+			_, claim, pod := m.createPod(ctx, pvcReference)
+			if pod == nil {
+				return
+			}
+
+			ginkgo.By("Checking if VolumeAttachment was created for the pod")
+			testConfig := storageframework.ConvertTestConfig(m.config)
+			attachmentName := e2evolume.GetVolumeAttachmentName(ctx, m.cs, testConfig, m.provisioner, claim.Name, claim.Namespace)
+
+			var va *storagev1.VolumeAttachment
+			err := wait.PollUntilContextTimeout(ctx, framework.Poll, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+				var getErr error
+				va, getErr = m.cs.StorageV1().VolumeAttachments().Get(ctx, attachmentName, metav1.GetOptions{})
+				if getErr != nil {
+					if apierrors.IsNotFound(getErr) {
+						return false, nil
+					}
+					return false, getErr
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err, "VolumeAttachment not created")
+
+			// Patch VolumeAttachment.Status.AttachError.ErrorCode with ResourceExhausted
+			clone := va.DeepCopy()
+			clone.Status.Attached = false
+			errorCode := int32(codes.ResourceExhausted)
+			clone.Status.AttachError = &storagev1.VolumeError{
+				Message:   "ResourceExhausted: attachment limit exceeded",
+				Time:      metav1.Now(),
+				ErrorCode: &errorCode,
+			}
+			patch, err := createMergePatch(va, clone)
+			framework.ExpectNoError(err, "Failed to create merge patch")
+			_, err = m.cs.StorageV1().VolumeAttachments().Patch(ctx, attachmentName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+			framework.ExpectNoError(err, "Failed to patch VolumeAttachment status")
+
+			ginkgo.By("Waiting for Pod to fail with VolumeAttachmentLimitExceeded")
+			err = e2epod.WaitForPodFailedReason(ctx, m.cs, pod, "VolumeAttachmentLimitExceeded", 4*time.Minute)
+			framework.ExpectNoError(err, "Pod did not fail with VolumeAttachmentLimitExceeded")
+		})
 	})
 })
 
@@ -141,4 +244,20 @@ func readCSINodeLimit(ctx context.Context, cs clientset.Interface, node, drv str
 		}
 	}
 	return 0, fmt.Errorf("driver %q not present on CSINode", drv)
+}
+
+func createMergePatch(original, new interface{}) ([]byte, error) {
+	pvByte, err := json.Marshal(original)
+	if err != nil {
+		return nil, err
+	}
+	cloneByte, err := json.Marshal(new)
+	if err != nil {
+		return nil, err
+	}
+	patch, err := jsonpatch.CreateMergePatch(pvByte, cloneByte)
+	if err != nil {
+		return nil, err
+	}
+	return patch, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a CSI volume fails to attach due to a lack of attachment slots on the node, the pod can get stuck indefinitely in the `ContainerCreating` state - kubelet's volumeManager continuously retries to mount the volume, unaware that the underlying attachment error is terminal.

This change introduces a mechanism for the kubelet to detect this specific failure case. After the standard volume mount process times out, the volumeManager now investigates the cause of the failure by checking the status of the underlying VolumeAttachment object. I think this is the best place to perform the check as it resolves any high frequency polling issue.

If a terminal `ResourceExhausted` error is found, `WaitForAttachAndMount` returns a specific `ErrVolumeAttachLimitExceeded` error. The kubelet's SyncPod loop catches this error and cleanly terminates the pod by setting its phase to 'Failed'. This allows the pod's owning controller (such as a StatefulSet) to take corrective action.

--- 

I validated this CR by building kubelet with this patch and the external attacher with https://github.com/kubernetes-csi/external-attacher/pull/662 to populate the ErrorCode field when a CSI plugin returns the attach limit exceeded error.

After Kubelet's `verifyVolumesMountedFunc` timed out in `WaitForAttachAndMount`, it checked and saw that the volume failed to mount due to the limit exceeded error as reported in the VA object and rejected the pod, the SS then re-created the pod and scheduled it to another node.

```
kubectl get events                                                                                            
LAST SEEN   TYPE      REASON                          OBJECT                                                      MESSAGE
10m         Normal    Scheduled                       pod/app-0                                                   Successfully assigned default/app-0 to i-0f3f6a42ec7d87aa2
10m         Warning   FailedAttachVolume              pod/app-0                                                   AttachVolume.Attach failed for volume "pvc-6e49f588-a11a-4d3a-ad59-4e434361f644" : rpc error: code = ResourceExhausted desc = Attachment limit exceeded for volume
8m          Normal    Scheduled                       pod/app-0                                                   Successfully assigned default/app-0 to i-09c909676a26480cc
```

#### Which issue(s) this PR is related to:

[KEP-4876: Mutable CSINode Allocatable Property](https://github.com/torredil/enhancements/blob/master/keps/sig-storage/4876-mutable-csinode-allocatable/README.md)
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet now detects terminal CSI volume mount failures due to exceeded attachment limits on the node and marks the stateful pod as Failed, allowing its controller to recreate it. This prevents pods from getting stuck indefinitely in the `ContainerCreating` state.
```