### PR TITLE
feat: add CSR status.conditions approved+denied declarative validation tags to v1 and v1beta1 and add associated tests

### DIFF
--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -22,7 +22,16 @@ limitations under the License.
 package v1
 
 import (
+	context "context"
+	fmt "fmt"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
+	operation "k8s.io/apimachinery/pkg/api/operation"
+	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	field "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
@@ -30,5 +39,91 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	scheme.AddValidationFunc((*certificatesv1.CertificateSigningRequest)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/", "/approval", "/status":
+			return Validate_CertificateSigningRequest(ctx, op, nil /* fldPath */, obj.(*certificatesv1.CertificateSigningRequest), safe.Cast[*certificatesv1.CertificateSigningRequest](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	scheme.AddValidationFunc((*certificatesv1.CertificateSigningRequestList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_CertificateSigningRequestList(ctx, op, nil /* fldPath */, obj.(*certificatesv1.CertificateSigningRequestList), safe.Cast[*certificatesv1.CertificateSigningRequestList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
+}
+
+func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequest) (errs field.ErrorList) {
+	// field certificatesv1.CertificateSigningRequest.TypeMeta has no validation
+	// field certificatesv1.CertificateSigningRequest.ObjectMeta has no validation
+	// field certificatesv1.CertificateSigningRequest.Spec has no validation
+
+	// field certificatesv1.CertificateSigningRequest.Status
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestStatus) (errs field.ErrorList) {
+			errs = append(errs, Validate_CertificateSigningRequestStatus(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("status"), &obj.Status, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequest) *certificatesv1.CertificateSigningRequestStatus {
+			return &oldObj.Status
+		}))...)
+
+	return errs
+}
+
+func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestList) (errs field.ErrorList) {
+	// field certificatesv1.CertificateSigningRequestList.TypeMeta has no validation
+	// field certificatesv1.CertificateSigningRequestList.ListMeta has no validation
+
+	// field certificatesv1.CertificateSigningRequestList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1.CertificateSigningRequest) (errs field.ErrorList) {
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil // no changes
+			}
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CertificateSigningRequest)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestList) []certificatesv1.CertificateSigningRequest {
+			return oldObj.Items
+		}))...)
+
+	return errs
+}
+
+var zeroOrOneOfMembershipFor_k8s_io_api_certificates_v1_CertificateSigningRequestStatus_Conditions_ = validate.NewUnionMembership([2]string{"Conditions[{\"type\": \"Approved\"}]", ""}, [2]string{"Conditions[{\"type\": \"Denied\"}]", ""})
+
+func Validate_CertificateSigningRequestStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1.CertificateSigningRequestStatus) (errs field.ErrorList) {
+	// field certificatesv1.CertificateSigningRequestStatus.Conditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1.CertificateSigningRequestCondition) (errs field.ErrorList) {
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil // no changes
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ZeroOrOneOfUnion(ctx, op, fldPath, obj, oldObj, zeroOrOneOfMembershipFor_k8s_io_api_certificates_v1_CertificateSigningRequestStatus_Conditions_, func(list []certificatesv1.CertificateSigningRequestCondition) bool {
+				for i := range list {
+					if list[i].Type == "Approved" {
+						return true
+					}
+				}
+				return false
+			}, func(list []certificatesv1.CertificateSigningRequestCondition) bool {
+				for i := range list {
+					if list[i].Type == "Denied" {
+						return true
+					}
+				}
+				return false
+			})...)
+			return
+		}(fldPath.Child("conditions"), obj.Conditions, safe.Field(oldObj, func(oldObj *certificatesv1.CertificateSigningRequestStatus) []certificatesv1.CertificateSigningRequestCondition {
+			return oldObj.Conditions
+		}))...)
+
+	// field certificatesv1.CertificateSigningRequestStatus.Certificate has no validation
+	return errs
 }

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -22,7 +22,16 @@ limitations under the License.
 package v1beta1
 
 import (
+	context "context"
+	fmt "fmt"
+
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
+	operation "k8s.io/apimachinery/pkg/api/operation"
+	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	field "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
@@ -30,5 +39,91 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	scheme.AddValidationFunc((*certificatesv1beta1.CertificateSigningRequest)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/", "/approval", "/status":
+			return Validate_CertificateSigningRequest(ctx, op, nil /* fldPath */, obj.(*certificatesv1beta1.CertificateSigningRequest), safe.Cast[*certificatesv1beta1.CertificateSigningRequest](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	scheme.AddValidationFunc((*certificatesv1beta1.CertificateSigningRequestList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_CertificateSigningRequestList(ctx, op, nil /* fldPath */, obj.(*certificatesv1beta1.CertificateSigningRequestList), safe.Cast[*certificatesv1beta1.CertificateSigningRequestList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
+}
+
+func Validate_CertificateSigningRequest(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequest) (errs field.ErrorList) {
+	// field certificatesv1beta1.CertificateSigningRequest.TypeMeta has no validation
+	// field certificatesv1beta1.CertificateSigningRequest.ObjectMeta has no validation
+	// field certificatesv1beta1.CertificateSigningRequest.Spec has no validation
+
+	// field certificatesv1beta1.CertificateSigningRequest.Status
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestStatus) (errs field.ErrorList) {
+			errs = append(errs, Validate_CertificateSigningRequestStatus(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("status"), &obj.Status, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequest) *certificatesv1beta1.CertificateSigningRequestStatus {
+			return &oldObj.Status
+		}))...)
+
+	return errs
+}
+
+func Validate_CertificateSigningRequestList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestList) (errs field.ErrorList) {
+	// field certificatesv1beta1.CertificateSigningRequestList.TypeMeta has no validation
+	// field certificatesv1beta1.CertificateSigningRequestList.ListMeta has no validation
+
+	// field certificatesv1beta1.CertificateSigningRequestList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1beta1.CertificateSigningRequest) (errs field.ErrorList) {
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil // no changes
+			}
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CertificateSigningRequest)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequestList) []certificatesv1beta1.CertificateSigningRequest {
+			return oldObj.Items
+		}))...)
+
+	return errs
+}
+
+var zeroOrOneOfMembershipFor_k8s_io_api_certificates_v1beta1_CertificateSigningRequestStatus_Conditions_ = validate.NewUnionMembership([2]string{"Conditions[{\"type\": \"Approved\"}]", ""}, [2]string{"Conditions[{\"type\": \"Denied\"}]", ""})
+
+func Validate_CertificateSigningRequestStatus(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *certificatesv1beta1.CertificateSigningRequestStatus) (errs field.ErrorList) {
+	// field certificatesv1beta1.CertificateSigningRequestStatus.Conditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []certificatesv1beta1.CertificateSigningRequestCondition) (errs field.ErrorList) {
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil // no changes
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ZeroOrOneOfUnion(ctx, op, fldPath, obj, oldObj, zeroOrOneOfMembershipFor_k8s_io_api_certificates_v1beta1_CertificateSigningRequestStatus_Conditions_, func(list []certificatesv1beta1.CertificateSigningRequestCondition) bool {
+				for i := range list {
+					if list[i].Type == "Approved" {
+						return true
+					}
+				}
+				return false
+			}, func(list []certificatesv1beta1.CertificateSigningRequestCondition) bool {
+				for i := range list {
+					if list[i].Type == "Denied" {
+						return true
+					}
+				}
+				return false
+			})...)
+			return
+		}(fldPath.Child("conditions"), obj.Conditions, safe.Field(oldObj, func(oldObj *certificatesv1beta1.CertificateSigningRequestStatus) []certificatesv1beta1.CertificateSigningRequestCondition {
+			return oldObj.Conditions
+		}))...)
+
+	// field certificatesv1beta1.CertificateSigningRequestStatus.Certificate has no validation
+	return errs
 }

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -242,12 +242,12 @@ func validateConditions(fldPath *field.Path, csr *certificates.CertificateSignin
 			case certificates.CertificateApproved:
 				hasApproved = true
 				if hasDenied {
-					allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("type"), c.Type, "Approved and Denied conditions are mutually exclusive"))
+					allErrs = append(allErrs, field.Invalid(fldPath, c.Type, "Approved and Denied conditions are mutually exclusive").WithOrigin("zeroOrOneOf").MarkCoveredByDeclarative())
 				}
 			case certificates.CertificateDenied:
 				hasDenied = true
 				if hasApproved {
-					allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("type"), c.Type, "Approved and Denied conditions are mutually exclusive"))
+					allErrs = append(allErrs, field.Invalid(fldPath, c.Type, "Approved and Denied conditions are mutually exclusive").WithOrigin("zeroOrOneOf").MarkCoveredByDeclarative())
 				}
 			}
 		}

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -39,6 +39,8 @@ option go_package = "k8s.io/api/certificates/v1";
 // This API can be used to request client certificates to authenticate to kube-apiserver
 // (with the "kubernetes.io/kube-apiserver-client" signerName),
 // or to obtain certificates from custom non-Kubernetes signers.
+// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource=/approval
 message CertificateSigningRequest {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -203,6 +205,11 @@ message CertificateSigningRequestStatus {
   // +listType=map
   // +listMapKey=type
   // +optional
+  // +k8s:listType=map
+  // +k8s:listMapKey=type
+  // +k8s:optional
+  // +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+  // +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
   repeated CertificateSigningRequestCondition conditions = 1;
 
   // certificate is populated with an issued certificate by the signer after an Approved condition is present.

--- a/staging/src/k8s.io/api/certificates/v1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1/types.go
@@ -39,6 +39,8 @@ import (
 // This API can be used to request client certificates to authenticate to kube-apiserver
 // (with the "kubernetes.io/kube-apiserver-client" signerName),
 // or to obtain certificates from custom non-Kubernetes signers.
+// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource=/approval
 type CertificateSigningRequest struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -178,6 +180,11 @@ type CertificateSigningRequestStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
+	// +k8s:listType=map
+	// +k8s:listMapKey=type
+	// +k8s:optional
+	// +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+	// +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
 	// certificate is populated with an issued certificate by the signer after an Approved condition is present.

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -30,6 +30,8 @@ import "k8s.io/apimachinery/pkg/runtime/schema/generated.proto";
 option go_package = "k8s.io/api/certificates/v1beta1";
 
 // Describes a certificate signing request
+// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource=/approval
 message CertificateSigningRequest {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -182,6 +184,11 @@ message CertificateSigningRequestStatus {
   // +listType=map
   // +listMapKey=type
   // +optional
+  // +k8s:listType=map
+  // +k8s:listMapKey=type
+  // +k8s:optional
+  // +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+  // +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
   repeated CertificateSigningRequestCondition conditions = 1;
 
   // If request was approved, the controller will place the issued certificate here.

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -31,6 +31,8 @@ import (
 // +k8s:prerelease-lifecycle-gen:replacement=certificates.k8s.io,v1,CertificateSigningRequest
 
 // Describes a certificate signing request
+// +k8s:supportsSubresource=/status
+// +k8s:supportsSubresource=/approval
 type CertificateSigningRequest struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -175,6 +177,11 @@ type CertificateSigningRequestStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
+	// +k8s:listType=map
+	// +k8s:listMapKey=type
+	// +k8s:optional
+	// +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
+	// +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
 	// If request was approved, the controller will place the issued certificate here.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the declarative validation approved+denied mutually exclusive check to CertificateSigningRequest status.conditions by adding tags to the v1 and v1beta1 types.go files for CSR.  The full set of tags added  include:

- +k8s:listType
- +k8s:listMapKey
- +k8s:optional
- +k8s:item
- +k8s:zeroOrOneOfMember

```go
type CertificateSigningRequestStatus struct {
	// +listType=map
	// +listMapKey=type
	// +optional
	// +k8s:listType=map
	// +k8s:listMapKey=type
	// +k8s:optional
	// +k8s:item(type: "Approved")=+k8s:zeroOrOneOfMember
	// +k8s:item(type: "Denied")=+k8s:zeroOrOneOfMember
	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
```

- Modifies the related hand-written validation in certificates/validation/validation.go for CSR so that the hand-written error which was previously on the flagged item in the conditions list (`status.conditions[1].type`) is now on the list directly (`status.conditions`) to align with the best practice the union tags proposed and we want moving forward.  

- Updates the certificates/validation/validation_test.go to add additional test cases around the hand-written approved+denied mutually exclusive rule and to also check that this validation has WithOrigin("zeroOrOneOf") and MarkCoveredByDeclarative().  

- Adds the requisite migration test  `declarative_validation_test.go` which tests for the equivalence of hand-written validation  and declarative validation.  Of note, when using the root "/" resource, condition modifications are limited (see https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/certificates/validation/validation.go#L283-L322).  

- v1alpha1 is not tagged and is removed from the declarative_validation_test.go file in this PR.  This is because https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/certificates/v1alpha1/types.go does not have the CSR type. 

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/enhancements/issues/5073
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The related KEP updates have been merged:

https://github.com/kubernetes/enhancements/pull/5363
https://github.com/kubernetes/enhancements/pull/5292

This change was manually E2E tested and confirmed to work as intended across: "/", "/status" and "/approval"
The following cases/steps were run in the E2E test:
- Create valid CSR
- CSR update on /status
  - Valid: conditions[“Approved”]
  - Invalid: conditions[“Approved”, “Denied”]
- CSR update on /approval
  - Valid: conditions[“Approved”]
  - Invalid: conditions[“Approved”, “Denied”]

The results of the tests confirmed that Declarative Validation of the target approved+denied conditions rule was migrated correctly:
- DeclarativeValidation:true, DeclarativeValidationTakeover:false
  - 0 mismatch metrics reported
  - Error messages as expected (correct errors matching hand-written errors messages)
- DeclarativeValidation:true, DeclarativeValidationTakeover:true
  - 0 mismatch metrics reported
  - Error messages as expected (correct errors matching declarative validation errors messages)

Gist of the E2E test script used:
- https://gist.github.com/aaron-prindle/1dfc8f3e1265a502426bf19955601698


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The conditionType is "oneof" approved/denied check of CertificateSigningRequest's `.status.conditions` field has been migrated to declarative validation. 
If the `DeclarativeValidation` feature gate is enabled, mismatches with existing validation are reported via metrics.
If the `DeclarativeValidationTakeover` feature gate is enabled, declarative validation is the primary source of errors for migrated fields.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```
