### PR TITLE
e2e: podresources: disable memory manager integration

### DIFF
--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -952,25 +952,9 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	var reservedSystemCPUs cpuset.CPUSet
-	var memoryQuantity resource.Quantity
-	var defaultKubeParams *memoryManagerKubeletParams
 
 	ginkgo.BeforeEach(func() {
 		reservedSystemCPUs = cpuset.New(1)
-		memoryQuantity = resource.MustParse("1100Mi")
-		defaultKubeParams = &memoryManagerKubeletParams{
-			systemReservedMemory: []kubeletconfig.MemoryReservation{
-				{
-					NumaNode: 0,
-					Limits: v1.ResourceList{
-						resourceMemory: memoryQuantity,
-					},
-				},
-			},
-			systemReserved: map[string]string{resourceMemory: "500Mi"},
-			kubeReserved:   map[string]string{resourceMemory: "500Mi"},
-			evictionHard:   map[string]string{evictionHardMemory: "100Mi"},
-		}
 	})
 
 	ginkgo.Context("with SRIOV devices in the system", func() {
@@ -1253,9 +1237,6 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 		ginkgo.When("listing with restricted list output enabled", func() {
 
 			tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-				kubeParams := *defaultKubeParams
-				kubeParams.policy = staticPolicy
-				updateKubeletConfigWithMemoryManagerParams(initialConfig, &kubeParams)
 				initialConfig.CPUManagerPolicy = string(cpumanager.PolicyStatic)
 				initialConfig.CPUManagerReconcilePeriod = metav1.Duration{Duration: 10 * time.Minute} // set it long enough it is practically disabled
 				cpus := reservedSystemCPUs.String()
@@ -1536,9 +1517,6 @@ var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodReso
 		ginkgo.When("listing with restricted list output disabled for backward compatible defaults", func() {
 
 			tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-				kubeParams := *defaultKubeParams
-				kubeParams.policy = staticPolicy
-				updateKubeletConfigWithMemoryManagerParams(initialConfig, &kubeParams)
 				initialConfig.CPUManagerPolicy = string(cpumanager.PolicyStatic)
 				initialConfig.CPUManagerReconcilePeriod = metav1.Duration{Duration: 10 * time.Minute} // set it long enough it is practically disabled
 				cpus := reservedSystemCPUs.String()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:


#### Which issue(s) this PR is related to:

Fixes #133090

#### Special notes for your reviewer:
As part of the PR #132028 we added more e2e test coverage to validate the fix, and check as much as possible there are no regressions.
The issue and the fix become evident largely when inspecting memory allocation with the Memory Manager static policy enabled. (see: bc56d0e45a24b24ca9727911a891275b81bae69b)
Hence, it was (and still is) important to exercise it during the test.
Turns out the test is however wrong, likely because a hidden dependency between the test expectations and the lane configuration (notably machine specs), so we disable the memory manager activation for the time being, until we figure out a safe way to enable it.

Note this significantly weakens the signal for this specific test.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
