### PR TITLE
fix/update test/redis base image to alpine 3.22

### DIFF
--- a/test/images/redis/BASEIMAGE
+++ b/test/images/redis/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=alpine:3.6
-linux/arm=arm32v6/alpine:3.6
-linux/arm64=arm64v8/alpine:3.6
-linux/ppc64le=ppc64le/alpine:3.6
-linux/s390x=s390x/alpine:3.6
+linux/amd64=alpine:3.22
+linux/arm=arm32v6/alpine:3.22
+linux/arm64=arm64v8/alpine:3.22
+linux/ppc64le=ppc64le/alpine:3.22
+linux/s390x=s390x/alpine:3.22
 windows/amd64/1809=REGISTRY/busybox:1.29-2-windows-amd64-1809
 windows/amd64/ltsc2022=REGISTRY/busybox:1.29-2-windows-amd64-ltsc2022


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In reference to https://github.com/kubernetes/kubernetes/issues/131874 we want to update the base image for the redis test images. 

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/131874 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: