### PR TITLE
update template documentation links to use pkg.go.dev

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go
@@ -64,7 +64,7 @@ func (f *KubeTemplatePrintFlags) AddFlags(c *cobra.Command) {
 	}
 
 	if f.TemplateArgument != nil {
-		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
+		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [https://pkg.go.dev/text/template#pkg-overview].")
 		c.MarkFlagFilename("template")
 	}
 	if f.AllowMissingKeys != nil {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -115,7 +115,7 @@ func (f *GoTemplatePrintFlags) ToPrinter(templateFormat string) (printers.Resour
 // flags related to template printing to it
 func (f *GoTemplatePrintFlags) AddFlags(c *cobra.Command) {
 	if f.TemplateArgument != nil {
-		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
+		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [https://pkg.go.dev/text/template#pkg-overview].")
 		c.MarkFlagFilename("template")
 	}
 	if f.AllowMissingKeys != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces outdated and insecure link `http://golang.org/pkg` with `https://pkg.go.dev` in template flag description.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```