### PR TITLE
[BUG] [Selectors]: Return an error in case nil selectors are passed to the matcher functions

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_matcher.go
@@ -45,6 +45,8 @@ type PolicyMatcher interface {
 	GetNamespace(name string) (*corev1.Namespace, error)
 }
 
+var errNilSelector = "a nil %s selector was passed, please ensure selectors are initialized properly"
+
 type matcher struct {
 	Matcher *matching.Matcher
 }
@@ -66,6 +68,13 @@ func (c *matcher) DefinitionMatches(a admission.Attributes, o admission.ObjectIn
 	if constraints == nil {
 		return false, schema.GroupVersionResource{}, schema.GroupVersionKind{}, fmt.Errorf("policy contained no match constraints, a required field")
 	}
+	if constraints.NamespaceSelector == nil {
+		return false, schema.GroupVersionResource{}, schema.GroupVersionKind{}, fmt.Errorf(errNilSelector, "namespace")
+	}
+	if constraints.ObjectSelector == nil {
+		return false, schema.GroupVersionResource{}, schema.GroupVersionKind{}, fmt.Errorf(errNilSelector, "object")
+	}
+
 	criteria := matchCriteria{constraints: constraints}
 	return c.Matcher.Matches(a, o, &criteria)
 }
@@ -75,6 +84,12 @@ func (c *matcher) BindingMatches(a admission.Attributes, o admission.ObjectInter
 	matchResources := binding.GetMatchResources()
 	if matchResources == nil {
 		return true, nil
+	}
+	if matchResources.NamespaceSelector == nil {
+		return false, fmt.Errorf(errNilSelector, "namespace")
+	}
+	if matchResources.ObjectSelector == nil {
+		return false, fmt.Errorf(errNilSelector, "object")
 	}
 
 	criteria := matchCriteria{constraints: matchResources}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

An improperly defaulted policy may have nil selectors. Which later results in GetParsedNamespaceSelector returning a nothingSelector, leading to the automatic rejection of all resources. This fix returns an error in case a policy with nil selectors is passed to the matcher functions

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
