### PR TITLE
Migrate pkg/credentialprovider to structured logging

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -173,6 +173,7 @@ linters:
             structured k8s.io/kms/.*
             structured k8s.io/apiserver/pkg/storage/value/.*
             structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
+            structured k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
             
             # The following packages have been migrated to contextual logging.
             # Packages matched here do not have to be listed above because

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -187,6 +187,7 @@ linters:
             structured k8s.io/kms/.*
             structured k8s.io/apiserver/pkg/storage/value/.*
             structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
+            structured k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
             
             # The following packages have been migrated to contextual logging.
             # Packages matched here do not have to be listed above because

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -19,6 +19,7 @@ structured k8s.io/kubernetes/pkg/proxy/.*
 structured k8s.io/kms/.*
 structured k8s.io/apiserver/pkg/storage/value/.*
 structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
+structured k8s.io/kubernetes/pkg/credentialprovider/plugin/.*
 
 # The following packages have been migrated to contextual logging.
 # Packages matched here do not have to be listed above because

--- a/pkg/credentialprovider/plugin/plugin_test.go
+++ b/pkg/credentialprovider/plugin/plugin_test.go
@@ -373,6 +373,7 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 			name: "[service account mode] sa name required but empty",
 			pluginProvider: &perPodPluginProvider{
 				provider: &pluginProvider{
+					name:        "test-plugin",
 					matchImages: []string{"test.registry.io"},
 					serviceAccountProvider: &serviceAccountProvider{
 						requireServiceAccount: true,
@@ -380,15 +381,17 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 				},
 				podName:      "pod-name",
 				podNamespace: "ns",
+				podUID:       "pod-uid",
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      "Service account name is empty for pod ns/pod-name",
+			wantLog:      `Service account name is empty" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid"`,
 		},
 		{
 			name: "[service account mode] sa does not have required annotations",
 			pluginProvider: &perPodPluginProvider{
 				provider: &pluginProvider{
+					name:        "test-plugin",
 					matchImages: []string{"test.registry.io"},
 					serviceAccountProvider: &serviceAccountProvider{
 						requireServiceAccount: true,
@@ -408,16 +411,18 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 				},
 				podName:            "pod-name",
 				podNamespace:       "ns",
+				podUID:             "pod-uid",
 				serviceAccountName: "sa-name",
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      "Failed to get service account data ns/sa-name: required annotation domain.io/identity-id not found",
+			wantLog:      `"Failed to get service account data" err="required annotation domain.io/identity-id not found" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
 		},
 		{
 			name: "[service account mode] failed to get service account token",
 			pluginProvider: &perPodPluginProvider{
 				provider: &pluginProvider{
+					name:        "test-plugin",
 					matchImages: []string{"test.registry.io"},
 					serviceAccountProvider: &serviceAccountProvider{
 						requireServiceAccount: true,
@@ -445,16 +450,18 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 				},
 				podName:            "pod-name",
 				podNamespace:       "ns",
+				podUID:             "pod-uid",
 				serviceAccountName: "sa-name",
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      "Error getting service account token ns/sa-name: failed to get token",
+			wantLog:      `"Failed to provide credentials for image" err="failed to get service account token: failed to get token" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
 		},
 		{
 			name: "[service account mode] cache type not token but service account echoed back",
 			pluginProvider: &perPodPluginProvider{
 				provider: &pluginProvider{
+					name:           "test-plugin",
 					clock:          tclock,
 					lastCachePurge: tclock.Now(),
 					matchImages:    []string{"test.registry.io"},
@@ -494,11 +501,12 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 				},
 				podName:            "pod-name",
 				podNamespace:       "ns",
+				podUID:             "pod-uid",
 				serviceAccountName: "sa-name",
 			},
 			image:        "test.registry.io/foo/bar",
 			dockerconfig: credentialprovider.DockerConfig{},
-			wantLog:      `Credential provider plugin returned the service account token as the password for image "test.registry.io/foo/bar", which is not allowed when service account cache type is not set to 'Token'`,
+			wantLog:      `"Failed to provide credentials for image" err="credential provider plugin returned the service account token as the password which is not allowed when service account cache type is not set to 'Token'" provider="test-plugin" image="test.registry.io/foo/bar" pod="ns/pod-name" podUID="pod-uid" serviceAccount="ns/sa-name"`,
 		},
 		{
 			name: "[service account mode] exact image match",
@@ -588,6 +596,7 @@ func Test_ProvideWithCoordinates(t *testing.T) {
 			capturedOutput := buf.String()
 
 			if len(testcase.wantLog) > 0 && !strings.Contains(capturedOutput, testcase.wantLog) {
+				t.Log("Captured output:", capturedOutput)
 				t.Errorf("expected log message %q not found in captured output: %q", testcase.wantLog, capturedOutput)
 			}
 		})

--- a/pkg/credentialprovider/plugin/plugins.go
+++ b/pkg/credentialprovider/plugin/plugins.go
@@ -52,7 +52,7 @@ func registerCredentialProviderPlugin(name string, p *pluginProvider) {
 	seenProviderNames.Insert(name)
 
 	providers = append(providers, provider{name, p})
-	klog.V(4).Infof("Registered credential provider %q", name)
+	klog.V(4).InfoS("Registered credential provider", "provider", name)
 }
 
 type externalCredentialProviderKeyring struct {
@@ -69,7 +69,6 @@ func NewExternalCredentialProviderDockerKeyring(podNamespace, podName, podUID, s
 
 	for _, p := range providers {
 		pp := &perPodPluginProvider{
-			name:     p.name,
 			provider: p.impl,
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletServiceAccountTokenForCredentialProviders) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:
Current logs in the credential provider are unstructured, making it difficult to tell which plugin or image an error message refers to. This makes it hard to debug and correlate errors with image pulls. I’ve updated the package to use structured logging and added relevant metadata to the logs, so it’s easier to debug and connect errors to image pulls with or without a service account.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig auth
/triage accepted
/milestone v1.35
/priority important-longterm
/assign enj