### PR TITLE
Add flake debugging for admission test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -49,6 +49,7 @@ func makeTestDispatcher(authorizer.Authorizer, *matching.Matcher, kubernetes.Int
 
 func TestPolicySourceHasSyncedEmpty(t *testing.T) {
 	testContext, testCancel, err := generic.NewPolicyTestContext(
+		t,
 		func(fp *FakePolicy) generic.PolicyAccessor { return fp },
 		func(fb *FakeBinding) generic.BindingAccessor { return fb },
 		func(fp *FakePolicy) generic.Evaluator { return nil },
@@ -81,6 +82,7 @@ func TestPolicySourceHasSyncedInitialList(t *testing.T) {
 	}
 
 	testContext, testCancel, err := generic.NewPolicyTestContext(
+		t,
 		func(fp *FakePolicy) generic.PolicyAccessor { return fp },
 		func(fb *FakeBinding) generic.BindingAccessor { return fb },
 		func(fp *FakePolicy) generic.Evaluator { return nil },
@@ -150,6 +152,7 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 	}
 
 	testContext, testCancel, err := generic.NewPolicyTestContext(
+		t,
 		func(fp *FakePolicy) generic.PolicyAccessor { return fp },
 		func(fb *FakeBinding) generic.BindingAccessor { return fb },
 		func(fp *FakePolicy) generic.Evaluator { return nil },

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
@@ -46,6 +46,7 @@ func setupTest(
 ) *generic.PolicyTestContext[*mutating.Policy, *mutating.PolicyBinding, mutating.PolicyEvaluator] {
 
 	testContext, testCancel, err := generic.NewPolicyTestContext[*mutating.Policy, *mutating.PolicyBinding, mutating.PolicyEvaluator](
+		t,
 		mutating.NewMutatingAdmissionPolicyAccessor,
 		mutating.NewMutatingAdmissionPolicyBindingAccessor,
 		compiler,

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -360,6 +360,7 @@ func setupTestCommon(
 	shouldStartInformers bool,
 ) *generic.PolicyTestContext[*validating.Policy, *validating.PolicyBinding, validating.Validator] {
 	testContext, testContextCancel, err := generic.NewPolicyTestContext(
+		t,
 		validating.NewValidatingAdmissionPolicyAccessor,
 		validating.NewValidatingAdmissionPolicyBindingAccessor,
 		func(p *validating.Policy) validating.Validator {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Adds more test logging to help figure out https://github.com/kubernetes/kubernetes/issues/132995 and https://github.com/kubernetes/kubernetes/issues/132029

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig api-machinery
/assign @jpbetz 