### PR TITLE
kubelet: DRA: Handle grpc.ErrServerStopped in plugin tests

### DIFF
--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_test.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_test.go
@@ -18,6 +18,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"path"
@@ -80,7 +81,7 @@ func setupFakeGRPCServer(service, addr string) (tearDown, error) {
 
 	go func() {
 		go func() {
-			if err := s.Serve(listener); err != nil {
+			if err := s.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 				panic(err)
 			}
 		}()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

Update setupFakeGRPCServer to ignore grpc.ErrServerStopped when serving
    the gRPC test server. This prevents unnecessary panics during server
    shutdown and ensures clean test teardown. The change improves test
    stability by allowing expected server stop errors to be handled gracefully.

It should also fix `TestRegistrationHandler/replace` test failure: panic: grpc: the server has been stopped
The failure is caused by grpc.Server.Serve call returnning an error on server shutdown on some platforms.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```