### PR TITLE
[FG:InPlacePodVerticalScaling] refactor allocation feasibility check into its own admitHandler

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -36,7 +36,6 @@ import (
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
-	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"
@@ -115,12 +114,10 @@ type Manager interface {
 type manager struct {
 	allocated state.State
 
-	admitHandlers           lifecycle.PodAdmitHandlers
-	containerRuntime        kubecontainer.Runtime
-	statusManager           status.Manager
-	sourcesReady            config.SourcesReady
-	nodeConfig              cm.NodeConfig
-	nodeAllocatableAbsolute v1.ResourceList
+	admitHandlers    lifecycle.PodAdmitHandlers
+	containerRuntime kubecontainer.Runtime
+	statusManager    status.Manager
+	sourcesReady     config.SourcesReady
 
 	ticker         *time.Ticker
 	triggerPodSync func(pod *v1.Pod)
@@ -133,10 +130,7 @@ type manager struct {
 	recorder record.EventRecorderLogger
 }
 
-func NewManager(
-	checkpointDirectory string,
-	nodeConfig cm.NodeConfig,
-	nodeAllocatableAbsolute v1.ResourceList,
+func NewManager(checkpointDirectory string,
 	statusManager status.Manager,
 	triggerPodSync func(pod *v1.Pod),
 	getActivePods func() []*v1.Pod,
@@ -150,11 +144,9 @@ func NewManager(
 	return &manager{
 		allocated: newStateImpl(logger, checkpointDirectory, allocatedPodsStateFile),
 
-		statusManager:           statusManager,
-		admitHandlers:           lifecycle.PodAdmitHandlers{},
-		sourcesReady:            sourcesReady,
-		nodeConfig:              nodeConfig,
-		nodeAllocatableAbsolute: nodeAllocatableAbsolute,
+		statusManager: statusManager,
+		admitHandlers: lifecycle.PodAdmitHandlers{},
+		sourcesReady:  sourcesReady,
 
 		ticker:         time.NewTicker(initialRetryDelay),
 		triggerPodSync: triggerPodSync,
@@ -183,8 +175,6 @@ func newStateImpl(logger klog.Logger, checkpointDirectory, checkpointName string
 // NewInMemoryManager returns an allocation manager that doesn't persist state.
 // For testing purposes only!
 func NewInMemoryManager(
-	nodeConfig cm.NodeConfig,
-	nodeAllocatableAbsolute v1.ResourceList,
 	statusManager status.Manager,
 	triggerPodSync func(pod *v1.Pod),
 	getActivePods func() []*v1.Pod,
@@ -195,11 +185,9 @@ func NewInMemoryManager(
 	return &manager{
 		allocated: state.NewStateMemory(nil),
 
-		statusManager:           statusManager,
-		admitHandlers:           lifecycle.PodAdmitHandlers{},
-		sourcesReady:            sourcesReady,
-		nodeConfig:              nodeConfig,
-		nodeAllocatableAbsolute: nodeAllocatableAbsolute,
+		statusManager: statusManager,
+		admitHandlers: lifecycle.PodAdmitHandlers{},
+		sourcesReady:  sourcesReady,
 
 		ticker:         time.NewTicker(initialRetryDelay),
 		triggerPodSync: triggerPodSync,

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2399,8 +2399,6 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 		containerManager = cm.NewFakeContainerManagerWithNodeConfig(*nodeConfig)
 	}
 	allocationManager := NewInMemoryManager(
-		containerManager.GetNodeConfig(),
-		containerManager.GetNodeAllocatableAbsolute(),
 		statusManager,
 		func(pod *v1.Pod) {
 			/* For testing, just mark the pod as having a pod sync triggered in an annotation. */

--- a/pkg/kubelet/allocation/handlers.go
+++ b/pkg/kubelet/allocation/handlers.go
@@ -1,0 +1,171 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocation
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/api/v1/resource"
+	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
+)
+
+// NewPodResizesAdmitHandler returns a PodAdmitHandler which is used to evaluate
+// if a pod resize can be allocated by the kubelet.
+func NewPodResizesAdmitHandler(containerManager cm.ContainerManager, containerRuntime kubecontainer.Runtime, allocationManager Manager, logger klog.Logger) lifecycle.PodAdmitHandler {
+	return &podResizesAdmitHandler{
+		containerManager:  containerManager,
+		containerRuntime:  containerRuntime,
+		allocationManager: allocationManager,
+		logger:            logger,
+	}
+}
+
+type podResizesAdmitHandler struct {
+	containerManager  cm.ContainerManager
+	containerRuntime  kubecontainer.Runtime
+	allocationManager Manager
+	logger            klog.Logger
+}
+
+func (h *podResizesAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	if attrs.Operation != lifecycle.ResizeOperation {
+		return lifecycle.PodAdmitResult{Admit: true}
+	}
+
+	pod := attrs.Pod
+	allocatedPod, _ := h.allocationManager.UpdatePodFromAllocation(pod)
+	if resizable, msg, reason := IsInPlacePodVerticalScalingAllowed(pod); !resizable {
+		// If there is a pending resize but the resize is not allowed, always use the allocated resources.
+		metrics.PodInfeasibleResizes.WithLabelValues(reason).Inc()
+		return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
+	}
+	if resizeNotAllowed, msg := disallowResizeForSwappableContainers(h.containerRuntime, pod, allocatedPod); resizeNotAllowed {
+		// If this resize involve swap recalculation, set as infeasible, as IPPR with swap is not supported for beta.
+		metrics.PodInfeasibleResizes.WithLabelValues("swap_limitation").Inc()
+		return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
+	}
+	if !apiequality.Semantic.DeepEqual(pod.Spec.Resources, allocatedPod.Spec.Resources) {
+		if resizable, msg, reason := IsInPlacePodLevelResourcesVerticalScalingAllowed(pod); !resizable {
+			// If there is a pending pod-level resources resize but the resize is not allowed, always use the allocated resources.
+			metrics.PodInfeasibleResizes.WithLabelValues(reason).Inc()
+			return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
+		}
+	}
+
+	if v1qos.GetPodQOS(pod) == v1.PodQOSGuaranteed {
+		if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveCPUs) &&
+			h.containerManager.GetNodeConfig().CPUManagerPolicy == string(cpumanager.PolicyStatic) &&
+			h.guaranteedPodResourceResizeRequired(pod, v1.ResourceCPU) {
+			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods alongside CPU Manager policy \"%s\"", string(cpumanager.PolicyStatic))
+			h.logger.V(3).Info(msg, "pod", format.Pod(pod))
+			metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_cpu_manager_static_policy").Inc()
+			return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
+		}
+		if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingExclusiveMemory) &&
+			h.containerManager.GetNodeConfig().MemoryManagerPolicy == string(memorymanager.PolicyTypeStatic) &&
+			h.guaranteedPodResourceResizeRequired(pod, v1.ResourceMemory) {
+			msg := fmt.Sprintf("Resize is infeasible for Guaranteed Pods alongside Memory Manager policy \"%s\"", string(memorymanager.PolicyTypeStatic))
+			h.logger.V(3).Info(msg, "pod", format.Pod(pod))
+			metrics.PodInfeasibleResizes.WithLabelValues("guaranteed_pod_memory_manager_static_policy").Inc()
+			return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
+		}
+	}
+
+	allocatable := h.containerManager.GetNodeAllocatableAbsolute()
+	cpuAvailable := allocatable.Cpu().MilliValue()
+	memAvailable := allocatable.Memory().Value()
+	cpuRequests := resource.GetResourceRequest(pod, v1.ResourceCPU)
+	memRequests := resource.GetResourceRequest(pod, v1.ResourceMemory)
+
+	if cpuRequests > cpuAvailable || memRequests > memAvailable {
+		var msg string
+		if memRequests > memAvailable {
+			msg = fmt.Sprintf("memory, requested: %d, capacity: %d", memRequests, memAvailable)
+		} else {
+			msg = fmt.Sprintf("cpu, requested: %d, capacity: %d", cpuRequests, cpuAvailable)
+		}
+		msg = "Node didn't have enough capacity: " + msg
+		h.logger.V(3).Info(msg, "pod", klog.KObj(pod))
+		metrics.PodInfeasibleResizes.WithLabelValues("insufficient_node_allocatable").Inc()
+		return lifecycle.PodAdmitResult{Admit: false, Reason: v1.PodReasonInfeasible, Message: msg}
+	}
+
+	return lifecycle.PodAdmitResult{Admit: true}
+}
+
+func disallowResizeForSwappableContainers(runtime kubecontainer.Runtime, desiredPod, allocatedPod *v1.Pod) (bool, string) {
+	if desiredPod == nil || allocatedPod == nil {
+		return false, ""
+	}
+	restartableMemoryResizePolicy := func(resizePolicies []v1.ContainerResizePolicy) bool {
+		for _, policy := range resizePolicies {
+			if policy.ResourceName == v1.ResourceMemory {
+				return policy.RestartPolicy == v1.RestartContainer
+			}
+		}
+		return false
+	}
+	allocatedContainers := make(map[string]v1.Container)
+	for _, container := range append(allocatedPod.Spec.Containers, allocatedPod.Spec.InitContainers...) {
+		allocatedContainers[container.Name] = container
+	}
+	for _, desiredContainer := range append(desiredPod.Spec.Containers, desiredPod.Spec.InitContainers...) {
+		allocatedContainer, ok := allocatedContainers[desiredContainer.Name]
+		if !ok {
+			continue
+		}
+		origMemRequest := desiredContainer.Resources.Requests[v1.ResourceMemory]
+		newMemRequest := allocatedContainer.Resources.Requests[v1.ResourceMemory]
+		if !origMemRequest.Equal(newMemRequest) && !restartableMemoryResizePolicy(allocatedContainer.ResizePolicy) {
+			aSwapBehavior := runtime.GetContainerSwapBehavior(desiredPod, &desiredContainer)
+			bSwapBehavior := runtime.GetContainerSwapBehavior(allocatedPod, &allocatedContainer)
+			if aSwapBehavior != kubetypes.NoSwap || bSwapBehavior != kubetypes.NoSwap {
+				return true, "In-place resize of containers with swap is not supported."
+			}
+		}
+	}
+	return false, ""
+}
+
+func (h *podResizesAdmitHandler) guaranteedPodResourceResizeRequired(pod *v1.Pod, resourceName v1.ResourceName) bool {
+	for container, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if !IsResizableContainer(container, containerType) {
+			continue
+		}
+		requestedResources := container.Resources
+		allocatedresources, _ := h.allocationManager.GetContainerResourceAllocation(pod.UID, container.Name)
+		// For Guaranteed pods, requests must equal limits, so checking requests is sufficient.
+		if !requestedResources.Requests[resourceName].Equal(allocatedresources.Requests[resourceName]) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -689,8 +689,6 @@ func NewMainKubelet(ctx context.Context,
 	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet, kubeDeps.PodStartupLatencyTracker)
 	klet.allocationManager = allocation.NewManager(
 		klet.getRootDir(),
-		klet.containerManager.GetNodeConfig(),
-		klet.containerManager.GetNodeAllocatableAbsolute(),
 		klet.statusManager,
 		func(pod *v1.Pod) { klet.HandlePodSyncs(ctx, []*v1.Pod{pod}) },
 		klet.GetActivePods,

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -398,6 +398,7 @@ func newTestKubeletWithImageList(
 	kubelet.evictionManager = evictionManager
 	handlers := []lifecycle.PodAdmitHandler{}
 	handlers = append(handlers, evictionAdmitHandler)
+	handlers = append(handlers, allocation.NewPodResizesAdmitHandler(kubelet.containerManager, fakeRuntime, kubelet.allocationManager, logger))
 
 	// setup shutdown manager
 	shutdownManager := nodeshutdown.NewManager(&nodeshutdown.Config{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -332,8 +332,6 @@ func newTestKubeletWithImageList(
 	}
 
 	kubelet.allocationManager = allocation.NewInMemoryManager(
-		kubelet.containerManager.GetNodeConfig(),
-		kubelet.containerManager.GetNodeAllocatableAbsolute(),
 		kubelet.statusManager,
 		func(pod *v1.Pod) { kubelet.HandlePodSyncs(tCtx, []*v1.Pod{pod}) },
 		kubelet.GetActivePods,

--- a/pkg/kubelet/lifecycle/interfaces.go
+++ b/pkg/kubelet/lifecycle/interfaces.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package lifecycle
 
-import "k8s.io/api/core/v1"
+import v1 "k8s.io/api/core/v1"
 
 // PodAdmitAttributes is the context for a pod admission decision.
 // The member fields of this struct should never be mutated.
@@ -25,7 +25,19 @@ type PodAdmitAttributes struct {
 	Pod *v1.Pod
 	// all pods bound to the kubelet excluding the pod being evaluated
 	OtherPods []*v1.Pod
+	// the operation being performed; either "add" or "resize"
+	Operation Operation
 }
+
+// Operation represents the type of operation being performed on a pod.
+type Operation string
+
+const (
+	// AddOperation indicates that the pod is being added to the kubelet.
+	AddOperation Operation = "add"
+	// ResizeOperation indicates that the pod is being resized.
+	ResizeOperation Operation = "resize"
+)
 
 // PodAdmitResult provides the result of a pod admission decision.
 type PodAdmitResult struct {

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/kubelet/allocation"
-	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -455,7 +454,7 @@ func createPodWorkers() (*podWorkers, *containertest.FakeRuntime, map[types.UID]
 		time.Second,
 		time.Millisecond,
 		fakeCache,
-		allocation.NewInMemoryManager(cm.NodeConfig{}, nil, nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
 	)
 	workers := w.(*podWorkers)
 	workers.clock = clock
@@ -2135,7 +2134,7 @@ func TestFakePodWorkers(t *testing.T) {
 		time.Second,
 		time.Second,
 		fakeCache,
-		allocation.NewInMemoryManager(cm.NodeConfig{}, nil, nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
 	)
 	fakePodWorkers := &fakePodWorkers{
 		syncPodFn: kubeletForFakeWorkers.SyncPod,

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -281,6 +281,11 @@ func (m *manager) SetPodResizePendingCondition(podUID types.UID, reason, message
 
 	previousCondition := m.podResizeConditions[podUID].PodResizePending
 
+	if reason != v1.PodReasonInfeasible {
+		// For all other "pending" reasons, we set the reason to "Deferred".
+		reason = v1.PodReasonDeferred
+	}
+
 	m.podResizeConditions[podUID] = podResizeConditions{
 		PodResizePending:    updatedPodResizeCondition(v1.PodResizePending, m.podResizeConditions[podUID].PodResizePending, reason, message, observedGeneration),
 		PodResizeInProgress: m.podResizeConditions[podUID].PodResizeInProgress,

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -2161,7 +2161,7 @@ func TestPodResizeConditions(t *testing.T) {
 		{
 			name: "set pod resize pending condition to deferred with message",
 			updateFunc: func(podUID types.UID) bool {
-				return m.SetPodResizePendingCondition(podUID, v1.PodReasonDeferred, "some-message", 1)
+				return m.SetPodResizePendingCondition(podUID, "some-reason", "some-message", 1)
 			},
 			expectedUpdateFuncReturnVal: true,
 			expected: []*v1.PodCondition{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Move resize allocation check into its own admitHandler, and combine `canResizePod` with `canAdmitPod`. This addresses [an old TODO](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/allocation/allocation_manager.go#L715-L716), and removes a direct dependency of the allocation on the nodeConfig and nodeAllocatableAbsolute.

#### Special notes for your reviewer

Review might be easier by looking at individual commits

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/triage accepted
/assign @tallclair 
