### PR TITLE
Increase termination timeout for `evicted pods should be terminal` test

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -495,13 +495,23 @@ func WaitForPodsWithSchedulingGates(ctx context.Context, c clientset.Interface, 
 	return err
 }
 
-// WaitForPodTerminatedInNamespace returns an error if it takes too long for the pod to terminate,
+// WaitForPodTerminatedInNamespace returns an error if it takes too long for the pod to terminate after podStartTimeout,
 // if the pod Get api returns an error (IsNotFound or other), or if the pod failed (and thus did not
 // terminate) with an unexpected reason. Typically called to test that the passed-in pod is fully
 // terminated (reason==""), but may be called to detect if a pod did *not* terminate according to
 // the supplied reason.
 func WaitForPodTerminatedInNamespace(ctx context.Context, c clientset.Interface, podName, reason, namespace string) error {
-	return WaitForPodCondition(ctx, c, namespace, podName, fmt.Sprintf("terminated with reason %s", reason), podStartTimeout, func(pod *v1.Pod) (bool, error) {
+	return WaitForPodTerminatedInNamespaceTimeout(ctx, c, podName, reason, namespace, podStartTimeout)
+}
+
+// WaitForPodTerminatedInNamespaceTimeout returns an error if it takes too long
+// for the pod to terminate after the provided timeout, if the pod Get api
+// returns an error (IsNotFound or other), or if the pod failed (and thus did
+// not terminate) with an unexpected reason. Typically called to test that the
+// passed-in pod is fully terminated (reason==""), but may be called to detect
+// if a pod did *not* terminate according to the supplied reason.
+func WaitForPodTerminatedInNamespaceTimeout(ctx context.Context, c clientset.Interface, podName, reason, namespace string, timeout time.Duration) error {
+	return WaitForPodCondition(ctx, c, namespace, podName, fmt.Sprintf("terminated with reason %s", reason), timeout, func(pod *v1.Pod) (bool, error) {
 		// Only consider Failed pods. Successful pods will be deleted and detected in
 		// waitForPodCondition's Get call returning `IsNotFound`
 		if pod.Status.Phase == v1.PodFailed {

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -338,7 +338,8 @@ var _ = SIGDescribe("Pods Extended", func() {
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 
-			err := e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, pod.Name, "Evicted", f.Namespace.Name)
+			// Intentionally increase the timeout to ensure the metrics availability required for this test.
+			err := e2epod.WaitForPodTerminatedInNamespaceTimeout(ctx, f.ClientSet, pod.Name, "Evicted", f.Namespace.Name, 10*time.Minute)
 			if err != nil {
 				framework.Failf("error waiting for pod to be evicted: %v", err)
 			}


### PR DESCRIPTION


#### What type of PR is this?


/kind flake


#### What this PR does / why we need it:
This doubles the termination timeout for the eviction test from 5min to 10min. Reason for that is that the eviction manager relies on pod stats metrics, which may not be acceessible during a period of time because of the kubelet API unreachable. This could be reasoned in hardware or network pressure when multiple tests run in parallel.

#### Which issue(s) this PR is related to:
None


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
