### PR TITLE
Decouple `term` and `remotecommand` packages

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/resize.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/resize.go
@@ -16,16 +16,17 @@ limitations under the License.
 
 package remotecommand
 
-// TerminalSize and TerminalSizeQueue was a part of k8s.io/kubernetes/pkg/util/term
-// and were moved in order to decouple client from other term dependencies
-
 // TerminalSize represents the width and height of a terminal.
+// It is the same as staging/src/k8s.io/kubectl/pkg/util/term.TerminalSize.
+// Copied to decouple the packages. Terminal-related package should not depend on API client and vice versa.
 type TerminalSize struct {
 	Width  uint16
 	Height uint16
 }
 
 // TerminalSizeQueue is capable of returning terminal resize events as they occur.
+// It is the same as staging/src/k8s.io/kubectl/pkg/util/term.TerminalSizeQueue.
+// Copied to decouple the packages. Terminal-related package should not depend on API client and vice versa.
 type TerminalSizeQueue interface {
 	// Next returns the new terminal size after the terminal has been resized. It returns nil when
 	// monitoring has been stopped.

--- a/staging/src/k8s.io/kubectl/pkg/util/term/resize.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/term/resize.go
@@ -21,12 +21,28 @@ import (
 
 	"github.com/moby/term"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/remotecommand"
 )
+
+// TerminalSize represents the width and height of a terminal.
+// It is the same as staging/src/k8s.io/client-go/tools/remotecommand.TerminalSize.
+// Copied to decouple the packages. Terminal-related package should not depend on API client and vice versa.
+type TerminalSize struct {
+	Width  uint16
+	Height uint16
+}
+
+// TerminalSizeQueue is capable of returning terminal resize events as they occur.
+// It is the same as staging/src/k8s.io/client-go/tools/remotecommand.TerminalSizeQueue.
+// Copied to decouple the packages. Terminal-related package should not depend on API client and vice versa.
+type TerminalSizeQueue interface {
+	// Next returns the new terminal size after the terminal has been resized. It returns nil when
+	// monitoring has been stopped.
+	Next() *TerminalSize
+}
 
 // GetSize returns the current size of the user's terminal. If it isn't a terminal,
 // nil is returned.
-func (t TTY) GetSize() *remotecommand.TerminalSize {
+func (t TTY) GetSize() *TerminalSize {
 	outFd, isTerminal := term.GetFdInfo(t.Out)
 	if !isTerminal {
 		return nil
@@ -35,19 +51,19 @@ func (t TTY) GetSize() *remotecommand.TerminalSize {
 }
 
 // GetSize returns the current size of the terminal associated with fd.
-func GetSize(fd uintptr) *remotecommand.TerminalSize {
+func GetSize(fd uintptr) *TerminalSize {
 	winsize, err := term.GetWinsize(fd)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("unable to get terminal size: %v", err))
 		return nil
 	}
 
-	return &remotecommand.TerminalSize{Width: winsize.Width, Height: winsize.Height}
+	return &TerminalSize{Width: winsize.Width, Height: winsize.Height}
 }
 
 // MonitorSize monitors the terminal's size. It returns a TerminalSizeQueue primed with
 // initialSizes, or nil if there's no TTY present.
-func (t *TTY) MonitorSize(initialSizes ...*remotecommand.TerminalSize) remotecommand.TerminalSizeQueue {
+func (t *TTY) MonitorSize(initialSizes ...*TerminalSize) TerminalSizeQueue {
 	outFd, isTerminal := term.GetFdInfo(t.Out)
 	if !isTerminal {
 		return nil
@@ -57,7 +73,7 @@ func (t *TTY) MonitorSize(initialSizes ...*remotecommand.TerminalSize) remotecom
 		t: *t,
 		// make it buffered so we can send the initial terminal sizes without blocking, prior to starting
 		// the streaming below
-		resizeChan:   make(chan remotecommand.TerminalSize, len(initialSizes)),
+		resizeChan:   make(chan TerminalSize, len(initialSizes)),
 		stopResizing: make(chan struct{}),
 	}
 
@@ -70,16 +86,16 @@ func (t *TTY) MonitorSize(initialSizes ...*remotecommand.TerminalSize) remotecom
 type sizeQueue struct {
 	t TTY
 	// resizeChan receives a Size each time the user's terminal is resized.
-	resizeChan   chan remotecommand.TerminalSize
+	resizeChan   chan TerminalSize
 	stopResizing chan struct{}
 }
 
-// make sure sizeQueue implements the resize.TerminalSizeQueue interface
-var _ remotecommand.TerminalSizeQueue = &sizeQueue{}
+// make sure sizeQueue implements the TerminalSizeQueue interface
+var _ TerminalSizeQueue = &sizeQueue{}
 
 // monitorSize primes resizeChan with initialSizes and then monitors for resize events. With each
 // new event, it sends the current terminal size to resizeChan.
-func (s *sizeQueue) monitorSize(outFd uintptr, initialSizes ...*remotecommand.TerminalSize) {
+func (s *sizeQueue) monitorSize(outFd uintptr, initialSizes ...*TerminalSize) {
 	// send the initial sizes
 	for i := range initialSizes {
 		if initialSizes[i] != nil {
@@ -87,7 +103,7 @@ func (s *sizeQueue) monitorSize(outFd uintptr, initialSizes ...*remotecommand.Te
 		}
 	}
 
-	resizeEvents := make(chan remotecommand.TerminalSize, 1)
+	resizeEvents := make(chan TerminalSize, 1)
 
 	monitorResizeEvents(outFd, resizeEvents, s.stopResizing)
 
@@ -118,7 +134,7 @@ func (s *sizeQueue) monitorSize(outFd uintptr, initialSizes ...*remotecommand.Te
 
 // Next returns the new terminal size after the terminal has been resized. It returns nil when
 // monitoring has been stopped.
-func (s *sizeQueue) Next() *remotecommand.TerminalSize {
+func (s *sizeQueue) Next() *TerminalSize {
 	size, ok := <-s.resizeChan
 	if !ok {
 		return nil

--- a/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents.go
@@ -25,13 +25,12 @@ import (
 
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/remotecommand"
 )
 
 // monitorResizeEvents spawns a goroutine that waits for SIGWINCH signals (these indicate the
 // terminal has resized). After receiving a SIGWINCH, this gets the terminal size and tries to send
 // it to the resizeEvents channel. The goroutine stops when the stop channel is closed.
-func monitorResizeEvents(fd uintptr, resizeEvents chan<- remotecommand.TerminalSize, stop chan struct{}) {
+func monitorResizeEvents(fd uintptr, resizeEvents chan<- TerminalSize, stop chan struct{}) {
 	go func() {
 		defer runtime.HandleCrash()
 

--- a/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents_windows.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents_windows.go
@@ -20,13 +20,12 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/remotecommand"
 )
 
 // monitorResizeEvents spawns a goroutine that periodically gets the terminal size and tries to send
 // it to the resizeEvents channel if the size has changed. The goroutine stops when the stop channel
 // is closed.
-func monitorResizeEvents(fd uintptr, resizeEvents chan<- remotecommand.TerminalSize, stop chan struct{}) {
+func monitorResizeEvents(fd uintptr, resizeEvents chan<- TerminalSize, stop chan struct{}) {
 	go func() {
 		defer runtime.HandleCrash()
 

--- a/staging/src/k8s.io/kubectl/pkg/util/term/term_writer.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/term/term_writer.go
@@ -23,8 +23,6 @@ import (
 
 	wordwrap "github.com/mitchellh/go-wordwrap"
 	"github.com/moby/term"
-
-	"k8s.io/client-go/tools/remotecommand"
 )
 
 type wordWrapWriter struct {
@@ -70,7 +68,7 @@ func NewWordWrapWriter(w io.Writer, limit uint) io.Writer {
 	}
 }
 
-func getTerminalLimitWidth(terminalSize *remotecommand.TerminalSize) uint {
+func getTerminalLimitWidth(terminalSize *TerminalSize) uint {
 	var limit uint
 	switch {
 	case terminalSize.Width >= 120:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This allows consumers of `term` to not pull in dependencies on `github.com/gorilla/websocket` and `github.com/moby/spdystream`. Below is an example from my project. As you can see, these two types are the only reason the packages are coupled. I think it makes sense to untangle them a bit.

Currently:

```console
➜ go mod why -m k8s.io/client-go/tools/remotecommand
# k8s.io/client-go/tools/remotecommand
(main module does not need module k8s.io/client-go/tools/remotecommand)

➜ go mod why -m github.com/gorilla/websocket        
# github.com/gorilla/websocket
myproject
k8s.io/kubectl/pkg/cmd/util
k8s.io/kubectl/pkg/util/templates
k8s.io/kubectl/pkg/util/term
k8s.io/client-go/tools/remotecommand
github.com/gorilla/websocket

➜ go mod why -m github.com/moby/spdystream          
# github.com/moby/spdystream
myproject
k8s.io/kubectl/pkg/cmd/util
k8s.io/kubectl/pkg/util/templates
k8s.io/kubectl/pkg/util/term
k8s.io/client-go/tools/remotecommand
k8s.io/client-go/transport/spdy
k8s.io/apimachinery/pkg/util/httpstream/spdy
github.com/moby/spdystream
```

This PR (using `go.mod` `replace` to consume everything from `staging`):

```console
➜ go mod why -m k8s.io/client-go/tools/remotecommand
# k8s.io/client-go/tools/remotecommand
(main module does not need module k8s.io/client-go/tools/remotecommand)

➜ go mod why -m github.com/gorilla/websocket        
# github.com/gorilla/websocket
(main module does not need module github.com/gorilla/websocket)

➜ go mod why -m github.com/moby/spdystream  
# github.com/moby/spdystream
(main module does not need module github.com/moby/spdystream)
```

This is a breaking change to types in `staging/src/k8s.io/kubectl/pkg/util/term/resize.go` since we are changing the returned types. But hopefully it is ok? Some consumers will not notice, trivial to fix otherwise.

#### Which issue(s) this PR is related to:

Previous (old) refactoring to decouple things: https://github.com/kubernetes/kubernetes/pull/41543.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
