### PR TITLE
fix: fixed an issue with growSlice taking a long time; fixed an issue where DeepEqual was never returned true.

### DIFF
--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -270,7 +270,7 @@ func AddOrUpdateTolerationInPodSpec(spec *v1.PodSpec, toleration *v1.Toleration)
 	for i := range podTolerations {
 		if toleration.MatchToleration(&podTolerations[i]) {
 			if helper.Semantic.DeepEqual(*toleration, podTolerations[i]) {
-				return false
+				return updated
 			}
 			newTolerations = append(newTolerations, *toleration)
 			updated = true

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -264,7 +264,7 @@ func AddOrUpdateTolerationInPodSpec(spec *v1.PodSpec, toleration *v1.Toleration)
 	podTolerations := spec.Tolerations
 
 	// do not grow the slice in runtime, the length is already known (PodSpec.Tolerations + toleration)
-	newTolerations := make([]v1.Toleration, len(podTolerations) + 1)
+	newTolerations := make([]v1.Toleration, 0, len(podTolerations) + 1)
 
 	updated := false
 	for i := range podTolerations {
@@ -272,21 +272,21 @@ func AddOrUpdateTolerationInPodSpec(spec *v1.PodSpec, toleration *v1.Toleration)
 			if helper.Semantic.DeepEqual(*toleration, podTolerations[i]) {
 				return false
 			}
-			newTolerations[i] = *toleration
+			newTolerations = append(newTolerations, *toleration)
 			updated = true
 			continue
 		}
 
-		newTolerations[i] = podTolerations[i]
+		newTolerations = append(newTolerations, podTolerations[i])
 	}
 
 	if !updated {
-		newTolerationsLastIndex := len(newTolerations) - 1
-		newTolerations[newTolerationsLastIndex] = *toleration
+		newTolerations = append(newTolerations, *toleration)
+		updated = true
 	}
 
 	spec.Tolerations = newTolerations
-	return true
+	return updated
 }
 
 // GetMatchingTolerations returns true and list of Tolerations matching all Taints if all are tolerated, or false otherwise.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixed an issue in the controller manager that could occur in large clusters with thousands of nodes and dozens of daemon sets.
Also fixed a bug where one of the code branches never started.

The main problem:
in our cluster controller-manager is spending a lot of time just to grow a slice
pprof flamegraph:
<img width="1511" height="716" alt="image" src="https://github.com/user-attachments/assets/a902e51b-3726-41b6-8c40-8acce5df3ba4" />


#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
