### PR TITLE
Respect metric deprecation policy for hiding metrics

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/collector_test.go
+++ b/staging/src/k8s.io/component-base/metrics/collector_test.go
@@ -70,7 +70,7 @@ func TestBaseCustomCollector(t *testing.T) {
 		deprecatedDesc = NewDesc("metric_deprecated", "stable deprecated metrics", []string{"name"}, nil,
 			STABLE, "1.17.0")
 		hiddenDesc = NewDesc("metric_hidden", "stable hidden metrics", []string{"name"}, nil,
-			STABLE, "1.16.0")
+			STABLE, "1.14.0")
 	)
 
 	registry := newKubeRegistry(currentVersion)

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -60,8 +60,7 @@ func TestCounter(t *testing.T) {
 				StabilityLevel:    ALPHA,
 				DeprecatedVersion: "1.15.0",
 			},
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) counter help",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",
@@ -148,8 +147,7 @@ func TestCounterVec(t *testing.T) {
 				DeprecatedVersion: "1.15.0",
 			},
 			labels:                    []string{"label_a", "label_b"},
-			expectedMetricFamilyCount: 1,
-			expectedHelp:              "[ALPHA] (Deprecated since 1.15.0) counter help",
+			expectedMetricFamilyCount: 0,
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -51,7 +51,7 @@ func TestCounter(t *testing.T) {
 			expectedHelp:        "[ALPHA] counter help",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "Test deprecated ALPHA",
 			CounterOpts: &CounterOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
@@ -61,6 +61,32 @@ func TestCounter(t *testing.T) {
 				DeprecatedVersion: "1.15.0",
 			},
 			expectedMetricCount: 0,
+		},
+		{
+			desc: "Test deprecated BETA",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "counter help",
+				StabilityLevel:    BETA,
+				DeprecatedVersion: "1.15.0",
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] (Deprecated since 1.15.0) counter help",
+		},
+		{
+			desc: "Test deprecated STABLE",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "counter help",
+				StabilityLevel:    STABLE,
+				DeprecatedVersion: "1.15.0",
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] (Deprecated since 1.15.0) counter help",
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/desc.go
+++ b/staging/src/k8s.io/component-base/metrics/desc.go
@@ -120,7 +120,7 @@ func (d *Desc) determineDeprecationStatus(version semver.Version) {
 			klog.Warningf("Hidden metrics(%s) have been manually overridden, showing this very deprecated metric.", d.fqName)
 			return
 		}
-		if shouldHide(&version, selfVersion) {
+		if shouldHide(d.stabilityLevel, &version, selfVersion) {
 			// TODO(RainbowMango): Remove this log temporarily. https://github.com/kubernetes/kubernetes/issues/85369
 			// klog.Warningf("This metric(%s) has been deprecated for more than one release, hiding.", d.fqName)
 			d.isHidden = true

--- a/staging/src/k8s.io/component-base/metrics/desc_test.go
+++ b/staging/src/k8s.io/component-base/metrics/desc_test.go
@@ -72,7 +72,7 @@ func TestDescCreate(t *testing.T) {
 			fqName:                "hidden_stable_descriptor",
 			help:                  "this is a hidden descriptor",
 			stabilityLevel:        STABLE,
-			deprecatedVersion:     "1.16.0",
+			deprecatedVersion:     "1.14.0",
 			shouldCreate:          false,
 			expectedAnnotatedHelp: "this is a hidden descriptor", // hidden descriptor shall not be annotated.
 		},

--- a/staging/src/k8s.io/component-base/metrics/gauge_test.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge_test.go
@@ -59,8 +59,7 @@ func TestGauge(t *testing.T) {
 				DeprecatedVersion: "1.15.0",
 			},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) gauge help",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",
@@ -146,8 +145,7 @@ func TestGaugeVec(t *testing.T) {
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) gauge help",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",
@@ -234,11 +232,7 @@ namespace_subsystem_metric_non_deprecated 1
 				Help:              "gauge help",
 				DeprecatedVersion: "1.17.0",
 			},
