### PR TITLE
chore: residual uint64ptr removal with ptr.To

### DIFF
--- a/pkg/kubelet/metrics/collectors/volume_stats_test.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats_test.go
@@ -25,11 +25,8 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	statstest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
+	"k8s.io/utils/ptr"
 )
-
-func newUint64Pointer(i uint64) *uint64 {
-	return &i
-}
 
 func TestVolumeStatsCollector(t *testing.T) {
 	ctx := context.Background()
@@ -61,12 +58,12 @@ func TestVolumeStatsCollector(t *testing.T) {
 					{
 						FsStats: statsapi.FsStats{
 							Time:           metav1.Now(),
-							AvailableBytes: newUint64Pointer(5.663154176e+09),
-							CapacityBytes:  newUint64Pointer(1.0434699264e+10),
-							UsedBytes:      newUint64Pointer(4.21789696e+09),
-							InodesFree:     newUint64Pointer(655344),
-							Inodes:         newUint64Pointer(655360),
-							InodesUsed:     newUint64Pointer(16),
+							AvailableBytes: ptr.To[uint64](5.663154176e+09),
+							CapacityBytes:  ptr.To[uint64](1.0434699264e+10),
+							UsedBytes:      ptr.To[uint64](4.21789696e+09),
+							InodesFree:     ptr.To[uint64](655344),
+							Inodes:         ptr.To[uint64](655360),
+							InodesUsed:     ptr.To[uint64](16),
 						},
 						Name:   "test",
 						PVCRef: nil,
@@ -74,12 +71,12 @@ func TestVolumeStatsCollector(t *testing.T) {
 					{
 						FsStats: statsapi.FsStats{
 							Time:           metav1.Now(),
-							AvailableBytes: newUint64Pointer(5.663154176e+09),
-							CapacityBytes:  newUint64Pointer(1.0434699264e+10),
-							UsedBytes:      newUint64Pointer(4.21789696e+09),
-							InodesFree:     newUint64Pointer(655344),
-							Inodes:         newUint64Pointer(655360),
-							InodesUsed:     newUint64Pointer(16),
+							AvailableBytes: ptr.To[uint64](5.663154176e+09),
+							CapacityBytes:  ptr.To[uint64](1.0434699264e+10),
+							UsedBytes:      ptr.To[uint64](4.21789696e+09),
+							InodesFree:     ptr.To[uint64](655344),
+							Inodes:         ptr.To[uint64](655360),
+							InodesUsed:     ptr.To[uint64](16),
 						},
 						Name: "test",
 						PVCRef: &statsapi.PVCReference{
@@ -100,12 +97,12 @@ func TestVolumeStatsCollector(t *testing.T) {
 					{
 						FsStats: statsapi.FsStats{
 							Time:           metav1.Now(),
-							AvailableBytes: newUint64Pointer(5.663154176e+09),
-							CapacityBytes:  newUint64Pointer(1.0434699264e+10),
-							UsedBytes:      newUint64Pointer(4.21789696e+09),
-							InodesFree:     newUint64Pointer(655344),
-							Inodes:         newUint64Pointer(655360),
-							InodesUsed:     newUint64Pointer(16),
+							AvailableBytes: ptr.To[uint64](5.663154176e+09),
+							CapacityBytes:  ptr.To[uint64](1.0434699264e+10),
+							UsedBytes:      ptr.To[uint64](4.21789696e+09),
+							InodesFree:     ptr.To[uint64](655344),
+							Inodes:         ptr.To[uint64](655360),
+							InodesUsed:     ptr.To[uint64](16),
 						},
 						Name: "test",
 						PVCRef: &statsapi.PVCReference{
@@ -178,12 +175,12 @@ func TestVolumeStatsCollectorWithNullVolumeStatus(t *testing.T) {
 					{
 						FsStats: statsapi.FsStats{
 							Time:           metav1.Now(),
-							AvailableBytes: newUint64Pointer(5.663154176e+09),
-							CapacityBytes:  newUint64Pointer(1.0434699264e+10),
-							UsedBytes:      newUint64Pointer(4.21789696e+09),
-							InodesFree:     newUint64Pointer(655344),
-							Inodes:         newUint64Pointer(655360),
-							InodesUsed:     newUint64Pointer(16),
+							AvailableBytes: ptr.To[uint64](5.663154176e+09),
+							CapacityBytes:  ptr.To[uint64](1.0434699264e+10),
+							UsedBytes:      ptr.To[uint64](4.21789696e+09),
+							InodesFree:     ptr.To[uint64](655344),
+							Inodes:         ptr.To[uint64](655360),
+							InodesUsed:     ptr.To[uint64](16),
 						},
 						Name:   "test",
 						PVCRef: nil,
@@ -191,12 +188,12 @@ func TestVolumeStatsCollectorWithNullVolumeStatus(t *testing.T) {
 					{
 						FsStats: statsapi.FsStats{
 							Time:           metav1.Now(),
-							AvailableBytes: newUint64Pointer(5.663154176e+09),
-							CapacityBytes:  newUint64Pointer(1.0434699264e+10),
-							UsedBytes:      newUint64Pointer(4.21789696e+09),
-							InodesFree:     newUint64Pointer(655344),
-							Inodes:         newUint64Pointer(655360),
-							InodesUsed:     newUint64Pointer(16),
+							AvailableBytes: ptr.To[uint64](5.663154176e+09),
+							CapacityBytes:  ptr.To[uint64](1.0434699264e+10),
+							UsedBytes:      ptr.To[uint64](4.21789696e+09),
+							InodesFree:     ptr.To[uint64](655344),
+							Inodes:         ptr.To[uint64](655360),
+							InodesUsed:     ptr.To[uint64](16),
 						},
 						Name: "test",
 						PVCRef: &statsapi.PVCReference{

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
 	"k8s.io/kubernetes/pkg/volume"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 )
 
 type fakeNetworkStatsProvider struct {
@@ -150,15 +151,15 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.NewTime(fakeClock.Now()),
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test",
-						RxBytes: toP(1),
-						TxBytes: toP(10),
+						RxBytes: ptr.To[uint64](1),
+						TxBytes: ptr.To[uint64](10),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test",
-							RxBytes: toP(1),
+							RxBytes: ptr.To[uint64](1),
 
-							TxBytes: toP(10),
+							TxBytes: ptr.To[uint64](10),
 						},
 					},
 				},
@@ -166,14 +167,14 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.Time{},
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test2",
-						RxBytes: toP(2),
-						TxBytes: toP(20),
+						RxBytes: ptr.To[uint64](2),
+						TxBytes: ptr.To[uint64](20),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test2",
-							RxBytes: toP(2),
-							TxBytes: toP(20),
+							RxBytes: ptr.To[uint64](2),
+							TxBytes: ptr.To[uint64](20),
 						},
 					},
 				},
@@ -227,15 +228,15 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.NewTime(fakeClock.Now()),
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test",
-						RxBytes: toP(1),
-						TxBytes: toP(10),
+						RxBytes: ptr.To[uint64](1),
+						TxBytes: ptr.To[uint64](10),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test",
-							RxBytes: toP(1),
+							RxBytes: ptr.To[uint64](1),
 
-							TxBytes: toP(10),
+							TxBytes: ptr.To[uint64](10),
 						},
 					},
 				},
@@ -243,14 +244,14 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.Time{},
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test2",
-						RxBytes: toP(2),
-						TxBytes: toP(20),
+						RxBytes: ptr.To[uint64](2),
+						TxBytes: ptr.To[uint64](20),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test2",
-							RxBytes: toP(2),
-							TxBytes: toP(20),
+							RxBytes: ptr.To[uint64](2),
+							TxBytes: ptr.To[uint64](20),
 						},
 					},
 				},
@@ -258,14 +259,14 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.Time{},
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test2",
-						RxBytes: toP(2),
-						TxBytes: toP(20),
+						RxBytes: ptr.To[uint64](2),
+						TxBytes: ptr.To[uint64](20),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test2",
-							RxBytes: toP(2),
-							TxBytes: toP(20),
+							RxBytes: ptr.To[uint64](2),
+							TxBytes: ptr.To[uint64](20),
 						},
 					},
 				},
