### PR TITLE
Http probe request object reuse 

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -80,7 +81,7 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -99,7 +100,7 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		return results.Success, nil
 	}
 
-	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
+	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, req, maxProbeRetries)
 
 	if err != nil {
 		// Handle probe error
@@ -135,12 +136,12 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request, retries int) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
 	for i := 0; i < retries; i++ {
-		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID)
+		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID, req)
 		if err == nil {
 			return result, output, nil
 		}
@@ -148,7 +149,7 @@ func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, 
 	return result, output, err
 }
 
-func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
+func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request) (probe.Result, string, error) {
 	logger := klog.FromContext(ctx)
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	switch {
@@ -158,7 +159,19 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		return pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, command, timeout))
 
 	case p.HTTPGet != nil:
+		if req != nil {
+			// Use the provided request object
+			if klogV4 := klog.V(4); klogV4.Enabled() {
+				klogV4.InfoS("HTTP-Probe using cached request",
+					"scheme", req.URL.Scheme, "host", req.URL.Hostname(),
+					"port", req.URL.Port(), "path", req.URL.Path)
+			}
+			return pb.http.Probe(req, timeout)
+		}
+
+		// Fallback to creating new request if cached one isn't available
 		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
+
 		if err != nil {
 			// Log and record event for Unknown result
 			logger.V(4).Info("HTTP-Probe failed to create request", "error", err)

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -159,24 +159,9 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		return pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, command, timeout))
 
 	case p.HTTPGet != nil:
