### PR TITLE
kubectl: add spec.nodeName field selector support to top pods

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_edge_cases_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_edge_cases_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package top
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest/fake"
+	core "k8s.io/client-go/testing"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/kubectl/pkg/scheme"
+	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+func TestEdgeCases(t *testing.T) {
+	t.Run("EmptyNodeName", func(t *testing.T) {
+		selector, err := fields.ParseSelector("spec.nodeName=")
+		if err != nil {
+			t.Fatalf("Failed to parse field selector: %v", err)
+		}
+		nodeNameValue, _ := extractNodeNameFieldSelector(selector)
+		if nodeNameValue != "" {
+			t.Errorf("Expected empty node name, got %q", nodeNameValue)
+		}
+	})
+
+	t.Run("NodeNameWithSpaces", func(t *testing.T) {
+		selector, err := fields.ParseSelector("spec.nodeName=worker node 1")
+		if err != nil {
+			t.Fatalf("Failed to parse field selector: %v", err)
+		}
+		nodeNameValue, _ := extractNodeNameFieldSelector(selector)
+		if nodeNameValue != "worker node 1" {
+			t.Errorf("Expected 'worker node 1', got %q", nodeNameValue)
+		}
+	})
+
+	t.Run("MultipleSpecNodeName", func(t *testing.T) {
+		// This should not happen in normal usage but let's test robustness
+		selector, err := fields.ParseSelector("spec.nodeName=worker-1,spec.nodeName=worker-2")
+		if err != nil {
+			t.Fatalf("Failed to parse field selector: %v", err)
+		}
+		nodeNameValue, _ := extractNodeNameFieldSelector(selector)
+		// Should return one of them (behavior is undefined but should not crash)
+		if nodeNameValue != "worker-1" && nodeNameValue != "worker-2" {
+			t.Errorf("Expected either 'worker-1' or 'worker-2', got %q", nodeNameValue)
+		}
+	})
+
+	t.Run("CombinedWithNamespace", func(t *testing.T) {
+		selector, err := fields.ParseSelector("spec.nodeName=worker-1,metadata.namespace=default")
+		if err != nil {
+			t.Fatalf("Failed to parse field selector: %v", err)
+		}
+		nodeNameValue, filteredSelector := extractNodeNameFieldSelector(selector)
+		if nodeNameValue != "worker-1" {
+			t.Errorf("Expected 'worker-1', got %q", nodeNameValue)
+		}
+		if !strings.Contains(filteredSelector.String(), "metadata.namespace=default") {
+			t.Errorf("Expected filtered selector to contain namespace filter, got %q", filteredSelector.String())
+		}
+	})
+}
+
+func TestTopPodWithNodeNameComplexScenarios(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	
+	// Test scenario with pods that don't exist (deleted after metrics were retrieved)
+	testMetrics := []metricsv1beta1api.PodMetrics{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-pod", Namespace: "test"},
+			Containers: []metricsv1beta1api.ContainerMetrics{{
+				Name: "container1",
+				Usage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "deleted-pod", Namespace: "test"},
+			Containers: []metricsv1beta1api.ContainerMetrics{{
+				Name: "container2",
+				Usage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("150m"),
+					corev1.ResourceMemory: resource.MustParse("250Mi"),
+				},
+			}},
+		},
+	}
+
+	testPods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "existing-pod", Namespace: "test"},
+			Spec: corev1.PodSpec{NodeName: "worker-1"},
+		},
+		// deleted-pod is intentionally missing to test error handling
+	}
+
+	fakemetricsClientset := &metricsfake.Clientset{}
+	fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		res := &metricsv1beta1api.PodMetricsList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: "2",
+			},
+			Items: testMetrics,
+		}
+		return true, res, nil
+	})
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	ns := scheme.Codecs.WithoutConversion()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/api":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+			case p == "/apis":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+			case p == "/api/v1/namespaces/test/pods/existing-pod" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &testPods[0])}, nil
+			case p == "/api/v1/namespaces/test/pods/deleted-pod" && m == "GET":
+				// Return 404 for deleted pod
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(`{"kind":"Status","message":"pods \"deleted-pod\" not found"}`)))}, nil
+			default:
+				t.Logf("unexpected request: %s %s", m, p)
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte{}))}, nil
+			}
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdTopPod(tf, nil, streams)
+
+	cmdOptions := &TopPodOptions{
+		FieldSelector: "spec.nodeName=worker-1",
+		IOStreams:     streams,
+	}
+
+	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
+		t.Fatal(err)
+	}
+	
+	cmdOptions.MetricsClient = fakemetricsClientset
+	
+	if err := cmdOptions.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	
+	if err := cmdOptions.RunTopPod(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	t.Logf("Command output:\n%s", output)
+	
+	// Should contain only existing-pod (deleted-pod should be filtered out due to 404)
+	if !strings.Contains(output, "existing-pod") {
+		t.Errorf("Expected output to contain existing-pod")
+	}
+	if strings.Contains(output, "deleted-pod") {
+		t.Errorf("Expected output to NOT contain deleted-pod (should be filtered due to 404)")
+	}
+}
+
+func TestFilterMetricsByNodeNameEdgeCases(t *testing.T) {
+	// Test empty input
+	result, err := filterMetricsByNodeName([]metricsv1beta1api.PodMetrics{}, "worker-1", "test", nil)
+	if err != nil {
+		t.Errorf("Unexpected error for empty input: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("Expected empty result for empty input, got %d items", len(result))
+	}
+
+	// Test empty node name
+	testMetrics := []metricsv1beta1api.PodMetrics{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test"}},
+	}
+	result, err = filterMetricsByNodeName(testMetrics, "", "test", nil)
+	if err != nil {
+		t.Errorf("Unexpected error for empty node name: %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("Expected 1 item for empty node name (should return all), got %d items", len(result))
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_nodename_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_nodename_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package top
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest/fake"
+	core "k8s.io/client-go/testing"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/kubectl/pkg/scheme"
+	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+func TestExtractNodeNameFieldSelector(t *testing.T) {
+	tests := []struct {
+		name           string
+		fieldSelector  string
+		expectedNode   string
+		expectedOther  string
+	}{
+		{
+			name:           "spec.nodeName only",
+			fieldSelector:  "spec.nodeName=worker-1",
+			expectedNode:   "worker-1",
+			expectedOther:  "",
+		},
+		{
+			name:           "spec.nodeName with other field",
+			fieldSelector:  "spec.nodeName=worker-1,metadata.namespace=default",
+			expectedNode:   "worker-1",
+			expectedOther:  "metadata.namespace=default",
+		},
+		{
+			name:           "no spec.nodeName",
+			fieldSelector:  "metadata.namespace=default",
+			expectedNode:   "",
+			expectedOther:  "metadata.namespace=default",
+		},
+		{
+			name:           "empty selector",
+			fieldSelector:  "",
+			expectedNode:   "",
+			expectedOther:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var selector fields.Selector
+			var err error
+			
+			if tt.fieldSelector == "" {
+				selector = fields.Everything()
+			} else {
+				selector, err = fields.ParseSelector(tt.fieldSelector)
+				if err != nil {
+					t.Fatalf("Failed to parse field selector: %v", err)
+				}
+			}
+
+			nodeNameValue, filteredSelector := extractNodeNameFieldSelector(selector)
+			
+			if nodeNameValue != tt.expectedNode {
+				t.Errorf("Expected node name %q, got %q", tt.expectedNode, nodeNameValue)
+			}
+
+			filteredSelectorString := filteredSelector.String()
+			if tt.expectedOther == "" && filteredSelectorString != "" {
+				t.Errorf("Expected empty filtered selector, got %q", filteredSelectorString)
+			} else if tt.expectedOther != "" && !strings.Contains(filteredSelectorString, tt.expectedOther) {
+				t.Errorf("Expected filtered selector to contain %q, got %q", tt.expectedOther, filteredSelectorString)
+			}
+		})
+	}
+}
+
+func TestTopPodWithNodeNameFieldSelector(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	
+	// Define test metrics - pods on different nodes
+	testMetrics := []metricsv1beta1api.PodMetrics{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-on-worker1", Namespace: "test"},
+			Containers: []metricsv1beta1api.ContainerMetrics{{
+				Name: "container1",
+				Usage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-on-worker2", Namespace: "test"},
+			Containers: []metricsv1beta1api.ContainerMetrics{{
+				Name: "container2",
+				Usage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("150m"),
+					corev1.ResourceMemory: resource.MustParse("250Mi"),
+				},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "another-pod-on-worker1", Namespace: "test"},
+			Containers: []metricsv1beta1api.ContainerMetrics{{
+				Name: "container3",
+				Usage: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("120m"),
+					corev1.ResourceMemory: resource.MustParse("180Mi"),
+				},
+			}},
+		},
+	}
+
+	// Create test pods with nodeName specs
+	testPods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-on-worker1", Namespace: "test"},
+			Spec: corev1.PodSpec{NodeName: "worker-1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-on-worker2", Namespace: "test"},
+			Spec: corev1.PodSpec{NodeName: "worker-2"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "another-pod-on-worker1", Namespace: "test"},
+			Spec: corev1.PodSpec{NodeName: "worker-1"},
+		},
+	}
+
+	// Create fake metrics client
+	fakemetricsClientset := &metricsfake.Clientset{}
+	fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		res := &metricsv1beta1api.PodMetricsList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: "2",
+			},
+			Items: testMetrics,
+		}
+		return true, res, nil
+	})
+
+	// Create test factory
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	ns := scheme.Codecs.WithoutConversion()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	// Create fake REST client to handle pod GET requests
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/api":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+			case p == "/apis":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+			case p == "/api/v1/namespaces/test/pods/pod-on-worker1" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &testPods[0])}, nil
+			case p == "/api/v1/namespaces/test/pods/pod-on-worker2" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &testPods[1])}, nil  
+			case p == "/api/v1/namespaces/test/pods/another-pod-on-worker1" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &testPods[2])}, nil
+			default:
+				t.Logf("unexpected request: %s %s", m, p)
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte{}))}, nil
+			}
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	// Create streams for output
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	
+	// Create command
+	cmd := NewCmdTopPod(tf, nil, streams)
+
+	// Set up options for field selector test
+	cmdOptions := &TopPodOptions{
+		FieldSelector: "spec.nodeName=worker-1",
+		IOStreams:     streams,
+	}
+
+	// Complete options
+	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
+		t.Fatal(err)
+	}
+	
+	// Set metrics client
+	cmdOptions.MetricsClient = fakemetricsClientset
+	
+	// Validate options
+	if err := cmdOptions.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	
+	// Run the command
+	if err := cmdOptions.RunTopPod(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check output
+	output := buf.String()
+	t.Logf("Command output:\n%s", output)
+	
+	// Should contain pods on worker-1 only
+	if !strings.Contains(output, "pod-on-worker1") {
+		t.Errorf("Expected output to contain pod-on-worker1")
+	}
+	if !strings.Contains(output, "another-pod-on-worker1") {
+		t.Errorf("Expected output to contain another-pod-on-worker1")
+	}
+	// Should NOT contain pod on worker-2
+	if strings.Contains(output, "pod-on-worker2") {
+		t.Errorf("Expected output to NOT contain pod-on-worker2")
+	}
+}


### PR DESCRIPTION
This commit implements support for filtering pods by node name using the --field-selector flag with kubectl top pods command.

Addresses issue #131896 by adding:
- Client-side filtering for spec.nodeName field selector
- Integration between Metrics API and Pod API to retrieve node information
- Comprehensive test coverage for the new functionality
- Updated help text and examples

The implementation uses a hybrid approach:
1. Extract spec.nodeName from field selector
2. Query Metrics API with remaining field selectors
3. For each pod metric, fetch the pod spec to check node assignment
4. Filter results to only include pods on the specified node

This approach works around the limitation that the Metrics API server does not support spec.nodeName field selectors directly.

Usage example:
  kubectl top pod --field-selector spec.nodeName=worker-1

Fixes #131896

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
