### PR TITLE
scheduler_perf: remove outdated TODO comments

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -45,8 +45,8 @@ const (
 	GoroutineResultError   = "error"
 )
 
-// ExtentionPoints is a list of possible values for the extension_point label.
-var ExtentionPoints = []string{
+// ExtensionPoints is a list of possible values for the extension_point label.
+var ExtensionPoints = []string{
 	PreFilter,
 	Filter,
 	PreFilterExtensionAddPod,
@@ -56,6 +56,7 @@ var ExtentionPoints = []string{
 	Score,
 	ScoreExtensionNormalize,
 	PreBind,
+	PreBindPreFlight,
 	Bind,
 	PostBind,
 	Reserve,

--- a/test/integration/scheduler_perf/label_selector.go
+++ b/test/integration/scheduler_perf/label_selector.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package benchmark
 
-// enabled checks a a label filter that works as in GitHub:
+// enabled checks a label filter that works as in GitHub:
 // - empty string means enabled
 // - individual labels are comma-separated
 // - [+]<label> means the workload must have that label

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -142,7 +142,7 @@ var (
 			"scheduler_framework_extension_point_duration_seconds": {
 				{
 					Label:  extensionPointsLabelName,
-					Values: metrics.ExtentionPoints,
+					Values: metrics.ExtensionPoints,
 				},
 			},
 			"scheduler_scheduling_attempt_duration_seconds": {
@@ -159,7 +159,7 @@ var (
 				},
 				{
 					Label:  extensionPointsLabelName,
-					Values: metrics.ExtentionPoints,
+					Values: metrics.ExtensionPoints,
 				},
 			},
 		},
@@ -276,8 +276,7 @@ type testCase struct {
 	// Optional
 	MetricsCollectorConfig *metricsCollectorConfig
 	// Template for sequence of ops that each workload must follow. Each op will
-	// be executed serially one after another. Each element of the list must be
-	// createNodesOp, createPodsOp, or barrierOp.
+	// be executed serially one after another.
 	WorkloadTemplate []op
 	// List of workloads to run under this testCase.
 	Workloads []*workload
@@ -360,7 +359,7 @@ func (w *workload) setDefaults(testCaseThresholdMetricSelector *thresholdMetricS
 		w.ThresholdMetricSelector = testCaseThresholdMetricSelector
 		return
 	}
-	// By defult, SchedulingThroughput should be compared with the threshold.
+	// By default, SchedulingThroughput should be compared with the threshold.
 	w.ThresholdMetricSelector = &thresholdMetricSelector{
 		Name: "SchedulingThroughput",
 	}
@@ -438,7 +437,7 @@ func (p *params) UnmarshalJSON(b []byte) error {
 
 // get retrieves the parameter as an integer
 func (p params) get(key string) (int, error) {
-	// JSON unmarshals integer constants in an "any" field as float.
+	// JSON unmarshal integer constants in an "any" field as float.
 	f, err := getParam[float64](p, key)
 	if err != nil {
 		return 0, err
@@ -447,7 +446,7 @@ func (p params) get(key string) (int, error) {
 }
 
 // getParam retrieves the parameter as specific type. There is no conversion,
-// so in practice this means that only types that JSON unmarshaling uses
+// so in practice this means that only types that JSON unmarshalling uses
 // (float64, string, bool) work.
 func getParam[T float64 | string | bool](p params, key string) (T, error) {
 	p.isUsed[key] = true
@@ -542,7 +541,7 @@ type realOp interface {
 	patchParams(w *workload) (realOp, error)
 }
 
-// runnableOp is an interface implemented by some operations. It makes it posssible
+// runnableOp is an interface implemented by some operations. It makes it possible
 // to execute the operation without having to add separate code into runWorkload.
 type runnableOp interface {
 	realOp
@@ -676,7 +675,7 @@ type createPodsOp struct {
 	Duration metav1.Duration
 	// Template parameter for Duration.
 	DurationParam string
-	// Whether or not to enable metrics collection for this createPodsOp.
+	// Whether to enable metrics collection for this createPodsOp.
 	// Optional. Both CollectMetrics and SkipWaitToCompletion cannot be true at
 	// the same time for a particular createPodsOp.
 	CollectMetrics bool
@@ -688,7 +687,7 @@ type createPodsOp struct {
 	// If nil, DefaultPodTemplatePath will be used.
 	// Optional
 	PodTemplatePath *string
-	// Whether or not to wait for all pods in this op to get scheduled.
+	// Whether to wait for all pods in this op to get scheduled.
 	// Defaults to false if not specified.
 	// Optional
 	SkipWaitToCompletion bool
@@ -787,7 +786,7 @@ type deletePodsOp struct {
 	// If empty, it will delete all Pods in the namespace.
 	// Optional.
 	LabelSelector map[string]string
-	// Whether or not to wait for all pods in this op to be deleted.
+	// Whether to wait for all pods in this op to be deleted.
 	// Defaults to false if not specified.
 	// Optional
 	SkipWaitToCompletion bool
@@ -1203,9 +1202,6 @@ func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName strin
 					featureGates := featureGatesMerge(tc.FeatureGates, w.FeatureGates)
 					informerFactory, tCtx := setupTestCase(b, tc, featureGates, outOfTreePluginRegistry)
 
-					// TODO(#93795): make sure each workload within a test case has a unique
-					// name? The name is used to identify the stats in benchmark reports.
-					// TODO(#94404): check for unused template parameters? Probably a typo.
 					err := w.isValid(tc.MetricsCollectorConfig)
 					if err != nil {
 						b.Fatalf("workload %s is not valid: %v", w.Name, err)
@@ -1894,17 +1890,17 @@ func (e *WorkloadExecutor) runChurnOp(opIndex int, op *churnOp) error {
 }
 
 func (e *WorkloadExecutor) runDefaultOp(opIndex int, op realOp) error {
-	runable, ok := op.(runnableOp)
+	runnable, ok := op.(runnableOp)
 	if !ok {
 		return fmt.Errorf("invalid op %v", op)
 	}
-	for _, namespace := range runable.requiredNamespaces() {
+	for _, namespace := range runnable.requiredNamespaces() {
 		err := createNamespaceIfNotPresent(e.tCtx, namespace, &e.numPodsScheduledPerNamespace)
 		if err != nil {
 			return err
 		}
 	}
-	runable.run(e.tCtx)
+	runnable.run(e.tCtx)
 	return nil
 }
 
@@ -2175,7 +2171,7 @@ func waitUntilPodsScheduledInNamespace(tCtx ktesting.TContext, podInformer corei
 }
 
 // waitUntilPodsAttemptedInNamespace blocks until all pods in the given
-// namespace at least once went through a schedyling cycle.
+// namespace at least once went through a scheduling cycle.
 // Times out after 10 minutes similarly to waitUntilPodsScheduledInNamespace.
 func waitUntilPodsAttemptedInNamespace(tCtx ktesting.TContext, podInformer coreinformers.PodInformer, labelSelector map[string]string, namespace string, wantCount int) error {
 	var pendingPod *v1.Pod
@@ -2236,7 +2232,7 @@ func waitUntilPodsScheduled(tCtx ktesting.TContext, podInformer coreinformers.Po
 }
 
 // waitUntilPodsAttempted blocks until the all pods in the given namespaces are
-// attempted (at least once went through a schedyling cycle).
+// attempted (at least once went through a scheduling cycle).
 func waitUntilPodsAttempted(tCtx ktesting.TContext, podInformer coreinformers.PodInformer, labelSelector map[string]string, namespaces []string, numPodsScheduledPerNamespace map[string]int) error {
 	// If unspecified, default to all known namespaces.
 	if len(namespaces) == 0 {
@@ -2324,7 +2320,8 @@ func validateTestCases(testCases []*testCase) error {
 			return fmt.Errorf("%s: no ops defined", tc.Name)
 		}
 		// Make sure there's at least one CreatePods op with collectMetrics set to
-		// true in each workload. What's the point of running a performance
+		// true, or a startCollectingMetricsOp together with stopCollectingMetricsOp
+		// in each workload. What's the point of running a performance
 		// benchmark if no statistics are collected for reporting?
 		if !tc.collectsMetrics() {
 			return fmt.Errorf("%s: no op in the workload template collects metrics", tc.Name)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

These TODOs are no longer relevant and can be safely cleaned up.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
