### PR TITLE
Use `math/rand/v2` in `k8s.io/apimachinery/pkg/util/rand`

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/rand/rand_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/rand/rand_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package rand
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"testing"
 )
@@ -65,7 +65,7 @@ func TestIntn(t *testing.T) {
 
 func TestPerm(t *testing.T) {
 	Seed(5)
-	r := rand.New(rand.NewSource(5))
+	r := rand.New(rand.NewPCG(5, 0))
 	for i := 1; i < 20; i++ {
 		actual := Perm(i)
 		expected := r.Perm(i)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

The `math/rand/v2` Go standard libary package was added in Go 1.22[^1][^2][^3]. The new package provides a way to construct PRNG sources which can be accessed concurrently, making the locking in `k8s.io/apimachinery/pkg/util/rand` unnecessary.

[^1]: https://go.dev/blog/randv2
[^2]: https://go.dev/doc/go1.22#math_rand_v2
[^3]: https://pkg.go.dev/math/rand/v2

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
