### PR TITLE
chore: replace ptr caster with unified ptr.To

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/ratcheting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/ratcheting_test.go
@@ -24,35 +24,36 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	"k8s.io/utils/ptr"
 )
 
 var zeroIntSchema *spec.Schema = &spec.Schema{
 	SchemaProps: spec.SchemaProps{
 		Type:    spec.StringOrArray{"number"},
-		Minimum: ptr(float64(0)),
-		Maximum: ptr(float64(0)),
+		Minimum: ptr.To[float64](0),
+		Maximum: ptr.To[float64](0),
 	},
 }
 
 var smallIntSchema *spec.Schema = &spec.Schema{
 	SchemaProps: spec.SchemaProps{
 		Type:    spec.StringOrArray{"number"},
-		Maximum: ptr(float64(50)),
+		Maximum: ptr.To[float64](50),
 	},
 }
 
 var mediumIntSchema *spec.Schema = &spec.Schema{
 	SchemaProps: spec.SchemaProps{
 		Type:    spec.StringOrArray{"number"},
-		Minimum: ptr(float64(50)),
-		Maximum: ptr(float64(10000)),
+		Minimum: ptr.To[float64](50),
+		Maximum: ptr.To[float64](10000),
 	},
 }
 
 var largeIntSchema *spec.Schema = &spec.Schema{
 	SchemaProps: spec.SchemaProps{
 		Type:    spec.StringOrArray{"number"},
-		Minimum: ptr(float64(10000)),
+		Minimum: ptr.To[float64](10000),
 	},
 }
 
@@ -129,8 +130,4 @@ func TestObjectObjectFieldsRatcheting(t *testing.T) {
 		"nested": map[string]interface{}{
 			"small": 501,
 		}}, validation.WithRatcheting(nil)).IsValid())
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
@@ -55,6 +55,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	"k8s.io/utils/ptr"
 )
 
 var stringSchema *apiextensionsv1.JSONSchemaProps = &apiextensionsv1.JSONSchemaProps{
@@ -1115,7 +1116,7 @@ func TestRatchetingFunctionality(t *testing.T) {
 					Properties: map[string]apiextensionsv1.JSONSchemaProps{
 						"field": {
 							Type:         "array",
-							XListType:    ptr("map"),
+							XListType:    ptr.To("map"),
 							XListMapKeys: []string{"name", "port"},
 							Items: &apiextensionsv1.JSONSchemaPropsOrArray{
 								Schema: &apiextensionsv1.JSONSchemaProps{
@@ -1395,7 +1396,7 @@ func TestRatchetingFunctionality(t *testing.T) {
 								{
 									Rule:            "!oldSelf.hasValue()",
 									Message:         "oldSelf must be null",
-									OptionalOldSelf: ptr(true),
+									OptionalOldSelf: ptr.To(true),
 								},
 							},
 						},
@@ -1445,7 +1446,7 @@ func TestRatchetingFunctionality(t *testing.T) {
 			Operations: []ratchetingTestOperation{
 				updateMyCRDV1Beta1Schema{&apiextensionsv1.JSONSchemaProps{
 					Type:                   "object",
-					XPreserveUnknownFields: ptr(true),
+					XPreserveUnknownFields: ptr.To(true),
 				}},
 				applyPatchOperation{
 					"create instance with strings that do not start with k8s",
@@ -1457,7 +1458,7 @@ func TestRatchetingFunctionality(t *testing.T) {
 				},
 				updateMyCRDV1Beta1Schema{&apiextensionsv1.JSONSchemaProps{
 					Type:                   "object",
-					XPreserveUnknownFields: ptr(true),
+					XPreserveUnknownFields: ptr.To(true),
 					Properties: map[string]apiextensionsv1.JSONSchemaProps{
 						"myStringField": {
 							Type: "string",
@@ -1759,10 +1760,6 @@ func TestRatchetingFunctionality(t *testing.T) {
 	runTests(t, cases)
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 type validator func(new, old *unstructured.Unstructured)
 
 func newValidator(customResourceValidation *apiextensionsinternal.JSONSchemaProps, kind schema.GroupVersionKind, namespaceScoped bool) (validator, error) {
@@ -2031,7 +2028,7 @@ func TestRatchetingDropFields(t *testing.T) {
 											{
 												// Results in error if field wasn't dropped
 												Rule:            "self == oldSelf",
-												OptionalOldSelf: ptr(true),
+												OptionalOldSelf: ptr.To(true),
 											},
 										},
 									},
@@ -2064,7 +2061,7 @@ func TestRatchetingDropFields(t *testing.T) {
 		if err != nil {
 			return false, err
 		}
-		existing.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["field"].XValidations[0].OptionalOldSelf = ptr(true)
+		existing.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["field"].XValidations[0].OptionalOldSelf = ptr.To(true)
 		updated, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), existing, metav1.UpdateOptions{})
 		if err != nil {
 			if apierrors.IsConflict(err) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/priority backlog

#### What this PR does / why we need it:

Remove deprecated utility usage

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/132749

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE