### PR TITLE
fix docs: resizePolicy not allowed for ephemeral containers

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4819,7 +4819,7 @@ type EphemeralContainerCommon struct {
 	// already allocated to the pod.
 	// +optional
 	Resources ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"`
-	// Resources resize policy for the container.
+	// ResizePolicy is not allowed for ephemeral containers.
 	// +featureGate=InPlacePodVerticalScaling
 	// +optional
 	// +listType=atomic

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4819,6 +4819,7 @@ type EphemeralContainerCommon struct {
 	// already allocated to the pod.
 	// +optional
 	Resources ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"`
+	// Resources resize policy for the container.
 	// ResizePolicy is not allowed for ephemeral containers.
 	// +featureGate=InPlacePodVerticalScaling
 	// +optional


### PR DESCRIPTION
```release-note
  Fixed documentation to clarify that resizePolicy cannot be applied to ephemeral containers

 **What type of PR is this?**
  /kind documentation

  **What this PR does / why we need it:**
  This PR clarifies in the API documentation that `resizePolicy` cannot be applied to ephemeral containers,
  aligning with the existing restriction that ephemeral containers cannot have resource requests or limits.

  **Which issue(s) this PR fixes:**
  Fixes #128384

  **Special notes for your reviewer:**
  The change is made in the source file `types.go` rather than the generated file. The swagger documentation will
  be updated when the code generation runs.

  **Does this PR introduce a user-facing change?**
  NONE

 /sig api-machinery

  /priority backlog

  /release-note-none

  /assign @jpbetz