### PR TITLE
DRA E2E: promote one test to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2842,6 +2842,14 @@
     lifecycle of a container.
   release: v1.19
   file: test/e2e/common/node/expansion.go
+- testname: 'Dynamic Resource Allocation: supports claim and class parameters'
+  codename: '[sig-node] [DRA] control plane supports claim and class parameters [Conformance]'
+  description: The Kubernetes API must support specifying parameters in a ResourceClaimTemplate
+    and DeviceClass. kube-controller-manager must create the ResourceClaim for a Pod
+    referencing the ResourceClaimTemplate. kube-scheduler must allocate a suitable
+    device from a ResourceSlice and copy the parameters into the allocation result.
+  release: v1.34
+  file: test/e2e/dra/dra.go
 - testname: LimitRange, resources
   codename: '[sig-scheduling] LimitRange should create a LimitRange with defaults
     and ensure pod has those defaults applied. [Conformance]'

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -697,12 +697,6 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		})
 	})
 
-	// Tests that have the `withKubelet` argument can run with or without kubelet support for plugins and DRA, aka feature.DynamicResourceAllocation.
-	// Without it, the test driver publishes ResourceSlices, but does not attempt to register itself.
-	// Tests only expect pods to get scheduled, but not to become running.
-	//
-	// TODO before conformance promotion: add https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#sample-conformance-test meta data
-
 	singleNodeTests := func(withKubelet bool) {
 		nodes := drautils.NewNodes(f, 1, 1)
 		maxAllocations := 1
@@ -716,13 +710,34 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		_, expected := b.ParametersEnv()
 		expectedEnv = append(expectedEnv, expected...)
 
-		ginkgo.It("supports claim and class parameters", func(ctx context.Context) {
-			pod, template := b.PodInline()
-			b.Create(ctx, pod, template)
-			b.TestPod(ctx, f, pod, expectedEnv...)
-		})
+		if withKubelet {
+			f.It("supports claim and class parameters", func(ctx context.Context) {
+				pod, template := b.PodInline()
+				b.Create(ctx, pod, template)
+				b.TestPod(ctx, f, pod, expectedEnv...)
+			})
+		} else {
+			/*
+			   Release: v1.34
+			   Testname: Dynamic Resource Allocation: supports claim and class parameters
+			   Description: The Kubernetes API must support specifying parameters in a ResourceClaimTemplate and DeviceClass.
+			   kube-controller-manager must create the ResourceClaim for a Pod referencing the ResourceClaimTemplate.
+			   kube-scheduler must allocate a suitable device from a ResourceSlice and copy the parameters into the allocation result.
+			*/
+			framework.ConformanceIt("supports claim and class parameters", func(ctx context.Context) {
+				pod, template := b.PodInline()
+				b.Create(ctx, pod, template)
+				framework.ExpectNoError(e2epod.WaitForPodScheduled(ctx, f.ClientSet, pod.Namespace, pod.Name), "schedule pod")
+			})
+		}
 
-		ginkgo.It("supports reusing resources", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports reusing resources
+		   Description: The kube-controller-manager must deallocate ResourceClaims as soon as they are not in use anymore.
+		   kube-scheduler then must use the resources that are available again to schedule pending pods.
+		*/
+		f.It("supports reusing resources", func(ctx context.Context) {
 			var objects []klog.KMetadata
 			pods := make([]*v1.Pod, numPods)
 			for i := 0; i < numPods; i++ {
@@ -750,7 +765,13 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			wg.Wait()
 		})
 
-		ginkgo.It("supports sharing a claim concurrently", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports sharing a claim concurrently
+		   Description: kube-scheduler must allow different pods to reference the same ResourceClaim and schedule all of them.
+		   kube-controller-manager must deallocate once the last pod has terminated.
+		*/
+		f.It("supports sharing a claim concurrently", func(ctx context.Context) {
 			var objects []klog.KMetadata
 			objects = append(objects, b.ExternalClaim())
 			pods := make([]*v1.Pod, numPods)
@@ -777,7 +798,12 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			wg.Wait()
 		})
 
-		ginkgo.It("retries pod scheduling after creating device class", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: kube-scheduler: retries pod scheduling after creating device class
+		   Description: kube-scheduler must retry pod scheduling when a DeviceClass that was missing initially gets created later.
+		*/
+		f.It("retries pod scheduling after creating device class", func(ctx context.Context) {
 			var objects []klog.KMetadata
 			pod, template := b.PodInline()
 			deviceClassName := template.Spec.Spec.Devices.Requests[0].Exactly.DeviceClassName
@@ -798,7 +824,12 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			b.TestPod(ctx, f, pod, expectedEnv...)
 		})
 
-		ginkgo.It("retries pod scheduling after updating device class", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: kube-scheduler: retries pod scheduling after updating device class
+		   Description: kube-scheduler must retry pod scheduling when a DeviceClass that initially did not match any devices gets updated later such that it does.
+		*/
+		f.It("retries pod scheduling after updating device class", func(ctx context.Context) {
 			var objects []klog.KMetadata
 			pod, template := b.PodInline()
 
@@ -829,7 +860,14 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			b.TestPod(ctx, f, pod, expectedEnv...)
 		})
 
-		ginkgo.It("runs a pod without a generated resource claim", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: runs a pod without a generated resource claim
+		   Description: kube-controller-manager is allowed to skip creating a ResourceClaim for a ResourceClaimTemplate.
+		   kube-scheduler and the kubelet (not part of conformance) the must proceed as if the ResourceClaimTemplate had
+		   not been referenced in the first place.
+		*/
+		f.It("runs a pod without a generated resource claim", func(ctx context.Context) {
 			pod, _ /* template */ := b.PodInline()
 			created := b.Create(ctx, pod)
 			pod = created[0].(*v1.Pod)
@@ -847,26 +885,57 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
 		})
 
-		ginkgo.It("supports simple pod referencing inline resource claim", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports simple pod referencing inline resource claim
+		   Description: The Kubernetes API must support creating a pod which references a ResourceClaimTemplate for a single container.
+		   kube-controller-manager must create a ResourceClaim for it.
+		   kube-scheduler must wait for that ResourceClaim and then schedule the pod.
+		   kubelet must invoke a DRA driver referencing that ResourceClaim (not part of conformance).
+		*/
+		f.It("supports simple pod referencing inline resource claim", func(ctx context.Context) {
 			pod, template := b.PodInline()
 			b.Create(ctx, pod, template)
 			b.TestPod(ctx, f, pod)
 		})
 
-		ginkgo.It("supports inline claim referenced by multiple containers", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports inline claim referenced by multiple containers
+		   Description: The Kubernetes API must support creating a pod which references a ResourceClaimTemplate for different containers.
+		   kube-controller-manager must create a ResourceClaim for it.
+		   kube-scheduler must wait for that ResourceClaim and then schedule the pod.
+		   kubelet must invoke a DRA driver referencing that ResourceClaim (not part of conformance).
+		*/
+		f.It("supports inline claim referenced by multiple containers", func(ctx context.Context) {
 			pod, template := b.PodInlineMultiple()
 			b.Create(ctx, pod, template)
 			b.TestPod(ctx, f, pod)
 		})
 
-		ginkgo.It("supports simple pod referencing external resource claim", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports simple pod referencing external resource claim
+		   Description: The Kubernetes API must support creating a pod which references a ResourceClaim for a single container.
+		   kube-scheduler must wait for that ResourceClaim and then schedule the pod.
+		   kubelet must invoke a DRA driver referencing that ResourceClaim (not part of conformance).
+		*/
+		f.It("supports simple pod referencing external resource claim", func(ctx context.Context) {
 			pod := b.PodExternal()
 			claim := b.ExternalClaim()
 			b.Create(ctx, claim, pod)
 			b.TestPod(ctx, f, pod)
 		})
 
-		ginkgo.It("supports external claim referenced by multiple pods", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports external claim referenced by multiple pods
+		   Description: The Kubernetes API must support creating multiple pods which reference the same ResourceClaim.
+		   kube-scheduler must wait for that ResourceClaim and then schedule all pods.
+		   kubelet must invoke a DRA driver once referencing that ResourceClaim when the first pod
+		   gets started and again when last pod terminates (not part of conformance).
+		*/
+		f.It("supports external claim referenced by multiple pods", func(ctx context.Context) {
 			pod1 := b.PodExternal()
 			pod2 := b.PodExternal()
 			pod3 := b.PodExternal()
@@ -878,7 +947,15 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			}
 		})
 
-		ginkgo.It("supports external claim referenced by multiple containers of multiple pods", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports external claim referenced by multiple containers of multiple pods
+		   Description: The Kubernetes API must support creating multiple pods which reference the same ResourceClaim for different containers in each pod.
+		   kube-scheduler must wait for that ResourceClaim and then schedule all pods.
+		   kubelet must invoke a DRA driver once referencing that ResourceClaim when the first pod
+		   gets started and again when last pod terminates (not part of conformance).
+		*/
+		f.It("supports external claim referenced by multiple containers of multiple pods", func(ctx context.Context) {
 			pod1 := b.PodExternalMultiple()
 			pod2 := b.PodExternalMultiple()
 			pod3 := b.PodExternalMultiple()
@@ -890,7 +967,15 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			}
 		})
 
-		ginkgo.It("supports init containers", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: supports init containers
+		   Description: The Kubernetes API must support creating a pod where init containers depend on a ResourceClaimTemplate.
+		   kube-controller-manager must create a ResourceClaim for it.
+		   kube-scheduler must wait for that ResourceClaim and then schedule the pod.
+		   kubelet must invoke a DRA driver referencing that ResourceClaim (not part of conformance).
+		*/
+		f.It("supports init containers", func(ctx context.Context) {
 			pod, template := b.PodInline()
 			pod.Spec.InitContainers = []v1.Container{pod.Spec.Containers[0]}
 			pod.Spec.InitContainers[0].Name += "-init"
@@ -901,7 +986,12 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			b.TestPod(ctx, f, pod)
 		})
 
-		ginkgo.It("must deallocate after use", func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: must deallocate after use
+		   Description: The kube-controller-manager must deallocate ResourceClaims as soon as a pod got deleted and kubelet acknowledges that the pod has terminated.
+		*/
+		f.It("must deallocate after use", func(ctx context.Context) {
 			pod := b.PodExternal()
 			claim := b.ExternalClaim()
 			b.Create(ctx, claim, pod)
@@ -965,7 +1055,14 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			driver.WithKubelet = withKubelet
 			b := drautils.NewBuilder(f, driver)
 
-			ginkgo.It("keeps pod pending because of CEL runtime errors", func(ctx context.Context) {
+			/*
+			   Release: v1.??
+			   Testname: Dynamic Resource Allocation: keeps pod pending because of CEL runtime errors
+			   Description: kube-scheduler must handle CEL runtime errors that occur when checking
+			   some node by not scheduling the pod at all, even if the problem does not occur for
+			   other nodes, because the CEL expression supplied by the user is faulty.
+			*/
+			f.It("keeps pod pending because of CEL runtime errors", func(ctx context.Context) {
 				// When pod scheduling encounters CEL runtime errors for some nodes, but not all,
 				// it should still not schedule the pod because there is something wrong with it.
 				// Scheduling it would make it harder to detect that there is a problem.
@@ -1024,7 +1121,13 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			driver.WithKubelet = withKubelet
 			b := drautils.NewBuilder(f, driver)
 
-			ginkgo.It("uses all resources", func(ctx context.Context) {
+			/*
+			   Release: v1.??
+			   Testname: Dynamic Resource Allocation: with node-local resources uses all resources
+			   Description: kube-scheduler must be able to schedule pods such that they
+			   use all available devices on a node.
+			*/
+			f.It("uses all resources", func(ctx context.Context) {
 				var objs []klog.KMetadata
 				var pods []*v1.Pod
 				for i := 0; i < len(nodes.NodeNames); i++ {
@@ -1799,10 +1902,10 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 	// It is okay to use the same context multiple times (like "control plane"),
 	// as long as the test names the still remain unique overall.
 
-	framework.Context("control plane", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func() { singleNodeTests(false) })
+	framework.Context("control plane", func() { singleNodeTests(false) })
 	framework.Context("kubelet", feature.DynamicResourceAllocation, "on single node", func() { singleNodeTests(true) })
 
-	framework.Context("control plane", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func() { multiNodeTests(false) })
+	framework.Context("control plane", func() { multiNodeTests(false) })
 	framework.Context("kubelet", feature.DynamicResourceAllocation, "on multiple nodes", func() { multiNodeTests(true) })
 
 	framework.Context("kubelet", feature.DynamicResourceAllocation, f.WithFeatureGate(features.DRAPrioritizedList), prioritizedListTests)
@@ -2076,12 +2179,12 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 	})
 
 	ginkgo.Context("ResourceSlice Controller", func() {
-		// This is a stress test for creating many large slices.
-		// Each slice is as large as API limits allow.
-		//
-		// Could become a conformance test because it only depends
-		// on the apiserver.
-		f.It("creates slices", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: DRA driver: creates slices
+		   Description: The kube-apiserver must be able to store large ResourceSlices.
+		*/
+		f.It("creates slices", func(ctx context.Context) {
 			// Define desired resource slices.
 			driverName := f.Namespace.Name
 			numSlices := 100
@@ -2171,6 +2274,8 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		})
 	})
 
+	// Tests here only run without kubelet.
+	// Some of them may be conformance tests.
 	framework.Context("control plane", func() {
 		nodes := drautils.NewNodes(f, 1, 1)
 		driver := drautils.NewDriver(f, nodes, drautils.NetworkResources(10, false))
@@ -2217,7 +2322,13 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			}).Should(gomega.Succeed())
 		})
 
-		f.It("truncates the name of a generated resource claim", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: truncates the name of a generated resource claim
+		   Description: When the name of a ResourceClaim is too large to be stored completely in the generated ResourceClaim,
+		   then kube-controller-manager and kube-apiserver must shorten the generated name.
+		*/
+		f.It("truncates the name of a generated resource claim", func(ctx context.Context) {
 			pod, template := b.PodInline()
 			pod.Name = strings.Repeat("p", 63)
 			pod.Spec.ResourceClaims[0].Name = strings.Repeat("c", 63)
@@ -2227,7 +2338,9 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			b.TestPod(ctx, f, pod)
 		})
 
-		f.It("supports count/resourceclaims.resource.k8s.io ResourceQuota", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func(ctx context.Context) {
+		// This could be required for conformance, but there have been some rare known flakes in the quota controller, so it's not considered
+		// for immmediate promotion.
+		f.It("supports count/resourceclaims.resource.k8s.io ResourceQuota", func(ctx context.Context) {
 			claim := &resourceapi.ResourceClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "claim-0",
@@ -2362,7 +2475,15 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		driver := drautils.NewDriver(f, nodes, drautils.DriverResources(1))
 		driver.WithKubelet = false
 
-		f.It("must apply per-node permission checks", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func(ctx context.Context) {
+		/*
+		   Release: v1.??
+		   Testname: Dynamic Resource Allocation: must apply per-node permission checks
+		   Description: kube-apiserver must apply a DRA driver's validating admission policy (VAP)
+		   when the DRA driver creates, updates or deletes ResourceSlices such that each driver
+		   instance is only allowed to access ResourceSlices associated with the node that it is
+		   running on.
+		*/
+		f.It("must apply per-node permission checks", func(ctx context.Context) {
 			// All of the operations use the client set of a kubelet plugin for
 			// a fictional node which both don't exist, so nothing interferes
 			// when we actually manage to create a slice.

--- a/test/e2e/dra/utils/builder.go
+++ b/test/e2e/dra/utils/builder.go
@@ -53,11 +53,10 @@ import (
 // "example.com/resource" is not special, any valid extended resource name can be used
 // instead, except when using example device plugin in the test, which hard coded it,
 // see test/e2e/dra/deploy_device_plugin.go.
-// i == -1 is special, the extended resource name has no extra suffix, it is
-// used in the test where a cluster has both DRA driver and device plugin.
+// i == -1 == SingletonIndex is special, the extended resource name has no extra suffix.
 func ExtendedResourceName(i int) string {
 	suffix := ""
-	if i >= 0 {
+	if i != SingletonIndex {
 		suffix = strconv.Itoa(i)
 	}
 	return "example.com/resource" + suffix
@@ -80,17 +79,26 @@ func (b *Builder) ClassName() string {
 	return b.f.UniqueName + b.driver.NameSuffix + "-class"
 }
 
+// SingletonIndex causes Builder.Class and ExtendedResourceName to create a
+// DeviceClass where the class name and extended resource name have no -%d
+// suffix. Tests using this cannot run in parallel.
+const SingletonIndex = -1
+
 // Class returns the device Class that the builder's other objects
 // reference.
 // The input i is used to pick the extended resource name whose suffix has the
 // same i for the device class.
-// i == -1 is special, the extended resource name has no extra suffix, it is
-// used in the test where a cluster has both DRA driver and device plugin.
+// i == -1 == SingletonIndex is special, the extended resource name has no extra suffix.
 func (b *Builder) Class(i int) *resourceapi.DeviceClass {
 	ern := ExtendedResourceName(i)
 	name := b.ClassName()
-	if i >= 0 {
-		name = b.ClassName() + strconv.Itoa(i)
+	switch i {
+	case SingletonIndex:
+		name += "-singleton"
+	case 0:
+		// No numeric suffix. This is what most tests use.
+	default:
+		name += "-" + strconv.Itoa(i)
 	}
 	class := &resourceapi.DeviceClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -467,9 +475,7 @@ func NewBuilderNow(ctx context.Context, f *framework.Framework, driver *Driver) 
 func (b *Builder) setUp(ctx context.Context) {
 	b.podCounter = 0
 	b.claimCounter = 0
-	for i := -1; i < 6; i++ {
-		b.Create(ctx, b.Class(i))
-	}
+	b.Create(ctx, b.Class(0))
 	ginkgo.DeferCleanup(b.tearDown)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

All of these tests already ran before for a while in
        https://testgrid.k8s.io/sig-release-master-informing#kind-master-beta&include-filter-by-regex=DRA
    
Now that DRA is GA, they also ran e.g. in
        https://testgrid.k8s.io/sig-release-master-blocking#kind-master&include-filter-by-regex=DRA&include-filter-by-regex=DRA
        https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=DRA
    
For the sake of starting conservatively, only a single basic test which exercises ResourceSlice, DeviceClass, ResourceClaimTemplate, ResourceClaim and ResourceClaim/Status gets promoted to a conformance test:
    
        dra/dra.go:747: [sig-node] [DRA] control plane supports claim and class parameters [Conformance]
    

Documentation for other tests which could get promoted to conformance gets  added for future reference. Such documentation is useful also when the tests  never become conformance tests. Whether they are worth turning into conformance tests remains to be seen, in particular if that means duplicating  and potentially rewriting the test body as it was done for the one test which  gets promoted.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/114183 (not 100% coverage!)
KEP: https://github.com/kubernetes/enhancements/issues/4381

#### Special notes for your reviewer:

/area conformance
cc @kubernetes/sig-architecture-pr-reviews @kubernetes/sig-node-pr-reviews @kubernetes/cncf-conformance-wg

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
