### PR TITLE
ci: client-go: test should cleanup their temp dir

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/main_test.go
@@ -29,5 +29,5 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(tmp)
 	os.Setenv("KUBECONFIG", filepath.Join(tmp, "dummy-nonexistent-kubeconfig"))
-	os.Exit(m.Run())
+	m.Run()
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Gets a rid of `/tmp/testkubeconfig1015943687` and similar files in your `/tmp` whenever you run client-go tests.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Previously, calling `os.Exit()` skipped the `defer os.RemoveAll(tmp)` and thus dangling files & dirs would appear in their $TMPDIR.

Since go1.15 we can safely remove `os.Exit()` from `TestMain()` function. As this exact issue was common enough so that [go1.15 changed the API of TestMain](https://go-review.googlesource.com/c/go/+/219639) to no longer require os.Exit to be called.

Reproducer:

    $ (cd staging/src/k8s.io/client-go; go test ./tools/clientcmd)
    $ ls -d /tmp/testkubeconfig*
    /tmp/testkubeconfig1015943687

(There is only one instance of this exact issue).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
