### PR TITLE
Add PodCPUAndMemoryStats to stats.Provider interface

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -341,6 +341,7 @@ func newTestKubeletWithImageList(
 		fakeRuntime,
 		kubelet.statusManager,
 		fakeHostStatsProvider,
+		kubelet.containerManager,
 	)
 	fakeImageGCPolicy := images.ImageGCPolicy{
 		HighThresholdPercent: 90,

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -23,6 +23,7 @@ import (
 
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ import (
 	kubelettypes "k8s.io/kubelet/pkg/types"
 	"k8s.io/kubernetes/pkg/features"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
+	cmtesting "k8s.io/kubernetes/pkg/kubelet/cm/testing"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
@@ -273,7 +275,7 @@ func TestCadvisorListPodStats(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, mockRuntime, mockStatus, NewFakeHostStatsProvider(&containertest.FakeOS{}))
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, mockRuntime, mockStatus, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	pods, err := p.ListPodStats(ctx)
 	assert.NoError(t, err)
 
@@ -365,6 +367,99 @@ func TestCadvisorListPodStats(t *testing.T) {
 	checkSwapStats(t, "Pod3Container1", seedPod3Container1, infos["/pod3-c1"], con.Swap)
 	checkIOStats(t, "Pod3Container1", seedPod3Container1, infos["/pod3-c1"], con.IO)
 	checkContainersSwapStats(t, ps, infos["/pod3-c1"])
+}
+
+func TestCadvisorPodCPUAndMemoryStats(t *testing.T) {
+	ctx := context.Background()
+	const (
+		namespace = "test0"
+		podName   = "pod0"
+		podUID    = "abcdef-pod0-uid"
+		cName0    = "c0"
+		cName1    = "c1"
+
+		seedPod0           = 500
+		seedPod0Infra      = 1000
+		seedPod0Container0 = 2000
+		seedPod0Container1 = 2001
+	)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			UID:       podUID,
+		},
+	}
+	infos := map[string]cadvisorapiv2.ContainerInfo{
+		"/pods/pod0":    getTestContainerInfo(seedPod0, podName, namespace, ""),
+		"/pods/pod0-i":  getTestContainerInfo(seedPod0Infra, podName, namespace, ""),
+		"/pods/pod0-c0": getTestContainerInfo(seedPod0Container0, podName, namespace, cName0),
+		"/pods/pod0-c1": getTestContainerInfo(seedPod0Container1, podName, namespace, cName1),
+	}
+
+	// memory limit overrides for each container (used to test available bytes if a memory limit is known)
+	memoryLimitOverrides := map[string]uint64{
+		"/pods/pod0-c0": uint64(1 << 15),
+	}
+	for name, memoryLimitOverride := range memoryLimitOverrides {
+		info, found := infos[name]
+		if !found {
+			t.Errorf("No container defined with name %v", name)
+		}
+		info.Spec.Memory.Limit = memoryLimitOverride
+		infos[name] = info
+	}
+
+	mockCadvisor := cadvisortest.NewMockInterface(t)
+	mockCadvisor.EXPECT().ContainerInfoV2("/pods/pod0", mock.Anything).Return(infos, nil)
+
+	mockPCM := cmtesting.NewMockPodContainerManager(t)
+	mockPCM.EXPECT().GetPodContainerName(pod).Return(nil, "/pods/pod0")
+	mockCM := cmtesting.NewMockContainerManager(t)
+	mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+
+	p := NewCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, nil, nil, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), mockCM)
+
+	ps, err := p.PodCPUAndMemoryStats(ctx, pod, nil)
+	require.NoError(t, err)
+	assert.Equal(t, podName, ps.PodRef.Name)
+	assert.Equal(t, namespace, ps.PodRef.Namespace)
+	assert.Equal(t, podUID, ps.PodRef.UID)
+
+	assert.Equal(t, testTime(creationTime, seedPod0).Unix(), ps.StartTime.Unix(), "ps.StartTime")
+	checkCPUStats(t, "Pod0", seedPod0, ps.CPU)
+	checkMemoryStats(t, "Pod0", seedPod0, infos["/pods/pod0"], ps.Memory)
+	assert.Nil(t, ps.Swap)
+	assert.Nil(t, ps.EphemeralStorage)
+	assert.Nil(t, ps.VolumeStats)
+	assert.Nil(t, ps.Network)
+
+	assert.Len(t, ps.Containers, 2)
+	indexCon := make(map[string]statsapi.ContainerStats, len(ps.Containers))
+	for _, con := range ps.Containers {
+		indexCon[con.Name] = con
+	}
+	con := indexCon[cName0]
+	assert.Equal(t, testTime(creationTime, seedPod0Container0).Unix(), con.StartTime.Unix())
+	checkCPUStats(t, "Pod0Container0", seedPod0Container0, con.CPU)
+	checkMemoryStats(t, "Pod0Conainer0", seedPod0Container0, infos["/pods/pod0-c0"], con.Memory)
+	checkSwapStats(t, "Pod0Conainer0", seedPod0Container0, infos["/pods/pod0-c0"], con.Swap)
+	assert.Nil(t, con.Rootfs)
+	assert.Nil(t, con.Logs)
+	assert.Nil(t, con.Accelerators)
+	assert.Nil(t, con.UserDefinedMetrics)
+	assert.Nil(t, con.IO)
+
+	con = indexCon[cName1]
+	assert.Equal(t, testTime(creationTime, seedPod0Container1).Unix(), con.StartTime.Unix())
+	checkCPUStats(t, "Pod0Container1", seedPod0Container1, con.CPU)
+	checkMemoryStats(t, "Pod0Container1", seedPod0Container1, infos["/pods/pod0-c1"], con.Memory)
+	checkSwapStats(t, "Pod0Container1", seedPod0Container1, infos["/pods/pod0-c1"], con.Swap)
+	assert.Nil(t, con.Rootfs)
+	assert.Nil(t, con.Logs)
+	assert.Nil(t, con.Accelerators)
+	assert.Nil(t, con.UserDefinedMetrics)
+	assert.Nil(t, con.IO)
 }
 
 func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
