### PR TITLE
kubectl: include container fieldPath in event messages

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4421,12 +4421,16 @@ func DescribeEvents(el *corev1.EventList, w PrefixWriter) {
 		if source == "" {
 			source = e.ReportingController
 		}
+		message := strings.TrimSpace(e.Message)
+		if len(e.InvolvedObject.FieldPath) > 0 {
+			message = fmt.Sprintf("%s: %s", e.InvolvedObject.FieldPath, message)
+		}
 		w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
 			e.Type,
 			e.Reason,
 			interval,
 			source,
-			strings.TrimSpace(e.Message),
+			message,
 		)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind enhancement


#### What this PR does / why we need it:

This PR enhances the event output in kubectl describe pods by prepending the involvedObject.fieldPath (e.g., the container name) to the event message.

Currently, events lack crucial context, making it difficult to identify which container in a pod encountered an issue.

**Example of new output with this PR:**

```
Events:
  Type     Reason   Age                 From               Message
  ----     ------   ----                ----               -------
  Warning  Failed   7m11s (x2 over 7m33s) kubelet          spec.containers{nginx}: Failed to pull image "nginx": failed to pull and unpack image...
```

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1771

#### Special notes for your reviewer:

- The implementation modifies the existing `message` string to prepend the `e.InvolvedObject.FieldPath`
- The change is minimal and contained to the event printing function.

#### Does this PR introduce a user-facing change?

Yes. This change modifies the format of the Message string for events that have an `involvedObject.fieldPath`.

**Before:**
`Message: Failed to pull image "nginx"`

**After:**
`Message: spec.containers{nginx}: Failed to pull image "nginx"`


```release-note
kubectl describe pods now includes the involved object's fieldPath (e.g., the container name) within the event message to provide better context for debugging multi-container pods. Note: This alters the previous message format for events that have a fieldPath.```
