### PR TITLE
Align metric deprecation and hiding with metrics deprecation policy

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/collector_test.go
+++ b/staging/src/k8s.io/component-base/metrics/collector_test.go
@@ -70,7 +70,7 @@ func TestBaseCustomCollector(t *testing.T) {
 		deprecatedDesc = NewDesc("metric_deprecated", "stable deprecated metrics", []string{"name"}, nil,
 			STABLE, "1.17.0")
 		hiddenDesc = NewDesc("metric_hidden", "stable hidden metrics", []string{"name"}, nil,
-			STABLE, "1.16.0")
+			STABLE, "1.14.0")
 	)
 
 	registry := newKubeRegistry(currentVersion)

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
@@ -32,14 +31,22 @@ import (
 )
 
 func TestCounter(t *testing.T) {
+	version1_15Alpha1 := apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	}
+
 	var tests = []struct {
 		desc string
 		*CounterOpts
+		currentVersion      apimachineryversion.Info
 		expectedMetricCount int
 		expectedHelp        string
 	}{
+		// Non-deprecated metrics
 		{
-			desc: "Test non deprecated",
+			desc: "ALPHA metric non deprecated",
 			CounterOpts: &CounterOpts{
 				Namespace:      "namespace",
 				Name:           "metric_test_name",
@@ -51,7 +58,32 @@ func TestCounter(t *testing.T) {
 			expectedHelp:        "[ALPHA] counter help",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "BETA metric non deprecated",
+			CounterOpts: &CounterOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: BETA,
+				Help:           "counter help",
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] counter help",
+		},
+		{
+			desc: "STABLE metric non deprecated",
+			CounterOpts: &CounterOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: STABLE,
+				Help:           "counter help",
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] counter help",
+		},
+		// Deprecated metrics
+		{
+			desc: "ALPHA metric deprecated",
 			CounterOpts: &CounterOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
@@ -60,30 +92,78 @@ func TestCounter(t *testing.T) {
 				StabilityLevel:    ALPHA,
 				DeprecatedVersion: "1.15.0",
 			},
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) counter help",
+			expectedMetricCount: 0,
+			expectedHelp:        "counter help",
 		},
 		{
-			desc: "Test hidden",
+			desc: "BETA metric deprecated",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "counter help",
+				StabilityLevel:    BETA,
+				DeprecatedVersion: "1.15.0",
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] (Deprecated since 1.15.0) counter help",
+		},
+		{
+			desc: "STABLE metric deprecated",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "counter help",
+				StabilityLevel:    STABLE,
+				DeprecatedVersion: "1.14.0",
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] (Deprecated since 1.14.0) counter help",
+		},
+		// Hidden metrics
+		{
+			desc: "ALPHA metric hidden",
 			CounterOpts: &CounterOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "counter help",
 				StabilityLevel:    ALPHA,
-				DeprecatedVersion: "1.14.0",
+				DeprecatedVersion: "1.15.0",
 			},
 			expectedMetricCount: 0,
+			expectedHelp:        "counter help",
+		},
+		{
+			desc: "BETA metric hidden",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "counter help",
+				StabilityLevel:    BETA,
+				DeprecatedVersion: "1.14.0",
+			},
+			expectedMetricCount: 0},
+		{
+			desc: "STABLE metric hidden",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				Help:              "counter help",
+				StabilityLevel:    STABLE,
+				DeprecatedVersion: "1.12.0",
+			},
+			expectedMetricCount: 0,
+			expectedHelp:        "counter help",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			registry := newKubeRegistry(apimachineryversion.Info{
-				Major:      "1",
-				Minor:      "15",
-				GitVersion: "v1.15.0-alpha-1.12345",
-			})
+			registry := newKubeRegistry(version1_15Alpha1)
 			// c is a pointer to a Counter
 			c := NewCounter(test.CounterOpts)
 			registry.MustRegister(c)
