### PR TITLE
feat(apis/batch): PodFailurePolicyOnPodConditionsPattern.Status can be omitted

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4771,8 +4771,7 @@
         }
       },
       "required": [
-        "type",
-        "status"
+        "type"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -582,8 +582,7 @@
           }
         },
         "required": [
-          "type",
-          "status"
+          "type"
         ],
         "type": "object"
       },

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -212,6 +212,7 @@ type PodFailurePolicyOnPodConditionsPattern struct {
 	// Specifies the required Pod condition status. To match a pod condition
 	// it is required that the specified status equals the pod condition status.
 	// Defaults to True.
+	// +optional
 	Status api.ConditionStatus
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -18565,7 +18565,7 @@ func schema_k8sio_api_batch_v1_PodFailurePolicyOnPodConditionsPattern(ref common
 						},
 					},
 				},
-				Required: []string{"type", "status"},
+				Required: []string{"type"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -532,6 +532,7 @@ message PodFailurePolicyOnPodConditionsPattern {
   // Specifies the required Pod condition status. To match a pod condition
   // it is required that the specified status equals the pod condition status.
   // Defaults to True.
+  // +optional
   optional string status = 2;
 }
 

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -209,6 +209,7 @@ type PodFailurePolicyOnPodConditionsPattern struct {
 	// Specifies the required Pod condition status. To match a pod condition
 	// it is required that the specified status equals the pod condition status.
 	// Defaults to True.
+	// +optional
 	Status corev1.ConditionStatus `json:"status" protobuf:"bytes,2,req,name=status"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

Optionally add one or more of the following kinds if applicable:

/kind api-change

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/blob/0d10d5b24678f507caced6f4735f23ac74e6d29d/pkg/apis/batch/types.go#L205-L217
`Status` is not explicitly set to "True", which may lead to errors in  Python Kubernetes client generated by upstream.

In kube-apiserver,  the `Status` will be set to "True" automatically even if we don't set it manually - this can be done by a webhook or controller — but this does not resolve downstream errors.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes-client/python/issues/2430
https://github.com/kubernetes-client/python/pull/2432
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->



#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: 

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes-client/python/blob/master/CONTRIBUTING.md
```
