### PR TITLE
feat: Add warnings for unrecognized formats in CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
@@ -105,6 +105,22 @@ func StripUnsupportedFormatsPostProcessorForVersion(compatibilityVersion *versio
 	}
 }
 
+// GetUnrecognizedFormats returns a list of unrecognized formats found in the given schema.
+// It uses the same source of truth as StripUnsupportedFormatsPostProcessorForVersion.
+func GetUnrecognizedFormats(schema *spec.Schema, compatibilityVersion *version.Version) []string {
+	var unrecognizedFormats []string
+	if len(schema.Format) == 0 {
+		return unrecognizedFormats
+	}
+
+	normalized := strings.ReplaceAll(schema.Format, "-", "") // go-openapi default format name normalization
+	if !supportedFormatsAtVersion(compatibilityVersion).supported.Has(normalized) {
+		unrecognizedFormats = append(unrecognizedFormats, schema.Format)
+	}
+
+	return unrecognizedFormats
+}
+
 type versionedFormats struct {
 	introducedVersion *version.Version
 	formats           sets.Set[string]

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
@@ -138,3 +138,86 @@ func TestSupportedFormats(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUnrecognizedFormats(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		schema               *spec.Schema
+		compatibilityVersion *version.Version
+		expectedFormats      []string
+	}{
+		{
+			name:                 "empty format",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: ""}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{},
+		},
+		{
+			name:                 "recognized format at version 1.0",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "email"}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{},
+		},
+		{
+			name:                 "unrecognized format at version 1.0",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "unknown-format"}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{"unknown-format"},
+		},
+		{
+			name:                 "recognized format with normalization",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "k8s-short-name"}},
+			compatibilityVersion: version.MajorMinor(1, 34),
+			expectedFormats:      []string{},
+		},
+		{
+			name:                 "unrecognized format with normalization",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "k8s-long-name"}},
+			compatibilityVersion: version.MajorMinor(1, 33),
+			expectedFormats:      []string{"k8s-long-name"},
+		},
+		{
+			name:                 "format introduced in later version",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "k8s-short-name"}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{"k8s-short-name"},
+		},
+		{
+			name:                 "format with dash normalization",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "k8sshortname"}},
+			compatibilityVersion: version.MajorMinor(1, 34),
+			expectedFormats:      []string{},
+		},
+		{
+			name:                 "recognized format at exact version",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "uuid"}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{},
+		},
+		{
+			name:                 "recognized format at higher version",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "email"}},
+			compatibilityVersion: version.MajorMinor(1, 35),
+			expectedFormats:      []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetUnrecognizedFormats(tc.schema, tc.compatibilityVersion)
+
+			if len(got) != len(tc.expectedFormats) {
+				t.Errorf("expected %d unrecognized formats, got %d", len(tc.expectedFormats), len(got))
+				return
+			}
+
+			// Convert to sets for comparison to handle order differences
+			gotSet := sets.New(got...)
+			expectedSet := sets.New(tc.expectedFormats...)
+
+			if !gotSet.Equal(expectedSet) {
+				t.Errorf("expected unrecognized formats %v, got %v", tc.expectedFormats, got)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
+	apiservervalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,10 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apiserver/pkg/cel/environment"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // strategy implements behavior for CustomResources.
@@ -118,7 +122,24 @@ func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorLis
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
-func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string { return nil }
+func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	newCRD := obj.(*apiextensions.CustomResourceDefinition)
+
+	var warnings []string
+
+	// Use the system's default compatibility version for format checking
+	compatibilityVersion := environment.DefaultCompatibilityVersion()
+
+	// Get unrecognized formats from the new CRD
+	unrecognizedFormats := getUnrecognizedFormatsInCRD(&newCRD.Spec, compatibilityVersion)
+
+	// Create warnings for unrecognized formats
+	for _, format := range unrecognizedFormats {
+		warnings = append(warnings, fmt.Sprintf("unrecognized format %q", format))
+	}
+
+	return warnings
+}
 
 // AllowCreateOnUpdate is false for CustomResourceDefinition; this means a POST is
 // needed to create one.
