### PR TITLE
fix: cleaner garbage collect Approved CSRs that were not issued after 24h

### DIFF
--- a/pkg/controller/certificates/cleaner/cleaner_test.go
+++ b/pkg/controller/certificates/cleaner/cleaner_test.go
@@ -90,6 +90,30 @@ func TestCleanerWithApprovedExpiredCSR(t *testing.T) {
 			[]string{},
 		},
 		{
+			"delete approved passed 24h deadline but not issued",
+			metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			nil,
+			[]capi.CertificateSigningRequestCondition{
+				{
+					Type:           capi.CertificateApproved,
+					LastUpdateTime: metav1.NewTime(time.Now().Add(-25 * time.Hour)),
+				},
+			},
+			[]string{"delete"},
+		},
+		{
+			"no delete approved less than 24h deadline but not issued",
+			metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			nil,
+			[]capi.CertificateSigningRequestCondition{
+				{
+					Type:           capi.CertificateApproved,
+					LastUpdateTime: metav1.NewTime(time.Now().Add(-23 * time.Hour)),
+				},
+			},
+			[]string{},
+		},
+		{
 			"delete approved passed deadline",
 			metav1.NewTime(time.Now().Add(-1 * time.Minute)),
 			[]byte(unexpiredCert),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a new garbage collection condition to the CSR cleaner controller:
> Clean up CSRs that are in `Approved` state but have not been issued a certificate after 24 hours.

In some cluster setups (such as when using external CAs like HashiCorp Vault), CSRs may be auto-approved but never issued a certificate. These CSRs accumulate over time without cleanup.  
This change prevents etcd bloat from such orphaned CSRs by applying garbage collection after 24 hours, consistent with how `Pending` CSRs are handled.


#### Which issue(s) this PR is related to:
Fixes: https://github.com/kubernetes/kubernetes/issues/132947
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The related issue has not been triaged yet, but I opened this PR because the problem is clearly reproducible and the proposed fix is minor, isolated, and safe.  
If the change is deemed unnecessary or should follow a different path, feel free to close this PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The CSR cleaner controller now removes CSRs that are `Approved` but have not been issued a certificate after 24 hours.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
