### PR TITLE
kubelet: add memory commit metrics for node and container for windows

### DIFF
--- a/pkg/kubelet/metrics/collectors/resource_metrics.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics.go
@@ -41,6 +41,13 @@ var (
 		metrics.STABLE,
 		"")
 
+	nodeMemoryCommitDesc = metrics.NewDesc("node_memory_commit_bytes",
+		"Committed memory of the node in bytes. Reported only on Windows systems",
+		nil,
+		nil,
+		metrics.ALPHA,
+		"")
+
 	nodeSwapUsageDesc = metrics.NewDesc("node_swap_usage_bytes",
 		"Current swap usage of the node in bytes. Reported only on non-windows systems",
 		nil,
@@ -60,6 +67,13 @@ var (
 		[]string{"container", "pod", "namespace"},
 		nil,
 		metrics.STABLE,
+		"")
+
+	containerMemoryCommitDesc = metrics.NewDesc("container_memory_commit_bytes",
+		"Committed memory of the container in bytes. Reported only on Windows systems",
+		[]string{"container", "pod", "namespace"},
+		nil,
+		metrics.ALPHA,
 		"")
 
 	containerSwapUsageDesc = metrics.NewDesc("container_swap_usage_bytes",
@@ -88,6 +102,13 @@ var (
 		[]string{"pod", "namespace"},
 		nil,
 		metrics.STABLE,
+		"")
+
+	podMemoryCommitDesc = metrics.NewDesc("pod_memory_commit_bytes",
+		"Committed memory of the pod in bytes. Reported only on Windows systems",
+		[]string{"pod", "namespace"},
+		nil,
+		metrics.ALPHA,
 		"")
 
 	podSwapUsageDesc = metrics.NewDesc("pod_swap_usage_bytes",
@@ -139,14 +160,17 @@ var _ metrics.StableCollector = &resourceMetricsCollector{}
 func (rc *resourceMetricsCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 	ch <- nodeCPUUsageDesc
 	ch <- nodeMemoryUsageDesc
+	ch <- nodeMemoryCommitDesc
 	ch <- nodeSwapUsageDesc
 	ch <- containerStartTimeDesc
 	ch <- containerCPUUsageDesc
 	ch <- containerMemoryUsageDesc
+	ch <- containerMemoryCommitDesc
 	ch <- containerSwapUsageDesc
 	ch <- containerSwapLimitDesc
 	ch <- podCPUUsageDesc
 	ch <- podMemoryUsageDesc
+	ch <- podMemoryCommitDesc
 	ch <- podSwapUsageDesc
 	ch <- resourceScrapeResultDesc
 	ch <- resourceScrapeErrorResultDesc
@@ -172,6 +196,7 @@ func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- metrics.Metri
 
 	rc.collectNodeCPUMetrics(ch, statsSummary.Node)
 	rc.collectNodeMemoryMetrics(ch, statsSummary.Node)
+	rc.collectNodeMemoryCommitMetrics(ch, statsSummary.Node)
 	rc.collectNodeSwapMetrics(ch, statsSummary.Node)
 
 	for _, pod := range statsSummary.Pods {
@@ -179,10 +204,13 @@ func (rc *resourceMetricsCollector) CollectWithStability(ch chan<- metrics.Metri
 			rc.collectContainerStartTime(ch, pod, container)
 			rc.collectContainerCPUMetrics(ch, pod, container)
 			rc.collectContainerMemoryMetrics(ch, pod, container)
+			rc.collectContainerMemoryCommitMetrics(ch, pod, container)
 			rc.collectContainerSwapMetrics(ch, pod, container)
 		}
+
 		rc.collectPodCPUMetrics(ch, pod)
 		rc.collectPodMemoryMetrics(ch, pod)
+		rc.collectPodMemoryCommitMetrics(ch, pod)
 		rc.collectPodSwapMetrics(ch, pod)
 	}
 }
@@ -205,12 +233,21 @@ func (rc *resourceMetricsCollector) collectNodeMemoryMetrics(ch chan<- metrics.M
 		metrics.NewLazyConstMetric(nodeMemoryUsageDesc, metrics.GaugeValue, float64(*s.Memory.WorkingSetBytes)))
 }
 
+func (rc *resourceMetricsCollector) collectNodeMemoryCommitMetrics(ch chan<- metrics.Metric, s summary.NodeStats) {
+	if s.Memory == nil || s.Memory.UsageBytes == nil {
+		return
+	}
+
+	ch <- metrics.NewLazyMetricWithTimestamp(s.Memory.Time.Time,
+		metrics.NewLazyConstMetric(nodeMemoryCommitDesc, metrics.GaugeValue, float64(*s.Memory.UsageBytes)))
+}
+
 func (rc *resourceMetricsCollector) collectNodeSwapMetrics(ch chan<- metrics.Metric, s summary.NodeStats) {
 	if s.Swap == nil || s.Swap.SwapUsageBytes == nil {
 		return
 	}
 
-	ch <- metrics.NewLazyMetricWithTimestamp(s.Memory.Time.Time,
+	ch <- metrics.NewLazyMetricWithTimestamp(s.Swap.Time.Time,
 		metrics.NewLazyConstMetric(nodeSwapUsageDesc, metrics.GaugeValue, float64(*s.Swap.SwapUsageBytes)))
 }
 
@@ -240,6 +277,16 @@ func (rc *resourceMetricsCollector) collectContainerMemoryMetrics(ch chan<- metr
 	ch <- metrics.NewLazyMetricWithTimestamp(s.Memory.Time.Time,
 		metrics.NewLazyConstMetric(containerMemoryUsageDesc, metrics.GaugeValue,
 			float64(*s.Memory.WorkingSetBytes), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
+}
+
+func (rc *resourceMetricsCollector) collectContainerMemoryCommitMetrics(ch chan<- metrics.Metric, pod summary.PodStats, s summary.ContainerStats) {
+	if s.Memory == nil || s.Memory.UsageBytes == nil {
+		return
+	}
+
+	ch <- metrics.NewLazyMetricWithTimestamp(s.Memory.Time.Time,
+		metrics.NewLazyConstMetric(containerMemoryCommitDesc, metrics.GaugeValue,
+			float64(*s.Memory.UsageBytes), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
 }
 
 func (rc *resourceMetricsCollector) collectContainerSwapMetrics(ch chan<- metrics.Metric, pod summary.PodStats, s summary.ContainerStats) {
@@ -280,6 +327,16 @@ func (rc *resourceMetricsCollector) collectPodMemoryMetrics(ch chan<- metrics.Me
 	ch <- metrics.NewLazyMetricWithTimestamp(pod.Memory.Time.Time,
 		metrics.NewLazyConstMetric(podMemoryUsageDesc, metrics.GaugeValue,
 			float64(*pod.Memory.WorkingSetBytes), pod.PodRef.Name, pod.PodRef.Namespace))
+}
+
+func (rc *resourceMetricsCollector) collectPodMemoryCommitMetrics(ch chan<- metrics.Metric, pod summary.PodStats) {
+	if pod.Memory == nil || pod.Memory.AvailableBytes == nil {
+		return
+	}
+
+	ch <- metrics.NewLazyMetricWithTimestamp(pod.Memory.Time.Time,
+		metrics.NewLazyConstMetric(podMemoryCommitDesc, metrics.GaugeValue,
+			float64(*pod.Memory.AvailableBytes), pod.PodRef.Name, pod.PodRef.Namespace))
 }
 
 func (rc *resourceMetricsCollector) collectPodSwapMetrics(ch chan<- metrics.Metric, pod summary.PodStats) {

--- a/pkg/kubelet/metrics/collectors/resource_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics_test.go
@@ -39,6 +39,7 @@ func TestCollectResourceMetrics(t *testing.T) {
 		"resource_scrape_error",
 		"node_cpu_usage_seconds_total",
 		"node_memory_working_set_bytes",
+		"node_memory_commit_bytes",
 		"node_swap_usage_bytes",
 		"container_cpu_usage_seconds_total",
 		"container_memory_working_set_bytes",
@@ -80,6 +81,7 @@ func TestCollectResourceMetrics(t *testing.T) {
 					Memory: &statsapi.MemoryStats{
 						Time:            testTime,
 						WorkingSetBytes: ptr.To[uint64](1000),
+						UsageBytes:      ptr.To[uint64](2000),
 					},
 					Swap: &statsapi.SwapStats{
 						Time:           testTime,
@@ -95,6 +97,9 @@ func TestCollectResourceMetrics(t *testing.T) {
 				# HELP node_memory_working_set_bytes [STABLE] Current working set of the node in bytes
 				# TYPE node_memory_working_set_bytes gauge
 				node_memory_working_set_bytes 1000 1624396278302
+				# HELP node_memory_commit_bytes [ALPHA] Committed memory of the node in bytes. Reported only on Windows systems
+				# TYPE node_memory_commit_bytes gauge
+				node_memory_commit_bytes 2000 1624396278302
 				# HELP node_swap_usage_bytes [ALPHA] Current swap usage of the node in bytes. Reported only on non-windows systems
 				# TYPE node_swap_usage_bytes gauge
 				node_swap_usage_bytes 500 1624396278302
@@ -150,6 +155,7 @@ func TestCollectResourceMetrics(t *testing.T) {
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
 									WorkingSetBytes: ptr.To[uint64](1000),
+									UsageBytes:      ptr.To[uint64](2000),
 								},
 								Swap: &statsapi.SwapStats{
 									Time:               testTime,
@@ -187,6 +193,7 @@ func TestCollectResourceMetrics(t *testing.T) {
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
 									WorkingSetBytes: ptr.To[uint64](1000),
+									UsageBytes:      ptr.To[uint64](2000),
 								},
 							},
 						},
@@ -211,6 +218,10 @@ func TestCollectResourceMetrics(t *testing.T) {
 				container_memory_working_set_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 1000 1624396278302
 				container_memory_working_set_bytes{container="container_a",namespace="namespace_b",pod="pod_b"} 1000 1624396278302
 				container_memory_working_set_bytes{container="container_b",namespace="namespace_a",pod="pod_a"} 1000 1624396278302
+				# HELP container_memory_commit_bytes [ALPHA] Committed memory of the container in bytes. Reported only on Windows systems
+				# TYPE container_memory_commit_bytes gauge
+				container_memory_commit_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 2000 1624396278302
+				container_memory_commit_bytes{container="container_a",namespace="namespace_b",pod="pod_b"} 2000 1624396278302
 				# HELP container_start_time_seconds [STABLE] Start time of the container since unix epoch in seconds
 				# TYPE container_start_time_seconds gauge
 				container_start_time_seconds{container="container_a",namespace="namespace_a",pod="pod_a"} 1.6243962483020916e+09
@@ -244,6 +255,7 @@ func TestCollectResourceMetrics(t *testing.T) {
 								Memory: &statsapi.MemoryStats{
 									Time:            testTime,
 									WorkingSetBytes: ptr.To[uint64](1000),
+									UsageBytes:      ptr.To[uint64](2000),
 								},
 							},
 						},
@@ -264,6 +276,9 @@ func TestCollectResourceMetrics(t *testing.T) {
 				# HELP container_memory_working_set_bytes [STABLE] Current working set of the container in bytes
 				# TYPE container_memory_working_set_bytes gauge
 				container_memory_working_set_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 1000 1624396278302
+				# HELP container_memory_commit_bytes [ALPHA] Committed memory of the container in bytes. Reported only on Windows systems
+				# TYPE container_memory_commit_bytes gauge
+				container_memory_commit_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 2000 1624396278302
 			`,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/sig windows

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds support for memory commit metrics collection in the kubelet resource metrics collector

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #112111

#### Special notes for your reviewer:
On Windows systems, commit memory represents the real memory usage and provides more accurate resource monitoring compared to working set memory. The commit charge indicates the amount of virtual memory that has been allocated and for which physical storage (either RAM or page file) has been reserved. This metric is crucial for:

- Understanding actual memory consumption on Windows nodes
- Proper resource planning and capacity management
- Detecting memory pressure and allocation patterns
- Providing customers with accurate memory usage visibility

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Kubelet now exposes memory commit metrics (node_memory_commit_bytes, container_memory_commit_bytes, pod_memory_commit_bytes) in the /metrics/resource endpoint. These metrics provide committed memory usage information, particularly useful for Windows nodes where commit charge represents actual memory consumption.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
