### PR TITLE
Mark KubeletServiceAccountTokenForCredentialProviders feature gate as beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1344,6 +1344,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	KubeletServiceAccountTokenForCredentialProviders: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KubeletTracing: {

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -260,6 +260,14 @@ func TestPullWithSecrets(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	podSandboxConfig := &runtimeapi.PodSandboxConfig{
+		Metadata: &runtimeapi.PodSandboxMetadata{
+			Name:      "testpod",
+			Namespace: "testpod-ns",
+			Uid:       "testpod-uid",
+		},
+	}
+
 	tests := map[string]struct {
 		imageName           string
 		passedSecrets       []v1.Secret
@@ -335,7 +343,7 @@ func TestPullWithSecrets(t *testing.T) {
 			&fakePodPullingTimeRecorder{},
 		)
 
-		_, _, err = fakeManager.imagePuller.EnsureImageExists(tCtx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, nil, "", v1.PullAlways)
+		_, _, err = fakeManager.imagePuller.EnsureImageExists(tCtx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, podSandboxConfig, "", v1.PullAlways)
 		require.NoError(t, err)
 		fakeImageService.AssertImagePulledWithAuth(t, &runtimeapi.ImageSpec{Image: test.imageName, Annotations: make(map[string]string)}, test.expectedAuth, description)
 	}
@@ -356,6 +364,14 @@ func TestPullWithSecretsWithError(t *testing.T) {
 	dockerConfigJSON, err := json.Marshal(dockerCfg)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	podSandboxConfig := &runtimeapi.PodSandboxConfig{
+		Metadata: &runtimeapi.PodSandboxMetadata{
+			Name:      "testpod",
+			Namespace: "testpod-ns",
+			Uid:       "testpod-uid",
+		},
 	}
 
 	for _, test := range []struct {
@@ -409,7 +425,7 @@ func TestPullWithSecretsWithError(t *testing.T) {
 				&fakePodPullingTimeRecorder{},
 			)
 
-			imageRef, _, err := fakeManager.imagePuller.EnsureImageExists(tCtx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, nil, "", v1.PullAlways)
+			imageRef, _, err := fakeManager.imagePuller.EnsureImageExists(tCtx, nil, makeTestPod("testpod", "testpod-ns", "testpod-uid", []v1.Container{}), test.imageName, test.passedSecrets, podSandboxConfig, "", v1.PullAlways)
 			assert.Error(t, err)
 			assert.Equal(t, "", imageRef)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2847,6 +2847,14 @@ func TestGetImageVolumes(t *testing.T) {
 	imageSpec1 := runtimeapi.ImageSpec{Image: image1, UserSpecifiedImage: image1}
 	imageSpec2 := runtimeapi.ImageSpec{Image: image2, UserSpecifiedImage: image2}
 
+	podSandboxConfig := &runtimeapi.PodSandboxConfig{
+		Metadata: &runtimeapi.PodSandboxMetadata{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			Uid:       "test-uid",
+		},
+	}
+
 	for desc, tc := range map[string]struct {
 		pod                      *v1.Pod
 		expectedImageVolumePulls imageVolumePulls
@@ -2883,7 +2891,8 @@ func TestGetImageVolumes(t *testing.T) {
 			},
 		},
 	} {
-		imageVolumePulls, err := manager.getImageVolumes(tCtx, tc.pod, nil, nil)
+
+		imageVolumePulls, err := manager.getImageVolumes(tCtx, tc.pod, podSandboxConfig, nil)
 		if tc.expectedError != nil {
 			require.EqualError(t, err, tc.expectedError.Error())
 		} else {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1105,6 +1105,12 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - get
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -799,6 +799,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.33"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.34"
 - name: KubeletTracing
   versionedSpecs:
   - default: false


### PR DESCRIPTION
/kind feature
/kind api-change
/sig auth
/assign enj liggitt
/triage accepted

```release-note
The KubeletServiceAccountTokenForCredentialProviders feature is now beta and enabled by default.
```

KEP: https://github.com/kubernetes/enhancements/issues/4412

Hold for:

- https://github.com/kubernetes/kubernetes/pull/132617
- https://github.com/kubernetes/kubernetes/pull/132803
- https://github.com/kubernetes/kubernetes/pull/132771
- https://github.com/kubernetes/kubernetes/pull/133016