### PR TITLE
Fix gocritic issues - test/e2e_node

### DIFF
--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -93,7 +93,7 @@ const (
 )
 
 func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
-	pluginSockDir = filepath.Join(pluginSockDir) + "/"
+	pluginSockDir = filepath.Clean(pluginSockDir) + "/"
 
 	type ResourceValue struct {
 		Allocatable int

--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -583,7 +583,7 @@ func (g *GCERunner) createGCEInstance(imageConfig *internalGCEImage) (string, er
 		if err != nil {
 			continue
 		}
-		if strings.ToUpper(instance.Status) != "RUNNING" {
+		if !strings.EqualFold(instance.Status, "RUNNING") {
 			_ = fmt.Errorf("instance %s not in state RUNNING, was %s", name, instance.Status)
 			continue
 		}
@@ -669,7 +669,7 @@ func (g *GCERunner) registerGceHostIP(host string) error {
 	if err != nil {
 		return err
 	}
-	if strings.ToUpper(instance.Status) != "RUNNING" {
+	if !strings.EqualFold(instance.Status, "RUNNING") {
 		return fmt.Errorf("instance %s not in state RUNNING, was %s", host, instance.Status)
 	}
 	externalIP := g.getExternalIP(instance)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix gocritic errors. Standardize and improve case-insensitive string comparisons.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Part of https://github.com/kubernetes/kubernetes/issues/131475

#### Special notes for your reviewer:

`filepath.Join(pluginSockDir) + "/"` was introduced in #71739 to ensure compatibility with paths both with and without a trailing slash. This worked because `filepath.Join` implicitly calls `filepath.Clean`.

Calling `filepath.Clean` directly is more appropriate here and resolve the gocritic error.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
