### PR TITLE
DRA: fix conversion of watch

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
@@ -45,7 +45,7 @@ func init() {
 //
 // More legacy types will get added when reaching GA.
 
-func newConvertingClient[NP objectPtr[N], N, NL, NAC any, OP objectPtr[O], O, OL, OAC any](c *client, native funcs[N, NL, NAC], v1beta1 funcs[O, OL, OAC]) *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC] {
+func newConvertingClient[NP objectPtr[N], N, NL, NAC any, OP objectPtr[O], O, OL, OAC any](c *Client, native funcs[N, NL, NAC], v1beta1 funcs[O, OL, OAC]) *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC] {
 	return &convertingClient[NP, N, NL, NAC, OP, O, OL, OAC]{
 		c:       c,
 		native:  native,
@@ -54,7 +54,7 @@ func newConvertingClient[NP objectPtr[N], N, NL, NAC any, OP objectPtr[O], O, OL
 }
 
 type convertingClient[NP objectPtr[N], N, NL, NAC any, OP objectPtr[O], O, OL, OAC any] struct {
-	c       *client
+	c       *Client
 	native  funcs[N, NL, NAC]
 	v1beta1 funcs[O, OL, OAC]
 }
@@ -198,7 +198,7 @@ func (t *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC]) ApplyStatus(ctx conte
 	return nil, ErrNotImplemented
 }
 
-func newCall[N any](c *client, call func(currentAPI int32) (N, error)) callSequence[N] {
+func newCall[N any](c *Client, call func(currentAPI int32) (N, error)) callSequence[N] {
 	seq := callSequence[N]{
 		c:    c,
 		call: call,
@@ -207,7 +207,7 @@ func newCall[N any](c *client, call func(currentAPI int32) (N, error)) callSeque
 }
 
 type callSequence[N any] struct {
-	c    *client
+	c    *Client
 	call func(currentAPI int32) (N, error)
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
@@ -303,6 +303,8 @@ func (w *watchSomething[NP, N, OP]) ResultChan() <-chan watch.Event {
 }
 
 func (w *watchSomething[NP, N, OP]) run() {
+	defer utilruntime.HandleCrash()
+	defer close(w.resultChan)
 	resultChan := w.upstream.ResultChan()
 	for {
 		e, ok := <-resultChan
@@ -320,9 +322,6 @@ func (w *watchSomething[NP, N, OP]) run() {
 				Type:   e.Type,
 				Object: NP(out),
 			}
-		} else {
-			//nolint:logcheck // Shouldn't happen.
-			klog.Errorf("unexpected object with type %T received from watch", e.Object)
 		}
 		// This must not get blocked when the consumer stops reading,
 		// hence the stopChan.

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -41,7 +41,6 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	cgocore "k8s.io/client-go/kubernetes/typed/core/v1"
-	cgoresource "k8s.io/client-go/kubernetes/typed/resource/v1beta2"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	draclient "k8s.io/dynamic-resource-allocation/client"
@@ -77,7 +76,7 @@ type Controller struct {
 	cancel         func(cause error)
 	driverName     string
 	owner          *Owner
-	resourceClient cgoresource.ResourceV1beta2Interface
+	resourceClient *draclient.Client
 	coreClient     cgocore.CoreV1Interface
 	wg             sync.WaitGroup
 	// The queue is keyed with the pool name that needs work.
@@ -436,11 +435,19 @@ func (c *Controller) initInformer(ctx context.Context) error {
 		&cache.ListWatch{
 			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 				tweakListOptions(&options)
-				return c.resourceClient.ResourceSlices().List(ctx, options)
+				slices, err := c.resourceClient.ResourceSlices().List(ctx, options)
+				if err == nil {
+					logger.V(5).Info("Listed ResourceSlices", "resourceAPI", c.resourceClient.CurrentAPI(), "numSlices", len(slices.Items), "listMeta", slices.ListMeta)
+				} else {
+					logger.V(5).Info("Listed ResourceSlices", "resourceAPI", c.resourceClient.CurrentAPI(), "err", err)
+				}
+				return slices, err
 			},
 			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				tweakListOptions(&options)
-				return c.resourceClient.ResourceSlices().Watch(ctx, options)
+				w, err := c.resourceClient.ResourceSlices().Watch(ctx, options)
+				logger.V(5).Info("Started watching ResourceSlices", "resourceAPI", c.resourceClient.CurrentAPI(), "err", err)
+				return w, err
 			},
 		},
 		&resourceapi.ResourceSlice{},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/priority important-critical
/assign @bart0sh 

#### What this PR does / why we need it:

When conversion of a ResourceSlice or ResourceClaim watch was necessary (for example, DRA driver with recent helper code on Kubernetes 1.32 or the GA branch on Kubernetes 1.33) and the apiserver closed the watch (as in the new upgrade/downgrade test), then the channel wrapper didn't close the downstream event channel and the informer did not retry after an apiserver restart.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/132706#issuecomment-3090745788

#### Special notes for your reviewer:

This was found in https://github.com/kubernetes/kubernetes/pull/132706 and confirmed there to fix the problem. The "new driver on Kubernetes 1.32" case was not encountered in the wild.

The first commit contains debug logging which was used to track this down. It's being kept because it seems useful to have it around. Unit tests of course would be nice, but as we have seen now, the new upgrade/downgrade testing is covering it.

#### Does this PR introduce a user-facing change?
```release-note
DRA driver helper: fixed handling of apiserver restart when running on a Kubernetes version which does not support the resource.k8s.io version used by the DRA driver.
```
