### PR TITLE
test-integration: set KUBE_PANIC_WATCH_DECODE_ERROR to false

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -29,8 +29,9 @@ kube::util::require-jq
 KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"
 export KUBE_CACHE_MUTATION_DETECTOR
 
-# panic the server on watch decode errors since they are considered coder mistakes
-KUBE_PANIC_WATCH_DECODE_ERROR="${KUBE_PANIC_WATCH_DECODE_ERROR:-true}"
+# default set to "false" to avoid panic on decode errors.
+# integration tests intentionally insert data that cannot be decoded.
+KUBE_PANIC_WATCH_DECODE_ERROR="${KUBE_PANIC_WATCH_DECODE_ERROR:-false}"
 export KUBE_PANIC_WATCH_DECODE_ERROR
 
 KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=${KUBE_INTEGRATION_TEST_MAX_CONCURRENCY:-"-1"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Some integration tests like [TestAPIServiceWaitOnStart](https://github.com/kubernetes/kubernetes/blob/dab8758a59de023c066b785200c000c7951479cb/test/integration/examples/apiserver_test.go#L89) or [TestCascadingDeleteOnCRDConversionFailure](https://github.com/kubernetes/kubernetes/blob/5dd244ff0030a7b7af5f9834db181479c03cb07b/test/integration/garbagecollector/garbage_collector_test.go#L1340) intentionally insert undecodable data to verify edge cases. 

After enabling [WatchListClient](https://github.com/kubernetes/kubernetes/pull/133340), these tests started to [panic](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/133340/pull-kubernetes-integration/1950921789357953024) because `KUBE_PANIC_WATCH_DECODE_ERROR` was set to true, causing the storage layer to [panic](https://github.com/kubernetes/kubernetes/blob/ec78b8305ad392f6faf4e5247ea33ceabb484c3f/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go#L764) on watch decode errors. 

This PR sets `KUBE_PANIC_WATCH_DECODE_ERROR=false` in the integration tests so the server no longer panics. The tests still validate their scenarios, but failures are handled differently rather than process termination.


Note that the env var is still set to true for other jobs, such as `e2e-node`, and we might even enable it for `e2e-gce`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
