### PR TITLE
fix: enhance websocket fallback to handle CRI incompatibility

### DIFF
--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
@@ -127,8 +127,9 @@ func (rt *RoundTripper) RoundTrip(request *http.Request) (retResp *http.Response
 	}
 	wsConn, resp, err := dialer.DialContext(request.Context(), request.URL.String(), request.Header)
 	if err != nil {
-		// BadHandshake error becomes an "UpgradeFailureError" (used for streaming fallback).
-		if errors.Is(err, gwebsocket.ErrBadHandshake) {
+		// BadHandshake error and WebSocket server incompatibility error during establishment
+		// become "UpgradeFailureError" (used for streaming fallback).
+		if errors.Is(err, gwebsocket.ErrBadHandshake) || errors.Is(err, wsstream.ErrWebSocketServerNotReady) {
 			cause := err
 			// Enhance the error message with the error response if possible.
 			if resp != nil && len(resp.Status) > 0 {


### PR DESCRIPTION
Previously, WebSocket fallback to SPDY only occurred for HTTP handshake errors (ErrBadHandshake). When CRI-O's WebSocket server terminates during initialization due to WebSocket v5 protocol incompatibility, kubectl debug would hang with "websocket server finished before becoming ready" errors instead of falling back to SPDY.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
We started seeing this issue in Openshift CI where `kubectl debug` operations fail with websocket connection errors in Kubernetes 1.32+ environments, while kubectl run --attach works correctly.  Here's the error:
```sh
Unhandled Error: unable to upgrade websocket connection: websocket server finished before becoming ready
```
What Works:
 `kubectl run --attach`, `kubectl debug\exec on regular pods`
- Uses client-side streaming
- Has proper websocket → SPDY fallback mechanism
- Test result: [sig-cli] Kubectl client Simple pod should support inline execution and attach with websockets or fallback to spdy PASSED

What Fails:
`kubectl debug on nodes `
- Uses server-side streaming through CRI-O
- No fallback mechanism when websocket upgrade fails

xref: https://issues.redhat.com/browse/OCPBUGS-60036
#### Special notes for your reviewer:

I think all WebSocket connection attempts go through `RoundTripper.RoundTrip()`. It’s the only spot where:
  - HTTP upgrade success vs failure can be distinguished
  - WebSocket-specific errors can be caught before they propagate
  - Errors can be transformed into types that trigger existing fallback logic

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
