### PR TITLE
kube-proxy node manager (take 2)

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -607,7 +607,9 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	nodeConfig.RegisterEventHandler(&proxy.NodeEligibleHandler{
 		HealthServer: s.HealthzServer,
 	})
-	nodeConfig.RegisterEventHandler(s.Proxier)
+
+	nodeTopologyConfig := config.NewNodeTopologyConfig(ctx, currentNodeInformerFactory.Core().V1().Nodes(), s.Config.ConfigSyncPeriod.Duration)
+	nodeTopologyConfig.RegisterEventHandler(s.Proxier)
 
 	go nodeConfig.Run(wait.NeverStop)
 

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -76,7 +76,6 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	proxymetrics "k8s.io/kubernetes/pkg/proxy/metrics"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
-	utilnode "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/oom"
 	netutils "k8s.io/utils/net"
 )
@@ -173,7 +172,8 @@ type ProxyServer struct {
 	NodeIPs         map[v1.IPFamily]net.IP
 	flagz           flagz.Reader
 
-	podCIDRs []string // only used for LocalModeNodeCIDR
+	podCIDRs    []string // only used for LocalModeNodeCIDR
+	NodeManager *proxy.NodeManager
 
 	Proxier proxy.Provider
 }
@@ -207,7 +207,16 @@ func newProxyServer(ctx context.Context, config *kubeproxyconfig.KubeProxyConfig
 		return nil, err
 	}
 
-	rawNodeIPs := getNodeIPs(ctx, s.Client, s.NodeName)
+	// NodeManager makes an informer that selects for the node where this kube-proxy is running
+	s.NodeManager, err = proxy.NewNodeManager(ctx, s.Client, s.Config.ConfigSyncPeriod.Duration, s.NodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	rawNodeIPs := s.NodeManager.NodeIPs()
+	if len(rawNodeIPs) > 0 {
+		logger.Info("Successfully retrieved NodeIPs", "NodeIPs", rawNodeIPs)
+	}
 	s.PrimaryIPFamily, s.NodeIPs = detectNodeIPs(ctx, rawNodeIPs, config.BindAddress)
 
 	if len(config.NodePortAddresses) == 1 && config.NodePortAddresses[0] == kubeproxyconfig.NodePortAddressesPrimary {
@@ -594,28 +603,22 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	informerFactory.Start(wait.NeverStop)
 	serviceInformerFactory.Start(wait.NeverStop)
 
-	// Make an informer that selects for our nodename.
-	currentNodeInformerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", s.NodeRef.Name).String()
-		}))
-	nodeConfig := config.NewNodeConfig(ctx, currentNodeInformerFactory.Core().V1().Nodes(), s.Config.ConfigSyncPeriod.Duration)
-	// https://issues.k8s.io/111321
-	if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR {
-		nodeConfig.RegisterEventHandler(proxy.NewNodePodCIDRHandler(ctx, s.podCIDRs))
+	// hollow-proxy doesn't need node config, and we don't create nodeManager for hollow-proxy.
+	if s.NodeManager != nil {
+		nodeConfig := config.NewNodeConfig(ctx, s.NodeManager.NodeInformer(), s.Config.ConfigSyncPeriod.Duration)
+		// https://issues.k8s.io/111321
+		if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR {
+			nodeConfig.RegisterEventHandler(proxy.NewNodePodCIDRHandler(ctx, s.podCIDRs))
+		}
+		nodeConfig.RegisterEventHandler(&proxy.NodeEligibleHandler{
+			HealthServer: s.HealthzServer,
+		})
+		nodeConfig.RegisterEventHandler(s.NodeManager)
+		nodeTopologyConfig := config.NewNodeTopologyConfig(ctx, s.NodeManager.NodeInformer(), s.Config.ConfigSyncPeriod.Duration)
+		nodeTopologyConfig.RegisterEventHandler(s.Proxier)
+
+		go nodeConfig.Run(wait.NeverStop)
 	}
-	nodeConfig.RegisterEventHandler(&proxy.NodeEligibleHandler{
-		HealthServer: s.HealthzServer,
-	})
-
-	nodeTopologyConfig := config.NewNodeTopologyConfig(ctx, currentNodeInformerFactory.Core().V1().Nodes(), s.Config.ConfigSyncPeriod.Duration)
-	nodeTopologyConfig.RegisterEventHandler(s.Proxier)
-
-	go nodeConfig.Run(wait.NeverStop)
-
-	// This has to start after the calls to NewNodeConfig because that must
-	// configure the shared informer event handler first.
-	currentNodeInformerFactory.Start(wait.NeverStop)
 
 	// Birth Cry after the birth is successful
 	s.birthCry()
@@ -686,35 +689,4 @@ func detectNodeIPs(ctx context.Context, rawNodeIPs []net.IP, bindAddress string)
 		logger.Info("Can't determine this node's IP, assuming loopback; if this is incorrect, please set the --bind-address flag")
 	}
 	return primaryFamily, nodeIPs
-}
-
-// getNodeIP returns IPs for the node with the provided name.  If
-// required, it will wait for the node to be created.
-func getNodeIPs(ctx context.Context, client clientset.Interface, name string) []net.IP {
-	logger := klog.FromContext(ctx)
-	var nodeIPs []net.IP
-	backoff := wait.Backoff{
-		Steps:    6,
-		Duration: 1 * time.Second,
-		Factor:   2.0,
-		Jitter:   0.2,
-	}
-
-	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		node, err := client.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			logger.Error(err, "Failed to retrieve node info")
-			return false, nil
-		}
-		nodeIPs, err = utilnode.GetNodeHostIPs(node)
-		if err != nil {
-			logger.Error(err, "Failed to retrieve node IPs")
-			return false, nil
-		}
-		return true, nil
-	})
-	if err == nil {
-		logger.Info("Successfully retrieved node IP(s)", "IPs", nodeIPs)
-	}
-	return nodeIPs
 }

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -243,7 +243,7 @@ func newProxyServer(ctx context.Context, config *kubeproxyconfig.KubeProxyConfig
 	}
 
 	if len(config.HealthzBindAddress) > 0 {
-		s.HealthzServer = healthcheck.NewProxyHealthServer(config.HealthzBindAddress, 2*config.SyncPeriod.Duration)
+		s.HealthzServer = healthcheck.NewProxyHealthServer(config.HealthzBindAddress, 2*config.SyncPeriod.Duration, s.NodeManager)
 	}
 
 	err = s.platformSetup(ctx)
