### PR TITLE
component-base/metrics: store WithContext ctx in a wrapper to avoid race

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -107,14 +107,6 @@ func (c *Counter) WithContext(ctx context.Context) CounterMetric {
 	return &exemplarCounterMetric{ctx: ctx, delegate: c.CounterMetric}
 }
 
-func (c *Counter) Add(v float64) {
-	c.CounterMetric.Add(v)
-}
-
-func (c *Counter) Inc() {
-	c.CounterMetric.Add(1)
-}
-
 // Add attaches an exemplar to the metric and then calls the delegate.
 func (e *exemplarCounterMetric) Add(v float64) {
 	if m, ok := e.delegate.(prometheus.ExemplarAdder); ok {

--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -30,7 +30,6 @@ import (
 // Counter is our internal representation for our wrapping struct around prometheus
 // counters. Counter implements both kubeCollector and CounterMetric.
 type Counter struct {
-	ctx context.Context
 	CounterMetric
 	*CounterOpts
 	lazyMetric
@@ -40,12 +39,10 @@ type Counter struct {
 // The implementation of the Metric interface is expected by testutil.GetCounterMetricValue.
 var _ Metric = &Counter{}
 
-// All supported exemplar metric types implement the metricWithExemplar interface.
-var _ metricWithExemplar = &Counter{}
-
 // exemplarCounterMetric holds a context to extract exemplar labels from, and a counter metric to attach them to. It implements the metricWithExemplar interface.
 type exemplarCounterMetric struct {
-	*Counter
+	ctx      context.Context
+	delegate CounterMetric
 }
 
 // NewCounter returns an object which satisfies the kubeCollector and CounterMetric interfaces.
@@ -107,26 +104,20 @@ func (c *Counter) initializeDeprecatedMetric() {
 
 // WithContext allows the normal Counter metric to pass in context.
 func (c *Counter) WithContext(ctx context.Context) CounterMetric {
-	c.ctx = ctx
-	return c.CounterMetric
-}
-
-// withExemplar initializes the exemplarMetric object and sets the exemplar value.
-func (c *Counter) withExemplar(v float64) {
-	(&exemplarCounterMetric{c}).withExemplar(v)
+	return &exemplarCounterMetric{ctx: ctx, delegate: c.CounterMetric}
 }
 
 func (c *Counter) Add(v float64) {
-	c.withExemplar(v)
+	c.CounterMetric.Add(v)
 }
 
 func (c *Counter) Inc() {
-	c.withExemplar(1)
+	c.CounterMetric.Add(1)
 }
 
-// withExemplar attaches an exemplar to the metric.
-func (e *exemplarCounterMetric) withExemplar(v float64) {
-	if m, ok := e.CounterMetric.(prometheus.ExemplarAdder); ok {
+// Add attaches an exemplar to the metric and then calls the delegate.
+func (e *exemplarCounterMetric) Add(v float64) {
+	if m, ok := e.delegate.(prometheus.ExemplarAdder); ok {
 		maybeSpanCtx := trace.SpanContextFromContext(e.ctx)
 		if maybeSpanCtx.IsValid() && maybeSpanCtx.IsSampled() {
 			exemplarLabels := prometheus.Labels{
@@ -138,7 +129,12 @@ func (e *exemplarCounterMetric) withExemplar(v float64) {
 		}
 	}
 
-	e.CounterMetric.Add(v)
+	e.delegate.Add(v)
+}
+
+// Inc attaches an exemplar to the metric and then calls the delegate.
+func (e *exemplarCounterMetric) Inc() {
+	e.Add(1)
 }
 
 // CounterVec is the internal representation of our wrapping struct around prometheus

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"bytes"
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
@@ -380,4 +382,119 @@ func TestCounterWithExemplar(t *testing.T) {
 			t.Fatalf("Got unexpected label %s", *l.Name)
 		}
 	}
+}
+
+// TestCounterConcurrentWithContextRace reproduces the race condition in Counter.WithContext
+// where c.ctx is written concurrently with reads in withExemplar method.
+// This test simulates the real authentication flow that triggers the race:
+// x509.AuthenticateRequest -> union.AuthenticateRequest -> group.AuthenticateRequest
+func TestCounterConcurrentWithContextRace(t *testing.T) {
+	opts := &CounterOpts{
+		Namespace: "apiserver",
+		Subsystem: "authentication",
+		Name:      "requests_total",
+		Help:      "Authentication requests counter for race condition testing",
+	}
+
+	c := NewCounter(opts)
+
+	// Force initialization by calling initializeMetric directly
+	c.initializeMetric()
+
+	// Create contexts with trace spans to trigger exemplar code path
+	ctx1, span1 := createContextWithSpanCounter("x509-auth", "authenticate-request")
+	defer span1.End()
+	ctx2, span2 := createContextWithSpanCounter("union-auth", "union-authenticate")
+	defer span2.End()
+
+	var wg sync.WaitGroup
+	iterations := 10000 // Increase iterations to make race more likely
+
+	// Goroutine 1: Simulate x509 Authenticator calling WithContext
+	// This matches: x509.(*Authenticator).AuthenticateRequest() calling WithContext
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Simulate authentication request processing
+			simulateX509AuthenticateRequestCounter(c, ctx1, i)
+		}
+	}()
+
+	// Goroutine 2: Simulate concurrent Add/Inc calls (metrics collection)
+	// This matches the withExemplar/Add path that reads c.ctx
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			c.Add(float64(i % 10))
+			if i%2 == 0 {
+				c.Inc()
+			}
+		}
+	}()
+
+	// Goroutine 3: Simulate union AuthenticateRequest calling WithContext
+	// This matches: union.(*unionAuthRequestHandler).AuthenticateRequest()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Simulate union authentication processing
+			simulateUnionAuthenticateRequestCounter(c, ctx2, i)
+		}
+	}()
+
+	// Goroutine 4: Simulate group AuthenticateRequest calling WithContext
+	// This matches: group.(*AuthenticatedGroupAdder).AuthenticateRequest()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Simulate group authentication processing
+			simulateGroupAuthenticateRequestCounter(c, ctx1, ctx2, i)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// simulateX509AuthenticateRequestCounter simulates the call path from x509 authenticator
+func simulateX509AuthenticateRequestCounter(c CounterMetric, ctx context.Context, iteration int) {
+	// Simulate the authentication request processing that calls WithContext
+	if cWithCtx, ok := c.(*Counter); ok {
+		cWithCtx.WithContext(ctx)
+	}
+}
+
+// simulateUnionAuthenticateRequestCounter simulates the call path from union authenticator
+func simulateUnionAuthenticateRequestCounter(c CounterMetric, ctx context.Context, iteration int) {
+	// Simulate union authentication processing
+	if cWithCtx, ok := c.(*Counter); ok {
+		cWithCtx.WithContext(ctx)
+	}
+}
+
+// simulateGroupAuthenticateRequestCounter simulates the call path from group authenticator
+func simulateGroupAuthenticateRequestCounter(c CounterMetric, ctx1, ctx2 context.Context, iteration int) {
+	// Alternate between contexts to simulate different authentication scenarios
+	ctx := ctx1
+	if iteration%3 == 0 {
+		ctx = ctx2
+	}
+
+	if cWithCtx, ok := c.(*Counter); ok {
+		cWithCtx.WithContext(ctx)
+	}
+}
+
+// Helper function to create a context with a valid trace span
+func createContextWithSpanCounter(traceID, spanID string) (context.Context, trace.Span) {
+	ctx := context.Background()
+
+	// Create a noop tracer and span for testing
+	tracer := tracenoop.NewTracerProvider().Tracer("test")
+	ctx, span := tracer.Start(ctx, "test-span")
+
+	return ctx, span
 }

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -314,7 +314,6 @@ func TestCounterWithExemplar(t *testing.T) {
 		Name: "metric_exemplar_test",
 		Help: "helpless",
 	})
-	_ = counter.WithContext(ctxForSpanCtx)
 
 	// Register counter.
 	registry := newKubeRegistry(apimachineryversion.Info{
@@ -325,9 +324,9 @@ func TestCounterWithExemplar(t *testing.T) {
 	registry.MustRegister(counter)
 
 	// Call underlying exemplar methods.
-	counter.Add(toAdd)
-	counter.Inc()
-	counter.Inc()
+	counter.WithContext(ctxForSpanCtx).Add(toAdd)
+	counter.WithContext(ctxForSpanCtx).Inc()
+	counter.WithContext(ctxForSpanCtx).Inc()
 
 	// Gather.
 	mfs, err := registry.Gather()

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -333,7 +333,6 @@ func TestHistogramWithExemplar(t *testing.T) {
 		Help:    "helpless",
 		Buckets: []float64{100},
 	})
-	_ = histogram.WithContext(ctxForSpanCtx)
 
 	registry := newKubeRegistry(apimachineryversion.Info{
 		Major:      "1",
@@ -343,7 +342,7 @@ func TestHistogramWithExemplar(t *testing.T) {
 	registry.MustRegister(histogram)
 
 	// Act.
-	histogram.Observe(value)
+	histogram.WithContext(ctxForSpanCtx).Observe(value)
 
 	// Assert.
 	mfs, err := registry.Gather()

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -26,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
@@ -490,4 +492,117 @@ func TestHistogramVecWithExemplar(t *testing.T) {
 			t.Fatalf("Got unexpected label %s", *l.Name)
 		}
 	}
+}
+
+// TestHistogramConcurrentWithContextRace reproduces the race condition in Histogram.WithContext
+// where h.ctx is written concurrently with reads in withExemplar method.
+// This test simulates the real authentication flow that triggers the race:
+// x509.AuthenticateRequest -> union.AuthenticateRequest -> group.AuthenticateRequest
+func TestHistogramConcurrentWithContextRace(t *testing.T) {
+	opts := &HistogramOpts{
+		Namespace: "apiserver",
+		Subsystem: "authentication",
+		Name:      "requests_total",
+		Help:      "Authentication requests histogram for race condition testing",
+		Buckets:   prometheus.DefBuckets,
+	}
+
+	h := NewHistogram(opts)
+
+	// Force initialization by calling initializeMetric directly
+	h.initializeMetric()
+
+	// Create contexts with trace spans to trigger exemplar code path
+	ctx1, span1 := createContextWithSpan("x509-auth", "authenticate-request")
+	defer span1.End()
+	ctx2, span2 := createContextWithSpan("union-auth", "union-authenticate")
+	defer span2.End()
+
+	var wg sync.WaitGroup
+	iterations := 10000 // Increase iterations to make race more likely
+
+	// Goroutine 1: Simulate x509 Authenticator calling WithContext
+	// This matches: x509.(*Authenticator).AuthenticateRequest() calling WithContext
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Simulate authentication request processing
+			simulateX509AuthenticateRequest(h, ctx1, i)
+		}
+	}()
+
+	// Goroutine 2: Simulate concurrent Observe calls (metrics collection)
+	// This matches the withExemplar/Observe path that reads h.ctx
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			h.Observe(float64(i % 10))
+		}
+	}()
+
+	// Goroutine 3: Simulate union AuthenticateRequest calling WithContext
+	// This matches: union.(*unionAuthRequestHandler).AuthenticateRequest()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Simulate union authentication processing
+			simulateUnionAuthenticateRequest(h, ctx2, i)
+		}
+	}()
+
+	// Goroutine 4: Simulate group AuthenticateRequest calling WithContext
+	// This matches: group.(*AuthenticatedGroupAdder).AuthenticateRequest()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Simulate group authentication processing
+			simulateGroupAuthenticateRequest(h, ctx1, ctx2, i)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// simulateX509AuthenticateRequest simulates the call path from x509 authenticator
+func simulateX509AuthenticateRequest(h ObserverMetric, ctx context.Context, iteration int) {
+	// Simulate the authentication request processing that calls WithContext
+	if hWithCtx, ok := h.(*Histogram); ok {
+		hWithCtx.WithContext(ctx)
+	}
+}
+
+// simulateUnionAuthenticateRequest simulates the call path from union authenticator
+func simulateUnionAuthenticateRequest(h ObserverMetric, ctx context.Context, iteration int) {
+	// Simulate union authentication processing
+	if hWithCtx, ok := h.(*Histogram); ok {
+		hWithCtx.WithContext(ctx)
+	}
+}
+
+// simulateGroupAuthenticateRequest simulates the call path from group authenticator
+func simulateGroupAuthenticateRequest(h ObserverMetric, ctx1, ctx2 context.Context, iteration int) {
+	// Alternate between contexts to simulate different authentication scenarios
+	ctx := ctx1
+	if iteration%3 == 0 {
+		ctx = ctx2
+	}
+
+	if hWithCtx, ok := h.(*Histogram); ok {
+		hWithCtx.WithContext(ctx)
+	}
+}
+
+// Helper function to create a context with a valid trace span
+func createContextWithSpan(traceID, spanID string) (context.Context, trace.Span) {
+	ctx := context.Background()
+
+	// Create a noop tracer and span for testing
+	tracer := tracenoop.NewTracerProvider().Tracer("test")
+	ctx, span := tracer.Start(ctx, "test-span")
+
+	return ctx, span
 }

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -210,11 +210,6 @@ func (c *selfCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- c.metric
 }
 
