### PR TITLE
Revert "DRAAdminAccess: add upgrade downgrade test"

### DIFF
--- a/test/e2e/dra/utils/builder.go
+++ b/test/e2e/dra/utils/builder.go
@@ -56,15 +56,11 @@ type Builder struct {
 	podCounter      int
 	claimCounter    int
 	ClassParameters string // JSON
-	classname       string // Ensures all subsequent resources use the same deviceClass
 }
 
 // ClassName returns the default device class name.
 func (b *Builder) ClassName() string {
-	if b.classname == "" {
-		b.classname = b.f.UniqueName + b.driver.NameSuffix + "-class"
-	}
-	return b.classname
+	return b.f.UniqueName + b.driver.NameSuffix + "-class"
 }
 
 // Class returns the device Class that the builder's other objects
@@ -117,7 +113,7 @@ func (b *Builder) claimSpecWithV1beta1() resourcev1beta1.ResourceClaimSpec {
 		Devices: resourcev1beta1.DeviceClaim{
 			Requests: []resourcev1beta1.DeviceRequest{{
 				Name:            "my-request",
-				DeviceClassName: b.classname,
+				DeviceClassName: b.ClassName(),
 			}},
 			Config: []resourcev1beta1.DeviceClaimConfiguration{{
 				DeviceConfiguration: resourcev1beta1.DeviceConfiguration{
@@ -172,7 +168,7 @@ func (b *Builder) ClaimSpec() resourceapi.ResourceClaimSpec {
 			Requests: []resourceapi.DeviceRequest{{
 				Name: "my-request",
 				Exactly: &resourceapi.ExactDeviceRequest{
-					DeviceClassName: b.classname,
+					DeviceClassName: b.ClassName(),
 				},
 			}},
 			Config: []resourceapi.DeviceClaimConfiguration{{
@@ -188,14 +184,6 @@ func (b *Builder) ClaimSpec() resourceapi.ResourceClaimSpec {
 		},
 	}
 
-	return spec
-}
-
-// ClaimSpecWithAdminAccess returns the device request for a claim or claim template
-// with AdminAccess enabled using the v1beta2 API.
-func (b *Builder) ClaimSpecWithAdminAccess() resourceapi.ResourceClaimSpec {
-	spec := b.ClaimSpec()
-	spec.Devices.Requests[0].Exactly.AdminAccess = ptr.To(true)
 	return spec
 }
 
@@ -261,13 +249,6 @@ func (b *Builder) PodInlineWithV1beta1() (*v1.Pod, *resourcev1beta1.ResourceClai
 	return pod, template
 }
 
-// PodInlineWithAdminAccess returns a pod with inline resource claim template that has AdminAccess enabled.
-func (b *Builder) PodInlineWithAdminAccess() (*v1.Pod, *resourceapi.ResourceClaimTemplate) {
-	pod, template := b.PodInline()
-	template.Spec.Spec = b.ClaimSpecWithAdminAccess()
-	return pod, template
-}
-
 func (b *Builder) PodInlineWithV1beta2() (*v1.Pod, *resourcev1beta2.ResourceClaimTemplate) {
 	pod, _ := b.PodInline()
 	template := &resourcev1beta2.ResourceClaimTemplate{
@@ -282,7 +263,6 @@ func (b *Builder) PodInlineWithV1beta2() (*v1.Pod, *resourcev1beta2.ResourceClai
 	return pod, template
 }
 
-// PodInlineMultiple returns a pod with inline resource claim referenced by 3 containers
 func (b *Builder) PodInlineMultiple() (*v1.Pod, *resourceapi.ResourceClaimTemplate) {
 	pod, template := b.PodInline()
 	pod.Spec.Containers = append(pod.Spec.Containers, *pod.Spec.Containers[0].DeepCopy(), *pod.Spec.Containers[0].DeepCopy())


### PR DESCRIPTION
Reverts kubernetes/kubernetes#133110.

There was one flake:

>  [FAILED] create *v1.DeviceClass: deviceclasses.resource.k8s.io "dra-9691-class" already exists

I think what happens now is that the first E2E test which uses a builder instance (shared between tests!) locks the DeviceClass name, so tests cannot run in parallel reliably anymore.

/assign @bart0sh 
/cc @ritazh 