### PR TITLE
kubelet: don't fetch image credentials if the image is present and if we don't need to check if the pod is allowed to pull it

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -178,6 +178,12 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 		return "", message, err
 	}
 
+	if imageRef != "" && !utilfeature.DefaultFeatureGate.Enabled(features.KubeletEnsureSecretPulledImages) {
+		msg := fmt.Sprintf("Container image %q already present on machine", requestedImage)
+		m.logIt(objRef, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
+		return imageRef, msg, nil
+	}
+
 	repoToPull, _, _, err := parsers.ParseImageName(spec.Image)
 	if err != nil {
 		return "", err.Error(), err
@@ -207,12 +213,6 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 	pullCredentials, _ := keyring.Lookup(repoToPull)
 
 	if imageRef != "" {
-		if !utilfeature.DefaultFeatureGate.Enabled(features.KubeletEnsureSecretPulledImages) {
-			msg := fmt.Sprintf("Container image %q already present on machine", requestedImage)
-			m.logIt(objRef, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
-			return imageRef, msg, nil
-		}
-
 		var imagePullSecrets []kubeletconfiginternal.ImagePullSecret
 		for _, s := range pullCredentials {
 			if s.Source == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Commit 3793becbb9467f600b4726761d3c3a1870757377 changed kubelet's behavior such that it always looks up container registry credentials - even if the image is already present on the node, the image pull policy is `Never` or `IfNotPresent`, and the experimental feature gate `KubeletEnsureSecretPulledImages` is disabled or configured to not verify pod image access. This change creates a problem for network management solutions such as Cilium, as credentials provider plugins may not be able to acquire credentials while the network management daemonset pod is being recreated (e.g. after an update):

```
kubelet[4649]: E0715 08:08:30.537102    4649 plugin.go:440] Failed getting credential from external registry credential provider: error execing credential provider plugin acr-credential-provider for image xxxxxxx.azurecr.io/cilium/cilium-dev: exit status 1: E0715 08:08:30.536082  659403 azure_credentials.go:209] failed to receive challenge: error reaching registry endpoint https://xxxxxxx.azurecr.io/v2/, error: Get "https://xxxxxxx.azurecr.io/v2/": dial tcp: lookup xxxxxxx.azurecr.io on 168.63.129.16:53: read udp 172.25.64.35:34236->168.63.129.16:53: i/o timeout
kubelet[4649]: E0715 08:08:30.536136  659403 azure_credentials.go:146] error getting credentials from ACR for xxxxxxx.azurecr.io: error reaching registry endpoint https://xxxxxxx.azurecr.io/v2/, error: Get "https://xxxxxxx.azurecr.io/v2/": dial tcp: lookup xxxxxxx.azurecr.io on 168.63.129.16:53: read udp 172.25.64.35:34236->168.63.129.16:53: i/o timeout
kubelet[4649]: E0715 08:08:30.536146  659403 main.go:59] Error running acr credential provider: error reaching registry endpoint https://xxxxxxx.azurecr.io/v2/, error: Get "https://xxxxxxx.azurecr.io/v2/": dial tcp: lookup xxxxxxx.azurecr.io on 168.63.129.16:53: read udp 172.25.64.35:34236->168.63.129.16:53: i/o timeout
```

This problem should not normally be fatal, because `DockerConfigProvider.Provide()` just returns an empty set of credentials when the credential provider fails. However, depending on DNS and other connection timeouts configured in the credential provider (a component external to kubelet), the new behavior leads to potentially long delays in network management daemonset pod startup, especially when such pods use many init containers to tighten up the main container's security context. In my testing, a standard Cilium daemonset with 6 init containers, a main agent container and a sidecar takes 3 minutes to restart (8 x 20s spent in the credential provider plugin waiting for the DNS request to time out, plus a few seconds for containers to actually run/start), during which interval the whole node is not fully functional.

This PR restores the original behavior. There appears to be no reason to look up container registry credentials if they are not going to be used.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: