### PR TITLE
check invariant metrics after e2e tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -54,6 +54,7 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/common"
 	_ "k8s.io/kubernetes/test/e2e/dra"
 	_ "k8s.io/kubernetes/test/e2e/instrumentation"
+	_ "k8s.io/kubernetes/test/e2e/invariants"
 	_ "k8s.io/kubernetes/test/e2e/kubectl"
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"
 	_ "k8s.io/kubernetes/test/e2e/lifecycle/bootstrap"

--- a/test/e2e/invariants/OWNERS
+++ b/test/e2e/invariants/OWNERS
@@ -1,0 +1,11 @@
+# go.k8s.io/owners
+options:
+  no_parent_owners: true
+approvers:
+  - bentheelder
+  - aojea
+  - pohly
+reviewers:
+  - bentheelder
+  - aojea
+  - pohly

--- a/test/e2e/invariants/README.md
+++ b/test/e2e/invariants/README.md
@@ -1,0 +1,12 @@
+# Invariant Tests
+
+This package implements [KEP-5468 Invariant Testing][kep].
+
+Before adding new tests here, please reach out to SIG-Testing to discuss
+with the SIG and Tech Leads.
+
+https://github.com/kubernetes/community/tree/master/sig-testing#contact
+
+For more details, see [the kep][kep].
+
+[kep]: https://git.k8s.io/enhancements/keps/sig-testing/5468-invariant-testing

--- a/test/e2e/invariants/metrics.go
+++ b/test/e2e/invariants/metrics.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// please speak to SIG-Testing leads before adding anything to this package
+// see: https://git.k8s.io/enhancements/keps/sig-testing/5468-invariant-testing
+package invariants
+
+import (
+	"context"
+	"strings"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+
+	"github.com/onsi/ginkgo/v2"
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
+)
+
+// checks for api-server metrics that indicate an internal bug has occurred
+const invariantMetricsLeafText = "should enable checking invariant metrics"
+
+var _ = framework.SIGDescribe("testing")("Invariant Metrics", func() {
+	// this test is a sentinel for selecting the report after suite logic
+	//
+	// this allows us to run it by default in most jobs, but it can be opted-out,
+	// does not run when selecting Conformance, and it can be tagged Flaky
+	// if we encounter issues with it
+	ginkgo.It(invariantMetricsLeafText, func() {})
+})
+
+var _ = ginkgo.ReportAfterSuite("Invariant Metrics", func(ctx ginkgo.SpecContext, report ginkgo.Report) {
+	// skip early if we are in dry-run mode and didn't really run any tests
+	if report.SuiteConfig.DryRun {
+		return
+	}
+	// check if we ran the 'should enabled checking invariants' "test"
+	invariantsSelected := false
+	for _, spec := range report.SpecReports {
+		if spec.LeafNodeText == invariantMetricsLeafText {
+			invariantsSelected = spec.State.Is(ginkgotypes.SpecStatePassed)
+			break
+		}
+	}
+	// skip if the associated "test" was skipped
+	if !invariantsSelected {
+		return
+	}
+	// otherwise actually check invariants now
+	checkInvariantMetrics(ctx)
+})
+
+// apiServerMetricInvariant represents an api-server metric invariant, all
+// fields must be specified
+type apiServerMetricInvariant struct {
+	// Metric is the metric name
+	Metric string
+	// SIG associated with the invariant
+	// Bugs related to this invariant check failing should be labeled with
+	// this SIG.
+	SIG string
+	// Owners are the individuals responsible for the invariant
+	// Bugs related to this invariant check failing should be assigned to these
+	// GitHub handles
+	Owners []string
+	// IsValid should return false if the metric samples violate the invariant
+	IsValid func(testutil.Samples) bool
+}
+
+// Please speak to SIG-Testing leads before adding anything here.
+// All fields must be specified
+var apiServerMetricInvariants = []apiServerMetricInvariant{
+	{
+		Metric: "apiserver_validation_declarative_validation_mismatch_total",
+		SIG:    "api-machinery",
+		Owners: []string{"aaron-prindle", "jpbetz", "thockin"},
+		IsValid: func(samples testutil.Samples) bool {
+			// declarative validation mismatch should never be non-zero
+			for _, sample := range samples {
+				if sample.Value != 0 {
+					return false
+				}
+			}
+			return true
+		},
+	},
+}
+
+func checkInvariantMetrics(ctx context.Context) {
+	// Grab metrics
+	config, err := framework.LoadConfig()
+	if err != nil {
+		framework.Failf("error loading client config: %v", err)
+	}
+	c, err := clientset.NewForConfig(config)
+	if err != nil {
+		framework.Failf("error loading client config: %v", err)
+	}
+	grabber, err := e2emetrics.NewMetricsGrabber(ctx, c, nil, config, false, false, false, true, false, false)
+	if err != nil {
+		framework.Failf("error creating metrics grabber: %v", err)
+	}
+	apiserverMetrics, err := grabber.GrabFromAPIServer(ctx)
+	if err != nil {
+		framework.Failf("error grabbing api-server metrics: %v", err)
+	}
+
+	// Check invariant metrics.
+	//
+	//
+	// Please speak to SIG-Testing leads before adding anything here.
+	for _, invariant := range apiServerMetricInvariants {
+		checkAPIServerInvariant(apiserverMetrics, &invariant)
+	}
+}
+
+func checkAPIServerInvariant(metrics e2emetrics.APIServerMetrics, invariant *apiServerMetricInvariant) {
+	metric := invariant.Metric
+	samples, ok := metrics[metric]
+	if !ok || len(samples) == 0 {
+		framework.Failf(
+			`Invariant failed for missing metric: %v
+
+If this failed on a pull request, please check if the PR changes may be related to the failure.
+If not, you can also search for an existing GitHub issue before filing a new issue.
+
+If this failed in a periodic CI job, please file a bug and /assign the owners.
+
+Owners for this metric: %v
+Associated SIG: %v`,
+			metric, strings.Join(invariant.Owners, " "), invariant.SIG,
+		)
+	}
+	if !invariant.IsValid(samples) {
+		framework.Failf(
+			`Invariant failed for metric: %v
+
+If this failed on a pull request, please check if the PR changes may be related to the failure.
+If not, you can also search for an existing GitHub issue before filing a new issue.
+
+If this failed in a periodic CI job, please file a bug and /assign the owners.
+
+Owners for this metric: %v
+Associated SIG: %v`,
+			metric, strings.Join(invariant.Owners, " "), invariant.SIG,
+		)
+	}
+}

