### PR TITLE
Update NodeRestriction to prevent nodes from updating their OwnerReferences

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -518,6 +518,11 @@ func (p *Plugin) admitNode(nodeName string, a admission.Attributes) error {
 			return admission.NewForbidden(a, fmt.Errorf("node %q is not allowed to modify taints", nodeName))
 		}
 
+		// Don't allow a node to update its own ownerReferences.
+		if !apiequality.Semantic.DeepEqual(node.OwnerReferences, oldNode.OwnerReferences) {
+			return admission.NewForbidden(a, fmt.Errorf("node %q is not allowed to modify ownerReferences", nodeName))
+		}
+
 		// Don't allow a node to update labels outside the allowed set.
 		// This would allow a node to add or modify its labels in a way that would let it steer privileged workloads to itself.
 		modifiedLabels := getModifiedLabels(node.Labels, oldNode.Labels)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
A vulnerability exists in the NodeRestriction admission controller where node users can delete their corresponding node object by patching themselves with an OwnerReference to a cluster-scoped resource. If the OwnerReference resource does not exist or is subsequently deleted, the given node object will be deleted via garbage collection. This PR adds functionality to the NodeRestriction admission controller to prevent nodes from updating their OwnerReferences.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This PR was authored by @SergeyKanzhelev 

```release-note
Changed the node restrictions to disallow the node to change it's ownerReferences.
```