-// metricWithExemplar is an interface that knows how to attach an exemplar to certain supported metric types.
-type metricWithExemplar interface {
-	withExemplar(v float64)
-}
-
 // no-op vecs for convenience
 var noopCounterVec = &prometheus.CounterVec{}
 var noopHistogramVec = &prometheus.HistogramVec{}


### PR DESCRIPTION
/kind bug

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The `Histogram.WithContext` func changed the instance in-place, and it is called in x509 authenticate with that. All requests going in there race:

```
==================
WARNING: DATA RACE
Write at 0x00c0007b2000 by goroutine 1636:
  k8s.io/component-base/metrics.(*Histogram).WithContext()
      .cache/go/mod/k8s.io/component-base@v0.32.3/metrics/histogram.go:116 +0x54d
  k8s.io/apiserver/pkg/authentication/request/x[509](.../jobs/193911942#L509).(*Authenticator).AuthenticateRequest()
      .cache/go/mod/k8s.io/apiserver@v0.32.3/pkg/authentication/request/x509/x509.go:180 +0x492
  k8s.io/apiserver/pkg/authentication/request/union.(*unionAuthRequestHandler).AuthenticateRequest()
      .cache/go/mod/k8s.io/apiserver@v0.32.3/pkg/authentication/request/union/union.go:56 +0xee
  k8s.io/apiserver/pkg/authentication/group.(*AuthenticatedGroupAdder).AuthenticateRequest()
      .cache/go/mod/k8s.io/apiserver@v0.32.3/pkg/authentication/group/authenticated_group_adder.go:40 +0x62
```

Probably this was introduced in https://github.com/kubernetes/kubernetes/pull/124013.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
