### PR TITLE
Change KYAML gate to on-by-default

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -33,7 +33,7 @@ func (f *JSONYamlPrintFlags) AllowedFormats() []string {
 	}
 	formats := []string{"json", "yaml"}
 	// We can't use the cmdutil pkg directly because of import cycle.
-	if strings.ToLower(os.Getenv("KUBECTL_KYAML")) == "true" {
+	if strings.ToLower(os.Getenv("KUBECTL_KYAML")) != "false" {
 		formats = append(formats, "kyaml")
 	}
 	return formats

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources_test.go
@@ -18,6 +18,7 @@ package apiresources
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -57,8 +58,8 @@ See 'kubectl api-resources -h' for help and examples`
 	if err == nil {
 		t.Fatalf("An error was expected but not returned")
 	}
-	expectedError = `unable to match a printer suitable for the output format "foo", allowed formats are: json,name,wide,yaml`
-	if err.Error() != expectedError {
+	expectedError = `unable to match a printer suitable for the output format "foo", allowed formats are:`
+	if !strings.HasPrefix(err.Error(), expectedError) {
 		t.Fatalf("Unexpected error: %v\n expected: %v", err, expectedError)
 	}
 }


### PR DESCRIPTION
Should be low-risk because it is something you have to CHOOSE to use.

/kind feature
/kind api-change

KEP: https://github.com/kubernetes/enhancements/issues/5295

```release-note
Support for `kubectl get -o kyaml` is now on by default.  To disable it, set `KUBECTL_KYAML=false`.
```
