### PR TITLE
apiserver trust-controller: always include default RequestHeaders in the trust CM

### DIFF
--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller_test.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller_test.go
@@ -116,9 +116,9 @@ func TestWriteClientCAs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
 						"client-ca-file":                     string(someRandomCA),
-						"requestheader-username-headers":     `["alfa","bravo","charlie"]`,
-						"requestheader-group-headers":        `["delta"]`,
-						"requestheader-extra-headers-prefix": `["echo","foxtrot"]`,
+						"requestheader-username-headers":     `["X-Remote-User","alfa","bravo","charlie"]`,
+						"requestheader-group-headers":        `["X-Remote-Group","delta"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-","echo","foxtrot"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `["first","second"]`,
 					},
@@ -142,10 +142,10 @@ func TestWriteClientCAs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
 						"client-ca-file":                     string(someRandomCA),
-						"requestheader-username-headers":     `["alfa","bravo","charlie"]`,
-						"requestheader-uid-headers":          `["golf","hotel","india"]`,
-						"requestheader-group-headers":        `["delta"]`,
-						"requestheader-extra-headers-prefix": `["echo","foxtrot"]`,
+						"requestheader-username-headers":     `["X-Remote-User","alfa","bravo","charlie"]`,
+						"requestheader-uid-headers":          `["X-Remote-Uid","golf","hotel","india"]`,
+						"requestheader-group-headers":        `["X-Remote-Group","delta"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-","echo","foxtrot"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `["first","second"]`,
 					},