@@ -118,45 +198,110 @@ func TestCounter(t *testing.T) {
 }
 
 func TestCounterVec(t *testing.T) {
+	version1_15Alpha1 := apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	}
+
 	var tests = []struct {
 		desc string
 		*CounterOpts
 		labels                    []string
-		registryVersion           *semver.Version
 		expectedMetricFamilyCount int
 		expectedHelp              string
 	}{
+		// Non-deprecated metrics
 		{
-			desc: "Test non deprecated",
+			desc: "ALPHA metric non deprecated",
 			CounterOpts: &CounterOpts{
-				Namespace: "namespace",
-				Name:      "metric_test_name",
-				Subsystem: "subsystem",
-				Help:      "counter help",
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: ALPHA,
+				Help:           "counter help",
 			},
 			labels:                    []string{"label_a", "label_b"},
 			expectedMetricFamilyCount: 1,
 			expectedHelp:              "[ALPHA] counter help",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "BETA metric non deprecated",
+			CounterOpts: &CounterOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: BETA,
+				Help:           "counter help",
+			},
+			labels:                    []string{"label_a", "label_b"},
+			expectedMetricFamilyCount: 1,
+			expectedHelp:              "[BETA] counter help",
+		},
+		{
+			desc: "STABLE metric non deprecated",
+			CounterOpts: &CounterOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: STABLE,
+				Help:           "counter help",
+			},
+			labels:                    []string{"label_a", "label_b"},
+			expectedMetricFamilyCount: 1,
+			expectedHelp:              "[STABLE] counter help",
+		},
+		// Deprecated metrics
+		{
+			desc: "ALPHA metric deprecated",
 			CounterOpts: &CounterOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
+				StabilityLevel:    ALPHA,
+				Help:              "counter help",
+				DeprecatedVersion: "1.15.0",
+			},
+			labels:                    []string{"label_a", "label_b"},
+			expectedMetricFamilyCount: 0,
+			expectedHelp:              "counter help",
+		},
+		{
+			desc: "BETA metric deprecated",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    BETA,
 				Help:              "counter help",
 				DeprecatedVersion: "1.15.0",
 			},
 			labels:                    []string{"label_a", "label_b"},
 			expectedMetricFamilyCount: 1,
-			expectedHelp:              "[ALPHA] (Deprecated since 1.15.0) counter help",
+			expectedHelp:              "[BETA] (Deprecated since 1.15.0) counter help",
 		},
 		{
-			desc: "Test hidden",
+			desc: "STABLE metric deprecated",
 			CounterOpts: &CounterOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
+				StabilityLevel:    STABLE,
+				Help:              "counter help",
+				DeprecatedVersion: "1.15.0",
+			},
+			labels:                    []string{"label_a", "label_b"},
+			expectedMetricFamilyCount: 1,
+			expectedHelp:              "[STABLE] (Deprecated since 1.15.0) counter help",
+		},
+		// Hidden metrics
+		{
+			desc: "ALPHA metric hidden",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    ALPHA,
 				Help:              "counter help",
 				DeprecatedVersion: "1.14.0",
 			},
@@ -165,27 +310,38 @@ func TestCounterVec(t *testing.T) {
 			expectedHelp:              "counter help",
 		},
 		{
-			desc: "Test alpha",
+			desc: "BETA metric hidden",
 			CounterOpts: &CounterOpts{
-				StabilityLevel: ALPHA,
-				Namespace:      "namespace",
-				Name:           "metric_test_name",
-				Subsystem:      "subsystem",
-				Help:           "counter help",
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    BETA,
+				Help:              "counter help",
+				DeprecatedVersion: "1.14.0",
 			},
 			labels:                    []string{"label_a", "label_b"},
-			expectedMetricFamilyCount: 1,
-			expectedHelp:              "[ALPHA] counter help",
+			expectedMetricFamilyCount: 0,
+			expectedHelp:              "counter help",
+		},
+		{
+			desc: "STABLE metric hidden",
+			CounterOpts: &CounterOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    STABLE,
+				Help:              "counter help",
+				DeprecatedVersion: "1.12.0",
+			},
+			labels:                    []string{"label_a", "label_b"},
+			expectedMetricFamilyCount: 0,
+			expectedHelp:              "counter help",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			registry := newKubeRegistry(apimachineryversion.Info{
-				Major:      "1",
-				Minor:      "15",
-				GitVersion: "v1.15.0-alpha-1.12345",
-			})
+			registry := newKubeRegistry(version1_15Alpha1)
 			c := NewCounterVec(test.CounterOpts, test.labels)
 			registry.MustRegister(c)
 			c.WithLabelValues("1", "2").Inc()

