### PR TITLE
kubelet: Don't ignore idsPerPod config

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1075,12 +1075,17 @@ func NewMainKubelet(ctx context.Context,
 		StateDirectory:                   rootDirectory,
 	})
 	klet.shutdownManager = shutdownManager
-	klet.usernsManager, err = userns.MakeUserNsManager(klet)
+	handlers = append(handlers, shutdownManager)
+	klet.allocationManager.AddPodAdmitHandlers(handlers)
+
+	var usernsIDsPerPod *int64
+	if kubeCfg.UserNamespaces != nil {
+		usernsIDsPerPod = kubeCfg.UserNamespaces.IDsPerPod
+	}
+	klet.usernsManager, err = userns.MakeUserNsManager(klet, usernsIDsPerPod)
 	if err != nil {
 		return nil, fmt.Errorf("create user namespace manager: %w", err)
 	}
-	handlers = append(handlers, shutdownManager)
-	klet.allocationManager.AddPodAdmitHandlers(handlers)
 
 	// Finally, put the most recent version of the config on the Kubelet, so
 	// people can see how it was configured.

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -133,8 +133,8 @@ func (kl *Kubelet) HandlerSupportsUserNamespaces(rtHandler string) (bool, error)
 }
 
 // GetKubeletMappings gets the additional IDs allocated for the Kubelet.
