### PR TITLE
fix using stale pod when evict failed and retry

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -19,6 +19,7 @@ package drain
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -151,10 +152,11 @@ func NewDrainCmdOptions(f cmdutil.Factory, ioStreams genericiooptions.IOStreams)
 		PrintFlags: genericclioptions.NewPrintFlags("drained").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
 		drainer: &drain.Helper{
-			GracePeriodSeconds: -1,
-			Out:                ioStreams.Out,
-			ErrOut:             ioStreams.ErrOut,
-			ChunkSize:          cmdutil.DefaultChunkSize,
+			GracePeriodSeconds:   -1,
+			EvictErrorRetryDelay: 5 * time.Second,
+			Out:                  ioStreams.Out,
+			ErrOut:               ioStreams.ErrOut,
+			ChunkSize:            cmdutil.DefaultChunkSize,
 		},
 	}
 	o.drainer.OnPodDeletionOrEvictionFinished = o.onPodDeletionOrEvictionFinished

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -321,7 +321,7 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 					return
 				}
 
-				freshPod, err := getPodFn(pod.Namespace, pod.Name)
+				freshPod, err := getPodFn(activePod.Namespace, activePod.Name)
 				// we ignore errors and let eviction sort it out with the original pod.
 				if err == nil {
 					activePod = *freshPod

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -278,35 +278,23 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 	defer cancel()
 	for _, pod := range pods {
 		go func(pod corev1.Pod, returnCh chan error) {
-			refreshPod := false
+			activePod := pod
 			for {
 				switch d.DryRunStrategy {
 				case cmdutil.DryRunServer:
-					fmt.Fprintf(d.Out, "evicting pod %s/%s (server dry run)\n", pod.Namespace, pod.Name)
+					fmt.Fprintf(d.Out, "evicting pod %s/%s (server dry run)\n", activePod.Namespace, activePod.Name)
 				default:
 					if d.OnPodDeletionOrEvictionStarted != nil {
-						d.OnPodDeletionOrEvictionStarted(&pod, true)
+						d.OnPodDeletionOrEvictionStarted(&activePod, true)
 					}
-					fmt.Fprintf(d.Out, "evicting pod %s/%s\n", pod.Namespace, pod.Name)
+					fmt.Fprintf(d.Out, "evicting pod %s/%s\n", activePod.Namespace, activePod.Name)
 				}
 				select {
 				case <-ctx.Done():
 					// return here or we'll leak a goroutine.
-					returnCh <- fmt.Errorf("error when evicting pods/%q -n %q: global timeout reached: %v", pod.Name, pod.Namespace, globalTimeout)
+					returnCh <- fmt.Errorf("error when evicting pods/%q -n %q: global timeout reached: %v", activePod.Name, activePod.Namespace, globalTimeout)
 					return
 				default:
-				}
-
-				// Create a temporary pod so we don't mutate the pod in the loop.
-				activePod := pod
-				if refreshPod {
-					freshPod, err := getPodFn(pod.Namespace, pod.Name)
-					// We ignore errors and let eviction sort it out with
-					// the original pod.
-					if err == nil {
-						activePod = *freshPod
-					}
-					refreshPod = false
 				}
 
 				err := d.EvictPod(activePod, evictionGroupVersion)
@@ -316,7 +304,6 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 					returnCh <- nil
 					return
 				} else if apierrors.IsTooManyRequests(err) {
-					refreshPod = true
 					fmt.Fprintf(d.ErrOut, "error when evicting pods/%q -n %q (will retry after 5s): %v\n", activePod.Name, activePod.Namespace, err)
 					time.Sleep(5 * time.Second)
 				} else if !activePod.ObjectMeta.DeletionTimestamp.IsZero() && apierrors.IsForbidden(err) && apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
@@ -327,12 +314,17 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				} else if apierrors.IsForbidden(err) && apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
 					// an eviction request in a deleting namespace will throw a forbidden error,
 					// if the pod is not marked deleted, we retry until it is.
-					refreshPod = true
 					fmt.Fprintf(d.ErrOut, "error when evicting pod %q from terminating namespace %q (will retry after 5s): %v\n", activePod.Name, activePod.Namespace, err)
 					time.Sleep(5 * time.Second)
 				} else {
 					returnCh <- fmt.Errorf("error when evicting pods/%q -n %q: %v", activePod.Name, activePod.Namespace, err)
 					return
+				}
+
+				freshPod, err := getPodFn(pod.Namespace, pod.Name)
+				// we ignore errors and let eviction sort it out with the original pod.
+				if err == nil {
+					activePod = *freshPod
 				}
 			}
 			if d.DryRunStrategy == cmdutil.DryRunServer {

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -316,6 +316,7 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 					returnCh <- nil
 					return
 				} else if apierrors.IsTooManyRequests(err) {
+					refreshPod = true
 					fmt.Fprintf(d.ErrOut, "error when evicting pods/%q -n %q (will retry after 5s): %v\n", activePod.Name, activePod.Namespace, err)
 					time.Sleep(5 * time.Second)
 				} else if !activePod.ObjectMeta.DeletionTimestamp.IsZero() && apierrors.IsForbidden(err) && apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
