### PR TITLE
feat: list available endpoints in /statusz for kubelet

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -160,6 +160,7 @@ func (a *filteringContainer) Handle(path string, handler http.Handler) {
 	a.HandleWithFilter(path, handler)
 	a.registeredHandlePaths = append(a.registeredHandlePaths, path)
 }
+
 func (a *filteringContainer) RegisteredHandlePaths() []string {
 	return a.registeredHandlePaths
 }
@@ -576,7 +577,7 @@ func (s *Server) InstallAuthRequiredHandlers() {
 
 	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
 		s.addMetricsBucketMatcher("statusz")
-		statusz.Install(s.restfulCont, ComponentKubelet, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion()))
+		statusz.Install(s.restfulCont, ComponentKubelet, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion(), statusz.WithListedPaths(s.restfulCont.RegisteredHandlePaths())))
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentFlagz) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Previously api-machinery members removed the hard-coded paths (/healthz, /livez, /readyz) in staging package. Should restore the 'Useful links' used by kubelet.

#### Which issue(s) this PR is related to:

Umbrella issue: https://github.com/kubernetes/kubernetes/issues/132474
Fixes: https://github.com/kubernetes/kubernetes/issues/133184

#### Special notes for your reviewer:

Tested locally with a custom build of kube-proxy confirming that /statusz correctly shows the listed endpoints.

```log
root@kind-control-plane:/# curl -k https://127.0.0.1:10250/statusz

kubelet statusz
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

Started: Tue Aug  5 14:20:13 UTC 2025
Up: 0 hr 00 min 54 sec
Go version: go1.24.5
Binary version: 1.34.0-beta.0.536+416a7e7e3fe083-dirty
Emulation version: 1.34
Paths:  /configz /healthz /metrics
```

#### Does this PR introduce a user-facing change?

```release-note
The `/statusz` handle for kubelet now includes a list of exposed endpoints, making it easier to debug and introspect.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
