### PR TITLE
proxy: node-manager ignores timeouts to get NodeIPs

### DIFF
--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -82,6 +82,10 @@ func TestNewNodeManager(t *testing.T) {
 	}{
 		{
 			name: "node object doesn't exist",
+		},
+		{
+			name:          "watchPodCIDRs and node object doesn't exist",
+			watchPodCIDRs: true,
 			// assert on error thrown by node lister
 			expectedError: "node \"test-node\" not found",
 		},
@@ -97,8 +101,6 @@ func TestNewNodeManager(t *testing.T) {
 					_, _ = client.CoreV1().Nodes().Create(ctx, makeNode(), metav1.CreateOptions{})
 				},
 			},
-			// assert on error thrown by GetNodeHostIPs()
-			expectedError: "host IP unknown; known addresses: []",
 		},
 		{
 			name: "node object exist with NodeIP",
@@ -122,7 +124,7 @@ func TestNewNodeManager(t *testing.T) {
 			expectedNodeIPs: []net.IP{netutils.ParseIPSloppy("192.168.1.10")},
 		},
 		{
-			name:          "watchPodCIDRs and node object exist without PodCIDRs",
+			name:          "watchPodCIDRs and node object exist with NodeIP and without PodCIDRs",
 			watchPodCIDRs: true,
 			nodeUpdates: []func(ctx context.Context, client clientset.Interface){
 				func(ctx context.Context, client clientset.Interface) {
@@ -192,8 +194,7 @@ func TestNewNodeManager(t *testing.T) {
 					), metav1.UpdateOptions{})
 				},
 			},
-			// assert on error thrown by GetNodeHostIPs()
-			expectedError: "host IP unknown; known addresses: []",
+			expectedPodCIDRs: []string{"10.0.0.0/24"},
 		},
 	}
 
@@ -245,10 +246,9 @@ func TestNodeManagerOnNodeChange(t *testing.T) {
 			expectedExitCode: nil,
 		},
 		{
-			name:             "node updated with different NodeIPs",
-			initialNodeIPs:   []string{"192.168.1.1", "fd00:1:2:3::1"},
-			updatedNodeIPs:   []string{"10.0.1.1", "fd00:3:2:1::2"},
-			expectedExitCode: ptr.To(1),
+			name:           "node updated with different NodeIPs",
+			initialNodeIPs: []string{"192.168.1.1", "fd00:1:2:3::1"},
+			updatedNodeIPs: []string{"10.0.1.1", "fd00:3:2:1::2"},
 		},
 		{
 			name:             "watchPodCIDR and node updated with same PodCIDRs",


### PR DESCRIPTION
Kube-proxy NodeManager does not consider timeouts to fetch NodeIPs as fatal.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is a followup of https://github.com/kubernetes/kubernetes/pull/130837 
With this change, kube-proxy would not consider timeouts on getting the NodeIPs from Node objects fatal.
(ref: https://github.com/kubernetes/kubernetes/pull/130837)
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