@@ -313,15 +314,15 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.NewTime(fakeClock.Now()),
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test",
-						RxBytes: toP(1),
-						TxBytes: toP(10),
+						RxBytes: ptr.To[uint64](1),
+						TxBytes: ptr.To[uint64](10),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test",
-							RxBytes: toP(1),
+							RxBytes: ptr.To[uint64](1),
 
-							TxBytes: toP(10),
+							TxBytes: ptr.To[uint64](10),
 						},
 					},
 				},
@@ -329,14 +330,14 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.Time{},
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test2",
-						RxBytes: toP(2),
-						TxBytes: toP(20),
+						RxBytes: ptr.To[uint64](2),
+						TxBytes: ptr.To[uint64](20),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test2",
-							RxBytes: toP(2),
-							TxBytes: toP(20),
+							RxBytes: ptr.To[uint64](2),
+							TxBytes: ptr.To[uint64](20),
 						},
 					},
 				},
@@ -384,21 +385,21 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.NewTime(fakeClock.Now()),
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test",
-						RxBytes: toP(1),
-						TxBytes: toP(10),
+						RxBytes: ptr.To[uint64](1),
+						TxBytes: ptr.To[uint64](10),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test",
-							RxBytes: toP(1),
+							RxBytes: ptr.To[uint64](1),
 
