### PR TITLE
[FG:InPlacePodVerticalScaling] Support reducing memory limits

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -26880,12 +26880,12 @@ func TestValidatePodResize(t *testing.T) {
 			test: "no restart policy: memory limit decrease",
 			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", "")),
 			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", "")),
-			err:  "memory limits cannot be decreased",
+			err:  "",
 		}, {
 			test: "restart NotRequired: memory limit decrease",
 			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", ""), resizePolicy("memory", core.NotRequired)),
 			new:  mkPod(core.ResourceList{}, getResources("100m", "100Mi", "", ""), resizePolicy("memory", core.NotRequired)),
-			err:  "memory limits cannot be decreased",
+			err:  "",
 		}, {
 			test: "RestartContainer: memory limit decrease",
 			old:  mkPod(core.ResourceList{}, getResources("100m", "200Mi", "", ""), resizePolicy("memory", core.RestartContainer)),
@@ -27104,19 +27104,9 @@ func TestValidatePodResize(t *testing.T) {
 			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways),
 			err:  "",
 		}, {
-			test: "memory limit decrease for sidecar containers, no resize policy",
+			test: "memory limit decrease for sidecar containers",
 			old:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways),
 			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "100Mi", "", ""), core.ContainerRestartPolicyAlways),
-			err:  "memory limits cannot be decreased",
-		}, {
-			test: "memory limit decrease for sidecar containers, resize policy NotRequired",
-			old:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.NotRequired)),
-			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "100Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.NotRequired)),
-			err:  "memory limits cannot be decreased",
-		}, {
-			test: "memory limit decrease for sidecar containers, resize policy RestartContainer",
-			old:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "200Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.RestartContainer)),
-			new:  mkPodWithInitContainers(core.ResourceList{}, getResources("100m", "100Mi", "", ""), core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.RestartContainer)),
 			err:  "",
 		}, {
 			test: "storage limit change for sidecar containers",

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	sc "k8s.io/kubernetes/pkg/securitycontext"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
@@ -69,6 +70,9 @@ type RuntimeHelper interface {
 
 	// SetPodWatchCondition flags a pod to be inspected until the condition is met.
 	SetPodWatchCondition(types.UID, string, func(*PodStatus) bool)
+
+	// PodCPUAndMemoryStats reads the latest CPU & memory usage stats.
+	PodCPUAndMemoryStats(context.Context, *v1.Pod, *PodStatus) (*statsapi.PodStats, error)
 }
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1446,6 +1446,11 @@ func (kl *Kubelet) ListPodCPUAndMemoryStats(ctx context.Context) ([]statsapi.Pod
 	return kl.StatsProvider.ListPodCPUAndMemoryStats(ctx)
 }
 
+// PodCPUAndMemoryStats is delegated to StatsProvider
+func (kl *Kubelet) PodCPUAndMemoryStats(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) (*statsapi.PodStats, error) {
+	return kl.StatsProvider.PodCPUAndMemoryStats(ctx, pod, podStatus)
+}
+
 // ListPodStatsAndUpdateCPUNanoCoreUsage is delegated to StatsProvider, which implements stats.Provider interface
 func (kl *Kubelet) ListPodStatsAndUpdateCPUNanoCoreUsage(ctx context.Context) ([]statsapi.PodStats, error) {
 	return kl.StatsProvider.ListPodStatsAndUpdateCPUNanoCoreUsage(ctx)

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -212,6 +212,21 @@ func doPodResizeTests(f *framework.Framework) {
 			},
 		},
 		{
+			name: "Burstable QoS pod with memory requests + limits - decrease memory limit",
+			containers: []podresize.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &cgroups.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
+				},
+			},
+			expected: []podresize.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &cgroups.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: reducedMemLimit},
+				},
+			},
+		},
+		{
 			name: "Burstable QoS pod, one container with cpu & memory requests + limits - decrease CPU requests only",
 			containers: []podresize.ResizableContainerInfo{
 				{
@@ -1207,22 +1222,6 @@ func doPodResizeErrorTests(f *framework.Framework) {
 				},
 			},
 			patchError: "spec.containers[0].name: Forbidden: containers may not be renamed or reordered on resize, spec.containers[1].name: Forbidden: containers may not be renamed or reordered on resize",
-		},
-		{
-			name: "Burstable QoS pod with memory requests + limits - decrease memory limit",
-			containers: []podresize.ResizableContainerInfo{
-				{
-					Name:      "c1",
-					Resources: &cgroups.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: originalMemLimit},
-				},
-			},
-			attemptResize: []podresize.ResizableContainerInfo{
-				{
-					Name:      "c1",
-					Resources: &cgroups.ContainerResources{CPUReq: originalCPU, CPULim: originalCPULimit, MemReq: originalMem, MemLim: reducedMemLimit},
-				},
-			},
-			patchError: "memory limits cannot be decreased",
 		},
 	}
 

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -19,6 +19,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -1271,6 +1272,127 @@ func doPodResizeErrorTests(f *framework.Framework) {
 	}
 }
 
