### PR TITLE
kube-proxy: list available endpoints in /statusz

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -486,7 +486,11 @@ func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyco
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
-		statusz.Install(proxyMux, kubeProxy, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion()))
+		reg := statusz.NewRegistry(
+			compatibility.DefaultBuildEffectiveVersion(),
+			statusz.WithListedPaths(proxyMux.ListedPaths()),
+		)
+		statusz.Install(proxyMux, kubeProxy, reg)
 	}
 
 	fn := func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a list of available HTTP endpoints for the kube-proxy component under the /statusz page. It enhances the visibility of active health/metrics/debug endpoints for instrumentation and operational introspection.
It follows the pattern introduced for other control plane components like kube-apiserver, kube-scheduler, and kube-controller-manager.
#### Which issue(s) this PR is related to:
Fixes: [#133185](https://github.com/kubernetes/kubernetes/issues/133185)
Part of umbrella issue: [#132474](https://github.com/kubernetes/kubernetes/issues/132474)
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Tested the changes in a local kind cluster:

First, built and ran the kube-proxy binary locally to confirm it worked.

Then edited the kube-proxy config in the cluster:

kubectl -n kube-system edit configmap kube-proxy 

and under featureGates: added:

featureGates:
  ComponentStatusz: true
After restarting kube-proxy with the updated config, I port-forwarded and curled the /statusz endpoint:

```
 % curl http://localhost:10249/statusz

kube-proxy statusz
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

Started: Fri Aug 22 12:55:43 UTC 2025
Up: 0 hr 00 min 45 sec
Go version: go1.24.6
Binary version: 1.35.0-alpha.0.51+429226753afc05
Emulation version: 1.35
Paths:  /configz /healthz /metrics /proxyMode
```

Got the expected response with kube-proxy status info, which confirms the feature gate works as intended.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `/statusz` page for `kube-proxy` now includes a list of exposed endpoints, making it easier to debug and introspect.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
