### PR TITLE
hack: Add gofmt to update-codegen.sh for consistent code formatting

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -153,6 +153,10 @@ function codegen::protobuf() {
       kube::log::status "protoc ${PROTOC_VERSION} not found (can install with hack/install-protoc.sh); generating containerized..."
       build/run.sh hack/_update-generated-protobuf-dockerized.sh "${apis[@]}"
     fi
+
+    # Run gofmt on generated protobuf files
+    kube::log::status "Running gofmt on generated protobuf files"
+    git_find -z ':(glob)**/generated.pb.go' | xargs -0 gofmt -w -s
 }
 
 # Deep-copy generation
@@ -219,6 +223,10 @@ function codegen::deepcopy() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated deepcopy code"
     fi
+
+    # Run gofmt on generated deepcopy files
+    kube::log::status "Running gofmt on generated deepcopy files"
+    git_find -z ':(glob)**'/"${output_file}" | xargs -0 gofmt -w -s
 }
 
 # Generates types_swagger_doc_generated file for the given group version.
@@ -296,6 +304,10 @@ function codegen::swagger() {
     for group_version in "${group_versions[@]}"; do
       gen_types_swagger_doc "${group_version}" "$(kube::util::group-version-to-pkg-path "${group_version}")"
     done
+
+    # Run gofmt on generated swagger files
+    kube::log::status "Running gofmt on generated swagger files"
+    git_find -z ':(glob)**/types_swagger_doc_generated.go' | xargs -0 gofmt -w -s
 }
 
 # prerelease-lifecycle generation
@@ -356,6 +368,10 @@ function codegen::prerelease() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated prerelease-lifecycle code"
     fi
+
+    # Run gofmt on generated prerelease-lifecycle files
+    kube::log::status "Running gofmt on generated prerelease-lifecycle files"
+    git_find -z ':(glob)**'/"${output_file}" | xargs -0 gofmt -w -s
 }
 
 # Defaulter generation
@@ -427,6 +443,10 @@ function codegen::defaults() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated defaulter code"
     fi
+
+    # Run gofmt on generated defaulter files
+    kube::log::status "Running gofmt on generated defaulter files"
+    git_find -z ':(glob)**'/"${output_file}" | xargs -0 gofmt -w -s
 }
 
 # Validation generation
@@ -510,6 +530,10 @@ function codegen::validation() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated validation code"
     fi
+
+    # Run gofmt on generated validation files
+    kube::log::status "Running gofmt on generated validation files"
+    git_find -z ':(glob)**'/"${output_file}" | xargs -0 gofmt -w -s
 }
 
 # Conversion generation
@@ -593,6 +617,10 @@ function codegen::conversions() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated conversion code"
     fi
+
+    # Run gofmt on generated conversion files
+    kube::log::status "Running gofmt on generated conversion files"
+    git_find -z ':(glob)**'/"${output_file}" | xargs -0 gofmt -w -s
 }
 
 # Register generation
@@ -654,6 +682,10 @@ function codegen::register() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated register code"
     fi
+
+    # Run gofmt on generated register files
+    kube::log::status "Running gofmt on generated register files"
+    git_find -z ':(glob)**'/"${output_file}" | xargs -0 gofmt -w -s
 }
 
 # $@: directories to exclude
@@ -762,6 +794,10 @@ function codegen::openapi() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated openapi code"
     fi
+
+    # Run gofmt on generated openapi files
+    kube::log::status "Running gofmt on generated openapi files"
+    git_find -z ':(glob)pkg/generated/**'/"${output_file}" | xargs -0 gofmt -w -s
 }
 
 function codegen::applyconfigs() {
@@ -811,6 +847,10 @@ function codegen::applyconfigs() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated apply-config code"
     fi
+
+    # Run gofmt on generated applyconfigs files
+    kube::log::status "Running gofmt on generated applyconfigs files"
+    git_find -z ':(glob)staging/src/k8s.io/client-go/**/*.go' | xargs -0 gofmt -w -s
 }
 
 function codegen::clients() {
@@ -873,6 +913,10 @@ function codegen::clients() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated client code"
     fi
+
+    # Run gofmt on generated client files
+    kube::log::status "Running gofmt on generated client files"
+    git_find -z ':(glob)staging/src/k8s.io/client-go/**/*.go' | xargs -0 gofmt -w -s
 }
 
 function codegen::listers() {
@@ -920,6 +964,10 @@ function codegen::listers() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated lister code"
     fi
+
+    # Run gofmt on generated lister files
+    kube::log::status "Running gofmt on generated lister files"
+    git_find -z ':(glob)staging/src/k8s.io/client-go/**/*.go' | xargs -0 gofmt -w -s
 }
 
 function codegen::informers() {
@@ -970,6 +1018,10 @@ function codegen::informers() {
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "Generated informer code"
     fi
+
+    # Run gofmt on generated informer files
+    kube::log::status "Running gofmt on generated informer files"
+    git_find -z ':(glob)staging/src/k8s.io/client-go/**/*.go' | xargs -0 gofmt -w -s
 }
 
 function indent() {
@@ -1060,6 +1112,12 @@ function codegen::protobindings() {
       build/run.sh hack/_update-generated-proto-bindings-dockerized.sh gogo   "${apis_using_gogo[@]}"
       build/run.sh hack/_update-generated-proto-bindings-dockerized.sh protoc "${apis_using_protoc[@]}"
     fi
+
+    # Run gofmt on generated protobuf binding files
+    kube::log::status "Running gofmt on generated protobuf binding files"
+    for api in "${apis[@]}"; do
+        git_find -z ":(glob)${api}"/'**/api*.pb.go' | xargs -0 gofmt -w -s
+    done
 }
 
 #


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds `gofmt -w -s` calls after each code generation step in `hack/update-codegen.sh` to ensure consistent code formatting and simplification of generated Go code.

**Why we need it:**
- While the script runs `goimports`, it doesn't run `gofmt` with the `-s` flag to simplify code
- This leads to inconsistent formatting of generated code
- Some code generators have added complexity to handle formatting during generation
- Running `gofmt` ensures all generated code follows Go best practices consistently

**What it fixes:**
- Addresses the issue where generated code wasn't consistently formatted
- Simplifies generated code using `gofmt -s` (removes unnecessary complexity)
- Allows code generators to focus on logic rather than formatting concerns
- Ensures consistent code quality across all generated files

#### Which issue(s) this PR is related to:

Fixes #133609

#### Special notes for your reviewer:

- This change follows the existing pattern already used in the `gen_types_swagger_doc` function
- All `gofmt` calls use `-w -s` flags for consistent behavior
- The changes are additive and don't modify existing functionality
- Each code generation step now has a corresponding `gofmt` step for consistency
- This is a low-risk change that improves code quality without breaking existing workflows

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
