### PR TITLE
Inconsistency resets cache snapshots and prevents collection of new ones until cache is marked consistent again

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1140,6 +1140,10 @@ func (c *Cacher) Compact(resourceVersion string) error {
 	return nil
 }
 
+func (c *Cacher) MarkConsistent(consistent bool) {
+	c.watchCache.MarkConsistent(consistent)
+}
+
 // Stop implements the graceful termination.
 func (c *Cacher) Stop() {
 	c.stopLock.Lock()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -219,16 +219,15 @@ type dummyCacher struct {
 	dummyStorage
 	ready bool
 
-	lastCompactedResourceVersion string
+	consistent bool
 }
 
 func (d *dummyCacher) Ready() bool {
 	return d.ready
 }
 
-func (d *dummyCacher) Compact(resourceVersion string) error {
-	d.lastCompactedResourceVersion = resourceVersion
-	return nil
+func (d *dummyCacher) MarkConsistent(consistent bool) {
+	d.consistent = consistent
 }
 
 func TestShouldDelegateList(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -155,7 +156,8 @@ type watchCache struct {
 	waitingUntilFresh *progress.ConditionalProgressRequester
 
 	// Stores previous snapshots of orderedLister to allow serving requests from previous revisions.
-	snapshots Snapshotter
+	snapshots           Snapshotter
+	snapshottingEnabled atomic.Bool
 
 	getCurrentRV func(context.Context) (uint64, error)
 }
@@ -193,6 +195,7 @@ func newWatchCache(
 		getCurrentRV:        getCurrentRV,
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+		wc.snapshottingEnabled.Store(true)
 		wc.snapshots = newStoreSnapshotter()
 	}
 	metrics.WatchCacheCapacity.WithLabelValues(groupResource.Group, groupResource.Resource).Set(float64(wc.capacity))
@@ -327,7 +330,7 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		if err != nil {
 			return err
 		}
-		if w.snapshots != nil {
+		if w.snapshots != nil && w.snapshottingEnabled.Load() {
 			if orderedLister, ordered := w.store.(orderedLister); ordered {
 				if w.isCacheFullLocked() {
 					oldestRV := w.cache[w.startIndex%w.capacity].ResourceVersion
@@ -774,7 +777,7 @@ func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
 	}
 	if w.snapshots != nil {
 		w.snapshots.Reset()
-		if orderedLister, ordered := w.store.(orderedLister); ordered {
+		if orderedLister, ordered := w.store.(orderedLister); ordered && w.snapshottingEnabled.Load() {
 			w.snapshots.Add(version, orderedLister)
 		}
 	}
@@ -941,4 +944,13 @@ func (w *watchCache) Compact(rev uint64) {
 		return
 	}
 	w.snapshots.RemoveLess(rev)
+}
+
+func (w *watchCache) MarkConsistent(consistent bool) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+		w.snapshottingEnabled.Store(consistent)
+		if !consistent && w.snapshots != nil {
+			w.snapshots.Reset()
+		}
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
@@ -59,7 +59,7 @@ func NewKubernetesRecorder(client kubernetes.Interface) *KubernetesRecorder {
 }
 
 func (r *KubernetesRecorder) List(ctx context.Context, key string, opts kubernetes.ListOptions) (kubernetes.ListResponse, error) {
-	recorderKey, ok := ctx.Value(recorderContextKey).(string)
+	recorderKey, ok := ctx.Value(RecorderContextKey).(string)
 	if ok {
 		r.mux.Lock()
 		r.listsPerKey[recorderKey] = append(r.listsPerKey[recorderKey], RecordedList{Key: key, ListOptions: opts})
@@ -79,6 +79,6 @@ type RecordedList struct {
 	kubernetes.ListOptions
 }
 
-var recorderContextKey recorderKeyType
+var RecorderContextKey recorderKeyType
 
 type recorderKeyType struct{}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -1672,7 +1672,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 				Recursive:            true,
 			}
 			recorderKey := t.Name()
-			listCtx := context.WithValue(ctx, recorderContextKey, recorderKey)
+			listCtx := context.WithValue(ctx, RecorderContextKey, recorderKey)
 			err := store.GetList(listCtx, tt.prefix, storageOpts, out)
 			if tt.expectRVTooLarge {
 				if !storage.IsTooLargeResourceVersion(err) {


### PR DESCRIPTION
/kind feature

```release-note
NONE
```

Ref https://github.com/kubernetes/enhancements/issues/4988

/assign @jpbetz 