@@ -164,9 +164,9 @@ func TestWriteClientCAs(t *testing.T) {
 				"extension-apiserver-authentication": {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `["first","second"]`,
 					},
@@ -198,9 +198,9 @@ func TestWriteClientCAs(t *testing.T) {
 				"extension-apiserver-authentication": {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -243,9 +243,9 @@ func TestWriteClientCAs(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(someRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -255,9 +255,9 @@ func TestWriteClientCAs(t *testing.T) {
 				"extension-apiserver-authentication": {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(someRandomCA) + string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -295,9 +295,9 @@ func TestWriteClientCAs(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -320,10 +320,10 @@ func TestWriteClientCAs(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-uid-headers":          `["snorlax"]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-uid-headers":          `["X-Remote-Uid","snorlax"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -333,9 +333,9 @@ func TestWriteClientCAs(t *testing.T) {
 				"extension-apiserver-authentication": {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -347,7 +347,7 @@ func TestWriteClientCAs(t *testing.T) {
 			name: "add uid with feature gate",
 			clusterAuthInfo: ClusterAuthenticationInfo{
 				RequestHeaderUsernameHeaders:     headerrequest.StaticStringSlice{},
-				RequestHeaderUIDHeaders:          headerrequest.StaticStringSlice{"panda"},
+				RequestHeaderUIDHeaders:          headerrequest.StaticStringSlice{},
 				RequestHeaderGroupHeaders:        headerrequest.StaticStringSlice{},
 				RequestHeaderExtraHeaderPrefixes: headerrequest.StaticStringSlice{},
 				RequestHeaderCA:                  anotherRandomCAProvider,
@@ -357,9 +357,9 @@ func TestWriteClientCAs(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -369,10 +369,10 @@ func TestWriteClientCAs(t *testing.T) {
 				"extension-apiserver-authentication": {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-uid-headers":          `["panda"]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-uid-headers":          `["X-Remote-Uid"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -395,10 +395,10 @@ func TestWriteClientCAs(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-uid-headers":          `["snorlax"]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-uid-headers":          `["X-Remote-Uid","snorlax"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -408,10 +408,10 @@ func TestWriteClientCAs(t *testing.T) {
 				"extension-apiserver-authentication": {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
-						"requestheader-username-headers":     `[]`,
-						"requestheader-uid-headers":          `["snorlax","panda"]`,
-						"requestheader-group-headers":        `[]`,
-						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-username-headers":     `["X-Remote-User"]`,
+						"requestheader-uid-headers":          `["X-Remote-Uid","snorlax","panda"]`,
+						"requestheader-group-headers":        `["X-Remote-Group"]`,
+						"requestheader-extra-headers-prefix": `["X-Remote-Extra-"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
 						"requestheader-allowed-names":        `[]`,
 					},
@@ -433,12 +433,11 @@ func TestWriteClientCAs(t *testing.T) {
 			}
 			configmapLister := corev1listers.NewConfigMapLister(configMapIndexer)
 
-			c := &Controller{
-				configMapLister:            configmapLister,
-				configMapClient:            client.CoreV1(),
-				namespaceClient:            client.CoreV1(),
-				requiredAuthenticationData: test.clusterAuthInfo,
-			}
+			// use the init to merge the test config with the defaults
+			c := NewClusterAuthenticationTrustController(test.clusterAuthInfo, client)
+			// instead of having to go through the process of feeding the lister
+			// through a started informer, just use one we prepared ourselves
+			c.configMapLister = configmapLister
 
 			err := c.syncConfigMap()
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
@@ -281,22 +281,22 @@ func (c *RequestHeaderAuthRequestController) hasRequestHeaderBundleChanged(cm *c
 }
 
 func (c *RequestHeaderAuthRequestController) getRequestHeaderBundleFromConfigMap(cm *corev1.ConfigMap) (*requestHeaderBundle, error) {
-	usernameHeaderCurrentValue, err := deserializeStrings(cm.Data[c.usernameHeadersKey])
+	usernameHeaderCurrentValue, err := uniqueHTTPHeaders(cm.Data[c.usernameHeadersKey])
 	if err != nil {
 		return nil, err
 	}
 
-	uidHeaderCurrentValue, err := deserializeStrings(cm.Data[c.uidHeadersKey])
+	uidHeaderCurrentValue, err := uniqueHTTPHeaders(cm.Data[c.uidHeadersKey])
 	if err != nil {
 		return nil, err
 	}
 
-	groupHeadersCurrentValue, err := deserializeStrings(cm.Data[c.groupHeadersKey])
+	groupHeadersCurrentValue, err := uniqueHTTPHeaders(cm.Data[c.groupHeadersKey])
 	if err != nil {
 		return nil, err
 	}
 
-	extraHeaderPrefixesCurrentValue, err := deserializeStrings(cm.Data[c.extraHeaderPrefixesKey])
+	extraHeaderPrefixesCurrentValue, err := uniqueHTTPHeaders(cm.Data[c.extraHeaderPrefixesKey])
 	if err != nil {
 		return nil, err
 
@@ -342,6 +342,20 @@ func (c *RequestHeaderAuthRequestController) loadRequestHeaderFor(key string) []
 func (c *RequestHeaderAuthRequestController) keyFn() string {
 	// this format matches DeletionHandlingMetaNamespaceKeyFunc for our single key
 	return c.configmapNamespace + "/" + c.configmapName
+}
+
+func uniqueHTTPHeaders(jsonArray string) ([]string, error) {
+	headers, err := deserializeStrings(jsonArray)
+	if err != nil {
+		return nil, err
+	}
+
+	headers, err = normalizeHeaders(headers...)
+	if err != nil {
+		return nil, err
+	}
+
+	return uniqueStrings(headers), nil
 }
 
 func deserializeStrings(in string) ([]string, error) {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller_test.go
@@ -57,12 +57,12 @@ func TestRequestHeaderAuthRequestController(t *testing.T) {
 	}{
 		{
 			name: "happy-path: headers values are populated form a config map",
-			cm:   defaultConfigMap(t, []string{"user-val"}, []string{"uid-val"}, []string{"group-val"}, []string{"extra-val"}, []string{"names-val"}),
+			cm:   defaultConfigMap(t, []string{"user-val", "USER-val"}, []string{"uid-val"}, []string{"group-val", "gRoUp-VaL"}, []string{"extra-val"}, []string{"names-val"}),
 			expectedHeader: expectedHeadersHolder{
-				usernameHeaders:     []string{"user-val"},
-				uidHeaders:          []string{"uid-val"},
-				groupHeaders:        []string{"group-val"},
-				extraHeaderPrefixes: []string{"extra-val"},
+				usernameHeaders:     []string{"User-Val"},
+				uidHeaders:          []string{"Uid-Val"},
+				groupHeaders:        []string{"Group-Val"},
+				extraHeaderPrefixes: []string{"Extra-Val"},
 				allowedClientNames:  []string{"names-val"},
 			},
 		},
@@ -124,10 +124,10 @@ func TestRequestHeaderAuthRequestControllerPreserveState(t *testing.T) {
 			name: "scenario 1: headers values are populated form a config map",
 			cm:   defaultConfigMap(t, []string{"user-val"}, []string{"uid-val"}, []string{"group-val"}, []string{"extra-val"}, []string{"names-val"}),
 			expectedHeader: expectedHeadersHolder{
-				usernameHeaders:     []string{"user-val"},
-				uidHeaders:          []string{"uid-val"},
-				groupHeaders:        []string{"group-val"},
-				extraHeaderPrefixes: []string{"extra-val"},
+				usernameHeaders:     []string{"User-Val"},
+				uidHeaders:          []string{"Uid-Val"},
+				groupHeaders:        []string{"Group-Val"},
+				extraHeaderPrefixes: []string{"Extra-Val"},
 				allowedClientNames:  []string{"names-val"},
 			},
 		},
@@ -142,10 +142,10 @@ func TestRequestHeaderAuthRequestControllerPreserveState(t *testing.T) {
 			}(),
 			expectErr: true,
 			expectedHeader: expectedHeadersHolder{
-				usernameHeaders:     []string{"user-val"},
-				uidHeaders:          []string{"uid-val"},
-				groupHeaders:        []string{"group-val"},
-				extraHeaderPrefixes: []string{"extra-val"},
+				usernameHeaders:     []string{"User-Val"},
+				uidHeaders:          []string{"Uid-Val"},
+				groupHeaders:        []string{"Group-Val"},
+				extraHeaderPrefixes: []string{"Extra-Val"},
 				allowedClientNames:  []string{"names-val"},
 			},
 		},
@@ -153,10 +153,10 @@ func TestRequestHeaderAuthRequestControllerPreserveState(t *testing.T) {
 			name: "scenario 3: some headers values have changed (prev set by scenario 1)",
 			cm:   defaultConfigMap(t, []string{"user-val"}, []string{"uid-val"}, []string{"group-val-scenario-3"}, []string{"extra-val"}, []string{"names-val"}),
 			expectedHeader: expectedHeadersHolder{
-				usernameHeaders:     []string{"user-val"},
-				uidHeaders:          []string{"uid-val"},
-				groupHeaders:        []string{"group-val-scenario-3"},
-				extraHeaderPrefixes: []string{"extra-val"},
+				usernameHeaders:     []string{"User-Val"},
+				uidHeaders:          []string{"Uid-Val"},
+				groupHeaders:        []string{"Group-Val-Scenario-3"},
+				extraHeaderPrefixes: []string{"Extra-Val"},
 				allowedClientNames:  []string{"names-val"},
 			},
 		},
@@ -164,10 +164,10 @@ func TestRequestHeaderAuthRequestControllerPreserveState(t *testing.T) {
 			name: "scenario 4: all headers values have changed (prev set by scenario 3)",
 			cm:   defaultConfigMap(t, []string{"user-val-scenario-4"}, []string{"uid-val-scenario-4"}, []string{"group-val-scenario-4"}, []string{"extra-val-scenario-4"}, []string{"names-val-scenario-4"}),
 			expectedHeader: expectedHeadersHolder{
-				usernameHeaders:     []string{"user-val-scenario-4"},
-				uidHeaders:          []string{"uid-val-scenario-4"},
-				groupHeaders:        []string{"group-val-scenario-4"},
-				extraHeaderPrefixes: []string{"extra-val-scenario-4"},
+				usernameHeaders:     []string{"User-Val-Scenario-4"},
+				uidHeaders:          []string{"Uid-Val-Scenario-4"},
+				groupHeaders:        []string{"Group-Val-Scenario-4"},
+				extraHeaderPrefixes: []string{"Extra-Val-Scenario-4"},
 				allowedClientNames:  []string{"names-val-scenario-4"},
 			},
 		},
@@ -213,10 +213,10 @@ func TestRequestHeaderAuthRequestControllerSyncOnce(t *testing.T) {
 			name: "headers values are populated form a config map",
 			cm:   defaultConfigMap(t, []string{"user-val"}, []string{"uid-val"}, []string{"group-val"}, []string{"extra-val"}, []string{"names-val"}),
 			expectedHeader: expectedHeadersHolder{
-				usernameHeaders:     []string{"user-val"},
-				uidHeaders:          []string{"uid-val"},
-				groupHeaders:        []string{"group-val"},
-				extraHeaderPrefixes: []string{"extra-val"},
+				usernameHeaders:     []string{"User-Val"},
+				uidHeaders:          []string{"Uid-Val"},
+				groupHeaders:        []string{"Group-Val"},
+				extraHeaderPrefixes: []string{"Extra-Val"},
 				allowedClientNames:  []string{"names-val"},
 			},
 		},
@@ -283,15 +283,15 @@ func newDefaultTarget() *RequestHeaderAuthRequestController {
 
 func validateExpectedHeaders(t *testing.T, target *RequestHeaderAuthRequestController, expected expectedHeadersHolder) {
 	if !equality.Semantic.DeepEqual(target.UsernameHeaders(), expected.usernameHeaders) {
-		t.Fatalf("incorrect usernameHeaders, got %v, wanted %v", target.UsernameHeaders(), expected.usernameHeaders)
+		t.Errorf("incorrect usernameHeaders, got %v, wanted %v", target.UsernameHeaders(), expected.usernameHeaders)
 	}
 	if !equality.Semantic.DeepEqual(target.GroupHeaders(), expected.groupHeaders) {
-		t.Fatalf("incorrect groupHeaders, got %v, wanted %v", target.GroupHeaders(), expected.groupHeaders)
+		t.Errorf("incorrect groupHeaders, got %v, wanted %v", target.GroupHeaders(), expected.groupHeaders)
 	}
 	if !equality.Semantic.DeepEqual(target.ExtraHeaderPrefixes(), expected.extraHeaderPrefixes) {
-		t.Fatalf("incorrect extraheaderPrefixes, got %v, wanted %v", target.ExtraHeaderPrefixes(), expected.extraHeaderPrefixes)
+		t.Errorf("incorrect extraheaderPrefixes, got %v, wanted %v", target.ExtraHeaderPrefixes(), expected.extraHeaderPrefixes)
 	}
 	if !equality.Semantic.DeepEqual(target.AllowedClientNames(), expected.allowedClientNames) {
-		t.Fatalf("incorrect expectedAllowedClientNames, got %v, wanted %v", target.AllowedClientNames(), expected.allowedClientNames)
+		t.Errorf("incorrect expectedAllowedClientNames, got %v, wanted %v", target.AllowedClientNames(), expected.allowedClientNames)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
@@ -100,6 +100,20 @@ func TestRequestHeader(t *testing.T) {
 			},
 			expectedOk: true,
 		},
+		"group headers repeat with different case": {
+			nameHeaders:  []string{"X-Remote-User"},
+			groupHeaders: []string{"X-Remote-Group", "X-REMOTE-Group"},
+			requestHeaders: http.Header{
+				"X-Remote-User":  {"Bob"},
+				"X-Remote-Group": {"one-a", "one-b"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name:   "Bob",
+				Groups: []string{"one-a", "one-b"},
+				Extra:  map[string][]string{},
+			},
+			expectedOk: true,
+		},
 		"groups all matches": {
 			nameHeaders:  []string{"X-Remote-User"},
 			groupHeaders: []string{"X-Remote-Group-1", "X-Remote-Group-2"},

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -261,6 +261,8 @@ func TestAggregatedAPIServer(t *testing.T) {
 
 func TestFrontProxyConfig(t *testing.T) {
 	t.Run("WithoutUID", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MajorMinor(1, 33))
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RemoteRequestHeaderUID, false)
 		testFrontProxyConfig(t, false)
 	})
 	t.Run("WithUID", func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds the standard Kubernetes headers for authentication with remote headers to the
`kube-system/extension-apiserver-authentication` config map of every cluster. These headers
are used to relay user information from the kube-apiserver to the aggregated API servers and
so they should always be present in the authentication discovery that's based off of this CM.

#### Which issue(s) this PR is related to:

Fixes #126821 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Standard Kubernetes HTTP headers for communication to the aggregated API servers are now always added to the `kube-system/extension-apiserver-authentication` config map.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/cc enj liggitt
