### PR TITLE
Use kubelet root dir for device manager socket

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -304,7 +304,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 
 	klog.InfoS("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(machineInfo.Topology, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(machineInfo.Topology, cm.topologyManager, nodeConfig.KubeletRootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -184,7 +184,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 
 	klog.InfoS("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(nil, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(nil, cm.topologyManager, nodeConfig.KubeletRootDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Device manager socket dir uses /var/lib/kubelet/ for linux and
\\var\\lib\\kubelet\\ always even if kubelet root dir is defined to
a different path. This commit tries to fix this.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

If we start kubelet with --root-dir different to /var/lib/kubelet , device manager socket is under 
/var/lib/kubelet the unix socket instead of define root-dir. This commit tries to fix this by storing
socket under the defined root-dir

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