--- a/test/e2e/invariants/metrics.go
+++ b/test/e2e/invariants/metrics.go
@@ -98,6 +98,20 @@ var apiServerMetricInvariants = []apiServerMetricInvariant{
 			return true
 		},
 	},
+	{
+		Metric: "apiserver_validation_declarative_validation_panic_total",
+		SIG:    "api-machinery",
+		Owners: []string{"aaron-prindle", "jpbetz", "thockin"},
+		IsValid: func(samples testutil.Samples) bool {
+			// declarative validation panics should never be non-zero
+			for _, sample := range samples {
+				if sample.Value != 0 {
+					return false
+				}
+			}
+			return true
+		},
+	},
 }
 
 func checkInvariantMetrics(ctx context.Context) {

--- a/test/e2e/invariants/metrics.go
+++ b/test/e2e/invariants/metrics.go
@@ -85,6 +85,9 @@ type apiServerMetricInvariant struct {
 // All fields must be specified
 var apiServerMetricInvariants = []apiServerMetricInvariant{
 	{
+		// TODO: Migrate to apiserver_validation_declarative_validation_parity_discrepancies_total
+		// when it reaches beta / when this metric is deprecated.
+		// For now we uare using the previous beta metric.
 		Metric: "apiserver_validation_declarative_validation_mismatch_total",
 		SIG:    "api-machinery",
 		Owners: []string{"aaron-prindle", "jpbetz", "thockin"},
@@ -99,6 +102,9 @@ var apiServerMetricInvariants = []apiServerMetricInvariant{
 		},
 	},
 	{
+		// TODO: Migrate to apiserver_validation_declarative_validation_panics_total
+		// when it reaches beta / when this metric is deprecated.
+		// For now we uare using the previous beta metric.
 		Metric: "apiserver_validation_declarative_validation_panic_total",
 		SIG:    "api-machinery",
 		Owners: []string{"aaron-prindle", "jpbetz", "thockin"},

--- a/test/e2e/invariants/metrics_test.go
+++ b/test/e2e/invariants/metrics_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package invariants
+
+import "testing"
+
+func TestApiServerMetricInvariantsFieldsAreSet(t *testing.T) {
+	// enforce that all fields are set for all registered metrics
+	for i, inv := range apiServerMetricInvariants {
+		if inv.Metric == "" {
+			t.Errorf("apiServerMetricInvariants[%d].Metric is not set", i)
+		}
+		if inv.SIG == "" {
+			t.Errorf("apiServerMetricInvariants[%d].SIG is not set", i)
+		}
+		if len(inv.Owners) == 0 {
+			t.Errorf("apiServerMetricInvariants[%d].Owners is not set", i)
+		}
+		if inv.IsValid == nil {
+			t.Errorf("apiServerMetricInvariants[%d].IsValid is not set", i)
+		}
+	}
+}

--- a/test/e2e/suites.go
+++ b/test/e2e/suites.go
@@ -35,6 +35,7 @@ func AfterSuiteActions(ctx context.Context) {
 	if framework.TestContext.ReportDir != "" {
 		framework.CoreDump(framework.TestContext.ReportDir)
 	}
+	// TODO: nothing is using this? what should we do with it?
 	if framework.TestContext.GatherSuiteMetricsAfterTest {
 		if err := gatherTestSuiteMetrics(ctx); err != nil {
 			framework.Logf("Error gathering metrics: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Implements https://kep.k8s.io/5514

Introduces special tests which run after the entire test suite to validate invariant metrics.

Specifically starting with the declarative validation metric which compares legacy validation code and declarative validation, a non-zero value indicating a bug in api-server.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduces e2e tests that check component invariant metrics across the entire suite run.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/5514
```
