### PR TITLE
fix: Update unit test to catch actual nil Labels case and fix functionality to handle nil Labels

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -77,6 +77,9 @@ func (ll *LeaseLock) Update(ctx context.Context, ler LeaderElectionRecord) error
 	ll.lease.Spec = LeaderElectionRecordToLeaseSpec(&ler)
 
 	if ll.Labels != nil {
+		if ll.lease.Labels == nil {
+			ll.lease.Labels = map[string]string{}
+		}
 		// Only overwrite the labels that are specifically set
 		for k, v := range ll.Labels {
 			ll.lease.Labels[k] = v

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
@@ -266,7 +266,28 @@ func TestLeaseConversion(t *testing.T) {
 	}
 }
 
-func TestUpdateWithNilLabels(t *testing.T) {
+func TestUpdateWithNilLabelsOnLease(t *testing.T) {
+	setup()
+
+	// Create initial lease
+	if err := leaseLock.Create(context.Background(), testRecord); err != nil {
+		t.Fatalf("Failed to create lease: %v", err)
+	}
+	// Get the lease to initialize leaseLock.lease
+	if _, _, err := leaseLock.Get(context.Background()); err != nil {
+		t.Fatalf("Failed to get lease: %v", err)
+	}
+
+	leaseLock.Labels = map[string]string{"custom-key": "custom-val"}
+
+	// Update should succeed even with nil Labels on the lease itself
+	if err := leaseLock.Update(context.Background(), testRecord); err != nil {
+		t.Errorf("Update failed with nil Labels: %v", err)
+	}
+}
+
+
+func TestUpdateWithNilLabelsOnLeaseLock(t *testing.T) {
 	setup()
 
 	// Create initial lease
@@ -280,21 +301,7 @@ func TestUpdateWithNilLabels(t *testing.T) {
 
 	leaseLock.lease.Labels = map[string]string{"custom-key": "custom-val"}
 
-	// Update labels
-	lease, err := leaseLock.Client.Leases(testNamespace).Update(context.Background(), leaseLock.lease, metav1.UpdateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to update lease labels: %v", err)
-	}
-
-	val, exists := lease.Labels["custom-key"]
-	if !exists {
-		t.Error("Label was overidden on the lease")
-	}
-	if val != "custom-val" {
-		t.Errorf("Label value mismatch, got %q want %q", val, "custom-val")
-	}
-
-	// Update should succeed even with nil Labels
+	// Update should succeed even with nil Labels on the leaselock
 	if err := leaseLock.Update(context.Background(), testRecord); err != nil {
 		t.Errorf("Update failed with nil Labels: %v", err)
 	}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
@@ -278,6 +278,8 @@ func TestUpdateWithNilLabelsOnLease(t *testing.T) {
 		t.Fatalf("Failed to get lease: %v", err)
 	}
 
+	leaseLock.lease.Labels = nil
+
 	leaseLock.Labels = map[string]string{"custom-key": "custom-val"}
 
 	// Update should succeed even with nil Labels on the lease itself
@@ -285,7 +287,6 @@ func TestUpdateWithNilLabelsOnLease(t *testing.T) {
 		t.Errorf("Update failed with nil Labels: %v", err)
 	}
 }
-
 
 func TestUpdateWithNilLabelsOnLeaseLock(t *testing.T) {
 	setup()
@@ -298,6 +299,8 @@ func TestUpdateWithNilLabelsOnLeaseLock(t *testing.T) {
 	if _, _, err := leaseLock.Get(context.Background()); err != nil {
 		t.Fatalf("Failed to get lease: %v", err)
 	}
+
+	leaseLock.Labels = nil
 
 	leaseLock.lease.Labels = map[string]string{"custom-key": "custom-val"}
 


### PR DESCRIPTION
…
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Right now, if a user uses the custom lease metadata functionality and the lease has no existing labels, the process panics due to a nil assignment:

```
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map
```

Now the unit tests handle both the leaselock having nil labels as well as the lease object itself

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
