### PR TITLE
Fix: Add garbage collection to handle Approved-Unissued CSRs

### DIFF
--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -107,7 +107,12 @@ func (ccc *CSRCleanerController) worker(ctx context.Context) {
 
 func (ccc *CSRCleanerController) handle(ctx context.Context, csr *capi.CertificateSigningRequest) error {
 	logger := klog.FromContext(ctx)
-	if isIssuedPastDeadline(logger, csr) || isDeniedPastDeadline(logger, csr) || isFailedPastDeadline(logger, csr) || isPendingPastDeadline(logger, csr) || isIssuedExpired(logger, csr) {
+	if isIssuedPastDeadline(logger, csr) ||
+	   isDeniedPastDeadline(logger, csr) ||
+	   isFailedPastDeadline(logger, csr) ||
+	   isPendingPastDeadline(logger, csr) ||
+	   isIssuedExpired(logger, csr) ||
+	   isApprovedUnissuedPastDeadline(logger, csr) {
 		if err := ccc.csrClient.Delete(ctx, csr.Name, metav1.DeleteOptions{}); err != nil {
 			return fmt.Errorf("unable to delete CSR %q: %v", csr.Name, err)
 		}
@@ -173,6 +178,19 @@ func isIssuedPastDeadline(logger klog.Logger, csr *capi.CertificateSigningReques
 	for _, c := range csr.Status.Conditions {
 		if c.Type == capi.CertificateApproved && isIssued(csr) && isOlderThan(c.LastUpdateTime, approvedExpiration) {
 			logger.Info("Cleaning CSR as it is more than approvedExpiration duration old and approved.", "csr", csr.Name, "approvedExpiration", approvedExpiration)
+			return true
+		}
+	}
+	return false
+}
+
+// isApprovedUnissuedPastDeadline checks if the certificate has an Approved status but
+// no certificate has been issued, and the approval time has passed the deadline
+// that pending requests are maintained for.
+func isApprovedUnissuedPastDeadline(logger klog.Logger, csr *capi.CertificateSigningRequest) bool {
+	for _, c := range csr.Status.Conditions {
+		if c.Type == capi.CertificateApproved && !(isIssued(csr) && isOlderThan(c.LastUpdateTime, pendingExpiration)) {
+			logger.Info("Cleaning CSR as it is approved but unissued for more than pendingExpiration duration.", "csr", csr.Name, "pendingExpiration", pendingExpiration)
 			return true
 		}
 	}

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -108,11 +108,11 @@ func (ccc *CSRCleanerController) worker(ctx context.Context) {
 func (ccc *CSRCleanerController) handle(ctx context.Context, csr *capi.CertificateSigningRequest) error {
 	logger := klog.FromContext(ctx)
 	if isIssuedPastDeadline(logger, csr) ||
-	   isDeniedPastDeadline(logger, csr) ||
-	   isFailedPastDeadline(logger, csr) ||
-	   isPendingPastDeadline(logger, csr) ||
-	   isIssuedExpired(logger, csr) ||
-	   isApprovedUnissuedPastDeadline(logger, csr) {
+		isDeniedPastDeadline(logger, csr) ||
+		isFailedPastDeadline(logger, csr) ||
+		isPendingPastDeadline(logger, csr) ||
+		isIssuedExpired(logger, csr) ||
+		isApprovedUnissuedPastDeadline(logger, csr) {
 		if err := ccc.csrClient.Delete(ctx, csr.Name, metav1.DeleteOptions{}); err != nil {
 			return fmt.Errorf("unable to delete CSR %q: %v", csr.Name, err)
 		}

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -175,8 +175,11 @@ func isFailedPastDeadline(logger klog.Logger, csr *capi.CertificateSigningReques
 // creation time of the CSR is passed the deadline that issued requests are
 // maintained for.
 func isIssuedPastDeadline(logger klog.Logger, csr *capi.CertificateSigningRequest) bool {
+	if !isIssued(csr) {
+		return false
+	}
 	for _, c := range csr.Status.Conditions {
-		if c.Type == capi.CertificateApproved && isIssued(csr) && isOlderThan(c.LastUpdateTime, approvedExpiration) {
+		if c.Type == capi.CertificateApproved && isOlderThan(c.LastUpdateTime, approvedExpiration) {
 			logger.Info("Cleaning CSR as it is more than approvedExpiration duration old and approved.", "csr", csr.Name, "approvedExpiration", approvedExpiration)
 			return true
 		}
@@ -188,8 +191,11 @@ func isIssuedPastDeadline(logger klog.Logger, csr *capi.CertificateSigningReques
 // no certificate has been issued, and the approval time has passed the deadline
 // that pending requests are maintained for.
 func isApprovedUnissuedPastDeadline(logger klog.Logger, csr *capi.CertificateSigningRequest) bool {
+	if isIssued(csr) {
+		return false
+	}
 	for _, c := range csr.Status.Conditions {
-		if c.Type == capi.CertificateApproved && !(isIssued(csr) && isOlderThan(c.LastUpdateTime, pendingExpiration)) {
+		if c.Type == capi.CertificateApproved && isOlderThan(c.LastUpdateTime, pendingExpiration) {
 			logger.Info("Cleaning CSR as it is approved but unissued for more than pendingExpiration duration.", "csr", csr.Name, "pendingExpiration", pendingExpiration)
 			return true
 		}

--- a/pkg/controller/certificates/cleaner/cleaner_test.go
+++ b/pkg/controller/certificates/cleaner/cleaner_test.go
@@ -172,6 +172,30 @@ func TestCleanerWithApprovedExpiredCSR(t *testing.T) {
 			[]string{"delete"},
 		},
 		{
+			"delete approved unissued past deadline",
+			metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			nil,
+			[]capi.CertificateSigningRequestCondition{
+				{
+					Type:           capi.CertificateApproved,
+					LastUpdateTime: metav1.NewTime(time.Now().Add(-25 * time.Hour)),
+				},
+			},
+			[]string{"delete"},
+		},
+		{
+			"no delete approved unissued not past deadline",
+			metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			nil,
+			[]capi.CertificateSigningRequestCondition{
+				{
+					Type:           capi.CertificateApproved,
+					LastUpdateTime: metav1.NewTime(time.Now().Add(-5 * time.Hour)),
+				},
+			},
+			[]string{},
+		},
+		{
 			"no delete approved not passed deadline unexpired",
 			metav1.NewTime(time.Now().Add(-1 * time.Minute)),
 			[]byte(unexpiredCert),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently there is no mechanism to account for garbage collection of Approved-But-Unissued kubelet client CSRs which may happen in scenarios like HashiVault managed certificate signing, which over time will lead to excessive etcd space consumption. This implements the suggestion in issue #132947 where a condition is added to the cleaner which will treat certificates in this state, in the same way it treats `Pending` CSRs so they can get garbage collected every 24 hours.

#### Which issue(s) this PR is related to:

#132947

#### Special notes for your reviewer:

* Easy to reproduce as demonstrated in the investigation notes on the issue.
* Change is perceived to be minimal and carries low risk of regression.
* If implemented a seperate documentation update might be required that explains that it treats GC of Approved CSRs which get issued certificates differently, or alternatively this PR could be adjusted to delete them hourly unless there is a specific reason why this would want to be avoided.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Docs: Kubelet TLS Bootstrapping] https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/
```
