### PR TITLE
Make PSA host enforcement honor emulation version

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -713,6 +713,12 @@ const (
 	// Denies pod admission if static pods reference other API objects.
 	PreventStaticPodAPIReferences featuregate.Feature = "PreventStaticPodAPIReferences"
 
+	// owner: @tssurya
+	// kep: https://kep.k8s.io/4559
+	//
+	// Enables probe host enforcement for Pod Security Standards.
+	ProbeHostPodSecurityStandards featuregate.Feature = "ProbeHostPodSecurityStandards"
+
 	// owner: @jessfraz
 	//
 	// Enables control over ProcMountType for containers.
@@ -1529,6 +1535,11 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	PreventStaticPodAPIReferences: {
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	// Policy is GA in first release, this gate only exists to disable the enforcement when emulating older minors
+	ProbeHostPodSecurityStandards: {
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
 	ProcMountType: {

--- a/plugin/pkg/admission/security/podsecurity/admission.go
+++ b/plugin/pkg/admission/security/podsecurity/admission.go
@@ -153,6 +153,10 @@ func (p *Plugin) updateDelegate() {
 func (c *Plugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
 	c.inspectedFeatureGates = true
 	policy.RelaxPolicyForUserNamespacePods(featureGates.Enabled(features.UserNamespacesPodSecurityStandards))
+
+	if !featureGates.Enabled(features.ProbeHostPodSecurityStandards) {
+		policy.SkipProbeHostEnforcement()
+	}
 }
 
 // ValidateInitialization ensures all required options are set

--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostProbesAndhostLifecycle.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostProbesAndhostLifecycle.go
@@ -18,6 +18,7 @@ package policy
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,7 +74,21 @@ func CheckHostProbesAndHostLifecycle() Check {
 	}
 }
 
+// TODO(liggitt): rework this to make emulation version influence "latest" across all checks, instead of piece-mill feature gate checking.
+var skipProbeHostEnforcement = &atomic.Bool{}
+
+// SkipProbeHostEnforcement allows opting out of probe host enforcement in baseline policies.
+// This should only be done in clusters emulating minor versions prior to introduction of this check.
+func SkipProbeHostEnforcement() {
+	skipProbeHostEnforcement.Store(true)
+}
+
 func hostProbesAndHostLifecycleV1Dot34(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	// cluster is emulating a minor prior to this check existing
+	if skipProbeHostEnforcement.Load() {
+		return CheckResult{Allowed: true}
+	}
+
 	badContainers := sets.New[string]()
 	forbidden := sets.New[string]()
 	visitContainers(podSpec, func(container *corev1.Container) {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1205,6 +1205,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.34"
+- name: ProbeHostPodSecurityStandards
+  versionedSpecs:
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.34"
 - name: ProcMountType
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/kind feature

#### What this PR does / why we need it:

Follow up to https://github.com/kubernetes/kubernetes/pull/125271 to make the new PSA check honor emulation version by skipping the new check added in 1.34 when emulating a prior minor.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @deads2k  @tssurya
/sig auth
