### PR TITLE
kubelet/nodeshutdown: decouple from volumemanager via tiny VolumeWaiter interface

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -33,7 +33,6 @@ import (
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
-	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
 	"k8s.io/utils/clock"
 )
 
@@ -49,7 +48,7 @@ type Manager interface {
 // Config represents Manager configuration
 type Config struct {
 	Logger                           klog.Logger
-	VolumeManager                    volumemanager.VolumeManager
+	VolumeManager                    PodVolumeTeardown
 	Recorder                         record.EventRecorder
 	NodeRef                          *v1.ObjectReference
 	GetPodsFunc                      eviction.ActivePodsFunc
@@ -95,7 +94,7 @@ type podManager struct {
 	shutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGracePeriodByPodPriority
 	clock                            clock.Clock
 	killPodFunc                      eviction.KillPodFunc
-	volumeManager                    volumemanager.VolumeManager
+	volumeManager                    PodVolumeTeardown
 }
 
 func newPodManager(conf *Config) *podManager {

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -48,7 +48,7 @@ type Manager interface {
 // Config represents Manager configuration
 type Config struct {
 	Logger                           klog.Logger
-	VolumeManager                    PodVolumeTeardown
+	VolumeManager                    VolumeWaiter
 	Recorder                         record.EventRecorder
 	NodeRef                          *v1.ObjectReference
 	GetPodsFunc                      eviction.ActivePodsFunc
@@ -94,7 +94,7 @@ type podManager struct {
 	shutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGracePeriodByPodPriority
 	clock                            clock.Clock
 	killPodFunc                      eviction.KillPodFunc
-	volumeManager                    PodVolumeTeardown
+	volumeManager                    VolumeWaiter
 }
 
 func newPodManager(conf *Config) *podManager {

--- a/pkg/kubelet/nodeshutdown/volume_iface.go
+++ b/pkg/kubelet/nodeshutdown/volume_iface.go
@@ -22,8 +22,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// PodVolumeTeardown is the minimal surface node shutdown needs from volume handling.
+// VolumeWaiter is the minimal surface node shutdown needs from volume handling.
 // Keeping this tiny avoids importing volumemanager and helps break circular deps.
-type PodVolumeTeardown interface {
+type VolumeWaiter interface {
 	WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error
 }

--- a/pkg/kubelet/nodeshutdown/volume_iface.go
+++ b/pkg/kubelet/nodeshutdown/volume_iface.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeshutdown
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// PodVolumeTeardown is the minimal surface node shutdown needs from volume handling.
+// Keeping this tiny avoids importing volumemanager and helps break circular deps.
+type PodVolumeTeardown interface {
+	WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error
+}


### PR DESCRIPTION
/kind cleanup
/sig node
/area kubelet

## What this PR does / why we need it
Decouples the node shutdown code from the volume manager by introducing a tiny local interface `VolumeWaiter` in `pkg/kubelet/nodeshutdown`.
This removes the direct import/type dependency on `volumemanager` and keeps behavior identical. It’s a small step toward untangling kubelet dependencies per #132298.

## How
- Add `pkg/kubelet/nodeshutdown/volume_iface.go` defining:
  ```go
  type VolumeWaiter interface {
      WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error
  }
Update nodeshutdown_manager.go (Config and podManager) to use the interface.

No changes to runtime behavior.

Which issue(s) this PR is related to
Ref #132298 (addresses the shutdown ↔ volume leg only)

Special notes for your reviewer
- Build and package tests pass locally.

- Kept the interface minimal since nodeshutdown only calls WaitForAllPodsUnmount; happy to adjust if you prefer a different shape.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```




Tests

- make WHAT=cmd/kubelet (darwin/arm64) succeeds.

- go test ./pkg/kubelet/nodeshutdown -race succeeds.