-func (kl *Kubelet) GetKubeletMappings() (uint32, uint32, error) {
-	return kl.getKubeletMappings()
+func (kl *Kubelet) GetKubeletMappings(idsPerPod uint32) (uint32, uint32, error) {
+	return kl.getKubeletMappings(idsPerPod)
 }
 
 func (kl *Kubelet) GetMaxPods() int {

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -141,20 +141,6 @@ func (kl *Kubelet) GetMaxPods() int {
 	return kl.maxPods
 }
 
-func (kl *Kubelet) GetUserNamespacesIDsPerPod() uint32 {
-	userNs := kl.kubeletConfiguration.UserNamespaces
-	if userNs == nil {
-		return config.DefaultKubeletUserNamespacesIDsPerPod
-	}
-	idsPerPod := userNs.IDsPerPod
-	if idsPerPod == nil || *idsPerPod == 0 {
-		return config.DefaultKubeletUserNamespacesIDsPerPod
-	}
-	// The value is already validated to be <= MaxUint32,
-	// so we can safely drop the upper bits.
-	return uint32(*idsPerPod)
-}
-
 // getPodDir returns the full path to the per-pod directory for the pod with
 // the given UID.
 func (kl *Kubelet) getPodDir(podUID types.UID) string {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -403,7 +403,7 @@ func newTestKubeletWithImageList(
 		ShutdownGracePeriodCriticalPods: 0,
 	})
 	kubelet.shutdownManager = shutdownManager
-	kubelet.usernsManager, err = userns.MakeUserNsManager(kubelet)
+	kubelet.usernsManager, err = userns.MakeUserNsManager(kubelet, nil)
 	if err != nil {
 		t.Fatalf("Failed to create UserNsManager: %v", err)
 	}

--- a/pkg/kubelet/userns/types.go
+++ b/pkg/kubelet/userns/types.go
@@ -24,6 +24,6 @@ type userNsPodsManager interface {
 	HandlerSupportsUserNamespaces(runtimeHandler string) (bool, error)
 	GetPodDir(podUID types.UID) string
 	ListPodsFromDisk() ([]types.UID, error)
-	GetKubeletMappings() (uint32, uint32, error)
+	GetKubeletMappings(idsPerPod uint32) (uint32, uint32, error)
 	GetMaxPods() int
 }

--- a/pkg/kubelet/userns/types.go
+++ b/pkg/kubelet/userns/types.go
@@ -26,5 +26,4 @@ type userNsPodsManager interface {
 	ListPodsFromDisk() ([]types.UID, error)
 	GetKubeletMappings() (uint32, uint32, error)
 	GetMaxPods() int
-	GetUserNamespacesIDsPerPod() uint32
 }

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -130,16 +130,15 @@ func (m *UsernsManager) readMappingsFromFile(pod types.UID) ([]byte, error) {
 }
 
 func MakeUserNsManager(kl userNsPodsManager, idsPerPod *int64) (*UsernsManager, error) {
-	kubeletMappingID, kubeletMappingLen, err := kl.GetKubeletMappings()
-	if err != nil {
-		return nil, fmt.Errorf("kubelet mappings: %w", err)
-	}
-
 	userNsLength := uint32(kubedefaults.DefaultKubeletUserNamespacesIDsPerPod)
 	if idsPerPod != nil {
 		// The value is already validated as part of kubelet config validation, so we can safely
 		// cast it.
 		userNsLength = uint32(*idsPerPod)
+	}
+	kubeletMappingID, kubeletMappingLen, err := kl.GetKubeletMappings(userNsLength)
+	if err != nil {
+		return nil, fmt.Errorf("kubelet mappings: %w", err)
 	}
 
 	if userNsLength%userNsUnitLength != 0 {

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -130,6 +130,10 @@ func (m *UsernsManager) readMappingsFromFile(pod types.UID) ([]byte, error) {
 }
 
 func MakeUserNsManager(kl userNsPodsManager, idsPerPod *int64) (*UsernsManager, error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) {
+		return nil, nil
+	}
+
 	userNsLength := uint32(kubedefaults.DefaultKubeletUserNamespacesIDsPerPod)
 	if idsPerPod != nil {
 		// The value is already validated as part of kubelet config validation, so we can safely
@@ -168,11 +172,6 @@ func MakeUserNsManager(kl userNsPodsManager, idsPerPod *int64) (*UsernsManager, 
 		off:          off,
 		len:          len,
 		userNsLength: userNsLength,
-	}
-
-	// do not bother reading the list of pods if user namespaces are not enabled.
-	if !utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) {
-		return &m, nil
 	}
 
 	found, err := kl.ListPodsFromDisk()

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -36,7 +36,7 @@ func TestMakeUserNsManagerDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	_, err := MakeUserNsManager(testUserNsPodsManager)
+	_, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	assert.NoError(t, err)
 }
 
@@ -44,7 +44,7 @@ func TestReleaseDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(testUserNsPodsManager)
+	m, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	m.Release("some-pod")
@@ -96,7 +96,7 @@ func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testUserNsPodsManager := &testUserNsPodsManager{}
-			m, err := MakeUserNsManager(testUserNsPodsManager)
+			m, err := MakeUserNsManager(testUserNsPodsManager, nil)
 			require.NoError(t, err)
 
 			userns, err := m.GetOrCreateUserNamespaceMappings(test.pod, "")
@@ -114,7 +114,7 @@ func TestCleanupOrphanedPodUsernsAllocationsDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(testUserNsPodsManager)
+	m, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	err = m.CleanupOrphanedPodUsernsAllocations(nil, nil)

--- a/pkg/kubelet/userns/userns_manager_switch_test.go
+++ b/pkg/kubelet/userns/userns_manager_switch_test.go
@@ -44,7 +44,7 @@ func TestMakeUserNsManagerSwitch(t *testing.T) {
 		// manager, it will find these pods on disk with userns data.
 		podList: pods,
 	}
-	m, err := MakeUserNsManager(testUserNsPodsManager)
+	m, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// Record the pods on disk.
@@ -57,7 +57,7 @@ func TestMakeUserNsManagerSwitch(t *testing.T) {
 	// Test re-init works when the feature gate is disabled and there were some
 	// pods written on disk.
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
-	m2, err := MakeUserNsManager(testUserNsPodsManager)
+	m2, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// The feature gate is off, no pods should be allocated.
@@ -79,7 +79,7 @@ func TestGetOrCreateUserNamespaceMappingsSwitch(t *testing.T) {
 		// manager, it will find these pods on disk with userns data.
 		podList: pods,
 	}
-	m, err := MakeUserNsManager(testUserNsPodsManager)
+	m, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// Record the pods on disk.
@@ -93,7 +93,7 @@ func TestGetOrCreateUserNamespaceMappingsSwitch(t *testing.T) {
 	// pods registered on disk.
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 	// Create a new manager with the feature gate off and verify the userns range is nil.
-	m2, err := MakeUserNsManager(testUserNsPodsManager)
+	m2, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	for _, podUID := range pods {
@@ -116,7 +116,7 @@ func TestCleanupOrphanedPodUsernsAllocationsSwitch(t *testing.T) {
 		podList: listPods,
 	}
 
-	m, err := MakeUserNsManager(testUserNsPodsManager)
+	m, err := MakeUserNsManager(testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// Record the pods on disk.

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -77,7 +77,7 @@ func (m *testUserNsPodsManager) HandlerSupportsUserNamespaces(runtimeHandler str
 	return m.userns, nil
 }
 
-func (m *testUserNsPodsManager) GetKubeletMappings() (uint32, uint32, error) {
+func (m *testUserNsPodsManager) GetKubeletMappings(idsPerPod uint32) (uint32, uint32, error) {
 	if m.mappingFirstID != 0 {
 		return m.mappingFirstID, m.mappingLen, nil
 	}

--- a/pkg/kubelet/userns/userns_manager_windows.go
+++ b/pkg/kubelet/userns/userns_manager_windows.go
@@ -25,7 +25,7 @@ import (
 
 type UsernsManager struct{}
 
-func MakeUserNsManager(kl userNsPodsManager) (*UsernsManager, error) {
+func MakeUserNsManager(kl userNsPodsManager, idsPerPod *int64) (*UsernsManager, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
The idsPerPod where completely ignored since they were introduced in PR:
	https://github.com/kubernetes/kubernetes/pull/130028

The problem was the following:
	1. The userns manager (as well as all managers) is created before the config is copied to the kubelet object[1]
	2. The userns manager on creation is calling the kubelet_getter GetUserNamespacesIDsPerPod to get the idsPerPod
	3. The getter checks the configuration stored in the kubelet object, which hasn't been set at that point.
	4. As the config ss nil (unset), it returns the default value.

Therefore, the value was ignored.

To solve this, let's just pass the idsPerPod as a parameter to MakeUserNsManager(). This is the common pattern already used in the kubelet initialization.

[1]: https://github.com/kubernetes/kubernetes/blob/461ba83084ab7cb91ab692687bb7aedb05c6eb65/pkg/kubelet/kubelet.go#L1078-L1087
[2]: https://github.com/kubernetes/kubernetes/blob/461ba83084ab7cb91ab692687bb7aedb05c6eb65/pkg/kubelet/kubelet_getters.go#L145

cc @AkihiroSuda @giuseppe 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We now honor the idsPerPod config from the kubelet.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #133144 
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes: #133144 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The kubelet now honors the configuration userNamespaces.idsPerPod. Before it was ignored.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