@@ -142,7 +163,75 @@ func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) fie
 
 // WarningsOnUpdate returns warnings for the given update.
 func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	newCRD := obj.(*apiextensions.CustomResourceDefinition)
+	oldCRD := old.(*apiextensions.CustomResourceDefinition)
+
+	var warnings []string
+
+	// Use the system's default compatibility version for format checking
+	compatibilityVersion := environment.DefaultCompatibilityVersion()
+
+	// Get unrecognized formats from both old and new CRDs
+	oldUnrecognizedFormats := getUnrecognizedFormatsInCRD(&oldCRD.Spec, compatibilityVersion)
+	newUnrecognizedFormats := getUnrecognizedFormatsInCRD(&newCRD.Spec, compatibilityVersion)
+
+	// Find newly introduced unrecognized formats (ratcheting)
+	oldFormatsSet := make(map[string]bool)
+	for _, format := range oldUnrecognizedFormats {
+		oldFormatsSet[format] = true
+	}
+
+	var newlyIntroducedFormats []string
+	for _, format := range newUnrecognizedFormats {
+		if !oldFormatsSet[format] {
+			newlyIntroducedFormats = append(newlyIntroducedFormats, format)
+		}
+	}
+
+	// Create warnings for newly introduced unrecognized formats
+	for _, format := range newlyIntroducedFormats {
+		warnings = append(warnings, fmt.Sprintf("unrecognized format %q", format))
+	}
+
+	return warnings
+}
+
+// getUnrecognizedFormatsInCRD returns a list of unrecognized formats found in the CRD schema.
+func getUnrecognizedFormatsInCRD(spec *apiextensions.CustomResourceDefinitionSpec, compatibilityVersion *version.Version) []string {
+	var unrecognizedFormats []string
+
+	// Check top-level validation schema (deprecated in v1, but still supported for backward compatibility)
+	if spec.Validation != nil && spec.Validation.OpenAPIV3Schema != nil {
+		unrecognizedFormats = append(unrecognizedFormats, getUnrecognizedFormatsInSchema(spec.Validation.OpenAPIV3Schema, compatibilityVersion)...)
+	}
+
+	// Check per-version schemas
+	for _, v := range spec.Versions {
+		if v.Schema != nil && v.Schema.OpenAPIV3Schema != nil {
+			unrecognizedFormats = append(unrecognizedFormats, getUnrecognizedFormatsInSchema(v.Schema.OpenAPIV3Schema, compatibilityVersion)...)
+		}
+	}
+
+	return unrecognizedFormats
+}
+
+// getUnrecognizedFormatsInSchema recursively traverses the schema and collects unrecognized formats.
+func getUnrecognizedFormatsInSchema(schema *apiextensions.JSONSchemaProps, compatibilityVersion *version.Version) []string {
+	var unrecognizedFormats []string
+
+	// Use the existing SchemaHas function to traverse the schema
+	validation.SchemaHas(schema, func(s *apiextensions.JSONSchemaProps) bool {
+		if len(s.Format) > 0 {
+			// Convert to spec.Schema for format validation
+			specSchema := &spec.Schema{SchemaProps: spec.SchemaProps{Format: s.Format}}
+			if formats := apiservervalidation.GetUnrecognizedFormats(specSchema, compatibilityVersion); len(formats) > 0 {
+				unrecognizedFormats = append(unrecognizedFormats, formats...)
+			}
+		}
+		return false // Continue traversing
+	})
+
+	return unrecognizedFormats
 }
 
 type statusStrategy struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR implements warning generation for unrecognized "format" strings in CRD schemas. When users specify unsupported format values (e.g., "invalidformat"), the API server now generates warnings during CRD creation and updates.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes: #132532

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed handling of CustomResourceDefinitions with unrecognized formats. Writing a schema with an unrecognized formats now triggers a warning (the write is still accepted).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
