### PR TITLE
Fix the bug where StartedPodsErrorsTotal metrics implementation doesn't match its name

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1550,26 +1550,34 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 
 		logger.V(4).Info("Creating PodSandbox for pod", "pod", klog.KObj(pod))
 		metrics.StartedPodsTotal.Inc()
-		if utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) && pod.Spec.HostUsers != nil && !*pod.Spec.HostUsers {
+		isUserNamespaced := utilfeature.DefaultFeatureGate.Enabled(features.UserNamespacesSupport) && pod.Spec.HostUsers != nil && !*pod.Spec.HostUsers
+		if isUserNamespaced {
 			metrics.StartedUserNamespacedPodsTotal.Inc()
-			// Failures in user namespace creation could happen at any point in the pod lifecycle,
-			// but usually will be caught in container creation.
-			// To avoid specifically handling each error case, loop through the result after the sync finishes
-			defer func() {
-				// catch unhandled errors
+		}
+		var createSandboxResult *kubecontainer.SyncResult
+		defer func() {
+			hasError := result.SyncError != nil
+			// catch unhandled errors
+			if !hasError {
 				for _, res := range result.SyncResults {
 					if res.Error != nil {
-						metrics.StartedUserNamespacedPodsErrorsTotal.Inc()
-						return
+						hasError = true
+						break
 					}
 				}
-				// catch handled error
-				if result.SyncError != nil {
+			}
+
+			if hasError {
+				metrics.StartedPodsErrorsTotal.WithLabelValues(metrics.StartedPodErrorStartup).Inc()
+				if createSandboxResult != nil && createSandboxResult.Error != nil {
+					metrics.StartedPodsErrorsTotal.WithLabelValues(metrics.StartedPodErrorSandbox).Inc()
+				}
+				if isUserNamespaced {
 					metrics.StartedUserNamespacedPodsErrorsTotal.Inc()
 				}
-			}()
-		}
-		createSandboxResult := kubecontainer.NewSyncResult(kubecontainer.CreatePodSandbox, format.Pod(pod))
+			}
+		}()
+		createSandboxResult = kubecontainer.NewSyncResult(kubecontainer.CreatePodSandbox, format.Pod(pod))
 		result.AddSyncResult(createSandboxResult)
 
 		// ConvertPodSysctlsVariableToDotsSeparator converts sysctl variable
@@ -1609,7 +1617,6 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 				logger.V(4).Info("Pod was deleted and sandbox failed to be created", "pod", klog.KObj(pod), "podUID", pod.UID)
 				return
 			}
-			metrics.StartedPodsErrorsTotal.Inc()
 			createSandboxResult.Fail(kubecontainer.ErrCreatePodSandbox, msg)
 			logger.Error(err, "CreatePodSandbox for pod failed", "pod", klog.KObj(pod))
 			ref, referr := ref.GetReference(legacyscheme.Scheme, pod)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2902,6 +2902,91 @@ func TestSyncPodWithSandboxAndDeletedPod(t *testing.T) {
 	require.NoError(t, result.Error())
 }
 
