### PR TITLE
Update protobindings scripts to drop gogo references

### DIFF
--- a/hack/_update-generated-proto-bindings-dockerized.sh
+++ b/hack/_update-generated-proto-bindings-dockerized.sh
@@ -27,11 +27,9 @@ source "${KUBE_ROOT}/hack/lib/protoc.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
 if (( $# < 2 )); then
-    echo "usage: $0 [gogo|protoc] <api_dir>..."
+    echo "usage: $0 <api_dir>..."
     exit 1
 fi
-
-generator=$1; shift
 
 kube::protoc::check_protoc
 
@@ -49,16 +47,6 @@ for api; do
 
     for file in "${protos[@]}"; do
         dir="$(dirname "${file}")"
-        case "${generator}" in
-        gogo)
-          kube::protoc::generate_proto_gogo "${dir}"
-          ;;
-        protoc)
-          kube::protoc::generate_proto "${dir}"
-          ;;
-        *)
-          echo "Unknown generator ${generator}" >&2
-          exit 1
-        esac        
+        kube::protoc::generate_proto "${dir}"
     done
 done

--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -42,20 +42,6 @@ function kube::protoc::generate_proto() {
   kube::protoc::format "${package}"
 }
 
-# Generates $1/api.pb.go from the protobuf file $1/api.proto
-# and formats it correctly
-# $1: Full path to the directory where the api.proto file is
-function kube::protoc::generate_proto_gogo() {
-  kube::golang::setup_env
-  GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
-
-  kube::protoc::check_protoc
-
-  local package=${1}
-  kube::protoc::protoc_gogo "${package}"
-  kube::protoc::format "${package}"
-}
-
 # Checks that the current protoc version matches the required version and
 # exit 1 if it's not the case
 function kube::protoc::check_protoc() {
@@ -69,29 +55,6 @@ function kube::protoc::check_protoc() {
 }
 
 # Generates $1/api.pb.go from the protobuf file $1/api.proto
-# $1: Full path to the directory where the api.proto file is
-function kube::protoc::protoc_gogo() {
-  local package=${1}
-  gogopath=$(dirname "$(kube::util::find-binary "protoc-gen-gogo")")
-
-  (
-    cd "${package}"
-
-    # This invocation of --gogo_out produces its output in the current
-    # directory (despite gogo docs saying it would be source-relative, it
-    # isn't).  The inputs to this function do not all have a common root, so
-    # this works best for all inputs.
-    PATH="${gogopath}:${PATH}" protoc \
-      --proto_path="$(pwd -P)" \
-      --proto_path="${KUBE_ROOT}/vendor" \
-      --proto_path="${KUBE_ROOT}/staging/src" \
-      --proto_path="${KUBE_ROOT}/third_party/protobuf" \
-      --gogo_out=paths=source_relative,plugins=grpc:. \
-      api.proto
-  )
-}
-
-# Generates $1/api.pb.go from the protobuf file $1/api.proto without using gogo
 # $1: Full path to the directory where the api.proto file is
 function kube::protoc::protoc() {
   local package=${1}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1047,13 +1047,13 @@ function codegen::protobindings() {
     done
 
     if kube::protoc::check_protoc >/dev/null; then
-      hack/_update-generated-proto-bindings-dockerized.sh protoc "${apis[@]}"
+      hack/_update-generated-proto-bindings-dockerized.sh "${apis[@]}"
     else
       kube::log::status "protoc ${PROTOC_VERSION} not found (can install with hack/install-protoc.sh); generating containerized..."
       # NOTE: All output from this script needs to be copied back to the calling
       # source tree.  This is managed in kube::build::copy_output in build/common.sh.
       # If the output set is changed update that function.
-      build/run.sh hack/_update-generated-proto-bindings-dockerized.sh protoc "${apis[@]}"
+      build/run.sh hack/_update-generated-proto-bindings-dockerized.sh "${apis[@]}"
     fi
 }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Cleanup the available scripts to remove unused code paths after all gogo references have been migrated to native protobuf.
#### Which issue(s) this PR is related to:
Requires https://github.com/kubernetes/kubernetes/pull/133026
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
