### PR TITLE
scheduler_perf: fix data race warning around klog flush

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1054,6 +1054,11 @@ func setupTestCase(t testing.TB, tc *testCase, featureGates map[featuregate.Feat
 			//
 			// This is a major issue because many Kubernetes goroutines get
 			// started without waiting for them to stop :-(
+			//
+			// In practice, klog's own flushing got called out by the race detector.
+			// As we know about that one, we can force it to stop explicitly to
+			// satisfy the race detector.
+			klog.StopFlushDaemon()
 			if err := logsapi.ResetForTest(LoggingFeatureGate); err != nil {
 				t.Errorf("Failed to reset the logging configuration: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Explicitly shutting down background flushing addresses the following data race:

    WARNING: DATA RACE
    Write at 0x0000091173b8 by goroutine 166:
      k8s.io/component-base/logs/api/v1.apply.FlushLogger.func2()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/contextual.go:95 +0x35
      k8s.io/klog/v2.SetLoggerWithOptions()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/contextual.go:75 +0xb4
      k8s.io/component-base/logs/api/v1.apply()
          /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/component-base/logs/api/v1/options.go:277 +0x10fb
      k8s.io/component-base/logs/api/v1.validateAndApply()
          /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/component-base/logs/api/v1/options.go:132 +0x90
      k8s.io/component-base/logs/api/v1.ValidateAndApply()
          /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/component-base/logs/api/v1/options.go:94 +0xd4
      k8s.io/component-base/logs/api/v1.ResetForTest()
          /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/component-base/logs/api/v1/options.go:314 +0xd5
      k8s.io/kubernetes/test/integration/scheduler_perf.setupTestCase.func1()
          /nvme/gopath/src/k8s.io/kubernetes/test/integration/scheduler_perf/scheduler_perf.go:1062 +0x95
      testing.(*common).Cleanup.func1()
          /nvme/gopath/go-1.24.0/src/testing/testing.go:1211 +0x16f
      testing.(*common).runCleanup()
          /nvme/gopath/go-1.24.0/src/testing/testing.go:1445 +0x2b3
      testing.(*common).runCleanup()
          /nvme/gopath/go-1.24.0/src/testing/testing.go:1445 +0x2b3
      testing.tRunner.func2()
          /nvme/gopath/go-1.24.0/src/testing/testing.go:1786 +0x4c
      runtime.deferreturn()
          /nvme/gopath/go-1.24.0/src/runtime/panic.go:605 +0x5d
      k8s.io/apiserver/pkg/endpoints.(*APIInstaller).Install()
          /nvme/gopath/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go:208 +0x3ad

    ...

    Previous read at 0x0000091173b8 by goroutine 169:
      k8s.io/klog/v2.(*loggingT).flushAll()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1215 +0x166
      k8s.io/klog/v2.(*loggingT).lockAndFlushAll()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1193 +0x58
      k8s.io/klog/v2.(*loggingT).lockAndFlushAll-fm()
          <autogenerated>:1 +0x33
      k8s.io/klog/v2.(*flushDaemon).run.func1()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1143 +0x179

#### Which issue(s) this PR is related to:

https://testgrid.k8s.io/sig-testing-canaries#integration-race-master

#### Special notes for your reviewer:

That the cleanup code is shown as being called by runtime/panic.go and k8s.io/apiserver/pkg/endpoints/installer.go seems to be an oddity of `go test -race`. Under a debugger it gets called normally, without a panic, and the test finishes normally either way.

It's debatable whether StopFlushDaemon should be called by the caller of ResetForTest or by ResetForTest itself. It's explicitly called out as "not thread safe", so making the caller responsible seems appropriate.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