@@ -608,9 +608,6 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	// hollow-proxy doesn't need node config, and we don't create nodeManager for hollow-proxy.
 	if s.NodeManager != nil {
 		nodeConfig := config.NewNodeConfig(ctx, s.NodeManager.NodeInformer(), s.Config.ConfigSyncPeriod.Duration)
-		nodeConfig.RegisterEventHandler(&proxy.NodeEligibleHandler{
-			HealthServer: s.HealthzServer,
-		})
 		nodeConfig.RegisterEventHandler(s.NodeManager)
 		nodeTopologyConfig := config.NewNodeTopologyConfig(ctx, s.NodeManager.NodeInformer(), s.Config.ConfigSyncPeriod.Duration)
 		nodeTopologyConfig.RegisterEventHandler(s.Proxier)

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -208,7 +208,8 @@ func newProxyServer(ctx context.Context, config *kubeproxyconfig.KubeProxyConfig
 	}
 
 	// NodeManager makes an informer that selects for the node where this kube-proxy is running
-	s.NodeManager, err = proxy.NewNodeManager(ctx, s.Client, s.Config.ConfigSyncPeriod.Duration, s.NodeName)
+	s.NodeManager, err = proxy.NewNodeManager(ctx, s.Client, s.Config.ConfigSyncPeriod.Duration,
+		s.NodeName, s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR)
 	if err != nil {
 		return nil, err
 	}
@@ -218,6 +219,7 @@ func newProxyServer(ctx context.Context, config *kubeproxyconfig.KubeProxyConfig
 		logger.Info("Successfully retrieved NodeIPs", "NodeIPs", rawNodeIPs)
 	}
 	s.PrimaryIPFamily, s.NodeIPs = detectNodeIPs(ctx, rawNodeIPs, config.BindAddress)
+	s.podCIDRs = s.NodeManager.PodCIDRs()
 
 	if len(config.NodePortAddresses) == 1 && config.NodePortAddresses[0] == kubeproxyconfig.NodePortAddressesPrimary {
 		var nodePortAddresses []string
@@ -606,10 +608,6 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	// hollow-proxy doesn't need node config, and we don't create nodeManager for hollow-proxy.
 	if s.NodeManager != nil {
 		nodeConfig := config.NewNodeConfig(ctx, s.NodeManager.NodeInformer(), s.Config.ConfigSyncPeriod.Duration)
-		// https://issues.k8s.io/111321
-		if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR {
-			nodeConfig.RegisterEventHandler(proxy.NewNodePodCIDRHandler(ctx, s.podCIDRs))
-		}
 		nodeConfig.RegisterEventHandler(&proxy.NodeEligibleHandler{
 			HealthServer: s.HealthzServer,
 		})

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	netutils "k8s.io/utils/net"
@@ -59,83 +57,6 @@ func (s *fakeProxyServerError) Run(ctx context.Context) error {
 // CleanupAndExit runs in the specified ProxyServer.
 func (s *fakeProxyServerError) CleanupAndExit() error {
 	return errors.New("mocking error from ProxyServer.CleanupAndExit()")
-}
-
-func makeNodeWithAddress(name, primaryIP string) *v1.Node {
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Status: v1.NodeStatus{
-			Addresses: []v1.NodeAddress{},
-		},
-	}
-
-	if primaryIP != "" {
-		node.Status.Addresses = append(node.Status.Addresses,
-			v1.NodeAddress{Type: v1.NodeInternalIP, Address: primaryIP},
-		)
-	}
-
-	return node
-}
-
-// Test that getNodeIPs retries on failure
-func Test_getNodeIPs(t *testing.T) {
-	var chans [3]chan error
-
-	client := clientsetfake.NewSimpleClientset(
-		// node1 initially has no IP address.
-		makeNodeWithAddress("node1", ""),
-
-		// node2 initially has an invalid IP address.
-		makeNodeWithAddress("node2", "invalid-ip"),
-
-		// node3 initially does not exist.
-	)
-
-	for i := range chans {
-		chans[i] = make(chan error)
-		ch := chans[i]
-		nodeName := fmt.Sprintf("node%d", i+1)
-		expectIP := fmt.Sprintf("192.168.0.%d", i+1)
-		go func() {
-			_, ctx := ktesting.NewTestContext(t)
-			ips := getNodeIPs(ctx, client, nodeName)
-			if len(ips) == 0 {
-				ch <- fmt.Errorf("expected IP %s for %s but got nil", expectIP, nodeName)
-			} else if ips[0].String() != expectIP {
-				ch <- fmt.Errorf("expected IP %s for %s but got %s", expectIP, nodeName, ips[0].String())
-			} else if len(ips) != 1 {
-				ch <- fmt.Errorf("expected IP %s for %s but got multiple IPs", expectIP, nodeName)
-			}
-			close(ch)
-		}()
-	}
-
-	// Give the goroutines time to fetch the bad/non-existent nodes, then fix them.
-	time.Sleep(1200 * time.Millisecond)
-
-	_, _ = client.CoreV1().Nodes().UpdateStatus(context.TODO(),
-		makeNodeWithAddress("node1", "192.168.0.1"),
-		metav1.UpdateOptions{},
-	)
-	_, _ = client.CoreV1().Nodes().UpdateStatus(context.TODO(),
-		makeNodeWithAddress("node2", "192.168.0.2"),
-		metav1.UpdateOptions{},
-	)
-	_, _ = client.CoreV1().Nodes().Create(context.TODO(),
-		makeNodeWithAddress("node3", "192.168.0.3"),
-		metav1.CreateOptions{},
-	)
-
-	// Ensure each getNodeIP completed as expected
-	for i := range chans {
-		err := <-chans[i]
-		if err != nil {
-			t.Error(err.Error())
-		}
-	}
 }
 
 func Test_detectNodeIPs(t *testing.T) {

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -273,24 +274,6 @@ type NodeHandler interface {
 	OnNodeSynced()
 }
 
-// NoopNodeHandler is a noop handler for proxiers that have not yet
-// implemented a full NodeHandler.
-type NoopNodeHandler struct{}
-
-// OnNodeAdd is a noop handler for Node creates.
-func (*NoopNodeHandler) OnNodeAdd(node *v1.Node) {}
-
-// OnNodeUpdate is a noop handler for Node updates.
-func (*NoopNodeHandler) OnNodeUpdate(oldNode, node *v1.Node) {}
-
-// OnNodeDelete is a noop handler for Node deletes.
-func (*NoopNodeHandler) OnNodeDelete(node *v1.Node) {}
-
-// OnNodeSynced is a noop handler for Node syncs.
-func (*NoopNodeHandler) OnNodeSynced() {}
-
-var _ NodeHandler = &NoopNodeHandler{}
-
 // NodeConfig tracks a set of node configurations.
 // It accepts "set", "add" and "remove" operations of node via channels, and invokes registered handlers on change.
 type NodeConfig struct {
@@ -481,5 +464,88 @@ func (c *ServiceCIDRConfig) handleServiceCIDREvent(oldObj, newObj interface{}) {
 	for i := range c.eventHandlers {
 		c.logger.V(4).Info("Calling handler.OnServiceCIDRsChanged")
 		c.eventHandlers[i].OnServiceCIDRsChanged(c.cidrs.UnsortedList())
+	}
+}
+
+// NodeTopologyHandler is an abstract interface for objects which receive
+// notifications about changes in proxy relevant node topology labels.
+type NodeTopologyHandler interface {
+	// OnTopologyChange is called whenever a change is observed in proxy
+	// relevant node topology labels, and provides the observed change.
+	OnTopologyChange(topologyLabels map[string]string)
+}
+
+// NodeTopologyConfig tracks node topology labels.
+type NodeTopologyConfig struct {
+	listerSynced   cache.InformerSynced
+	eventHandlers  []NodeTopologyHandler
+	topologyLabels map[string]string
+	logger         klog.Logger
+}
+
+// NewNodeTopologyConfig creates a new NodeTopologyConfig.
+func NewNodeTopologyConfig(ctx context.Context, nodeInformer v1informers.NodeInformer, resyncPeriod time.Duration) *NodeTopologyConfig {
+	return newNodeTopologyConfig(ctx, nodeInformer, resyncPeriod, nil)
+}
+
+// newNodeTopologyConfig implements NewNodeTopologyConfig by additionally consuming a callback function which is invoked when
+// event handler completes processing and is only used for testing.
+func newNodeTopologyConfig(ctx context.Context, nodeInformer v1informers.NodeInformer, resyncPeriod time.Duration, callback func()) *NodeTopologyConfig {
+	result := &NodeTopologyConfig{
+		logger:         klog.FromContext(ctx),
+		topologyLabels: make(map[string]string),
+	}
+
+	handlerRegistration, _ := nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				result.handleNodeEvent(obj)
+				if callback != nil {
+					callback()
+				}
+			},
+			UpdateFunc: func(_, newObj interface{}) {
+				result.handleNodeEvent(newObj)
+				if callback != nil {
+					callback()
+				}
+			},
+			DeleteFunc: func(_ interface{}) {},
+		},
+		resyncPeriod,
+	)
+	result.listerSynced = handlerRegistration.HasSynced
+
+	return result
+}
+
+// RegisterEventHandler registers a handler which is called on Node object change.
+func (n *NodeTopologyConfig) RegisterEventHandler(handler NodeTopologyHandler) {
+	n.eventHandlers = append(n.eventHandlers, handler)
+}
+
+// handleNodeEvent is a helper function to handle Add, Update and Delete
+// events on Node objects and call downstream event handlers.
+func (n *NodeTopologyConfig) handleNodeEvent(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+		return
+	}
+
+	topologyLabels := make(map[string]string)
+	if _, ok = node.Labels[v1.LabelTopologyZone]; ok {
+		topologyLabels[v1.LabelTopologyZone] = node.Labels[v1.LabelTopologyZone]
+	}
+
+	// skip calling event handlers when no change in topology labels
+	if reflect.DeepEqual(n.topologyLabels, topologyLabels) {
+		return
+	}
+
+	n.topologyLabels = topologyLabels
+	for i := range n.eventHandlers {
+		n.logger.V(4).Info("Calling handler.OnTopologyChange")
+		n.eventHandlers[i].OnTopologyChange(n.topologyLabels)
 	}
 }

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -260,12 +260,9 @@ func (c *ServiceConfig) handleDeleteService(obj interface{}) {
 // NodeHandler is an abstract interface of objects which receive
 // notifications about node object changes.
 type NodeHandler interface {
-	// OnNodeAdd is called whenever creation of new node object
-	// is observed.
-	OnNodeAdd(node *v1.Node)
-	// OnNodeUpdate is called whenever modification of an existing
-	// node object is observed.
-	OnNodeUpdate(oldNode, node *v1.Node)
+	// OnNodeChange is called whenever creation or modification
+	// of node object is observed.
+	OnNodeChange(node *v1.Node)
 	// OnNodeDelete is called whenever deletion of an existing node
 	// object is observed.
 	OnNodeDelete(node *v1.Node)
@@ -290,8 +287,8 @@ func NewNodeConfig(ctx context.Context, nodeInformer v1informers.NodeInformer, r
 
 	handlerRegistration, _ := nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    result.handleAddNode,
-			UpdateFunc: result.handleUpdateNode,
+			AddFunc:    func(obj interface{}) { result.handleChangeNode(obj) },
+			UpdateFunc: func(_, newObj interface{}) { result.handleChangeNode(newObj) },
 			DeleteFunc: result.handleDeleteNode,
 		},
 		resyncPeriod,
@@ -321,32 +318,15 @@ func (c *NodeConfig) Run(stopCh <-chan struct{}) {
 	}
 }
 
-func (c *NodeConfig) handleAddNode(obj interface{}) {
+func (c *NodeConfig) handleChangeNode(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
 		return
 	}
 	for i := range c.eventHandlers {
-		c.logger.V(4).Info("Calling handler.OnNodeAdd")
-		c.eventHandlers[i].OnNodeAdd(node)
-	}
-}
-
-func (c *NodeConfig) handleUpdateNode(oldObj, newObj interface{}) {
-	oldNode, ok := oldObj.(*v1.Node)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", oldObj))
-		return
-	}
-	node, ok := newObj.(*v1.Node)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
-		return
-	}
-	for i := range c.eventHandlers {
-		c.logger.V(5).Info("Calling handler.OnNodeUpdate")
-		c.eventHandlers[i].OnNodeUpdate(oldNode, node)
+		c.logger.V(4).Info("Calling handler.OnNodeChange")
+		c.eventHandlers[i].OnNodeChange(node)
 	}
 }
 

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -454,14 +454,7 @@ func NewNodeHandlerMock() *NodeHandlerMock {
 	return h
 }
 
