### PR TITLE
Refactor API group validation and error reporting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/resourceconfig"
 	serverstore "k8s.io/apiserver/pkg/server/storage"
@@ -70,20 +71,22 @@ func (s *APIEnablementOptions) Validate(registries ...GroupRegistry) []error {
 	errors := []error{}
 	if s.RuntimeConfig[resourceconfig.APIAll] == "false" && len(s.RuntimeConfig) == 1 {
 		// Do not allow only set api/all=false, in such case apiserver startup has no meaning.
-		return append(errors, fmt.Errorf("invalid key with only %v=false", resourceconfig.APIAll))
+		return append(errors, fmt.Errorf("invalid runtime-config with only %v=false", resourceconfig.APIAll))
 	}
 
-	groups, err := resourceconfig.ParseGroups(s.RuntimeConfig)
+	groupVersions, err := resourceconfig.ParseGroupVersions(s.RuntimeConfig)
 	if err != nil {
 		return append(errors, err)
 	}
 
-	for _, registry := range registries {
-		// filter out known groups
-		groups = unknownGroups(groups, registry)
+	unknownGroupVersions := sets.New[string]()
+	for _, groupVersion := range groupVersions {
+		if !isGroupRegistered(groupVersion.Group, registries) {
+			unknownGroupVersions.Insert(groupVersion.String())
+		}
 	}
-	if len(groups) != 0 {
-		errors = append(errors, fmt.Errorf("unknown api groups %s", strings.Join(groups, ",")))
+	if len(unknownGroupVersions) != 0 {
+		errors = append(errors, fmt.Errorf("unknown api groups %s", strings.Join(sets.List(unknownGroupVersions), ",")))
 	}
 
 	return errors
@@ -117,18 +120,17 @@ func (s *APIEnablementOptions) ApplyTo(c *server.Config, defaultResourceConfig *
 	return err
 }
 
-func unknownGroups(groups []string, registry GroupRegistry) []string {
-	unknownGroups := []string{}
-	for _, group := range groups {
-		if !registry.IsGroupRegistered(group) {
-			unknownGroups = append(unknownGroups, group)
-		}
-	}
-	return unknownGroups
-}
-
 // GroupRegistry provides a method to check whether given group is registered.
 type GroupRegistry interface {
-	// IsRegistered returns true if given group is registered.
+	// IsGroupRegistered returns true if given group is registered.
 	IsGroupRegistered(group string) bool
+}
+
+func isGroupRegistered(group string, registries []GroupRegistry) bool {
+	for _, registry := range registries {
+		if registry.IsGroupRegistered(group) {
+			return true
+		}
+	}
+	return false
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement_test.go
@@ -40,9 +40,9 @@ func TestAPIEnablementOptionsValidate(t *testing.T) {
 			name: "test when options is nil",
 		},
 		{
-			name:          "test when invalid key with only api/all=false",
+			name:          "test when invalid runtime-config with only api/all=false",
 			runtimeConfig: cliflag.ConfigurationMap{"api/all": "false"},
-			expectErr:     "invalid key with only api/all=false",
+			expectErr:     "invalid runtime-config with only api/all=false",
 		},
 		{
 			name:          "test when ConfigurationMap key is invalid",
@@ -51,11 +51,15 @@ func TestAPIEnablementOptionsValidate(t *testing.T) {
 		},
 		{
 			name:          "test when unknown api groups",
-			runtimeConfig: cliflag.ConfigurationMap{"api/v1": "true"},
-			expectErr:     "unknown api groups",
+			runtimeConfig: cliflag.ConfigurationMap{"api/v1": "true", "api/v1beta2": "true"},
+			expectErr:     "unknown api groups api/v1,api/v1beta2",
 		},
 		{
 			name:          "test when valid api groups",
+			runtimeConfig: cliflag.ConfigurationMap{"apiregistration.k8s.io/v1beta1": "true"},
+		},
+		{
+			name:          "test when invalid api groups",
 			runtimeConfig: cliflag.ConfigurationMap{"apiregistration.k8s.io/v1beta1": "true"},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a fix for validation error messages produced by the `APIEnablementOptions.Validate`. Error message for unknown API groups didn't contain versions, which could be confusing. Here is an example of the latest one from this [failing ci-node-e2e-crio-cgrpv2-dra-1-34 job](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-node-e2e-crio-cgrpv2-dra-1-34/1954534626470924288/artifacts/test-fedora-coreos-42-20250721-3-0-gcp-x86-64/services.log): 
`F0810 13:37:19.210421    2969 services.go:119] Failed to run e2e services: failed to validate ServerRunOptions: unknown api groups api`. With this fix the error would be more descriptive and easier to understand: `Failed to run e2e services: failed to validate ServerRunOptions: unknown api groups api/stable1`

Updated API group validation logic to improve error reporting. The Validate method now checks for unknown API groups using group versions and provides more descriptive error messages when invalid or unknown API groups are encountered.
Unit test cases are updated to match the new error messages.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/133460

#### Does this PR introduce a user-facing change?

```release-note
NONE
```