### PR TITLE
KEP-5229: Run Unschedulable scheduler_perf test case with SchedulerAsyncAPICalls feature gate enabled

### DIFF
--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -291,6 +291,16 @@
   - name: 5Nodes/1Init/10Pods_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
+      SchedulerAsyncAPICalls: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 1
+      measurePods: 10
+  - name: 5Nodes/1Init/10Pods_AsyncAPICallsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+      SchedulerAsyncAPICalls: true
     labels: [integration-test, short]
     params:
       initNodes: 5
@@ -320,6 +330,17 @@
   - name: 5kNodes/100Init/10kPods_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
+      SchedulerAsyncAPICalls: false
+    labels: [performance]
+    threshold: 170
+    params:
+      initNodes: 5000
+      initPods: 100
+      measurePods: 10000
+  - name: 5kNodes/100Init/10kPods_AsyncAPICallsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+      SchedulerAsyncAPICalls: true
     labels: [performance]
     threshold: 170
     params:
@@ -337,6 +358,16 @@
   - name: 5kNodes/20kInit/10kPods_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
+      SchedulerAsyncAPICalls: false
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPods: 20000
+      measurePods: 10000
+  - name: 5kNodes/20kInit/10kPods_AsyncAPICallsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+      SchedulerAsyncAPICalls: true
     labels: [performance]
     params:
       initNodes: 5000


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change adds new test configurations that specifically toggle `SchedulerAsyncAPICalls` for the `_QueueingHintsEnabled` scenarios within the `Unschedulable` test. 

#### Which issue(s) this PR is related to:

Fixes #132495

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
