### PR TITLE
scheduler integration: fail test instead of existing

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -131,7 +131,7 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 
 	// Not all config options will be effective but only those mostly related with scheduler performance will
 	// be applied to start a scheduler, most of them are defined in `scheduler.schedulerOptions`.
-	_, informerFactory := util.StartScheduler(tCtx, tCtx.Client(), cfg, config, outOfTreePluginRegistry)
+	_, informerFactory := util.StartScheduler(tCtx, config, outOfTreePluginRegistry)
 	util.StartFakePVController(tCtx, tCtx.Client(), informerFactory)
 	runGC := util.CreateGCController(tCtx, tCtx, *cfg, informerFactory)
 	runNS := util.CreateNamespaceController(tCtx, tCtx, *cfg, informerFactory)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Calling klog.FlushAndExit causes the `go test` binary to quit without properly recording which test failed. Both callers of StartScheduler already have a ktesting.TContext, so switching to that is easy and also reduces the number of parameters.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