@@ -459,7 +554,7 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	pods, err := p.ListPodCPUAndMemoryStats(ctx)
 	assert.NoError(t, err)
 
@@ -563,7 +658,7 @@ func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageStats(ctx).Return(imageStats, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	stats, _, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -644,7 +739,7 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 			mockCadvisor.EXPECT().ContainerFsInfo(ctx).Return(res, nil)
 		}
 
-		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
+		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 		stats, containerfs, err := provider.ImageFsStats(ctx)
 		if tc.shouldErr {
 			require.Error(t, err, desc)
@@ -681,7 +776,7 @@ func TestCadvisorImagesFsStats(t *testing.T) {
 	mockCadvisor.EXPECT().ImagesFsInfo(ctx).Return(imageFsInfo, nil)
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -735,7 +830,7 @@ func TestCadvisorSplitImagesFsStats(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	assert.NoError(err)
 
@@ -788,7 +883,7 @@ func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
 	mockRuntime.EXPECT().ImageFsInfo(ctx).Return(imageFsInfoResponse, nil)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)
 
-	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}))
+	provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider(&containertest.FakeOS{}), nil)
 	stats, containerfs, err := provider.ImageFsStats(ctx)
 	require.NoError(t, err, "imageFsStats should have no error")
 
@@ -899,7 +994,7 @@ func TestCadvisorListPodStatsWhenContainerLogFound(t *testing.T) {
 
 	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
 
-	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, mockRuntime, mockStatus, NewFakeHostStatsProviderWithData(fakeStats, fakeOS))
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, mockRuntime, mockStatus, NewFakeHostStatsProviderWithData(fakeStats, fakeOS), nil)
 	pods, err := p.ListPodStats(ctx)
 	assert.NoError(t, err)
 

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -42,7 +43,9 @@ import (
 	kubetypes "k8s.io/kubelet/pkg/types"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 )