-		if req != nil {
-			// Use the provided request object
-			if klogV4 := klog.V(4); klogV4.Enabled() {
-				klogV4.InfoS("HTTP-Probe using cached request",
-					"scheme", req.URL.Scheme, "host", req.URL.Hostname(),
-					"port", req.URL.Port(), "path", req.URL.Path)
-			}
-			return pb.http.Probe(req, timeout)
-		}
-
-		// Fallback to creating new request if cached one isn't available
-		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
-
-		if err != nil {
-			// Log and record event for Unknown result
-			logger.V(4).Info("HTTP-Probe failed to create request", "error", err)
-			return probe.Unknown, "", err
-		}
+		/*  Request object is impossible to be nil since the worker will only
+		call the http probe fuction if the request object was successfully
+		created. Otherwise the worker will keep trying to create the request object. */
 		if loggerV4 := logger.V(4); logger.Enabled() {
 			port := req.URL.Port()
 			host := req.URL.Hostname()

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -253,7 +253,7 @@ func TestProbe(t *testing.T) {
 				prober.exec = fakeExecProber{test.execResult, nil}
 			}
 
-			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID, nil)
 
 			if test.expectError {
 				require.Error(t, err, "[%s] Expected probe error but no error was returned.", testID)
@@ -266,7 +266,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID, nil)
 				require.NoError(t, err, "[%s] Didn't expect probe error ", testID)
 
 				if !reflect.DeepEqual(test.expectCommand, prober.runner.(*containertest.FakeContainerCommandRunner).Cmd) {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -333,7 +333,8 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	if w.httpProbeRequest != nil {
 		req, err = w.httpProbeRequest.getRequest(&w.container) // either returns cached request or creates a new one
 		if err != nil {
-			klog.V(4).InfoS("HTTP-Probe failed to create request", "error", err)
+			// Request creation/reuse failed, try again next time.
+			klog.V(4).InfoS("HTTP-Probe worker failed to create request", "error", err)
 			return true
 		}
 	}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -170,6 +170,14 @@ func newWorker(
 	w.proberDurationSuccessfulMetricLabels = deepCopyPrometheusLabels(proberDurationLabels)
 	w.proberDurationUnknownMetricLabels = deepCopyPrometheusLabels(proberDurationLabels)
 
+	// Initailzie the HTTP probe request holder if this worker will perform HTTP probing
+	if w.spec != nil && w.spec.HTTPGet != nil {
+		w.httpProbeRequest = &httpProbeRequestHolder{
+			httpGet: w.spec.HTTPGet,
+			podIP:   "", // Empty Initially because we are not sure if the pod IP is available yet (better to dynamically set in worker loop)
+		}
+	}
+
 	return w
 }
 

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -98,6 +98,9 @@ type worker struct {
 	// If set, skip probing.
 	onHold bool
 
+	// Holder for HTTP probe request object
+	httpProbeRequest *httpProbeRequestHolder
+
 	// proberResultsMetricLabels holds the labels attached to this worker
 	// for the ProberResults metric by result.
 	proberResultsSuccessfulMetricLabels metrics.Labels

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package prober
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
@@ -573,4 +575,80 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
+}
+
+func TestWorkerHTTPProbeRequestCaching(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	m := newTestManager()
+	pod := getTestPod()
+	httpGet := &v1.HTTPGetAction{
+		Host: "",
+		Path: "",
+		Port: intstr.FromInt32(8080),
+	}
+	probeSpec := v1.Probe{
+		ProbeHandler: v1.ProbeHandler{
+			HTTPGet: httpGet,
+		},
+		TimeoutSeconds:   1,
+		PeriodSeconds:    1,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+	}
+	pod.Spec.Containers[0].LivenessProbe = &probeSpec
+	// the test worker is always initialized with an exec probe , so we we call the newWorker function explicitly
+	w := newWorker(m, liveness, pod, pod.Spec.Containers[0])
+	podIP1 := "10.0.0.1"
+	containerID1 := "docker://abc123"
+	status := getTestRunningStatusWithStarted(true)
+	status.PodIP = podIP1
+	status.ContainerStatuses[0].ContainerID = containerID1
+	m.statusManager.SetPodStatus(logger, w.pod, status)
+
+	// First probe: should create a new request
+	req1, err := w.httpProbeRequest.getRequest(&w.container, status.PodIP)
+	if err != nil {
+		t.Fatalf("Expected no error when creating first request, got: %v", err)
+	}
+	if w.httpProbeRequest == nil || w.httpProbeRequest.request == nil {
+		t.Fatal("Expected httpProbeRequest and request to be initialized after first probe")
+	}
+
+	// Second probe with same podIP and containerID: should reuse request
+	req2, err := w.httpProbeRequest.getRequest(&w.container, status.PodIP)
+	if err != nil {
+		t.Fatalf("Expected no error when reusing request, got: %v", err)
+	}
+	if req2 != req1 {
+		t.Error("Expected cached request to be reused when podIP and containerID do not change")
+	}
+
+	// Simulate pod IP change
+	podIP2 := "10.0.0.2"
+	status.PodIP = podIP2
+	m.statusManager.SetPodStatus(logger, w.pod, status)
+	req3, err := w.httpProbeRequest.getRequest(&w.container, status.PodIP)
+	if err != nil {
+		t.Fatalf("Expected no error when creating request after pod IP change, got: %v", err)
+	}
+	if req3 == req1 {
+		t.Error("Expected new request after pod IP change")
+	}
+	if req3 == nil {
+		t.Fatal("Expected request to be initialized after pod IP change")
+	}
+
+	// Simulate container restart by setting a new container ID
+	containerID2 := "docker://def456"
+	status.ContainerStatuses[0].ContainerID = containerID2
+	m.statusManager.SetPodStatus(logger, w.pod, status)
+	// Trigger container restart logic by calling doProbe
+	w.doProbe(context.Background()) // maybe refactor the getRequest logic to avoid needing to call doProbe here (include the container ID in the request creation logic)
+	// After container restart, the request should be reset
+	if w.httpProbeRequest.request == req3 {
+		t.Error("Expected request to be reset after container ID change (container restart)")
+	}
+	if w.httpProbeRequest.request == nil {
+		t.Fatal("Expected request to be recreated after container restart")
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Avoid creating a new request object everytime when making an http probe instead the worker  just constructs the request once and every http probe uses the same request object
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #115939

#### Special notes for your reviewer:

I am open to any modification to my approach for request reuse.

My implemntation was as follows:
1) created a new object that will store the request object
2) The worker when making an http probe will create a new request (if none was created) or use the same request that was created earlier
3) For all the probing fucntions, I modified them to accept  a new argument, which is the request object ---it can be null (old behavior) or have a value that was provided by the worker (the reused request object)

If there’s a better approach or anything you’d like me to change, I’m happy to do so.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