-							TxBytes: toP(10),
+							TxBytes: ptr.To[uint64](10),
 						},
 						{
 							Name:    "test3",
-							RxBytes: toP(3),
+							RxBytes: ptr.To[uint64](3),
 
-							TxBytes: toP(30),
+							TxBytes: ptr.To[uint64](30),
 						},
 					},
 				},
@@ -406,14 +407,14 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 					Time: v1.Time{},
 					InterfaceStats: statsapi.InterfaceStats{
 						Name:    "test2",
-						RxBytes: toP(2),
-						TxBytes: toP(20),
+						RxBytes: ptr.To[uint64](2),
+						TxBytes: ptr.To[uint64](20),
 					},
 					Interfaces: []statsapi.InterfaceStats{
 						{
 							Name:    "test2",
-							RxBytes: toP(2),
-							TxBytes: toP(20),
+							RxBytes: ptr.To[uint64](2),
+							TxBytes: ptr.To[uint64](20),
 						},
 					},
 				},
@@ -444,10 +445,6 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 			}
 		})
 	}
-}
-
-func toP(i uint64) *uint64 {
-	return &i
 }
 
 func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
@@ -532,20 +529,20 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 		StartTime: v1.NewTime(time.Unix(0, containerStartTime.Unix())),
 		CPU: &statsapi.CPUStats{
 			Time:                 v1.NewTime(time.Unix(0, cpuUsageTimestamp)),
-			UsageNanoCores:       toP(cpuUsageNanoCores),
-			UsageCoreNanoSeconds: toP(cpuUsageNanoSeconds),
+			UsageNanoCores:       ptr.To[uint64](cpuUsageNanoCores),
+			UsageCoreNanoSeconds: ptr.To[uint64](cpuUsageNanoSeconds),
 		},
 		Memory: &statsapi.MemoryStats{
 			Time:            v1.NewTime(time.Unix(0, memoryUsageTimestamp)),
-			AvailableBytes:  toP(memoryUsageAvailableBytes),
-			WorkingSetBytes: toP(memoryUsageWorkingSetBytes),
-			PageFaults:      toP(memoryUsagePageFaults),
+			AvailableBytes:  ptr.To[uint64](memoryUsageAvailableBytes),
+			WorkingSetBytes: ptr.To[uint64](memoryUsageWorkingSetBytes),
+			PageFaults:      ptr.To[uint64](memoryUsagePageFaults),
 		},
 		Rootfs: &statsapi.FsStats{},
 		Logs: &statsapi.FsStats{
 			Time:       c0LogStats.Time,
-			UsedBytes:  toP(logStatsUsed),
-			InodesUsed: toP(logStatsInodesUsed),
+			UsedBytes:  ptr.To[uint64](logStatsUsed),
+			InodesUsed: ptr.To[uint64](logStatsInodesUsed),
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/priority backlog

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE