### PR TITLE
Fix storage counting all objects instead of objects for resource

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -634,7 +634,14 @@ func (s *store) Stats(ctx context.Context) (stats storage.Stats, err error) {
 		return s.stats.Stats(ctx)
 	}
 	startTime := time.Now()
-	count, err := s.client.Kubernetes.Count(ctx, s.pathPrefix, kubernetes.CountOptions{})
+	prefix, err := s.prepareKey(s.resourcePrefix)
+	if err != nil {
+		return storage.Stats{}, err
+	}
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	count, err := s.client.Kubernetes.Count(ctx, prefix, kubernetes.CountOptions{})
 	metrics.RecordEtcdRequest("listWithCount", s.groupResource, err, startTime)
 	if err != nil {
 		return storage.Stats{}, err
@@ -652,7 +659,14 @@ func (s *store) SetKeysFunc(keys storage.KeysFunc) {
 
 func (s *store) getKeys(ctx context.Context) ([]string, error) {
 	startTime := time.Now()
-	resp, err := s.client.KV.Get(ctx, s.pathPrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	prefix, err := s.prepareKey(s.resourcePrefix)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	resp, err := s.client.KV.Get(ctx, prefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
 	metrics.RecordEtcdRequest("listOnlyKeys", s.groupResource, err, startTime)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

```release-note
Fixes a regression in 1.34 release candidates where object storage count metrics could include all instances of all types instead of only the object count for a particular type
```

https://github.com/kubernetes/kubernetes/commit/ec78b8305ad392f6faf4e5247ea33ceabb484c3f changed the storage interface method `Count(ctx, prefix)` to `Stats(ctx)`. Before the storage dependent on the caller to provide proper resource RootKey, after this change storage generates it itself. Instead of using `resourcePrefix` (e.g. `pods`) we incorrectly used `pathPrefix` (default `/registry`). This resulted in storage counting all objects within etcd instead of just under the resource. 

This unfortunately passed our tests as storage tests only consider single resource. Scalability tests also didn't pick this out as the issue only manifests on resources with watch cache disabled. By default watch cache is always enabled with exception of events. In scalability tests we run events that run in separate etcd instance, meaning there is no performance impact in this setup.

Impact of the regression:
* For resources with watch cache disabled: Higher load on etcd as each resource will count/getKeys all objects from all resources, instead of just its own. This increases complexity to from O(N) to O(N*M), where N is number of objects and M is number of resources.
* If `SizeBasedListCostEstimate` is disabled, the APF and metric for object will have incorrect data. No impact otherwise as the number of keys is based on watch cache. 

/cc @liggitt @jpbetz @BenTheElder 

