### PR TITLE
Pluginmanager: unregister plugin on a service socket file removal

### DIFF
--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -169,7 +169,7 @@ func TestPluginManager(t *testing.T) {
 
 		// Add a new plugin
 		pluginName := fmt.Sprintf("example-plugin-%d", i)
-		p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+		p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 		require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 
 		// Verify that the plugin is registered

--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher_test.go
@@ -114,7 +114,7 @@ func TestPluginRegistration(t *testing.T) {
 		socketPath := filepath.Join(socketDir, fmt.Sprintf("plugin-%d.sock", i))
 		pluginName := fmt.Sprintf("example-plugin-%d", i)
 
-		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 		require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 
 		pluginInfo := GetPluginInfo(p)
@@ -149,7 +149,7 @@ func TestPluginRegistrationSameName(t *testing.T) {
 	pluginName := "dep-example-plugin"
 	for i := 0; i < 10; i++ {
 		socketPath := filepath.Join(socketDir, fmt.Sprintf("plugin-%d.sock", i))
-		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 		require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 
 		pluginInfo := GetPluginInfo(p)
@@ -174,7 +174,7 @@ func TestPluginReRegistration(t *testing.T) {
 	// and recreate it.
 	socketPath := filepath.Join(socketDir, "plugin-reregistration.sock")
 	pluginName := "reregister-plugin"
-	p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+	p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 	pluginInfo := GetPluginInfo(p)
 	lastTimestamp := time.Now()
@@ -190,7 +190,7 @@ func TestPluginReRegistration(t *testing.T) {
 
 		// Add the plugin again
 		pluginName := fmt.Sprintf("dep-example-plugin-%d", i)
-		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 		require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 		waitForRegistration(t, pluginInfo.SocketPath, dsw)
 
@@ -216,7 +216,7 @@ func TestPluginRegistrationAtKubeletStart(t *testing.T) {
 		socketPath := filepath.Join(socketDir, fmt.Sprintf("plugin-%d.sock", i))
 		pluginName := fmt.Sprintf("example-plugin-%d", i)
 
-		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+		p := NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 		require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 		defer func(p *examplePlugin) {
 			require.NoError(t, p.Stop())

--- a/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler_test.go
@@ -191,7 +191,7 @@ func Test_Run_Positive_Register(t *testing.T) {
 	go reconciler.Run(stopChan)
 	socketPath := filepath.Join(socketDir, "plugin.sock")
 	pluginName := fmt.Sprintf("example-plugin")
-	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 	defer func() {
 		require.NoError(t, p.Stop())
@@ -240,7 +240,7 @@ func Test_Run_Positive_RegisterThenUnregister(t *testing.T) {
 
 	socketPath := filepath.Join(socketDir, "plugin.sock")
 	pluginName := fmt.Sprintf("example-plugin")
-	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 	dsw.AddOrUpdatePlugin(socketPath)
 	plugins := dsw.GetPluginsToRegister()
@@ -296,7 +296,7 @@ func Test_Run_Positive_ReRegister(t *testing.T) {
 
 	socketPath := filepath.Join(socketDir, "plugin2.sock")
 	pluginName := fmt.Sprintf("example-plugin2")
-	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, supportedVersions...)
+	p := pluginwatcher.NewTestExamplePlugin(pluginName, registerapi.DevicePlugin, socketPath, "", supportedVersions...)
 	require.NoError(t, p.Serve("v1beta1", "v1beta2"))
 	dsw.AddOrUpdatePlugin(socketPath)
 	plugins := dsw.GetPluginsToRegister()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Plugin manger only monitored registration sockets and triggered plugin unregistration on their removal. This PR adds similar functionality for a service sockets. The setup with different registration and service sockets is used by `CSI` and `DRA` plugin setups, so this change improves their reliability and ensures proper cleanup.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/132660

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
pluginmanager: unregister plugin when service socket is removed.
```

/sig node
/cc @pohly @nojnhuh @lauralorenz @SergeyKanzhelev 
