### PR TITLE
[PodLevelResources] Event for unsupported pod-level resource manager alignment

### DIFF
--- a/pkg/kubelet/cm/admission/errors.go
+++ b/pkg/kubelet/cm/admission/errors.go
@@ -20,11 +20,19 @@ import (
 	"errors"
 	"fmt"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
 const (
 	ErrorReasonUnexpected = "UnexpectedAdmissionError"
+
+	// Explicit reason when CPU/Memory manager's policy is incompatible with pod level resources.
+	PodLevelResourcesIncompatible = "PodLevelResourcesIncompatible"
+
+	// Warnings for pod level resources when manager's policy incompatibility.
+	CPUManagerPodLevelResourcesError    = "CPUManagerPodLevelResourcesError"
+	MemoryManagerPodLevelResourcesError = "MemoryManagerPodLevelResourcesError"
 )
 
 type Error interface {
@@ -49,14 +57,53 @@ func GetPodAdmitResult(err error) lifecycle.PodAdmitResult {
 		return lifecycle.PodAdmitResult{Admit: true}
 	}
 
+	var errs []error
+	// To support multiple pod-level resource errors, we need to check if the error
+	// is an aggregate error.
+	var agg utilerrors.Aggregate
+	if errors.As(err, &agg) {
+		errs = agg.Errors()
+	} else {
+		errs = []error{err}
+	}
+
+	var podLevelWarnings []error
+	var otherErrs []error
+	for _, e := range errs {
+		var admissionErr Error
+		if errors.As(e, &admissionErr) && (admissionErr.Type() == CPUManagerPodLevelResourcesError || admissionErr.Type() == MemoryManagerPodLevelResourcesError) {
+			podLevelWarnings = append(podLevelWarnings, e)
+		} else {
+			otherErrs = append(otherErrs, e)
+		}
+	}
+
+	// If all errors are pod-level resource errors, we should treat them as warnings
+	// and not block pod admission.
+	if len(otherErrs) == 0 && len(podLevelWarnings) > 0 {
+		return lifecycle.PodAdmitResult{
+			Admit:   true,
+			Reason:  PodLevelResourcesIncompatible,
+			Message: "",
+			Errors:  podLevelWarnings,
+		}
+	}
+
+	if len(otherErrs) == 0 {
+		// This should not happen if err != nil, but as a safeguard.
+		return lifecycle.PodAdmitResult{Admit: true}
+	}
+
+	// At this point, we have at least one error that requires pod rejection.
+	firstErr := otherErrs[0]
 	var admissionErr Error
-	if !errors.As(err, &admissionErr) {
-		admissionErr = &unexpectedAdmissionError{err}
+	if !errors.As(firstErr, &admissionErr) {
+		admissionErr = &unexpectedAdmissionError{firstErr}
 	}
 
 	return lifecycle.PodAdmitResult{
+		Admit:   false,
 		Message: admissionErr.Error(),
 		Reason:  admissionErr.Type(),
-		Admit:   false,
 	}
 }

--- a/pkg/kubelet/cm/admission/errors.go
+++ b/pkg/kubelet/cm/admission/errors.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
@@ -91,6 +92,9 @@ func GetPodAdmitResult(err error) lifecycle.PodAdmitResult {
 
 	if len(otherErrs) == 0 {
 		// This should not happen if err != nil, but as a safeguard.
+		// This indicates a logical inconsistency where a primary error was
+		// detected, but supporting detailed errors are missing. This is a bug.
+		klog.ErrorS(err, "Logical inconsistency: Primary error detected, but 'otherErrs' list is empty")
 		return lifecycle.PodAdmitResult{Admit: true}
 	}
 

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -172,6 +172,22 @@ func makePod(podUID, containerName, cpuRequest, cpuLimit string) *v1.Pod {
 	return pod
 }
 
+func makePodWithPodLevelResources(podUID, podCPURequest, podCPULimit, containerName, cpuRequest, cpuLimit string) *v1.Pod {
+	pod := makePod(podUID, containerName, cpuRequest, cpuLimit)
+	pod.Spec.Resources = &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceName(v1.ResourceCPU):    resource.MustParse(podCPURequest),
+			v1.ResourceName(v1.ResourceMemory): resource.MustParse("1G"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceName(v1.ResourceCPU):    resource.MustParse(podCPULimit),
+			v1.ResourceName(v1.ResourceMemory): resource.MustParse("1G"),
+		},
+	}
+
+	return pod
+}
+
 func makeMultiContainerPod(initCPUs, appCPUs []struct{ request, limit string }) *v1.Pod {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -486,7 +486,7 @@ func (p *staticPolicy) guaranteedCPUs(pod *v1.Pod, container *v1.Container) int 
 	}
 
 	// The CPU manager static policy does not support pod-level resources.
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
+	if p.isPodWithPodLevelResources(pod) {
 		return 0
 	}
 
@@ -840,7 +840,7 @@ func updateAllocationPerNUMAMetric(topo *topology.CPUTopology, allocatedCPUs cpu
 
 func (p *staticPolicy) isPodWithPodLevelResources(pod *v1.Pod) bool {
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
-		// The Memory manager static policy does not support pod-level resources.
+		// The CPU manager static policy does not support pod-level resources.
 		klog.V(5).InfoS("CPU Manager allocation skipped, pod is using pod-level resources which are not supported by the static CPU manager policy", "pod", klog.KObj(pod))
 
 		return true

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -18,6 +18,7 @@ package memorymanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -273,6 +274,12 @@ func (m *manager) Allocate(pod *v1.Pod, container *v1.Container) error {
 
 	// Call down into the policy to assign this container memory if required.
 	if err := m.policy.Allocate(ctx, m.state, pod, container); err != nil {
+		// If it gets this error it means that the pod requires pod level resources but this is not aligned.
+		// We do not want the pod to fail to schedule on this error so we Admit it, this is just a warning
+		if errors.As(err, &MemoryManagerPodLevelResourcesError{}) {
+			return err
+		}
+
 		logger.Error(err, "Allocate error", "pod", klog.KObj(pod), "containerName", container.Name)
 		return err
 	}

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -151,6 +151,13 @@ func getPod(podUID string, containerName string, requirements *v1.ResourceRequir
 	}
 }
 
+func getPodWithPodLevelResources(podUID string, podRequirements *v1.ResourceRequirements, containerName string, containerRequirements *v1.ResourceRequirements) *v1.Pod {
+	pod := getPod(podUID, containerName, containerRequirements)
+	pod.Spec.Resources = podRequirements
+
+	return pod
+}
+
 func getPodWithInitContainers(podUID string, containers []v1.Container, initContainers []v1.Container) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -2017,9 +2017,9 @@ func TestStaticPolicyAllocate(t *testing.T) {
 			}
 
 			err = p.Allocate(tCtx, s, testCase.pod, &testCase.pod.Spec.Containers[0])
-			if !reflect.DeepEqual(err, testCase.expectedError) {
-				t.Fatalf("The actual error %v is different from the expected one %v", err, testCase.expectedError)
-			}
+			if (err == nil) != (testCase.expectedError == nil) || (err != nil && testCase.expectedError != nil && err.Error() != testCase.expectedError.Error()) {
+ 				t.Fatalf("The actual error %v is different from the expected one %v", err, testCase.expectedError)
+ 			}
 
 			if err != nil {
 				return

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -19,8 +19,11 @@ package topologymanager
 import (
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -148,11 +151,21 @@ func (s *scope) admitPolicyNone(pod *v1.Pod) lifecycle.PodAdmitResult {
 // It would be better to implement this function in topologymanager instead of scope
 // but topologymanager do not track providers anymore
 func (s *scope) allocateAlignedResources(pod *v1.Pod, container *v1.Container) error {
+	isPodLevelResourcesEnabled := utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources)
+
+	var errs []error
 	for _, provider := range s.hintProviders {
 		err := provider.Allocate(pod, container)
-		if err != nil {
+		if err != nil && isPodLevelResourcesEnabled {
+			errs = append(errs, err)
+		} else if err != nil {
 			return err
 		}
 	}
+
+	if isPodLevelResourcesEnabled {
+		return utilerrors.NewAggregate(errs)
+	}
+
 	return nil
 }

--- a/pkg/kubelet/lifecycle/interfaces.go
+++ b/pkg/kubelet/lifecycle/interfaces.go
@@ -35,6 +35,8 @@ type PodAdmitResult struct {
 	Reason string
 	// a brief message explaining why the pod could not be admitted.
 	Message string
+	// all errors for why the pod could not be admitted.
+	Errors []error
 }
 
 // PodAdmitHandler is notified during pod admission.

--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -201,6 +201,10 @@ func getHugepagesTestPod(f *framework.Framework, podResources *v1.ResourceRequir
 		},
 	}
 
+	if podResources == nil {
+		return pod
+	}
+
 	if podResources.Requests != nil || podResources.Limits != nil {
 		pod.Spec.Resources = podResources
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
This PR allows to surface no CPU nor Memory alignment events when Pod level resources are used in the pod spec, the following changes are required:

CPU and Memory manager event when using pod level resources
Unit tests for no hints nor aligment of CPU and Memory
E2E tests for no hints nor aligment of CPU and Memory managers

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes https://github.com/kubernetes/kubernetes/issues/132445

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Prevents any type of CPU/Memory alignment or hint generation with the Topology manager from the CPU or Memory manager when Pod Level resources are used in the pod spec.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: [kubernetes/enhancements#2837](https://github.com/kubernetes/enhancements/issues/2837)
```
