### PR TITLE
chore: residual intptr removal with ptr.To

### DIFF
--- a/pkg/registry/apps/statefulset/strategy_test.go
+++ b/pkg/registry/apps/statefulset/strategy_test.go
@@ -359,10 +359,6 @@ func makeStatefulSetWithMaxUnavailable(maxUnavailable *int) *apps.StatefulSet {
 	}
 }
 
-func getMaxUnavailable(maxUnavailable int) *int {
-	return &maxUnavailable
-}
-
 func createOrdinalsWithStart(start int) *apps.StatefulSetOrdinals {
 	return &apps.StatefulSetOrdinals{
 		Start: int32(start),
@@ -431,30 +427,30 @@ func TestDropStatefulSetDisabledFields(t *testing.T) {
 		{
 			name:                 "MaxUnavailable not enabled, field used in new, not in old",
 			enableMaxUnavailable: false,
-			ss:                   makeStatefulSetWithMaxUnavailable(getMaxUnavailable(3)),
+			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(3)),
 			oldSS:                nil,
 			expectedSS:           makeStatefulSetWithMaxUnavailable(nil),
 		},
 		{
 			name:                 "MaxUnavailable not enabled, field used in old and new",
 			enableMaxUnavailable: false,
-			ss:                   makeStatefulSetWithMaxUnavailable(getMaxUnavailable(3)),
-			oldSS:                makeStatefulSetWithMaxUnavailable(getMaxUnavailable(3)),
-			expectedSS:           makeStatefulSetWithMaxUnavailable(getMaxUnavailable(3)),
+			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(3)),
+			oldSS:                makeStatefulSetWithMaxUnavailable(ptr.To(3)),
+			expectedSS:           makeStatefulSetWithMaxUnavailable(ptr.To(3)),
 		},
 		{
 			name:                 "MaxUnavailable enabled, field used in new only",
 			enableMaxUnavailable: true,
-			ss:                   makeStatefulSetWithMaxUnavailable(getMaxUnavailable(3)),
+			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(3)),
 			oldSS:                nil,
-			expectedSS:           makeStatefulSetWithMaxUnavailable(getMaxUnavailable(3)),
+			expectedSS:           makeStatefulSetWithMaxUnavailable(ptr.To(3)),
 		},
 		{
 			name:                 "MaxUnavailable enabled, field used in both old and new",
 			enableMaxUnavailable: true,
-			ss:                   makeStatefulSetWithMaxUnavailable(getMaxUnavailable(1)),
-			oldSS:                makeStatefulSetWithMaxUnavailable(getMaxUnavailable(3)),
-			expectedSS:           makeStatefulSetWithMaxUnavailable(getMaxUnavailable(1)),
+			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(1)),
+			oldSS:                makeStatefulSetWithMaxUnavailable(ptr.To(3)),
+			expectedSS:           makeStatefulSetWithMaxUnavailable(ptr.To(1)),
 		},
 		{
 			name:       "set ordinals, ordinals in use in new only",

--- a/staging/src/k8s.io/apimachinery/pkg/util/dump/dump_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/dump/dump_test.go
@@ -23,10 +23,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func ptrint(i int) *int {
-	return &i
-}
-
 // custom type to test Stringer interface on non-pointer receiver.
 type customString string
 
@@ -99,7 +95,7 @@ func TestPretty(t *testing.T) {
 		{uint32(93), "(uint32) 93\n"},
 		{uint64(93), "(uint64) 93\n"},
 		{uintptr(93), "(uintptr) 0x5d\n"},
-		{ptrint(93), "(*int)(93)\n"},
+		{ptr.To(93), "(*int)(93)\n"},
 		{float32(93.76), "(float32) 93.76\n"},
 		{float64(93.76), "(float64) 93.76\n"},
 		{complex64(93i), "(complex64) (0+93i)\n"},
@@ -178,7 +174,7 @@ func TestForHash(t *testing.T) {
 		{uint32(93), "(uint32)93"},
 		{uint64(93), "(uint64)93"},
 		{uintptr(93), "(uintptr)0x5d"},
-		{ptrint(93), "(*int)93"},
+		{ptr.To(93), "(*int)93"},
 		{float32(93.76), "(float32)93.76"},
 		{float64(93.76), "(float64)93.76"},
 		{complex64(93i), "(complex64)(0+93i)"},
@@ -257,7 +253,7 @@ func TestOneLine(t *testing.T) {
 		{uint32(93), "(uint32)93"},
 		{uint64(93), "(uint64)93"},
 		{uintptr(93), "(uintptr)0x5d"},
-		{ptrint(93), "(*int)93"},
+		{ptr.To(93), "(*int)93"},
 		{float32(93.76), "(float32)93.76"},
 		{float64(93.76), "(float64)93.76"},
 		{complex64(93i), "(complex64)(0+93i)"},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/priority backlog

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE