### PR TITLE
chore: residual strPtr utility removal with ptr.To

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers_linux_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux_test.go
@@ -81,7 +81,7 @@ func TestGetSeccompProfile(t *testing.T) {
 		},
 		{
 			description: "pod seccomp profile set to SeccompProfileTypeLocalhost returns 'localhost/' + LocalhostProfile",
-			podSc:       &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("filename")}},
+			podSc:       &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("filename")}},
 			expectedProfile: &runtimeapi.SecurityProfile{
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
 				LocalhostRef: seccompLocalhostRef("filename"),
@@ -99,7 +99,7 @@ func TestGetSeccompProfile(t *testing.T) {
 		},
 		{
 			description: "container seccomp profile set to SeccompProfileTypeLocalhost returns 'localhost/' + LocalhostProfile",
-			containerSc: &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("filename2")}},
+			containerSc: &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("filename2")}},
 			expectedProfile: &runtimeapi.SecurityProfile{
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
 				LocalhostRef: seccompLocalhostRef("filename2"),
@@ -113,8 +113,8 @@ func TestGetSeccompProfile(t *testing.T) {
 		},
 		{
 			description:   "prioritise container field over pod field",
-			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("field-pod-profile.json")}},
-			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("field-cont-profile.json")}},
+			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("field-pod-profile.json")}},
+			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("field-cont-profile.json")}},
 			containerName: "container1",
 			expectedProfile: &runtimeapi.SecurityProfile{
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
@@ -181,7 +181,7 @@ func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
 		},
 		{
 			description: "pod seccomp profile set to SeccompProfileTypeLocalhost returns 'localhost/' + LocalhostProfile",
-			podSc:       &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("filename")}},
+			podSc:       &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("filename")}},
 			expectedProfile: &runtimeapi.SecurityProfile{
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
 				LocalhostRef: seccompLocalhostRef("filename"),
@@ -199,7 +199,7 @@ func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
 		},
 		{
 			description: "container seccomp profile set to SeccompProfileTypeLocalhost returns 'localhost/' + LocalhostProfile",
-			containerSc: &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("filename2")}},
+			containerSc: &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("filename2")}},
 			expectedProfile: &runtimeapi.SecurityProfile{
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
 				LocalhostRef: seccompLocalhostRef("filename2"),
@@ -213,8 +213,8 @@ func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
 		},
 		{
 			description:   "prioritise container field over pod field",
-			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("field-pod-profile.json")}},
-			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: getLocal("field-cont-profile.json")}},
+			podSc:         &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("field-pod-profile.json")}},
+			containerSc:   &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("field-cont-profile.json")}},
 			containerName: "container1",
 			expectedProfile: &runtimeapi.SecurityProfile{
 				ProfileType:  runtimeapi.SecurityProfile_Localhost,
@@ -232,10 +232,6 @@ func TestGetSeccompProfileDefaultSeccomp(t *testing.T) {
 			assert.Equal(t, test.expectedProfile, seccompProfile, "TestCase[%d]: %s", i, test.description)
 		}
 	}
