### PR TITLE
Add missing conversion for timeoutForControlPlane

### DIFF
--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -380,6 +380,11 @@ func documentMapToInitConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 	// If ClusterConfiguration was given, populate it in the InitConfiguration struct
 	if clustercfg != nil {
 		initcfg.ClusterConfiguration = *clustercfg
+
+		// TODO: Workaround for missing v1beta3 ClusterConfiguration timeout conversion. Remove this conversion once the v1beta3 is removed
+		if clustercfg.APIServer.TimeoutForControlPlane.Duration != 0 && clustercfg.APIServer.TimeoutForControlPlane.Duration != kubeadmconstants.ControlPlaneComponentHealthCheckTimeout {
+			initcfg.Timeouts.ControlPlaneComponentHealthCheck.Duration = clustercfg.APIServer.TimeoutForControlPlane.Duration
+		}
 	} else {
 		// Populate the internal InitConfiguration.ClusterConfiguration with defaults
 		extclustercfg := &kubeadmapiv1.ClusterConfiguration{}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When using `kubeadm init` with a `kubeadm.k8s.io/v1beta3.ClusterConfiguration`, the `timeoutForControlPlane` is not honoured. Excerpt of an example kubeadm.conf:
```yaml
apiVersion: kubeadm.k8s.io/v1beta3
kind: ClusterConfiguration
apiServer:
  timeoutForControlPlane: 10s
```
And from the init logs:
```
[kubelet-check] The kubelet is healthy after 502.218435ms
[control-plane-check] Waiting for healthy control plane components. This can take up to 4m0s
[control-plane-check] Checking kube-apiserver at https://172.18.0.2:6443/livez
[control-plane-check] Checking kube-controller-manager at https://127.0.0.1:10257/healthz
[control-plane-check] Checking kube-scheduler at https://127.0.0.1:10259/livez
```
Default of `4m0s` is used.
It seems like the problem is related to the missing conversion of the `timeoutForControlPlane` parameter. This PR proposes a fix to the problem.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
I am not 100% sure whether this is the right place to do the conversion and I can also add test cases if the PR is accepted.

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: fixed bug where v1beta3's ClusterConfiguration.APIServer.TimeoutForControlPlane is not respected in newer versions of kubeadm where v1beta4 is the default.
```