### PR TITLE
Use indexer to acclerate volume limit plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -23,11 +23,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/tools/cache"
 	ephemeral "k8s.io/component-helpers/storage/ephemeral"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
 	csitrans "k8s.io/csi-translation-lib"
@@ -63,6 +63,7 @@ type CSILimits struct {
 	scLister        storagelisters.StorageClassLister
 	vaLister        storagelisters.VolumeAttachmentLister
 	csiDriverLister storagelisters.CSIDriverLister
+	vaindexer       cache.Indexer
 
 	randomVolumeIDPrefix     string
 	enableVolumeLimitScaling bool
@@ -590,6 +591,14 @@ func NewCSI(_ context.Context, _ runtime.Object, handle fwk.Handle, fts feature.
 	scLister := informerFactory.Storage().V1().StorageClasses().Lister()
 	vaLister := informerFactory.Storage().V1().VolumeAttachments().Lister()
 	csiDriverLister := informerFactory.Storage().V1().CSIDrivers().Lister()
+	vaindexer := informerFactory.Storage().V1().VolumeAttachments().Informer().GetIndexer()
+	informerFactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{"nodename": func(obj interface{}) ([]string, error) {
+		va, ok := obj.(*storagev1.VolumeAttachment)
+		if !ok {
+			return []string{}, nil
+		}
+		return []string{va.Spec.NodeName}, nil
+	}})
 	csiTranslator := csitrans.New()
 
 	return &CSILimits{
@@ -602,6 +611,7 @@ func NewCSI(_ context.Context, _ runtime.Object, handle fwk.Handle, fts feature.
 		enableVolumeLimitScaling: fts.EnableVolumeLimitScaling,
 		randomVolumeIDPrefix:     rand.String(32),
 		translator:               csiTranslator,
+		vaindexer:                vaindexer,
 	}, nil
 }
 
@@ -624,11 +634,15 @@ func getVolumeLimits(csiNode *storagev1.CSINode) map[string]int64 {
 // getNodeVolumeAttachmentInfo returns a map of volumeID to driver name for the given node.
 func (pl *CSILimits) getNodeVolumeAttachmentInfo(logger klog.Logger, nodeName string) (map[string]string, error) {
 	volumeAttachments := make(map[string]string)
-	vas, err := pl.vaLister.List(labels.Everything())
+	vas, err := pl.vaindexer.ByIndex("nodename", nodeName)
 	if err != nil {
 		return nil, err
 	}
-	for _, va := range vas {
+	for _, vao := range vas {
+		va, ok := vao.(*storagev1.VolumeAttachment)
+		if !ok {
+			continue
+		}
 		if va.Spec.NodeName == nodeName {
 			if va.Spec.Attacher == "" {
 				logger.V(5).Info("VolumeAttachment has no attacher", "VolumeAttachment", klog.KObj(va))

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -592,13 +592,15 @@ func NewCSI(_ context.Context, _ runtime.Object, handle fwk.Handle, fts feature.
 	vaLister := informerFactory.Storage().V1().VolumeAttachments().Lister()
 	csiDriverLister := informerFactory.Storage().V1().CSIDrivers().Lister()
 	vaindexer := informerFactory.Storage().V1().VolumeAttachments().Informer().GetIndexer()
-	informerFactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{"nodename": func(obj interface{}) ([]string, error) {
+	if err := informerFactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{"nodename": func(obj interface{}) ([]string, error) {
 		va, ok := obj.(*storagev1.VolumeAttachment)
 		if !ok {
 			return []string{}, nil
 		}
 		return []string{va.Spec.NodeName}, nil
-	}})
+	}}); err != nil {
+		return nil, fmt.Errorf("failed to add index to VA informer: %w", err)
+	}
 	csiTranslator := csitrans.New()
 
 	return &CSILimits{

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -648,13 +648,7 @@ func TestCSILimits(t *testing.T) {
 			vas := getFakeVolumeAttachmentLister(test.vaCount, test.driverNames...)
 			fakecli := fake.NewClientset(vas...)
 			informerfactory := informers.NewSharedInformerFactory(fakecli, 0)
-			if err := informerfactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{vaIndexKey: func(obj interface{}) ([]string, error) {
-				va, ok := obj.(*storagev1.VolumeAttachment)
-				if !ok {
-					return []string{}, nil
-				}
-				return []string{va.Spec.NodeName}, nil
-			}}); err != nil {
+			if err := informerfactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{vaIndexKey: volumeAttachmentIndexer}); err != nil {
 				t.Error(err)
 			}
 			_, ctx := ktesting.NewTestContext(t)
@@ -1345,13 +1339,7 @@ func TestVolumeLimitScalingGate(t *testing.T) {
 			vas := getFakeVolumeAttachmentLister(0, ebsCSIDriverName)
 			fakecli := fake.NewClientset(vas...)
 			informerfactory := informers.NewSharedInformerFactory(fakecli, 0)
-			if err := informerfactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{vaIndexKey: func(obj interface{}) ([]string, error) {
-				va, ok := obj.(*storagev1.VolumeAttachment)
-				if !ok {
-					return []string{}, nil
-				}
-				return []string{va.Spec.NodeName}, nil
-			}}); err != nil {
+			if err := informerfactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{vaIndexKey: volumeAttachmentIndexer}); err != nil {
 				t.Error(err)
 			}
 			_, ctx := ktesting.NewTestContext(t)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

NodeVolumeLimit plugin list all volumeAttachments in every node's scheduling for every pod. So when the number of volumeAttachments increases, scheduling become very slow. 

After replacing the original implementation with an indexer, we achieved significant performance improvements, from 1010ms to 14ms. We also tried to make a better implementation but failed. 

<img width="2156" height="270" alt="image" src="https://github.com/user-attachments/assets/39463595-3057-4954-b857-bb8f3862dc09" />

Here are the benchmark:

```
func TestCSILimits_join(t *testing.T) {
	metrics.InitMetrics()
	nodeCount := 1000
	vacount := 100000
	mockedVolumeAttachments := make([]*storagev1.VolumeAttachment, vacount)
	for i := 0; i < vacount; i++ {
		mockedVolumeAttachments[i] = &storagev1.VolumeAttachment{
			ObjectMeta: metav1.ObjectMeta{
				Name: fmt.Sprintf("mock-volume-attachment-%v", i),
			},
			Spec: storagev1.VolumeAttachmentSpec{
				NodeName: fmt.Sprintf("node-%v", i%nodeCount),
				Attacher: "mock-attacher",
				Source: storagev1.VolumeAttachmentSource{
					PersistentVolumeName: ptr.To(fmt.Sprintf("mock-volume-%v", i)),
				},
			},
		}
	}
	mockedPV := make([]*v1.PersistentVolume, vacount)
	for i := 0; i < vacount; i++ {
		mockedPV[i] = &v1.PersistentVolume{
			ObjectMeta: metav1.ObjectMeta{
				Name: fmt.Sprintf("mock-volume-%v", i),
			},
			Spec: v1.PersistentVolumeSpec{
				PersistentVolumeSource: v1.PersistentVolumeSource{
					CSI: &v1.CSIPersistentVolumeSource{
						Driver:       "mock-driver",
						VolumeHandle: fmt.Sprintf("mock-volume-%v", i),
					},
				},
			},
		}
	}

	objs := []runtime.Object{}
	for _, pv := range mockedPV {
		objs = append(objs, pv)
	}
	for _, va := range mockedVolumeAttachments {
		objs = append(objs, va)
	}
	cli := fake.NewClientset(objs...)
	informerFactory := informers.NewSharedInformerFactory(cli, 0)

	pvLister := informerFactory.Core().V1().PersistentVolumes().Lister()
	pvcLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
	csiNodesLister := informerFactory.Storage().V1().CSINodes().Lister()
	scLister := informerFactory.Storage().V1().StorageClasses().Lister()
	vaLister := informerFactory.Storage().V1().VolumeAttachments().Lister()
	vaindexer := informerFactory.Storage().V1().VolumeAttachments().Informer().GetIndexer()
	informerFactory.Storage().V1().VolumeAttachments().Informer().AddIndexers(cache.Indexers{"nodename": func(obj interface{}) ([]string, error) {
		va, ok := obj.(*storagev1.VolumeAttachment)
		if !ok {
			return []string{}, nil
		}
		return []string{va.Spec.NodeName}, nil
	}})
	informerFactory.Start(context.TODO().Done())
	informerFactory.WaitForCacheSync(context.TODO().Done())

	pl := &CSILimits{
		csiNodeLister:        csiNodesLister,
		pvLister:             pvLister,
		pvcLister:            pvcLister,
		scLister:             scLister,
		vaLister:             vaLister,
		vaindexer:            vaindexer,
		randomVolumeIDPrefix: rand.String(32),
	}

	parallelizer := parallelize.NewParallelizer(32)
	nodes := []string{}
	for i := 0; i < nodeCount; i++ {
		nodes = append(nodes, fmt.Sprintf("node-%d", i))
	}

	state := framework.NewCycleState()
	logger := klog.FromContext(context.TODO())

	var lock sync.Mutex
	res1 := map[string][]framework.Volumeattachment{}
	start := time.Now()
	parallelizer.Until(context.TODO(), len(nodes), func(piece int) {
		nodeName := nodes[piece]
		r, _ := pl.join(state, nodeName, logger)
		lock.Lock()
		res1[nodeName] = r
		lock.Unlock()
	}, "join")
	t.Logf("join and calculate result for all nodes %v ms", time.Since(start).Milliseconds())

	res2 := map[string][]framework.Volumeattachment{}
	state = framework.NewCycleState()
	start = time.Now()
	parallelizer.Until(context.TODO(), len(nodes), func(piece int) {
		nodeName := nodes[piece]
		r, _ := pl.join1(state, nodeName, logger)
		lock.Lock()
		res2[nodeName] = r
		lock.Unlock()
	}, "join")
	t.Logf("join but traverse all va for every node %v ms", time.Since(start).Milliseconds())

	start = time.Now()
	parallelizer.Until(context.TODO(), len(nodes), func(piece int) {
		nodeName := nodes[piece]
		pl.getNodeVolumeAttachmentInfoByIndex(logger, nodeName)
	}, "join")
	t.Logf("origin with index %v ms", time.Since(start).Milliseconds())

	expRes := map[string]map[string]string{}
	start = time.Now()
	parallelizer.Until(context.TODO(), len(nodes), func(piece int) {
		nodeName := nodes[piece]
		r, _ := pl.getNodeVolumeAttachmentInfo(logger, nodeName)
		lock.Lock()
		expRes[nodeName] = r
		lock.Unlock()
	}, "join")
	t.Logf("origin %v ms", time.Since(start).Milliseconds())

	t.Logf("start to check result")

	expected := map[string][]framework.Volumeattachment{}
	for node, nodeRes := range expRes {
		expected[node] = []framework.Volumeattachment{}
		for uniqid, handle := range nodeRes {
			expected[node] = append(expected[node], framework.Volumeattachment{VolumeUniqueName: uniqid, DriverName: handle})
		}
	}

	for node, nodeRes := range expected {
		sort.Slice(nodeRes, func(i, j int) bool {
			return nodeRes[i].VolumeUniqueName < nodeRes[j].VolumeUniqueName || nodeRes[i].DriverName < nodeRes[j].DriverName
		})
		sort.Slice(res1[node], func(i, j int) bool {
			return res1[node][i].VolumeUniqueName < res1[node][j].VolumeUniqueName || res1[node][i].DriverName < res1[node][j].DriverName
		})
		if diff := cmp.Diff(nodeRes, res1[node]); diff != "" {
			t.Fatalf("unexpected result (-want, +got):\n%s", diff)
		}
	}
	for node, nodeRes := range expected {
		sort.Slice(nodeRes, func(i, j int) bool {
			return nodeRes[i].VolumeUniqueName < nodeRes[j].VolumeUniqueName || nodeRes[i].DriverName < nodeRes[j].DriverName
		})
		sort.Slice(res2[node], func(i, j int) bool {
			return res2[node][i].VolumeUniqueName < res2[node][j].VolumeUniqueName || res2[node][i].DriverName < res2[node][j].DriverName
		})
		if diff := cmp.Diff(nodeRes, res2[node]); diff != "" {
			t.Fatalf("unexpected result (-want, +got):\n%s", diff)
		}
	}
	t.Logf("check result completed")
}
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
