### PR TITLE
Add context-based warning suppression to SetEmulationVersion 

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package featuregate
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -1331,14 +1330,14 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 		if !f.Enabled("TestFeature2") {
 			t.Error("expected TestFeature2 to have effective default of true")
 		}
-		require.NoError(t, f.SetEmulationVersionWithContext(WithTestLoggerContext(context.Background(), t), version.MustParse("1.29")))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.29")))
 		if !f.Enabled("TestFeature1") {
 			t.Error("expected TestFeature1 to have effective default of true")
 		}
 		if f.Enabled("TestFeature2") {
 			t.Error("expected TestFeature2 to have effective default of false")
 		}
-		require.NoError(t, f.SetEmulationVersionWithContext(WithTestLoggerContext(context.Background(), t), version.MustParse("1.26")))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.26")))
 		if f.Enabled("TestFeature1") {
 			t.Error("expected TestFeature1 to have effective default of false")
 		}
@@ -1384,11 +1383,11 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 		assert.True(t, f.Enabled("TestFeature"))
 		assert.False(t, fcopy.Enabled("TestFeature"))
 
-		require.NoError(t, f.SetEmulationVersionWithContext(WithTestLoggerContext(context.Background(), t), version.MustParse("1.29")))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.29")))
 		assert.False(t, f.Enabled("TestFeature"))
 		assert.False(t, fcopy.Enabled("TestFeature"))
 
-		require.NoError(t, fcopy.SetEmulationVersionWithContext(WithTestLoggerContext(context.Background(), t), version.MustParse("1.29")))
+		require.NoError(t, fcopy.SetEmulationVersion(version.MustParse("1.29")))
 		assert.False(t, f.Enabled("TestFeature"))
 		assert.True(t, fcopy.Enabled("TestFeature"))
 	})
@@ -1738,7 +1737,7 @@ func TestResetFeatureValueToDefault(t *testing.T) {
 	assert.True(t, f.Enabled("TestAlpha"))
 	assert.True(t, f.Enabled("TestBeta"))
 
-	require.NoError(t, f.SetEmulationVersionWithContext(WithTestLoggerContext(context.Background(), t), version.MustParse("1.28")))
+	require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 	assert.False(t, f.Enabled("AllAlpha"))
 	assert.False(t, f.Enabled("AllBeta"))
 	assert.False(t, f.Enabled("TestAlpha"))
@@ -1902,134 +1901,6 @@ func TestAddVersioned(t *testing.T) {
 
 			if err == nil && test.expectError {
 				t.Errorf("expected errors, no errors found")
-			}
-		})
-	}
-}
-
-// TestSetEmulationVersionWithContext tests various scenarios for SetEmulationVersionWithContext
-func TestSetEmulationVersionWithContext(t *testing.T) {
-	tests := []struct {
-		name            string
-		features        map[Feature]VersionedSpecs
-		queriedFeatures []string
-		targetVersion   *version.Version
-		context         context.Context
-		expectError     bool
-		errorContains   []string
-		expectNoError   bool
-	}{
-		{
-			name: "warning redirection with test logger",
-			features: map[Feature]VersionedSpecs{
-				"TestFeature": {
-					{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
-					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
-				},
-			},
-			queriedFeatures: []string{"TestFeature"},
-			targetVersion:   version.MustParse("1.28"),
-			context:         WithTestLoggerContext(context.Background(), t),
-			expectNoError:   true,
-		},
-		{
-			name: "error on feature change without test logger",
-			features: map[Feature]VersionedSpecs{
-				"TestFeature": {
-					{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
-					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
-				},
-			},
-			queriedFeatures: []string{"TestFeature"},
-			targetVersion:   version.MustParse("1.28"),
-			context:         context.Background(),
-			expectError:     true,
-			errorContains:   []string{"SetEmulationVersion would change already queried features"},
-		},
-		{
-			name: "multiple features changing",
-			features: map[Feature]VersionedSpecs{
-				"TestFeature1": {
-					{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
-					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
-				},
-				"TestFeature2": {
-					{Version: version.MustParse("1.28"), Default: true, PreRelease: Alpha},
-					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
-				},
-			},
-			queriedFeatures: []string{"TestFeature1", "TestFeature2"},
-			targetVersion:   version.MustParse("1.28"),
-			context:         context.Background(),
-			expectError:     true,
-			errorContains:   []string{"TestFeature1", "TestFeature2"},
-		},
-		{
-			name: "no change with regular context",
-			features: map[Feature]VersionedSpecs{
-				"TestFeature": {
-					{Version: version.MustParse("1.28"), Default: true, PreRelease: Alpha},
-					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
-				},
-			},
-			queriedFeatures: []string{"TestFeature"},
-			targetVersion:   version.MustParse("1.28"),
-			context:         context.Background(),
-			expectNoError:   true,
-		},
-		{
-			name: "no change with test logger context",
-			features: map[Feature]VersionedSpecs{
-				"TestFeature": {
-					{Version: version.MustParse("1.28"), Default: true, PreRelease: Alpha},
-					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
-				},
-			},
-			queriedFeatures: []string{"TestFeature"},
-			targetVersion:   version.MustParse("1.28"),
-			context:         WithTestLoggerContext(context.Background(), t),
-			expectNoError:   true,
-		},
-		{
-			name: "nil context with feature change",
-			features: map[Feature]VersionedSpecs{
-				"TestFeature": {
-					{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
-					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
-				},
-			},
-			queriedFeatures: []string{"TestFeature"},
-			targetVersion:   version.MustParse("1.28"),
-			context:         nil,
-			expectError:     true,
-			errorContains:   []string{"SetEmulationVersion would change already queried features"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create feature gate
-			f := NewVersionedFeatureGate(version.MustParse("1.29"))
-
-			// Add features
-			err := f.AddVersioned(tt.features)
-			require.NoError(t, err)
-
-			// Query features to mark them as queried
-			for _, featureName := range tt.queriedFeatures {
-				_ = f.Enabled(Feature(featureName))
-			}
-
-			// Test SetEmulationVersionWithContext
-			err = f.SetEmulationVersionWithContext(tt.context, tt.targetVersion)
-
-			if tt.expectError {
-				require.Error(t, err)
-				for _, expectedText := range tt.errorContains {
-					require.Contains(t, err.Error(), expectedText)
-				}
-			} else if tt.expectNoError {
-				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature



#### What this PR does / why we need it:
implement a context logger to optimize the warning logic 
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fix: https://github.com/kubernetes/kubernetes/issues/133056

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
