### PR TITLE
fix: handle corner cases in the async preemption

### DIFF
--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -190,10 +190,8 @@ func NewEvaluator(pluginName string, fh framework.Handle, i Interface, enableAsy
 			if err := util.DeletePod(ctx, ev.Handler.ClientSet(), victim); err != nil {
 				if !apierrors.IsNotFound(err) {
 					logger.Error(err, "Tried to preempted pod", "pod", klog.KObj(victim), "preemptor", klog.KObj(preemptor))
-					return err
 				}
-				logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
-				return nil
+				return err
 			}
 			logger.V(2).Info("Preemptor Pod preempted victim Pod", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
 		}
@@ -435,7 +433,18 @@ func (ev *Evaluator) prepareCandidate(ctx context.Context, c Candidate, pod *v1.
 	logger := klog.FromContext(ctx)
 	errCh := parallelize.NewErrorChannel()
 	fh.Parallelizer().Until(ctx, len(c.Victims().Pods), func(index int) {
-		if err := ev.PreemptPod(ctx, c, pod, c.Victims().Pods[index], pluginName); err != nil {
+		victimPod := c.Victims().Pods[index]
+		if victimPod.DeletionTimestamp != nil {
+			// If the victim Pod is already being deleted, we don't have to make another deletion api call.
+			logger.V(2).Info("Victim Pod is already deleted, skipping the API call for it", "preemptor", klog.KObj(pod), "node", c.Name(), "victim", klog.KObj(victimPod))
+			return
+		}
+
+		if err := ev.PreemptPod(ctx, c, pod, victimPod, pluginName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(pod), "victim", klog.KObj(victimPod), "node", c.Name())
+				return
+			}
 			errCh.SendErrorWithCancel(err, cancel)
 		}
 	}, ev.PluginName)
@@ -471,9 +480,24 @@ func (ev *Evaluator) prepareCandidateAsync(c Candidate, pod *v1.Pod, pluginName 
 	// Intentionally create a new context, not using a ctx from the scheduling cycle, to create ctx,
 	// because this process could continue even after this scheduling cycle finishes.
 	ctx, cancel := context.WithCancel(context.Background())
+	logger := klog.FromContext(ctx)
+	victimPods := make([]*v1.Pod, 0, len(c.Victims().Pods))
+	for _, victim := range c.Victims().Pods {
+		if victim.DeletionTimestamp != nil {
+			// If the victim Pod is already being deleted, we don't have to make another deletion api call.
+			logger.V(2).Info("Victim Pod is already deleted, skipping the API call for it", "preemptor", klog.KObj(pod), "node", c.Name(), "victim", klog.KObj(victim))
+			continue
+		}
+		victimPods = append(victimPods, victim)
+	}
+	if len(victimPods) == 0 {
+		cancel()
+		return
+	}
+
 	errCh := parallelize.NewErrorChannel()
 	preemptPod := func(index int) {
-		victim := c.Victims().Pods[index]
+		victim := victimPods[index]
 		if err := ev.PreemptPod(ctx, c, pod, victim, pluginName); err != nil {
 			errCh.SendErrorWithCancel(err, cancel)
 		}
@@ -483,21 +507,26 @@ func (ev *Evaluator) prepareCandidateAsync(c Candidate, pod *v1.Pod, pluginName 
 	ev.preempting.Insert(pod.UID)
 	ev.mu.Unlock()
 
-	logger := klog.FromContext(ctx)
 	go func() {
 		startTime := time.Now()
 		result := metrics.GoroutineResultSuccess
+
+		// Whether all victim pods are already deleted before making API call.
+		allPodsAlreadyDeleted := true
 		defer metrics.PreemptionGoroutinesDuration.WithLabelValues(result).Observe(metrics.SinceInSeconds(startTime))
 		defer metrics.PreemptionGoroutinesExecutionTotal.WithLabelValues(result).Inc()
 		defer func() {
-			if result == metrics.GoroutineResultError {
-				// When API call isn't successful, the Pod may get stuck in the unschedulable pod pool in the worst case.
-				// So, we should move the Pod to the activeQ.
+			// When API call isn't successful, the Pod may get stuck in the unschedulable pod pool in the worst case.
+			// So, we should move the Pod to the activeQ.
+			if result == metrics.GoroutineResultError ||
+				// When all pods are already deleted (which is very rare, but could happen in theory),
+				// it's safe to activate the preemptor Pod because it might miss Pod/delete event that requeues the pod.
+				allPodsAlreadyDeleted {
 				ev.Handler.Activate(logger, map[string]*v1.Pod{pod.Name: pod})
 			}
 		}()
 		defer cancel()
-		logger.V(2).Info("Start the preemption asynchronously", "preemptor", klog.KObj(pod), "node", c.Name(), "numVictims", len(c.Victims().Pods))
+		logger.V(2).Info("Start the preemption asynchronously", "preemptor", klog.KObj(pod), "node", c.Name(), "numVictims", len(c.Victims().Pods), "numVictimsToDelete", len(victimPods))
 
 		// Lower priority pods nominated to run on this node, may no longer fit on
 		// this node. So, we should remove their nomination. Removing their
@@ -510,33 +539,39 @@ func (ev *Evaluator) prepareCandidateAsync(c Candidate, pod *v1.Pod, pluginName 
 			// We do not return as this error is not critical.
 		}
 
-		if len(c.Victims().Pods) == 0 {
-			ev.mu.Lock()
-			delete(ev.preempting, pod.UID)
-			ev.mu.Unlock()
-
-			return
-		}
-
-		// We can evict all victims in parallel, but the last one.
-		// We have to remove the pod from the preempting map before the last one is evicted
-		// because, otherwise, the pod removal might be notified to the scheduling queue before
-		// we remove this pod from the preempting map,
-		// and the pod could end up stucking at the unschedulable pod pool
-		// by all the pod removal events being ignored.
-		ev.Handler.Parallelizer().Until(ctx, len(c.Victims().Pods)-1, preemptPod, ev.PluginName)
-		if err := errCh.ReceiveError(); err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption")
-			result = metrics.GoroutineResultError
+		if len(victimPods) > 1 {
+			// We can evict all victims in parallel, but the last one.
+			// We have to remove the pod from the preempting map before the last one is evicted
+			// because, otherwise, the pod removal might be notified to the scheduling queue before
+			// we remove this pod from the preempting map,
+			// and the pod could end up stucking at the unschedulable pod pool
+			// by all the pod removal events being ignored.
+			ev.Handler.Parallelizer().Until(ctx, len(victimPods)-1, preemptPod, ev.PluginName)
+			err := errCh.ReceiveError()
+			switch {
+			case apierrors.IsNotFound(err):
+				logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(pod), "node", c.Name(), "err", err)
+			case err != nil:
+				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption")
+				result = metrics.GoroutineResultError
+			default:
+				allPodsAlreadyDeleted = false
+			}
 		}
 
 		ev.mu.Lock()
 		delete(ev.preempting, pod.UID)
 		ev.mu.Unlock()
 
-		if err := ev.PreemptPod(ctx, c, pod, c.Victims().Pods[len(c.Victims().Pods)-1], pluginName); err != nil {
+		err := ev.PreemptPod(ctx, c, pod, victimPods[len(victimPods)-1], pluginName)
+		switch {
+		case apierrors.IsNotFound(err):
+			logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(pod), "node", c.Name(), "err", err)
+		case err != nil:
 			utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption")
 			result = metrics.GoroutineResultError
+		default:
+			allPodsAlreadyDeleted = false
 		}
 
 		logger.V(2).Info("Async Preemption finished completely", "preemptor", klog.KObj(pod), "node", c.Name(), "result", result)

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -30,6 +30,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -416,6 +418,11 @@ func TestPrepareCandidate(t *testing.T) {
 			Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 			Obj()
 
+		notFoundVictim1 = st.MakePod().Name("not-found-victim").UID("victim1").
+				Node(node1Name).SchedulerName(defaultSchedulerName).Priority(midPriority).
+				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+				Obj()
+
 		failVictim = st.MakePod().Name("fail-victim").UID("victim1").
 				Node(node1Name).SchedulerName(defaultSchedulerName).Priority(midPriority).
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
@@ -443,6 +450,12 @@ func TestPrepareCandidate(t *testing.T) {
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 				Obj()
 	)
+
+	victimWithDeletionTimestamp := victim1.DeepCopy()
+	victimWithDeletionTimestamp.Name = "victim1-with-deletion-timestamp"
+	victimWithDeletionTimestamp.UID = "victim1-with-deletion-timestamp"
+	victimWithDeletionTimestamp.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(-100 * time.Second)}
+	victimWithDeletionTimestamp.Finalizers = []string{"test"}
 
 	tests := []struct {
 		name      string
@@ -472,9 +485,8 @@ func TestPrepareCandidate(t *testing.T) {
 			testPods: []*v1.Pod{
 				victim1,
 			},
-			nodeNames:             []string{node1Name},
-			expectedStatus:        nil,
-			expectedPreemptingMap: sets.New(types.UID("preemptor")),
+			nodeNames:      []string{node1Name},
+			expectedStatus: nil,
 		},
 		{
 			name: "one victim without condition",
@@ -494,6 +506,42 @@ func TestPrepareCandidate(t *testing.T) {
 			nodeNames:             []string{node1Name},
 			expectedDeletedPod:    []string{"victim1"},
 			expectedStatus:        nil,
+			expectedPreemptingMap: sets.New(types.UID("preemptor")),
+		},
+		{
+			name: "one victim, but victim is already being deleted",
+
+			candidate: &fakeCandidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						victimWithDeletionTimestamp,
+					},
+				},
+			},
+			preemptor: preemptor,
+			testPods: []*v1.Pod{
+				victimWithDeletionTimestamp,
+			},
+			nodeNames:      []string{node1Name},
+			expectedStatus: nil,
+		},
+		{
+			name: "one victim, but victim is already deleted",
+
+			candidate: &fakeCandidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						notFoundVictim1,
+					},
+				},
+			},
+			preemptor:             preemptor,
+			testPods:              []*v1.Pod{},
+			nodeNames:             []string{node1Name},
+			expectedStatus:        nil,
+			expectedActivatedPods: map[string]*v1.Pod{preemptor.Name: preemptor},
 			expectedPreemptingMap: sets.New(types.UID("preemptor")),
 		},
 		{
@@ -655,6 +703,11 @@ func TestPrepareCandidate(t *testing.T) {
 						deletionFailure = true
 						return true, nil, fmt.Errorf("delete pod failed")
 					}
+					// fake clientset does not return an error for not-found pods, so we simulate it here.
+					if name == "not-found-victim" {
+						// Simulate a not-found error.
+						return true, nil, apierrors.NewNotFound(v1.Resource("pods"), name)
+					}
 
 					deletedPods.Insert(name)
 					return true, nil, nil
@@ -666,6 +719,10 @@ func TestPrepareCandidate(t *testing.T) {
 					if action.(clienttesting.PatchAction).GetName() == "fail-victim" {
 						patchFailure = true
 						return true, nil, fmt.Errorf("patch pod status failed")
+					}
+					// fake clientset does not return an error for not-found pods, so we simulate it here.
+					if action.(clienttesting.PatchAction).GetName() == "not-found-victim" {
+						return true, nil, apierrors.NewNotFound(v1.Resource("pods"), "not-found-victim")
 					}
 					return true, nil, nil
 				})
@@ -797,7 +854,8 @@ func TestPrepareCandidate(t *testing.T) {
 
 					return true, nil
 				}); err != nil {
-					t.Fatal(lastErrMsg)
+					t.Error(lastErrMsg)
+					t.Error(err)
 				}
 			})
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- skip victim pods with `deletionTimestamp != nil` before making deletion API calls.
  - It enhances the performance by reducing the number of API calls. 
  - Also, it reduces the chance of a corner case bug to happen: e.g., The pod preempts victim-a, but victim-a is already deleted a moment ago, during the preemptor pod's scheduling cycle. The pod should be requeued immediately (via inFlightEvents) by Pod/Delete, but the preemption plugin might block this requeueing because it can notice victim-a is already deleted after the API returns not-found error. 
- activate the preemptor pod if all pods are already deleted.
  - This is for the same corner case scenario above. Even if we checked `deletionTimestamp != nil` before making deletion API calls, the bad scenario could happen, depending on the timing, if you're super unlucky. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that the async preemption feature keeps preemptor pods unnecessarily in the queue.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
