### PR TITLE
Add unit tests to cover kubectl auth command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/auth_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/auth_test.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+func TestNewCmdAuth_Help(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	streams := genericiooptions.IOStreams{
+		In:     bytes.NewReader(nil),
+		Out:    &outBuf,
+		ErrOut: &errBuf,
+	}
+
+	cmd := NewCmdAuth(nil, streams)
+
+	// 🔧 Tell Cobra to print help to these buffers
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Cobra may print to ErrOut or Out depending on context
+	helpText := outBuf.String() + errBuf.String()
+
+	if !strings.Contains(helpText, "Inspect authorization") {
+		t.Errorf("Expected help output to contain 'Inspect authorization', got:\n%s", helpText)
+	}
+}
+
+
+func TestNewCmdAuth_SubcommandsRegistered(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	streams := genericiooptions.IOStreams{
+		In:     bytes.NewReader(nil),
+		Out:    &outBuf,
+		ErrOut: &errBuf,
+	}
+	cmd := NewCmdAuth(nil, streams)
+
+	expected := []string{"can-i", "reconcile", "whoami"}
+	found := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		found[sub.Name()] = true
+	}
+
+	for _, name := range expected {
+		if !found[name] {
+			t.Errorf("Expected subcommand '%s' to be registered", name)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/sig cli
/kind cleanup
/area kubectl

#### What this PR does / why we need it:

Adds unit test coverage for the `kubectl auth` command, specifically the `NewCmdAuth()` function which wires together the `can-i`, `reconcile`, and `whoami` subcommands.

Prior to this PR, the core command file `auth.go` had 0% test coverage. This change introduces a test that validates:
- The correct structure of the root `auth` command
- Cobra help output behavior

After this PR, the `auth.go` file achieves **100% coverage**, improving the robustness of the CLI.

#### Which issue(s) this PR is related to:

Part of #1760

#### Special notes for your reviewer:

- This follows the structure of other `kubectl` command tests
- Used `IOStreams` injection to capture CLI help output
- Verified coverage using `make test KUBE_COVER=y`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
