### PR TITLE
kubectl: add port names to describe pod output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1865,7 +1865,11 @@ func describeContainerBasicInfo(container corev1.Container, status corev1.Contai
 func describeContainerPorts(cPorts []corev1.ContainerPort) string {
 	ports := make([]string, 0, len(cPorts))
 	for _, cPort := range cPorts {
-		ports = append(ports, fmt.Sprintf("%d/%s", cPort.ContainerPort, cPort.Protocol))
+		portStr := fmt.Sprintf("%d/%s", cPort.ContainerPort, cPort.Protocol)
+		if cPort.Name != "" {
+			portStr = fmt.Sprintf("%s (%s)", portStr, cPort.Name)
+		}
+		ports = append(ports, portStr)
 	}
 	return strings.Join(ports, ", ")
 }
@@ -1873,7 +1877,11 @@ func describeContainerPorts(cPorts []corev1.ContainerPort) string {
 func describeContainerHostPorts(cPorts []corev1.ContainerPort) string {
 	ports := make([]string, 0, len(cPorts))
 	for _, cPort := range cPorts {
-		ports = append(ports, fmt.Sprintf("%d/%s", cPort.HostPort, cPort.Protocol))
+		portStr := fmt.Sprintf("%d/%s", cPort.HostPort, cPort.Protocol)
+		if cPort.Name != "" {
+			portStr = fmt.Sprintf("%s (%s)", portStr, cPort.Name)
+		}
+		ports = append(ports, portStr)
 	}
 	return strings.Join(ports, ", ")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig cli

**What this PR does / why we need it:**
Adds port names to `kubectl describe pod` output to make it easier to identify port purposes without referencing the original manifest.

**Which issue(s) this PR fixes:**
Fixes https://github.com/kubernetes/kubectl/issues/1755

**Special notes for your reviewer:**
This change only affects the display formatting of container ports in describe output. The logic gracefully handles both named and unnamed ports.

When describing pods, include port names alongside port numbers to make it easier to identify port purposes without referencing the original manifest.

Example output:
```code
Ports: 80/TCP (http), 443/TCP (https)
```
This eliminates work when creating services or understanding port purposes, especially for external resources deployed via helm charts.

**Does this PR introduce a user-facing change?**
```release-note
kubectl: `describe pod` now includes port names alongside port numbers (e.g., "80/TCP (http)") when port names are specified in the pod spec.