### PR TITLE
Add --proxy-url flag to kubectl for localhost proxy support

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -56,6 +56,7 @@ const (
 	flagUsername           = "username"
 	flagPassword           = "password"
 	flagTimeout            = "request-timeout"
+	flagProxyURL           = "proxy-url"
 	flagCacheDir           = "cache-dir"
 	flagDisableCompression = "disable-compression"
 )
@@ -100,6 +101,7 @@ type ConfigFlags struct {
 	Username           *string
 	Password           *string
 	Timeout            *string
+	ProxyURL           *string
 	DisableCompression *bool
 	// If non-nil, wrap config function can transform the Config
 	// before it is returned in ToRESTConfig function.
@@ -208,6 +210,9 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	}
 	if f.DisableCompression != nil {
 		overrides.ClusterInfo.DisableCompression = *f.DisableCompression
+	}
+	if f.ProxyURL != nil {
+		overrides.ClusterInfo.ProxyURL = *f.ProxyURL
 	}
 
 	// bind context flags
@@ -407,6 +412,9 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 	if f.Timeout != nil {
 		flags.StringVar(f.Timeout, flagTimeout, *f.Timeout, "The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests.")
 	}
+	if f.ProxyURL != nil {
+		flags.StringVar(f.ProxyURL, flagProxyURL, *f.ProxyURL, "HTTP/HTTPS proxy URL to use for connecting to the API server. Overrides any proxy-url specified in kubeconfig. Supports http://, https://, and socks5:// schemes.")
+	}
 	if f.DisableCompression != nil {
 		flags.BoolVar(f.DisableCompression, flagDisableCompression, *f.DisableCompression, "If true, opt-out of response compression for all requests to the server")
 	}
@@ -452,6 +460,7 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 	return &ConfigFlags{
 		Insecure:   &insecure,
 		Timeout:    ptr.To("0"),
+		ProxyURL:   ptr.To(""),
 		KubeConfig: ptr.To(""),
 
 		CacheDir:           ptr.To(getDefaultCacheDir()),


### PR DESCRIPTION
#### What type of PR is this?
/sig cli
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
fixes https://github.com/kubernetes/kubectl/issues/1655
Updated test mentioned https://github.com/kubernetes/kubernetes/pull/131462


#### Special notes for your reviewer:
  - Precedence order: CLI flag > kubeconfig > environment variables
  - Tested with kind clusters and localhost proxy scenarios
  - Added test coverage for the --proxy-url flag by expanding the existing HTTP proxy test. The test
  verifies that --proxy-url successfully proxies kubectl exec commands and, unlike environment
  variables, works even when the API server is on localhost.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --proxy-url flag to kubectl commands for specifying proxy URL that overrides kubeconfig proxy settings. This is useful for localhost proxy scenarios where HTTPS_PROXY environment variable doesn't work.
```