-func (h *NodeHandlerMock) OnNodeAdd(node *v1.Node) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	h.state[node.Name] = node
-	h.sendNodes()
-}
-
-func (h *NodeHandlerMock) OnNodeUpdate(oldNode, node *v1.Node) {
+func (h *NodeHandlerMock) OnNodeChange(node *v1.Node) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	h.state[node.Name] = node

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -18,13 +18,15 @@ package config
 
 import (
 	"reflect"
-	"sort"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,18 +37,6 @@ import (
 	klogtesting "k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
-
-type sortedServices []*v1.Service
-
-func (s sortedServices) Len() int {
-	return len(s)
-}
-func (s sortedServices) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s sortedServices) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
-}
 
 type ServiceHandlerMock struct {
 	lock sync.Mutex
@@ -107,7 +97,7 @@ func (h *ServiceHandlerMock) sendServices() {
 	for _, svc := range h.state {
 		services = append(services, svc)
 	}
-	sort.Sort(sortedServices(services))
+	slices.SortFunc(services, func(a, b *v1.Service) int { return strings.Compare(a.Name, b.Name) })
 	h.process(services)
 }
 
@@ -126,101 +116,6 @@ func (h *ServiceHandlerMock) ValidateServices(t *testing.T, expectedServices []*
 		// and surface a clearer reason for failure.
 		case <-time.After(wait.ForeverTestTimeout):
 			t.Errorf("Timed out. Expected %#v, Got %#v", expectedServices, services)
-			return
-		}
-	}
-}
-
-type sortedEndpointSlices []*discoveryv1.EndpointSlice
-
-func (s sortedEndpointSlices) Len() int {
-	return len(s)
-}
-func (s sortedEndpointSlices) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s sortedEndpointSlices) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
-}
-
-type EndpointSliceHandlerMock struct {
-	lock sync.Mutex
-
-	state   map[types.NamespacedName]*discoveryv1.EndpointSlice
-	synced  bool
-	updated chan []*discoveryv1.EndpointSlice
-	process func([]*discoveryv1.EndpointSlice)
-}
-
-func NewEndpointSliceHandlerMock() *EndpointSliceHandlerMock {
-	ehm := &EndpointSliceHandlerMock{
-		state:   make(map[types.NamespacedName]*discoveryv1.EndpointSlice),
-		updated: make(chan []*discoveryv1.EndpointSlice, 5),
-	}
-	ehm.process = func(endpoints []*discoveryv1.EndpointSlice) {
-		ehm.updated <- endpoints
-	}
-	return ehm
-}
-
-func (h *EndpointSliceHandlerMock) OnEndpointSliceAdd(slice *discoveryv1.EndpointSlice) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name}
-	h.state[namespacedName] = slice
-	h.sendEndpointSlices()
-}
-
-func (h *EndpointSliceHandlerMock) OnEndpointSliceUpdate(oldSlice, slice *discoveryv1.EndpointSlice) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name}
-	h.state[namespacedName] = slice
-	h.sendEndpointSlices()
-}
-
-func (h *EndpointSliceHandlerMock) OnEndpointSliceDelete(slice *discoveryv1.EndpointSlice) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name}
-	delete(h.state, namespacedName)
-	h.sendEndpointSlices()
-}
-
-func (h *EndpointSliceHandlerMock) OnEndpointSlicesSynced() {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	h.synced = true
-	h.sendEndpointSlices()
-}
-
-func (h *EndpointSliceHandlerMock) sendEndpointSlices() {
-	if !h.synced {
-		return
-	}
-	slices := make([]*discoveryv1.EndpointSlice, 0, len(h.state))
-	for _, eps := range h.state {
-		slices = append(slices, eps)
-	}
-	sort.Sort(sortedEndpointSlices(slices))
-	h.process(slices)
-}
-
-func (h *EndpointSliceHandlerMock) ValidateEndpointSlices(t *testing.T, expectedSlices []*discoveryv1.EndpointSlice) {
-	// We might get 1 or more updates for N endpointslice updates, because we
-	// over write older snapshots of endpointslices from the producer go-routine
-	// if the consumer falls behind. Unittests will hard timeout in 5m.
-	var slices []*discoveryv1.EndpointSlice
-	for {
-		select {
-		case slices = <-h.updated:
-			if reflect.DeepEqual(slices, expectedSlices) {
-				return
-			}
-		// Unittests will hard timeout in 5m with a stack trace, prevent that
-		// and surface a clearer reason for failure.
-		case <-time.After(wait.ForeverTestTimeout):
-			t.Errorf("Timed out. Expected %#v, Got %#v", expectedSlices, slices)
 			return
 		}
 	}
@@ -321,6 +216,89 @@ func TestNewServicesMultipleHandlersAddedAndNotified(t *testing.T) {
 	services := []*v1.Service{service2, service1}
 	handler.ValidateServices(t, services)
 	handler2.ValidateServices(t, services)
+}
+
+type EndpointSliceHandlerMock struct {
+	lock sync.Mutex
+
+	state   map[types.NamespacedName]*discoveryv1.EndpointSlice
+	synced  bool
+	updated chan []*discoveryv1.EndpointSlice
+	process func([]*discoveryv1.EndpointSlice)
+}
+
+func NewEndpointSliceHandlerMock() *EndpointSliceHandlerMock {
+	ehm := &EndpointSliceHandlerMock{
+		state:   make(map[types.NamespacedName]*discoveryv1.EndpointSlice),
+		updated: make(chan []*discoveryv1.EndpointSlice, 5),
+	}
+	ehm.process = func(endpoints []*discoveryv1.EndpointSlice) {
+		ehm.updated <- endpoints
+	}
+	return ehm
+}
+
+func (h *EndpointSliceHandlerMock) OnEndpointSliceAdd(slice *discoveryv1.EndpointSlice) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	namespacedName := types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name}
+	h.state[namespacedName] = slice
+	h.sendEndpointSlices()
+}
+
+func (h *EndpointSliceHandlerMock) OnEndpointSliceUpdate(oldSlice, slice *discoveryv1.EndpointSlice) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	namespacedName := types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name}
+	h.state[namespacedName] = slice
+	h.sendEndpointSlices()
+}
+
+func (h *EndpointSliceHandlerMock) OnEndpointSliceDelete(slice *discoveryv1.EndpointSlice) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	namespacedName := types.NamespacedName{Namespace: slice.Namespace, Name: slice.Name}
+	delete(h.state, namespacedName)
+	h.sendEndpointSlices()
+}
+
+func (h *EndpointSliceHandlerMock) OnEndpointSlicesSynced() {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.synced = true
+	h.sendEndpointSlices()
+}
+
+func (h *EndpointSliceHandlerMock) sendEndpointSlices() {
+	if !h.synced {
+		return
+	}
+	endpointSlices := make([]*discoveryv1.EndpointSlice, 0, len(h.state))
+	for _, eps := range h.state {
+		endpointSlices = append(endpointSlices, eps)
+	}
+	slices.SortFunc(endpointSlices, func(a, b *discoveryv1.EndpointSlice) int { return strings.Compare(a.Name, b.Name) })
+	h.process(endpointSlices)
+}
+
+func (h *EndpointSliceHandlerMock) ValidateEndpointSlices(t *testing.T, expectedSlices []*discoveryv1.EndpointSlice) {
+	// We might get 1 or more updates for N endpointslice updates, because we
+	// over write older snapshots of endpointslices from the producer go-routine
+	// if the consumer falls behind. Unittests will hard timeout in 5m.
+	var slices []*discoveryv1.EndpointSlice
+	for {
+		select {
+		case slices = <-h.updated:
+			if reflect.DeepEqual(slices, expectedSlices) {
+				return
+			}
+		// Unittests will hard timeout in 5m with a stack trace, prevent that
+		// and surface a clearer reason for failure.
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Errorf("Timed out. Expected %#v, Got %#v", expectedSlices, slices)
+			return
+		}
+	}
 }
 
 func TestNewEndpointsMultipleHandlersAddedAndNotified(t *testing.T) {
@@ -453,7 +431,302 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 	handler2.ValidateEndpointSlices(t, endpoints)
 }
 
