### PR TITLE
Fix incorrect validation on the kubelet

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -575,8 +575,8 @@ func (kl *Kubelet) GeneratePodHostNameAndDomain(pod *v1.Pod) (string, string, er
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.HostnameOverride) && pod.Spec.HostnameOverride != nil {
 		hostname := *pod.Spec.HostnameOverride
-		if msgs := utilvalidation.IsDNS1123Label(hostname); len(msgs) != 0 {
-			return "", "", fmt.Errorf("pod HostnameOverride %q is not a valid DNS label: %s", hostname, strings.Join(msgs, ";"))
+		if msgs := utilvalidation.IsDNS1123Subdomain(hostname); len(msgs) != 0 {
+			return "", "", fmt.Errorf("pod HostnameOverride %q is not a valid DNS subdomain: %s", hostname, strings.Join(msgs, ";"))
 		}
 		truncatedHostname, err := truncatePodHostnameIfNeeded(pod.Name, hostname)
 		if err != nil {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -7468,7 +7468,15 @@ func TestGeneratePodHostNameAndDomain(t *testing.T) {
 			podHostnameOverride: ptr.To("Invalid-Hostname-!"),
 			featureGateEnabled:  true,
 			expectError:         true,
-			errorContains:       "pod HostnameOverride \"Invalid-Hostname-!\" is not a valid DNS label",
+			errorContains:       "pod HostnameOverride \"Invalid-Hostname-!\" is not a valid DNS subdomain",
+		},
+		{
+			name:                "HostnameOverride - enabled - overrides all - valid DNS hostname",
+			podName:             "test-pod",
+			podHostnameOverride: ptr.To("valid.hostname"),
+			expectedHostname:    "valid.hostname",
+			featureGateEnabled:  true,
+			errorContains:       "",
 		},
 		{
 			name:                "HostnameOverride - disabled - is ignored",

--- a/test/e2e/common/node/pod_hostnameoverride.go
+++ b/test/e2e/common/node/pod_hostnameoverride.go
@@ -56,6 +56,14 @@ var _ = SIGDescribe("Override hostname of Pod", framework.WithFeatureGate(featur
 	f := framework.NewDefaultFramework("hostfqdn")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
+	ginkgo.It("a pod has hostnameOverride field with value that is a valid DNS subdomain.", func(ctx context.Context) {
+		pod := newTestPod(f.Namespace.Name)
+		hostnameOverride := "override.example.host"
+		pod.Spec.HostnameOverride = &hostnameOverride
+		output := []string{fmt.Sprintf("%s;%s;", hostnameOverride, hostnameOverride)}
+		e2eoutput.TestContainerOutput(ctx, f, "hostnameOverride overrides hostname", pod, 0, output)
+	})
+
 	ginkgo.It("a pod with hostname and hostnameOverride fields will have hostnameOverride as hostname", func(ctx context.Context) {
 		pod := newTestPod(f.Namespace.Name)
 		hostname := "custom-host"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
During implementation, I added incorrect validation logic to the kubelet. Unlike the `hostname` and `subdomain` fields, `hostnameOverride` should accept values conforming to DNS subdomain, I identified this issue during a re-review of this functionality

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]:  https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/4762-allow-arbitrary-fqdn-as-pod-hostname
```
