### PR TITLE
Configure JSON content type for generic webhook RESTClient.

### DIFF
--- a/cmd/kubelet/app/auth_test.go
+++ b/cmd/kubelet/app/auth_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	authenticationv1client "k8s.io/client-go/kubernetes/typed/authentication/v1"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/rest"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+)
+
+func TestAuthzWebhookRequestEncoding(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		ContentType             string
+		ExpectContentType       string
+		ExpectRequestBodyPrefix []byte
+	}{
+		{
+			name:                    "json",
+			ContentType:             "application/json",
+			ExpectContentType:       "application/json",
+			ExpectRequestBodyPrefix: []byte(`{`),
+		},
+		{
+			name:                    "empty",
+			ContentType:             "",
+			ExpectContentType:       "application/json",
+			ExpectRequestBodyPrefix: []byte(`{`),
+		},
+		{
+			name:                    "protobuf",
+			ContentType:             "application/vnd.kubernetes.protobuf",
+			ExpectContentType:       "application/vnd.kubernetes.protobuf",
+			ExpectRequestBodyPrefix: []byte("\x6b\x38\x73\x00"), // k8s protobuf magic number
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handlerInvoked := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(handlerInvoked)
+
+				if got := r.Header.Get("Content-Type"); got != tc.ExpectContentType {
+					t.Errorf("unexpected Content-Type: got %q, want %q", got, tc.ExpectContentType)
+				}
+
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+				if !bytes.HasPrefix(body, tc.ExpectRequestBodyPrefix) {
+					t.Errorf("request body should have prefix %q, but got %q", tc.ExpectRequestBodyPrefix, body)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte(`{"kind":"SubjectAccessReview","apiVersion":"authorization.k8s.io/v1","status":{"allowed":true}}`)); err != nil {
+					t.Fatalf("unexpected response write failure: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			cfg := &rest.Config{
+				Host: server.URL,
+				ContentConfig: rest.ContentConfig{
+					ContentType: tc.ContentType,
+				},
+			}
+
+			authzClient, err := authorizationv1client.NewForConfigAndClient(cfg, server.Client())
+			if err != nil {
+				t.Fatalf("failed to create authorization client: %v", err)
+			}
+
+			authz, err := BuildAuthz(authzClient, kubeletconfig.KubeletAuthorization{Mode: kubeletconfig.KubeletAuthorizationModeWebhook})
+			if err != nil {
+				t.Fatalf("failed to build authorizer: %v", err)
+			}
+
+			if _, _, err := authz.Authorize(context.Background(), &authorizer.AttributesRecord{}); err != nil {
+				t.Fatalf("Authorize failed: %v", err)
+			}
+
+			select {
+			case <-handlerInvoked:
+			default:
+				t.Fatal("webhook handler not invoked")
+			}
+		})
+	}
+}
+
+func TestAuthnWebhookRequestEncoding(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		ContentType             string
+		ExpectContentType       string
+		ExpectRequestBodyPrefix []byte
+	}{
+		{
+			name:                    "json",
+			ContentType:             "application/json",
+			ExpectContentType:       "application/json",
+			ExpectRequestBodyPrefix: []byte(`{`),
+		},
+		{
+			name:                    "empty",
+			ContentType:             "",
+			ExpectContentType:       "application/json",
+			ExpectRequestBodyPrefix: []byte(`{`),
+		},
+		{
+			name:                    "protobuf",
+			ContentType:             "application/vnd.kubernetes.protobuf",
+			ExpectContentType:       "application/vnd.kubernetes.protobuf",
+			ExpectRequestBodyPrefix: []byte("\x6b\x38\x73\x00"), // k8s protobuf magic number
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handlerInvoked := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(handlerInvoked)
+
+				if got := r.Header.Get("Content-Type"); got != tc.ExpectContentType {
+					t.Errorf("unexpected Content-Type: got %q, want %q", got, tc.ExpectContentType)
+				}
+
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+				if !bytes.HasPrefix(body, tc.ExpectRequestBodyPrefix) {
+					t.Errorf("request body should have prefix %q, but got %q", tc.ExpectRequestBodyPrefix, body)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte(`{"kind":"TokenReview","apiVersion":"authentication.k8s.io/v1","status":{"authenticated":true}}`)); err != nil {
+					t.Fatalf("unexpected response write failure: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			cfg := &rest.Config{
+				Host: server.URL,
+				ContentConfig: rest.ContentConfig{
+					ContentType: tc.ContentType,
+				},
+			}
+
+			authnClient, err := authenticationv1client.NewForConfigAndClient(cfg, server.Client())
+			if err != nil {
+				t.Fatalf("failed to create authentication client: %v", err)
+			}
+
+			authn, _, err := BuildAuthn(authnClient, kubeletconfig.KubeletAuthentication{
+				Webhook: kubeletconfig.KubeletWebhookAuthentication{
+					Enabled: true,
+				},
+			})
+			if err != nil {
+				t.Fatalf("failed to build authenticator: %v", err)
+			}
+
+			request, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, "/fooz", nil)
+			if err != nil {
+				t.Fatalf("failed to build test request: %v", err)
+			}
+			request.Header.Set("Authorization", "Bearer foo")
+
+			if _, _, err := authn.AuthenticateRequest(request); err != nil {
+				t.Fatalf("AuthenticateToken failed: %v", err)
+			}
+
+			select {
+			case <-handlerInvoked:
+			default:
+				t.Fatal("webhook handler not invoked")
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
@@ -83,6 +83,7 @@ func NewGenericWebhook(scheme *runtime.Scheme, codecFactory serializer.CodecFact
 	clientConfig := rest.CopyConfig(config)
 
 	codec := codecFactory.LegacyCodec(groupVersions...)
+	clientConfig.ContentType = runtime.ContentTypeJSON
 	clientConfig.ContentConfig.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})
 
 	clientConfig.Wrap(x509metrics.NewDeprecatedCertificateRoundTripperWrapperConstructor(

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -33,11 +34,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+	exampleinstall "k8s.io/apiserver/pkg/apis/example/install"
+	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -926,4 +931,58 @@ func getSingleCounterValueFromRegistry(t *testing.T, r metrics.Gatherer, name st
 	}
 
 	return -1
+}
+
+func TestRESTConfigContentType(t *testing.T) {
+	server, err := newTestServer(clientCert, clientKey, caCert, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != runtime.ContentTypeJSON {
+			t.Errorf("expected request content-type: want %q got %q", runtime.ContentTypeJSON, got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			return
+		}
+		if err := json.Unmarshal(body, new(any)); err != nil {
+			switch {
+			case len(body) == 0:
+				t.Log("empty request body")
+			case utf8.Valid(body):
+				t.Logf("request body: %s", string(body))
+			default:
+				t.Logf("request body: 0x%x", body)
+			}
+			t.Errorf("failed to unmarshal request body as json: %v", err)
+		}
+	})
+	if err != nil {
+		t.Errorf("failed to create server: %v", err)
+		return
+	}
+	defer server.Close()
+
+	config := &rest.Config{
+		ContentConfig: rest.ContentConfig{
+			ContentType: "foo/bar",
+		},
+		Host: server.URL,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData:   caCert,
+			CertData: clientCert,
+			KeyData:  clientKey,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	exampleinstall.Install(scheme)
+	codecs := serializer.NewCodecFactory(scheme)
+	groupVersions := []schema.GroupVersion{examplev1.SchemeGroupVersion}
+	wh, err := NewGenericWebhook(scheme, codecs, config, groupVersions, retryBackoff)
+	if err != nil {
+		t.Fatalf("failed to create the webhook: %v", err)
+	}
+
+	if err := wh.RestClient.Post().Body(&examplev1.Pod{}).Do(context.TODO()).Error(); err != nil {
+		t.Fatalf("failed to complete request: %v", err)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

- restclients used to call webhooks are configured with a LegacyCodec (always encodes to json) here: 
https://github.com/kubernetes/kubernetes/blob/f2bed63ca55d24b48fbc3446a5d6e043aa35f138/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go#L86
- when encoding a runtime.object to a request body, the encoder is selected here https://github.com/kubernetes/kubernetes/blob/f2bed63ca55d24b48fbc3446a5d6e043aa35f138/staging/src/k8s.io/client-go/rest/request.go#L525. webhook clients select the legacycodec due to a special case for SerializerInfo with empty MediaType: https://github.com/kubernetes/kubernetes/blob/f2bed63ca55d24b48fbc3446a5d6e043aa35f138/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go#L272
- there's no indication to the callsite in `request.go` that encoder selection ignored the requested media type argument, and the Content-Type request header is set to the requested media type argument: https://github.com/kubernetes/kubernetes/blob/f2bed63ca55d24b48fbc3446a5d6e043aa35f138/staging/src/k8s.io/client-go/rest/request.go#L537
- if the rest config is set up to use a content type other than "application/json", webhook request bodies are encoded to JSON but the media type in the Content-Type request header will not match. a webhook server that understands Content-Type and does negotiation will not be able to decode the request body

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

AFAICT all REST configs used to construct these clients are loaded from kubeconfig files, so the only way to reproduce it is by enabling a client-go feature gate that affects the default when no content type is configured (at least for in-tree uses of `k8s.io/apiserver/pkg/util/webhook`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that caused apiservers to send an inappropriate Content-Type request header to authorization, token authentication, imagepolicy admission, and audit webhooks when the alpha client-go feature gate "ClientsPreferCBOR" is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