+type NodeHandlerMock struct {
+	lock sync.Mutex
+
+	state   map[string]*v1.Node
+	synced  bool
+	updated chan []*v1.Node
+	process func([]*v1.Node)
+}
+
+func NewNodeHandlerMock() *NodeHandlerMock {
+	h := &NodeHandlerMock{
+		state:   make(map[string]*v1.Node),
+		updated: make(chan []*v1.Node, 5),
+	}
+	h.process = func(nodes []*v1.Node) {
+		h.updated <- nodes
+	}
+	return h
+}
+
+func (h *NodeHandlerMock) OnNodeAdd(node *v1.Node) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.state[node.Name] = node
+	h.sendNodes()
+}
+
+func (h *NodeHandlerMock) OnNodeUpdate(oldNode, node *v1.Node) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.state[node.Name] = node
+	h.sendNodes()
+}
+
+func (h *NodeHandlerMock) OnNodeDelete(node *v1.Node) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	delete(h.state, node.Name)
+	h.sendNodes()
+}
+
+func (h *NodeHandlerMock) OnNodeSynced() {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.synced = true
+	h.sendNodes()
+}
+
+func (h *NodeHandlerMock) sendNodes() {
+	if !h.synced {
+		return
+	}
+	nodes := make([]*v1.Node, 0, len(h.state))
+	for _, svc := range h.state {
+		nodes = append(nodes, svc)
+	}
+	slices.SortFunc(nodes, func(a, b *v1.Node) int { return strings.Compare(a.Name, b.Name) })
+	h.process(nodes)
+}
+
+func (h *NodeHandlerMock) ValidateNodes(t *testing.T, expectedNodes []*v1.Node) {
+	// We might get 1 or more updates for N node updates, because we
+	// over write older snapshots of nodes from the producer go-routine
+	// if the consumer falls behind.
+	var nodes []*v1.Node
+	for {
+		select {
+		case nodes = <-h.updated:
+			if reflect.DeepEqual(nodes, expectedNodes) {
+				return
+			}
+		// Unittests will hard timeout in 5m with a stack trace, prevent that
+		// and surface a clearer reason for failure.
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Errorf("Timed out. Expected %#v, Got %#v", expectedNodes, nodes)
+			return
+		}
+	}
+}
+
+func TestNewNodesMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
+	_, ctx := klogtesting.NewTestContext(t)
+	client := fake.NewSimpleClientset()
+	fakeWatch := watch.NewFake()
+	client.PrependWatchReactor("nodes", ktesting.DefaultWatchReactor(fakeWatch, nil))
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
+
+	config := NewNodeConfig(ctx, sharedInformers.Core().V1().Nodes(), time.Minute)
+	handler := NewNodeHandlerMock()
+	handler2 := NewNodeHandlerMock()
+	config.RegisterEventHandler(handler)
+	config.RegisterEventHandler(handler2)
+	sharedInformers.Start(stopCh)
+	go config.Run(stopCh)
+
+	nodes1 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "1.1.1.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "2.2.2.2",
+				},
+			},
+		},
+	}
+	nodes2 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bar"},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "3.3.3.3",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "fc00::4",
+				},
+			},
+		},
+	}
+	fakeWatch.Add(nodes1)
+	fakeWatch.Add(nodes2)
+
+	nodes := []*v1.Node{nodes2, nodes1}
+	handler.ValidateNodes(t, nodes)
+	handler2.ValidateNodes(t, nodes)
+
+	// Add one more
+	nodes3 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "foobar"},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "5.5.5.5",
+				},
+			},
+		},
+	}
+	fakeWatch.Add(nodes3)
+	nodes = []*v1.Node{nodes2, nodes1, nodes3}
+	handler.ValidateNodes(t, nodes)
+	handler2.ValidateNodes(t, nodes)
+
+	// Update the "foo" node with a new address
+	nodes1v2 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "6.6.6.6",
+				},
+			},
+		},
+	}
+	fakeWatch.Modify(nodes1v2)
+	nodes = []*v1.Node{nodes2, nodes1v2, nodes3}
+	handler.ValidateNodes(t, nodes)
+	handler2.ValidateNodes(t, nodes)
+
+	// Remove "bar" node
+	fakeWatch.Delete(nodes2)
+	nodes = []*v1.Node{nodes1v2, nodes3}
+	handler.ValidateNodes(t, nodes)
+	handler2.ValidateNodes(t, nodes)
+}
+
+type ServiceCIDRHandlerMock struct {
+	lock sync.Mutex
+
+	state   []string
+	updated chan []string
+	process func([]string)
+}
+
+func NewServiceCIDRHandlerMock() *ServiceCIDRHandlerMock {
+	h := &ServiceCIDRHandlerMock{
+		updated: make(chan []string, 5),
+	}
+	h.process = func(serviceCIDRs []string) {
+		h.updated <- serviceCIDRs
+	}
+	return h
+}
+
+func (h *ServiceCIDRHandlerMock) OnServiceCIDRsChanged(serviceCIDRs []string) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.state = serviceCIDRs
+	h.sendServiceCIDRs()
+}
+
+func (h *ServiceCIDRHandlerMock) sendServiceCIDRs() {
+	serviceCIDRs := append([]string{}, h.state...)
+	slices.Sort(serviceCIDRs)
+	h.process(serviceCIDRs)
+}
+
+func (h *ServiceCIDRHandlerMock) ValidateServiceCIDRs(t *testing.T, expectedServiceCIDRs []string) {
+	// We might get 1 or more updates for N serviceCIDR updates, because we
+	// over write older snapshots of nodes from the producer go-routine
+	// if the consumer falls behind.
+	var serviceCIDRs []string
+	for {
+		select {
+		case serviceCIDRs = <-h.updated:
+			if reflect.DeepEqual(serviceCIDRs, expectedServiceCIDRs) {
+				return
+			}
+			t.Logf("Expected %#v, Got %#v", expectedServiceCIDRs, serviceCIDRs)
+		// Unittests will hard timeout in 5m with a stack trace, prevent that
+		// and surface a clearer reason for failure.
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Errorf("Timed out. Expected %#v, Got %#v", expectedServiceCIDRs, serviceCIDRs)
+			return
+		}
+	}
+}
+
+func TestNewServiceCIDRsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
+	_, ctx := klogtesting.NewTestContext(t)
+	client := fake.NewSimpleClientset()
+	fakeWatch := watch.NewFake()
+	client.PrependWatchReactor("servicecidrs", ktesting.DefaultWatchReactor(fakeWatch, nil))
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
+
+	config := NewServiceCIDRConfig(ctx, sharedInformers.Networking().V1().ServiceCIDRs(), time.Minute)
+	handler := NewServiceCIDRHandlerMock()
+	handler2 := NewServiceCIDRHandlerMock()
+	config.RegisterEventHandler(handler)
+	config.RegisterEventHandler(handler2)
+	sharedInformers.Start(stopCh)
+	go config.Run(stopCh)
+
+	serviceCIDRs1 := &networkingv1.ServiceCIDR{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		Spec: networkingv1.ServiceCIDRSpec{
+			CIDRs: []string{"1.1.1.0/24"},
+		},
+	}
+	serviceCIDRs2 := &networkingv1.ServiceCIDR{
+		ObjectMeta: metav1.ObjectMeta{Name: "bar"},
+		Spec: networkingv1.ServiceCIDRSpec{
+			CIDRs: []string{"2.2.2.0/24", "fc00::/64"},
+		},
+	}
+	fakeWatch.Add(serviceCIDRs1)
+	fakeWatch.Add(serviceCIDRs2)
+
+	serviceCIDRs := []string{"1.1.1.0/24", "2.2.2.0/24", "fc00::/64"}
+	handler.ValidateServiceCIDRs(t, serviceCIDRs)
+	handler2.ValidateServiceCIDRs(t, serviceCIDRs)
+
+	// Add one more
+	serviceCIDRs3 := &networkingv1.ServiceCIDR{
+		ObjectMeta: metav1.ObjectMeta{Name: "foobar"},
+		Spec: networkingv1.ServiceCIDRSpec{
+			CIDRs: []string{"3.3.3.0/24", "2001:db8::/64"},
+		},
+	}
+	fakeWatch.Add(serviceCIDRs3)
+	serviceCIDRs = []string{"1.1.1.0/24", "2.2.2.0/24", "2001:db8::/64", "3.3.3.0/24", "fc00::/64"}
+	handler.ValidateServiceCIDRs(t, serviceCIDRs)
+	handler2.ValidateServiceCIDRs(t, serviceCIDRs)
+
+	// Update the "foo" ServiceCIDR
+	serviceCIDRs1v2 := &networkingv1.ServiceCIDR{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		Spec: networkingv1.ServiceCIDRSpec{
+			CIDRs: []string{"4.4.4.0/24"},
+		},
+	}
+	fakeWatch.Modify(serviceCIDRs1v2)
+	serviceCIDRs = []string{"2.2.2.0/24", "2001:db8::/64", "3.3.3.0/24", "4.4.4.0/24", "fc00::/64"}
+	handler.ValidateServiceCIDRs(t, serviceCIDRs)
+	handler2.ValidateServiceCIDRs(t, serviceCIDRs)
+
+	// Remove "bar" ServiceCIDR
+	fakeWatch.Delete(serviceCIDRs2)
+	serviceCIDRs = []string{"2001:db8::/64", "3.3.3.0/24", "4.4.4.0/24"}
+	handler.ValidateServiceCIDRs(t, serviceCIDRs)
+	handler2.ValidateServiceCIDRs(t, serviceCIDRs)
+}
+
 // TODO: Add a unittest for interrupts getting processed in a timely manner.
-// Currently this module has a circular dependency with config, and so it's
-// named config_test, which means even test methods need to be public. This
-// is refactoring that we can avoid by resolving the dependency.

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -727,6 +730,138 @@ func TestNewServiceCIDRsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 	serviceCIDRs = []string{"2001:db8::/64", "3.3.3.0/24", "4.4.4.0/24"}
 	handler.ValidateServiceCIDRs(t, serviceCIDRs)
 	handler2.ValidateServiceCIDRs(t, serviceCIDRs)
