### PR TITLE
ContainerRestartRules feature gate should work with probes

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1222,7 +1222,9 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 
 				restartOnFailure := restartOnFailure
 				if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
-					restartOnFailure = kubecontainer.ShouldContainerBeRestarted(container, pod, podStatus)
+					if container.RestartPolicy != nil {
+						restartOnFailure = *container.RestartPolicy != v1.ContainerRestartPolicyNever
+					}
 				}
 				if !restartOnFailure {
 					changes.KillPod = true

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1222,6 +1222,9 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 
 				restartOnFailure := restartOnFailure
 				if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
+					// Only container-level restart policy is used. The container-level restart
+					// rules are not evaluated because the container might not have exited, so
+					// there is no exit code on which the rules can be used.
 					if container.RestartPolicy != nil {
 						restartOnFailure = *container.RestartPolicy != v1.ContainerRestartPolicyNever
 					}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1147,7 +1147,9 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		var reason containerKillReason
 		restart := shouldRestartOnFailure(pod)
 		if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
-			restart = kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus)
+			if container.RestartPolicy != nil {
+				restart = *container.RestartPolicy != v1.ContainerRestartPolicyNever
+			}
 		}
 		if _, _, changed := containerChanged(&container, containerStatus); changed {
 			message = fmt.Sprintf("Container %s definition changed", container.Name)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -589,16 +589,6 @@ func containerChanged(container *v1.Container, containerStatus *kubecontainer.St
 }
 
 func shouldRestartOnFailure(pod *v1.Pod) bool {
-	// With feature ContainerRestartRules enabled, the pod should be restarted
-	// on failure if any of its containers have container-level restart policy
-	// that is restartable.
-	if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
-		for _, c := range pod.Spec.Containers {
-			if podutil.IsContainerRestartable(pod.Spec, c) {
-				return true
-			}
-		}
-	}
 	return pod.Spec.RestartPolicy != v1.RestartPolicyNever
 }
 
@@ -1147,6 +1137,8 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		var reason containerKillReason
 		restart := shouldRestartOnFailure(pod)
 		if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
+			// For probe failures, use container-level restart policy only. Container-level restart
+			// rules are not evaluated because the container is still running.
 			if container.RestartPolicy != nil {
 				restart = *container.RestartPolicy != v1.ContainerRestartPolicyNever
 			}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2110,6 +2110,11 @@ func TestComputePodActionsWithInitAndEphemeralContainers(t *testing.T) {
 }
 
 func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
+	// Make sure existing test cases pass with feature enabled
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ContainerRestartRules, true)
+	TestComputePodActions(t)
+	TestComputePodActionsWithInitContainers(t)
+
 	var (
 		containerRestartPolicyAlways    = v1.ContainerRestartPolicyAlways
 		containerRestartPolicyOnFailure = v1.ContainerRestartPolicyOnFailure
@@ -2231,7 +2236,6 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 			},
 		},
 	} {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ContainerRestartRules, true)
 		pod, status := makeBasePodAndStatus()
 		if test.mutatePodFn != nil {
 			test.mutatePodFn(pod)

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -718,7 +718,7 @@ var _ = SIGDescribe("Pods Extended (pod generation)", feature.PodObservedGenerat
 	})
 })
 
-var _ = SIGDescribe("Pod Extended (container restart policy)", feature.ContainerRestartRules, framework.WithFeatureGate(features.ContainerRestartRules), func() {
+var _ = SIGDescribe("Pod Extended (container restart policy)", framework.WithFeatureGate(features.ContainerRestartRules), func() {
 	f := framework.NewDefaultFramework("pods")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the feature gate ContainerRestartRules not working with readiness probes.

#### Which issue(s) this PR is related to:

Fixes #133216 
KEP: https://github.com/kubernetes/enhancements/issues/5307

#### Special notes for your reviewer:

Added the `computePodAction` unit tests under the feature gate ContainerRestartRules to ensure all existing behavior stays the same when the feature is enabled.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5307
```
