### PR TITLE
scheduler_perf: hide "metric ... not found" errors

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -406,7 +406,10 @@ func uniqueLVCombos(lvs []*labelValues) []map[string]string {
 func collectHistogramVec(metric string, labels map[string]string, lvMap map[string]string) *DataItem {
 	vec, err := testutil.GetHistogramVecFromGatherer(legacyregistry.DefaultGatherer, metric, lvMap)
 	if err != nil {
-		klog.Error(err)
+		// "metric ... not found" is pretty normal. Don't spam the output with it!
+		if !strings.HasSuffix(err.Error(), "not found") {
+			klog.Error(err)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

They get logged as errors although this occurs quite frequently in some tests and isn't a problem. Makes the output hard to follow.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

I saw this a lot recently when debugging scheduler_perf tests with DRA v1. It's a paper cut, but can be very annoying: the entire console window and history fills up with this log output line.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
