### PR TITLE
golangci: Disable staticcheck QF1008 in hints

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -314,5 +314,6 @@ linters:
     staticcheck:
       checks:
         - "all"
+        - "-QF1008"  # Omit embedded fields from selector expression
     testifylint:
       enable-all: true

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -326,6 +326,7 @@ linters:
     staticcheck:
       checks:
         - "all"
+        - "-QF1008"  # Omit embedded fields from selector expression
         - "-QF1001"  # Apply De Morgan’s law
         - "-QF1002"  # Convert untagged switch to tagged switch
         - "-QF1003"  # Convert if/else-if chain to tagged switch

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -251,6 +251,7 @@ linters:
     staticcheck:
       checks:
         - "all"
+        - "-QF1008"  # Omit embedded fields from selector expression
         {{- if .Base }}
         - "-QF1001"  # Apply De Morgan’s law
         - "-QF1002"  # Convert untagged switch to tagged switch


### PR DESCRIPTION
Disable QF1008 in pull-kubernetes-linter-hints, based on discussion in Slack #k8s-code-organization.  We might want a blocking check that forced a consistent style within a single file, but there is no reason to prefer a global choice between `obj.ObjectMeta.Name` and `obj.Name`.

/kind cleanup

```release-note
None
```