### PR TITLE
Fixed: function TransportConfig, if c is nil, it will crash

### DIFF
--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -82,6 +82,9 @@ func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTrip
 
 // TransportConfig converts a client config to an appropriate transport config.
 func (c *Config) TransportConfig() (*transport.Config, error) {
+	if c == nil {
+		return nil, errors.New("config cannot be nil")
+	}
 	conf := &transport.Config{
 		UserAgent:          c.UserAgent,
 		Transport:          c.Transport,


### PR DESCRIPTION
 Fixed: function TransportConfig, if c is nil, it will crash
Signed-off-by: zhikuodu <duzhk@qq.com>


#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
 Fixed: function TransportConfig, if c is nil, it will crash

#### Which issue(s) this PR fixes:

no issue

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 Fixed: function TransportConfig, if c is nil, it will crash
```