+}
+
+type nodeTopologyHandlerMock struct {
+	topologyLabels map[string]string
+}
+
+func (n *nodeTopologyHandlerMock) OnTopologyChange(topologyLabels map[string]string) {
+	n.topologyLabels = topologyLabels
+}
+
+// waitForInvocation waits for event handler to complete processing of the invocation.
+func waitForInvocation(invoked <-chan struct{}) error {
+	select {
+	// unit tests will hard timeout in 5m with a stack trace, prevent that
+	// and surface a clearer reason for failure.
+	case <-time.After(wait.ForeverTestTimeout):
+		return fmt.Errorf("timed out waiting for event handler to process update")
+	case <-invoked:
+		return nil
+	}
+}
+
+func TestNewNodeTopologyConfig(t *testing.T) {
+	_, ctx := klogtesting.NewTestContext(t)
+	client := fake.NewClientset()
+	fakeWatch := watch.NewFake()
+	client.PrependWatchReactor("nodes", ktesting.DefaultWatchReactor(fakeWatch, nil))
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
+	nodeInformer := sharedInformers.Core().V1().Nodes()
+	invoked := make(chan struct{})
+	config := newNodeTopologyConfig(ctx, nodeInformer, time.Minute, func() {
+		// The callback is invoked after the event has been processed by the
+		// handlers. For this unit test, we write to the channel here and wait
+		// for it in waitForInvocation() which is called before doing assertions.
+		invoked <- struct{}{}
+	})
+
+	handler := &nodeTopologyHandlerMock{
+		topologyLabels: make(map[string]string),
+	}
+	config.RegisterEventHandler(handler)
+	sharedInformers.Start(stopCh)
+
+	testNodeName := "test-node"
+
+	// add non-topology labels, handle should receive no notification
+	fakeWatch.Add(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+			Labels: map[string]string{
+				v1.LabelInstanceType: "m4.large",
+				v1.LabelOSStable:     "linux",
+			},
+		},
+	})
+	err := waitForInvocation(invoked)
+	require.NoError(t, err)
+	require.Empty(t, handler.topologyLabels)
+
+	// add topology label not relevant to kube-proxy, handle should receive no notification
+	fakeWatch.Add(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+			Labels: map[string]string{
+				v1.LabelInstanceType:   "m4.large",
+				v1.LabelOSStable:       "linux",
+				v1.LabelTopologyRegion: "us-east-1",
+			},
+		},
+	})
+	err = waitForInvocation(invoked)
+	require.NoError(t, err)
+	require.Empty(t, handler.topologyLabels)
+
+	// add relevant zone topology label, handle should receive notification
+	fakeWatch.Add(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+			Labels: map[string]string{
+				v1.LabelInstanceType: "c6.large",
+				v1.LabelOSStable:     "windows",
+				v1.LabelTopologyZone: "us-west-2a",
+			},
+		},
+	})
+
+	err = waitForInvocation(invoked)
+	require.NoError(t, err)
+	require.Len(t, handler.topologyLabels, 1)
+	require.Equal(t, map[string]string{
+		v1.LabelTopologyZone: "us-west-2a",
+	}, handler.topologyLabels)
+
+	// add region topology label, handle should not receive notification
+	// because kube-proxy doesn't do any region-based topology.
+	fakeWatch.Add(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+			Labels: map[string]string{
+				v1.LabelInstanceType:   "m3.medium",
+				v1.LabelOSStable:       "windows",
+				v1.LabelTopologyRegion: "us-east-1",
+				v1.LabelTopologyZone:   "us-east-1b",
+			},
+		},
+	})
+	err = waitForInvocation(invoked)
+	require.NoError(t, err)
+	require.Len(t, handler.topologyLabels, 1)
+	require.Equal(t, map[string]string{
+		v1.LabelTopologyZone: "us-east-1b",
+	}, handler.topologyLabels)
+
+	// update non-topology label, handle should not receive notification
+	fakeWatch.Add(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+			Labels: map[string]string{
+				v1.LabelInstanceType:   "m3.large",
+				v1.LabelOSStable:       "windows",
+				v1.LabelTopologyRegion: "us-east-1",
+				v1.LabelTopologyZone:   "us-east-1b",
+			},
+		},
+	})
+	err = waitForInvocation(invoked)
+	require.NoError(t, err)
+	require.Len(t, handler.topologyLabels, 1)
 }
 
 // TODO: Add a unittest for interrupts getting processed in a timely manner.

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -27,20 +27,23 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/component-base/metrics/testutil"
-
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/dump"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
-
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	basemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 )
+
+const testNodeName = "test-node"
 
 type fakeListener struct {
 	openPorts sets.Set[string]
@@ -431,7 +434,16 @@ func tHandler(hcs *server, nsn types.NamespacedName, status int, endpoints int, 
 type nodeTweak func(n *v1.Node)
 
 func makeNode(tweaks ...nodeTweak) *v1.Node {
-	n := &v1.Node{}
+	n := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+		},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{{
+				Type: v1.NodeInternalIP, Address: "192.168.0.1",
+			}},
+		},
+	}
 	for _, tw := range tweaks {
 		tw(n)
 	}
@@ -464,8 +476,10 @@ func TestHealthzServer(t *testing.T) {
 	listener := newFakeListener()
 	httpFactory := newFakeHTTPServerFactory()
 	fakeClock := testingclock.NewFakeClock(time.Now())
+	client := clientsetfake.NewClientset(makeNode())
 
-	hs := newProxyHealthServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second)
+	nodeManager, _ := proxy.NewNodeManager(context.TODO(), client, time.Second, testNodeName, false)
+	hs := newProxyHealthServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second, nodeManager)
 	server := hs.httpFactory.New(healthzHandler{hs: hs})
 
 	hsTest := &serverTest{
@@ -481,7 +495,7 @@ func TestHealthzServer(t *testing.T) {
 	testProxyHealthUpdater(hs, hsTest, fakeClock, ptr.To(true), t)
 
 	// Should return 200 "OK" if we've synced a node, tainted in any other way
-	hs.SyncNode(makeNode(tweakTainted("other")))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -495,7 +509,7 @@ func TestHealthzServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 503 "ServiceUnavailable" if we've synced a ToBeDeletedTaint node
-	hs.SyncNode(makeNode(tweakTainted(ToBeDeletedTaint)))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted(ToBeDeletedTaint)))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -509,7 +523,7 @@ func TestHealthzServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusServiceUnavailable, expectedPayload, t)
 
 	// Should return 200 "OK" if we've synced a node, tainted in any other way
