### PR TITLE
DRA: wait for stats to converge in "creates slices" e2e test

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -2167,6 +2167,14 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			emptySlice := gomega.HaveField("Spec.Devices", gomega.BeEmpty())
 			gomega.Eventually(ctx, listSlices).WithTimeout(2 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveExactElements(emptySlice)))
 			expectStats = resourceslice.Stats{NumCreates: int64(numSlices) + 1, NumDeletes: int64(numSlices)}
+
+			// There is a window of time where the ResourceSlice exists and is
+			// returned in a list but before that ResourceSlice is accounted for
+			// in the controller's stats, consisting mostly of network latency
+			// between this test process and the API server. Wait for the stats
+			// to converge before asserting there are no further changes.
+			gomega.Eventually(ctx, controller.GetStats).WithTimeout(30 * time.Second).Should(gomega.Equal(expectStats))
+
 			gomega.Consistently(ctx, controller.GetStats).WithTimeout(2 * mutationCacheTTL).Should(gomega.Equal(expectStats))
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes the flake in the "ResourceSlice Controller creates slices" e2e test as described by #133494. Network latency between the test process and the API server mixed with bad luck can cause the test to see the ResourceSlices it expects before the controller has fully updated its accounting which is checked immediately after the list of ResourceSlices.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#133494

#### Special notes for your reviewer:

Without this fix, I can get the test to fail reliably locally in a kind cluster with this change:
```diff
diff --git a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
index 271cbd7adf3..a3b4f53c5ce 100644
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -835,6 +835,10 @@ func (c *Controller) syncPool(ctx context.Context, poolName string) error {
 			return fmt.Errorf("create resource slice: %w", err)
 		}
 		logger.V(5).Info("Created new resource slice", "slice", klog.KObj(actualSlice))
+		if len(pool.Slices) == 1 {
+			time.Sleep(2 * time.Second) // the polling interval for the list call in the test.
+		}
+		logger.V(5).Info("Counting created resource slice", "slice", klog.KObj(actualSlice))
 		atomic.AddInt64(&c.numCreates, 1)
 		added = true
 		c.sliceStored(ctx, "create ResourceSlice", poolName, pool, i, slice, actualSlice)

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```