### PR TITLE
Deflake test stream translator web socket server errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
@@ -771,8 +771,8 @@ apiserver_stream_translator_requests_total{code="400"} 1
 // redirects; it will thrown an error instead.
 func TestStreamTranslator_BlockRedirects(t *testing.T) {
 	metrics.Register()
-	metrics.ResetForTest()
 	t.Cleanup(metrics.ResetForTest)
+
 	for _, statusCode := range []int{
 		http.StatusMovedPermanently,  // 301
 		http.StatusFound,             // 302
@@ -780,65 +780,67 @@ func TestStreamTranslator_BlockRedirects(t *testing.T) {
 		http.StatusTemporaryRedirect, // 307
 		http.StatusPermanentRedirect, // 308
 	} {
-		// Create upstream fake SPDY server which returns a redirect.
-		spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			w.Header().Set("Location", "/")
-			w.WriteHeader(statusCode)
-		}))
-		defer spdyServer.Close()
-		spdyLocation, err := url.Parse(spdyServer.URL)
-		if err != nil {
-			t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
-		}
-		spdyTransport, err := fakeTransport()
-		if err != nil {
-			t.Fatalf("Unexpected error creating transport: %v", err)
-		}
-		streams := Options{Stdout: true}
-		streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
-		streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			streamTranslator.ServeHTTP(w, req)
-		}))
-		defer streamTranslatorServer.Close()
-		// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
-		streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
-		if err != nil {
-			t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
-		}
-		exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
-		if err != nil {
-			t.Errorf("unexpected error creating websocket executor: %v", err)
-		}
-		errorChan := make(chan error)
-		go func() {
-			// Start the streaming on the WebSocket "exec" client.
-			// Should return "redirect not allowed" error.
-			errorChan <- exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{})
-		}()
+		t.Run(fmt.Sprintf("statusCode=%d", statusCode), func(t *testing.T) {
+			metrics.ResetForTest()
+			// Create upstream fake SPDY server which returns a redirect.
+			spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Location", "/")
+				w.WriteHeader(statusCode)
+			}))
+			defer spdyServer.Close()
+			spdyLocation, err := url.Parse(spdyServer.URL)
+			if err != nil {
+				t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+			}
+			spdyTransport, err := fakeTransport()
+			if err != nil {
+				t.Fatalf("Unexpected error creating transport: %v", err)
+			}
+			streams := Options{Stdout: true}
+			streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
+			streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				streamTranslator.ServeHTTP(w, req)
+			}))
+			defer streamTranslatorServer.Close()
+			// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+			streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+			if err != nil {
+				t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+			}
+			exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+			if err != nil {
+				t.Errorf("unexpected error creating websocket executor: %v", err)
+			}
+			errorChan := make(chan error)
+			go func() {
+				// Start the streaming on the WebSocket "exec" client.
+				// Should return "redirect not allowed" error.
+				errorChan <- exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{})
+			}()
 
-		select {
-		case <-time.After(wait.ForeverTestTimeout):
-			t.Fatalf("expect stream to be closed after connection is closed.")
-		case err := <-errorChan:
-			// Must return "redirect now allowed" error.
-			if err == nil {
-				t.Fatalf("expected error, but received none")
+			select {
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Fatalf("expect stream to be closed after connection is closed.")
+			case err := <-errorChan:
+				// Must return "redirect now allowed" error.
+				if err == nil {
+					t.Fatalf("expected error, but received none")
+				}
+				if !strings.Contains(err.Error(), "redirect not allowed") {
+					t.Errorf("expected redirect not allowed error, got (%s)", err)
+				}
 			}
-			if !strings.Contains(err.Error(), "redirect not allowed") {
-				t.Errorf("expected redirect not allowed error, got (%s)", err)
-			}
-		}
-		// Validate the streamtranslator metrics; should have one 500 failure each loop.
-		metricNames := []string{"apiserver_stream_translator_requests_total"}
-		expected := `
+			// Validate the streamtranslator metrics; should have one 500 failure each loop.
+			metricNames := []string{"apiserver_stream_translator_requests_total"}
+			expected := `
 # HELP apiserver_stream_translator_requests_total [ALPHA] Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5
 # TYPE apiserver_stream_translator_requests_total counter
 apiserver_stream_translator_requests_total{code="500"} 1
 `
-		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
-			t.Fatal(err)
-		}
-		metrics.ResetForTest() // Clear metrics each loop
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION

/kind flake

```release-note
NONE
```

Fixes: #132506

First commit use subtests for better debugging

```
stress ./proxy.test -test.run TestStreamTranslator_BlockRedirects
5s: 1878 runs so far, 0 failures
10s: 3509 runs so far, 0 failures
15s: 4545 runs so far, 0 failures
20s: 5442 runs so far, 0 failures
25s: 6279 runs so far, 0 failures
```

Second commit checks asynchronous to avoid the race until the metric is updated


```
 stress ./proxy.test -test.run TestStreamTranslator_WebSocketServerErrors
tress ./proxy.test -test.run TestStreamTranslator_WebSocketServerErrors
5s: 5013 runs so far, 0 failures
10s: 9818 runs so far, 0 failures
15s: 14559 runs so far, 0 failures
20s: 19167 runs so far, 0 failures
25s: 23483 runs so far, 0 failures
30s: 27529 runs so far, 0 failures
35s: 30932 runs so far, 0 failures
40s: 34357 runs so far, 0 failures
45s: 37631 runs so far, 0 failures
50s: 40886 runs so far, 0 failures
55s: 43955 runs so far, 0 failures
1m0s: 46955 runs so far, 0 failures
1m5s: 50931 runs so far, 0 failures
1m10s: 55298 runs so far, 0 failures
```

/assign @liggitt 