### PR TITLE
Add release-1.34 configuration publishing bot rules for v1.34

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -24,6 +24,12 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/apimachinery
+  - name: release-1.34
+    go: 1.24.5
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/apimachinery
   library: true
 - destination: api
   branches:
@@ -60,6 +66,15 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/api
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/api
   library: true
@@ -124,6 +139,21 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/client-go
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
   library: true
 - destination: code-generator
   branches:
@@ -160,6 +190,15 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/code-generator
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/code-generator
 - destination: component-base
@@ -213,6 +252,19 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/component-base
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/component-base
   library: true
@@ -269,6 +321,19 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/component-helpers
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/component-helpers
   library: true
 - destination: kms
   branches:
@@ -305,6 +370,15 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/kms
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/kms
   library: true
@@ -375,6 +449,23 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/apiserver
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/apiserver
   library: true
@@ -461,6 +552,27 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    - repository: code-generator
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/kube-aggregator
 - destination: sample-apiserver
@@ -568,6 +680,32 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: code-generator
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
 - destination: sample-controller
   branches:
   - name: master
@@ -642,6 +780,26 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/sample-controller
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: code-generator
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/sample-controller
     required-packages:
@@ -742,6 +900,29 @@ rules:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: code-generator
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
   branches:
   - name: master
@@ -803,6 +984,21 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/metrics
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: code-generator
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/metrics
   library: true
 - destination: cli-runtime
   branches:
@@ -855,6 +1051,19 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/cli-runtime
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/cli-runtime
   library: true
@@ -919,6 +1128,21 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: cli-runtime
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
 - destination: kube-proxy
   branches:
   - name: master
@@ -980,6 +1204,21 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/kube-proxy
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   library: true
 - destination: cri-api
   branches:
@@ -1004,6 +1243,12 @@ rules:
     go: 1.24.5
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/cri-api
+  - name: release-1.34
+    go: 1.24.5
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/cri-api
   library: true
@@ -1074,6 +1319,23 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/cri-client
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: cri-api
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/cri-client
   library: true
@@ -1162,6 +1424,27 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/kubelet
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: cri-api
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/kubelet
   library: true
 - destination: kube-scheduler
   branches:
@@ -1222,6 +1505,21 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/kube-scheduler
   library: true
@@ -1300,6 +1598,25 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/controller-manager
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/controller-manager
   library: true
@@ -1394,6 +1711,29 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/cloud-provider
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: controller-manager
+      branch: release-1.34
+    - repository: component-helpers
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/cloud-provider
   library: true
@@ -1498,6 +1838,31 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/kube-controller-manager
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: controller-manager
+      branch: release-1.34
+    - repository: cloud-provider
+      branch: release-1.34
+    - repository: component-helpers
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   library: true
 - destination: cluster-bootstrap
   branches:
@@ -1542,6 +1907,17 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   library: true
@@ -1590,6 +1966,17 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/csi-translation-lib
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   library: true
 - destination: mount-utils
   branches:
@@ -1614,6 +2001,12 @@ rules:
     go: 1.24.5
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/mount-utils
+  - name: release-1.34
+    go: 1.24.5
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/mount-utils
   library: true
@@ -1710,6 +2103,29 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/kubectl
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: cli-runtime
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: code-generator
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: component-helpers
+      branch: release-1.34
+    - repository: metrics
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/kubectl
   library: true
 - destination: pod-security-admission
   branches:
@@ -1786,6 +2202,25 @@ rules:
       branch: release-1.33
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/pod-security-admission
   library: true
@@ -1890,6 +2325,31 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: apiserver
+      branch: release-1.34
+    - repository: api
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: cri-api
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    - repository: component-helpers
+      branch: release-1.34
+    - repository: kms
+      branch: release-1.34
+    - repository: kubelet
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/dynamic-resource-allocation
 - destination: endpointslice
   branches:
   - name: master
@@ -1951,6 +2411,21 @@ rules:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/endpointslice
+  - name: release-1.34
+    go: 1.24.5
+    dependencies:
+    - repository: api
+      branch: release-1.34
+    - repository: apimachinery
+      branch: release-1.34
+    - repository: client-go
+      branch: release-1.34
+    - repository: component-base
+      branch: release-1.34
+    source:
+      branch: release-1.34
+      dirs:
+      - staging/src/k8s.io/endpointslice
 - destination: externaljwt
   branches:
   - name: master
@@ -1968,6 +2443,12 @@ rules:
     go: 1.24.5
     source:
       branch: release-1.33
+      dirs:
+      - staging/src/k8s.io/externaljwt
+  - name: release-1.34
+    go: 1.24.5
+    source:
+      branch: release-1.34
       dirs:
       - staging/src/k8s.io/externaljwt
 recursive-delete-patterns:


### PR DESCRIPTION
Adding k8s release 1.34 rules

**Does this PR introduce a user-facing change?**:

```
Action Required: None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```
```

cc @kubernetes/release-managers