### PR TITLE
integration: fix etcd output handling

### DIFF
--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -151,6 +151,7 @@ func RunCustomEtcd(logger klog.Logger, dataDir string, customFlags []string) (ur
 	go func() {
 		defer wg.Done()
 		buffer := make([]byte, 100*1024)
+	reading:
 		for {
 			n, err := reader.Read(buffer)
 			// Unfortunately in practice we get an untyped errors.errorString wrapped in an os.Path error,
@@ -177,9 +178,9 @@ func RunCustomEtcd(logger klog.Logger, dataDir string, customFlags []string) (ur
 				if err != nil {
 					offset := int(dec.InputOffset())
 					if offset < n {
-						logger.Info("etcd output", "msg", string(buffer[0:n]))
+						logger.Info("etcd output", "msg", string(buffer[offset:n]))
 					}
-					continue
+					continue reading
 				}
 
 				// Skip harmless messages.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/assign @bart0sh

#### What this PR does / why we need it:

The code path for handling non-JSON output from etcd was broken:
- It did not skip over already parsed JSON output.
- It got stuck in the wrong for loop and repeatedly tried parsing the same non-JSON output. This prevented test shutdown.

#### Which issue(s) this PR is related to:

Not sure why yet, but in the branch with DRA v1 graduation the following error started to show up for the first time (?!):

     2025/07/18 19:24:48 WARNING: [core] [Server #3]grpc: Server.processUnaryRPC failed to write status: connection error: desc = "transport is closing"

https://github.com/kubernetes/kubernetes/pull/132706#issuecomment-3090064601

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
