### PR TITLE
Automated cherry pick of #129755: Concurrentmap Iteration

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -628,9 +628,8 @@ func (pm *VolumePluginMgr) initProbedPlugin(probedPlugin VolumePlugin) error {
 // specification.  If no plugins can support or more than one plugin can
 // support it, return error.
 func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
-	pm.mutex.RLock()
-	defer pm.mutex.RUnlock()
-
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
 	if spec == nil {
 		return nil, fmt.Errorf("could not find plugin because volume spec is nil")
 	}
@@ -643,12 +642,7 @@ func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
 			matchedPluginNames = append(matchedPluginNames, v.GetPluginName())
 		}
 	}
-
-	pm.mutex.RUnlock()
-	pm.mutex.Lock()
 	pm.refreshProbedPlugins()
-	pm.mutex.Unlock()
-	pm.mutex.RLock()
 
 	for _, plugin := range pm.probedPlugins {
 		if plugin.CanSupport(spec) {
@@ -669,19 +663,14 @@ func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
 
 // FindPluginByName fetches a plugin by name. If no plugin is found, returns error.
 func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
-	pm.mutex.RLock()
-	defer pm.mutex.RUnlock()
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
 
 	var match VolumePlugin
 	if v, found := pm.plugins[name]; found {
 		match = v
 	}
-
-	pm.mutex.RUnlock()
-	pm.mutex.Lock()
 	pm.refreshProbedPlugins()
-	pm.mutex.Unlock()
-	pm.mutex.RLock()
 	if plugin, found := pm.probedPlugins[name]; found {
 		if match != nil {
 			return nil, fmt.Errorf("multiple volume plugins matched: %s and %s", match.GetPluginName(), plugin.GetPluginName())
@@ -707,6 +696,7 @@ func (pm *VolumePluginMgr) refreshProbedPlugins() {
 	// because the probe function can return a list of valid plugins
 	// even when an error is present we still must add the plugins
 	// or they will be skipped because each event only fires once
+
 	for _, event := range events {
 		if event.Op == ProbeAddOrUpdate {
 			if err := pm.initProbedPlugin(event.Plugin); err != nil {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -644,7 +644,12 @@ func (pm *VolumePluginMgr) FindPluginBySpec(spec *Spec) (VolumePlugin, error) {
 		}
 	}
 
+	pm.mutex.RUnlock()
+	pm.mutex.Lock()
 	pm.refreshProbedPlugins()
+	pm.mutex.Unlock()
+	pm.mutex.RLock()
+
 	for _, plugin := range pm.probedPlugins {
 		if plugin.CanSupport(spec) {
 			match = plugin
@@ -672,7 +677,11 @@ func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
 		match = v
 	}
 
+	pm.mutex.RUnlock()
+	pm.mutex.Lock()
 	pm.refreshProbedPlugins()
+	pm.mutex.Unlock()
+	pm.mutex.RLock()
 	if plugin, found := pm.probedPlugins[name]; found {
 		if match != nil {
 			return nil, fmt.Errorf("multiple volume plugins matched: %s and %s", match.GetPluginName(), plugin.GetPluginName())


### PR DESCRIPTION
Cherry pick of #129755 on release-1.32.

#129755: Concurrentmap Iteration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```