### PR TITLE
ci: migrate logexporter image to community-hosted one

### DIFF
--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v20200401-c3269f485
+        image: registry.k8s.io/logexporter:v0.1.1
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/sig testing
/priority important-longterm

#### What this PR does / why we need it:

Remove image reference to Google-owned legacy registry. Use the community-hosted registry.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/k8s.io/issues/1523
(No tracking issue in kuberketes/kubernetes repo but there should be one)

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE