### PR TITLE
Deprecate apiserver_storage_objects and replace it with apiserver_resource_objects metric using labels consistent with other metrics

### DIFF
--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -414,6 +414,7 @@
   help: Number of stored objects at the time of last check split by kind. In case
     of a fetching error, the value will be -1.
   type: Gauge
+  deprecatedVersion: 1.34.0
   stabilityLevel: STABLE
   labels:
   - resource


### PR DESCRIPTION
/kind feature

```release-note
Deprecate apiserver_storage_objects and replace it with apiserver_resource_objects metric using labels consistent with other metrics
```
/assign @dgrisonnet 

Name is complementary to https://github.com/kubernetes/kubernetes/pull/132893

Fixes https://github.com/kubernetes/kubernetes/issues/131796
