### PR TITLE
Adding an optional config to kube-scheduler to limit the maximum nodes for scoring

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -437,6 +437,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		scheduler.WithKubeConfig(cc.KubeConfig),
 		scheduler.WithProfiles(cc.ComponentConfig.Profiles...),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),
+		scheduler.WithMaxNodesToScore(cc.ComponentConfig.MaxNodesToScore),
 		scheduler.WithFrameworkOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithPodMaxBackoffSeconds(cc.ComponentConfig.PodMaxBackoffSeconds),
 		scheduler.WithPodInitialBackoffSeconds(cc.ComponentConfig.PodInitialBackoffSeconds),

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -64129,6 +64129,13 @@ func schema_k8sio_kube_scheduler_config_v1_KubeSchedulerConfiguration(ref common
 							Format:      "int32",
 						},
 					},
+					"maxNodesToScore": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxNodesToScore is the maximum number of nodes to score, the scheduler will stop searching for more feasible nodes when this limit is reached. This configuration will override the computed number from PercentageOfNodesToScore.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"podInitialBackoffSeconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PodInitialBackoffSeconds is the initial backoff for unschedulable pods. If specified, it must be greater than 0. If this value is null, the default value (1s) will be used.",

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -69,6 +69,11 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored. It is overridden by profile level PercentageOfNodesToScore.
 	PercentageOfNodesToScore *int32
 
+	// MaxNodesToScore is the maximum number of nodes to score, the scheduler will stop searching
+	// for more feasible nodes when this limit is reached. This configuration will override the
+	// computed number from PercentageOfNodesToScore.
+	MaxNodesToScore *int32
+
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 	// If specified, it must be greater than 0. If this value is null, the default value (1s)
 	// will be used.

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -411,6 +411,7 @@ func autoConvert_v1_KubeSchedulerConfiguration_To_config_KubeSchedulerConfigurat
 		return err
 	}
 	out.PercentageOfNodesToScore = (*int32)(unsafe.Pointer(in.PercentageOfNodesToScore))
+	out.MaxNodesToScore = (*int32)(unsafe.Pointer(in.MaxNodesToScore))
 	if err := metav1.Convert_Pointer_int64_To_int64(&in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds, s); err != nil {
 		return err
 	}
@@ -447,6 +448,7 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1_KubeSchedulerConfigurat
 		return err
 	}
 	out.PercentageOfNodesToScore = (*int32)(unsafe.Pointer(in.PercentageOfNodesToScore))
+	out.MaxNodesToScore = (*int32)(unsafe.Pointer(in.MaxNodesToScore))
 	if err := metav1.Convert_int64_To_Pointer_int64(&in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds, s); err != nil {
 		return err
 	}

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -162,6 +162,11 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaxNodesToScore != nil {
+		in, out := &in.MaxNodesToScore, &out.MaxNodesToScore
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Profiles != nil {
 		in, out := &in.Profiles, &out.Profiles
 		*out = make([]KubeSchedulerProfile, len(*in))

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -686,6 +686,9 @@ func (sched *Scheduler) numFeasibleNodesToFind(percentageOfNodesToScore *int32, 
 	}
 
 	numNodes = numAllNodes * percentage / 100
+	if sched.maxNodesToScore != nil && numNodes > *sched.maxNodesToScore {
+		numNodes = *sched.maxNodesToScore
+	}
 	if numNodes < minFeasibleNodesToFind {
 		return minFeasibleNodesToFind
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -101,6 +101,7 @@ type Scheduler struct {
 	nodeInfoSnapshot *internalcache.Snapshot
 
 	percentageOfNodesToScore int32
+	maxNodesToScore          *int32
 
 	nextStartNodeIndex int
 
@@ -124,6 +125,7 @@ type schedulerOptions struct {
 	kubeConfig             *restclient.Config
 	// Overridden by profile level percentageOfNodesToScore if set in v1.
 	percentageOfNodesToScore          int32
+	maxNodesToScore                   *int32
 	podInitialBackoffSeconds          int64
 	podMaxBackoffSeconds              int64
 	podMaxInUnschedulablePodsDuration time.Duration
@@ -191,6 +193,16 @@ func WithPercentageOfNodesToScore(percentageOfNodesToScore *int32) Option {
 	return func(o *schedulerOptions) {
 		if percentageOfNodesToScore != nil {
 			o.percentageOfNodesToScore = *percentageOfNodesToScore
+		}
+	}
+}
+
+// WithMaxNodesToScore sets percentageOfNodesToScore for Scheduler.
+// It won't apply a limit if the value is empty.
+func WithMaxNodesToScore(maxNodesToScore *int32) Option {
+	return func(o *schedulerOptions) {
+		if maxNodesToScore != nil {
+			o.maxNodesToScore = maxNodesToScore
 		}
 	}
 }
@@ -403,6 +415,7 @@ func New(ctx context.Context,
 		client:                   client,
 		nodeInfoSnapshot:         snapshot,
 		percentageOfNodesToScore: options.percentageOfNodesToScore,
+		maxNodesToScore:          options.maxNodesToScore,
 		Extenders:                extenders,
 		StopEverything:           stopEverything,
 		SchedulingQueue:          podQueue,

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -67,6 +67,11 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored. It is overridden by profile level PercentageOfNodesToScore.
 	PercentageOfNodesToScore *int32 `json:"percentageOfNodesToScore,omitempty"`
 
+	// MaxNodesToScore is the maximum number of nodes to score, the scheduler will stop searching
+	// for more feasible nodes when this limit is reached. This configuration will override the
+	// computed number from PercentageOfNodesToScore.
+	MaxNodesToScore *int32 `json:"maxNodesToScore,omitempty"`
+
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 	// If specified, it must be greater than 0. If this value is null, the default value (1s)
 	// will be used.

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -182,6 +182,11 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaxNodesToScore != nil {
+		in, out := &in.MaxNodesToScore, &out.MaxNodesToScore
+		*out = new(int32)
+		**out = **in
+	}
 	if in.PodInitialBackoffSeconds != nil {
 		in, out := &in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds
 		*out = new(int64)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

This PR purposes adding a new field to kube-scheduler's component config named `maxNodesToScore`  so we can limit number of candidates to score if the computed number from `percentageOfNodesToScore` is still too high. This is needed because the `percentageOfNodesToScore` field is designed to be an integer hence the minimum it can reach is 1%. This new configuration is helpful when 1% is too high for supporting certain scheduler throughput.

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adding an optional config "maxNodesToScore" to kube-scheduler to limit the maximum nodes for scoring
```
