### PR TITLE
HPA: increase max stabilization and period seconds limits

### DIFF
--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -31,9 +31,9 @@ import (
 
 const (
 	// MaxPeriodSeconds is the largest allowed scaling policy period (in seconds)
-	MaxPeriodSeconds int32 = 1800
+	MaxPeriodSeconds int32 = 3600
 	// MaxStabilizationWindowSeconds is the largest allowed stabilization window (in seconds)
-	MaxStabilizationWindowSeconds int32 = 3600
+	MaxStabilizationWindowSeconds int32 = 7200
 )
 
 // ValidateScale validates a Scale and returns an ErrorList with any errors.


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
This PR increases the maximum stabilization window and period seconds for the Horizontal Pod Autoscaler (HPA) v2 API validation:

- MaxStabilizationWindowSeconds: from 3600 (1h) → 7200 (2h)
- MaxPeriodSeconds: from 1800 (30m) → 3600 (1h)

This allows workloads with long initialization or stabilization times to be properly handled by the HPA without hitting validation errors.

#### Which issue(s) this PR is related to:
Fixes #130774

#### Special notes for your reviewer:
Only constants and related tests were updated. No API changes other than validation limits.

#### Does this PR introduce a user-facing change?
```release-note
The maximum stabilization window and period seconds for HPA v2 have been increased:
- MaxStabilizationWindowSeconds: 3600 → 7200
- MaxPeriodSeconds: 1800 → 3600

