### PR TITLE
node: unblock e2e serial lanes

### DIFF
--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -73,6 +73,7 @@ var _ = SIGDescribe("Node Container Manager", framework.WithSerial(), func() {
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	f.Describe("Validate Node Allocatable", feature.NodeAllocatable, func() {
 		ginkgo.It("sets up the node and runs the test", func(ctx context.Context) {
+			ginkgo.Skip("currently broken")
 			framework.ExpectNoError(runTest(ctx, f))
 		})
 	})
@@ -85,6 +86,8 @@ var _ = SIGDescribe("Node Container Manager", framework.WithSerial(), func() {
 		// The closest approximation is this test in this current form, using a kubelet restart. This at least
 		// acts as non regression testing, so it still brings value.
 		ginkgo.It("should correctly start with cpumanager none policy in use with systemd", func(ctx context.Context) {
+			ginkgo.Skip("currently broken")
+
 			if !IsCgroup2UnifiedMode() {
 				ginkgo.Skip("this test requires cgroups v2")
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
sig-node serial lanes are currently severely broken. We need to quickly restore signal.
Because of time pressure, disable problematic tests to recover signal.
By all means we will need to fix these tests once signal is restored, so this is a band-aid PR meant to fix the worst emergency, not the complete solution

#### Which issue(s) this PR is related to:
#133314

#### Special notes for your reviewer:
Will track long-term fixes editing this message
- https://github.com/kubernetes/kubernetes/pull/133336

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
