### PR TITLE
adds a list of available HTTP endpoints for the kube-controller-manag…

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -225,7 +225,14 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
-			statusz.Install(unsecuredMux, kubeControllerManager, statusz.NewRegistry(c.ComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent)))
+			statusz.Install(
+				unsecuredMux,
+				kubeControllerManager,
+				statusz.NewRegistry(
+					c.ComponentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent),
+					statusz.WithListedPaths(unsecuredMux.ListedPaths()),
+				),
+			)
 		}
 
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind cleanup  
/kind documentation

#### What this PR does / why we need it:

This PR enhances the `/statusz` page of the `kube-controller-manager` by including a list of all registered HTTP endpoints exposed by the component.  
This provides better visibility into available health, metrics, and debug endpoints, which is particularly valuable for observability and operational tooling.  
It aligns with the ongoing effort to improve introspection across Kubernetes control plane components.

#### Which issue(s) this PR is related to:

Fixes #133182  
Part of umbrella issue: #132474

#### Special notes for your reviewer:

- This mirrors similar efforts recently merged for `kube-scheduler` and `kube-apiserver`.  
- The endpoint list is sorted and clearly grouped to improve readability.  
- Only non-private handlers are shown to avoid leaking sensitive internals.

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Example Response:

```release-note
kube-controller-manager statusz
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

Started  Thu Jul 31 22:23:19 UTC 2025
Up  0 hr 01 min 00 sec
Go version  go1.24.5
Binary version  1.34.0-beta.0.631+2a3faeb5c9ffbb
Emulation version  1.34
Paths   /configz /healthz /metrics