--- a/staging/src/k8s.io/component-base/metrics/desc_test.go
+++ b/staging/src/k8s.io/component-base/metrics/desc_test.go
@@ -72,7 +72,7 @@ func TestDescCreate(t *testing.T) {
 			fqName:                "hidden_stable_descriptor",
 			help:                  "this is a hidden descriptor",
 			stabilityLevel:        STABLE,
-			deprecatedVersion:     "1.16.0",
+			deprecatedVersion:     "1.14.0",
 			shouldCreate:          false,
 			expectedAnnotatedHelp: "this is a hidden descriptor", // hidden descriptor shall not be annotated.
 		},

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -31,52 +30,141 @@ import (
 )
 
 func TestHistogram(t *testing.T) {
-	v115 := semver.MustParse("1.15.0")
+	version1_15Alpha1 := apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	}
+
 	var tests = []struct {
 		desc string
 		*HistogramOpts
-		registryVersion     *semver.Version
 		expectedMetricCount int
 		expectedHelp        string
 	}{
+		// Non-deprecated metrics
 		{
-			desc: "Test non deprecated",
+			desc: "ALPHA metric non deprecated",
 			HistogramOpts: &HistogramOpts{
-				Namespace: "namespace",
-				Name:      "metric_test_name",
-				Subsystem: "subsystem",
-				Help:      "histogram help message",
-				Buckets:   prometheus.DefBuckets,
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: ALPHA,
+				Help:           "histogram help message",
+				Buckets:        prometheus.DefBuckets,
 			},
-			registryVersion:     &v115,
 			expectedMetricCount: 1,
 			expectedHelp:        "[ALPHA] histogram help message",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "BETA metric non deprecated",
+			HistogramOpts: &HistogramOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: BETA,
+				Help:           "histogram help message",
+				Buckets:        prometheus.DefBuckets,
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] histogram help message",
+		},
+		{
+			desc: "STABLE metric non deprecated",
+			HistogramOpts: &HistogramOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: STABLE,
+				Help:           "histogram help message",
+				Buckets:        prometheus.DefBuckets,
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] histogram help message",
+		},
+		// Deprecated metrics
+		{
+			desc: "ALPHA metric deprecated",
 			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
+				StabilityLevel:    ALPHA,
 				Help:              "histogram help message",
 				DeprecatedVersion: "1.15.0",
 				Buckets:           prometheus.DefBuckets,
 			},
-			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) histogram help message",
+			expectedMetricCount: 0,
+			expectedHelp:        "histogram help message",
 		},
 		{
-			desc: "Test hidden",
+			desc: "BETA metric deprecated",
 			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
+				StabilityLevel:    BETA,
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           prometheus.DefBuckets,
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] (Deprecated since 1.15.0) histogram help message",
+		},
+		{
+			desc: "STABLE metric deprecated",
+			HistogramOpts: &HistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    STABLE,
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           prometheus.DefBuckets,
+			},
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] (Deprecated since 1.15.0) histogram help message",
+		},
+		// Hidden metrics
+		{
+			desc: "ALPHA metric hidden",
+			HistogramOpts: &HistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    ALPHA,
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           prometheus.DefBuckets,
+			},
+			expectedMetricCount: 0,
+			expectedHelp:        "histogram help message",
+		},
+		{
+			desc: "BETA metric hidden",
+			HistogramOpts: &HistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    BETA,
 				Help:              "histogram help message",
 				DeprecatedVersion: "1.14.0",
 				Buckets:           prometheus.DefBuckets,
 			},
-			registryVersion:     &v115,
+			expectedMetricCount: 0,
+			expectedHelp:        "histogram help message",
+		},
+		{
+			desc: "STABLE metric hidden",
+			HistogramOpts: &HistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    STABLE,
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.12.0",
+				Buckets:           prometheus.DefBuckets,
+			},
 			expectedMetricCount: 0,
 			expectedHelp:        "histogram help message",
 		},
