### PR TITLE
[Carry 133278] kubelet: Don't ignore idsPerPod config #133278

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1076,12 +1076,17 @@ func NewMainKubelet(ctx context.Context,
 		StateDirectory:                   rootDirectory,
 	})
 	klet.shutdownManager = shutdownManager
-	klet.usernsManager, err = userns.MakeUserNsManager(logger, klet)
+	handlers = append(handlers, shutdownManager)
+	klet.allocationManager.AddPodAdmitHandlers(handlers)
+
+	var usernsIDsPerPod *int64
+	if kubeCfg.UserNamespaces != nil {
+		usernsIDsPerPod = kubeCfg.UserNamespaces.IDsPerPod
+	}
+	klet.usernsManager, err = userns.MakeUserNsManager(logger, klet, usernsIDsPerPod)
 	if err != nil {
 		return nil, fmt.Errorf("create user namespace manager: %w", err)
 	}
-	handlers = append(handlers, shutdownManager)
-	klet.allocationManager.AddPodAdmitHandlers(handlers)
 
 	// Finally, put the most recent version of the config on the Kubelet, so
 	// people can see how it was configured.

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -133,8 +133,8 @@ func (kl *Kubelet) HandlerSupportsUserNamespaces(rtHandler string) (bool, error)
 }
 
 // GetKubeletMappings gets the additional IDs allocated for the Kubelet.
