### PR TITLE
DRA E2E cleanup

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -921,74 +921,6 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), framework.With
 			}).WithTimeout(f.Timeouts.PodDelete).Should(gomega.HaveField("Status.Allocation", (*resourceapi.AllocationResult)(nil)))
 		})
 
-		f.It("must be possible for the driver to update the ResourceClaim.Status.Devices once allocated", f.WithFeatureGate(features.DRAResourceClaimDeviceStatus), func(ctx context.Context) {
-			pod := b.PodExternal()
-			claim := b.ExternalClaim()
-			b.Create(ctx, claim, pod)
-
-			// Waits for the ResourceClaim to be allocated and the pod to be scheduled.
-			b.TestPod(ctx, f, pod)
-
-			allocatedResourceClaim, err := f.ClientSet.ResourceV1beta2().ResourceClaims(f.Namespace.Name).Get(ctx, claim.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			gomega.Expect(allocatedResourceClaim).ToNot(gomega.BeNil())
-			gomega.Expect(allocatedResourceClaim.Status.Allocation).ToNot(gomega.BeNil())
-			gomega.Expect(allocatedResourceClaim.Status.Allocation.Devices.Results).To(gomega.HaveLen(1))
-
-			scheduledPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			gomega.Expect(scheduledPod).ToNot(gomega.BeNil())
-
-			ginkgo.By("Setting the device status a first time")
-			allocatedResourceClaim.Status.Devices = append(allocatedResourceClaim.Status.Devices,
-				resourceapi.AllocatedDeviceStatus{
-					Driver:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Driver,
-					Pool:       allocatedResourceClaim.Status.Allocation.Devices.Results[0].Pool,
-					Device:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Device,
-					Conditions: []metav1.Condition{{Type: "a", Status: "True", Message: "c", Reason: "d", LastTransitionTime: metav1.NewTime(time.Now().Truncate(time.Second))}},
-					Data:       &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)},
-					NetworkData: &resourceapi.NetworkDeviceData{
-						InterfaceName:   "inf1",
-						IPs:             []string{"10.9.8.0/24", "2001:db8::/64"},
-						HardwareAddress: "bc:1c:b6:3e:b8:25",
-					},
-				})
-
-			// Updates the ResourceClaim from the driver on the same node as the pod.
-			plugin, ok := driver.Nodes[scheduledPod.Spec.NodeName]
-			if !ok {
-				framework.Failf("pod got scheduled to node %s without a plugin", scheduledPod.Spec.NodeName)
-			}
-			updatedResourceClaim, err := plugin.UpdateStatus(ctx, allocatedResourceClaim)
-			framework.ExpectNoError(err)
-			gomega.Expect(updatedResourceClaim).ToNot(gomega.BeNil())
-			gomega.Expect(updatedResourceClaim.Status.Devices).To(gomega.Equal(allocatedResourceClaim.Status.Devices))
-
-			ginkgo.By("Updating the device status")
-			updatedResourceClaim.Status.Devices[0] = resourceapi.AllocatedDeviceStatus{
-				Driver:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Driver,
-				Pool:       allocatedResourceClaim.Status.Allocation.Devices.Results[0].Pool,
-				Device:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Device,
-				Conditions: []metav1.Condition{{Type: "e", Status: "True", Message: "g", Reason: "h", LastTransitionTime: metav1.NewTime(time.Now().Truncate(time.Second))}},
-				Data:       &runtime.RawExtension{Raw: []byte(`{"bar":"foo"}`)},
-				NetworkData: &resourceapi.NetworkDeviceData{
-					InterfaceName:   "inf2",
-					IPs:             []string{"10.9.8.1/24", "2001:db8::1/64"},
-					HardwareAddress: "bc:1c:b6:3e:b8:26",
-				},
-			}
-
-			updatedResourceClaim2, err := plugin.UpdateStatus(ctx, updatedResourceClaim)
-			framework.ExpectNoError(err)
-			gomega.Expect(updatedResourceClaim2).ToNot(gomega.BeNil())
-			gomega.Expect(updatedResourceClaim2.Status.Devices).To(gomega.Equal(updatedResourceClaim.Status.Devices))
-
-			getResourceClaim, err := f.ClientSet.ResourceV1beta2().ResourceClaims(f.Namespace.Name).Get(ctx, claim.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			gomega.Expect(getResourceClaim).ToNot(gomega.BeNil())
-			gomega.Expect(getResourceClaim.Status.Devices).To(gomega.Equal(updatedResourceClaim.Status.Devices))
-		})
-
 		if withKubelet {
 			// Serial because the example device plugin can only be deployed with one instance at a time.
 			f.It("supports extended resources together with ResourceClaim", f.WithSerial(), func(ctx context.Context) {
@@ -2123,6 +2055,74 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), framework.With
 				_, err := f.ClientSet.ResourceV1beta2().ResourceClaims(f.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
 				return err
 			}).Should(gomega.MatchError(gomega.ContainSubstring("exceeded quota: object-count, requested: count/resourceclaims.resource.k8s.io=1, used: count/resourceclaims.resource.k8s.io=1, limited: count/resourceclaims.resource.k8s.io=1")), "creating second claim not allowed")
+		})
+
+		f.It("must be possible for the driver to update the ResourceClaim.Status.Devices once allocated", f.WithFeatureGate(features.DRAResourceClaimDeviceStatus), func(ctx context.Context) {
+			pod := b.PodExternal()
+			claim := b.ExternalClaim()
+			b.Create(ctx, claim, pod)
+
+			// Waits for the ResourceClaim to be allocated and the pod to be scheduled.
+			b.TestPod(ctx, f, pod)
+
+			allocatedResourceClaim, err := f.ClientSet.ResourceV1beta2().ResourceClaims(f.Namespace.Name).Get(ctx, claim.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(allocatedResourceClaim).ToNot(gomega.BeNil())
+			gomega.Expect(allocatedResourceClaim.Status.Allocation).ToNot(gomega.BeNil())
+			gomega.Expect(allocatedResourceClaim.Status.Allocation.Devices.Results).To(gomega.HaveLen(1))
+
+			scheduledPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(scheduledPod).ToNot(gomega.BeNil())
+
+			ginkgo.By("Setting the device status a first time")
+			allocatedResourceClaim.Status.Devices = append(allocatedResourceClaim.Status.Devices,
+				resourceapi.AllocatedDeviceStatus{
+					Driver:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Driver,
+					Pool:       allocatedResourceClaim.Status.Allocation.Devices.Results[0].Pool,
+					Device:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Device,
+					Conditions: []metav1.Condition{{Type: "a", Status: "True", Message: "c", Reason: "d", LastTransitionTime: metav1.NewTime(time.Now().Truncate(time.Second))}},
+					Data:       &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)},
+					NetworkData: &resourceapi.NetworkDeviceData{
+						InterfaceName:   "inf1",
+						IPs:             []string{"10.9.8.0/24", "2001:db8::/64"},
+						HardwareAddress: "bc:1c:b6:3e:b8:25",
+					},
+				})
+
+			// Updates the ResourceClaim from the driver on the same node as the pod.
+			plugin, ok := driver.Nodes[scheduledPod.Spec.NodeName]
+			if !ok {
+				framework.Failf("pod got scheduled to node %s without a plugin", scheduledPod.Spec.NodeName)
+			}
+			updatedResourceClaim, err := plugin.UpdateStatus(ctx, allocatedResourceClaim)
+			framework.ExpectNoError(err)
+			gomega.Expect(updatedResourceClaim).ToNot(gomega.BeNil())
+			gomega.Expect(updatedResourceClaim.Status.Devices).To(gomega.Equal(allocatedResourceClaim.Status.Devices))
+
+			ginkgo.By("Updating the device status")
+			updatedResourceClaim.Status.Devices[0] = resourceapi.AllocatedDeviceStatus{
+				Driver:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Driver,
+				Pool:       allocatedResourceClaim.Status.Allocation.Devices.Results[0].Pool,
+				Device:     allocatedResourceClaim.Status.Allocation.Devices.Results[0].Device,
+				Conditions: []metav1.Condition{{Type: "e", Status: "True", Message: "g", Reason: "h", LastTransitionTime: metav1.NewTime(time.Now().Truncate(time.Second))}},
+				Data:       &runtime.RawExtension{Raw: []byte(`{"bar":"foo"}`)},
+				NetworkData: &resourceapi.NetworkDeviceData{
+					InterfaceName:   "inf2",
+					IPs:             []string{"10.9.8.1/24", "2001:db8::1/64"},
+					HardwareAddress: "bc:1c:b6:3e:b8:26",
+				},
+			}
+
+			updatedResourceClaim2, err := plugin.UpdateStatus(ctx, updatedResourceClaim)
+			framework.ExpectNoError(err)
+			gomega.Expect(updatedResourceClaim2).ToNot(gomega.BeNil())
+			gomega.Expect(updatedResourceClaim2.Status.Devices).To(gomega.Equal(updatedResourceClaim.Status.Devices))
+
+			getResourceClaim, err := f.ClientSet.ResourceV1beta2().ResourceClaims(f.Namespace.Name).Get(ctx, claim.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(getResourceClaim).ToNot(gomega.BeNil())
+			gomega.Expect(getResourceClaim.Status.Devices).To(gomega.Equal(updatedResourceClaim.Status.Devices))
 		})
 	})
 

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -940,7 +940,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), framework.With
 	// The following tests only make sense when there is more than one node.
 	// They get skipped when there's only one node.
 	multiNodeTests := func(withKubelet bool) {
-		nodes := drautils.NewNodes(f, 3, 8)
+		nodes := drautils.NewNodes(f, 2, 8)
 
 		ginkgo.Context("with different ResourceSlices", func() {
 			firstDevice := "pre-defined-device-01"

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1750,10 +1750,13 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), framework.With
 		})
 	}
 
-	framework.Context("control plane with single node", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func() { singleNodeTests(false) })
+	// It is okay to use the same context multiple times (like "control plane"),
+	// as long as the test names the still remain unique overall.
+
+	framework.Context("control plane", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func() { singleNodeTests(false) })
 	framework.Context("kubelet", feature.DynamicResourceAllocation, "on single node", func() { singleNodeTests(true) })
 
-	framework.Context("control plane with multiple nodes", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func() { multiNodeTests(false) })
+	framework.Context("control plane", framework.WithLabel("ConformanceCandidate") /* TODO: replace with framework.WithConformance() */, func() { multiNodeTests(false) })
 	framework.Context("kubelet", feature.DynamicResourceAllocation, "on multiple nodes", func() { multiNodeTests(true) })
 
 	framework.Context("kubelet", feature.DynamicResourceAllocation, f.WithFeatureGate(features.DRAPrioritizedList), prioritizedListTests)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- avoid running one test twice unnecessarily (first commit)
- shorter and cleaner test names (second commit)
- reduce node number requirement for multi-node to two, because that allows them to be conformance tests

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/133132#issuecomment-3104915799

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 
/priority critical-urgent