@@ -84,11 +172,7 @@ func TestHistogram(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			registry := newKubeRegistry(apimachineryversion.Info{
-				Major:      "1",
-				Minor:      "15",
-				GitVersion: "v1.15.0-alpha-1.12345",
-			})
+			registry := newKubeRegistry(version1_15Alpha1)
 			c := NewHistogram(test.HistogramOpts)
 			registry.MustRegister(c)
 			cm := c.ObserverMetric.(prometheus.Metric)
@@ -132,17 +216,22 @@ func TestHistogram(t *testing.T) {
 }
 
 func TestHistogramVec(t *testing.T) {
-	v115 := semver.MustParse("1.15.0")
+	version1_15Alpha1 := apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	}
+
 	var tests = []struct {
 		desc string
 		*HistogramOpts
 		labels              []string
-		registryVersion     *semver.Version
 		expectedMetricCount int
 		expectedHelp        string
 	}{
+		// Non-deprecated metrics
 		{
-			desc: "Test non deprecated",
+			desc: "ALPHA metric non deprecated",
 			HistogramOpts: &HistogramOpts{
 				Namespace: "namespace",
 				Name:      "metric_test_name",
@@ -151,37 +240,115 @@ func TestHistogramVec(t *testing.T) {
 				Buckets:   prometheus.DefBuckets,
 			},
 			labels:              []string{"label_a", "label_b"},
-			registryVersion:     &v115,
 			expectedMetricCount: 1,
 			expectedHelp:        "[ALPHA] histogram help message",
 		},
 		{
-			desc: "Test deprecated",
+			desc: "BETA metric non deprecated",
+			HistogramOpts: &HistogramOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: BETA,
+				Help:           "histogram help message",
+				Buckets:        prometheus.DefBuckets,
+			},
+			labels:              []string{"label_a", "label_b"},
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] histogram help message",
+		},
+		{
+			desc: "STABLE metric non deprecated",
+			HistogramOpts: &HistogramOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: STABLE,
+				Help:           "histogram help message",
+				Buckets:        prometheus.DefBuckets,
+			},
+			labels:              []string{"label_a", "label_b"},
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] histogram help message",
+		},
+		// Deprecated metrics
+		{
+			desc: "ALPHA metric deprecated",
 			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
+				StabilityLevel:    ALPHA,
 				Help:              "histogram help message",
 				DeprecatedVersion: "1.15.0",
 				Buckets:           prometheus.DefBuckets,
 			},
 			labels:              []string{"label_a", "label_b"},
-			registryVersion:     &v115,
-			expectedMetricCount: 1,
-			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) histogram help message",
+			expectedMetricCount: 0,
+			expectedHelp:        "histogram help message",
 		},
 		{
-			desc: "Test hidden",
+			desc: "BETA metric deprecated",
 			HistogramOpts: &HistogramOpts{
 				Namespace:         "namespace",
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
+				StabilityLevel:    BETA,
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.15.0",
+				Buckets:           prometheus.DefBuckets,
+			},
+			labels:              []string{"label_a", "label_b"},
+			expectedMetricCount: 1,
+			expectedHelp:        "[BETA] (Deprecated since 1.15.0) histogram help message",
+		},
+		{
+			desc: "STABLE metric deprecated",
+			HistogramOpts: &HistogramOpts{
+				Namespace:      "namespace",
+				Name:           "metric_test_name",
+				Subsystem:      "subsystem",
+				StabilityLevel: STABLE,
+				Help:           "histogram help message",
+
+				DeprecatedVersion: "1.15.0",
+				Buckets:           prometheus.DefBuckets,
+			},
+			labels:              []string{"label_a", "label_b"},
+			expectedMetricCount: 1,
+			expectedHelp:        "[STABLE] (Deprecated since 1.15.0) histogram help message",
+		},
+		// Hidden metrics
+		{
+			desc: "ALPHA metric hidden",
+			HistogramOpts: &HistogramOpts{
+				Namespace:         "namespace",
+				Name:              "metric_test_name",
+				Subsystem:         "subsystem",
+				StabilityLevel:    ALPHA,
 				Help:              "histogram help message",
 				DeprecatedVersion: "1.14.0",
 				Buckets:           prometheus.DefBuckets,
 			},
 			labels:              []string{"label_a", "label_b"},
-			registryVersion:     &v115,
+			expectedMetricCount: 0,
+			expectedHelp:        "histogram help message",
+		},
+		{
+			desc: "BETA metric hidden",
+			HistogramOpts: &HistogramOpts{
+				Namespace: "namespace",
+				Name:      "metric_test_name",
+
+				Subsystem:      "subsystem",
+				StabilityLevel: BETA,
+
+				Help:              "histogram help message",
+				DeprecatedVersion: "1.14.0",
+				Buckets:           prometheus.DefBuckets,
+			},
+
+			labels:              []string{"label_a", "label_b"},
 			expectedMetricCount: 0,
 			expectedHelp:        "histogram help message",
 		},
