### PR TITLE
DRA scheduler plugin: add pohly as approver

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/OWNERS
+++ b/pkg/scheduler/framework/plugins/dynamicresources/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+  - pohly
 reviewers:
   - klueska
   - pohly


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is meant for simple changes, like code cleanup or API changes of the allocator code. For more complex changes and new features, SIG Scheduling approvers will be required to approve, as before.

#### Which issue(s) this PR is related to:

Example PR: https://github.com/kubernetes/kubernetes/pull/132976

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @macsko @dom4ha @sanposhiho 
