### PR TITLE
feat: trigger PreBindPreFlight in the binding cycle

### DIFF
--- a/pkg/scheduler/backend/api_dispatcher/call_queue.go
+++ b/pkg/scheduler/backend/api_dispatcher/call_queue.go
@@ -132,8 +132,8 @@ func (cq *callQueue) merge(oldAPICall, apiCall *queuedAPICall) error {
 		return nil
 	}
 
-	// Merge API calls if they are of the same type for the same object.
-	err := apiCall.Merge(oldAPICall)
+	// Send a concrete APICall object to allow for a type assertion.
+	err := apiCall.Merge(oldAPICall.APICall)
 	if err != nil {
 		err := fmt.Errorf("failed to merge API calls: %w", err)
 		apiCall.sendOnFinish(err)

--- a/pkg/scheduler/framework/cycle_state.go
+++ b/pkg/scheduler/framework/cycle_state.go
@@ -34,6 +34,8 @@ type CycleState struct {
 	skipFilterPlugins sets.Set[string]
 	// skipScorePlugins are plugins that will be skipped in the Score extension point.
 	skipScorePlugins sets.Set[string]
+	// skipPreBindPlugins are plugins that will be skipped in the PreBind extension point.
+	skipPreBindPlugins sets.Set[string]
 }
 
 // NewCycleState initializes a new CycleState and returns its pointer.
@@ -73,6 +75,14 @@ func (c *CycleState) GetSkipScorePlugins() sets.Set[string] {
 	return c.skipScorePlugins
 }
 
+func (c *CycleState) SetSkipPreBindPlugins(plugins sets.Set[string]) {
+	c.skipPreBindPlugins = plugins
+}
+
+func (c *CycleState) GetSkipPreBindPlugins() sets.Set[string] {
+	return c.skipPreBindPlugins
+}
+
 // Clone creates a copy of CycleState and returns its pointer. Clone returns
 // nil if the context being cloned is nil.
 func (c *CycleState) Clone() fwk.CycleState {
@@ -89,6 +99,7 @@ func (c *CycleState) Clone() fwk.CycleState {
 	copy.recordPluginMetrics = c.recordPluginMetrics
 	copy.skipFilterPlugins = c.skipFilterPlugins
 	copy.skipScorePlugins = c.skipScorePlugins
+	copy.skipPreBindPlugins = c.skipPreBindPlugins
 
 	return copy
 }

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -73,6 +73,7 @@ const (
 	Score                       = "Score"
 	ScoreExtensionNormalize     = "ScoreExtensionNormalize"
 	PreBind                     = "PreBind"
+	PreBindPreFlight            = "PreBindPreFlight"
 	Bind                        = "Bind"
 	PostBind                    = "PostBind"
 	Reserve                     = "Reserve"

--- a/pkg/scheduler/testing/framework/fake_plugins.go
+++ b/pkg/scheduler/testing/framework/fake_plugins.go
@@ -199,7 +199,8 @@ func NewFakeReservePlugin(status *fwk.Status) frameworkruntime.PluginFactory {
 
 // FakePreBindPlugin is a test prebind plugin.
 type FakePreBindPlugin struct {
-	Status *fwk.Status
+	PreBindPreFlightStatus *fwk.Status
+	PreBindStatus          *fwk.Status
 }
 
 // Name returns name of the plugin.
@@ -209,25 +210,27 @@ func (pl *FakePreBindPlugin) Name() string {
 
 // PreBindPreFlight invoked at the PreBind extension point.
 func (pl *FakePreBindPlugin) PreBindPreFlight(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) *fwk.Status {
-	return pl.Status
+	return pl.PreBindPreFlightStatus
 }
 
 // PreBind invoked at the PreBind extension point.
 func (pl *FakePreBindPlugin) PreBind(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) *fwk.Status {
-	return pl.Status
+	return pl.PreBindStatus
 }
 
 // NewFakePreBindPlugin initializes a fakePreBindPlugin and returns it.
-func NewFakePreBindPlugin(status *fwk.Status) frameworkruntime.PluginFactory {
+func NewFakePreBindPlugin(preBindPreFlightStatus, preBindStatus *fwk.Status) frameworkruntime.PluginFactory {
 	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
 		return &FakePreBindPlugin{
-			Status: status,
+			PreBindPreFlightStatus: preBindPreFlightStatus,
+			PreBindStatus:          preBindStatus,
 		}, nil
 	}
 }
 
 // FakePermitPlugin is a test permit plugin.
 type FakePermitPlugin struct {
+	Handle  framework.Handle
 	Status  *fwk.Status
 	Timeout time.Duration
 }
@@ -238,16 +241,17 @@ func (pl *FakePermitPlugin) Name() string {
 }
 
 // Permit invoked at the Permit extension point.
-func (pl *FakePermitPlugin) Permit(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ string) (*fwk.Status, time.Duration) {
+func (pl *FakePermitPlugin) Permit(_ context.Context, _ fwk.CycleState, p *v1.Pod, _ string) (*fwk.Status, time.Duration) {
 	return pl.Status, pl.Timeout
 }
 
 // NewFakePermitPlugin initializes a fakePermitPlugin and returns it.
 func NewFakePermitPlugin(status *fwk.Status, timeout time.Duration) frameworkruntime.PluginFactory {
-	return func(_ context.Context, _ runtime.Object, _ framework.Handle) (framework.Plugin, error) {
+	return func(_ context.Context, _ runtime.Object, h framework.Handle) (framework.Plugin, error) {
 		return &FakePermitPlugin{
 			Status:  status,
 			Timeout: timeout,
+			Handle:  h,
 		}, nil
 	}
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/cycle_state.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/cycle_state.go
@@ -59,6 +59,12 @@ type CycleState interface {
 	// SetSkipScorePlugins sets plugins that should be skipped in the Score extension point.
 	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
 	SetSkipScorePlugins(plugins sets.Set[string])
+	// GetSkipPreBindPlugins returns plugins that will be skipped in the PreBind extension point.
+	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
+	GetSkipPreBindPlugins() sets.Set[string]
+	// SetSkipPreBindPlugins sets plugins that should be skipped in the PerBind extension point.
+	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
+	SetSkipPreBindPlugins(plugins sets.Set[string])
 	// Read retrieves data with the given "key" from CycleState. If the key is not
 	// present, ErrNotFound is returned.
 	//

--- a/test/integration/scheduler/nominated_node_name/main_test.go
+++ b/test/integration/scheduler/nominated_node_name/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nominatednodename
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nominatednodename
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	schedulerutils "k8s.io/kubernetes/test/integration/scheduler"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+type FakePermitPlugin struct {
+	code fwk.Code
+}
+
+type RunForeverPreBindPlugin struct {
+	cancel <-chan struct{}
+}
+
+type NoNNNPostBindPlugin struct {
+	t      *testing.T
+	cancel <-chan struct{}
+}
+
+func (bp *NoNNNPostBindPlugin) Name() string {
+	return "NoNNNPostBindPlugin"
+}
+
+func (bp *NoNNNPostBindPlugin) PostBind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) {
+	if p.Status.NominatedNodeName != "" {
+		bp.t.Fatalf("PostBind should not set .status.nominatedNodeName for pod %v/%v, but it was set to %v", p.Namespace, p.Name, p.Status.NominatedNodeName)
+	}
+}
+
+// Name returns name of the plugin.
+func (pp *FakePermitPlugin) Name() string {
+	return "FakePermitPlugin"
+}
+
+// Permit implements the permit test plugin.
+func (pp *FakePermitPlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
+	if pp.code == fwk.Wait {
+		return fwk.NewStatus(pp.code, ""), 10 * time.Minute
+	}
+	return fwk.NewStatus(pp.code, ""), 0
+}
+
+// Name returns name of the plugin.
+func (pp *RunForeverPreBindPlugin) Name() string {
+	return "RunForeverPreBindPlugin"
+}
+
+// PreBindPreFlight is a test function that returns nil for testing.
+func (pp *RunForeverPreBindPlugin) PreBindPreFlight(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	return nil
+}
+
+// PreBind is a test function that returns (true, nil) or errors for testing.
+func (pp *RunForeverPreBindPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	select {
+	case <-ctx.Done():
+		return fwk.NewStatus(fwk.Error, "context cancelled")
+	case <-pp.cancel:
+		return fwk.NewStatus(fwk.Error, "pre-bind cancelled")
+	}
+}
+
+// Test_PutNominatedNodeNameInBindingCycle makes sure that nominatedNodeName is set in the binding cycle
+// when the PreBind or Permit plugin (WaitOnPermit) is going to work.
+func Test_PutNominatedNodeNameInBindingCycle(t *testing.T) {
+	cancel := make(chan struct{})
+	tests := []struct {
+		name                    string
+		plugin                  framework.Plugin
+		expectNominatedNodeName bool
+		cleanup                 func()
+	}{
+		{
+			name:                    "NominatedNodeName is put if PreBindPlugin will run",
+			plugin:                  &RunForeverPreBindPlugin{cancel: cancel},
+			expectNominatedNodeName: true,
+			cleanup: func() {
+				close(cancel)
+			},
+		},
+		{
+			name:                    "NominatedNodeName is put if PermitPlugin will run at WaitOnPermit",
+			expectNominatedNodeName: true,
+			plugin: &FakePermitPlugin{
+				code: fwk.Wait,
+			},
+		},
+		{
+			name: "NominatedNodeName is not put if PermitPlugin won't run at WaitOnPermit",
+			plugin: &FakePermitPlugin{
+				code: fwk.Success,
+			},
+		},
+		{
+			name:   "NominatedNodeName is not put if PermitPlugin nor PreBindPlugin will run",
+			plugin: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testContext := testutils.InitTestAPIServer(t, "nnn-test", nil)
+			if test.cleanup != nil {
+				defer test.cleanup()
+			}
+
+			pf := func(plugin framework.Plugin) frameworkruntime.PluginFactory {
+				return func(_ context.Context, _ runtime.Object, fh framework.Handle) (framework.Plugin, error) {
+					return plugin, nil
+				}
+			}
+
+			plugins := []framework.Plugin{&NoNNNPostBindPlugin{cancel: testContext.Ctx.Done(), t: t}}
+			if test.plugin != nil {
+				plugins = append(plugins, test.plugin)
+			}
+
+			registry, prof := schedulerutils.InitRegistryAndConfig(t, pf, plugins...)
+
+			testCtx, teardown := schedulerutils.InitTestSchedulerForFrameworkTest(t, testContext, 10, true,
+				scheduler.WithProfiles(prof),
+				scheduler.WithFrameworkOutOfTreeRegistry(registry))
+			defer teardown()
+
+			pod, err := testutils.CreatePausePod(testCtx.ClientSet,
+				testutils.InitPausePod(&testutils.PausePodConfig{Name: "test-pod", Namespace: testCtx.NS.Name}))
+			if err != nil {
+				t.Fatalf("Error while creating a test pod: %v", err)
+			}
+
+			if test.expectNominatedNodeName {
+				if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
+					t.Errorf(".status.nominatedNodeName was not set for pod %v/%v: %v", pod.Namespace, pod.Name, err)
+				}
+			} else {
+				if err := testutils.WaitForPodToSchedule(testCtx.Ctx, testCtx.ClientSet, pod); err != nil {
+					t.Errorf("Pod %v/%v was not scheduled: %v", pod.Namespace, pod.Name, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If PreBindPreFlight returns Skip, the scheduler doesn't run the plugin at PreBind.
If any PreBindPreFlight returns Success, the scheduler puts NominatedNodeName to the pod 
so that other components (such as the cluster autoscaler) can notice the pod is going to be bound to the node.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #132383

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
If PreBindPreFlight returns Skip, the scheduler doesn't run the plugin at PreBind.
If any PreBindPreFlight returns Success, the scheduler puts NominatedNodeName to the pod 
so that other components (such as the cluster autoscaler) can notice the pod is going to be bound to the node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