-func (kl *Kubelet) GetKubeletMappings() (uint32, uint32, error) {
-	return kl.getKubeletMappings()
+func (kl *Kubelet) GetKubeletMappings(idsPerPod uint32) (uint32, uint32, error) {
+	return kl.getKubeletMappings(idsPerPod)
 }
 
 func (kl *Kubelet) GetMaxPods() int {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -405,7 +405,7 @@ func newTestKubeletWithImageList(
 		ShutdownGracePeriodCriticalPods: 0,
 	})
 	kubelet.shutdownManager = shutdownManager
-	kubelet.usernsManager, err = userns.MakeUserNsManager(logger, kubelet)
+	kubelet.usernsManager, err = userns.MakeUserNsManager(logger, kubelet, nil)
 	if err != nil {
 		t.Fatalf("Failed to create UserNsManager: %v", err)
 	}

--- a/pkg/kubelet/userns/types.go
+++ b/pkg/kubelet/userns/types.go
@@ -24,6 +24,6 @@ type userNsPodsManager interface {
 	HandlerSupportsUserNamespaces(runtimeHandler string) (bool, error)
 	GetPodDir(podUID types.UID) string
 	ListPodsFromDisk() ([]types.UID, error)
-	GetKubeletMappings() (uint32, uint32, error)
+	GetKubeletMappings(idsPerPod uint32) (uint32, uint32, error)
 	GetMaxPods() int
 }

--- a/pkg/kubelet/userns/types.go
+++ b/pkg/kubelet/userns/types.go
@@ -26,5 +26,4 @@ type userNsPodsManager interface {
 	ListPodsFromDisk() ([]types.UID, error)
 	GetKubeletMappings() (uint32, uint32, error)
 	GetMaxPods() int
-	GetUserNamespacesIDsPerPod() uint32
 }

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -131,6 +131,10 @@ func (m *UsernsManager) readMappingsFromFile(pod types.UID) ([]byte, error) {
 }
 
 func MakeUserNsManager(logger klog.Logger, kl userNsPodsManager, idsPerPod *int64) (*UsernsManager, error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) {
+		return nil, nil
+	}
+
 	userNsLength := uint32(kubeletconfig.DefaultKubeletUserNamespacesIDsPerPod)
 	if idsPerPod != nil {
 		// The value is already validated as part of kubelet config validation, so we can safely
@@ -169,11 +173,6 @@ func MakeUserNsManager(logger klog.Logger, kl userNsPodsManager, idsPerPod *int6
 		off:          off,
 		len:          len,
 		userNsLength: userNsLength,
-	}
-
-	// do not bother reading the list of pods if user namespaces are not enabled.
-	if !utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) {
-		return &m, nil
 	}
 
 	found, err := kl.ListPodsFromDisk()

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig"
 	utilstore "k8s.io/kubernetes/pkg/kubelet/util/store"
 	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
@@ -129,13 +130,18 @@ func (m *UsernsManager) readMappingsFromFile(pod types.UID) ([]byte, error) {
 	return fstore.Read(mappingsFile)
 }
 
-func MakeUserNsManager(logger klog.Logger, kl userNsPodsManager) (*UsernsManager, error) {
+func MakeUserNsManager(logger klog.Logger, kl userNsPodsManager, idsPerPod *int64) (*UsernsManager, error) {
 	kubeletMappingID, kubeletMappingLen, err := kl.GetKubeletMappings()
 	if err != nil {
 		return nil, fmt.Errorf("kubelet mappings: %w", err)
 	}
 
-	userNsLength := kl.GetUserNamespacesIDsPerPod()
+	userNsLength := uint32(kubeletconfig.DefaultKubeletUserNamespacesIDsPerPod)
+	if idsPerPod != nil {
+		// The value is already validated as part of kubelet config validation, so we can safely
+		// cast it.
+		userNsLength = uint32(*idsPerPod)
+	}
 
 	if userNsLength%userNsUnitLength != 0 {
 		return nil, fmt.Errorf("kubelet user namespace length %v is not a multiple of %d", userNsLength, userNsUnitLength)

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -131,16 +131,15 @@ func (m *UsernsManager) readMappingsFromFile(pod types.UID) ([]byte, error) {
 }
 
 func MakeUserNsManager(logger klog.Logger, kl userNsPodsManager, idsPerPod *int64) (*UsernsManager, error) {
-	kubeletMappingID, kubeletMappingLen, err := kl.GetKubeletMappings()
-	if err != nil {
-		return nil, fmt.Errorf("kubelet mappings: %w", err)
-	}
-
 	userNsLength := uint32(kubeletconfig.DefaultKubeletUserNamespacesIDsPerPod)
 	if idsPerPod != nil {
 		// The value is already validated as part of kubelet config validation, so we can safely
 		// cast it.
 		userNsLength = uint32(*idsPerPod)
+	}
+	kubeletMappingID, kubeletMappingLen, err := kl.GetKubeletMappings(userNsLength)
+	if err != nil {
+		return nil, fmt.Errorf("kubelet mappings: %w", err)
 	}
 
 	if userNsLength%userNsUnitLength != 0 {

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -38,7 +38,7 @@ func TestMakeUserNsManagerDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	_, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	_, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	assert.NoError(t, err)
 }
 
@@ -47,7 +47,7 @@ func TestReleaseDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	m.Release(logger, "some-pod")
@@ -100,7 +100,7 @@ func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
 			testUserNsPodsManager := &testUserNsPodsManager{}
-			m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+			m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 			require.NoError(t, err)
 
 			userns, err := m.GetOrCreateUserNamespaceMappings(ctx, test.pod, "")
@@ -119,7 +119,7 @@ func TestCleanupOrphanedPodUsernsAllocationsDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	err = m.CleanupOrphanedPodUsernsAllocations(ctx, nil, nil)

--- a/pkg/kubelet/userns/userns_manager_switch_test.go
+++ b/pkg/kubelet/userns/userns_manager_switch_test.go
@@ -46,7 +46,7 @@ func TestMakeUserNsManagerSwitch(t *testing.T) {
 		// manager, it will find these pods on disk with userns data.
 		podList: pods,
 	}
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// Record the pods on disk.
@@ -59,7 +59,7 @@ func TestMakeUserNsManagerSwitch(t *testing.T) {
 	// Test re-init works when the feature gate is disabled and there were some
 	// pods written on disk.
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
-	m2, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m2, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// The feature gate is off, no pods should be allocated.
@@ -82,7 +82,7 @@ func TestGetOrCreateUserNamespaceMappingsSwitch(t *testing.T) {
 		// manager, it will find these pods on disk with userns data.
 		podList: pods,
 	}
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// Record the pods on disk.
@@ -96,7 +96,7 @@ func TestGetOrCreateUserNamespaceMappingsSwitch(t *testing.T) {
 	// pods registered on disk.
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)
 	// Create a new manager with the feature gate off and verify the userns range is nil.
-	m2, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m2, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	for _, podUID := range pods {
@@ -120,7 +120,7 @@ func TestCleanupOrphanedPodUsernsAllocationsSwitch(t *testing.T) {
 		podList: listPods,
 	}
 
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// Record the pods on disk.

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -93,13 +93,6 @@ func (m *testUserNsPodsManager) GetMaxPods() int {
 	return testMaxPods
 }
 
-func (m *testUserNsPodsManager) GetUserNamespacesIDsPerPod() uint32 {
-	if m.userNsLength != 0 {
-		return m.userNsLength
-	}
-	return testUserNsLength
-}
-
 func TestUserNsManagerAllocate(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
@@ -133,7 +126,8 @@ func TestUserNsManagerAllocate(t *testing.T) {
 				mappingFirstID: tc.mappingFirstID,
 				mappingLen:     tc.mappingLen,
 			}
-			m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+			idsPerPod := int64(tc.userNsLength)
+			m, err := MakeUserNsManager(logger, testUserNsPodsManager, &idsPerPod)
 			require.NoError(t, err)
 
 			allocated, length, err := m.allocateOne(logger, "one")
@@ -226,7 +220,7 @@ func TestMakeUserNsManager(t *testing.T) {
 				mappingLen:     tc.mappingLen,
 				maxPods:        tc.maxPods,
 			}
-			_, err := MakeUserNsManager(logger, testUserNsPodsManager)
+			_, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 
 			if tc.success {
 				assert.NoError(t, err)
@@ -305,7 +299,7 @@ func TestUserNsManagerParseUserNsFile(t *testing.T) {
 	}
 
 	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	assert.NoError(t, err)
 
 	for _, tc := range cases {
@@ -397,7 +391,7 @@ func TestGetOrCreateUserNamespaceMappings(t *testing.T) {
 				userns: tc.runtimeUserns,
 			}
 			logger, ctx := ktesting.NewTestContext(t)
-			m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+			m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 			assert.NoError(t, err)
 
 			userns, err := m.GetOrCreateUserNamespaceMappings(ctx, tc.pod, tc.runtimeHandler)
@@ -470,7 +464,7 @@ func TestCleanupOrphanedPodUsernsAllocations(t *testing.T) {
 				podDir:  t.TempDir(),
 				podList: tc.listPods,
 			}
-			m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+			m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 			require.NoError(t, err)
 
 			// Record the userns range as used
@@ -508,7 +502,7 @@ func TestMakeUserNsManagerFailsListPod(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)
 
 	testUserNsPodsManager := &failingUserNsPodsManager{}
-	_, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	_, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "read pods from disk")
 }
@@ -523,7 +517,7 @@ func TestRecordBounds(t *testing.T) {
 		mappingLen:     65536,
 		maxPods:        1,
 	}
-	m, err := MakeUserNsManager(logger, testUserNsPodsManager)
+	m, err := MakeUserNsManager(logger, testUserNsPodsManager, nil)
 	require.NoError(t, err)
 
 	// The first pod allocation should succeed.

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -78,7 +78,7 @@ func (m *testUserNsPodsManager) HandlerSupportsUserNamespaces(runtimeHandler str
 	return m.userns, nil
 }
 
-func (m *testUserNsPodsManager) GetKubeletMappings() (uint32, uint32, error) {
+func (m *testUserNsPodsManager) GetKubeletMappings(idsPerPod uint32) (uint32, uint32, error) {
 	if m.mappingFirstID != 0 {
 		return m.mappingFirstID, m.mappingLen, nil
 	}

--- a/pkg/kubelet/userns/userns_manager_windows.go
+++ b/pkg/kubelet/userns/userns_manager_windows.go
@@ -28,7 +28,7 @@ import (
 
 type UsernsManager struct{}
 
-func MakeUserNsManager(klog.Logger, userNsPodsManager) (*UsernsManager, error) {
+func MakeUserNsManager(klog.Logger, userNsPodsManager, *int64) (*UsernsManager, error) {
 	return nil, nil
 }
 

--- a/test/e2e_node/user_namespaces_test.go
+++ b/test/e2e_node/user_namespaces_test.go
@@ -20,21 +20,37 @@ limitations under the License.
 package e2enode
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var (
+	customIDsPerPod int64 = 65536 * 2
+	// kubelet user used for userns mapping.
+	kubeletUserForUsernsMapping = "kubelet"
+	getsubuidsBinary            = "getsubids"
 )
 
 var _ = SIGDescribe("UserNamespaces", "[LinuxOnly]", feature.UserNamespacesSupport, framework.WithSerial(), func() {
@@ -87,3 +103,100 @@ var _ = SIGDescribe("UserNamespaces", "[LinuxOnly]", feature.UserNamespacesSuppo
 		})
 	})
 })
+
+var _ = SIGDescribe("user namespaces kubeconfig tests", "[LinuxOnly]", feature.UserNamespacesSupport, framework.WithFeatureGate(kubefeatures.UserNamespacesSupport), framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("userns-kubeconfig")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	f.Context("test config using userNamespaces.idsPerPod", func() {
+		ginkgo.BeforeEach(func() {
+			if hasMappings, err := hasKubeletUsernsMappings(); err != nil {
+				framework.Failf("failed to check kubelet user namespace mappings: %v", err)
+			} else if hasMappings {
+				// idsPerPod needs to be in sync with the kubelet's user namespace
+				// mappings. Let's skip the test if there are mappings present.
+				e2eskipper.Skipf("kubelet is configured with custom user namespace mappings, skipping test")
+			}
+		})
+
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			if initialConfig.UserNamespaces == nil {
+				initialConfig.UserNamespaces = &kubeletconfig.UserNamespaces{}
+			}
+			initialConfig.UserNamespaces.IDsPerPod = &customIDsPerPod
+		})
+		f.It("honors idsPerPod in userns pods", func(ctx context.Context) {
+			if !supportsUserNS(ctx, f) {
+				e2eskipper.Skipf("runtime does not support user namespaces")
+			}
+			falseVar := false
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "userns-pod" + string(uuid.NewUUID())},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "container",
+							Image: imageutils.GetE2EImage(imageutils.BusyBox),
+							// The third field is the mapping length, that must be equal to idsPerPod.
+							Command: []string{"awk", "NR != 1 { exit 1 } { print $3 }", "/proc/self/uid_map"},
+						},
+					},
+					HostUsers:     &falseVar,
+					RestartPolicy: v1.RestartPolicyNever,
+				},
+			}
+			expected := []string{strconv.FormatInt(customIDsPerPod, 10)}
+			e2eoutput.TestContainerOutput(ctx, f, "idsPerPod is configured correctly", pod, 0, expected)
+		})
+	})
+})
+
+func hasKubeletUsernsMappings() (bool, error) {
+	if _, err := user.Lookup(kubeletUserForUsernsMapping); err != nil {
+		var e user.UnknownUserError
+		if errors.As(err, &e) {
+			err = nil
+		}
+		return false, err
+	}
+	cmdBin, err := exec.LookPath(getsubuidsBinary)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			err = nil
+		}
+		return false, err
+	}
+	outUids, err := getsubids(cmdBin, kubeletUserForUsernsMapping)
+	if err != nil {
+		return false, err
+	}
+	if outUids == "" {
+		return false, nil
+	}
+	outGids, err := getsubids(cmdBin, "-g", kubeletUserForUsernsMapping)
+	if err != nil {
+		return false, err
+	}
+	if string(outUids) != string(outGids) {
+		return false, fmt.Errorf("user %q has different subuids and subgids: %q vs %q", kubeletUserForUsernsMapping, outUids, outGids)
+	}
+	return true, nil
+}
+
+// getsubids runs the getsubids command to fetch subuid mappings for a user.
+// If the command fails with "Error fetching ranges", it returns an empty string
+// to indicate that no subuid mappings were found, which is not considered an error.
+// Otherwise, it returns the output of the command as a string.
+// (e.g., "0: user 100000 65536")
+func getsubids(cmdBin string, cmdArgs ...string) (string, error) {
+	var stderr bytes.Buffer
+	cmd := exec.Command(cmdBin, cmdArgs...)
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if strings.TrimSpace(stderr.String()) == "Error fetching ranges" {
+			return "", nil // No subuid mappings found, this is not an error
+		}
+		return "", fmt.Errorf("failed to run %v: %w (stderr=%q)", cmd.Args, err, stderr.String())
+	}
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
Carry #133278, so as to address my own comments ([tests/e2e_node: Add test for userNamespaces.idsPerPod](https://github.com/kubernetes/kubernetes/pull/133373/commits/53c35b747cb9e56fdb2cd4d8e20ee428394c00e6))

- - -
(Below is copied from #133278)

The idsPerPod where completely ignored since they were introduced in PR: #130028

The problem was the following:
1. The userns manager (as well as all managers) is created before the config is copied to the kubelet object[1](https://github.com/kubernetes/kubernetes/blob/461ba83084ab7cb91ab692687bb7aedb05c6eb65/pkg/kubelet/kubelet.go#L1078-L1087)
2. The userns manager on creation is calling the kubelet_getter GetUserNamespacesIDsPerPod to get the idsPerPod
3. The getter checks the configuration stored in the kubelet object, which hasn't been set at that point.
4. As the config ss nil (unset), it returns the default value.

Therefore, the value was ignored.

To solve this, let's just pass the idsPerPod as a parameter to MakeUserNsManager(). This is the common pattern already used in the kubelet initialization.

cc @AkihiroSuda @giuseppe

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We now honor the idsPerPod config from the kubelet.

#### Which issue(s) this PR is related to:
Fixes: #133144

#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?
```release-note
The kubelet now honors the configuration userNamespaces.idsPerPod. Before it was ignored.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

