### PR TITLE
test: add batch pod deletion for kubelet e2e tests

### DIFF
--- a/test/e2e/framework/pod/delete.go
+++ b/test/e2e/framework/pod/delete.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -54,6 +55,21 @@ func DeletePodWithWait(ctx context.Context, c clientset.Interface, pod *v1.Pod) 
 		return nil
 	}
 	return DeletePodWithWaitByName(ctx, c, pod.GetName(), pod.GetNamespace())
+}
+
+// DeletePodsWithWait deletes the passed-in pods, waits for them to be terminated, and reports any deletion errors that occur.
+func DeletePodsWithWait(ctx context.Context, c clientset.Interface, pods []*v1.Pod) {
+	var delErrs []error
+	for _, testPod := range pods {
+		delErr := c.CoreV1().Pods(testPod.Namespace).Delete(ctx, testPod.Name, metav1.DeleteOptions{})
+		if delErr != nil && !apierrors.IsNotFound(delErr) {
+			delErrs = append(delErrs, delErr)
+		}
+	}
+	framework.ExpectNoError(errors.NewAggregate(delErrs), "while deleting pods")
+	for _, testPod := range pods {
+		framework.ExpectNoError(WaitForPodNotFoundInNamespace(ctx, c, testPod.Name, testPod.Namespace, PodDeleteTimeout))
+	}
 }
 
 // DeletePodWithWaitByName deletes the named and namespaced pod and waits for the pod to be terminated. Resilient to the pod

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -409,10 +409,7 @@ var _ = SIGDescribe("kubelet", func() {
 			})
 
 			ginkgo.AfterEach(func(ctx context.Context) {
-				err := e2epod.DeletePodWithWait(ctx, c, pod)
-				framework.ExpectNoError(err, "AfterEach: Failed to delete client pod ", pod.Name)
-				err = e2epod.DeletePodWithWait(ctx, c, nfsServerPod)
-				framework.ExpectNoError(err, "AfterEach: Failed to delete server pod ", nfsServerPod.Name)
+				e2epod.DeletePodsWithWait(ctx, c, []*v1.Pod{pod, nfsServerPod})
 			})
 
 			// execute It blocks from above table of tests


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node
/sig tests
/priority backlog

#### What this PR does / why we need it:

e2e test simplicity and speedup purpose

#### Which issue(s) this PR is related to:

[Clean up e2e pods in parallel #132974](https://github.com/kubernetes/kubernetes/issues/132974)

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