-			expectedMetrics: `
-# HELP namespace_subsystem_metric_deprecated [ALPHA] (Deprecated since 1.17.0) gauge help
-# TYPE namespace_subsystem_metric_deprecated gauge
-namespace_subsystem_metric_deprecated 1
-`,
+			expectedMetrics: "",
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/gauge_test.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge_test.go
@@ -135,7 +135,7 @@ func TestGaugeVec(t *testing.T) {
 			expectedHelp:        "[ALPHA] gauge help",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "Test deprecated ALPHA",
 			GaugeOpts: &GaugeOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
@@ -146,6 +146,36 @@ func TestGaugeVec(t *testing.T) {
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,
 			expectedMetricCount: 0,
+		},
+		{
+			desc: "Test deprecated BETA",
+			GaugeOpts: &GaugeOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "gauge help",
+				DeprecatedVersion: "1.15.0",
+				StabilityLevel:    BETA,
+			},
+			labels:              []string{"label_a", "label_b"},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] (Deprecated since 1.15.0) gauge help",
+		},
+		{
+			desc: "Test deprecated STABLE",
+			GaugeOpts: &GaugeOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "gauge help",
+				DeprecatedVersion: "1.15.0",
+				StabilityLevel:    STABLE,
+			},
+			labels:              []string{"label_a", "label_b"},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] (Deprecated since 1.15.0) gauge help",
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -63,8 +63,7 @@ func TestHistogram(t *testing.T) {
 				Buckets:           prometheus.DefBuckets,
 			},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) histogram help message",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",
@@ -167,8 +166,7 @@ func TestHistogramVec(t *testing.T) {
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) histogram help message",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -53,7 +53,7 @@ func TestHistogram(t *testing.T) {
 			expectedHelp:        "[ALPHA] histogram help message",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "Test deprecated ALPHA",
 			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
@@ -64,6 +64,36 @@ func TestHistogram(t *testing.T) {
 			},
 			registryVersion:     &v115,
 			expectedMetricCount: 0,
+		},
+		{
+			desc: "Test deprecated BETA",
+			HistogramOpts: &HistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           prometheus.DefBuckets,
+				StabilityLevel:    BETA,
+			},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] (Deprecated since 1.15.0) histogram help message",
+		},
+		{
+			desc: "Test deprecated STABLE",
+			HistogramOpts: &HistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           prometheus.DefBuckets,
+				StabilityLevel:    STABLE,
+			},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] (Deprecated since 1.15.0) histogram help message",
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -120,7 +120,7 @@ func (r *lazyMetric) preprocessMetric(version semver.Version) {
 			klog.Warningf("Hidden metrics (%s) have been manually overridden, showing this very deprecated metric.", r.fqName)
 			return
 		}
