### PR TITLE
[FG:InPlacePodVerticalScaling] Clean up outdated TODO about CPU MinShares edge case

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers_linux.go
+++ b/pkg/kubelet/kuberuntime/helpers_linux.go
@@ -27,8 +27,6 @@ import (
 )
 
 // sharesToMilliCPU converts CpuShares (cpu.shares) to milli-CPU value
-// TODO(vinaykul,InPlacePodVerticalScaling): Address issue that sets min req/limit to 2m/10m before beta
-// See: https://github.com/kubernetes/kubernetes/pull/102884#discussion_r662552642
 func sharesToMilliCPU(shares int64) int64 {
 	milliCPU := int64(0)
 	if shares >= int64(cm.MinShares) {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This TODO isn't relevant anymore, and causes confusion when looking through the remaining TODOs for InPlacePodVerticalScaling. 

#### Which issue(s) this PR is related to:

This was tracked in https://github.com/kubernetes/kubernetes/issues/114123 and fixed by https://github.com/kubernetes/kubernetes/pull/128680. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/triage accepted
/priority backlog
/assign @tallclair 
