### PR TITLE
kube-controller-manager: list available endpoints in /statusz

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -225,7 +225,14 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
-			statusz.Install(unsecuredMux, kubeControllerManager, statusz.NewRegistry(c.ComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent)))
+			statusz.Install(unsecuredMux, kubeControllerManager, statusz.NewRegistry(c.ComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent),
+				statusz.WithListedPaths([]string{
+					"/livez",
+					"/readyz",
+					"/healthz",
+					"/metrics",
+				}),
+			))
 		}
 
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds a list of available HTTP endpoints for the kube-controller-manager component under the /statusz page. It enhances the visibility of active health/metrics/debug endpoints for instrumentation and operational introspection.

#### Which issue(s) this PR is related to:

Fixes #133182
Part of umbrella issue: #132474

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The `/statusz` page for `kube-controller-manager` now includes a list of exposed endpoints, making it easier to debug and introspect.
```
