### PR TITLE
hack: more output about running tests

### DIFF
--- a/hack/lib/logging.sh
+++ b/hack/lib/logging.sh
@@ -169,3 +169,13 @@ kube::log::status() {
     echo "    ${message}"
   done
 }
+
+# Log a command and run it. Uses a subshell which gets replaced by the command after logging.
+kube::log::run() (
+  V="${V:-0}"
+  if (( KUBE_VERBOSE >= V )); then
+    timestamp=$(date +"[%m%d %H:%M:%S]")
+    echo "+++ ${timestamp} ${*}"
+  fi
+  exec "${@}"
+)

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -25,6 +25,8 @@ kube::golang::setup_env
 kube::golang::setup_gomaxprocs
 kube::util::require-jq
 
+set -x
+
 # start the cache mutation detector by default so that cache mutators will be found
 KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"
 export KUBE_CACHE_MUTATION_DETECTOR
@@ -46,6 +48,8 @@ LOG_LEVEL=${LOG_LEVEL:-2}
 KUBE_TEST_ARGS=${KUBE_TEST_ARGS:-}
 # Default glog module settings.
 KUBE_TEST_VMODULE=${KUBE_TEST_VMODULE:-""}
+
+set +x
 
 kube::test::find_integration_test_pkgs() {
   (

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -57,6 +57,8 @@ kube::test::find_go_packages() {
   )
 }
 
+set -x
+
 # TODO: This timeout should really be lower, this is a *long* time to test one
 # package, however pkg/api/testing in particular will fail with a lower timeout
 # currently. We should attempt to lower this over time.
@@ -84,6 +86,8 @@ fi
 KUBE_KEEP_VERBOSE_TEST_OUTPUT=${KUBE_KEEP_VERBOSE_TEST_OUTPUT:-n}
 # Set to 'false' to disable reduction of the JUnit file to only the top level tests.
 KUBE_PRUNE_JUNIT_TESTS=${KUBE_PRUNE_JUNIT_TESTS:-true}
+
+set +x
 
 kube::test::usage() {
   kube::log::usage_from_stdin <<EOF
@@ -225,7 +229,7 @@ runTests() {
   fi
 
   kube::log::status "Running tests ${cover_msg} ${KUBE_RACE:+"and with ${KUBE_RACE}"}"
-  gotestsum --format="${gotestsum_format}" \
+  kube::log::run gotestsum --format="${gotestsum_format}" \
             --jsonfile="${jsonfile}" \
             --junitfile="${junit_filename_prefix:+"${junit_filename_prefix}.xml"}" \
             --raw-command \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

set -x/+x wraps setting relevant configuration variables to debug how and where they get sets. The final gotestsum invocation gets logged in addition to being run.

I wanted this for debugging the timeout handling (resolved since then) and now want it for https://github.com/kubernetes/kubernetes/issues/133304#issuecomment-3135688191.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