+func TestStartedPodsErrorsTotalByType(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	metrics.Register()
+
+	testCases := map[string]struct {
+		setup func(t *testing.T) (*kubeGenericRuntimeManager, *v1.Pod)
+		wants string
+	}{
+		"sandbox creation error increments startup and sandbox labels": {
+			setup: func(t *testing.T) (*kubeGenericRuntimeManager, *v1.Pod) {
+				fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+				require.NoError(t, err)
+				fakeRuntime.ErrorOnSandboxCreate = true
+
+				return m, &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "12345678",
+						Name:      "foo",
+						Namespace: "new",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:            "foo",
+								Image:           "busybox",
+								ImagePullPolicy: v1.PullIfNotPresent,
+							},
+						},
+					},
+				}
+			},
+			wants: `
+				# HELP kubelet_started_pods_errors_total [ALPHA] Cumulative number of errors when starting pods
+				# TYPE kubelet_started_pods_errors_total counter
+				kubelet_started_pods_errors_total{error_type="sandbox"} 1
+				kubelet_started_pods_errors_total{error_type="startup"} 1
+			`,
+		},
+		"container startup error increments startup label only": {
+			setup: func(t *testing.T) (*kubeGenericRuntimeManager, *v1.Pod) {
+				_, _, m, err := createTestRuntimeManagerWithErrors(tCtx, map[string][]error{
+					"StartContainer": {errors.New("injected start container error")},
+				})
+				require.NoError(t, err)
+
+				return m, &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "12345678",
+						Name:      "foo",
+						Namespace: "new",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:            "foo",
+								Image:           "busybox",
+								ImagePullPolicy: v1.PullIfNotPresent,
+							},
+						},
+					},
+				}
+			},
+			wants: `
+				# HELP kubelet_started_pods_errors_total [ALPHA] Cumulative number of errors when starting pods
+				# TYPE kubelet_started_pods_errors_total counter
+				kubelet_started_pods_errors_total{error_type="startup"} 1
+			`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metrics.StartedPodsErrorsTotal.Reset()
+			m, pod := tc.setup(t)
+
+			backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
+			result := m.SyncPod(tCtx, pod, &kubecontainer.PodStatus{}, []v1.Secret{}, backOff, false)
+			require.Error(t, result.Error())
+
+			require.NoError(t, testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(tc.wants),
+				"kubelet_"+metrics.StartedPodsErrorsTotalKey))
+		})
+	}
+}
+
 func makeBasePodAndStatusWithInitAndEphemeralContainers() (*v1.Pod, *kubecontainer.PodStatus) {
 	pod, status := makeBasePodAndStatus()
 	pod.Spec.InitContainers = []v1.Container{

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -170,16 +170,19 @@ const (
 	MemoryQoSNodeMemoryLowBytesKey = "memory_qos_node_memory_low_bytes"
 
 	// Values used in metric labels
-	Container          = "container"
-	InitContainer      = "init_container"
-	EphemeralContainer = "ephemeral_container"
+	Container                 = "container"
+	InitContainer             = "init_container"
+	EphemeralContainer        = "ephemeral_container"
+	StartedPodsErrorTypeLabel = "error_type"
 
 	AlignScopePod       = "pod"
 	AlignScopeContainer = "container"
 
-	AlignedPhysicalCPU = "physical_cpu"
-	AlignedNUMANode    = "numa_node"
-	AlignedUncoreCache = "uncore_cache"
+	AlignedPhysicalCPU     = "physical_cpu"
+	AlignedNUMANode        = "numa_node"
+	AlignedUncoreCache     = "uncore_cache"
+	StartedPodErrorSandbox = "sandbox"
+	StartedPodErrorStartup = "startup"
 
 	// Metrics to track kubelet admission rejections.
 	AdmissionRejectionsTotalKey = "admission_rejections_total"
@@ -747,14 +750,15 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-	// StartedPodsErrorsTotal is a counter that tracks the number of errors creating pod sandboxes
-	StartedPodsErrorsTotal = metrics.NewCounter(
+	// StartedPodsErrorsTotal is a counter that tracks the number of errors creating pods by error type.
+	StartedPodsErrorsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      KubeletSubsystem,
 			Name:           StartedPodsErrorsTotalKey,
 			Help:           "Cumulative number of errors when starting pods",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{StartedPodsErrorTypeLabel},
 	)
 	// StartedContainersTotal is a counter that tracks the number of container creation operations
 	StartedContainersTotal = metrics.NewCounterVec(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The `StartedPodsErrorsTotal` metric should represent pods that failed during the startup process. However, we previously only counted pods that failed when creating the pod sandbox, which doesn't align with its name.

It is now modified to count the number of pods that failed during creation and startup, aligning with the logic of the newly added `StartedUserNamespacedPodsErrorsTotal` metric.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the bug where the kubelet_started_pods_errors_total metric only counts pods failing at sandbox creation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
