### PR TITLE
Fix non-existent PCI device hierarchy examples/testcases in "deviceattribute" package in " k8s.io/dynamic-resource-allocation" module

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
@@ -68,12 +68,12 @@ func GetPCIeRootAttributeByPCIBusID(pciBusID string) (DeviceAttribute, error) {
 // But, fortunately, /sys/bus/pci/devices/<address> is a symlink to the actual device path in /sys/devices.
 // So we can resolve the actual device path by reading the symlink at /sys/bus/pci/devices/<address>.
 //
-// For example, if the PCIAddress is "0000:00:1f.0",
-// /sys/bus/pci/devices/0000:00:1f.0 points to
-// /sys/devices/pci0000:01/...<intermediate PCI devices>.../0000:00:1f.0,
-// where "pci0000:01" is the PCIe Root.
+// For example, if the PCIAddress is "0000:04:1f.0",
+// /sys/bus/pci/devices/0000:04:1f.0 points to
+// /sys/devices/pci0000:00/...<intermediate PCI devices>.../0000:04:1f.0,
+// where "pci0000:00" is the PCIe Root.
 func resolvePCIeRoot(pciBusID string) (string, error) {
-	// e.g. /sys/bus/pci/devices/0000:00:1f.0
+	// e.g. /sys/bus/pci/devices/0000:04:1f.0
 	sysBusPath := sysfs.bus(filepath.Join("pci", "devices", pciBusID))
 
 	target, err := os.Readlink(sysBusPath)
@@ -86,7 +86,7 @@ func resolvePCIeRoot(pciBusID string) (string, error) {
 		target = filepath.Join(filepath.Dir(sysBusPath), target)
 	}
 
-	// targetAbs must be /sys/devices/pci0000:01/...<intermediate PCI devices>.../0000:00:1f.0
+	// targetAbs must be /sys/devices/pci0000:00/...<intermediate PCI devices>.../0000:04:1f.0
 	devicePathPrefix := sysfs.devices("pci")
 	if !strings.HasPrefix(target, devicePathPrefix) {
 		return "", fmt.Errorf("symlink target for PCI Bus ID %s is invalid: it must start with %s: %s", pciBusID, devicePathPrefix, target)

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
@@ -29,7 +29,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 )
 
-func TestGetPCIeRootBAttributeyPCIBusID(t *testing.T) {
+func TestGetPCIeRootAttributePCIBusID(t *testing.T) {
 	pciBusID := "0000:01:02.3"
 	pcieRoot := "pci0000:01"
 	expectedAttribute := DeviceAttribute{

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
@@ -30,8 +30,9 @@ import (
 )
 
 func TestGetPCIeRootAttributePCIBusID(t *testing.T) {
-	pciBusID := "0000:01:02.3"
-	pcieRoot := "pci0000:01"
+	pcieRoot := "pci0000:00"
+	intermediateBusID := "0000:01:00.0"
+	pciBusID := "0000:02:00.0"
 	expectedAttribute := DeviceAttribute{
 		Name:  StandardDeviceAttributePCIeRoot,
 		Value: resourceapi.DeviceAttribute{StringValue: ptr.To(pcieRoot)},
@@ -46,7 +47,7 @@ func TestGetPCIeRootAttributePCIBusID(t *testing.T) {
 	}{
 		"valid": {
 			mockSysfsSetup: func(t *testing.T, mockSysfs sysfsPath) {
-				devicePath := mockSysfs.devices(filepath.Join(pcieRoot, "0000:00:13.1", pciBusID))
+				devicePath := mockSysfs.devices(filepath.Join(pcieRoot, intermediateBusID, pciBusID))
 				touchFile(t, devicePath)
 				busPath := mockSysfs.bus(filepath.Join("pci", "devices", pciBusID))
 				createSymlink(t, devicePath, busPath)
@@ -75,7 +76,7 @@ func TestGetPCIeRootAttributePCIBusID(t *testing.T) {
 		},
 		"invalid symlink (invalid prefix)": {
 			mockSysfsSetup: func(t *testing.T, mockSysfs sysfsPath) {
-				devicePath := mockSysfs.devices(filepath.Join("invalid-pci-root", "0000:00:13.1", pciBusID))
+				devicePath := mockSysfs.devices(filepath.Join("invalid-pci-root", intermediateBusID, pciBusID))
 				touchFile(t, devicePath)
 				busPath := mockSysfs.bus(filepath.Join("pci", "devices", pciBusID))
 				createSymlink(t, devicePath, busPath)
@@ -87,7 +88,7 @@ func TestGetPCIeRootAttributePCIBusID(t *testing.T) {
 		},
 		"invalid symlink (invalid suffix)": {
 			mockSysfsSetup: func(t *testing.T, mockSysfs sysfsPath) {
-				devicePath := mockSysfs.devices(filepath.Join(pcieRoot, "0000:00:13.1", "0000:01:02.4")) // different PCI Bus ID
+				devicePath := mockSysfs.devices(filepath.Join(pcieRoot, intermediateBusID, "0000:00:13.1")) // different PCI Bus ID
 				touchFile(t, devicePath)
 				busPath := mockSysfs.bus(filepath.Join("pci", "devices", pciBusID))
 				createSymlink(t, devicePath, busPath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR aims to replace non-existent PCI device hierarchy examples/testcases with existing/realistic ones.

#### Which issue(s) this PR is related to:

Suggested by @bg-chun in the below threads:
https://github.com/kubernetes/kubernetes/pull/132296#discussion_r2229434657
https://github.com/kubernetes/kubernetes/pull/132296#discussion_r2229441037

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

I think this is NOT an urgent one. There is no problem if it can't hit the code freeze.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters
```
