### PR TITLE
kubectl attach: include namespace flag in reattach messages

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -352,8 +352,14 @@ func (o *AttachOptions) reattachMessage(containerName string, rawTTY bool) strin
 	if o.Quiet || !o.Stdin || !rawTTY || o.Pod.Spec.RestartPolicy != corev1.RestartPolicyAlways {
 		return ""
 	}
-	if _, path := podcmd.FindContainerByName(o.Pod, containerName); strings.HasPrefix(path, "spec.ephemeralContainers") {
-		return fmt.Sprintf("Session ended, the ephemeral container will not be restarted but may be reattached using '%s %s -c %s -i -t' if it is still running", o.CommandName, o.Pod.Name, containerName)
+
+	var namespaceFlag string
+	if o.Pod.Namespace != "" && o.Pod.Namespace != "default" {
+		namespaceFlag = fmt.Sprintf(" -n %s", o.Pod.Namespace)
 	}
-	return fmt.Sprintf("Session ended, resume using '%s %s -c %s -i -t' command when the pod is running", o.CommandName, o.Pod.Name, containerName)
+
+	if _, path := podcmd.FindContainerByName(o.Pod, containerName); strings.HasPrefix(path, "spec.ephemeralContainers") {
+		return fmt.Sprintf("Session ended, the ephemeral container will not be restarted but may be reattached using '%s%s %s -c %s -i -t' if it is still running", o.CommandName, namespaceFlag, o.Pod.Name, containerName)
+	}
+	return fmt.Sprintf("Session ended, resume using '%s%s %s -c %s -i -t' command when the pod is running", o.CommandName, namespaceFlag, o.Pod.Name, containerName)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a pod is not in the default namespace, the reattach message generated after an attach session ends now includes the -n flag with the namespace name. This ensures the suggested command will work correctly for pods in non-default namespaces.

Before: `Session ended, resume using 'kubectl attach pod-name -c container -i -t'`
After: `Session ended, resume using 'kubectl attach -n custom-ns pod-name -c container -i -t'`

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl attach: Fixed reattach command suggestions to include namespace flag when pod is not in default namespace. Previously, the suggested command would fail for pods in non-default namespaces because it was missing the `-n <namespace>` flag.
```
