### PR TITLE
cloudprovider: Remove GetLoadBalancerName from LoadBalancer interface

### DIFF
--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -81,11 +81,10 @@ type Clusters interface {
 	Master(ctx context.Context, clusterName string) (string, error)
 }
 
-// (DEPRECATED) DefaultLoadBalancerName is the default load balancer name that is called from
-// LoadBalancer.GetLoadBalancerName. Use this method to maintain backward compatible names for
-// LoadBalancers that were created prior to Kubernetes v1.12. In the future, each provider should
-// replace this method call in GetLoadBalancerName with a provider-specific implementation that
-// is less cryptic than the Service's UUID.
+// (DEPRECATED) DefaultLoadBalancerName returns the default load balancer name for a service.
+// Use this method to maintain backward compatible names for LoadBalancers.
+// In the future, each provider should replace this method call with a provider-specific implementation
+// that is less cryptic than the Service's UUID.
 func DefaultLoadBalancerName(service *v1.Service) string {
 	//GCE requires that the name of a load balancer starts with a lower case letter.
 	ret := "a" + string(service.UID)
@@ -142,9 +141,6 @@ type LoadBalancer interface {
 	// Parameter 'clusterName' is the name of the cluster as presented to kube-controller-manager.
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error)
-	// GetLoadBalancerName returns the name of the load balancer. Implementations must treat the
-	// *v1.Service parameter as read-only and not modify it.
-	GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string
 	// EnsureLoadBalancer creates a new load balancer 'name', or updates the existing one. Returns the status of the balancer
 	// Implementations must treat the *v1.Service and *v1.Node
 	// parameters as read-only and not modify them.

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider/api"
 	fakecloud "k8s.io/cloud-provider/fake"
 	servicehelper "k8s.io/cloud-provider/service/helpers"
@@ -329,7 +330,7 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 				}
 
 				for _, balancer := range cloud.Balancers {
-					if balancer.Name != controller.balancer.GetLoadBalancerName(ctx, "", tc.service) ||
+					if balancer.Name != cloudprovider.DefaultLoadBalancerName(tc.service) ||
 						balancer.Region != region ||
 						balancer.Ports[0].Port != tc.service.Spec.Ports[0].Port {
 						t.Errorf("Created load balancer has incorrect parameters: %v", balancer)

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -198,12 +198,6 @@ func (f *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service
 	return status, f.Exists, f.Err
 }
 
-// GetLoadBalancerName is a stub implementation of LoadBalancer.GetLoadBalancerName.
-func (f *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
-	// TODO: replace DefaultLoadBalancerName to generate more meaningful loadbalancer names.
-	return cloudprovider.DefaultLoadBalancerName(service)
-}
-
 // EnsureLoadBalancer is a test-spy implementation of LoadBalancer.EnsureLoadBalancer.
 // It adds an entry "create" into the internal method call record.
 func (f *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
@@ -213,7 +207,7 @@ func (f *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, serv
 		f.Balancers = make(map[string]Balancer)
 	}
 
-	name := f.GetLoadBalancerName(ctx, clusterName, service)
+	name := cloudprovider.DefaultLoadBalancerName(service)
 	spec := service.Spec
 
 	zone, err := f.GetZone(context.TODO())


### PR DESCRIPTION
The GetLoadBalancerName method is obsolete and no longer used by the cloud provider. This commit removes the method from the LoadBalancer interface and tests.

The method is problematic, because it surfaces a cloud-specific concept without clear direction as to how it is used.  Cloud providers may have multiple identifiers for a single load balancer.

/kind cleanup

```release-note
NONE
```