### PR TITLE
authz tests: delay response in context cancelled scenario

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics_test.go
@@ -107,9 +107,16 @@ func TestAuthorizerMetrics(t *testing.T) {
 			if service.statusCode == 0 {
 				service.statusCode = 200
 			}
-			service.reviewHook = func(*authorizationv1.SubjectAccessReview) {
-				if scenario.canceledRequest {
+
+			testFinishedCtx, testFinishedCancel := context.WithCancel(context.Background())
+			defer testFinishedCancel()
+			if scenario.canceledRequest {
+				service.reviewHook = func(*authorizationv1.SubjectAccessReview) {
 					cancel()
+					// net/http transport still attempts to use a response if it's
+					// available right when it's handling context cancellation,
+					// we need to delay the response.
+					<-testFinishedCtx.Done()
 				}
 			}
 			service.allow = !scenario.authFakeServiceDeny
@@ -120,6 +127,9 @@ func TestAuthorizerMetrics(t *testing.T) {
 				return
 			}
 			defer server.Close()
+			// testFinishedCtx must be cancelled before we close the server, otherwise
+			// closing the server hangs on an active connection from the listener.
+			defer testFinishedCancel()
 
 			fakeAuthzMetrics := &fakeAuthorizerMetrics{}
 			wh, err := newV1Authorizer(server.URL, scenario.clientCert, scenario.clientKey, scenario.clientCA, 0, fakeAuthzMetrics, cel.NewDefaultCompiler(), []apiserver.WebhookMatchCondition{}, "")


### PR DESCRIPTION
 #### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
It delays authorizer response right after context cancellation to avoid racing with the stdlib's net/http transport context cancellation handling.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/131069

#### Special notes for your reviewer:
https://cs.opensource.google/go/go/+/refs/tags/go1.24.5:src/net/http/transport.go;l=2864-2872

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
