### PR TITLE
Rename allocationManager stateFileName and fix comment

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -53,10 +53,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 )
 
-// podStatusManagerStateFile is the file name where status manager stores its state
+// allocatedPodsStateFileName and actuatedPodsStateFileName are the two file names where allocation manager stores its state,
+// for keeping track of pod resource information. allocatedPodsStateFileName records the resources allocated to a pod's container
+// while actuatedPodsStateFileName records the actuated resources.
 const (
-	allocatedPodsStateFile = "allocated_pods_state"
-	actuatedPodsStateFile  = "actuated_pods_state"
+	allocatedPodsStateFileName = "allocated_pods_state"
+	actuatedPodsStateFileName  = "actuated_pods_state"
 
 	initialRetryDelay = 30 * time.Second
 	retryDelay        = 3 * time.Minute
@@ -160,8 +162,8 @@ func NewManager(checkpointDirectory string,
 	recorder record.EventRecorder,
 ) Manager {
 	return &manager{
-		allocated: newStateImpl(checkpointDirectory, allocatedPodsStateFile),
-		actuated:  newStateImpl(checkpointDirectory, actuatedPodsStateFile),
+		allocated: newStateImpl(checkpointDirectory, allocatedPodsStateFileName),
+		actuated:  newStateImpl(checkpointDirectory, actuatedPodsStateFileName),
 
 		containerManager: containerManager,
 		statusManager:    statusManager,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

This commit renames allocationManager state file variable name, using same suffix ([StateFileName](https://cs.k8s.io/?q=StateFileName&i=nope&literal=nope&files=&excludeFiles=&repos=)) used in other managers state filenames. Comment fixed to use correct names, with a short summary. Reasoning to improve code readers understanding of the code while reading this code part.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