@@ -189,11 +356,7 @@ func TestHistogramVec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			registry := newKubeRegistry(apimachineryversion.Info{
-				Major:      "1",
-				Minor:      "15",
-				GitVersion: "v1.15.0-alpha-1.12345",
-			})
+			registry := newKubeRegistry(version1_15Alpha1)
 			c := NewHistogramVec(test.HistogramOpts, test.labels)
 			registry.MustRegister(c)
 			ov12 := c.WithLabelValues("1", "2")

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -99,7 +99,7 @@ func (r *lazyMetric) lazyInit(self kubeCollector, fqName string) {
 // Disclaimer:  disabling a metric via a CLI flag has higher precedence than
 // deprecation and will override show-hidden-metrics for the explicitly
 // disabled metric.
-func (r *lazyMetric) preprocessMetric(version semver.Version) {
+func (r *lazyMetric) preprocessMetric(currentVersion semver.Version) {
 	disabledMetricsLock.RLock()
 	defer disabledMetricsLock.RUnlock()
 	// disabling metrics is higher in precedence than showing hidden metrics
@@ -107,20 +107,18 @@ func (r *lazyMetric) preprocessMetric(version semver.Version) {
 		r.isHidden = true
 		return
 	}
-	selfVersion := r.self.DeprecatedVersion()
-	if selfVersion == nil {
+	deprecatedVersion := r.self.DeprecatedVersion()
+	if deprecatedVersion == nil {
 		return
 	}
 	r.markDeprecationOnce.Do(func() {
-		if selfVersion.LTE(version) {
-			r.isDeprecated = true
-		}
+		r.isDeprecated = isDeprecated(currentVersion, *deprecatedVersion)
 
-		if ShouldShowHidden() {
-			klog.Warningf("Hidden metrics (%s) have been manually overridden, showing this very deprecated metric.", r.fqName)
-			return
-		}
-		if shouldHide(&version, selfVersion) {
+		if shouldHide(r.stabilityLevel, &currentVersion, deprecatedVersion) {
+			if shouldShowHidden() {
+				klog.Warningf("Hidden metrics (%s) have been manually overridden, showing this very deprecated metric.", r.fqName)
+				return
+			}
 			// TODO(RainbowMango): Remove this log temporarily. https://github.com/kubernetes/kubernetes/issues/85369
 			// klog.Warningf("This metric has been deprecated for more than one release, hiding.")
 			r.isHidden = true

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -51,6 +51,16 @@ var (
 			DeprecatedVersion: "1.15.0",
 		},
 	)
+	betaDeprecatedCounter = NewCounter(
+		&CounterOpts{
+			Namespace:         "some_namespace",
+			Name:              "test_beta_dep_counter",
+			Subsystem:         "subsystem",
+			StabilityLevel:    BETA,
+			Help:              "counter help",
+			DeprecatedVersion: "1.15.0",
+		},
+	)
 	alphaHiddenCounter = NewCounter(
 		&CounterOpts{
 			Namespace:         "some_namespace",
@@ -64,25 +74,186 @@ var (
 )
 
 func TestShouldHide(t *testing.T) {
-	currentVersion := parseVersion(apimachineryversion.Info{
-		Major:      "1",
-		Minor:      "17",
-		GitVersion: "v1.17.1-alpha-1.12345",
-	})
+	currentV1_17 := parseSemver("1.17.0")
+	currentV1_18Alpha0 := parseSemver("1.18.0-alpha.0")
+	currentV1_18Alpha1 := parseSemver("1.18.0-alpha.1")
 
 	var tests = []struct {
 		desc              string
+		currentVersion    *semver.Version
+		stabilityLevel    StabilityLevel
 		deprecatedVersion string
 		shouldHide        bool
 	}{
 		{
-			desc:              "current minor release should not be hidden",
+			desc:              "INTERNAL metric deprecated in the current release - should be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    INTERNAL,
+			deprecatedVersion: "1.17.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "INTERNAL metric deprecated 1 release ago - should be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    INTERNAL,
+			deprecatedVersion: "1.16.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "INTERNAL metric to be deprecated 1 release later - should not be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    INTERNAL,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "BETA metric deprecated in the current release - should not be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    BETA,
 			deprecatedVersion: "1.17.0",
 			shouldHide:        false,
 		},
 		{
-			desc:              "older minor release should be hidden",
+			desc:              "BETA metric deprecated 1 release ago - should be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    BETA,
 			deprecatedVersion: "1.16.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "BETA metric to be deprecated 1 release later - should not be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    BETA,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "STABLE metric deprecated in the current release - should not be hidden",
+			currentVersion:    parseSemver("1.17.0"),
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.17.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "STABLE metric deprecated 3 releases ago - should be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.14.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "STABLE metric deprecated 2 releases ago - should not be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.15.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "STABLE metric to be deprecated 1 release later - should not be hidden",
+			currentVersion:    currentV1_17,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		// --- Pre-Alpha.0 Tests ---
+		{
+			desc:              "INTERNAL metric deprecated in the current minor - should not be hidden",
+			currentVersion:    currentV1_18Alpha0,
+			stabilityLevel:    INTERNAL,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "INTERNAL metric deprecated 1 release ago - should be hidden",
+			currentVersion:    currentV1_18Alpha0,
+			stabilityLevel:    INTERNAL,
+			deprecatedVersion: "1.17.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "BETA metric deprecated in the current minor - should not be hidden",
+			currentVersion:    currentV1_18Alpha0,
+			stabilityLevel:    BETA,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "BETA metric deprecated 1 release ago - should not be hidden",
+			currentVersion:    currentV1_18Alpha0,
+			stabilityLevel:    BETA,
+			deprecatedVersion: "1.17.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "STABLE metric deprecated in the current minor - should be hidden",
+			currentVersion:    currentV1_18Alpha0,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "STABLE metric deprecated 1 release ago - should not be hidden",
+			currentVersion:    currentV1_18Alpha0,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.17.0",
+			shouldHide:        false,
+		},
+		// --- Pre-Alpha.1 Tests ---
+		{
+
+			desc:              "INTERNAL metric in the current minor - should be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    INTERNAL,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "INTERNAL metric deprecated in prior patch - should be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    INTERNAL,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "BETA metric deprecated in the current minor - should not be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    BETA,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "BETA metric deprecated in prior patch - should not be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    BETA,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "BETA metric deprecated 1 release ago - should be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    BETA,
+			deprecatedVersion: "1.17.0",
+			shouldHide:        true,
+		},
+		{
+			desc:              "STABLE metric deprecated in the current minor - should not be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "STABLE metric deprecated in prior patch - should not be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.18.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "STABLE metric deprecated 3 minors ago - should be hidden",
+			currentVersion:    currentV1_18Alpha1,
+			stabilityLevel:    STABLE,
+			deprecatedVersion: "1.15.0",
 			shouldHide:        true,
 		},
 	}
@@ -90,7 +261,7 @@ func TestShouldHide(t *testing.T) {
 	for _, test := range tests {
 		tc := test
 		t.Run(tc.desc, func(t *testing.T) {
-			result := shouldHide(&currentVersion, parseSemver(tc.deprecatedVersion))
+			result := shouldHide(tc.stabilityLevel, tc.currentVersion, parseSemver(tc.deprecatedVersion))
 			assert.Equalf(t, tc.shouldHide, result, "expected should hide %v, but got %v", tc.shouldHide, result)
 		})
 	}
@@ -125,9 +296,9 @@ func TestRegister(t *testing.T) {
 			desc:                    "test alpha deprecated metric",
 			metrics:                 []*Counter{alphaDeprecatedCounter},
 			expectedErrors:          []error{nil},
-			expectedIsCreatedValues: []bool{true},
+			expectedIsCreatedValues: []bool{false},
 			expectedIsDeprecated:    []bool{true},
-			expectedIsHidden:        []bool{false},
+			expectedIsHidden:        []bool{true},
 		},
 		{
 			desc:                    "test alpha hidden metric",
@@ -192,7 +363,7 @@ func TestMustRegister(t *testing.T) {
 		},
 		{
 			desc:            "test must registering same deprecated metric",
-			metrics:         []*Counter{alphaDeprecatedCounter, alphaDeprecatedCounter},
+			metrics:         []*Counter{betaDeprecatedCounter, betaDeprecatedCounter},
 			registryVersion: &v115,
 			expectedPanics:  []bool{false, true},
 		},
@@ -331,11 +502,11 @@ func TestEnableHiddenMetrics(t *testing.T) {
 				Name:              "hidden_metric_register",
 				Help:              "counter help",
 				StabilityLevel:    STABLE,
-				DeprecatedVersion: "1.16.0",
+				DeprecatedVersion: "1.14.0",
 			}),
 			mustRegister: false,
 			expectedMetric: `
-				# HELP hidden_metric_register [STABLE] (Deprecated since 1.16.0) counter help
+				# HELP hidden_metric_register [STABLE] (Deprecated since 1.14.0) counter help
 				# TYPE hidden_metric_register counter
 				hidden_metric_register 1
 				`,
@@ -347,11 +518,11 @@ func TestEnableHiddenMetrics(t *testing.T) {
 				Name:              "hidden_metric_must_register",
 				Help:              "counter help",
 				StabilityLevel:    STABLE,
-				DeprecatedVersion: "1.16.0",
+				DeprecatedVersion: "1.14.0",
 			}),
 			mustRegister: true,
 			expectedMetric: `
-				# HELP hidden_metric_must_register [STABLE] (Deprecated since 1.16.0) counter help
+				# HELP hidden_metric_must_register [STABLE] (Deprecated since 1.14.0) counter help
 				# TYPE hidden_metric_must_register counter
 				hidden_metric_must_register 1
 				`,
@@ -394,8 +565,8 @@ func TestEnableHiddenStableCollector(t *testing.T) {
 		GitVersion: "v1.17.0-alpha-1.12345",
 	}
 	var normal = NewDesc("test_enable_hidden_custom_metric_normal", "this is a normal metric", []string{"name"}, nil, STABLE, "")
-	var hiddenA = NewDesc("test_enable_hidden_custom_metric_hidden_a", "this is the hidden metric A", []string{"name"}, nil, STABLE, "1.16.0")
-	var hiddenB = NewDesc("test_enable_hidden_custom_metric_hidden_b", "this is the hidden metric B", []string{"name"}, nil, STABLE, "1.16.0")
+	var hiddenA = NewDesc("test_enable_hidden_custom_metric_hidden_a", "this is the hidden metric A", []string{"name"}, nil, STABLE, "1.14.0")
+	var hiddenB = NewDesc("test_enable_hidden_custom_metric_hidden_b", "this is the hidden metric B", []string{"name"}, nil, STABLE, "1.14.0")
 
 	var tests = []struct {
 		name                      string
@@ -411,10 +582,10 @@ func TestEnableHiddenStableCollector(t *testing.T) {
 				"test_enable_hidden_custom_metric_hidden_b"},
 			expectMetricsBeforeEnable: "",
 			expectMetricsAfterEnable: `
-        		# HELP test_enable_hidden_custom_metric_hidden_a [STABLE] (Deprecated since 1.16.0) this is the hidden metric A
+        		# HELP test_enable_hidden_custom_metric_hidden_a [STABLE] (Deprecated since 1.14.0) this is the hidden metric A
         		# TYPE test_enable_hidden_custom_metric_hidden_a gauge
         		test_enable_hidden_custom_metric_hidden_a{name="value"} 1
-        		# HELP test_enable_hidden_custom_metric_hidden_b [STABLE] (Deprecated since 1.16.0) this is the hidden metric B
+        		# HELP test_enable_hidden_custom_metric_hidden_b [STABLE] (Deprecated since 1.14.0) this is the hidden metric B
         		# TYPE test_enable_hidden_custom_metric_hidden_b gauge
         		test_enable_hidden_custom_metric_hidden_b{name="value"} 1
 			`,
@@ -434,10 +605,10 @@ func TestEnableHiddenStableCollector(t *testing.T) {
         		# HELP test_enable_hidden_custom_metric_normal [STABLE] this is a normal metric
         		# TYPE test_enable_hidden_custom_metric_normal gauge
         		test_enable_hidden_custom_metric_normal{name="value"} 1
-        		# HELP test_enable_hidden_custom_metric_hidden_a [STABLE] (Deprecated since 1.16.0) this is the hidden metric A
+        		# HELP test_enable_hidden_custom_metric_hidden_a [STABLE] (Deprecated since 1.14.0) this is the hidden metric A
         		# TYPE test_enable_hidden_custom_metric_hidden_a gauge
         		test_enable_hidden_custom_metric_hidden_a{name="value"} 1
-        		# HELP test_enable_hidden_custom_metric_hidden_b [STABLE] (Deprecated since 1.16.0) this is the hidden metric B
+        		# HELP test_enable_hidden_custom_metric_hidden_b [STABLE] (Deprecated since 1.14.0) this is the hidden metric B
         		# TYPE test_enable_hidden_custom_metric_hidden_b gauge
         		test_enable_hidden_custom_metric_hidden_b{name="value"} 1
 			`,

--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil_test.go
@@ -31,11 +31,12 @@ func TestNewFakeKubeRegistry(t *testing.T) {
 			Help: "counter help",
 		},
 	)
-	deprecatedCounter := metrics.NewCounter(
+	deprecatedBetaCounter := metrics.NewCounter(
 		&metrics.CounterOpts{
 			Name:              "test_deprecated_total",
 			Help:              "counter help",
 			DeprecatedVersion: "1.18.0",
+			StabilityLevel:    metrics.BETA,
 		},
 	)
 	hiddenCounter := metrics.NewCounter(
@@ -62,9 +63,9 @@ func TestNewFakeKubeRegistry(t *testing.T) {
 		},
 		{
 			name:   "deprecated",
-			metric: deprecatedCounter,
+			metric: deprecatedBetaCounter,
 			expected: `
-				# HELP test_deprecated_total [ALPHA] (Deprecated since 1.18.0) counter help
+				# HELP test_deprecated_total [BETA] (Deprecated since 1.18.0) counter help
 				# TYPE test_deprecated_total counter
 				test_deprecated_total 0
 				`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
- The shouldHide() function now hides a metric based on its stability level. Additionally, it delays the hiding of newly removed metrics until the v1.x.0-alpha.1 release. This prevents accidental removals during the fast-forward phase of the previous minor release. This is bringing the code in parity with [metrics deprecation guidelines](https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-a-metric):

    - Alpha/Internal metric: Hidden in the same minor release they are deprecated.
    - Beta metric: Hidden one minor release after their DeprecatedVersion.
    - Stable metric: Hidden three minor releases after their DeprecatedVersion.

- A metric with DeprecatedVersion=1.x.0 is now marked as deprecated from its v1.x.0-alpha.0 release onward, regardless of its stability level
- New unit tests have been added to validate the updated deprecation and hiding behavior across all scenarios

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Issue: https://github.com/kubernetes/kubernetes/issues/133429

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deprecated metrics will be hidden as per the metrics deprecation policy https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-a-metric
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
