### PR TITLE
Automated cherry pick of #132680: Don't log irrelevant zone hints message on no endpoints

### DIFF
--- a/pkg/proxy/topology.go
+++ b/pkg/proxy/topology.go
@@ -153,6 +153,12 @@ func CategorizeEndpoints(endpoints []Endpoint, svcInfo ServicePort, nodeName str
 //     hinted for this node's zone, then it returns "PreferSameZone".
 //   - Otherwise it returns "" (meaning, no topology / default traffic distribution).
 func topologyModeFromHints(svcInfo ServicePort, endpoints []Endpoint, nodeName, zone string) string {
+	if len(endpoints) == 0 {
+		// The code below assumes at least 1 endpoint; if there are no endpoints,
+		// there are no hints.
+		return ""
+	}
+
 	hasEndpointForNode := false
 	allEndpointsHaveNodeHints := true
 	hasEndpointForZone := false

--- a/pkg/proxy/topology_test.go
+++ b/pkg/proxy/topology_test.go
@@ -390,6 +390,13 @@ func TestCategorizeEndpoints(t *testing.T) {
 		clusterEndpoints: nil,
 		localEndpoints:   sets.New[string]("10.0.0.1:80"),
 		allEndpoints:     sets.New[string]("10.0.0.1:80"),
+	}, {
+		name:             "empty cluster endpoints when no service endpoints exist",
+		serviceInfo:      &BaseServicePortInfo{},
+		endpoints:        nil,
+		clusterEndpoints: sets.New[string](),
+		localEndpoints:   nil,
+		allEndpoints:     nil,
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Cherry pick of #132680 on release-1.33.

#132680: Don't log irrelevant zone hints message on no endpoints

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes 1.33 regression causing spammy incorrect "Ignoring same-zone topology hints for service since no hints were provided for zone" messages in the kube-proxy logs.
```