### PR TITLE
Refactor Windows kube-proxy to reduce code complexity in syncProxyRules

### DIFF
--- a/pkg/proxy/winkernel/hcnutils.go
+++ b/pkg/proxy/winkernel/hcnutils.go
@@ -50,6 +50,7 @@ type HcnService interface {
 	// Policy functions
 	DeleteAllHnsLoadBalancerPolicy()
 	RemoteSubnetSupported() error
+	IsNotImplemented(err error) bool
 }
 
 type hcnImpl struct{}
@@ -143,4 +144,8 @@ func (hcnObj hcnImpl) DeleteAllHnsLoadBalancerPolicy() {
 
 func (hcnObj hcnImpl) RemoteSubnetSupported() error {
 	return hcn.RemoteSubnetSupported()
+}
+
+func (hcnObj hcnImpl) IsNotImplemented(err error) bool {
+	return hcn.IsNotImplemented(err)
 }

--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -371,31 +371,7 @@ func (hns hns) getLoadBalancer(endpoints []endpointInfo, flags loadBalancerFlags
 		return lb, nil
 	}
 
-	lbPortMappingFlags := hcn.LoadBalancerPortMappingFlagsNone
-	if flags.isILB {
-		lbPortMappingFlags |= hcn.LoadBalancerPortMappingFlagsILB
-	}
-	if flags.useMUX {
-		lbPortMappingFlags |= hcn.LoadBalancerPortMappingFlagsUseMux
-	}
-	if flags.preserveDIP {
-		lbPortMappingFlags |= hcn.LoadBalancerPortMappingFlagsPreserveDIP
-	}
-	if flags.localRoutedVIP {
-		lbPortMappingFlags |= hcn.LoadBalancerPortMappingFlagsLocalRoutedVIP
-	}
-	if flags.isVipExternalIP {
-		lbPortMappingFlags |= LoadBalancerPortMappingFlagsVipExternalIP
-	}
-
-	lbFlags := hcn.LoadBalancerFlagsNone
-	if flags.isDSR {
-		lbFlags |= hcn.LoadBalancerFlagsDSR
-	}
-
-	if flags.isIPv6 {
-		lbFlags |= LoadBalancerFlagsIPv6
-	}
+	lbPortMappingFlags, lbFlags := getLoadBalancerPolicyFlags(flags)
 
 	lbDistributionType := hcn.LoadBalancerDistributionNone
 

--- a/pkg/proxy/winkernel/loadbalancer.go
+++ b/pkg/proxy/winkernel/loadbalancer.go
@@ -1,0 +1,287 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package winkernel
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+type loadbalancerType string
+
+const (
+	loadbalancerTypeClusterIP   loadbalancerType = "ClusterIP"
+	loadbalancerTypeNodePort    loadbalancerType = "NodePort"
+	loadbalancerTypeIngressIP   loadbalancerType = "IngressIP"
+	loadbalancerTypeExternalIP  loadbalancerType = "ExternalIP"
+	loadbalancerTypeHealthCheck loadbalancerType = "HealthCheck"
+)
+
+type loadbalancerConfig struct {
+	hnsID                   string
+	srcVip                  string
+	vip                     string
+	protocol                uint16
+	internalPort            uint16
+	externalPort            uint16
+	winProxyOptimization    bool
+	endpointsAvailableForLB bool
+	lbFlags                 loadBalancerFlags
+	loadbalancerType        loadbalancerType
+	endpoints               []endpointInfo
+	queriedLoadBalancers    map[loadBalancerIdentifier]*loadBalancerInfo
+}
+
+func (lbConfig *loadbalancerConfig) String() string {
+	return fmt.Sprintf("LoadbalancerConfig: {hnsID: %s, srcVip: %s, vip: %s, protocol: %d, internalPort: %d, externalPort: %d, winProxyOptimization: %t, endpointsAvailableForLB: %t, lbFlags: %v, loadbalancerType: %s, endpoints: %v, queriedLoadBalancers: %v}",
+		lbConfig.hnsID, lbConfig.srcVip, lbConfig.vip, lbConfig.protocol, lbConfig.internalPort, lbConfig.externalPort, lbConfig.winProxyOptimization, lbConfig.endpointsAvailableForLB, lbConfig.lbFlags, lbConfig.loadbalancerType, lbConfig.endpoints, lbConfig.queriedLoadBalancers)
+}
+
+func (proxier *Proxier) requiresUpdateLoadbalancer(lbHnsID string, endpointCount int) bool {
+	return proxier.supportedFeatures.ModifyLoadbalancer && lbHnsID != "" && endpointCount > 0
+}
+
+// handleUpdateLoadbalancerFailure will handle the error returned by updatePolicy. If the error is due to unsupported feature,
+// then it will set the supportedFeatures.ModifyLoadbalancer to false. return true means skip the iteration.
+func (proxier *Proxier) handleUpdateLoadbalancerFailure(err error, hnsID, svcIP string, endpointCount int) (skipIteration bool) {
+	if err != nil {
+		if proxier.hcn.IsNotImplemented(err) {
+			klog.Warning("Update loadbalancer policies is not implemented.", "hnsID", hnsID, "svcIP", svcIP, "endpointCount", endpointCount)
+			proxier.supportedFeatures.ModifyLoadbalancer = false
+		} else {
+			klog.ErrorS(err, "Update loadbalancer policy failed", "hnsID", hnsID, "svcIP", svcIP, "endpointCount", endpointCount)
+			skipIteration = true
+		}
+	}
+	return skipIteration
+}
+
+// manageLoadbalancer handles the lifecycle of the load balancer.
+// It first checks whether an update is needed and if updates are supported (i.e., the ModifyLoadbalancer flag is true based on the supported HNS version range).
+// If so, it attempts to update the load balancer. If the update is rejected by HNS as unsupported, the ModifyLoadbalancer flag is set to false,
+// and the function proceeds with deleting and recreating the load balancer.
+// If the initial check determines that update criteria are not met, it directly proceeds with deletion (if necessary) and creation of the load balancer.
+func (proxier *Proxier) manageLoadbalancer(lbConfig *loadbalancerConfig) (success bool) {
+	klog.V(3).InfoS("manageLoadbalancer invoked", "LoadbalancerConfig", lbConfig)
+	success = true
+	if proxier.requiresUpdateLoadbalancer(lbConfig.hnsID, len(lbConfig.endpoints)) && lbConfig.endpointsAvailableForLB {
+		hnsLoadBalancer, err := proxier.hns.updateLoadBalancer(
+			lbConfig.hnsID,
+			lbConfig.srcVip,
+			lbConfig.vip,
+			lbConfig.endpoints,
+			lbConfig.lbFlags,
+			lbConfig.protocol,
+			lbConfig.internalPort,
+			lbConfig.externalPort,
+			lbConfig.queriedLoadBalancers,
+		)
+		if skipIteration := proxier.handleUpdateLoadbalancerFailure(err, lbConfig.hnsID, lbConfig.vip, len(lbConfig.endpoints)); skipIteration {
+			return false
+		}
+		if proxier.supportedFeatures.ModifyLoadbalancer {
+			klog.V(3).InfoS("Loadbalancer update successful.", "LoadbalancerType", lbConfig.loadbalancerType, "srcVip", lbConfig.srcVip, "vip", lbConfig.vip, "hnsID", hnsLoadBalancer.hnsID, "ExternalPort", lbConfig.externalPort, "InternalPort", lbConfig.internalPort, "protocol", lbConfig.protocol, "EndpointCount", len(lbConfig.endpoints))
+		} else {
+			klog.Warning("Loadbalancer update unsupported by hns", "LoadbalancerType", lbConfig.loadbalancerType, "srcVip", lbConfig.srcVip, "vip", lbConfig.vip, "hnsID", hnsLoadBalancer.hnsID, "ExternalPort", lbConfig.externalPort, "InternalPort", lbConfig.internalPort, "protocol", lbConfig.protocol, "EndpointCount", len(lbConfig.endpoints))
+		}
+	}
+
+	if !proxier.requiresUpdateLoadbalancer(lbConfig.hnsID, len(lbConfig.endpoints)) {
+		proxier.deleteExistingLoadBalancer(proxier.hns, lbConfig.winProxyOptimization, &lbConfig.hnsID, lbConfig.vip, lbConfig.protocol, lbConfig.internalPort, lbConfig.externalPort, lbConfig.endpoints, lbConfig.queriedLoadBalancers)
+		if len(lbConfig.endpoints) > 0 && lbConfig.endpointsAvailableForLB {
+
+			// If all endpoints are terminating, then no need to create Cluster IP LoadBalancer
+			// Cluster IP LoadBalancer creation
+			hnsLoadBalancer, err := proxier.hns.getLoadBalancer(
+				lbConfig.endpoints,
+				lbConfig.lbFlags,
+				lbConfig.srcVip,
+				lbConfig.vip,
+				lbConfig.protocol,
+				lbConfig.internalPort,
+				lbConfig.externalPort,
+				lbConfig.queriedLoadBalancers,
+			)
+			if err != nil {
+				klog.ErrorS(err, "Loadbalancer policy creation failed", "LoadbalancerType", lbConfig.loadbalancerType, "srcVip", lbConfig.srcVip, "vip", lbConfig.vip, "ExternalPort", lbConfig.externalPort, "InternalPort", lbConfig.internalPort, "protocol", lbConfig.protocol, "EndpointCount", len(lbConfig.endpoints))
+				return false
+			}
+
+			lbConfig.hnsID = hnsLoadBalancer.hnsID
+			klog.V(3).InfoS("Loadbalancer create successful.", "LoadbalancerType", lbConfig.loadbalancerType, "srcVip", lbConfig.srcVip, "vip", lbConfig.vip, "hnsID", hnsLoadBalancer.hnsID, "ExternalPort", lbConfig.externalPort, "InternalPort", lbConfig.internalPort, "protocol", lbConfig.protocol, "EndpointCount", len(lbConfig.endpoints))
+		} else {
+			klog.V(3).InfoS("Skipped creating Hns LoadBalancer for cluster ip resources. Reason : No endpoints available", "LoadbalancerType", lbConfig.loadbalancerType, "srcVip", lbConfig.srcVip, "vip", lbConfig.vip, "ExternalPort", lbConfig.externalPort, "InternalPort", lbConfig.internalPort, "protocol", lbConfig.protocol, "EndpointCount", len(lbConfig.endpoints))
+		}
+	}
+	return success
+}
+
+// manageClusterIPLoadbalancer manages the lifecycle of the ClusterIP load balancer.
+func (proxier *Proxier) manageClusterIPLoadbalancer(srcVip string, svcInfo *serviceInfo, endpoints []endpointInfo, queriedLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (success bool) {
+	success = true
+	sessionAffinityClientIP := svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP
+	lbConfig := loadbalancerConfig{
+		loadbalancerType:        loadbalancerTypeClusterIP,
+		hnsID:                   svcInfo.hnsID,
+		srcVip:                  srcVip,
+		vip:                     svcInfo.ClusterIP().String(),
+		protocol:                Enum(svcInfo.Protocol()),
+		internalPort:            uint16(svcInfo.targetPort),
+		externalPort:            uint16(svcInfo.Port()),
+		lbFlags:                 loadBalancerFlags{isDSR: proxier.isDSR, isIPv6: proxier.ipFamily == v1.IPv6Protocol, sessionAffinity: sessionAffinityClientIP},
+		endpoints:               endpoints,
+		winProxyOptimization:    svcInfo.winProxyOptimization,
+		endpointsAvailableForLB: true,
+		queriedLoadBalancers:    queriedLoadBalancers,
+	}
+	success = proxier.manageLoadbalancer(&lbConfig)
+	svcInfo.hnsID = lbConfig.hnsID
+	return success
+}
+
+// manageNodePortLoadbalancer manages the lifecycle of the NodePort load balancer.
+func (proxier *Proxier) manageNodePortLoadbalancer(srcVip string, svcInfo *serviceInfo, endpoints []endpointInfo, queriedLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo, endpointsAvailableForLB bool) (success bool) {
+	if svcInfo.NodePort() <= 0 {
+		return true
+	}
+	success = true
+	sessionAffinityClientIP := svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP
+	lbConfig := loadbalancerConfig{
+		loadbalancerType:        loadbalancerTypeNodePort,
+		hnsID:                   svcInfo.nodePorthnsID,
+		srcVip:                  srcVip,
+		vip:                     "",
+		protocol:                Enum(svcInfo.Protocol()),
+		internalPort:            uint16(svcInfo.targetPort),
+		externalPort:            uint16(svcInfo.NodePort()),
+		lbFlags:                 loadBalancerFlags{isVipExternalIP: true, isDSR: svcInfo.localTrafficDSR, localRoutedVIP: true, sessionAffinity: sessionAffinityClientIP, isIPv6: proxier.ipFamily == v1.IPv6Protocol},
+		endpoints:               endpoints,
+		winProxyOptimization:    svcInfo.winProxyOptimization,
+		endpointsAvailableForLB: endpointsAvailableForLB,
+		queriedLoadBalancers:    queriedLoadBalancers,
+	}
+	success = proxier.manageLoadbalancer(&lbConfig)
+	svcInfo.nodePorthnsID = lbConfig.hnsID
+	return success
+}
+
+// manageExternalIPLoadbalancers manages the lifecycle of the ExternalIP load balancers.
+func (proxier *Proxier) manageExternalIPLoadbalancers(srcVip string, svcInfo *serviceInfo, endpoints []endpointInfo, queriedLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo, endpointsAvailableForLB bool) (success bool) {
+	success = true
+	sessionAffinityClientIP := svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP
+	lbConfig := loadbalancerConfig{
+		loadbalancerType:        loadbalancerTypeExternalIP,
+		srcVip:                  srcVip,
+		protocol:                Enum(svcInfo.Protocol()),
+		internalPort:            uint16(svcInfo.targetPort),
+		externalPort:            uint16(svcInfo.Port()),
+		lbFlags:                 loadBalancerFlags{isVipExternalIP: true, isDSR: svcInfo.localTrafficDSR, sessionAffinity: sessionAffinityClientIP, isIPv6: proxier.ipFamily == v1.IPv6Protocol},
+		endpoints:               endpoints,
+		winProxyOptimization:    svcInfo.winProxyOptimization,
+		endpointsAvailableForLB: endpointsAvailableForLB,
+		queriedLoadBalancers:    queriedLoadBalancers,
+	}
+
+	// Create a Load Balancer Policy for each external IP
+	for _, externalIP := range svcInfo.externalIPs {
+		lbConfig.hnsID = externalIP.hnsID
+		lbConfig.vip = externalIP.ip
+		success = proxier.manageLoadbalancer(&lbConfig)
+		externalIP.hnsID = lbConfig.hnsID
+		if !success {
+			klog.Warning("Failed to manage ExternalIP loadbalancer", "hnsID", lbConfig.hnsID, "vip", lbConfig.vip)
+			return false
+		}
+	}
+
+	return success
+}
+
+// manageIngressIPLoadbalancers manages the lifecycle of the IngressIP load balancers.
+func (proxier *Proxier) manageIngressIPLoadbalancers(srcVip string, svcInfo *serviceInfo, endpoints []endpointInfo, queriedLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo, endpointsAvailableForLB bool) (success bool) {
+	var gatewayHnsendpoint *endpointInfo = nil
+	var gwEndpoints []endpointInfo
+	success = true
+	sessionAffinityClientIP := svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP
+	healthPort := proxier.healthzPort
+
+	if svcInfo.HealthCheckNodePort() != 0 {
+		healthPort = svcInfo.HealthCheckNodePort()
+	}
+
+	if proxier.forwardHealthCheckVip && endpointsAvailableForLB {
+		gatewayHnsendpoint, _ = proxier.hns.getEndpointByName(proxier.rootHnsEndpointName)
+	}
+
+	if gatewayHnsendpoint != nil {
+		gwEndpoints = append(gwEndpoints, *gatewayHnsendpoint)
+	}
+
+	lbConfigIngressIP := loadbalancerConfig{
+		loadbalancerType:        loadbalancerTypeIngressIP,
+		srcVip:                  srcVip,
+		protocol:                Enum(svcInfo.Protocol()),
+		internalPort:            uint16(svcInfo.targetPort),
+		externalPort:            uint16(svcInfo.Port()),
+		lbFlags:                 loadBalancerFlags{isVipExternalIP: true, isDSR: svcInfo.preserveDIP || svcInfo.localTrafficDSR, useMUX: svcInfo.preserveDIP, preserveDIP: svcInfo.preserveDIP, sessionAffinity: sessionAffinityClientIP, isIPv6: proxier.ipFamily == v1.IPv6Protocol},
+		endpoints:               endpoints,
+		winProxyOptimization:    svcInfo.winProxyOptimization,
+		endpointsAvailableForLB: endpointsAvailableForLB,
+		queriedLoadBalancers:    queriedLoadBalancers,
+	}
+
+	lbConfigHealthCheck := loadbalancerConfig{
+		loadbalancerType:        loadbalancerTypeHealthCheck,
+		srcVip:                  srcVip,
+		protocol:                Enum(svcInfo.Protocol()),
+		internalPort:            uint16(healthPort),
+		externalPort:            uint16(healthPort),
+		lbFlags:                 loadBalancerFlags{isDSR: false, useMUX: svcInfo.preserveDIP, preserveDIP: svcInfo.preserveDIP, isIPv6: proxier.ipFamily == v1.IPv6Protocol},
+		endpoints:               gwEndpoints,
+		winProxyOptimization:    svcInfo.winProxyOptimization,
+		endpointsAvailableForLB: endpointsAvailableForLB,
+		queriedLoadBalancers:    queriedLoadBalancers,
+	}
+
+	// Create a Load Balancer Policy for each Ingress IP
+	for _, lbIngressIP := range svcInfo.loadBalancerIngressIPs {
+		lbConfigIngressIP.hnsID = lbIngressIP.hnsID
+		lbConfigIngressIP.vip = lbIngressIP.ip
+		success = proxier.manageLoadbalancer(&lbConfigIngressIP)
+		lbIngressIP.hnsID = lbConfigIngressIP.hnsID
+		if !success {
+			klog.Warning("Failed to manage IngressIP loadbalancer", "hnsID", lbConfigIngressIP.hnsID, "vip", lbConfigIngressIP.vip)
+			return false
+		}
+
+		lbConfigHealthCheck.hnsID = lbIngressIP.healthCheckHnsID
+		lbConfigHealthCheck.vip = lbIngressIP.ip
+		success = proxier.manageLoadbalancer(&lbConfigHealthCheck)
+		lbIngressIP.healthCheckHnsID = lbConfigHealthCheck.hnsID
+		if !success {
+			klog.Warning("Failed to manage IngressIP HealthCheck loadbalancer", "hnsID", lbConfigHealthCheck.hnsID, "vip", lbConfigHealthCheck.vip)
+			return false
+		}
+	}
+
+	return success
+}

--- a/pkg/proxy/winkernel/loadbalancer_test.go
+++ b/pkg/proxy/winkernel/loadbalancer_test.go
@@ -1,0 +1,456 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package winkernel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/proxy"
+	mockhcn "k8s.io/kubernetes/pkg/proxy/winkernel/testing"
+	netutils "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
+)
+
+// Helper function to create test endpoints
+func createTestEndpoints(ips []string, port int) []endpointInfo {
+	endpoints := make([]endpointInfo, len(ips))
+	for i, ip := range ips {
+		endpoints[i] = endpointInfo{
+			hnsID:   fmt.Sprintf("test-ep-%d", i),
+			ip:      ip,
+			port:    uint16(port),
+			isLocal: false,
+		}
+	}
+	return endpoints
+}
+
+func TestManageLoadbalancer(t *testing.T) {
+	tests := []struct {
+		name                    string
+		expectedLBIDs           []string
+		testUpdateLB            bool
+		modifyLBSupported       bool
+		endpointsAvailableForLB bool
+		endpointCount           int
+		expectedSuccess         bool
+		shouldFailUpdate        bool
+		shouldFailCreate        bool
+	}{
+		{
+			name:                    "successful create when update supported",
+			expectedLBIDs:           []string{"LBID-1"},
+			modifyLBSupported:       true,
+			endpointsAvailableForLB: true,
+			endpointCount:           2,
+			expectedSuccess:         true,
+			shouldFailUpdate:        false,
+		},
+		{
+			name:                    "successful create when update not supported",
+			expectedLBIDs:           []string{"LBID-1"},
+			modifyLBSupported:       false,
+			endpointsAvailableForLB: true,
+			endpointCount:           2,
+			expectedSuccess:         true,
+			shouldFailCreate:        false,
+		},
+		{
+			name:                    "successful update when update supported",
+			expectedLBIDs:           []string{"LBID-1", "LBID-1"},
+			modifyLBSupported:       true,
+			testUpdateLB:            true,
+			endpointsAvailableForLB: true,
+			endpointCount:           2,
+			expectedSuccess:         true,
+			shouldFailUpdate:        false,
+		},
+		{
+			name:                    "successful update when update not supported",
+			expectedLBIDs:           []string{"LBID-1", "LBID-2"},
+			modifyLBSupported:       false,
+			testUpdateLB:            true,
+			endpointsAvailableForLB: true,
+			endpointCount:           2,
+			expectedSuccess:         true,
+			shouldFailCreate:        false,
+		},
+		{
+			name:                    "skip create when no endpoints available",
+			endpointsAvailableForLB: false,
+			endpointCount:           0,
+			expectedSuccess:         true,
+		},
+		{
+			name:                    "fail when update fails",
+			expectedLBIDs:           []string{"LBID-1", "LBID-1"},
+			modifyLBSupported:       true,
+			testUpdateLB:            true,
+			endpointsAvailableForLB: true,
+			endpointCount:           2,
+			expectedSuccess:         true,
+			shouldFailUpdate:        true,
+		},
+		{
+			name:                    "fail when create fails",
+			modifyLBSupported:       true,
+			testUpdateLB:            false,
+			endpointsAvailableForLB: true,
+			endpointCount:           2,
+			expectedSuccess:         false,
+			shouldFailCreate:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY, true)
+			hcnMock := (proxier.hcn).(*mockhcn.HcnMock)
+			proxier.supportedFeatures.ModifyLoadbalancer = tt.modifyLBSupported
+			hcnMock.ShouldFailCreateLB = tt.shouldFailCreate
+			hcnMock.ShouldFailUpdateLB = tt.shouldFailUpdate
+			endpoints := createTestEndpoints([]string{"10.0.0.10", "10.0.0.11"}, 8080)
+			if tt.endpointCount == 0 {
+				endpoints = []endpointInfo{}
+			}
+
+			lbConfig := &loadbalancerConfig{
+				loadbalancerType:        loadbalancerTypeClusterIP,
+				hnsID:                   "",
+				srcVip:                  "10.0.0.100",
+				vip:                     "10.0.0.200",
+				protocol:                6, // TCP
+				internalPort:            8080,
+				externalPort:            80,
+				winProxyOptimization:    true,
+				endpointsAvailableForLB: tt.endpointsAvailableForLB,
+				lbFlags:                 loadBalancerFlags{},
+				endpoints:               endpoints,
+				queriedLoadBalancers:    make(map[loadBalancerIdentifier]*loadBalancerInfo),
+			}
+
+			success := proxier.manageLoadbalancer(lbConfig)
+
+			if tt.shouldFailCreate {
+				assert.False(t, success, "LB Create: Expected Failure, got %v", success)
+			} else {
+				assert.True(t, success, "LB Create: Expected success, got %v", success)
+			}
+
+			if len(tt.expectedLBIDs) > 0 {
+				assert.Equal(t, tt.expectedLBIDs[0], lbConfig.hnsID, "LB Create: Expected Hns Loadbalancer Id %v does not match actual Loadbalancer Id: %v.", tt.expectedLBIDs[0], lbConfig.hnsID)
+			} else {
+				assert.Empty(t, lbConfig.hnsID, "LB Create: Expected no Hns Loadbalancer Id, got: %v", lbConfig.hnsID)
+			}
+
+			if tt.testUpdateLB {
+				lbConfig.endpoints = createTestEndpoints([]string{"10.0.0.10", "10.0.0.11", "10.0.0.12"}, 8080)
+				success = proxier.manageLoadbalancer(lbConfig)
+				if tt.shouldFailUpdate {
+					assert.False(t, success, "LB Update: Expected Failure, got %v", success)
+				} else {
+					assert.True(t, success, "LB Update: Expected success, got %v", success)
+				}
+				if len(tt.expectedLBIDs) > 1 {
+					if tt.modifyLBSupported {
+						assert.Equal(t, tt.expectedLBIDs[0], lbConfig.hnsID, "LB Update: Expected Hns Loadbalancer Id %v does not match actual Loadbalancer Id: %v.", tt.expectedLBIDs[0], lbConfig.hnsID)
+					} else {
+						assert.Equal(t, tt.expectedLBIDs[1], lbConfig.hnsID, "LB Update: Expected Hns Loadbalancer Id %v does not match actual Loadbalancer Id: %v.", tt.expectedLBIDs[1], lbConfig.hnsID)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestManageClusterIPLoadbalancer(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY, true)
+	// svcInfo := createTestServiceInfo("test-svc", "10.0.0.200", 80, 8080, 0)
+	endpoints := createTestEndpoints([]string{"10.0.0.10", "10.0.0.11"}, 8080)
+	queriedLBs := make(map[loadBalancerIdentifier]*loadBalancerInfo)
+
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = "10.0.0.200"
+			svc.Spec.ExternalIPs = []string{"50.60.70.81"}
+			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
+				ClientIP: &v1.ClientIPConfig{
+					TimeoutSeconds: ptr.To[int32](v1.DefaultClientIPServiceAffinitySeconds),
+				},
+			}
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:       svcPortName.Port,
+				Port:       int32(80),
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(8080),
+			}}
+		}),
+	)
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	success := proxier.manageClusterIPLoadbalancer("10.0.0.100", svcInfo, endpoints, queriedLBs)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.hnsID, "LBID-1", "Expected hnsID to be LBID-1, but got: %v", svcInfo.hnsID)
+	// Verify LoadBalancer creation
+	lbGet, lbGetErr := proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+
+	// Update without modify support
+	endpoints = createTestEndpoints([]string{"10.0.0.10", "10.0.0.11", "10.0.0.12"}, 8080)
+	success = proxier.manageClusterIPLoadbalancer("10.0.0.100", svcInfo, endpoints, queriedLBs)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.hnsID, "LBID-2", "Expected hnsID to be LBID-2, but got: %v", svcInfo.hnsID)
+	// Verify that the old load balancer has been deleted. This is necessary because updating a load balancer
+	// is handled by deleting the existing one and creating a new one, if direct modification is not supported.
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.Error(t, lbGetErr, "Expected error getting LoadBalancer by ID")
+	assert.Nil(t, lbGet, "Expected LoadBalancer to be not found")
+	// Verify new load balancer with ID LBID-2 exists
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-2")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+
+	// Update with modify support
+	proxier.supportedFeatures.ModifyLoadbalancer = true
+	endpoints = createTestEndpoints([]string{"10.0.0.10", "10.0.0.11", "10.0.0.13"}, 8080)
+	success = proxier.manageClusterIPLoadbalancer("10.0.0.100", svcInfo, endpoints, queriedLBs)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.hnsID, "LBID-2", "Expected hnsID to be LBID-2, but got: %v", svcInfo.hnsID)
+	// Verify new load balancer with ID LBID-2 exists
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-2")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+}
+
+func TestManageNodePortLoadbalancer(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.100"), NETWORK_TYPE_OVERLAY, true)
+	endpoints := createTestEndpoints([]string{"10.0.0.10", "10.0.0.11"}, 8080)
+	queriedLBs := make(map[loadBalancerIdentifier]*loadBalancerInfo)
+	endpointsAvailableForLB := true
+
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeNodePort
+			svc.Spec.ClusterIP = "10.0.0.200"
+			svc.Spec.ExternalIPs = []string{"50.60.70.81"}
+			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
+				ClientIP: &v1.ClientIPConfig{
+					TimeoutSeconds: ptr.To[int32](v1.DefaultClientIPServiceAffinitySeconds),
+				},
+			}
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:       svcPortName.Port,
+				Port:       int32(80),
+				Protocol:   v1.ProtocolTCP,
+				NodePort:   int32(3001),
+				TargetPort: intstr.FromInt32(8080),
+			}}
+		}),
+	)
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	success := proxier.manageNodePortLoadbalancer("10.0.0.100", svcInfo, endpoints, queriedLBs, endpointsAvailableForLB)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.nodePorthnsID, "LBID-1", "Expected hnsID to be LBID-1, but got: %v", svcInfo.hnsID)
+	// Verify LoadBalancer creation
+	lbGet, lbGetErr := proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+
+	// Update without modify support
+	endpoints = createTestEndpoints([]string{"10.0.0.10", "10.0.0.11", "10.0.0.12"}, 8080)
+	success = proxier.manageNodePortLoadbalancer("10.0.0.100", svcInfo, endpoints, queriedLBs, endpointsAvailableForLB)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.nodePorthnsID, "LBID-2", "Expected hnsID to be LBID-2, but got: %v", svcInfo.hnsID)
+	// Verify that the old load balancer has been deleted. This is necessary because updating a load balancer
+	// is handled by deleting the existing one and creating a new one, if direct modification is not supported.
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.Error(t, lbGetErr, "Expected error getting LoadBalancer by ID")
+	assert.Nil(t, lbGet, "Expected LoadBalancer to be not found")
+	// Verify new load balancer with ID LBID-2 exists
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-2")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+
+	// Update with modify support
+	proxier.supportedFeatures.ModifyLoadbalancer = true
+	endpoints = createTestEndpoints([]string{"10.0.0.10", "10.0.0.11", "10.0.0.13"}, 8080)
+	success = proxier.manageNodePortLoadbalancer("10.0.0.100", svcInfo, endpoints, queriedLBs, endpointsAvailableForLB)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.nodePorthnsID, "LBID-2", "Expected hnsID to be LBID-2, but got: %v", svcInfo.hnsID)
+	// Verify new load balancer with ID LBID-2 exists
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-2")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+}
+
+func TestManageExternalIPLoadbalancers(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.100"), NETWORK_TYPE_OVERLAY, true)
+	endpoints := createTestEndpoints([]string{"10.0.0.10", "10.0.0.11"}, 8080)
+	queriedLBs := make(map[loadBalancerIdentifier]*loadBalancerInfo)
+	endpointsAvailableForLB := true
+
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeLoadBalancer
+			svc.Spec.ClusterIP = "10.0.0.200"
+			svc.Spec.ExternalIPs = []string{"50.60.70.81"}
+			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
+				ClientIP: &v1.ClientIPConfig{
+					TimeoutSeconds: ptr.To[int32](v1.DefaultClientIPServiceAffinitySeconds),
+				},
+			}
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:       svcPortName.Port,
+				Port:       int32(80),
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(8080),
+			}}
+		}),
+	)
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	success := proxier.manageExternalIPLoadbalancers("10.0.0.100", svcInfo, endpoints, queriedLBs, endpointsAvailableForLB)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.externalIPs[0].hnsID, "LBID-1", "Expected hnsID to be LBID-1, but got: %v", svcInfo.hnsID)
+	// Verify LoadBalancer creation
+	lbGet, lbGetErr := proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+
+	// Update without modify support
+	endpoints = createTestEndpoints([]string{"10.0.0.10", "10.0.0.11", "10.0.0.12"}, 8080)
+	success = proxier.manageExternalIPLoadbalancers("10.0.0.100", svcInfo, endpoints, queriedLBs, endpointsAvailableForLB)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.externalIPs[0].hnsID, "LBID-2", "Expected hnsID to be LBID-2, but got: %v", svcInfo.hnsID)
+	// Verify that the old load balancer has been deleted. This is necessary because updating a load balancer
+	// is handled by deleting the existing one and creating a new one, if direct modification is not supported.
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.Error(t, lbGetErr, "Expected error getting LoadBalancer by ID")
+	assert.Nil(t, lbGet, "Expected LoadBalancer to be not found")
+	// Verify new load balancer with ID LBID-2 exists
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-2")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+}
+
+func TestManageIngressIPLoadbalancers(t *testing.T) {
+	proxier := NewFakeProxier(t, testNodeName, netutils.ParseIPSloppy("10.0.0.100"), NETWORK_TYPE_OVERLAY, true)
+	proxier.rootHnsEndpointName = mockhcn.DefaultRootEndpointName
+	endpoints := createTestEndpoints([]string{"10.0.0.10", "10.0.0.11"}, 8080)
+	queriedLBs := make(map[loadBalancerIdentifier]*loadBalancerInfo)
+	endpointsAvailableForLB := true
+
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeLoadBalancer
+			svc.Spec.ClusterIP = "10.0.0.200"
+			svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: "50.60.70.81"}}
+			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
+			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
+				ClientIP: &v1.ClientIPConfig{
+					TimeoutSeconds: ptr.To[int32](v1.DefaultClientIPServiceAffinitySeconds),
+				},
+			}
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:       svcPortName.Port,
+				Port:       int32(80),
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(8080),
+			}}
+		}),
+	)
+	proxier.setInitialized(true)
+	proxier.syncProxyRules()
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	success := proxier.manageIngressIPLoadbalancers("10.0.0.100", svcInfo, endpoints, queriedLBs, endpointsAvailableForLB)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.loadBalancerIngressIPs[0].hnsID, "LBID-1", "Expected hnsID to be LBID-1, but got: %v", svcInfo.hnsID)
+	assert.Equal(t, svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID, "LBID-2", "Expected healthCheckHnsID to be LBID-2, but got: %v", svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID)
+	// Verify LoadBalancer creation
+	lbGet, lbGetErr := proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+
+	// Update without modify support
+	endpoints = createTestEndpoints([]string{"10.0.0.10", "10.0.0.11", "10.0.0.12"}, 8080)
+	success = proxier.manageIngressIPLoadbalancers("10.0.0.100", svcInfo, endpoints, queriedLBs, endpointsAvailableForLB)
+	assert.True(t, success, "Expected success true, got false")
+	assert.Equal(t, svcInfo.loadBalancerIngressIPs[0].hnsID, "LBID-3", "Expected hnsID to be LBID-3, but got: %v", svcInfo.hnsID)
+	// Since gateway endpoints are not changing, the health check loadbalancer won't get deleted and healthCheckHnsID will remain the same.
+	assert.Equal(t, svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID, "LBID-2", "Expected healthCheckHnsID to be LBID-2, but got: %v", svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID)
+	// Verify that the old load balancer has been deleted. This is necessary because updating a load balancer
+	// is handled by deleting the existing one and creating a new one, if direct modification is not supported.
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-1")
+	assert.Error(t, lbGetErr, "Expected error getting LoadBalancer by ID")
+	assert.Nil(t, lbGet, "Expected LoadBalancer to be not found")
+	// Verify new load balancer with ID LBID-2 exists
+	lbGet, lbGetErr = proxier.hcn.GetLoadBalancerByID("LBID-3")
+	assert.NoError(t, lbGetErr, "Expected no error getting LoadBalancer by ID")
+	assert.NotNil(t, lbGet, "Expected LoadBalancer to be found")
+}

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -1358,7 +1358,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 
 	makeServiceMap(proxier,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
-			svc.Spec.Type = "NodePort"
+			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
 			svc.Spec.Ports = []v1.ServicePort{{

--- a/pkg/proxy/winkernel/testing/hcnutils_mock.go
+++ b/pkg/proxy/winkernel/testing/hcnutils_mock.go
@@ -26,6 +26,12 @@ import (
 	"github.com/Microsoft/hnslib/hcn"
 )
 
+const (
+	DefaultRootEndpointName = "RootEndpointName"
+	DefaultRootEndpointID   = "RootEndpointID"
+	DefaultRootEndpointIP   = "10.0.0.1"
+)
+
 var (
 	epIdCounter     int
 	lbIdCounter     int
@@ -34,8 +40,13 @@ var (
 )
 
 type HcnMock struct {
-	supportedFeatures hcn.SupportedFeatures
-	network           *hcn.HostComputeNetwork
+	supportedFeatures   hcn.SupportedFeatures
+	network             *hcn.HostComputeNetwork
+	ShouldFailCreateLB  bool   // If this flag is set, the CreateLB call will fail
+	ShouldFailUpdateLB  bool   // If this flag is set, the UpdateLB call will fail
+	UnsupportedUpdateLB bool   // If this flag is set, the UpdateLB call will be unsupported
+	CreateLBErrorStr    string // The error string to return when CreateLB fails
+	UpdateLBErrorStr    string // The error string to return when UpdateLB fails
 }
 
 func (hcnObj HcnMock) generateEndpointGuid() (endpointId string, endpointName string) {
@@ -122,6 +133,18 @@ func (hcnObj HcnMock) GetEndpointByID(endpointId string) (*hcn.HostComputeEndpoi
 }
 
 func (hcnObj HcnMock) GetEndpointByName(endpointName string) (*hcn.HostComputeEndpoint, error) {
+	if endpointName == DefaultRootEndpointName {
+		return &hcn.HostComputeEndpoint{
+			Id:   DefaultRootEndpointID,
+			Name: DefaultRootEndpointName,
+			IpConfigurations: []hcn.IpConfig{
+				{
+					IpAddress:    DefaultRootEndpointIP,
+					PrefixLength: 24,
+				},
+			},
+		}, nil
+	}
 	if ep, ok := endpointMap[endpointName]; ok {
 		return ep, nil
 	}
@@ -176,6 +199,9 @@ func (hcnObj HcnMock) GetLoadBalancerByID(loadBalancerId string) (*hcn.HostCompu
 }
 
 func (hcnObj HcnMock) CreateLoadBalancer(loadBalancer *hcn.HostComputeLoadBalancer) (*hcn.HostComputeLoadBalancer, error) {
+	if hcnObj.ShouldFailCreateLB {
+		return nil, errors.New(hcnObj.CreateLBErrorStr)
+	}
 	if _, ok := loadbalancerMap[loadBalancer.Id]; ok {
 		return nil, fmt.Errorf("LoadBalancer id %s Already Present", loadBalancer.Id)
 	}
@@ -185,6 +211,12 @@ func (hcnObj HcnMock) CreateLoadBalancer(loadBalancer *hcn.HostComputeLoadBalanc
 }
 
 func (hcnObj HcnMock) UpdateLoadBalancer(loadBalancer *hcn.HostComputeLoadBalancer, hnsLbID string) (*hcn.HostComputeLoadBalancer, error) {
+	if hcnObj.ShouldFailUpdateLB {
+		return nil, errors.New(hcnObj.UpdateLBErrorStr)
+	}
+	if hcnObj.UnsupportedUpdateLB {
+		return nil, fmt.Errorf("LoadBalancer id %s Not Present", loadBalancer.Id)
+	}
 	if _, ok := loadbalancerMap[hnsLbID]; !ok {
 		return nil, fmt.Errorf("LoadBalancer id %s Not Present", loadBalancer.Id)
 	}
@@ -231,4 +263,8 @@ func (hcnObj HcnMock) RemoteSubnetSupported() error {
 	}
 
 	return errors.New("remote Subnet Not Supported")
+}
+
+func (hcnObj HcnMock) IsNotImplemented(err error) bool {
+	return hcnObj.UnsupportedUpdateLB
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Refactor Windows kube-proxy to reduce code complexity in syncProxyRules

The pull request focuses on refactoring the syncProxyRules function in the Windows kube-proxy component. It involves significant changes across six files, including 812 lines of additions (including testcases) and 269 lines of deletions. These changes aim to reduce code complexity, likely making the codebase easier to maintain and understand. The effort is to target improving modularity and simplifying logic within a critical function, which aligns with the goal of enhancing overall system robustness.

#### Which issue(s) this PR is related to:
#133502
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
