### PR TITLE
fix flake in the dra scheduler plugin test

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1469,12 +1469,13 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, ind
 					if pollErr != nil {
 						logger.V(5).Info("Claim not stored in assume cache after retries", "claim", klog.KObj(claim), "err", pollErr)
 					}
-				}
-			} else {
-				if err := pl.draManager.ResourceClaims().AssumeClaimAfterAPICall(claim); err != nil {
-					logger.V(5).Info("Claim not stored in assume cache", "err", err)
+				} else {
+					if err := pl.draManager.ResourceClaims().AssumeClaimAfterAPICall(claim); err != nil {
+						logger.V(5).Info("Claim not stored in assume cache", "err", err)
+					}
 				}
 			}
+
 			for _, claimUID := range claimUIDs {
 				pl.draManager.ResourceClaims().RemoveClaimPendingAllocation(claimUID)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
#133493 

#### Special notes for your reviewer:
stress test with this PR seems to resolve the flake

```
$ go test -race ./pkg/scheduler/framework/plugins/dynamicresources/ -c

$ ❯ stress -p=32 ./dynamicresources.test -test.run="TestPlugin/with-resources-finalizer-gets-added"
5s: 55 runs so far, 0 failures
10s: 160 runs so far, 0 failures
15s: 263 runs so far, 0 failures
20s: 359 runs so far, 0 failures
25s: 449 runs so far, 0 failures
30s: 569 runs so far, 0 failures
...
10m30s: 13139 runs so far, 0 failures
10m35s: 13247 runs so far, 0 failures
10m40s: 13353 runs so far, 0 failures
10m45s: 13459 runs so far, 0 failures
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