+func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
+	// Tests the behavior when decreasing memory limit:
+	// 1. Decrease the limit a little bit - should succeed
+	// 2. Decrease the limit down to a tiny amount - should fail
+	// 3. Revert the limit back to the original value - should succeed
+	ginkgo.It("decrease memory limit below usage", func(ctx context.Context) {
+		podClient := e2epod.NewPodClient(f)
+		var testPod *v1.Pod
+		var pErr error
+
+		original := []podresize.ResizableContainerInfo{{
+			Name:      "c1",
+			Resources: &cgroups.ContainerResources{MemReq: originalMem, MemLim: originalMem},
+		}}
+
+		tStamp := strconv.Itoa(time.Now().Nanosecond())
+		testPod = podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod", tStamp, original)
+		testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+		ginkgo.By("creating pod")
+		testPod = podClient.CreateSync(ctx, testPod)
+
+		ginkgo.By("verifying initial pod resources are as expected")
+		podresize.VerifyPodResources(testPod, original)
+		ginkgo.By("verifying initial pod resize policy is as expected")
+		podresize.VerifyPodResizePolicy(testPod, original)
+
+		ginkgo.By("verifying initial pod status resources are as expected")
+		framework.ExpectNoError(podresize.VerifyPodStatusResources(testPod, original))
+		ginkgo.By("verifying initial cgroup config are as expected")
+		framework.ExpectNoError(podresize.VerifyPodContainersCgroupValues(ctx, f, testPod, original))
+
+		// 1. Decrease the limit a little bit - should succeed
+		ginkgo.By("Patching pod with a slightly lowered memory limit")
+		viableLoweredLimit := []podresize.ResizableContainerInfo{{
+			Name:      "c1",
+			Resources: &cgroups.ContainerResources{MemReq: reducedMem, MemLim: reducedMem},
+		}}
+		patch := podresize.MakeResizePatch(original, viableLoweredLimit)
+		testPod, pErr = f.ClientSet.CoreV1().Pods(testPod.Namespace).Patch(ctx, testPod.Name,
+			types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
+		framework.ExpectNoError(pErr, "failed to patch pod for viable lowered limit")
+
+		ginkgo.By("verifying pod patched for viable lowered limit")
+		podresize.VerifyPodResources(testPod, viableLoweredLimit)
+
+		ginkgo.By("waiting for viable lowered limit to be actuated")
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, viableLoweredLimit)
+		podresize.ExpectPodResized(ctx, f, resizedPod, viableLoweredLimit)
+
+		// 2. Decrease the limit down to a tiny amount - should fail
+		const nonViableMemoryLimit = "10Ki"
+		ginkgo.By("Patching pod with a greatly lowered memory limit")
+		nonViableLoweredLimit := []podresize.ResizableContainerInfo{{
+			Name:      "c1",
+			Resources: &cgroups.ContainerResources{MemReq: nonViableMemoryLimit, MemLim: nonViableMemoryLimit},
+		}}
+		patch = podresize.MakeResizePatch(viableLoweredLimit, nonViableLoweredLimit)
+		testPod, pErr = f.ClientSet.CoreV1().Pods(testPod.Namespace).Patch(ctx, testPod.Name,
+			types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
+		framework.ExpectNoError(pErr, "failed to patch pod for viable lowered limit")
+
+		framework.ExpectNoError(framework.Gomega().
+			Eventually(ctx, framework.RetryNotFound(framework.GetObject(f.ClientSet.CoreV1().Pods(testPod.Namespace).Get, testPod.Name, metav1.GetOptions{}))).
+			WithTimeout(f.Timeouts.PodStart).
+			Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+				// If VerifyPodStatusResources succeeds, it means the resize completed.
+				if podresize.VerifyPodStatusResources(pod, nonViableLoweredLimit) == nil {
+					return nil, fmt.Errorf("non-viable resize unexpectedly completed")
+				}
+
+				var inProgressCondition *v1.PodCondition
+				for i, condition := range pod.Status.Conditions {
+					switch condition.Type {
+					case v1.PodResizeInProgress:
+						inProgressCondition = &pod.Status.Conditions[i]
+					case v1.PodResizePending:
+						return func() string {
+							return fmt.Sprintf("pod should not be pending, got reason=%s, message=%q", condition.Reason, condition.Message)
+						}, nil
+					}
+				}
+				if inProgressCondition == nil {
+					return func() string { return "resize is not in progress" }, nil
+				}
+
+				if inProgressCondition.Reason != v1.PodReasonError {
+					return func() string { return "in-progress reason is not error" }, nil
+				}
+
+				expectedMsg := regexp.MustCompile(`memory limit \(\d+\) below current usage`)
+				if !expectedMsg.MatchString(inProgressCondition.Message) {
+					return func() string {
+						return fmt.Sprintf("Expected %q to contain %q", inProgressCondition.Message, expectedMsg)
+					}, nil
+				}
+				return nil, nil
+			})),
+		)
+		ginkgo.By("verifying pod status resources still match the viable resize")
+		framework.ExpectNoError(podresize.VerifyPodStatusResources(testPod, viableLoweredLimit))
+
+		// 3. Revert the limit back to the original value - should succeed
+		ginkgo.By("Patching pod to revert to original state")
+		patch = podresize.MakeResizePatch(nonViableLoweredLimit, original)
+		testPod, pErr = f.ClientSet.CoreV1().Pods(testPod.Namespace).Patch(ctx, testPod.Name,
+			types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
+		framework.ExpectNoError(pErr, "failed to patch pod back to original values")
+
+		ginkgo.By("verifying pod patched for original values")
+		podresize.VerifyPodResources(testPod, original)
+
+		ginkgo.By("waiting for the original values to be actuated")
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, original)
+		podresize.ExpectPodResized(ctx, f, resizedPod, original)
+
+		ginkgo.By("deleting pod")
+		podClient.DeleteSync(ctx, testPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+	})
+}
+
 // NOTE: Pod resize scheduler resource quota tests are out of scope in e2e_node tests,
 //       because in e2e_node tests
 //          a) scheduler and controller manager is not running by the Node e2e
@@ -1292,4 +1414,5 @@ var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithFeatureGate(fe
 
 	doPodResizeTests(f)
 	doPodResizeErrorTests(f)
+	doPodResizeMemoryLimitDecreaseTest(f)
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Remove the restriction on memory limit decrease for in-place resize. As a best effort protection, before performing the resize operation check whether a memory limit decrease is occuring, and if so check the current memory usage. Block the resize from proceeding if usage exceeds the desired limits.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/129152

#### Special notes for your reviewer:

~~Builds on https://github.com/kubernetes/kubernetes/pull/132973~~ (merged)

#### Does this PR introduce a user-facing change?
```release-note
Memory limits can now be decreased with a NotRequired resize restart policy. When decreasing memory limits, perform a best-effort check to prevent limits from decreasing below usage and triggering an OOM-kill.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/sig node
/assign @natasha41575 @roycaihw @dchen1107 