### PR TITLE
chore: residual boolptr and intptr removal with ptr.To

### DIFF
--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -4107,7 +4107,7 @@ func TestPrintControllerRevision(t *testing.T) {
 					CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Controller: boolP(true),
+							Controller: ptr.To(true),
 							APIVersion: "apps/v1",
 							Kind:       "DaemonSet",
 							Name:       "foo",
@@ -4125,7 +4125,7 @@ func TestPrintControllerRevision(t *testing.T) {
 					CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Controller: boolP(false),
+							Controller: ptr.To(false),
 							Kind:       "ABC",
 							Name:       "foo",
 						},
@@ -4171,10 +4171,6 @@ func TestPrintControllerRevision(t *testing.T) {
 			t.Errorf("%d mismatch: %s", i, cmp.Diff(test.expected, rows))
 		}
 	}
-}
-
-func boolP(b bool) *bool {
-	return &b
 }
 
 func TestPrintConfigMap(t *testing.T) {
@@ -5675,7 +5671,7 @@ func TestPrintStorageClass(t *testing.T) {
 				},
 				Provisioner:          "kubernetes.io/nfs",
 				ReclaimPolicy:        &policyRetain,
-				AllowVolumeExpansion: boolP(true),
+				AllowVolumeExpansion: ptr.To(true),
 				VolumeBindingMode:    &bindModeWait,
 			},
 			expected: []metav1.TableRow{{Cells: []interface{}{"sc6", "kubernetes.io/nfs", "Retain",

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/queryparams/convert_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/queryparams/convert_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion/queryparams"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 )
 
 type namedString string
@@ -161,20 +162,20 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			input: &baz{
-				Ptr:  intp(5),
-				Bptr: boolp(true),
+				Ptr:  ptr.To(5),
+				Bptr: ptr.To(true),
 			},
 			expected: url.Values{"ptr": {"5"}, "bptr": {"true"}},
 		},
 		{
 			input: &baz{
-				Bptr: boolp(true),
+				Bptr: ptr.To(true),
 			},
 			expected: url.Values{"ptr": {""}, "bptr": {"true"}},
 		},
 		{
 			input: &baz{
-				Ptr: intp(5),
+				Ptr: ptr.To(5),
 			},
 			expected: url.Values{"ptr": {"5"}},
 		},
@@ -213,7 +214,3 @@ func TestConvert(t *testing.T) {
 		validateResult(t, test.input, result, test.expected)
 	}
 }
-
-func intp(n int) *int { return &n }
-
-func boolp(b bool) *bool { return &b }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/priority backlog

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE