### PR TITLE
RealFIFO: send DELETE events if an object has changed UID while disconnected from apiserver

### DIFF
--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -58,6 +58,13 @@ const (
 	// alpha: v1.30
 	InformerResourceVersion Feature = "InformerResourceVersion"
 
+	// owner: @munnerz
+	// alpha: v1.35
+	//
+	// Ensure deletion events are sent for objects whose UID has changed after a disconnect
+	// and re-list to apiservers.
+	InformerDeleteEventsByUID Feature = "InformerDeleteEventsByUID"
+
 	// owner: @p0lyn0mial
 	// beta: v1.30
 	//
@@ -75,9 +82,10 @@ const (
 // After registering with the binary, the features are, by default, controllable using environment variables.
 // For more details, please see envVarFeatureGates implementation.
 var defaultKubernetesFeatureGates = map[Feature]FeatureSpec{
-	ClientsAllowCBOR:        {Default: false, PreRelease: Alpha},
-	ClientsPreferCBOR:       {Default: false, PreRelease: Alpha},
-	InOrderInformers:        {Default: true, PreRelease: Beta},
-	InformerResourceVersion: {Default: false, PreRelease: Alpha},
-	WatchListClient:         {Default: false, PreRelease: Beta},
+	ClientsAllowCBOR:          {Default: false, PreRelease: Alpha},
+	ClientsPreferCBOR:         {Default: false, PreRelease: Alpha},
+	InOrderInformers:          {Default: true, PreRelease: Beta},
+	InformerResourceVersion:   {Default: false, PreRelease: Alpha},
+	InformerDeleteEventsByUID: {Default: false, PreRelease: Alpha},
+	WatchListClient:           {Default: false, PreRelease: Beta},
 }

--- a/staging/src/k8s.io/client-go/tools/cache/fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo_test.go
@@ -21,6 +21,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // List returns a list of all the items.
@@ -71,13 +73,22 @@ func testFifoObjectKeyFunc(obj interface{}) (string, error) {
 	return obj.(testFifoObject).name, nil
 }
 
+func testFifoObjectUIDFunc(obj interface{}) (types.UID, error) {
+	return obj.(testFifoObject).uid, nil
+}
+
 type testFifoObject struct {
 	name string
+	uid  types.UID
 	val  interface{}
 }
 
 func mkFifoObj(name string, val interface{}) testFifoObject {
 	return testFifoObject{name: name, val: val}
+}
+
+func mkFifoUID(name, uid string, val interface{}) testFifoObject {
+	return testFifoObject{name: name, uid: types.UID(uid), val: val}
 }
 
 func TestFIFO_basic(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If a reflector/informer/store observes object A with UID 'A-1', and then:

1) the reflector disconnects from the apiserver
2) while disconnected, object A is deleted and recreated with the same name, now with UID 'A-2'
3) upon reconnect, RealFIFO will send a Replaced event for object A without sending a prior DELETE event

This matches behaviour in other FIFO implementations, however leads to correctness issues in the sequence of events, leading to an 'impossible' stream of events. In practice, this is mitigated if the consumer uses a 'level based' reconciliation approach and/or finalizers to manage the deletion of the  object, however some clients do against best practices take actions based on calls to `Add`/`Update`/`Delete` calls to event handlers.

This is especially problematic if a user is reflecting the state of one store into another concrete apiserver store, whereby the thing calling `Pop` would otherwise need to translate a `Replace` call into a 'delete or replace' by inspecting its own store once again, effectively, re-implementing the missing parts of FIFO (and possibly losing atomicity).

#### Which issue(s) this PR is related to:

I need to open an issue :)

#### Does this PR introduce a user-facing change?
```release-note
client-go: add InformerDeleteEventsByUID feature that ensures DELETE events are fired by informers when an object changes UID while the informer/reflector is disconnected from the apiserver
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

cc @deads2k @liggitt 