### PR TITLE
deflake e2e test: Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -169,6 +169,15 @@ func ReserveStaticNodePort(port int32) bool {
 // ReleaseStaticNodePort releases the specified port.
 // The corresponding service should have already been deleted, to ensure that the
 // port allocator doesn't try to reuse it before the apiserver considers it available.
+// The caller should do it like below:
+//
+//	ginkgo.DeferCleanup(func(ctx context.Context) {
+//		err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
+//		if err != nil && !apierrors.IsNotFound(err) {
+//			framework.ExpectNoError(err, "failed to delete service %s in namespace %s", serviceName, ns)
+//		}
+//		e2eservice.ReleaseStaticNodePort(nodePort)
+//	})
 func ReleaseStaticNodePort(port int32) {
 	staticPortAllocator.releasePort(port)
 }

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1747,7 +1747,13 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		nodePort := service.Spec.Ports[0].NodePort
-		defer e2eservice.ReleaseStaticNodePort(nodePort)
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				framework.ExpectNoError(err, "failed to delete service %s in namespace %s", serviceName, ns)
+			}
+			e2eservice.ReleaseStaticNodePort(nodePort)
+		})
 
 		if service.Spec.Type != v1.ServiceTypeNodePort {
 			framework.Failf("got unexpected Spec.Type for new service: %v", service)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

See  https://storage.googleapis.com/k8s-triage/index.html?text=Internal%20error%20occurred%3A%20failed%20to%20allocate%20requested%20HealthCheck%20NodePort

Don't release node port from the global staticPortAllocator before the service is deleted.

<img width="879" height="165" alt="image" src="https://github.com/user-attachments/assets/38749d1c-2cd0-4ac6-a820-be7adcfda0db" />


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
