### PR TITLE
Fix null pointer dereference in CSI volume handling

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -358,7 +358,7 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 
 	//TODO (vladimirvivien) implement better AccessModes mapping between k8s and CSI
 	accessMode := v1.ReadWriteOnce
-	if spec.PersistentVolume.Spec.AccessModes != nil {
+	if spec.PersistentVolume != nil && spec.PersistentVolume.Spec.AccessModes != nil {
 		accessMode = spec.PersistentVolume.Spec.AccessModes[0]
 	}
 

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -310,7 +310,7 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 
 	//TODO (vladimirvivien) implement better AccessModes mapping between k8s and CSI
 	accessMode := v1.ReadWriteOnce
-	if m.spec.PersistentVolume.Spec.AccessModes != nil {
+	if m.spec.PersistentVolume != nil && m.spec.PersistentVolume.Spec.AccessModes != nil {
 		accessMode = m.spec.PersistentVolume.Spec.AccessModes[0]
 	}
 
@@ -372,7 +372,7 @@ func (m *csiBlockMapper) MapPodDevice() (string, error) {
 
 	//TODO (vladimirvivien) implement better AccessModes mapping between k8s and CSI
 	accessMode := v1.ReadWriteOnce
-	if m.spec.PersistentVolume.Spec.AccessModes != nil {
+	if m.spec.PersistentVolume != nil && m.spec.PersistentVolume.Spec.AccessModes != nil {
 		accessMode = m.spec.PersistentVolume.Spec.AccessModes[0]
 	}
 

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -173,11 +173,13 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 		}
 
 		//TODO (vladimirvivien) implement better AccessModes mapping between k8s and CSI
-		if c.spec.PersistentVolume.Spec.AccessModes != nil {
+		if c.spec.PersistentVolume != nil && c.spec.PersistentVolume.Spec.AccessModes != nil {
 			accessMode = c.spec.PersistentVolume.Spec.AccessModes[0]
 		}
 
-		mountOptions = c.spec.PersistentVolume.Spec.MountOptions
+		if c.spec.PersistentVolume != nil {
+			mountOptions = c.spec.PersistentVolume.Spec.MountOptions
+		}
 
 		// Check for STAGE_UNSTAGE_VOLUME set and populate deviceMountPath if so
 		stageUnstageSet, err := csi.NodeSupportsStageUnstage(ctx)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

This PR fixes a potential null pointer dereference in CSI (Container Storage Interface) volume handling code identified by static analysis.

The issue occurs when volume specs are created from Volume sources (`spec.Volume.CSI`) rather than PersistentVolume sources (`spec.PersistentVolume.Spec.CSI`), which can result in `spec.PersistentVolume` being nil while still having valid CSI volume configuration.

## Which issue(s) this PR fixes:

Fixes #133177

## Special notes for your reviewer:

The fix adds defensive nil checks for `spec.PersistentVolume` before accessing its fields, making the code consistent with existing defensive patterns already present in the codebase (such as the MountOptions handling in `csi_attacher.go:320`).

Changes made:
- `pkg/volume/csi/csi_attacher.go`: Added nil check before accessing AccessModes
- `pkg/volume/csi/csi_mounter.go`: Added nil checks for both AccessModes and MountOptions  
- `pkg/volume/csi/csi_block.go`: Added nil checks for AccessModes in both SetUpDevice and MapPodDevice methods

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A