### PR TITLE
add paths section to kubelet statusz endpoint

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -317,6 +317,9 @@ func NewServer(
 	} else {
 		server.InstallDebuggingDisabledHandlers()
 	}
+
+	server.installStatusZ()
+
 	return server
 }
 
@@ -377,6 +380,13 @@ func (s *Server) InstallAuthFilter() {
 // InstallTracingFilter installs OpenTelemetry tracing filter with the restful Container.
 func (s *Server) InstallTracingFilter(tp oteltrace.TracerProvider, opts ...otelrestful.Option) {
 	s.restfulCont.Filter(otelrestful.OTelFilter("kubelet", append(opts, otelrestful.WithTracerProvider(tp))...))
+}
+
+func (s *Server) installStatusZ() {
+	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
+		s.addMetricsBucketMatcher("statusz")
+		statusz.Install(s.restfulCont, ComponentKubelet, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion(), statusz.WithListedPaths(s.restfulCont.RegisteredHandlePaths())))
+	}
 }
 
 // addMetricsBucketMatcher adds a regexp matcher and the relevant bucket to use when
@@ -573,11 +583,6 @@ func (s *Server) InstallAuthRequiredHandlers() {
 
 	s.addMetricsBucketMatcher("configz")
 	configz.InstallHandler(s.restfulCont)
-
-	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentStatusz) {
-		s.addMetricsBucketMatcher("statusz")
-		statusz.Install(s.restfulCont, ComponentKubelet, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion()))
-	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentFlagz) {
 		if s.flagz != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Fix https://github.com/kubernetes/kubernetes/issues/133184
#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
add paths section to kubelet statusz endpoint
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Example response: 
```
kubelet statusz
Warning: This endpoint is not meant to be machine parseable, has no formatting compatibility guarantees and is for debugging purposes only.

Started:  Sat Aug  2 13:38:51 UTC 2025
Up:  0 hr 00 min 07 sec
Go version:  go1.24.0
Binary version:  1.34
Emulation version:  1.34
Paths:   /configz /debug /healthz /metrics
```

