### PR TITLE
[client-go #1415] Embed proper interface in TransformingStore to ensure DeltaFIFO and RealFIFO are implementing it

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -270,7 +270,8 @@ func NewDeltaFIFOWithOptions(opts DeltaFIFOOptions) *DeltaFIFO {
 }
 
 var (
-	_ = Queue(&DeltaFIFO{}) // DeltaFIFO is a Queue
+	_ = Queue(&DeltaFIFO{})             // DeltaFIFO is a Queue
+	_ = TransformingStore(&DeltaFIFO{}) // DeltaFIFO implements TransformingStore to allow memory optimizations
 )
 
 var (

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -80,7 +80,7 @@ type ReflectorStore interface {
 // TransformingStore is an optional interface that can be implemented by the provided store.
 // If implemented on the provided store reflector will use the same transformer in its internal stores.
 type TransformingStore interface {
-	Store
+	ReflectorStore
 	Transformer() TransformFunc
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -2057,109 +2057,130 @@ func TestReflectorReplacesStoreOnUnsafeDelete(t *testing.T) {
 }
 
 func TestReflectorRespectStoreTransformer(t *testing.T) {
-	mkPod := func(id string, rv string) *v1.Pod {
-		return &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: id, ResourceVersion: rv},
-			Spec: v1.PodSpec{
-				Hostname: "test",
-			},
-		}
+	type testReflectorStore interface {
+		ReflectorStore
+		list() []interface{}
 	}
 
-	preExisting1 := mkPod("foo-1", "1")
-	preExisting2 := mkPod("foo-2", "2")
-	pod3 := mkPod("foo-3", "3")
-
-	lastExpectedRV := "3"
-	events := []watch.Event{
-		{Type: watch.Added, Object: preExisting1},
-		{Type: watch.Added, Object: preExisting2},
-		{Type: watch.Bookmark, Object: &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				ResourceVersion: lastExpectedRV,
-				Annotations: map[string]string{
-					metav1.InitialEventsAnnotationKey: "true",
+	for name, storeBuilder := range map[string]func(counter *atomic.Int32) testReflectorStore{
+		"real-fifo": func(counter *atomic.Int32) testReflectorStore {
+			return NewRealFIFO(MetaNamespaceKeyFunc, NewStore(MetaNamespaceKeyFunc), func(i interface{}) (interface{}, error) {
+				counter.Add(1)
+				cast := i.(*v1.Pod)
+				cast.Spec.Hostname = "transformed"
+				return cast, nil
+			})
+		},
+		"delta-fifo": func(counter *atomic.Int32) testReflectorStore {
+			return NewDeltaFIFOWithOptions(DeltaFIFOOptions{
+				KeyFunction: MetaNamespaceKeyFunc,
+				Transformer: func(i interface{}) (interface{}, error) {
+					counter.Add(1)
+					cast := i.(*v1.Pod)
+					cast.Spec.Hostname = "transformed"
+					return cast, nil
 				},
-			},
-		}},
-		{Type: watch.Added, Object: pod3},
-	}
-
-	var transformerInvoked atomic.Int32
-	s := NewDeltaFIFOWithOptions(DeltaFIFOOptions{
-		KeyFunction: MetaNamespaceKeyFunc,
-		Transformer: func(i interface{}) (interface{}, error) {
-			transformerInvoked.Add(1)
-			cast := i.(*v1.Pod)
-			cast.Spec.Hostname = "transformed"
-			return cast, nil
+			})
 		},
-	})
+	} {
+		t.Run(name, func(t *testing.T) {
+			mkPod := func(id string, rv string) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: id, ResourceVersion: rv},
+					Spec: v1.PodSpec{
+						Hostname: "test",
+					},
+				}
+			}
 
-	var once sync.Once
-	lw := &ListWatch{
-		WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
-			fw := watch.NewFake()
+			preExisting1 := mkPod("foo-1", "1")
+			preExisting2 := mkPod("foo-2", "2")
+			pod3 := mkPod("foo-3", "3")
+
+			lastExpectedRV := "3"
+			events := []watch.Event{
+				{Type: watch.Added, Object: preExisting1},
+				{Type: watch.Added, Object: preExisting2},
+				{Type: watch.Bookmark, Object: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: lastExpectedRV,
+						Annotations: map[string]string{
+							metav1.InitialEventsAnnotationKey: "true",
+						},
+					},
+				}},
+				{Type: watch.Added, Object: pod3},
+			}
+
+			var transformerInvoked atomic.Int32
+			s := storeBuilder(&transformerInvoked)
+
+			var once sync.Once
+			lw := &ListWatch{
+				WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
+					fw := watch.NewFake()
+					go func() {
+						once.Do(func() {
+							for _, e := range events {
+								fw.Action(e.Type, e.Object)
+							}
+						})
+					}()
+					return fw, nil
+				},
+				// ListFunc should never be used in WatchList mode
+				ListFunc: func(metav1.ListOptions) (runtime.Object, error) {
+					return nil, errors.New("list call not expected in WatchList mode")
+				},
+			}
+
+			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
+			r := NewReflector(lw, &v1.Pod{}, s, 0)
+			ctx, cancel := context.WithCancel(context.Background())
+			doneCh := make(chan struct{})
 			go func() {
-				once.Do(func() {
-					for _, e := range events {
-						fw.Action(e.Type, e.Object)
-					}
-				})
+				defer close(doneCh)
+				r.RunWithContext(ctx)
 			}()
-			return fw, nil
-		},
-		// ListFunc should never be used in WatchList mode
-		ListFunc: func(metav1.ListOptions) (runtime.Object, error) {
-			return nil, errors.New("list call not expected in WatchList mode")
-		},
-	}
 
-	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
-	ctx, cancel := context.WithCancel(context.Background())
-	doneCh := make(chan struct{})
-	go func() {
-		defer close(doneCh)
-		r.RunWithContext(ctx)
-	}()
+			// wait for the RV to sync to the version returned by the final list
+			err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+				if rv := r.LastSyncResourceVersion(); rv == lastExpectedRV {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				t.Fatalf("reflector never caught up with expected revision: %q, err: %v", lastExpectedRV, err)
+			}
 
-	// wait for the RV to sync to the version returned by the final list
-	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		if rv := r.LastSyncResourceVersion(); rv == lastExpectedRV {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		t.Fatalf("reflector never caught up with expected revision: %q, err: %v", lastExpectedRV, err)
-	}
+			if want, got := lastExpectedRV, r.LastSyncResourceVersion(); want != got {
+				t.Errorf("expected LastSyncResourceVersion to be %q, but got: %q", want, got)
+			}
 
-	if want, got := lastExpectedRV, r.LastSyncResourceVersion(); want != got {
-		t.Errorf("expected LastSyncResourceVersion to be %q, but got: %q", want, got)
-	}
+			if want, got := 3, len(s.list()); want != got {
+				t.Errorf("expected informer to contain %d objects, but got: %d", want, got)
+			}
+			for _, item := range s.list() {
+				cast := item.(*v1.Pod)
+				if cast.Spec.Hostname != "transformed" {
+					t.Error("Object was not transformed prior to replacement")
+				}
+			}
 
-	if want, got := 3, len(s.list()); want != got {
-		t.Errorf("expected informer to contain %d objects, but got: %d", want, got)
-	}
-	for _, item := range s.list() {
-		cast := item.(*v1.Pod)
-		if cast.Spec.Hostname != "transformed" {
-			t.Error("Object was not transformed prior to replacement")
-		}
-	}
+			// Transformer should have been invoked twice for the initial sync in the informer on the temporary store,
+			// then twice on replace, then once on the following update.
+			if want, got := 5, int(transformerInvoked.Load()); want != got {
+				t.Errorf("expected transformer to be invoked %d times, but got: %d", want, got)
+			}
 
-	// Transformer should have been invoked twice for the initial sync in the informer on the temporary store,
-	// then twice on replace, then once on the following update.
-	if want, got := 5, int(transformerInvoked.Load()); want != got {
-		t.Errorf("expected transformer to be invoked %d times, but got: %d", want, got)
-	}
-
-	cancel()
-	select {
-	case <-doneCh:
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("timed out waiting for Run to return")
+			cancel()
+			select {
+			case <-doneCh:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Errorf("timed out waiting for Run to return")
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
@@ -61,7 +61,8 @@ type RealFIFO struct {
 }
 
 var (
-	_ = Queue(&RealFIFO{}) // RealFIFO is a Queue
+	_ = Queue(&RealFIFO{})             // RealFIFO is a Queue
+	_ = TransformingStore(&RealFIFO{}) // RealFIFO implements TransformingStore to allow memory optimizations
 )
 
 // Close the queue.

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
@@ -18,8 +18,10 @@ package cache
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"runtime"
+	"slices"
 	"testing"
 	"time"
 )
@@ -31,6 +33,21 @@ func (f *RealFIFO) getItems() []Delta {
 	ret := make([]Delta, len(f.items))
 	copy(ret, f.items)
 	return ret
+}
+
+func (f *RealFIFO) list() []interface{} {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	objects := make(map[string]interface{})
+	for _, item := range f.items {
+		if item.Type == Deleted {
+			continue
+		}
+		key, _ := f.keyFunc(item.Object)
+		objects[key] = item.Object
+	}
+	return slices.Collect(maps.Values(objects))
 }
 
 const closedFIFOName = "FIFO WAS CLOSED"

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
@@ -18,10 +18,8 @@ package cache
 
 import (
 	"fmt"
-	"maps"
 	"reflect"
 	"runtime"
-	"slices"
 	"testing"
 	"time"
 )
@@ -33,21 +31,6 @@ func (f *RealFIFO) getItems() []Delta {
 	ret := make([]Delta, len(f.items))
 	copy(ret, f.items)
 	return ret
-}
-
-func (f *RealFIFO) list() []interface{} {
-	f.lock.Lock()
-	defer f.lock.Unlock()
-
-	objects := make(map[string]interface{})
-	for _, item := range f.items {
-		if item.Type == Deleted {
-			continue
-		}
-		key, _ := f.keyFunc(item.Object)
-		objects[key] = item.Object
-	}
-	return slices.Collect(maps.Values(objects))
 }
 
 const closedFIFOName = "FIFO WAS CLOSED"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR is a follow-up to #131799 to improve the memory utilization of informers using transformers.

In #131799 I added a new interface to match stores providing transformers in order to reuse them. The PR was extracted from our fork but a change to embed the `Store` interface in the `TransformingStore` (instead of `ReflectorStore`) mistakenly broke the interface matching. The tests did not catch it as they use `fakeStore` which is an implementation of `Store`.
This PR updates the embedded interface to the proper one, and add interface enforcement for `DeltaFIFO` and `RealFIFO`. It also updates the test to directly use `DeltaFIFO` (as this is the structure actually used in the informers). 
While adding the tests, I could not reproduce the issue as `DeltaFIFO` does implement `Store` through test files only. This is in my opinion a very poor behavior, as in this case tests would have passed without errors and failed again at runtime. It was only discovered while running the new tests against the old behavior and noting an unexpected success.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/client-go/issues/1415

#### Special notes for your reviewer:

The only functional change of the PR is the replacement of the embedded interface in `TransformingStore`. The rest of the PR is for maintainability and updated tests

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
