### PR TITLE
fix: setting serviceAccountName field to null should not rely on serviceAccount field

### DIFF
--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -351,12 +351,6 @@ func Convert_v1_PodSpec_To_core_PodSpec(in *v1.PodSpec, out *core.PodSpec, s con
 		return err
 	}
 
-	// We support DeprecatedServiceAccount as an alias for ServiceAccountName.
-	// If both are specified, ServiceAccountName (the new field) wins.
-	if in.ServiceAccountName == "" {
-		out.ServiceAccountName = in.DeprecatedServiceAccount
-	}
-
 	// the host namespace fields have to be handled specially for backward compatibility
 	// with v1.0.0
 	if out.SecurityContext == nil {

--- a/pkg/apis/core/v1/conversion_test.go
+++ b/pkg/apis/core/v1/conversion_test.go
@@ -165,8 +165,6 @@ func TestPodSpecConversion(t *testing.T) {
 	testCases := []*v1.PodSpec{
 		// New
 		{ServiceAccountName: name},
-		// Alias
-		{DeprecatedServiceAccount: name},
 		// Both: same
 		{ServiceAccountName: name, DeprecatedServiceAccount: name},
 		// Both: different


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change
/kind deprecation

#### What this PR does / why we need it:

Fix an issue where the `ServiceAccount` field prevents discarding `ServiceAccountName` by setting `ServiceAccountName` to null.

#### Which issue(s) this PR is related to:

Fixes [Deprecated field serviceAccount still influences serviceAccountName, preventing null updates](https://github.com/kubernetes/kubernetes/issues/133385)

#### Special notes for your reviewer:

May introduce breaking change for current deprecation approach. Need some discussion for the fixing idea.

#### Does this PR introduce a user-facing change?

```release-note
TBD
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