@@ -78,6 +81,12 @@ type criStatsProvider struct {
 	windowsNetworkStatsProvider interface{} //nolint:unused // U1000 We can't import hcsshim due to Build constraints in hcsshim
 	// clock is used report current time
 	clock clock.Clock
+	// fallbackStatsProvider is used to fill in missing information incase the CRI
+	// provides insufficient data.
+	// TODO: A lot of the cadvisorStatsProvider logic is duplicated in this file, and should be read
+	//       from the fallbackStatsProvider instead.
+	// Remove this once the CRI stats migration is complete.
+	fallbackStatsProvider containerStatsProvider
 
 	// cpuUsageCache caches the cpu usage for containers.
 	cpuUsageCache               map[string]*cpuUsageRecord
@@ -94,6 +103,7 @@ func newCRIStatsProvider(
 	imageService internalapi.ImageManagerService,
 	hostStatsProvider HostStatsProvider,
 	podAndContainerStatsFromCRI bool,
+	fallbackStatsProvider containerStatsProvider,
 ) containerStatsProvider {
 	return &criStatsProvider{
 		cadvisor:                    cadvisor,
@@ -104,6 +114,7 @@ func newCRIStatsProvider(
 		cpuUsageCache:               make(map[string]*cpuUsageRecord),
 		podAndContainerStatsFromCRI: podAndContainerStatsFromCRI,
 		clock:                       clock.RealClock{},
+		fallbackStatsProvider:       fallbackStatsProvider,
 	}
 }
 
@@ -272,6 +283,97 @@ func (p *criStatsProvider) listPodStatsStrictlyFromCRI(ctx context.Context, upda
 	return summarySandboxStats, nil
 }
 
+func (p *criStatsProvider) PodCPUAndMemoryStats(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) (*statsapi.PodStats, error) {
+	if len(podStatus.SandboxStatuses) == 0 {
+		return nil, fmt.Errorf("missing sandbox for pod %s", format.Pod(pod))
+	}
+	podSandbox := podStatus.SandboxStatuses[0]
+	ps := &statsapi.PodStats{
+		PodRef: statsapi.PodReference{
+			Name:      podSandbox.Metadata.Name,
+			UID:       podSandbox.Metadata.Uid,
+			Namespace: podSandbox.Metadata.Namespace,
+		},
+		// The StartTime in the summary API is the pod creation time.
+		StartTime: metav1.NewTime(time.Unix(0, podSandbox.CreatedAt)),
+	}
+	if p.podAndContainerStatsFromCRI {
+		criSandboxStats, err := p.runtimeService.PodSandboxStats(ctx, podSandbox.Id)
+		if err != nil {
+			// Call failed, why?
+			s, ok := status.FromError(err)
+			// Legitimate failure, rather than the CRI implementation does not support PodSandboxStats.
+			if !ok || s.Code() != codes.Unimplemented {
+				return nil, err
+			}
+			// CRI implementation doesn't support PodSandboxStats, warn and fallback.
+			klog.ErrorS(err,
+				"CRI implementation must be updated to support PodSandboxStats if PodAndContainerStatsFromCRI feature gate is enabled. Falling back to populating with cAdvisor; this call will fail in the future.",
+			)
+		} else {
+			addCRIPodCPUStats(ps, criSandboxStats)
+			addCRIPodMemoryStats(ps, criSandboxStats)
+		}
+	}
+
+	resp, err := p.runtimeService.ListContainerStats(ctx, &runtimeapi.ContainerStatsFilter{
+		PodSandboxId: podSandbox.Id,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list container stats from pod %s (sandbox %s): %w", format.Pod(pod), podSandbox.Id, err)
+	}
+
+	// Fallback if ListContainerStats doesn't return any results.
+	useFallback := ps.CPU == nil || ps.Memory == nil || len(resp) == 0
+	for _, stats := range resp {
+		containerStatus := podStatus.FindContainerStatusByName(stats.Attributes.Metadata.Name)
+		if containerStatus == nil {
+			klog.V(4).InfoS("Received stats for unknown container", "pod", klog.KObj(pod), "container", stats.Attributes.Metadata)
+			continue
+		}
+
+		// Fill available CPU and memory stats for full set of required pod stats
+		cs := p.makeContainerCPUAndMemoryStats(stats, containerStatus.CreatedAt, false)
+		useFallback = useFallback || cs.CPU == nil || cs.Memory == nil
+		ps.Containers = append(ps.Containers, *cs)
+	}
+
+	if useFallback {
+		fallbackStats, err := p.fallbackStatsProvider.PodCPUAndMemoryStats(ctx, pod, podStatus)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch stats for pod %s from fallback provider: %w", format.Pod(pod), err)
+		}
+		if ps.CPU == nil {
+			ps.CPU = fallbackStats.CPU
+		}
+		if ps.Memory == nil {
+			ps.Memory = fallbackStats.Memory
+		}
+
+		for _, fb := range fallbackStats.Containers {
+			var container *statsapi.ContainerStats
+			for i, cs := range ps.Containers {
+				if fb.Name == cs.Name {
+					container = &ps.Containers[i]
+					break
+				}
+			}
+			if container != nil {
+				if container.CPU == nil {
+					container.CPU = fb.CPU
+				}
+				if container.Memory == nil {
+					container.Memory = fb.Memory
+				}
+			} else {
+				ps.Containers = append(ps.Containers, fb)
+			}
+		}
+	}
+
+	return ps, nil
+}
+
 // ListPodCPUAndMemoryStats returns the CPU and Memory stats of all the pod-managed containers.
 func (p *criStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]statsapi.PodStats, error) {
 	// sandboxIDToPodStats is a temporary map from sandbox ID to its pod stats.
@@ -343,7 +445,7 @@ func (p *criStatsProvider) ListPodCPUAndMemoryStats(ctx context.Context) ([]stat
 		}
 
 		// Fill available CPU and memory stats for full set of required pod stats
-		cs := p.makeContainerCPUAndMemoryStats(stats, container)
+		cs := p.makeContainerCPUAndMemoryStats(stats, time.Unix(0, container.CreatedAt), true)
 		p.addPodCPUMemoryStats(ps, types.UID(podSandbox.Metadata.Uid), allInfos, cs)
 		p.addSwapStats(ps, types.UID(podSandbox.Metadata.Uid), allInfos, cs)
 
@@ -668,10 +770,18 @@ func (p *criStatsProvider) makeContainerStats(
 		if stats.Memory.WorkingSetBytes != nil {
 			result.Memory.WorkingSetBytes = &stats.Memory.WorkingSetBytes.Value
 		}
+		if stats.Memory.UsageBytes != nil {
+			result.Memory.UsageBytes = &stats.Memory.UsageBytes.Value
+		}
+		if stats.Memory.RssBytes != nil {
+			result.Memory.RSSBytes = &stats.Memory.RssBytes.Value
+		}
 		result.Memory.PSI = makePSIStats(stats.Memory.Psi)
 	} else {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
 		result.Memory.WorkingSetBytes = ptr.To[uint64](0)
+		result.Memory.UsageBytes = ptr.To[uint64](0)
+		result.Memory.RSSBytes = ptr.To[uint64](0)
 	}
 	if stats.Swap != nil {
 		result.Swap.Time = metav1.NewTime(time.Unix(0, stats.Swap.Timestamp))
@@ -738,54 +848,71 @@ func (p *criStatsProvider) makeContainerStats(
 
 func (p *criStatsProvider) makeContainerCPUAndMemoryStats(
 	stats *runtimeapi.ContainerStats,
-	container *runtimeapi.Container,
+	startTime time.Time,
+	zeroMissingValues bool, // whether to write zeros to missing values
 ) *statsapi.ContainerStats {
 	result := &statsapi.ContainerStats{
 		Name: stats.Attributes.Metadata.Name,
 		// The StartTime in the summary API is the container creation time.
-		StartTime: metav1.NewTime(time.Unix(0, container.CreatedAt)),
-		CPU:       &statsapi.CPUStats{},
-		Memory:    &statsapi.MemoryStats{},
-		Swap: &statsapi.SwapStats{
+		StartTime: metav1.NewTime(startTime),
+		// UserDefinedMetrics is not supported by CRI.
+	}
+	getUint64 := func(val *runtimeapi.UInt64Value) *uint64 {
+		if val != nil {
+			return &val.Value
+		} else if zeroMissingValues {
+			return ptr.To[uint64](0)
+		} else {
+			return nil
+		}
+	}
+	if stats.Cpu != nil {
+		result.CPU = &statsapi.CPUStats{
+			Time:                 metav1.NewTime(time.Unix(0, stats.Cpu.Timestamp)),
+			UsageNanoCores:       p.getContainerUsageNanoCores(stats),
+			UsageCoreNanoSeconds: getUint64(stats.Cpu.UsageCoreNanoSeconds),
+			PSI:                  makePSIStats(stats.Cpu.Psi),
+		}
+	} else if zeroMissingValues {
+		result.CPU = &statsapi.CPUStats{
+			Time:                 metav1.NewTime(time.Unix(0, time.Now().UnixNano())),
+			UsageCoreNanoSeconds: ptr.To[uint64](0),
+			UsageNanoCores:       ptr.To[uint64](0),
+		}
+	}
+	if stats.Memory != nil {
+		result.Memory = &statsapi.MemoryStats{
+			Time:            metav1.NewTime(time.Unix(0, stats.Memory.Timestamp)),
+			AvailableBytes:  getUint64(stats.Memory.AvailableBytes),
+			UsageBytes:      getUint64(stats.Memory.UsageBytes),
+			WorkingSetBytes: getUint64(stats.Memory.WorkingSetBytes),
+			RSSBytes:        getUint64(stats.Memory.RssBytes),
+			PageFaults:      getUint64(stats.Memory.PageFaults),
+			MajorPageFaults: getUint64(stats.Memory.MajorPageFaults),
+			PSI:             makePSIStats(stats.Memory.Psi),
+		}
+	} else if zeroMissingValues {
+		result.Memory = &statsapi.MemoryStats{
+			Time:            metav1.NewTime(time.Unix(0, time.Now().UnixNano())),
+			AvailableBytes:  ptr.To[uint64](0),
+			UsageBytes:      ptr.To[uint64](0),
+			WorkingSetBytes: ptr.To[uint64](0),
+			RSSBytes:        ptr.To[uint64](0),
+			PageFaults:      ptr.To[uint64](0),
+			MajorPageFaults: ptr.To[uint64](0),
+		}
+	}
+	if stats.Swap != nil {
+		result.Swap = &statsapi.SwapStats{
+			Time:               metav1.NewTime(time.Unix(0, stats.Swap.Timestamp)),
+			SwapUsageBytes:     getUint64(stats.Swap.SwapUsageBytes),
+			SwapAvailableBytes: getUint64(stats.Swap.SwapAvailableBytes),
+		}
+	} else if zeroMissingValues {
+		result.Swap = &statsapi.SwapStats{
 			Time:               metav1.NewTime(time.Unix(0, time.Now().UnixNano())),
 			SwapUsageBytes:     ptr.To[uint64](0),
 			SwapAvailableBytes: ptr.To[uint64](0),
-		},
-		// UserDefinedMetrics is not supported by CRI.
-	}
-	if stats.Cpu != nil {
-		result.CPU.Time = metav1.NewTime(time.Unix(0, stats.Cpu.Timestamp))
-		if stats.Cpu.UsageCoreNanoSeconds != nil {
-			result.CPU.UsageCoreNanoSeconds = &stats.Cpu.UsageCoreNanoSeconds.Value
-		}
-
-		usageNanoCores := p.getContainerUsageNanoCores(stats)
-		if usageNanoCores != nil {
-			result.CPU.UsageNanoCores = usageNanoCores
-		}
-		result.CPU.PSI = makePSIStats(stats.Cpu.Psi)
-	} else {
-		result.CPU.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.CPU.UsageCoreNanoSeconds = ptr.To[uint64](0)
-		result.CPU.UsageNanoCores = ptr.To[uint64](0)
-	}
-	if stats.Memory != nil {
-		result.Memory.Time = metav1.NewTime(time.Unix(0, stats.Memory.Timestamp))
-		if stats.Memory.WorkingSetBytes != nil {
-			result.Memory.WorkingSetBytes = &stats.Memory.WorkingSetBytes.Value
-		}
-		result.Memory.PSI = makePSIStats(stats.Memory.Psi)
-	} else {
-		result.Memory.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
-		result.Memory.WorkingSetBytes = ptr.To[uint64](0)
-	}
-	if stats.Swap != nil {
-		result.Swap.Time = metav1.NewTime(time.Unix(0, stats.Swap.Timestamp))
-		if stats.Swap.SwapUsageBytes != nil {
-			result.Swap.SwapUsageBytes = &stats.Swap.SwapUsageBytes.Value
-		}
-		if stats.Swap.SwapAvailableBytes != nil {
-			result.Swap.SwapAvailableBytes = &stats.Swap.SwapAvailableBytes.Value
 		}
 	}
 

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -30,6 +30,8 @@ import (
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,11 +45,13 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
 	kubepodtest "k8s.io/kubernetes/pkg/kubelet/pod/testing"
 	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -241,6 +245,7 @@ func TestCRIListPodStats(t *testing.T) {
 		fakeImageService,
 		NewFakeHostStatsProviderWithData(fakeStats, fakeOS),
 		false,
+		fakeContainerStatsProvider{},
 	)
 
 	stats, err := provider.ListPodStats(ctx)
@@ -475,6 +480,7 @@ func TestListPodStatsStrictlyFromCRI(t *testing.T) {
 		fakeImageService,
 		NewFakeHostStatsProviderWithData(fakeStats, fakeOS),
 		true,
+		fakeContainerStatsProvider{},
 	)
 
 	cadvisorInfos, err := getCadvisorContainerInfo(mockCadvisor)
@@ -652,6 +658,7 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 		nil,
 		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
 		false,
+		fakeContainerStatsProvider{},
 	)
 
 	stats, err := provider.ListPodCPUAndMemoryStats(ctx)
@@ -757,6 +764,107 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 	assert.Equal(containerStats9.Memory.Timestamp, p6.Memory.Time.UnixNano())
 }
 
+func TestCRIPodCPUAndMemoryStats(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		podName      = "test-pod"
+		podNamespace = "test-ns"
+		podUID       = types.UID(podName + "-uid")
+	)
+	var (
+		sandbox0        = makeFakePodSandbox(podName, string(podUID), podNamespace, false)
+		sandbox1        = makeFakePodSandbox(podName, string(podUID), podNamespace, true)
+		container0      = makeFakeContainer(sandbox0, cName0, 0, false)
+		containerStats0 = makeFakeContainerStatsStrictlyFromCRI(seedContainer0, container0, "")
+		container1      = makeFakeContainer(sandbox0, cName1, 0, false)
+		containerStats1 = makeFakeContainerStatsStrictlyFromCRI(seedContainer1, container1, "")
+	)
+
+	var (
+		mockCadvisor               = cadvisortest.NewMockInterface(t)
+		mockPodManager             = new(kubepodtest.MockManager)
+		resourceAnalyzer           = new(fakeResourceAnalyzer)
+		fakeRuntimeService         = critest.NewFakeRuntimeService()
+		fakeContainerStatsProvider = fakeContainerStatsProvider{
+			podStats: ptr.To(getPodSandboxStatsStrictlyFromCRI(seedSandbox0, sandbox0)),
+		}
+	)
+
+	fakeRuntimeService.SetFakeSandboxes([]*critest.FakePodSandbox{
+		sandbox0,
+	})
+	fakeRuntimeService.SetFakeContainers([]*critest.FakeContainer{
+		container0, container1,
+	})
+	fakeRuntimeService.SetFakeContainerStats([]*runtimeapi.ContainerStats{
+		containerStats0, containerStats1,
+	})
+
+	provider := NewCRIStatsProvider(
+		mockCadvisor,
+		resourceAnalyzer,
+		mockPodManager,
+		fakeRuntimeService,
+		nil,
+		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
+		false,
+		fakeContainerStatsProvider,
+	)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			UID:       podUID,
+		},
+	}
+	podStatus := &kubecontainer.PodStatus{
+		ID:              podUID,
+		Name:            podName,
+		Namespace:       podNamespace,
+		SandboxStatuses: []*runtimeapi.PodSandboxStatus{&sandbox0.PodSandboxStatus, &sandbox1.PodSandboxStatus},
+		ContainerStatuses: []*kubecontainer.Status{
+			{Name: cName0, CreatedAt: time.Unix(0, container0.CreatedAt)},
+			{Name: cName1, CreatedAt: time.Unix(0, container1.CreatedAt)},
+		},
+	}
+
+	stats, err := provider.PodCPUAndMemoryStats(ctx, pod, podStatus)
+	assert := assert.New(t)
+	require.NoError(t, err)
+
+	assert.Equal(sandbox0.CreatedAt, stats.StartTime.UnixNano())
+	assert.Len(stats.Containers, 2)
+	assert.Nil(stats.EphemeralStorage)
+	assert.Nil(stats.VolumeStats)
+	assert.Nil(stats.Network)
+	assert.Nil(stats.IO)
+	checkCRIPodCPUAndMemoryStatsStrictlyFromCRI(assert, *stats, getPodSandboxStatsStrictlyFromCRI(seedSandbox0, sandbox0))
+
+	containerStatsMap := make(map[string]statsapi.ContainerStats)
+	for _, s := range stats.Containers {
+		containerStatsMap[s.Name] = s
+	}
+
+	c0 := containerStatsMap[cName0]
+	assert.Equal(container0.CreatedAt, c0.StartTime.UnixNano())
+	checkCRICPUAndMemoryStatsForStrictlyFromCRI(assert, c0, getCRIContainerStatsStrictlyFromCRI(seedContainer0, cName0))
+	assert.Nil(c0.Rootfs)
+	assert.Nil(c0.Logs)
+	assert.Nil(c0.Accelerators)
+	assert.Nil(c0.UserDefinedMetrics)
+	assert.Nil(c0.IO)
+	c1 := containerStatsMap[cName1]
+	assert.Equal(container1.CreatedAt, c1.StartTime.UnixNano())
+	checkCRICPUAndMemoryStatsForStrictlyFromCRI(assert, c1, getCRIContainerStatsStrictlyFromCRI(seedContainer1, cName1))
+	assert.Nil(c1.Rootfs)
+	assert.Nil(c1.Logs)
+	assert.Nil(c1.Accelerators)
+	assert.Nil(c1.UserDefinedMetrics)
+	assert.Nil(c1.IO)
+}
+
 func TestCRIImagesFsStats(t *testing.T) {
 	ctx := context.Background()
 	var (
@@ -785,6 +893,7 @@ func TestCRIImagesFsStats(t *testing.T) {
 		fakeImageService,
 		NewFakeHostStatsProvider(&kubecontainertest.FakeOS{}),
 		false,
+		fakeContainerStatsProvider{},
 	)
 
 	stats, containerStats, err := provider.ImageFsStats(ctx)
@@ -910,6 +1019,8 @@ func makeFakeContainerStatsStrictlyFromCRI(seed int, container *critest.FakeCont
 		containerStats.Memory = &runtimeapi.MemoryUsage{
 			Timestamp:       timestamp.UnixNano(),
 			WorkingSetBytes: &runtimeapi.UInt64Value{Value: uint64(seed + offsetCRI + offsetMemWorkingSetBytes)},
+			UsageBytes:      &runtimeapi.UInt64Value{Value: uint64(seed + offsetCRI + offsetMemUsageBytes)},
+			RssBytes:        &runtimeapi.UInt64Value{Value: uint64(seed + offsetCRI + offsetMemRSSBytes)},
 			Psi:             getCRITestPSIStats(seed),
 		}
 		containerStats.Io = &runtimeapi.IoUsage{
@@ -942,6 +1053,8 @@ func makeFakePodSandboxStatsStrictlyFromCRI(seed int, podSandbox *critest.FakePo
 		podSandboxStats.Linux.Memory = &runtimeapi.MemoryUsage{
 			Timestamp:       timestamp.UnixNano(),
 			WorkingSetBytes: &runtimeapi.UInt64Value{Value: uint64(seed + offsetCRI + offsetMemWorkingSetBytes)},
+			UsageBytes:      &runtimeapi.UInt64Value{Value: uint64(seed + offsetCRI + offsetMemUsageBytes)},
+			RssBytes:        &runtimeapi.UInt64Value{Value: uint64(seed + offsetCRI + offsetMemRSSBytes)},
 			Psi:             getCRITestPSIStats(seed),
 		}
 		podSandboxStats.Linux.Io = &runtimeapi.IoUsage{
@@ -985,7 +1098,6 @@ func getPodSandboxStatsStrictlyFromCRI(seed int, podSandbox *critest.FakePodSand
 		podStats.IO = nil
 	} else {
 		usageCoreNanoSeconds := uint64(seed + offsetCRI + offsetCPUUsageCoreSeconds)
-		workingSetBytes := uint64(seed + offsetCRI + offsetMemWorkingSetBytes)
 		podStats.CPU = &statsapi.CPUStats{
 			Time:                 metav1.NewTime(timestamp),
 			UsageCoreNanoSeconds: &usageCoreNanoSeconds,
@@ -993,7 +1105,9 @@ func getPodSandboxStatsStrictlyFromCRI(seed int, podSandbox *critest.FakePodSand
 		}
 		podStats.Memory = &statsapi.MemoryStats{
 			Time:            metav1.NewTime(timestamp),
-			WorkingSetBytes: &workingSetBytes,
+			WorkingSetBytes: ptr.To(uint64(seed + offsetCRI + offsetMemWorkingSetBytes)),
+			UsageBytes:      ptr.To(uint64(seed + offsetCRI + offsetMemUsageBytes)),
+			RSSBytes:        ptr.To(uint64(seed + offsetCRI + offsetMemRSSBytes)),
 			PSI:             cadvisorPSIToStatsPSI(&psi),
 		}
 		podStats.IO = &statsapi.IOStats{
@@ -1067,6 +1181,8 @@ func checkCRICPUAndMemoryStatsForStrictlyFromCRI(assert *assert.Assertions, actu
 	assert.Equal(expected.CPU.Time.UnixNano(), actual.CPU.Time.UnixNano())
 	assert.Equal(*expected.CPU.UsageCoreNanoSeconds, *actual.CPU.UsageCoreNanoSeconds)
 	assert.Equal(*expected.Memory.WorkingSetBytes, *actual.Memory.WorkingSetBytes)
+	assert.Equal(*expected.Memory.UsageBytes, *actual.Memory.UsageBytes)
+	assert.Equal(*expected.Memory.RSSBytes, *actual.Memory.RSSBytes)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
 		checkCRIPSIStatsStrictlyFromCRI(assert, expected.CPU.PSI, actual.CPU.PSI)
@@ -1456,8 +1572,9 @@ func getCRIContainerStatsStrictlyFromCRI(seed int, containerName string) statsap
 	result.CPU.PSI = cadvisorPSIToStatsPSI(&psi)
 
 	result.Memory.Time = metav1.NewTime(timestamp)
-	workingSetBytes := uint64(seed + offsetCRI + offsetMemWorkingSetBytes)
-	result.Memory.WorkingSetBytes = &workingSetBytes
+	result.Memory.WorkingSetBytes = ptr.To(uint64(seed + offsetCRI + offsetMemWorkingSetBytes))
+	result.Memory.UsageBytes = ptr.To(uint64(seed + offsetCRI + offsetMemUsageBytes))
+	result.Memory.RSSBytes = ptr.To(uint64(seed + offsetCRI + offsetMemRSSBytes))
 	result.Memory.PSI = cadvisorPSIToStatsPSI(&psi)
 
 	result.IO.Time = metav1.NewTime(timestamp)

--- a/pkg/kubelet/stats/provider_test.go
+++ b/pkg/kubelet/stats/provider_test.go
@@ -30,12 +30,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/randfill"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/features"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubepodtest "k8s.io/kubernetes/pkg/kubelet/pod/testing"
 	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/volume"
@@ -627,6 +629,7 @@ type fakeContainerStatsProvider struct {
 	device      string
 	imageFs     *statsapi.FsStats
 	containerFs *statsapi.FsStats
+	podStats    *statsapi.PodStats
 }
 
 func (p fakeContainerStatsProvider) ListPodStats(context.Context) ([]statsapi.PodStats, error) {
@@ -635,6 +638,13 @@ func (p fakeContainerStatsProvider) ListPodStats(context.Context) ([]statsapi.Po
 
 func (p fakeContainerStatsProvider) ListPodStatsAndUpdateCPUNanoCoreUsage(context.Context) ([]statsapi.PodStats, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+func (p fakeContainerStatsProvider) PodCPUAndMemoryStats(context.Context, *v1.Pod, *kubecontainer.PodStatus) (*statsapi.PodStats, error) {
+	if p.podStats != nil {
+		return p.podStats, nil
+	}
+	return nil, fmt.Errorf("no podStats set")
 }
 
 func (p fakeContainerStatsProvider) ListPodCPUAndMemoryStats(context.Context) ([]statsapi.PodStats, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new method `PodCPUAndMemoryStats` to the `stats.Provider` interface for fetching the CPU & memory stats for a single pod.

When decreasing memory limits on containers in-place, we want to put in some best-effort protections to prevent oom-kill, so we will check current pod & container memory usage before resizing when the memory limit is decreasing. This PR lays the groundwork for this by adding a method for fetching the pod's memory usage from the stats provider.

#### Which issue(s) this PR is related to:

For https://github.com/kubernetes/kubernetes/issues/129152

#### Special notes for your reviewer:

In addition to the unit tests, I also tested these changes manually by adding handlers to expose these methods through the Kubelet server, and manually checking values against the cgroups. See https://github.com/tallclair/kubernetes/commit/e694f2d6d0306f68cd2569823e05af023c76fcba

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-soon
/milestone v1.34

/assign @roycaihw @haircommander 
/cc @natasha41575 