### PR TITLE
DRA: Fix flake in dra BindingConditions integration test

### DIFF
--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -1619,9 +1619,9 @@ func testDeviceBindingConditions(tCtx ktesting.TContext, enabled bool) {
 
 	// fail the binding condition for the second claim, so that it gets scheduled later.
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest, getErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim2.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return getErr
+		latest, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim2.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
 		}
 		latest.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
 			Driver: driverName,
@@ -1636,8 +1636,8 @@ func testDeviceBindingConditions(tCtx ktesting.TContext, enabled bool) {
 				Message:            "The test has seen the allocation and is failing the binding.",
 			}},
 		}}
-		_, updateErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, latest, metav1.UpdateOptions{})
-		return updateErr
+		_, err = tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, latest, metav1.UpdateOptions{})
+		return err
 	})
 	tCtx.ExpectNoError(err, "add binding failure condition to second claim")
 
@@ -1660,9 +1660,9 @@ func testDeviceBindingConditions(tCtx ktesting.TContext, enabled bool) {
 
 	// Allow the scheduler to proceed.
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest, getErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim2.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return getErr
+		latest, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim2.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
 		}
 		latest.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
 			Driver: driverName,
@@ -1677,8 +1677,8 @@ func testDeviceBindingConditions(tCtx ktesting.TContext, enabled bool) {
 				Message:            "The test has seen the allocation.",
 			}},
 		}}
-		_, updateErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, latest, metav1.UpdateOptions{})
-		return updateErr
+		_, err = tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, latest, metav1.UpdateOptions{})
+		return err
 	})
 	tCtx.ExpectNoError(err, "add binding condition to second claim")
 	err = waitForPodScheduled(tCtx, tCtx.Client(), namespace, pod.Name)

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/testutil"
@@ -1617,21 +1618,27 @@ func testDeviceBindingConditions(tCtx ktesting.TContext, enabled bool) {
 	}))), "second allocated claim")
 
 	// fail the binding condition for the second claim, so that it gets scheduled later.
-	claim2.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
-		Driver: driverName,
-		Pool:   poolWithBinding,
-		Device: "with-binding",
-		Conditions: []metav1.Condition{{
-			Type:               failureCondition,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: claim2.Generation,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "Testing",
-			Message:            "The test has seen the allocation and is failing the binding.",
-		}},
-	}}
-
-	claim2, err = tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, claim2, metav1.UpdateOptions{})
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, getErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim2.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		latest.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
+			Driver: driverName,
+			Pool:   poolWithBinding,
+			Device: "with-binding",
+			Conditions: []metav1.Condition{{
+				Type:               failureCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: latest.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Testing",
+				Message:            "The test has seen the allocation and is failing the binding.",
+			}},
+		}}
+		_, updateErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, latest, metav1.UpdateOptions{})
+		return updateErr
+	})
 	tCtx.ExpectNoError(err, "add binding failure condition to second claim")
 
 	// Wait until the claim.status.Devices[0].Conditions become nil again after rescheduling.
@@ -1652,21 +1659,27 @@ func testDeviceBindingConditions(tCtx ktesting.TContext, enabled bool) {
 	}).WithTimeout(30*time.Second).WithPolling(time.Second).Should(gomega.BeNil(), "claim should not have any condition")
 
 	// Allow the scheduler to proceed.
-	claim2.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
-		Driver: driverName,
-		Pool:   poolWithBinding,
-		Device: "with-binding",
-		Conditions: []metav1.Condition{{
-			Type:               bindingCondition,
-			Status:             metav1.ConditionTrue,
-			ObservedGeneration: claim2.Generation,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "Testing",
-			Message:            "The test has seen the allocation.",
-		}},
-	}}
-
-	claim2, err = tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, claim2, metav1.UpdateOptions{})
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, getErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claim2.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		latest.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
+			Driver: driverName,
+			Pool:   poolWithBinding,
+			Device: "with-binding",
+			Conditions: []metav1.Condition{{
+				Type:               bindingCondition,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: latest.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Testing",
+				Message:            "The test has seen the allocation.",
+			}},
+		}}
+		_, updateErr := tCtx.Client().ResourceV1().ResourceClaims(namespace).UpdateStatus(tCtx, latest, metav1.UpdateOptions{})
+		return updateErr
+	})
 	tCtx.ExpectNoError(err, "add binding condition to second claim")
 	err = waitForPodScheduled(tCtx, tCtx.Client(), namespace, pod.Name)
 	tCtx.ExpectNoError(err, "second pod scheduled")


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
#### What this PR does / why we need it:
This PR changes the `ResourceClaim UpdateStatus` in the DRA DeviceBindingConditions integration tests to wrap it in `RetryOnConflict` to automatically retry if a conflict occurs.

- To prevent the "the object has been modified" error from occurring when updating `ResourceClaim Status`, wrapped with `RetryOnConflict` to automatically re-acquire and retry in the event of a conflict.
- This improves test stability.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Related to #133435
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
