### PR TITLE
Promote VAC API test to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -3788,4 +3788,15 @@
     via deleteCollection MUST succeed and it MUST be confirmed.
   release: v1.30
   file: test/e2e/storage/volume_attachment.go
+- testname: VolumeAttributesClass, lifecycle
+  codename: '[sig-storage] VolumeAttributesClass [FeatureGate:VolumeAttributesClass]
+    should run through the lifecycle of a VolumeAttributesClass [Conformance]'
+  description: Creating a VolumeAttributesClass MUST succeed. Reading the VolumeAttributesClass
+    MUST succeed. Patching the VolumeAttributesClass MUST succeed with its new label
+    found. Deleting the VolumeAttributesClass MUST succeed and it MUST be confirmed.
+    Replacement VolumeAttributesClass MUST be created. Updating the VolumeAttributesClass
+    MUST succeed with its new label found. Deleting the VolumeAttributesClass via
+    deleteCollection MUST succeed and it MUST be confirmed.
+  release: v1.35
+  file: test/e2e/storage/volumeattributesclass.go
 

--- a/test/e2e/storage/volumeattributesclass.go
+++ b/test/e2e/storage/volumeattributesclass.go
@@ -40,7 +40,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 	f := framework.NewDefaultFramework("csi-volumeattributesclass")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	/*
-		Release: v1.29
+		Release: v1.35
 		Testname: VolumeAttributesClass, lifecycle
 		Description: Creating a VolumeAttributesClass MUST succeed. Reading the VolumeAttributesClass MUST
 		succeed. Patching the VolumeAttributesClass MUST succeed with its new label found. Deleting
@@ -48,7 +48,7 @@ var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(fea
 		MUST be created. Updating the VolumeAttributesClass MUST succeed with its new label found.
 		Deleting the VolumeAttributesClass via deleteCollection MUST succeed and it MUST be confirmed.
 	*/
-	framework.It("should run through the lifecycle of a VolumeAttributesClass", func(ctx context.Context) {
+	framework.ConformanceIt("should run through the lifecycle of a VolumeAttributesClass", func(ctx context.Context) {
 
 		vacClient := f.ClientSet.StorageV1().VolumeAttributesClasses()
 		var initialVAC, replacementVAC *storagev1.VolumeAttributesClass


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We missed this as part of GA graduation, but this test should be added to the conformance suite: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/volumeattributesclass.go

#### Which issue(s) this PR is related to:

Fixes #133610 #133692

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote VAC API test to conformance
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
