### PR TITLE
Remove patch/update from ServiceCIDR API conformance test

### DIFF
--- a/test/e2e/network/service_cidrs.go
+++ b/test/e2e/network/service_cidrs.go
@@ -180,33 +180,6 @@ var _ = common.SIGDescribe("ServiceCIDR and IPAddress API", func() {
 			framework.Failf("unexpected UID got %v expected: %v", gottenStatus.GetUID(), defaultServiceCIDR.GetUID())
 		}
 
-		ginkgo.By("patching")
-		patchedServiceCIDR, err := f.ClientSet.NetworkingV1().ServiceCIDRs().Patch(ctx, defaultservicecidr.DefaultServiceCIDRName, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
-		if err != nil {
-			framework.Failf("unexpected error patching IPAddress: %v", err)
-		}
-		if v, ok := patchedServiceCIDR.Annotations["patched"]; !ok || v != "true" {
-			framework.Failf("patched object should have the applied annotation")
-		}
-
-		ginkgo.By("updating")
-		var cidrToUpdate, updatedCIDR *networkingv1.ServiceCIDR
-		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			cidrToUpdate, err = f.ClientSet.NetworkingV1().ServiceCIDRs().Get(ctx, defaultservicecidr.DefaultServiceCIDRName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			cidrToUpdate.Annotations["updated"] = "true"
-			updatedCIDR, err = f.ClientSet.NetworkingV1().ServiceCIDRs().Update(ctx, cidrToUpdate, metav1.UpdateOptions{})
-			return err
-		})
-		if err != nil {
-			framework.Failf("unexpected error updating IPAddress: %v", err)
-		}
-		if v, ok := updatedCIDR.Annotations["updated"]; !ok || v != "true" {
-			framework.Failf("updated object should have the applied annotation")
-		}
-
 		ginkgo.By("listing")
 		list, err := f.ClientSet.NetworkingV1().ServiceCIDRs().List(ctx, metav1.ListOptions{})
 		if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
Removes PATCH and UPDATE testing from the ServiceCIDR API conformance test; those operations were already listed as ineligible for conformance testing in `ineligible_endpoints.yaml`:

https://github.com/kubernetes/kubernetes/blob/4e8b192b66cc2a6952b8f1a5067e563c4019c276/test/conformance/testdata/ineligible_endpoints.yaml#L286-L297

so we don't need to test. (ServiceCIDR changes are tested by non-conformance tests.)

#### Which issue(s) this PR is related to:
Fixes #133613

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/area conformance
/triage accepted
/priority important-soon
/assign aojea