@@ -326,6 +327,7 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				} else if apierrors.IsForbidden(err) && apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
 					// an eviction request in a deleting namespace will throw a forbidden error,
 					// if the pod is not marked deleted, we retry until it is.
+					refreshPod = true
 					fmt.Fprintf(d.ErrOut, "error when evicting pod %q from terminating namespace %q (will retry after 5s): %v\n", activePod.Name, activePod.Namespace, err)
 					time.Sleep(5 * time.Second)
 				} else {

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -529,3 +529,107 @@ func TestFilterPods(t *testing.T) {
 		})
 	}
 }
+
+func TestEvictDuringNamespaceTerminating(t *testing.T) {
+	testPodUID := types.UID("test-uid")
+	testPodName := "test-pod"
+	testNamespace := "default"
+	globalTimeout := time.Duration(10) * time.Second
+
+	tests := []struct {
+		description string
+		refresh     bool
+		err         error
+	}{
+		{
+			description: "Pod refreshed after NamespaceTerminating error",
+			refresh:     true,
+			err:         nil,
+		},
+		{
+			description: "Pod not refreshed after NamespaceTerminating error",
+			refresh:     false,
+			err:         fmt.Errorf("error when evicting pods/%q -n %q: global timeout reached: %v", testPodName, testNamespace, globalTimeout),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			var retry bool
+
+			initialPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+			}
+
+			// pod with DeletionTimestamp, indicating deletion in progress
+			deletedPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              testPodName,
+					Namespace:         testNamespace,
+					UID:               testPodUID,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			}
+
+			evictPods := []corev1.Pod{*initialPod}
+
+			k := fake.NewClientset(initialPod)
+			addEvictionSupport(t, k, "v1")
+
+			// mock eviction to return NamespaceTerminating error
+			k.PrependReactor("create", "pods", func(action ktest.Action) (bool, runtime.Object, error) {
+				if action.GetSubresource() != "eviction" {
+					return false, nil, nil
+				}
+
+				err := apierrors.NewForbidden(
+					schema.GroupResource{Resource: "pods"},
+					testPodName,
+					errors.New("namespace is terminating"),
+				)
+
+				err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{
+					Type: corev1.NamespaceTerminatingCause,
+				})
+
+				return true, nil, err
+			})
+
+			k.PrependReactor("get", "pods", func(action ktest.Action) (bool, runtime.Object, error) {
+				if !test.refresh {
+					// for non-refresh test, always return the initial pod
+					return true, initialPod, nil
+				}
+
+				if retry {
+					// second call, pod is deleted
+					return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, testPodName)
+				}
+
+				// first call, pod is being deleted
+				retry = true
+
+				return true, deletedPod, nil
+			})
+
+			h := &Helper{
+				Client:          k,
+				DisableEviction: false,
+				Out:             os.Stdout,
+				ErrOut:          os.Stderr,
+				Timeout:         globalTimeout,
+			}
+
+			err := h.DeleteOrEvictPods(evictPods)
+			if test.err == nil && err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			} else if test.err != nil && (err == nil || err.Error() != test.err.Error()) {
+				t.Errorf("%s: unexpected eviction; actual %v; expected %v", test.description, err, test.err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -534,7 +534,9 @@ func TestEvictDuringNamespaceTerminating(t *testing.T) {
 	testPodUID := types.UID("test-uid")
 	testPodName := "test-pod"
 	testNamespace := "default"
-	globalTimeout := time.Duration(10) * time.Second
+
+	retryDelay := 5 * time.Millisecond
+	globalTimeout := 2 * retryDelay
 
 	tests := []struct {
 		description string
@@ -617,11 +619,12 @@ func TestEvictDuringNamespaceTerminating(t *testing.T) {
 			})
 
 			h := &Helper{
-				Client:          k,
-				DisableEviction: false,
-				Out:             os.Stdout,
-				ErrOut:          os.Stderr,
-				Timeout:         globalTimeout,
+				Client:               k,
+				DisableEviction:      false,
+				Out:                  os.Stdout,
+				ErrOut:               os.Stderr,
+				Timeout:              globalTimeout,
+				EvictErrorRetryDelay: retryDelay,
 			}
 
 			err := h.DeleteOrEvictPods(evictPods)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

The kubectl drain command still uses stale Pods when it fails and retries after evicting Pods.
It should re-fetch the latest Pods when failing and retrying after evicting Pods.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes <https://github.com/kubernetes/kubectl/issues/1767>

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