-}
-
-func getLocal(v string) *string {
-	return &v
 }
 
 func TestSharesToMilliCPU(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/dump/dump_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/dump/dump_test.go
@@ -19,14 +19,12 @@ package dump
 import (
 	"fmt"
 	"testing"
+
+	"k8s.io/utils/ptr"
 )
 
 func ptrint(i int) *int {
 	return &i
-}
-
-func ptrstr(s string) *string {
-	return &s
 }
 
 // custom type to test Stringer interface on non-pointer receiver.
@@ -109,7 +107,7 @@ func TestPretty(t *testing.T) {
 		{bool(true), "(bool) true\n"},
 		{bool(false), "(bool) false\n"},
 		{string("test"), "(string) (len=4) \"test\"\n"},
-		{ptrstr("test"), "(*string)((len=4) \"test\")\n"},
+		{ptr.To("test"), "(*string)((len=4) \"test\")\n"},
 		{[1]string{"arr"}, "([1]string) (len=1) {\n  (string) (len=3) \"arr\"\n}\n"},
 		{[]string{"slice"}, "([]string) (len=1) {\n  (string) (len=5) \"slice\"\n}\n"},
 		{tcs, "(dump.customString) (len=4) \"test\"\n"},
@@ -188,7 +186,7 @@ func TestForHash(t *testing.T) {
 		{bool(true), "(bool)true"},
 		{bool(false), "(bool)false"},
 		{string("test"), "(string)test"},
-		{ptrstr("test"), "(*string)test"},
+		{ptr.To("test"), "(*string)test"},
 		{[1]string{"arr"}, "([1]string)[arr]"},
 		{[]string{"slice"}, "([]string)[slice]"},
 		{tcs, "(dump.customString)test"},
@@ -267,7 +265,7 @@ func TestOneLine(t *testing.T) {
 		{bool(true), "(bool)true"},
 		{bool(false), "(bool)false"},
 		{string("test"), "(string)test"},
-		{ptrstr("test"), "(*string)test"},
+		{ptr.To("test"), "(*string)test"},
 		{[1]string{"arr"}, "([1]string)[arr]"},
 		{[]string{"slice"}, "([]string)[slice]"},
 		{tcs, "(dump.customString)test"},

--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/marker_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/marker_test.go
@@ -25,11 +25,8 @@ import (
 	externalexternal "k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/external/external"
 	"k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/external2"
 	"k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/external3"
+	"k8s.io/utils/ptr"
 )
-
-func getPointerFromString(s string) *string {
-	return &s
-}
 
 var (
 	defaultInt32 int32 = 32
@@ -49,7 +46,7 @@ func Test_Marker(t *testing.T) {
 				StringDefault:      "bar",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      getPointerFromString("default"),
+				StringPointer:      ptr.To("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         1,
@@ -59,8 +56,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					getPointerFromString("foo"),
-					getPointerFromString("bar"),
+					ptr.To("foo"),
+					ptr.To("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -94,7 +91,7 @@ func Test_Marker(t *testing.T) {
 					"foo",
 				},
 				Map: map[string]Item{
-					"foo": getPointerFromString("bar"),
+					"foo": ptr.To("bar"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -108,7 +105,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: getPointerFromString("banana"),
+				AliasPtr: ptr.To("banana"),
 			},
 		},
 		{
@@ -121,7 +118,7 @@ func Test_Marker(t *testing.T) {
 				StringDefault:      "changed",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      getPointerFromString("default"),
+				StringPointer:      ptr.To("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         5,
@@ -131,8 +128,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					getPointerFromString("foo"),
-					getPointerFromString("bar"),
+					ptr.To("foo"),
+					ptr.To("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -166,7 +163,7 @@ func Test_Marker(t *testing.T) {
 					I: 1,
 				},
 				Map: map[string]Item{
-					"foo": getPointerFromString("bar"),
+					"foo": ptr.To("bar"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -180,7 +177,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: getPointerFromString("banana"),
+				AliasPtr: ptr.To("banana"),
 			},
 		},
 		{
@@ -188,14 +185,14 @@ func Test_Marker(t *testing.T) {
 			in: Defaulted{
 				List: []Item{
 					nil,
-					getPointerFromString("bar"),
+					ptr.To("bar"),
 				},
 			},
 			out: Defaulted{
 				StringDefault:      "bar",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      getPointerFromString("default"),
+				StringPointer:      ptr.To("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         1,
@@ -205,8 +202,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					getPointerFromString("apple"),
-					getPointerFromString("bar"),
+					ptr.To("apple"),
+					ptr.To("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -240,7 +237,7 @@ func Test_Marker(t *testing.T) {
 					I: 1,
 				},
 				Map: map[string]Item{
-					"foo": getPointerFromString("bar"),
+					"foo": ptr.To("bar"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -254,7 +251,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: getPointerFromString("banana"),
+				AliasPtr: ptr.To("banana"),
 			},
 		},
 		{
@@ -262,14 +259,14 @@ func Test_Marker(t *testing.T) {
 			in: Defaulted{
 				Map: map[string]Item{
 					"foo": nil,
-					"bar": getPointerFromString("banana"),
+					"bar": ptr.To("banana"),
 				},
 			},
 			out: Defaulted{
 				StringDefault:      "bar",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      getPointerFromString("default"),
+				StringPointer:      ptr.To("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         1,
@@ -279,8 +276,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					getPointerFromString("foo"),
-					getPointerFromString("bar"),
+					ptr.To("foo"),
+					ptr.To("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -314,8 +311,8 @@ func Test_Marker(t *testing.T) {
 					I: 1,
 				},
 				Map: map[string]Item{
-					"foo": getPointerFromString("apple"),
-					"bar": getPointerFromString("banana"),
+					"foo": ptr.To("apple"),
+					"bar": ptr.To("banana"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -329,7 +326,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: getPointerFromString("banana"),
+				AliasPtr: ptr.To("banana"),
 			},
 		},
 	}
@@ -387,7 +384,7 @@ func Test_DefaultingReference(t *testing.T) {
 				AliasOverride:                   Item(&SomeDefault),
 				AliasConvertDefaultPointer:      &dv,
 				AliasPointerDefault:             &dv,
-				PointerAliasDefault:             Item(getPointerFromString("apple")),
+				PointerAliasDefault:             Item(ptr.To("apple")),
 				AliasNonPointer:                 SomeValue,
 				AliasPointer:                    &SomeValue,
 				SymbolReference:                 SomeDefault,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/priority backlog

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE