### PR TITLE
ci: allow devs using delve to debug e2e locally without gce

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -185,7 +185,13 @@ case "${E2E_TEST_DEBUG_TOOL:-ginkgo}" in
     fi
     program+=("${ginkgo_args[@]:+${ginkgo_args[@]}}")
     ;;
-  delve) program=("dlv" "exec") ;;
+  delve) 
+    program=("dlv" "exec" "--headless=true")
+    if [[ -z "${DELVE_PORT:-}" ]]; then
+      DELVE_PORT="2345"
+    fi
+    program+=("--listen=:${DELVE_PORT}")
+    ;;
   gdb) program=("gdb") ;;
   *) kube::log::error_exit "Unsupported E2E_TEST_DEBUG_TOOL=${E2E_TEST_DEBUG_TOOL}" ;;
 esac


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind bug
/sig testing
/priority important-longterm

#### What this PR does / why we need it:

Enable devs to follow [Debugging an E2E test with a debugger (delve)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md#debugging-an-e2e-test-with-a-debugger-delve) document and debugging e2e locally with `kind`. Also fixed the underlying issue related to `--allow-non-terminal-interactive=true` complained by newer version of `delve`, which causes the document step to be unproducible. The original delve error message:

```log
Stdin is not a terminal, use '-r' to specify redirects for the target process or --allow-non-terminal-interactive=true if you really want to specify a redirect for Delve
```

#### Which issue(s) this PR is related to:

Resolve https://github.com/kubernetes/kubernetes/issues/133328

#### Special notes for your reviewer:

- This PR should be reviewed along with the [e2e-tests.md doc change](https://github.com/kubernetes/community/pull/8535)

- I have tested locally with terminal only and VSCode IDE, and the changes seem to be working pretty well.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
