### PR TITLE
test: remove fixed duration sleep for network_policy test

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -980,7 +979,6 @@ var _ = common.SIGDescribe("Netpol", func() {
 			ValidateOrFail(k8s, &TestCase{ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: reachability})
 
 			err := k8s.cleanNetworkPolicies(ctx)
-			time.Sleep(3 * time.Second) // TODO we can remove this eventually, its just a hack to keep CI stable.
 			framework.ExpectNoError(err, "unable to clean network policies")
 
 			// Now the policy is deleted, we expect all connectivity to work again.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig network
/sig testing
/priority backlog

#### What this PR does / why we need it:

Remove a `TODO` related to fixed-timeout sleeping. Implement a precise deletion for the network policy test.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/blob/1b6a6cc9c05ab55d8b22f2f5c16b93dbe6e6baf7/test/e2e/network/netpol/network_policy.go#L983

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
