### PR TITLE
Fix label selector parsing for consecutive commas

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -848,7 +848,6 @@ func (p *Parser) parseIdentifiersList() (sets.String, error) {
 				return s, nil
 			}
 			if tok2 == CommaToken {
-				p.consume(Values)
 				s.Insert("") // to handle ,, Double "" removed by StringSet
 			}
 		default: // it can be operator

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -636,8 +636,23 @@ func TestSetSelectorParser(t *testing.T) {
 		{"x in (abc,)", internalSelector{
 			getRequirement("x", selection.In, sets.NewString("abc", ""), t),
 		}, true, true},
+		{"x in (abc,abc)", internalSelector{
+			getRequirement("x", selection.In, sets.NewString("abc"), t),
+		}, true, true},
 		{"x in ()", internalSelector{
 			getRequirement("x", selection.In, sets.NewString(""), t),
+		}, true, true},
+		{"x in (a,,)", internalSelector{
+			getRequirement("x", selection.In, sets.NewString("a", ""), t),
+		}, true, true},
+		{"x in (a,,,)", internalSelector{
+			getRequirement("x", selection.In, sets.NewString("a", ""), t),
+		}, true, true},
+		{"x in (a,,,,,,)", internalSelector{
+			getRequirement("x", selection.In, sets.NewString("a", ""), t),
+		}, true, true},
+		{"x in (a,,a,,a,,a,,)", internalSelector{
+			getRequirement("x", selection.In, sets.NewString("a", ""), t),
 		}, true, true},
 		{"x notin (abc,,def),bar,z in (),w", internalSelector{
 			getRequirement("bar", selection.Exists, nil, t),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes label selector parsing to correctly handle consecutive commas in value lists (e.g., `x in (a,,)`). Previously, when encountering two consecutive commas immediately followed by a closing parenthesis, the parser would consume the second comma incorrectly, skipping over the `,)` case and resulting in an “expected identifier” error. This prevented valid expressions from being parsed successfully.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
