### PR TITLE
chore: ptrTo util removal with ptr.To

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -72,7 +73,7 @@ var (
 				APIVersion: paramsGVK.GroupVersion().String(),
 				Kind:       paramsGVK.Kind,
 			},
-			FailurePolicy: ptrTo(admissionregistrationv1.Fail),
+			FailurePolicy: ptr.To(admissionregistrationv1.Fail),
 			Validations: []admissionregistrationv1.Validation{
 				{
 					Expression: "messageId for deny policy",
@@ -105,7 +106,7 @@ var (
 				Name:      fakeParams.GetName(),
 				Namespace: fakeParams.GetNamespace(),
 				// fake object tracker does not populate defaults
-				ParameterNotFoundAction: ptrTo(admissionregistrationv1.DenyAction),
+				ParameterNotFoundAction: ptr.To(admissionregistrationv1.DenyAction),
 			},
 			ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Deny},
 		},
@@ -437,10 +438,6 @@ func attributeRecord(
 	}
 }
 
-func ptrTo[T any](obj T) *T {
-	return &obj
-}
-
 // //////////////////////////////////////////////////////////////////////////////
 // Functionality Tests
 // //////////////////////////////////////////////////////////////////////////////
@@ -655,7 +652,7 @@ func TestReconfigureBinding(t *testing.T) {
 			ParamRef: &admissionregistrationv1.ParamRef{
 				Name:                    fakeParams2.GetName(),
 				Namespace:               fakeParams2.GetNamespace(),
-				ParameterNotFoundAction: ptrTo(admissionregistrationv1.DenyAction),
+				ParameterNotFoundAction: ptr.To(admissionregistrationv1.DenyAction),
 			},
 			ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Deny},
 		},
@@ -991,7 +988,7 @@ func TestMultiplePoliciesSharedParamType(t *testing.T) {
 			APIVersion: paramsGVK.GroupVersion().String(),
 			Kind:       paramsGVK.Kind,
 		},
-		FailurePolicy: ptrTo(admissionregistrationv1.Fail),
+		FailurePolicy: ptr.To(admissionregistrationv1.Fail),
 		Validations: []admissionregistrationv1.Validation{
 			{
 				Expression: "policy1",
@@ -1006,7 +1003,7 @@ func TestMultiplePoliciesSharedParamType(t *testing.T) {
 			APIVersion: paramsGVK.GroupVersion().String(),
 			Kind:       paramsGVK.Kind,
 		},
-		FailurePolicy: ptrTo(admissionregistrationv1.Fail),
+		FailurePolicy: ptr.To(admissionregistrationv1.Fail),
 		Validations: []admissionregistrationv1.Validation{
 			{
 				Expression: "policy2",
@@ -1583,9 +1580,9 @@ func testParamRefCase(t *testing.T, paramIsClusterScoped, nameIsSet, namespaceIs
 	}
 
 	if denyNotFound {
-		paramRef.ParameterNotFoundAction = ptrTo(admissionregistrationv1.DenyAction)
+		paramRef.ParameterNotFoundAction = ptr.To(admissionregistrationv1.DenyAction)
 	} else {
-		paramRef.ParameterNotFoundAction = ptrTo(admissionregistrationv1.AllowAction)
+		paramRef.ParameterNotFoundAction = ptr.To(admissionregistrationv1.AllowAction)
 	}
 
 	compiler := &fakeCompiler{}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/priority backlog

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE