### PR TITLE
Add valid container name info in the kubectl logs/exec output

### DIFF
--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -582,7 +582,7 @@ func TestCheckLogLocation(t *testing.T) {
 			opts: &api.PodLogOptions{
 				Container: "unknown",
 			},
-			expectedErr:       errors.NewBadRequest("container unknown is not valid for pod test"),
+			expectedErr:       errors.NewBadRequest("container unknown is not valid for pod test out of: container1, container2"),
 			expectedTransport: nil,
 		},
 		{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
@@ -276,7 +276,7 @@ func TestAttach(t *testing.T) {
 			attachPath:   "/api/" + version + "/namespaces/test/pods/foo/attach",
 			pod:          attachPod(),
 			container:    "foo",
-			expectedErr:  "cannot attach to the container: container foo not found in pod foo",
+			expectedErr:  "cannot attach to the container: container foo not found in pod foo out of: bar, debugger (ephem), initfoo (init)",
 		},
 	}
 	for _, test := range tests {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
@@ -59,7 +59,7 @@ func FindOrDefaultContainerByName(pod *v1.Pod, name string, quiet bool, warn io.
 	if len(name) > 0 {
 		container, _ = FindContainerByName(pod, name)
 		if container == nil {
-			return nil, fmt.Errorf("container %s not found in pod %s", name, pod.Name)
+			return nil, fmt.Errorf("container %s not found in pod %s out of: %s", name, pod.Name, AllContainerNames(pod))
 		}
 		return container, nil
 	}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
@@ -116,7 +116,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 
 			container, fieldPath := podcmd.FindContainerByName(t, currOpts.Container)
 			if container == nil {
-				return nil, fmt.Errorf("container %s is not valid for pod %s", currOpts.Container, t.Name)
+				return nil, fmt.Errorf("container %s is not valid for pod %s out of: %s", currOpts.Container, t.Name, podcmd.AllContainerNames(t))
 			}
 			ref, err := reference.GetPartialReference(scheme.Scheme, t, fieldPath)
 			if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
When a pod with multiple containers, there is no valid container name info in the `kubectl logs xxx` and `kubectl exec xxx` output, so this PR add valid container name(s) info to choose easily.

#### Which issue(s) this PR is related to:
Fixes kubernetes/kubectl#1768

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add valid container name info in the kubectl logs/exec output.
```