### PR TITLE
Bump DRA API version to "v1" in "deviceattribute" package in "k8s.io/dynamic-resource-allocation" module

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
@@ -17,7 +17,7 @@ limitations under the License.
 package deviceattribute
 
 import (
-	resourceapi "k8s.io/api/resource/v1beta2"
+	resourceapi "k8s.io/api/resource/v1"
 )
 
 const (

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
@@ -23,7 +23,7 @@ import (
 	"regexp"
 	"strings"
 
-	resourceapi "k8s.io/api/resource/v1beta2"
+	resourceapi "k8s.io/api/resource/v1"
 )
 
 // GetPCIeRootAttributeByPCIBusID retrieves the PCIe Root Complex for a given PCI Bus ID.

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
@@ -26,7 +26,7 @@ import (
 
 	"k8s.io/utils/ptr"
 
-	resourceapi "k8s.io/api/resource/v1beta2"
+	resourceapi "k8s.io/api/resource/v1"
 )
 
 func TestGetPCIeRootBAttributeyPCIBusID(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This is follow up PR for https://github.com/kubernetes/kubernetes/pull/132296#discussion_r2222405208 to bump DRA API version to "v1" in "deviceattribute" package in "k8s.io/dynamic-resource-allocation" module.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

This is follow up PR for https://github.com/kubernetes/kubernetes/pull/132296#discussion_r2222405208

#### Special notes for your reviewer:

The test will fail until https://github.com/kubernetes/kubernetes/pull/132706 got merged. I will rebase this branch once the PR got merged.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Use DRA API version to "v1" in "deviceattribute" package in "k8s.io/dynamic-resource-allocation" module
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters
```