-		if shouldHide(&version, selfVersion) {
+		if shouldHide(r.stabilityLevel, &version, selfVersion) {
 			// TODO(RainbowMango): Remove this log temporarily. https://github.com/kubernetes/kubernetes/issues/85369
 			// klog.Warningf("This metric has been deprecated for more than one release, hiding.")
 			r.isHidden = true

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -76,7 +76,7 @@ var (
 // according to metrics deprecation lifecycle.
 // This follows rule #11b as stated here: https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-a-metric
 func shouldHide(stabilityLevel StabilityLevel, currentVersion, deprecatedVersion *semver.Version) bool {
-	guardVersion, err := semver.Make(fmt.Sprintf("%d.%d.0", currentVersion.Major, currentVersion.Minor))
+	guardVersion, err := semver.Make(fmt.Sprintf("%d.%d.0-alpha.1", currentVersion.Major, currentVersion.Minor))
 	if err != nil {
 		panic("failed to make version from current version")
 	}

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -73,16 +73,84 @@ func TestShouldHide(t *testing.T) {
 	var tests = []struct {
 		desc              string
 		deprecatedVersion string
+		stabilityLevel    StabilityLevel
 		shouldHide        bool
 	}{
+		// Current version tests
 		{
-			desc:              "current minor release should not be hidden",
+			desc:              "current INTERNAL version should be hidden",
 			deprecatedVersion: "1.17.0",
+			stabilityLevel:    INTERNAL,
+			shouldHide:        true,
+		},
+		{
+			desc:              "current ALPHA version should be hidden",
+			deprecatedVersion: "1.17.0",
+			stabilityLevel:    ALPHA,
+			shouldHide:        true,
+		},
+		{
+			desc:              "current BETA version should not be hidden",
+			deprecatedVersion: "1.17.0",
+			stabilityLevel:    BETA,
 			shouldHide:        false,
 		},
 		{
-			desc:              "older minor release should be hidden",
+			desc:              "current STABLE version should not be hidden",
+			deprecatedVersion: "1.17.0",
+			stabilityLevel:    STABLE,
+			shouldHide:        false,
+		},
+
+		// Current version - 1 (BETA) tests
+		{
+			desc:              "n-1 INTERNAL version should *remain* hidden",
 			deprecatedVersion: "1.16.0",
+			stabilityLevel:    INTERNAL,
+			shouldHide:        true,
+		},
+		{
+			desc:              "n-1 ALPHA version should *remain* hidden",
+			deprecatedVersion: "1.16.0",
+			stabilityLevel:    ALPHA,
+			shouldHide:        true,
+		},
+		{
+			desc:              "n-1 BETA version should be hidden",
+			deprecatedVersion: "1.16.0",
+			stabilityLevel:    BETA,
+			shouldHide:        true,
+		},
+		{
+			desc:              "n-1 STABLE version should not be hidden",
+			deprecatedVersion: "1.16.0",
+			stabilityLevel:    STABLE,
+			shouldHide:        false,
+		},
+
+		// Current version - 3 (STABLE) tests
+		{
+			desc:              "n-3 INTERNAL version should *remain* hidden",
+			deprecatedVersion: "1.14.0",
+			stabilityLevel:    INTERNAL,
+			shouldHide:        true,
+		},
+		{
+			desc:              "n-3 ALPHA version should *remain* hidden",
+			deprecatedVersion: "1.14.0",
+			stabilityLevel:    ALPHA,
+			shouldHide:        true,
+		},
+		{
+			desc:              "n-3 BETA version should *remain* hidden",
+			deprecatedVersion: "1.14.0",
+			stabilityLevel:    BETA,
+			shouldHide:        true,
+		},
+		{
+			desc:              "n-3 STABLE version should *remain* hidden",
+			deprecatedVersion: "1.14.0",
+			stabilityLevel:    STABLE,
 			shouldHide:        true,
 		},
 	}
@@ -90,7 +158,7 @@ func TestShouldHide(t *testing.T) {
 	for _, test := range tests {
 		tc := test
 		t.Run(tc.desc, func(t *testing.T) {
-			result := shouldHide(&currentVersion, parseSemver(tc.deprecatedVersion))
+			result := shouldHide(tc.stabilityLevel, &currentVersion, parseSemver(tc.deprecatedVersion))
 			assert.Equalf(t, tc.shouldHide, result, "expected should hide %v, but got %v", tc.shouldHide, result)
 		})
 	}

--- a/staging/src/k8s.io/component-base/metrics/summary_test.go
+++ b/staging/src/k8s.io/component-base/metrics/summary_test.go
@@ -59,8 +59,7 @@ func TestSummary(t *testing.T) {
 				StabilityLevel:    ALPHA,
 			},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) summary help message",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",
@@ -147,8 +146,7 @@ func TestSummaryVec(t *testing.T) {
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) summary help message",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/summary_test.go
+++ b/staging/src/k8s.io/component-base/metrics/summary_test.go
@@ -49,7 +49,7 @@ func TestSummary(t *testing.T) {
 			expectedHelp:        "[ALPHA] summary help message",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "Test deprecated ALPHA",
 			SummaryOpts: &SummaryOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
@@ -60,6 +60,34 @@ func TestSummary(t *testing.T) {
 			},
 			registryVersion:     &v115,
 			expectedMetricCount: 0,
+		},
+		{
+			desc: "Test deprecated BETA",
+			SummaryOpts: &SummaryOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "summary help message",
+				DeprecatedVersion: "1.15.0",
+				StabilityLevel:    BETA,
+			},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] (Deprecated since 1.15.0) summary help message",
+		},
+		{
+			desc: "Test deprecated STABLE",
+			SummaryOpts: &SummaryOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "summary help message",
+				DeprecatedVersion: "1.15.0",
+				StabilityLevel:    STABLE,
+			},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] (Deprecated since 1.15.0) summary help message",
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil_test.go
@@ -36,6 +36,7 @@ func TestNewFakeKubeRegistry(t *testing.T) {
 			Name:              "test_deprecated_total",
 			Help:              "counter help",
 			DeprecatedVersion: "1.18.0",
+			StabilityLevel:    metrics.BETA,
 		},
 	)
 	hiddenCounter := metrics.NewCounter(
@@ -43,6 +44,7 @@ func TestNewFakeKubeRegistry(t *testing.T) {
 			Name:              "test_hidden_counter",
 			Help:              "counter help",
 			DeprecatedVersion: "1.17.0",
+			StabilityLevel:    metrics.BETA,
 		},
 	)
 
@@ -64,7 +66,7 @@ func TestNewFakeKubeRegistry(t *testing.T) {
 			name:   "deprecated",
 			metric: deprecatedCounter,
 			expected: `
-				# HELP test_deprecated_total [ALPHA] (Deprecated since 1.18.0) counter help
+				# HELP test_deprecated_total [BETA] (Deprecated since 1.18.0) counter help
 				# TYPE test_deprecated_total counter
 				test_deprecated_total 0
 				`,

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
@@ -64,8 +64,7 @@ func TestTimingHistogram(t *testing.T) {
 				InitialValue:      3,
 			},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "EXPERIMENTAL: [ALPHA] (Deprecated since 1.15.0) histogram help message",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",
@@ -189,8 +188,7 @@ func TestTimingHistogramVec(t *testing.T) {
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "EXPERIMENTAL: [ALPHA] (Deprecated since 1.15.0) histogram help message",
+			expectedMetricCount: 0,
 		},
 		{
 			desc: "Test hidden",

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram_test.go
@@ -53,7 +53,7 @@ func TestTimingHistogram(t *testing.T) {
 			expectedHelp:        "EXPERIMENTAL: [ALPHA] histogram help message",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "Test deprecated ALPHA",
 			TimingHistogramOpts: &TimingHistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
@@ -65,6 +65,38 @@ func TestTimingHistogram(t *testing.T) {
 			},
 			registryVersion:     &v115,
 			expectedMetricCount: 0,
+		},
+		{
+			desc: "Test deprecated BETA",
+			TimingHistogramOpts: &TimingHistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           DefBuckets,
+				InitialValue:      3,
+				StabilityLevel:    BETA,
+			},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "EXPERIMENTAL: [BETA] (Deprecated since 1.15.0) histogram help message",
+		},
+		{
+			desc: "Test deprecated STABLE",
+			TimingHistogramOpts: &TimingHistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           DefBuckets,
+				InitialValue:      3,
+				StabilityLevel:    STABLE,
+			},
+			registryVersion:     &v115,
+			expectedMetricCount: 1,
+			expectedHelp:        "EXPERIMENTAL: [STABLE] (Deprecated since 1.15.0) histogram help message",
 		},
 		{
 			desc: "Test hidden",


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Bring component-base's `shouldHide` in-line with [1], which previously was just a less-than check.

[1]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-a-metric

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes: #133429

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
