### PR TITLE
test: add retry to getMetricsFromNode and deflake 'should grab all metrics from kubelet /metrics/resource endpoint'

### DIFF
--- a/test/e2e/framework/metrics/kubelet_metrics.go
+++ b/test/e2e/framework/metrics/kubelet_metrics.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	proxyTimeout = 2 * time.Minute
 	// dockerOperationsLatencyKey is the key for the operation latency metrics.
 	// Taken from k8s.io/kubernetes/pkg/kubelet/dockershim/metrics
 	dockerOperationsLatencyKey = "docker_operations_duration_seconds"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

Test: [should grab all metrics from kubelet /metrics/resource endpoint](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/instrumentation/metrics.go#L56C13-L56C76)

#### What this PR does / why we need it:
It's unclear why https://github.com/kubernetes/kubernetes/pull/114997 was seeing a proxy timeout. 114997 added logic to timeout the connection and error out on the timeout. In OpenShift CI we do see something similar. The case is rare - only about 3% of the time.

Instead of erroring completely we can improve the design of the getMetricsFromNode function to issue a retry, and setup the client to have a 45 second timeout. This will allow the function to gracefully recover and always return metrics - effectively deflaking the test.

45 seconds was selected for the timeout since the metrics endpoint in the Kubelet is sometimes returning metrics within 30 seconds. 30 seconds is a long time and is a separate issue under investigation.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
