### PR TITLE
scheduler cache: Fix memory leak in scheduler cache management

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -363,6 +363,10 @@ func podWithRequiredAntiAffinity(p *v1.Pod) bool {
 func removeFromSlice(logger klog.Logger, s []fwk.PodInfo, k string) ([]fwk.PodInfo, fwk.PodInfo) {
 	var removedPod fwk.PodInfo
 	for i := range s {
+		if s[i] == nil {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Found nil pod in slice", "index", i)
+			continue
+		}
 		tmpKey, err := GetPodKey(s[i].GetPod())
 		if err != nil {
 			utilruntime.HandleErrorWithLogger(logger, err, "Cannot get pod key", "pod", klog.KObj(s[i].GetPod()))
@@ -371,7 +375,11 @@ func removeFromSlice(logger klog.Logger, s []fwk.PodInfo, k string) ([]fwk.PodIn
 		if k == tmpKey {
 			removedPod = s[i]
 			// delete the element
-			s[i] = s[len(s)-1]
+			if i != len(s)-1 {
+				s[i] = s[len(s)-1]
+			}
+			// clear the reference to prevent potential memory leak
+			s[len(s)-1] = nil
 			s = s[:len(s)-1]
 			break
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This fixes a memory leak in the Kubernetes framework, in particular pods removal code path. It was caused by improper slice element removal in the [removeFromSlice()](https://github.com/kubernetes/kubernetes/blob/13ced7b7ddc2e4b86bcb098e7876030ae2eb8802/pkg/scheduler/framework/types.go#L363)
When pods were removed from NodeInfo slices (Pods, PodsWithAffinity, PodsWithRequiredAntiAffinity), the function was:
1. Moving the last element to the deleted position
2. Shrinking slice s = s[:len(s) - 1]
3. But not clearing the moved element reference. This is the fix I am proposing to explicitly clear the reference.

This meant that even after pod gets deleted, the array still held references to `PodInfo` objects at positions beyond the slice length. This is preventing garbage collection(GC). With `StatefulSets` using PVCs and anti-affinity (which populate these slices), this creates a significant memory leak as pods are deleted but their PodInfo objects remain referenced in memory.

#### Which issue(s) this PR is related to:
Fixes #133365

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

- This is a critical fix that resolves a memory leak affecting production scheduler deployments whoever is using kubernetes due to its wide adoption in the industry.
- The fixes are based on the collaborative thoughts from the kubernetes community and I am making attempting to identify root cause and fix
- I am proposing that we explicitly clear the reference after moving the element which will then allow the GC to properly clean up the deleted PodInfo objects.

```
go test -v ./pkg/scheduler/framework
```

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix memory leak in kube-scheduler framework where assumed pods were not properly cleaned up during pod removal, causing memory usage hikes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A