-	hs.SyncNode(makeNode(tweakTainted("other")))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -523,7 +537,7 @@ func TestHealthzServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 503 "ServiceUnavailable" if we've synced a deleted node
-	hs.SyncNode(makeNode(tweakDeleted()))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakDeleted()))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -542,8 +556,10 @@ func TestLivezServer(t *testing.T) {
 	listener := newFakeListener()
 	httpFactory := newFakeHTTPServerFactory()
 	fakeClock := testingclock.NewFakeClock(time.Now())
+	client := clientsetfake.NewClientset(makeNode())
 
-	hs := newProxyHealthServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second)
+	nodeManager, _ := proxy.NewNodeManager(context.TODO(), client, time.Second, testNodeName, false)
+	hs := newProxyHealthServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second, nodeManager)
 	server := hs.httpFactory.New(livezHandler{hs: hs})
 
 	hsTest := &serverTest{
@@ -559,7 +575,7 @@ func TestLivezServer(t *testing.T) {
 	testProxyHealthUpdater(hs, hsTest, fakeClock, nil, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	hs.SyncNode(makeNode(tweakTainted("other")))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),
@@ -572,7 +588,7 @@ func TestLivezServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	hs.SyncNode(makeNode(tweakTainted(ToBeDeletedTaint)))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted(ToBeDeletedTaint)))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),
@@ -585,7 +601,7 @@ func TestLivezServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	hs.SyncNode(makeNode(tweakTainted("other")))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),
@@ -598,7 +614,7 @@ func TestLivezServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	hs.SyncNode(makeNode(tweakDeleted()))
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakDeleted()))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -495,7 +495,7 @@ func TestHealthzServer(t *testing.T) {
 	testProxyHealthUpdater(hs, hsTest, fakeClock, ptr.To(true), t)
 
 	// Should return 200 "OK" if we've synced a node, tainted in any other way
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
+	nodeManager.OnNodeChange(makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -509,7 +509,7 @@ func TestHealthzServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 503 "ServiceUnavailable" if we've synced a ToBeDeletedTaint node
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted(ToBeDeletedTaint)))
+	nodeManager.OnNodeChange(makeNode(tweakTainted(ToBeDeletedTaint)))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -523,7 +523,7 @@ func TestHealthzServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusServiceUnavailable, expectedPayload, t)
 
 	// Should return 200 "OK" if we've synced a node, tainted in any other way
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
+	nodeManager.OnNodeChange(makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -537,7 +537,7 @@ func TestHealthzServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 503 "ServiceUnavailable" if we've synced a deleted node
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakDeleted()))
+	nodeManager.OnNodeChange(makeNode(tweakDeleted()))
 	expectedPayload = ProxyHealth{
 		CurrentTime:  fakeClock.Now(),
 		LastUpdated:  fakeClock.Now(),
@@ -575,7 +575,7 @@ func TestLivezServer(t *testing.T) {
 	testProxyHealthUpdater(hs, hsTest, fakeClock, nil, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
+	nodeManager.OnNodeChange(makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),
@@ -588,7 +588,7 @@ func TestLivezServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted(ToBeDeletedTaint)))
+	nodeManager.OnNodeChange(makeNode(tweakTainted(ToBeDeletedTaint)))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),
@@ -601,7 +601,7 @@ func TestLivezServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakTainted("other")))
+	nodeManager.OnNodeChange(makeNode(tweakTainted("other")))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),
@@ -614,7 +614,7 @@ func TestLivezServer(t *testing.T) {
 	testHTTPHandler(hsTest, http.StatusOK, expectedPayload, t)
 
 	// Should return 200 "OK" irrespective of node syncs
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakDeleted()))
+	nodeManager.OnNodeChange(makeNode(tweakDeleted()))
 	expectedPayload = ProxyHealth{
 		CurrentTime: fakeClock.Now(),
 		LastUpdated: fakeClock.Now(),

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net"
 	"os/exec"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -171,10 +170,10 @@ type Proxier struct {
 	endpointsChanges *proxy.EndpointsChangeTracker
 	serviceChanges   *proxy.ServiceChangeTracker
 
-	mu           sync.Mutex // protects the following fields
-	svcPortMap   proxy.ServicePortMap
-	endpointsMap proxy.EndpointsMap
-	nodeLabels   map[string]string
+	mu             sync.Mutex // protects the following fields
+	svcPortMap     proxy.ServicePortMap
+	endpointsMap   proxy.EndpointsMap
+	topologyLabels map[string]string
 	// initialSync is a bool indicating if the proxier is syncing for the first time.
 	// It is set to true when a new proxier is initialized and then set to false on all
 	// future syncs.
@@ -850,70 +849,13 @@ func (proxier *Proxier) OnEndpointSlicesSynced() {
 	proxier.syncProxyRules()
 }
 
-// OnNodeAdd is called whenever creation of new node object
-// is observed.
-func (proxier *Proxier) OnNodeAdd(node *v1.Node) {
-	if node.Name != proxier.nodeName {
-		proxier.logger.Error(nil, "Received a watch event for a node that doesn't match the current node", "eventNode", node.Name, "currentNode", proxier.nodeName)
-		return
-	}
-
-	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
-		return
-	}
-
+// OnTopologyChange is called whenever this node's proxy relevant topology-related labels change.
+func (proxier *Proxier) OnTopologyChange(topologyLabels map[string]string) {
 	proxier.mu.Lock()
-	proxier.nodeLabels = map[string]string{}
-	for k, v := range node.Labels {
-		proxier.nodeLabels[k] = v
-	}
+	proxier.topologyLabels = topologyLabels
 	proxier.mu.Unlock()
-	proxier.logger.V(4).Info("Updated proxier node labels", "labels", node.Labels)
-
+	proxier.logger.V(4).Info("Updated proxier node topology labels", "labels", topologyLabels)
 	proxier.Sync()
-}
-
-// OnNodeUpdate is called whenever modification of an existing
-// node object is observed.
-func (proxier *Proxier) OnNodeUpdate(oldNode, node *v1.Node) {
-	if node.Name != proxier.nodeName {
-		proxier.logger.Error(nil, "Received a watch event for a node that doesn't match the current node", "eventNode", node.Name, "currentNode", proxier.nodeName)
-		return
-	}
-
-	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
-		return
-	}
-
-	proxier.mu.Lock()
-	proxier.nodeLabels = map[string]string{}
-	for k, v := range node.Labels {
-		proxier.nodeLabels[k] = v
-	}
-	proxier.mu.Unlock()
-	proxier.logger.V(4).Info("Updated proxier node labels", "labels", node.Labels)
-
-	proxier.Sync()
-}
-
-// OnNodeDelete is called whenever deletion of an existing node
-// object is observed.
-func (proxier *Proxier) OnNodeDelete(node *v1.Node) {
-	if node.Name != proxier.nodeName {
-		proxier.logger.Error(nil, "Received a watch event for a node that doesn't match the current node", "eventNode", node.Name, "currentNode", proxier.nodeName)
-		return
-	}
-
-	proxier.mu.Lock()
-	proxier.nodeLabels = nil
-	proxier.mu.Unlock()
-
-	proxier.Sync()
-}
-
-// OnNodeSynced is called once all the initial event handlers were
-// called and the state is fully propagated to local cache.
-func (proxier *Proxier) OnNodeSynced() {
 }
 
 // OnServiceCIDRsChanged is called whenever a change is observed
@@ -1871,7 +1813,7 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 	if !ok {
 		proxier.logger.Info("Unable to filter endpoints due to missing service info", "servicePortName", svcPortName)
 	} else {
-		clusterEndpoints, localEndpoints, _, hasAnyEndpoints := proxy.CategorizeEndpoints(endpoints, svcInfo, proxier.nodeName, proxier.nodeLabels)
+		clusterEndpoints, localEndpoints, _, hasAnyEndpoints := proxy.CategorizeEndpoints(endpoints, svcInfo, proxier.nodeName, proxier.topologyLabels)
 		if onlyNodeLocalEndpoints {
 			if len(localEndpoints) > 0 {
 				endpoints = localEndpoints

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	proxyapp "k8s.io/kubernetes/cmd/kube-proxy/app"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/utils/ptr"
 )
 
@@ -38,9 +37,7 @@ type HollowProxy struct {
 	ProxyServer *proxyapp.ProxyServer
 }
 
-type FakeProxier struct {
-	proxyconfig.NoopNodeHandler
-}
+type FakeProxier struct{}
 
 func (*FakeProxier) Sync() {}
 func (*FakeProxier) SyncLoop() {
@@ -55,6 +52,7 @@ func (*FakeProxier) OnEndpointSliceUpdate(oldSlice, slice *discoveryv1.EndpointS
 func (*FakeProxier) OnEndpointSliceDelete(slice *discoveryv1.EndpointSlice)           {}
 func (*FakeProxier) OnEndpointSlicesSynced()                                          {}
 func (*FakeProxier) OnServiceCIDRsChanged(_ []string)                                 {}
+func (*FakeProxier) OnTopologyChange(_ map[string]string)                             {}
 
 func NewHollowProxy(
 	nodeName string,

--- a/pkg/proxy/metaproxier/meta_proxier.go
+++ b/pkg/proxy/metaproxier/meta_proxier.go
@@ -128,32 +128,10 @@ func (proxier *metaProxier) OnEndpointSlicesSynced() {
 	proxier.ipv6Proxier.OnEndpointSlicesSynced()
 }
 
-// OnNodeAdd is called whenever creation of new node object is observed.
-func (proxier *metaProxier) OnNodeAdd(node *v1.Node) {
-	proxier.ipv4Proxier.OnNodeAdd(node)
-	proxier.ipv6Proxier.OnNodeAdd(node)
-}
-
-// OnNodeUpdate is called whenever modification of an existing
-// node object is observed.
-func (proxier *metaProxier) OnNodeUpdate(oldNode, node *v1.Node) {
-	proxier.ipv4Proxier.OnNodeUpdate(oldNode, node)
-	proxier.ipv6Proxier.OnNodeUpdate(oldNode, node)
-}
-
-// OnNodeDelete is called whenever deletion of an existing node
-// object is observed.
-func (proxier *metaProxier) OnNodeDelete(node *v1.Node) {
-	proxier.ipv4Proxier.OnNodeDelete(node)
-	proxier.ipv6Proxier.OnNodeDelete(node)
-
-}
-
-// OnNodeSynced is called once all the initial event handlers were
-// called and the state is fully propagated to local cache.
-func (proxier *metaProxier) OnNodeSynced() {
-	proxier.ipv4Proxier.OnNodeSynced()
-	proxier.ipv6Proxier.OnNodeSynced()
+// OnTopologyChange is called whenever change in proxy relevant topology labels is observed.
+func (proxier *metaProxier) OnTopologyChange(topologyLabels map[string]string) {
+	proxier.ipv4Proxier.OnTopologyChange(topologyLabels)
+	proxier.ipv6Proxier.OnTopologyChange(topologyLabels)
 }
 
 // OnServiceCIDRsChanged is called whenever a change is observed

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -27,7 +27,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -151,10 +150,10 @@ type Proxier struct {
 	endpointsChanges *proxy.EndpointsChangeTracker
 	serviceChanges   *proxy.ServiceChangeTracker
 
-	mu           sync.Mutex // protects the following fields
-	svcPortMap   proxy.ServicePortMap
-	endpointsMap proxy.EndpointsMap
-	nodeLabels   map[string]string
+	mu             sync.Mutex // protects the following fields
+	svcPortMap     proxy.ServicePortMap
+	endpointsMap   proxy.EndpointsMap
+	topologyLabels map[string]string
 	// endpointSlicesSynced, and servicesSynced are set to true
 	// when corresponding objects are synced after startup. This is used to avoid
 	// updating nftables with some partial data after kube-proxy restart.
@@ -841,76 +840,14 @@ func (proxier *Proxier) OnEndpointSlicesSynced() {
 	proxier.syncProxyRules()
 }
 
-// OnNodeAdd is called whenever creation of new node object
-// is observed.
-func (proxier *Proxier) OnNodeAdd(node *v1.Node) {
-	if node.Name != proxier.nodeName {
-		proxier.logger.Error(nil, "Received a watch event for a node that doesn't match the current node",
-			"eventNode", node.Name, "currentNode", proxier.nodeName)
-		return
-	}
-
-	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
-		return
-	}
-
+// OnTopologyChange is called whenever this node's proxy relevant topology-related labels change.
+func (proxier *Proxier) OnTopologyChange(topologyLabels map[string]string) {
 	proxier.mu.Lock()
-	proxier.nodeLabels = map[string]string{}
-	for k, v := range node.Labels {
-		proxier.nodeLabels[k] = v
-	}
+	proxier.topologyLabels = topologyLabels
 	proxier.needFullSync = true
 	proxier.mu.Unlock()
-	proxier.logger.V(4).Info("Updated proxier node labels", "labels", node.Labels)
-
+	proxier.logger.V(4).Info("Updated proxier node topology labels", "labels", topologyLabels)
 	proxier.Sync()
-}
-
-// OnNodeUpdate is called whenever modification of an existing
-// node object is observed.
-func (proxier *Proxier) OnNodeUpdate(oldNode, node *v1.Node) {
-	if node.Name != proxier.nodeName {
-		proxier.logger.Error(nil, "Received a watch event for a node that doesn't match the current node",
-			"eventNode", node.Name, "currentNode", proxier.nodeName)
-		return
-	}
-
-	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
-		return
-	}
-
-	proxier.mu.Lock()
-	proxier.nodeLabels = map[string]string{}
-	for k, v := range node.Labels {
-		proxier.nodeLabels[k] = v
-	}
-	proxier.needFullSync = true
-	proxier.mu.Unlock()
-	proxier.logger.V(4).Info("Updated proxier node labels", "labels", node.Labels)
-
-	proxier.Sync()
-}
-
-// OnNodeDelete is called whenever deletion of an existing node
-// object is observed.
-func (proxier *Proxier) OnNodeDelete(node *v1.Node) {
-	if node.Name != proxier.nodeName {
-		proxier.logger.Error(nil, "Received a watch event for a node that doesn't match the current node",
-			"eventNode", node.Name, "currentNode", proxier.nodeName)
-		return
-	}
-
-	proxier.mu.Lock()
-	proxier.nodeLabels = nil
-	proxier.needFullSync = true
-	proxier.mu.Unlock()
-
-	proxier.Sync()
-}
-
-// OnNodeSynced is called once all the initial event handlers were
-// called and the state is fully propagated to local cache.
-func (proxier *Proxier) OnNodeSynced() {
 }
 
 // OnServiceCIDRsChanged is called whenever a change is observed
@@ -1312,7 +1249,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		// from this node, given the service's traffic policies. hasEndpoints is true
 		// if the service has any usable endpoints on any node, not just this one.
 		allEndpoints := proxier.endpointsMap[svcName]
-		clusterEndpoints, localEndpoints, allLocallyReachableEndpoints, hasEndpoints := proxy.CategorizeEndpoints(allEndpoints, svcInfo, proxier.nodeName, proxier.nodeLabels)
+		clusterEndpoints, localEndpoints, allLocallyReachableEndpoints, hasEndpoints := proxy.CategorizeEndpoints(allEndpoints, svcInfo, proxier.nodeName, proxier.topologyLabels)
 
 		// skipServiceUpdate is used for all service-related chains and their elements.
 		// If no changes were done to the service or its endpoints, these objects may be skipped.

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -18,13 +18,26 @@ package proxy
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
 	"reflect"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	v1informers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
+	utilnode "k8s.io/kubernetes/pkg/util/node"
 )
 
 // NodePodCIDRHandler handles the life cycle of kube-proxy based on the node PodCIDR assigned
@@ -109,3 +122,119 @@ func (n *NodeEligibleHandler) OnNodeDelete(node *v1.Node) { n.HealthServer.SyncN
 
 // OnNodeSynced is a handler for Node syncs.
 func (n *NodeEligibleHandler) OnNodeSynced() {}
+
+// NodeManager handles the life cycle of kube-proxy based on the NodeIPs, handles node watch events
+// and crashes kube-proxy if there are any changes in NodeIPs.
+type NodeManager struct {
+	nodeInformer v1informers.NodeInformer
+	nodeLister   corelisters.NodeLister
+	exitFunc     func(exitCode int)
+
+	nodeIPs []net.IP
+}
+
+// NewNodeManager initializes node informer that selects for the given node, waits for cache sync
+// and returns NodeManager after waiting some amount of time for the node object to exist
+// and have NodeIPs. Note: NewNodeManager doesn't return any error if failed to retrieve NodeIPs.
+func NewNodeManager(ctx context.Context, client clientset.Interface, resyncInterval time.Duration, nodeName string) (*NodeManager, error) {
+	return newNodeManager(ctx, client, resyncInterval, nodeName, os.Exit, time.Second, 30*time.Second)
+}
+
+// newNodeManager implements NewNodeManager with configurable exit function, poll interval and timeout.
+func newNodeManager(ctx context.Context, client clientset.Interface, resyncInterval time.Duration, nodeName string, exitFunc func(int), pollInterval, pollTimeout time.Duration) (*NodeManager, error) {
+	// make an informer that selects for the given node
+	thisNodeInformerFactory := informers.NewSharedInformerFactoryWithOptions(client, resyncInterval,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", nodeName).String()
+		}))
+	nodeInformer := thisNodeInformerFactory.Core().V1().Nodes()
+	nodeLister := nodeInformer.Lister()
+
+	// initialize the informer and wait for cache sync
+	thisNodeInformerFactory.Start(wait.NeverStop)
+	if !cache.WaitForNamedCacheSync("node informer cache", ctx.Done(), nodeInformer.Informer().HasSynced) {
+		return nil, fmt.Errorf("can not sync node informer")
+	}
+
+	node, nodeIPs := getNodeInfo(nodeLister, nodeName)
+
+	if len(nodeIPs) == 0 {
+		// wait for the node object to (hopefully) exist and have NodeIPs.
+		ctx, cancel := context.WithTimeout(ctx, pollTimeout)
+		defer cancel()
+		_ = wait.PollUntilContextCancel(ctx, pollInterval, true, func(context.Context) (bool, error) {
+			node, nodeIPs = getNodeInfo(nodeLister, nodeName)
+			return len(nodeIPs) != 0, nil
+		})
+	}
+
+	// For backward-compatibility, we keep going even if we didn't find a node or it
+	// didn't have IPs.
+	if node == nil {
+		klog.FromContext(ctx).Error(nil, "Timed out waiting for node %q to exist", nodeName)
+	} else if len(nodeIPs) == 0 {
+		klog.FromContext(ctx).Error(nil, "Timed out waiting for node %q to be assigned IPs", nodeName)
+	}
+
+	return &NodeManager{
+		nodeInformer: nodeInformer,
+		nodeLister:   nodeLister,
+		exitFunc:     exitFunc,
+
+		nodeIPs: nodeIPs,
+	}, nil
+}
+
+func getNodeInfo(nodeLister corelisters.NodeLister, nodeName string) (*v1.Node, []net.IP) {
+	node, _ := nodeLister.Get(nodeName)
+	if node == nil {
+		return nil, nil
+	}
+	nodeIPs, _ := utilnode.GetNodeHostIPs(node)
+	return node, nodeIPs
+}
+
+// NodeIPs returns the NodeIPs polled in NewNodeManager(). (This may be empty if
+// NewNodeManager timed out without getting any IPs.)
+func (n *NodeManager) NodeIPs() []net.IP {
+	return n.nodeIPs
+}
+
+// NodeInformer returns the NodeInformer.
+func (n *NodeManager) NodeInformer() v1informers.NodeInformer {
+	return n.nodeInformer
+}
+
+// OnNodeAdd is a handler for Node creates.
+func (n *NodeManager) OnNodeAdd(node *v1.Node) {
+	n.onNodeChange(node)
+}
+
+// OnNodeUpdate is a handler for Node updates.
+func (n *NodeManager) OnNodeUpdate(_, node *v1.Node) {
+	n.onNodeChange(node)
+}
+
+// onNodeChange functions helps to implement OnNodeAdd and OnNodeUpdate.
+func (n *NodeManager) onNodeChange(node *v1.Node) {
+	nodeIPs, _ := utilnode.GetNodeHostIPs(node)
+
+	// We exit whenever there is a change in NodeIPs detected initially, and NodeIPs received
+	// on node watch event.
+	if !reflect.DeepEqual(n.nodeIPs, nodeIPs) {
+		klog.InfoS("NodeIPs changed for the node",
+			"node", klog.KObj(node), "newNodeIPs", nodeIPs, "oldNodeIPs", n.nodeIPs)
+		klog.Flush()
+		n.exitFunc(1)
+	}
+}
+
+// OnNodeDelete is a handler for Node deletes.
+func (n *NodeManager) OnNodeDelete(node *v1.Node) {
+	klog.InfoS("Node is being deleted", "node", klog.KObj(node))
+	klog.Flush()
+	n.exitFunc(1)
+}
+
+// OnNodeSynced is called after the cache is synced and all pre-existing Nodes have been reported
+func (n *NodeManager) OnNodeSynced() {}

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -171,18 +171,8 @@ func (n *NodeManager) NodeInformer() v1informers.NodeInformer {
 	return n.nodeInformer
 }
 
-// OnNodeAdd is a handler for Node creates.
-func (n *NodeManager) OnNodeAdd(node *v1.Node) {
-	n.onNodeChange(node)
-}
-
-// OnNodeUpdate is a handler for Node updates.
-func (n *NodeManager) OnNodeUpdate(_, node *v1.Node) {
-	n.onNodeChange(node)
-}
-
-// onNodeChange functions helps to implement OnNodeAdd and OnNodeUpdate.
-func (n *NodeManager) onNodeChange(node *v1.Node) {
+// OnNodeChange is a handler for Node creation and update.
+func (n *NodeManager) OnNodeChange(node *v1.Node) {
 	// update the node object
 	n.mu.Lock()
 	n.node = node

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -196,16 +196,18 @@ func (n *NodeManager) OnNodeChange(node *v1.Node) {
 	if !reflect.DeepEqual(n.nodeIPs, nodeIPs) {
 		klog.InfoS("NodeIPs changed for the node",
 			"node", klog.KObj(node), "newNodeIPs", nodeIPs, "oldNodeIPs", n.nodeIPs)
-		klog.Flush()
-		n.exitFunc(1)
+		// FIXME: exit
+		// klog.Flush()
+		// n.exitFunc(1)
 	}
 }
 
 // OnNodeDelete is a handler for Node deletes.
 func (n *NodeManager) OnNodeDelete(node *v1.Node) {
 	klog.InfoS("Node is being deleted", "node", klog.KObj(node))
-	klog.Flush()
-	n.exitFunc(1)
+	// FIXME: exit
+	// klog.Flush()
+	// n.exitFunc(1)
 }
 
 // OnNodeSynced is called after the cache is synced and all pre-existing Nodes have been reported

--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -294,7 +294,7 @@ func TestNodeManagerOnNodeChange(t *testing.T) {
 			nodeManager, err := newNodeManager(ctx, client, 30*time.Second, testNodeName, tc.watchPodCIDRs, exitFunc, 10*time.Millisecond, time.Second, time.Second)
 			require.NoError(t, err)
 
-			nodeManager.onNodeChange(makeNode(tweakNodeIPs(tc.updatedNodeIPs...), tweakPodCIDRs(tc.updatedPodCIDRs...)))
+			nodeManager.OnNodeChange(makeNode(tweakNodeIPs(tc.updatedNodeIPs...), tweakPodCIDRs(tc.updatedPodCIDRs...)))
 			require.Equal(t, tc.expectedExitCode, exitCode)
 		})
 	}
@@ -328,7 +328,7 @@ func TestNodeManagerNode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1", nodeManager.Node().ResourceVersion)
 
-	nodeManager.OnNodeUpdate(nil, makeNode(tweakResourceVersion("2")))
+	nodeManager.OnNodeChange(makeNode(tweakResourceVersion("2")))
 	require.NoError(t, err)
 	require.Equal(t, "2", nodeManager.Node().ResourceVersion)
 }

--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -65,6 +65,12 @@ func tweakPodCIDRs(podCIDRs ...string) nodeTweak {
 	}
 }
 
+func tweakResourceVersion(resourceVersion string) nodeTweak {
+	return func(n *v1.Node) {
+		n.ResourceVersion = resourceVersion
+	}
+}
+
 func TestNewNodeManager(t *testing.T) {
 	testCases := []struct {
 		name             string
@@ -307,4 +313,22 @@ func TestNodeManagerOnNodeDelete(t *testing.T) {
 
 	nodeManager.OnNodeDelete(makeNode())
 	require.Equal(t, ptr.To(1), exitCode)
+}
+
+func TestNodeManagerNode(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+
+	client := clientsetfake.NewClientset()
+	_, _ = client.CoreV1().Nodes().Create(ctx, makeNode(
+		tweakNodeIPs("192.168.1.1"),
+		tweakResourceVersion("1")),
+		metav1.CreateOptions{})
+
+	nodeManager, err := newNodeManager(ctx, client, 30*time.Second, testNodeName, false, func(i int) {}, time.Nanosecond, time.Nanosecond, time.Nanosecond)
+	require.NoError(t, err)
+	require.Equal(t, "1", nodeManager.Node().ResourceVersion)
+
+	nodeManager.OnNodeUpdate(nil, makeNode(tweakResourceVersion("2")))
+	require.NoError(t, err)
+	require.Equal(t, "2", nodeManager.Node().ResourceVersion)
 }

--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -252,10 +252,11 @@ func TestNodeManagerOnNodeChange(t *testing.T) {
 			expectedExitCode: nil,
 		},
 		{
-			name:             "node updated with different NodeIPs",
-			initialNodeIPs:   []string{"192.168.1.1", "fd00:1:2:3::1"},
-			updatedNodeIPs:   []string{"10.0.1.1", "fd00:3:2:1::2"},
-			expectedExitCode: ptr.To(1),
+			name:           "node updated with different NodeIPs",
+			initialNodeIPs: []string{"192.168.1.1", "fd00:1:2:3::1"},
+			updatedNodeIPs: []string{"10.0.1.1", "fd00:3:2:1::2"},
+			// FIXME
+			// expectedExitCode: ptr.To(1),
 		},
 		{
 			name:             "watchPodCIDR and node updated with same PodCIDRs",
@@ -312,7 +313,9 @@ func TestNodeManagerOnNodeDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	nodeManager.OnNodeDelete(makeNode())
-	require.Equal(t, ptr.To(1), exitCode)
+	// FIXME
+	// require.Equal(t, ptr.To(1), exitCode)
+	require.Equal(t, (*int)(nil), exitCode)
 }
 
 func TestNodeManagerNode(t *testing.T) {

--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -41,7 +41,11 @@ import (
 // "Usable endpoints" means Ready endpoints by default, but will fall back to
 // Serving-Terminating endpoints (independently for Cluster and Local) if no Ready
 // endpoints are available.
-func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeName string, nodeLabels map[string]string) (clusterEndpoints, localEndpoints, allReachableEndpoints []Endpoint, hasAnyEndpoints bool) {
+//
+// Note: NodeTopologyConfig.handleNodeEvent (pkg/proxy/config) filters topology labels
+// before notifying proxiers. If you modify the logic over here to  watch other endpoint
+// types or labels, ensure the filtering logic in NodeTopologyConfig is updated accordingly.
+func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeName string, topologyLabels map[string]string) (clusterEndpoints, localEndpoints, allReachableEndpoints []Endpoint, hasAnyEndpoints bool) {
 	if len(endpoints) == 0 {
 		// If there are no endpoints, we have nothing to categorize
 		return
@@ -51,7 +55,7 @@ func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeName str
 	var useServingTerminatingEndpoints bool
 
 	if svcInfo.UsesClusterEndpoints() {
-		zone := nodeLabels[v1.LabelTopologyZone]
+		zone := topologyLabels[v1.LabelTopologyZone]
 		topologyMode = topologyModeFromHints(svcInfo, endpoints, nodeName, zone)
 		clusterEndpoints = filterEndpoints(endpoints, func(ep Endpoint) bool {
 			if !ep.IsReady() {

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -28,7 +28,7 @@ import (
 type Provider interface {
 	config.EndpointSliceHandler
 	config.ServiceHandler
-	config.NodeHandler
+	config.NodeTopologyHandler
 	config.ServiceCIDRHandler
 
 	// Sync immediately synchronizes the Provider's current state to proxy rules.

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -44,7 +44,6 @@ import (
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/proxy/apis/config"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
@@ -641,8 +640,6 @@ type endPointsReferenceCountMap map[string]*uint16
 type Proxier struct {
 	// ipFamily defines the IP family which this proxier is tracking.
 	ipFamily v1.IPFamily
-	// TODO(imroc): implement node handler for winkernel proxier.
-	proxyconfig.NoopNodeHandler
 
 	// endpointsChanges and serviceChanges contains all changes to endpoints and
 	// services that happened since policies were synced. For a single object,
@@ -1097,6 +1094,13 @@ func (proxier *Proxier) OnEndpointSlicesSynced() {
 // OnServiceCIDRsChanged is called whenever a change is observed
 // in any of the ServiceCIDRs, and provides complete list of service cidrs.
 func (proxier *Proxier) OnServiceCIDRsChanged(_ []string) {}
+
+// TODO(imroc): implement OnTopologyChanged for winkernel proxier.
+// OnTopologyChange is called whenever node topology labels are changed.
+// The informer is tweaked to listen for updates of the node where this
+// instance of kube-proxy is running, this guarantees the changed labels
+// are for this node.
+func (proxier *Proxier) OnTopologyChange(topologyLabels map[string]string) {}
 
 func (proxier *Proxier) cleanupAllPolicies() {
 	for svcName, svc := range proxier.svcPortMap {


### PR DESCRIPTION
#### What this PR does / why we need it:
Re-push of #130837, with more care to exactly preserve backward-compatibility so as to fix https://github.com/kubernetes-sigs/cloud-provider-azure/issues/9266. (@aroradaman is busy and didn't have time to redo this before code freeze so I picked it up.)

> This carries the work done in https://github.com/kubernetes/kubernetes/pull/125382 consolidates and simplifies how kube-proxy deals and watches over Node objects.

(Note: initial push is just a straight revert with the bug, so I can confirm that there's an e2e available here that will demonstrate it.)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/area kube-proxy
/priority important-soon
/triage accepted
