### PR TITLE
e2e: node: fix serial lanes

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -437,16 +437,6 @@ func loadSystemSpecFromFile(filename string) (*system.SysSpec, error) {
 	return spec, nil
 }
 
-// isNodeReady returns true if a node is ready; false otherwise.
-func isNodeReady(node *v1.Node) bool {
-	for _, c := range node.Status.Conditions {
-		if c.Type == v1.NodeReady {
-			return c.Status == v1.ConditionTrue
-		}
-	}
-	return false
-}
-
 func setExtraEnvs() {
 	for name, value := range framework.TestContext.ExtraEnvs {
 		os.Setenv(name, value)

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -45,6 +45,7 @@ import (
 )
 
 func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration, cgroupManager cm.CgroupManager) {
+	initialConfig.ReservedSystemCPUs = ""
 	initialConfig.EnforceNodeAllocatable = []string{"pods", kubeReservedCgroup, systemReservedCgroup}
 	initialConfig.SystemReserved = map[string]string{
 		string(v1.ResourceCPU):    "100m",
@@ -71,9 +72,9 @@ func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration, 
 var _ = SIGDescribe("Node Container Manager", framework.WithSerial(), func() {
 	f := framework.NewDefaultFramework("node-container-manager")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
 	f.Describe("Validate Node Allocatable", feature.NodeAllocatable, func() {
 		ginkgo.It("sets up the node and runs the test", func(ctx context.Context) {
-			ginkgo.Skip("currently broken")
 			framework.ExpectNoError(runTest(ctx, f))
 		})
 	})

--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -642,14 +642,6 @@ func emitSignalPrepareForShutdown(b bool) error {
 	return conn.Emit("/org/freedesktop/login1", "org.freedesktop.login1.Manager.PrepareForShutdown", b)
 }
 
-func getNodeReadyStatus(ctx context.Context, f *framework.Framework) bool {
-	nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	framework.ExpectNoError(err)
-	// Assuming that there is only one node, because this is a node e2e test.
-	gomega.Expect(nodeList.Items).To(gomega.HaveLen(1), "the number of nodes is not as expected")
-	return isNodeReady(&nodeList.Items[0])
-}
-
 const (
 	// https://github.com/kubernetes/kubernetes/blob/1dd781ddcad454cc381806fbc6bd5eba8fa368d7/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go#L43-L44
 	podShutdownReason  = "Terminated"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

- Fix the node container manager tests to safely reset the cpumanager policy using the existing, exercised utilities vs roll another (apparently buggy) variant.
- Fix the podresources tests to avoid panic for nil map when setting a feature gate


#### Which issue(s) this PR is related to:
133314

#### Special notes for your reviewer:
Collecting all the fixes in this PR

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
