### PR TITLE
Using processStart time to handle execution delays during stress tests

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -90,3 +90,8 @@ func CustomMustRegister(cs ...metrics.StableCollector) {
 		prometheus.MustRegister(c)
 	}
 }
+
+// GetProcessStart return processStart value
+func GetProcessStart() time.Time {
+	return processStart
+}

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
@@ -21,23 +21,34 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
-	"time"
 )
 
 const (
 	processStartTimeHeader = "Process-Start-Time-Unix"
 )
 
+var (
+	processStartTestCopy = &processStart
+)
+
 func TestProcessStartTimeHeader(t *testing.T) {
-	now := time.Now()
+	now := GetProcessStart()
 	handler := Handler()
 
-	request, _ := http.NewRequest("GET", "/", nil)
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
 	writer := httptest.NewRecorder()
 	handler.ServeHTTP(writer, request)
 	got := writer.Header().Get(processStartTimeHeader)
 	gotInt, _ := strconv.ParseInt(got, 10, 64)
 	if gotInt != now.Unix() {
 		t.Errorf("got %d, wanted %d", gotInt, now.Unix())
+	}
+}
+
+// processStart must never be reassigned after init.
+// This test ensures processStart doesn't change across calls
+func TestProcessStartImmutable(t *testing.T) {
+	if *processStartTestCopy != processStart {
+		t.Errorf("processStart test values differ: %v != %v", processStartTestCopy, processStart)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 Under stress conditions, there is minor execution delay b/w `time.Now()` and handler initialisation. Used existing `processStart` time to handle this.
#### Which issue(s) this PR is related to:
Fixes #132887
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Here is the o/p of stress tool with PR change on `arm64` arch

```
% stress ./legacyregistry.test -test.run ^TestProcessStartTimeHeader   


5s: 3089 runs so far, 0 failures, 10 active
10s: 6176 runs so far, 0 failures, 10 active
15s: 9257 runs so far, 0 failures, 10 active
20s: 12390 runs so far, 0 failures, 10 active
25s: 15471 runs so far, 0 failures, 10 active
30s: 18635 runs so far, 0 failures, 10 active
35s: 21644 runs so far, 0 failures, 10 active
40s: 24546 runs so far, 0 failures, 10 active
45s: 27442 runs so far, 0 failures, 10 active
50s: 30404 runs so far, 0 failures, 10 active
55s: 33381 runs so far, 0 failures, 10 active
1m0s: 36396 runs so far, 0 failures, 10 active
1m5s: 39415 runs so far, 0 failures, 10 active
1m10s: 42445 runs so far, 0 failures, 10 active
1m15s: 45432 runs so far, 0 failures, 10 active
1m20s: 48330 runs so far, 0 failures, 10 active
1m25s: 51292 runs so far, 0 failures, 10 active
1m30s: 54340 runs so far, 0 failures, 10 active
1m35s: 57421 runs so far, 0 failures, 10 active
1m40s: 60467 runs so far, 0 failures, 10 active
1m45s: 63412 runs so far, 0 failures, 10 active
1m50s: 66532 runs so far, 0 failures, 10 active
1m55s: 69622 runs so far, 0 failures, 10 active
2m0s: 72739 runs so far, 0 failures, 10 active
2m5s: 75821 runs so far, 0 failures, 10 active
2m10s: 78949 runs so far, 0 failures, 10 active
2m15s: 81750 runs so far, 0 failures, 10 active
2m20s: 84625 runs so far, 0 failures, 9 active
2m25s: 87513 runs so far, 0 failures, 10 active
2m30s: 90372 runs so far, 0 failures, 10 active
2m35s: 93371 runs so far, 0 failures, 10 active
2m40s: 96486 runs so far, 0 failures, 10 active
2m45s: 99498 runs so far, 0 failures, 10 active
2m50s: 102399 runs so far, 0 failures, 10 active
2m55s: 105473 runs so far, 0 failures, 10 active
3m0s: 108476 runs so far, 0 failures, 10 active
3m5s: 111470 runs so far, 0 failures, 10 active
3m10s: 114427 runs so far, 0 failures, 10 active
3m15s: 117560 runs so far, 0 failures, 10 active
3m20s: 120646 runs so far, 0 failures, 10 active
3m25s: 123802 runs so far, 0 failures, 10 active
3m30s: 126950 runs so far, 0 failures, 10 active
3m35s: 130067 runs so far, 0 failures, 10 active
3m40s: 133235 runs so far, 0 failures, 10 active
3m45s: 136386 runs so far, 0 failures, 10 active
3m50s: 139512 runs so far, 0 failures, 10 active
3m55s: 142686 runs so far, 0 failures, 10 active
4m0s: 145880 runs so far, 0 failures, 10 active
4m5s: 148959 runs so far, 0 failures, 10 active
4m10s: 152121 runs so far, 0 failures, 10 active
4m15s: 155310 runs so far, 0 failures, 10 active
4m20s: 158401 runs so far, 0 failures, 10 active
4m25s: 161539 runs so far, 0 failures, 10 active
4m30s: 164735 runs so far, 0 failures, 10 active
4m35s: 167797 runs so far, 0 failures, 10 active
4m40s: 170949 runs so far, 0 failures, 10 active
4m45s: 174070 runs so far, 0 failures, 10 active
4m50s: 177158 runs so far, 0 failures, 10 active
4m55s: 180299 runs so far, 0 failures, 10 active
5m0s: 183475 runs so far, 0 failures, 10 active
5m5s: 186575 runs so far, 0 failures, 10 active
5m10s: 189720 runs so far, 0 failures, 10 active
5m15s: 192899 runs so far, 0 failures, 10 active
5m20s: 196011 runs so far, 0 failures, 10 active
5m25s: 199057 runs so far, 0 failures, 10 active
5m30s: 202242 runs so far, 0 failures, 10 active
5m35s: 205352 runs so far, 0 failures, 10 active
5m40s: 208486 runs so far, 0 failures, 10 active
5m45s: 211653 runs so far, 0 failures, 10 active
5m50s: 214779 runs so far, 0 failures, 10 active
5m55s: 217890 runs so far, 0 failures, 10 active
6m0s: 220972 runs so far, 0 failures, 10 active
6m5s: 224096 runs so far, 0 failures, 10 active
6m10s: 227205 runs so far, 0 failures, 10 active
6m15s: 230381 runs so far, 0 failures, 10 active
6m20s: 233547 runs so far, 0 failures, 10 active
6m25s: 236635 runs so far, 0 failures, 10 active
6m30s: 239819 runs so far, 0 failures, 10 active
6m35s: 242989 runs so far, 0 failures, 10 active
6m40s: 246071 runs so far, 0 failures, 10 active
6m45s: 249175 runs so far, 0 failures, 10 active
6m50s: 252279 runs so far, 0 failures, 10 active
6m55s: 255360 runs so far, 0 failures, 10 active
7m0s: 258492 runs so far, 0 failures, 10 active
7m5s: 261657 runs so far, 0 failures, 10 active
7m10s: 264724 runs so far, 0 failures, 10 active
7m15s: 267669 runs so far, 0 failures, 10 active
7m20s: 270738 runs so far, 0 failures, 10 active
7m25s: 273725 runs so far, 0 failures, 10 active
7m30s: 276689 runs so far, 0 failures, 10 active
7m35s: 279620 runs so far, 0 failures, 10 active
7m40s: 282664 runs so far, 0 failures, 10 active
7m45s: 285795 runs so far, 0 failures, 10 active
7m50s: 288949 runs so far, 0 failures, 10 active
7m55s: 292061 runs so far, 0 failures, 10 active
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
