### PR TITLE
e2e: node: podresources: exercise with dynamicresources enabled

### DIFF
--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -294,6 +294,8 @@ func collectNamespacedNamesFromPodResources(prs []*podresourcesapi.PodResources)
 }
 
 func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.KubeletPodResourcesDynamicResources, true)
+
 	tCtx := ktesting.Init(t)
 	numaID := int64(1)
 
@@ -385,6 +387,7 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
 			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return([]*podresourcesapi.ContainerDevices{}).Maybe()
 			mockMemoryProvider.EXPECT().GetAllocatableMemory().Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(mock.Anything, mock.Anything).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:             mockPodsProvider,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Differently than all the other tests, the testsuite  `TestListPodResourcesUsesOnlyActivePodsV1` did not enable the `KubeletPodResourcesDynamicResources` FG.
Fixing to prevent a failure in https://github.com/kubernetes/kubernetes/pull/132940
    
#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/3695

#### Special notes for your reviewer:
The omission was just an [oversight](https://github.com/kubernetes/kubernetes/pull/132028), because the test doesn't care about the DynamicResources data, so the enablement was forgotten.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

