### PR TITLE
[FG:InPlacePodVerticalScaling] kubelet: record container_resize_requests metric for all resize updates

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -114,8 +114,7 @@ type Manager interface {
 	Run(ctx context.Context)
 
 	// PushPendingResize queues a pod with a pending resize request for later reevaluation.
-	// Returns true if the pending resize was added to the queue, false if it was already present.
-	PushPendingResize(uid types.UID) bool
+	PushPendingResize(uid types.UID)
 
 	// RetryPendingResizes retries all pending resizes.
 	RetryPendingResizes(trigger string)
@@ -328,21 +327,20 @@ func (m *manager) retryPendingResizes(trigger string) []*v1.Pod {
 	return successfulResizes
 }
 
-func (m *manager) PushPendingResize(uid types.UID) bool {
+func (m *manager) PushPendingResize(uid types.UID) {
 	m.allocationMutex.Lock()
 	defer m.allocationMutex.Unlock()
 
 	for _, p := range m.podsWithPendingResizes {
 		if p == uid {
 			// Pod is already in the pending resizes queue.
-			return false
+			return
 		}
 	}
 
 	// Add the pod to the pending resizes list and sort by priority.
 	m.podsWithPendingResizes = append(m.podsWithPendingResizes, uid)
 	m.sortPendingResizes()
-	return true
 }
 
 // sortPendingResizes sorts the list of pending resizes:

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -4166,6 +4166,7 @@ func TestHandlePodUpdates_RecordContainerRequestedResizes(t *testing.T) {
 			t.Cleanup(func() { testKubelet.Cleanup() })
 			kubelet := testKubelet.kubelet
 
+			kubelet.podManager.AddPod(initialPod)
 			require.NoError(t, kubelet.allocationManager.SetAllocatedResources(initialPod))
 			kubelet.HandlePodUpdates([]*v1.Pod{updatedPod})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Addresses the TODO in https://github.com/kubernetes/kubernetes/pull/132903#discussion_r2211029887.  Fetch the old pod in the pod manager in `HandlePodUpdates` to better detect if this particular update changes any of the container resources.

#### Special notes for your reviewer:

Builds on https://github.com/kubernetes/kubernetes/pull/132903 (only the last commit is new). 

Tested locally by running these changes against [this e2e test](https://github.com/kubernetes/kubernetes/blob/4a80270b30f4acdcdfd7b4dac62b298c49d3565b/test/e2e/node/pod_resize.go#L418) and querying the node for metrics (shoutout to Gemini for teaching me how):

```
$ docker exec -it kind-worker   curl -k -H "Authorization: Bearer $TOKEN"   https://localhost:10250/metrics | grep kubelet_container_requested_resizes_total

# HELP kubelet_container_requested_resizes_total [ALPHA] Number of requested resizes, counted at the container level. Different resources on the same container are counted separately. The 'requirement' label refers to 'memory' or 'limits'; the 'operation' label can be one of 'add', 'remove', 'increase' or 'decrease'.
# TYPE kubelet_container_requested_resizes_total counter
kubelet_container_requested_resizes_total{operation="decrease",requirement="limits",resource="cpu"} 1
kubelet_container_requested_resizes_total{operation="decrease",requirement="requests",resource="cpu"} 1
kubelet_container_requested_resizes_total{operation="increase",requirement="limits",resource="cpu"} 1
kubelet_container_requested_resizes_total{operation="increase",requirement="requests",resource="cpu"} 1

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix recording the kubelet_container_resize_requests_total metric to include all resize-related updates. 
```

/sig node
/triage accepted
/priority important soon
/assign @tallclair
