### PR TITLE
fix: use openjdk:8-jre to replace deprecated java image

### DIFF
--- a/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
         - name: workdir
           mountPath: "/work-dir"
       - name: bootstrap
-        image: java:openjdk-8-jre
+        image: openjdk:8-jre
         command:
         - "/work-dir/peer-finder"
         args:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig app
/sig tests

#### What this PR does / why we need it:

Remove deprecated image to resolve buggy e2e test

#### Which issue(s) this PR is related to:

[StatefulSet zookeeper test fails due to deprecated image: java:openjdk-8-jre not found #132984](https://github.com/kubernetes/kubernetes/issues/132984)

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
