### PR TITLE
Do not remove PVC ClaimRef to fix flaky VAC test

### DIFF
--- a/test/e2e/storage/testsuites/volume_modify.go
+++ b/test/e2e/storage/testsuites/volume_modify.go
@@ -328,7 +328,7 @@ func (v *volumeModifyTestSuite) DefineTests(driver storageframework.TestDriver, 
 		originPv := pv.DeepCopy()
 		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
 		_, err = f.ClientSet.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
-		ginkgo.DeferCleanup(recoverPvReclaimPolicyAndRemoveClaimRef, f.ClientSet, originPv)
+		ginkgo.DeferCleanup(recoverPvReclaimPolicy, f.ClientSet, originPv)
 		framework.ExpectNoError(err, "Failed to update PV %q reclaim policy", pvName)
 
 		// The vac_protection_controller make sure there is a VolumeAttributesClass that is not used by any PVC/PV
@@ -369,7 +369,7 @@ func (v *volumeModifyTestSuite) DefineTests(driver storageframework.TestDriver, 
 
 		ginkgo.By(fmt.Sprintf("Deleting PV %q to make the vac unused for the PV", newVAC.Name))
 		pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimDelete
-		recoverPvReclaimPolicyAndRemoveClaimRef(ctx, f.ClientSet, pv)
+		recoverPvReclaimPolicy(ctx, f.ClientSet, pv)
 
 		ginkgo.By(fmt.Sprintf("Waiting for PV %q to be deleted", pvName))
 		gomega.Eventually(func() bool {
@@ -432,8 +432,8 @@ func CleanupVAC(ctx context.Context, vac *storagev1beta1.VolumeAttributesClass, 
 	}, timeout, modifyPollInterval).Should(gomega.BeNil())
 }
 
-// recoverPvReclaimPolicyAndRemoveClaimRef recovers the test pv's reclaim policy to expected used for clean up test PV
-func recoverPvReclaimPolicyAndRemoveClaimRef(ctx context.Context, c clientset.Interface, expectedPv *v1.PersistentVolume) {
+// recoverPvReclaimPolicy recovers the test pv's reclaim policy to expected used for clean up test PV
+func recoverPvReclaimPolicy(ctx context.Context, c clientset.Interface, expectedPv *v1.PersistentVolume) {
 	setPvReclaimPolicyErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, expectedPv.Name, metav1.GetOptions{})
 		if err != nil {
@@ -443,11 +443,10 @@ func recoverPvReclaimPolicyAndRemoveClaimRef(ctx context.Context, c clientset.In
 			}
 			return err
 		}
-		if pv.Spec.PersistentVolumeReclaimPolicy == expectedPv.Spec.PersistentVolumeReclaimPolicy && pv.Spec.ClaimRef == nil {
+		if pv.Spec.PersistentVolumeReclaimPolicy == expectedPv.Spec.PersistentVolumeReclaimPolicy {
 			framework.Logf("PV %q reclaim policy is already recovered to %q", expectedPv.Name, expectedPv.Spec.PersistentVolumeReclaimPolicy)
 			return nil
 		}
-		pv.Spec.ClaimRef = nil
 		pv.Spec.PersistentVolumeReclaimPolicy = expectedPv.Spec.PersistentVolumeReclaimPolicy
 		_, err = c.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind flake

#### What this PR does / why we need it:

We are seeing significant flakes for the test "should be protected by vac-protection finalizer" on the EBS CSI repo (we run this test as part of the External Storage tests): https://testgrid.k8s.io/amazon-ec2-presubmits#test-e2e-external-eks-windows&show-stale-tests=&include-filter-by-regex=should%20be%20protected%20by%20vac-protection%20finalizer&width=20

(We've temporarily disabled this test, so it won't show any results on recent PR runs)

This happens to us because of the following race:
1. In the test, the PVC is deleted while the PV has reclaim policy `Reclaim` - this results in a PV in the `Released` state and a ClaimRef pointing to the deleted PVC that is kept around because of the `Retain` policy
2. Simultaneously in the same update, the PV is updated to `Delete` reclaim policy and an unset (nil) ClaimRef: https://github.com/kubernetes/kubernetes/blob/f9fde2dfbdfb73c25e0a17d675313748948cd78c/test/e2e/storage/testsuites/volume_modify.go#L372 - this triggers two simultaneous actions:
    1. The `external-provisioner` notices a volume that is in the `Released` state and with a `Delete` policy - it initiates a delete. For the flake to occur, this delete must not succeed - in our case it's often skipped because a `VolumeAttachment` still exists for the volume as it is still being unmounted and detached from the node
    2. The KCM notices a volume with an unset ClaimRef and moves it from the `Released` state to the `Available` state
3. Later, after the backoff duration, the `external-provisioner` retries - however, it will not delete the volume at this point, because it now sees that it's in an `Available` state: https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/e0ae7abb83cf44e81b6232afedd27b29c128c8b5/controller/controller.go#L1323

As far as I can tell, setting the ClaimRef to `nil` is not necessary for the test, and actually causes this race condition. Thus in this PR I have made the cleanup function only change the reclaim policy, and not set the `ClaimRef` to `nil`. This prevents the KCM from transitioning the PV to an `Available` state and preventing its deletion.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
