### PR TITLE
KEP-5278 Stop clearing NominatedNodeName in all cases

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -136,7 +136,15 @@ func (sched *Scheduler) ScheduleOne(ctx context.Context) {
 	}()
 }
 
-var clearNominatedNode = &framework.NominatingInfo{NominatingMode: framework.ModeOverride, NominatedNodeName: ""}
+// newFailureNominatingInfo returns the appropriate NominatingInfo for scheduling failures.
+// When NominatedNodeNameForExpectation feature is enabled, it returns nil (no clearing).
+// Otherwise, it returns NominatingInfo to clear the pod's nominated node.
+func (sched *Scheduler) newFailureNominatingInfo() *framework.NominatingInfo {
+	if sched.nominatedNodeNameForExpectationEnabled {
+		return nil
+	}
+	return &framework.NominatingInfo{NominatingMode: framework.ModeOverride, NominatedNodeName: ""}
+}
 
 // schedulingCycle tries to schedule a single Pod.
 func (sched *Scheduler) schedulingCycle(
@@ -156,13 +164,13 @@ func (sched *Scheduler) schedulingCycle(
 		}()
 		if err == ErrNoNodesAvailable {
 			status := fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
-			return ScheduleResult{nominatingInfo: clearNominatedNode}, podInfo, status
+			return ScheduleResult{nominatingInfo: sched.newFailureNominatingInfo()}, podInfo, status
 		}
 
 		fitError, ok := err.(*framework.FitError)
 		if !ok {
 			logger.Error(err, "Error selecting node for pod", "pod", klog.KObj(pod))
-			return ScheduleResult{nominatingInfo: clearNominatedNode}, podInfo, fwk.AsStatus(err)
+			return ScheduleResult{nominatingInfo: sched.newFailureNominatingInfo()}, podInfo, fwk.AsStatus(err)
 		}
 
 		// SchedulePod() may have failed because the pod would not fit on any host, so we try to
@@ -205,7 +213,7 @@ func (sched *Scheduler) schedulingCycle(
 		// This relies on the fact that Error will check if the pod has been bound
 		// to a node and if so will not add it back to the unscheduled pods queue
 		// (otherwise this would cause an infinite loop).
-		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, fwk.AsStatus(err)
+		return ScheduleResult{nominatingInfo: sched.newFailureNominatingInfo()}, assumedPodInfo, fwk.AsStatus(err)
 	}
 
 	// Run the Reserve method of reserve plugins.
@@ -226,9 +234,9 @@ func (sched *Scheduler) schedulingCycle(
 			}
 			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, sts)
 			fitErr.Diagnosis.AddPluginStatus(sts)
-			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, fwk.NewStatus(sts.Code()).WithError(fitErr)
+			return ScheduleResult{nominatingInfo: sched.newFailureNominatingInfo()}, assumedPodInfo, fwk.NewStatus(sts.Code()).WithError(fitErr)
 		}
-		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, sts
+		return ScheduleResult{nominatingInfo: sched.newFailureNominatingInfo()}, assumedPodInfo, sts
 	}
 
 	// Run "permit" plugins.
@@ -250,10 +258,10 @@ func (sched *Scheduler) schedulingCycle(
 			}
 			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, runPermitStatus)
 			fitErr.Diagnosis.AddPluginStatus(runPermitStatus)
-			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, fwk.NewStatus(runPermitStatus.Code()).WithError(fitErr)
+			return ScheduleResult{nominatingInfo: sched.newFailureNominatingInfo()}, assumedPodInfo, fwk.NewStatus(runPermitStatus.Code()).WithError(fitErr)
 		}
 
-		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, runPermitStatus
+		return ScheduleResult{nominatingInfo: sched.newFailureNominatingInfo()}, assumedPodInfo, runPermitStatus
 	}
 
 	// At the end of a successful scheduling cycle, pop and move up Pods if needed.
@@ -385,7 +393,7 @@ func (sched *Scheduler) handleBindingCycleError(
 		}
 	}
 
-	sched.FailureHandler(ctx, fwk, podInfo, status, clearNominatedNode, start)
+	sched.FailureHandler(ctx, fwk, podInfo, status, sched.newFailureNominatingInfo(), start)
 }
 
 func (sched *Scheduler) frameworkForPod(pod *v1.Pod) (framework.Framework, error) {

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -916,8 +916,31 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			mockScheduleResult: emptyScheduleResult,
 			eventReason:        "FailedScheduling",
 		},
+		{
+			name: "pod with existing nominated node name on scheduling error",
+			sendPod: func() *v1.Pod {
+				p := podWithID("foo", "")
+				p.Status.NominatedNodeName = "existing-node"
+				return p
+			}(),
+			injectSchedulingError: schedulingErr,
+			mockScheduleResult:    scheduleResultOk,
+			expectError:           schedulingErr,
+			expectErrorPod: func() *v1.Pod {
+				p := podWithID("foo", "")
+				p.Status.NominatedNodeName = "existing-node"
+				return p
+			}(),
+			expectPodInBackoffQ: func() *v1.Pod {
+				p := podWithID("foo", "")
+				p.Status.NominatedNodeName = "existing-node"
+				return p
+			}(),
+			eventReason: "FailedScheduling",
+		},
 	}
 
+	// Test with QueueingHints and NominatedNodeNameForExpectation feature gates
 	for _, qHintEnabled := range []bool{true, false} {
 		for _, item := range table {
 			asyncAPICallsEnabled := []bool{true, false}
@@ -930,8 +953,8 @@ func TestSchedulerScheduleOne(t *testing.T) {
 					nominatedNodeNameForExpectationEnabled = []bool{*item.nominatedNodeNameForExpectationEnabled}
 				}
 				for _, nominatedNodeNameForExpectationEnabled := range nominatedNodeNameForExpectationEnabled {
-					if nominatedNodeNameForExpectationEnabled && !qHintEnabled {
-						// If the QHint feature gate is disabled, NominatedNodeNameForExpectation cannot be enabled
+					if (asyncAPICallsEnabled || nominatedNodeNameForExpectationEnabled) && !qHintEnabled {
+						// If the QHint feature gate is disabled, NominatedNodeNameForExpectation and SchedulerAsyncAPICalls cannot be enabled
 						// because that means users set the emilation version to 1.33 or later.
 						continue
 					}
@@ -946,6 +969,8 @@ func TestSchedulerScheduleOne(t *testing.T) {
 						var gotForgetPod *v1.Pod
 						var gotAssumedPod *v1.Pod
 						var gotBinding *v1.Binding
+						var gotNominatingInfo *framework.NominatingInfo
+
 						client := clientsetfake.NewClientset(item.sendPod)
 						informerFactory := informers.NewSharedInformerFactory(client, 0)
 						client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
@@ -1050,6 +1075,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 						sched.FailureHandler = func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *framework.NominatingInfo, start time.Time) {
 							gotPod = p.Pod
 							gotError = status.AsError()
+							gotNominatingInfo = ni
 
 							sched.handleSchedulingFailure(ctx, fwk, p, status, ni, start)
 						}
@@ -1129,6 +1155,16 @@ func TestSchedulerScheduleOne(t *testing.T) {
 						} else {
 							if len(unschedulablePods) > 0 {
 								t.Errorf("Expected unschedulable pods to be empty, but it's not.\nGot: %v", unschedulablePods)
+							}
+						}
+						if item.expectError != nil {
+							var expectedNominatingInfo *framework.NominatingInfo
+							// Check nominatingInfo expectation based on feature gate
+							if !nominatedNodeNameForExpectationEnabled {
+								expectedNominatingInfo = &framework.NominatingInfo{NominatingMode: framework.ModeOverride, NominatedNodeName: ""}
+							}
+							if diff := cmp.Diff(expectedNominatingInfo, gotNominatingInfo); diff != "" {
+								t.Errorf("Unexpected nominatingInfo diff (-want +got):\n%s", diff)
 							}
 						}
 						stopFunc()
@@ -2171,6 +2207,55 @@ func TestUpdatePod(t *testing.T) {
 			newNominatingInfo:        &framework.NominatingInfo{NominatingMode: framework.ModeOverride, NominatedNodeName: "node1"},
 			expectPatchRequest:       true,
 			expectedPatchDataPattern: `{"status":{"nominatedNodeName":"node1"}}`,
+		},
+		{
+			name: "Should not update nominated node name when nominatingInfo is nil",
+			currentPodConditions: []v1.PodCondition{
+				{
+					Type:               "currentType",
+					Status:             "currentStatus",
+					LastProbeTime:      metav1.NewTime(time.Date(2020, 5, 13, 0, 0, 0, 0, time.UTC)),
+					LastTransitionTime: metav1.NewTime(time.Date(2020, 5, 12, 0, 0, 0, 0, time.UTC)),
+					Reason:             "currentReason",
+					Message:            "currentMessage",
+				},
+			},
+			newPodCondition: &v1.PodCondition{
+				Type:               "currentType",
+				Status:             "newStatus",
+				LastProbeTime:      metav1.NewTime(time.Date(2020, 5, 13, 1, 1, 1, 1, time.UTC)),
+				LastTransitionTime: metav1.NewTime(time.Date(2020, 5, 12, 1, 1, 1, 1, time.UTC)),
+				Reason:             "newReason",
+				Message:            "newMessage",
+			},
+			currentNominatedNodeName: "existing-node",
+			newNominatingInfo:        nil,
+			expectPatchRequest:       true,
+			expectedPatchDataPattern: `{"status":{"\$setElementOrder/conditions":\[{"type":"currentType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"currentType"}]}}`,
+		},
+		{
+			name: "Should not make patch request when nominatingInfo is nil and pod condition is unchanged",
+			currentPodConditions: []v1.PodCondition{
+				{
+					Type:               "currentType",
+					Status:             "currentStatus",
+					LastProbeTime:      metav1.NewTime(time.Date(2020, 5, 13, 0, 0, 0, 0, time.UTC)),
+					LastTransitionTime: metav1.NewTime(time.Date(2020, 5, 12, 0, 0, 0, 0, time.UTC)),
+					Reason:             "currentReason",
+					Message:            "currentMessage",
+				},
+			},
+			newPodCondition: &v1.PodCondition{
+				Type:               "currentType",
+				Status:             "currentStatus",
+				LastProbeTime:      metav1.NewTime(time.Date(2020, 5, 13, 0, 0, 0, 0, time.UTC)),
+				LastTransitionTime: metav1.NewTime(time.Date(2020, 5, 12, 0, 0, 0, 0, time.UTC)),
+				Reason:             "currentReason",
+				Message:            "currentMessage",
+			},
+			currentNominatedNodeName: "existing-node",
+			newNominatingInfo:        nil,
+			expectPatchRequest:       false,
 		},
 	}
 	for _, asyncAPICallsEnabled := range []bool{true, false} {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -121,7 +121,6 @@ type Scheduler struct {
 	// registeredHandlers contains the registrations of all handlers. It's used to check if all handlers have finished syncing before the scheduling cycles start.
 	registeredHandlers []cache.ResourceEventHandlerRegistration
 
-	// nominatedNodeNameForExpectationEnabled stores whether the NominatedNodeNameForExpectation feature gate is enabled.
 	nominatedNodeNameForExpectationEnabled bool
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -121,6 +121,7 @@ type Scheduler struct {
 	// registeredHandlers contains the registrations of all handlers. It's used to check if all handlers have finished syncing before the scheduling cycles start.
 	registeredHandlers []cache.ResourceEventHandlerRegistration
 
+	// nominatedNodeNameForExpectationEnabled stores whether the NominatedNodeNameForExpectation feature gate is enabled.
 	nominatedNodeNameForExpectationEnabled bool
 }
 

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1557,13 +1557,13 @@ func TestNominatedNode(t *testing.T) {
 		deleteFakeNode bool
 		// Pods to be deleted. Optional.
 		podNamesToDelete []string
+		// Whether NominatedNodeName will be always nil at the end of the test,
+		// regardless of the NominatedNodeNameForExpectation feature gate state.
+		expectNilNominatedNodeName bool
 
 		// Register dummy plugin to simulate particular scheduling failures. Optional.
 		customPlugins     *configv1.Plugins
 		outOfTreeRegistry frameworkruntime.Registry
-
-		// Enable NominatedNodeNameForExpectation feature gate
-		enableNominatedNodeNameForExpectation bool
 	}{
 		{
 			name:         "mid-priority pod preempts low-priority pod, followed by a high-priority pod with another preemption",
@@ -1587,7 +1587,8 @@ func TestNominatedNode(t *testing.T) {
 				testutils.WaitForNominatedNodeName,
 				testutils.WaitForNominatedNodeName,
 			},
-			podNamesToDelete: []string{"low-1", "low-2", "low-3", "low-4"},
+			podNamesToDelete:           []string{"low-1", "low-2", "low-3", "low-4"},
+			expectNilNominatedNodeName: true,
 		},
 		{
 			name:         "mid-priority pod preempts low-priority pod, followed by a high-priority pod without additional preemption",
@@ -1628,26 +1629,6 @@ func TestNominatedNode(t *testing.T) {
 			// Delete the fake node to simulate an ErrNoNodesAvailable error.
 			deleteFakeNode:   true,
 			podNamesToDelete: []string{"low"},
-		},
-		{
-			name:         "node removal causes unschedulable pods to be re-enqueued with feature gate enabled",
-			nodeCapacity: map[v1.ResourceName]string{v1.ResourceCPU: "2"},
-			podsToCreate: [][]*v1.Pod{
-				{
-					st.MakePod().Name("low").Priority(lowPriority).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-				},
-				{
-					st.MakePod().Name("medium").Priority(mediumPriority).Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj(),
-				},
-			},
-			postChecks: []func(ctx context.Context, cs clientset.Interface, pod *v1.Pod) error{
-				testutils.WaitForPodToSchedule,
-				testutils.WaitForNominatedNodeName,
-			},
-			// Delete the fake node to simulate an ErrNoNodesAvailable error.
-			deleteFakeNode:                        true,
-			podNamesToDelete:                      []string{"low"},
-			enableNominatedNodeNameForExpectation: true,
 		},
 		{
 			name: "mid-priority pod preempts low-priority pod at the beginning, but could not find candidates after the nominated node is deleted",
@@ -1709,112 +1690,102 @@ func TestNominatedNode(t *testing.T) {
 
 	for _, asyncPreemptionEnabled := range []bool{true, false} {
 		for _, asyncAPICallsEnabled := range []bool{true, false} {
-			for _, tt := range tests {
-				t.Run(fmt.Sprintf("%s (Async preemption enabled: %v, Async API calls enabled: %v, NominatedNodeName for expectation enabled: %v)", tt.name, asyncPreemptionEnabled, asyncAPICallsEnabled, tt.enableNominatedNodeNameForExpectation), func(t *testing.T) {
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncPreemption, asyncPreemptionEnabled)
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncAPICalls, asyncAPICallsEnabled)
-					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NominatedNodeNameForExpectation, tt.enableNominatedNodeNameForExpectation)
+			for _, nominatedNodeNameForExpectationEnabled := range []bool{false} {
+				for _, tt := range tests {
+					t.Run(fmt.Sprintf("%s (Async preemption: %v, Async API calls: %v, NNN for expectation: %v)", tt.name, asyncPreemptionEnabled, asyncAPICallsEnabled, nominatedNodeNameForExpectationEnabled), func(t *testing.T) {
+						featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncPreemption, asyncPreemptionEnabled)
+						featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncAPICalls, asyncAPICallsEnabled)
+						featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NominatedNodeNameForExpectation, nominatedNodeNameForExpectationEnabled)
 
-					cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
-						Profiles: []configv1.KubeSchedulerProfile{{
-							SchedulerName: ptr.To(v1.DefaultSchedulerName),
-							Plugins:       tt.customPlugins,
-						}},
-					})
-					testCtx := initTest(
-						t,
-						"preemption",
-						scheduler.WithProfiles(cfg.Profiles...),
-						scheduler.WithFrameworkOutOfTreeRegistry(tt.outOfTreeRegistry),
-					)
+						cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
+							Profiles: []configv1.KubeSchedulerProfile{{
+								SchedulerName: ptr.To(v1.DefaultSchedulerName),
+								Plugins:       tt.customPlugins,
+							}},
+						})
+						testCtx := initTest(
+							t,
+							"preemption",
+							scheduler.WithProfiles(cfg.Profiles...),
+							scheduler.WithFrameworkOutOfTreeRegistry(tt.outOfTreeRegistry),
+						)
 
-					cs, ns := testCtx.ClientSet, testCtx.NS.Name
-					for _, node := range tt.initNodes {
-						if _, err := createNode(cs, node); err != nil {
-							t.Fatalf("Error creating initial node %v: %v", node.Name, err)
-						}
-					}
-
-					// Create a node with the specified capacity.
-					nodeName := "fake-node"
-					if _, err := createNode(cs, st.MakeNode().Name(nodeName).Capacity(tt.nodeCapacity).Obj()); err != nil {
-						t.Fatalf("Error creating node %v: %v", nodeName, err)
-					}
-
-					// Track pods that were once nominated
-					podsOnceNominated := []string{}
-					// Create pods and run post check if necessary.
-					for i, pods := range tt.podsToCreate {
-						for _, p := range pods {
-							p.Namespace = ns
-							if _, err := createPausePod(cs, p); err != nil {
-								t.Fatalf("Error creating pod %v: %v", p.Name, err)
+						cs, ns := testCtx.ClientSet, testCtx.NS.Name
+						for _, node := range tt.initNodes {
+							if _, err := createNode(cs, node); err != nil {
+								t.Fatalf("Error creating initial node %v: %v", node.Name, err)
 							}
 						}
-						// If necessary, run the post check function.
-						if len(tt.postChecks) > i && tt.postChecks[i] != nil {
+
+						// Create a node with the specified capacity.
+						nodeName := "fake-node"
+						if _, err := createNode(cs, st.MakeNode().Name(nodeName).Capacity(tt.nodeCapacity).Obj()); err != nil {
+							t.Fatalf("Error creating node %v: %v", nodeName, err)
+						}
+
+						// Create pods and run post check if necessary.
+						for i, pods := range tt.podsToCreate {
 							for _, p := range pods {
-								if err := tt.postChecks[i](testCtx.Ctx, cs, p); err != nil {
-									t.Fatalf("Pod %v didn't pass the postChecks[%v]: %v", p.Name, i, err)
+								p.Namespace = ns
+								if _, err := createPausePod(cs, p); err != nil {
+									t.Fatalf("Error creating pod %v: %v", p.Name, err)
+								}
+							}
+							// If necessary, run the post check function.
+							if len(tt.postChecks) > i && tt.postChecks[i] != nil {
+								for _, p := range pods {
+									if err := tt.postChecks[i](testCtx.Ctx, cs, p); err != nil {
+										t.Fatalf("Pod %v didn't pass the postChecks[%v]: %v", p.Name, i, err)
+									}
 								}
 							}
 						}
 
-						for _, p := range pods {
-							if p.Status.NominatedNodeName != "" {
-								podsOnceNominated = append(podsOnceNominated, p.Name)
+						// Delete the fake node if necessary.
+						if tt.deleteFakeNode {
+							if err := cs.CoreV1().Nodes().Delete(testCtx.Ctx, nodeName, *metav1.NewDeleteOptions(0)); err != nil {
+								t.Fatalf("Node %v cannot be deleted: %v", nodeName, err)
 							}
 						}
-					}
 
-					// Delete the fake node if necessary.
-					if tt.deleteFakeNode {
-						if err := cs.CoreV1().Nodes().Delete(testCtx.Ctx, nodeName, *metav1.NewDeleteOptions(0)); err != nil {
-							t.Fatalf("Node %v cannot be deleted: %v", nodeName, err)
+						// Force deleting the terminating pods if necessary.
+						// This is required if we demand to delete terminating Pods physically.
+						for _, podName := range tt.podNamesToDelete {
+							if err := deletePod(cs, podName, ns); err != nil {
+								t.Fatalf("Pod %v cannot be deleted: %v", podName, err)
+							}
 						}
-					}
 
-					if tt.enableNominatedNodeNameForExpectation {
-						for _, podName := range podsOnceNominated {
+						if nominatedNodeNameForExpectationEnabled && !tt.expectNilNominatedNodeName {
+							// Verify if .status.nominatedNodeName is not cleared when NominatedNodeNameForExpectation is enabled.
+							// Wait for 1 second to make sure the pod is re-processed, what would potentially clear the NominatedNodeName (when the feature won't work).
+							select {
+							case <-time.After(time.Second):
+							case <-testCtx.Ctx.Done():
+							}
+							pod, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, "medium", metav1.GetOptions{})
+							if err != nil {
+								t.Errorf("Error getting the medium pod: %v", err)
+							} else if len(pod.Status.NominatedNodeName) == 0 {
+								t.Errorf(".status.nominatedNodeName of the medium pod was cleared: %v", err)
+							}
+						} else {
+							// Verify if .status.nominatedNodeName is cleared when NominatedNodeNameForExpectation is disabled.
 							if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-								pod, err := cs.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
+								pod, err := cs.CoreV1().Pods(ns).Get(ctx, "medium", metav1.GetOptions{})
 								if err != nil {
-									t.Errorf("Error getting the %s pod: %v", podName, err)
+									t.Errorf("Error getting the medium pod: %v", err)
 								}
-								if len(pod.Status.NominatedNodeName) != 0 {
+								if len(pod.Status.NominatedNodeName) == 0 {
 									return true, nil
 								}
 								return false, err
 							}); err != nil {
-								t.Errorf(".status.nominatedNodeName of the pod %v/%v was not cleared after node deletion: %v", ns, podName, err)
+								t.Errorf(".status.nominatedNodeName of the medium pod was not cleared: %v", err)
 							}
 						}
-					}
-
-					// Force deleting the terminating pods if necessary.
-					// This is required if we demand to delete terminating Pods physically.
-					for _, podName := range tt.podNamesToDelete {
-						if err := deletePod(cs, podName, ns); err != nil {
-							t.Fatalf("Pod %v cannot be deleted: %v", podName, err)
-						}
-					}
-
-					// Verify if .status.nominatedNodeName is cleared when NominatedNodeNameForExpectation is disabled.
-					if !tt.enableNominatedNodeNameForExpectation {
-						if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-							pod, err := cs.CoreV1().Pods(ns).Get(ctx, "medium", metav1.GetOptions{})
-							if err != nil {
-								t.Errorf("Error getting the medium pod: %v", err)
-							}
-							if len(pod.Status.NominatedNodeName) == 0 {
-								return true, nil
-							}
-							return false, err
-						}); err != nil {
-							t.Errorf(".status.nominatedNodeName of the medium pod was not cleared: %v", err)
-						}
-					}
-				})
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds removes NominatedNodeName clearing logic in case of scheduling failure.

This PR is co-authored by @utam0k 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes: #132384
KEP: https://github.com/kubernetes/enhancements/issues/5278

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The scheduler no longer clears the `nominatedNodeName` field for Pods. External components, such as Cluster Autoscaler and Karpenter, are responsible for managing this field when needed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
