### PR TITLE
Add integration tests for maxUnavailable in Statefulset

### DIFF
--- a/pkg/registry/apps/statefulset/strategy_test.go
+++ b/pkg/registry/apps/statefulset/strategy_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"k8s.io/utils/ptr"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -29,7 +31,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/utils/ptr"
 )
 
 func TestStatefulSetStrategy(t *testing.T) {
@@ -271,6 +272,180 @@ func TestStatefulSetStrategy(t *testing.T) {
 	if len(errs) == 0 {
 		t.Errorf("expected a validation error since updates are disallowed on statefulsets.")
 	}
+
+	t.Run("StatefulSet maxUnavailable field validations on creation and update", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MaxUnavailableStatefulSet, true)
+
+		// invalid negative integer maxUnavailable
+		invalidNegativeIntMU := &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-negative-int", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.ParallelPodManagement,
+				Selector:            &metav1.LabelSelector{MatchLabels: validSelector},
+				Template:            validPodTemplate.Template,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+					RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: -1},
+					},
+				},
+			},
+		}
+		Strategy.PrepareForCreate(ctx, invalidNegativeIntMU)
+		errs := Strategy.Validate(ctx, invalidNegativeIntMU)
+		if len(errs) == 0 {
+			t.Errorf("expected failure when MaxUnavailable is negative integer but got no error")
+		}
+
+		// invalid percentage > 100%
+		invalidPercentageMU := &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-invalid-percent", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.OrderedReadyPodManagement,
+				Selector:            &metav1.LabelSelector{MatchLabels: validSelector},
+				Template:            validPodTemplate.Template,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+					RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "150%"},
+					},
+				},
+			},
+		}
+		Strategy.PrepareForCreate(ctx, invalidPercentageMU)
+		errs = Strategy.Validate(ctx, invalidPercentageMU)
+		if len(errs) == 0 {
+			t.Errorf("expected failure when MaxUnavailable percentage > 100%% but got no error")
+		}
+
+		// invalid string format
+		invalidStringMU := &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-invalid-string", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.ParallelPodManagement,
+				Selector:            &metav1.LabelSelector{MatchLabels: validSelector},
+				Template:            validPodTemplate.Template,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+					RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "invalid"},
+					},
+				},
+			},
+		}
+		Strategy.PrepareForCreate(ctx, invalidStringMU)
+		errs = Strategy.Validate(ctx, invalidStringMU)
+		if len(errs) == 0 {
+			t.Errorf("expected failure when MaxUnavailable has invalid string format but got no error")
+		}
+
+		// valid positive integer
+		validIntMU := &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-valid-int", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.OrderedReadyPodManagement,
+				Selector:            &metav1.LabelSelector{MatchLabels: validSelector},
+				Template:            validPodTemplate.Template,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+					RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+					},
+				},
+			},
+		}
+		Strategy.PrepareForCreate(ctx, validIntMU)
+		errs = Strategy.Validate(ctx, validIntMU)
+		if len(errs) != 0 {
+			t.Errorf("unexpected error validating valid positive integer MaxUnavailable: %v", errs)
+		}
+
+		// valid percentage
+		validPercentMU := &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-valid-percent", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.ParallelPodManagement,
+				Selector:            &metav1.LabelSelector{MatchLabels: validSelector},
+				Template:            validPodTemplate.Template,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+					RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+					},
+				},
+			},
+		}
+		Strategy.PrepareForCreate(ctx, validPercentMU)
+		errs = Strategy.Validate(ctx, validPercentMU)
+		if len(errs) != 0 {
+			t.Errorf("unexpected error validating valid percentage MaxUnavailable: %v", errs)
+		}
+
+		// update validation should allow maxUnavailable changes
+		oldValidMU := validPercentMU.DeepCopy()
+		oldValidMU.ObjectMeta = metav1.ObjectMeta{ResourceVersion: "1", Generation: 1}
+
+		newValidMU := oldValidMU.DeepCopy()
+		newValidMU.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = &intstr.IntOrString{Type: intstr.String, StrVal: "50%"}
+
+		Strategy.PrepareForUpdate(ctx, newValidMU, oldValidMU)
+		errs = Strategy.ValidateUpdate(ctx, newValidMU, oldValidMU)
+		if len(errs) != 0 {
+			t.Errorf("updating MaxUnavailable should be allowed on a statefulset: %v", errs)
+		}
+
+		// maxUnavailable with OnDelete strategy should not be allowed
+		onDeleteMU := &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ondelete", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.OrderedReadyPodManagement,
+				Selector:            &metav1.LabelSelector{MatchLabels: validSelector},
+				Template:            validPodTemplate.Template,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.OnDeleteStatefulSetStrategyType,
+					RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+					},
+				},
+			},
+		}
+		Strategy.PrepareForCreate(ctx, onDeleteMU)
+		errs = Strategy.Validate(ctx, onDeleteMU)
+		if len(errs) == 0 {
+			t.Errorf("expected failure when MaxUnavailable is used with OnDelete strategy but got no error")
+		}
+	})
+
+	t.Run("StatefulSet maxUnavailable feature gate disabled behavior", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MaxUnavailableStatefulSet, false)
+
+		// creation with maxUnavailable when feature gate is disabled
+		maxUnavailableMU := &apps.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-feature-disabled", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.ParallelPodManagement,
+				Selector:            &metav1.LabelSelector{MatchLabels: validSelector},
+				Template:            validPodTemplate.Template,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+					RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+						MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+					},
+				},
+			},
+		}
+		Strategy.PrepareForCreate(ctx, maxUnavailableMU)
+
+		// The field should be dropped during prepare
+		if maxUnavailableMU.Spec.UpdateStrategy.RollingUpdate != nil && maxUnavailableMU.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable != nil {
+			t.Errorf("expected MaxUnavailable to be dropped when feature gate is disabled")
+		}
+
+		errs := Strategy.Validate(ctx, maxUnavailableMU)
+		if len(errs) != 0 {
+			t.Errorf("unexpected error validating StatefulSet when MaxUnavailable is dropped: %v", errs)
+		}
+	})
 }
 
 func TestStatefulSetStatusStrategy(t *testing.T) {
@@ -340,23 +515,29 @@ func generateStatefulSetWithMinReadySeconds(minReadySeconds int32) *apps.Statefu
 	}
 }
 
-func makeStatefulSetWithMaxUnavailable(maxUnavailable *int) *apps.StatefulSet {
-	rollingUpdate := apps.RollingUpdateStatefulSetStrategy{}
-	if maxUnavailable != nil {
-		maxUnavailableIntStr := intstr.FromInt32(int32(*maxUnavailable))
-		rollingUpdate = apps.RollingUpdateStatefulSetStrategy{
-			MaxUnavailable: &maxUnavailableIntStr,
+// makeStatefulSetWithMaxUnavailable creates a StatefulSet with maxUnavailable field.
+// If forceRollingUpdate is true, it creates a RollingUpdate struct even when maxUnavailable is nil.
+func makeStatefulSetWithMaxUnavailable(ss *apps.StatefulSet, maxUnavailable *intstr.IntOrString, forceRollingUpdate bool) *apps.StatefulSet {
+	if ss == nil {
+		ss = &apps.StatefulSet{
+			Spec: apps.StatefulSetSpec{
+				PodManagementPolicy: apps.OrderedReadyPodManagement,
+				UpdateStrategy: apps.StatefulSetUpdateStrategy{
+					Type: apps.RollingUpdateStatefulSetStrategyType,
+				},
+			},
 		}
 	}
 
-	return &apps.StatefulSet{
-		Spec: apps.StatefulSetSpec{
-			UpdateStrategy: apps.StatefulSetUpdateStrategy{
-				Type:          apps.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &rollingUpdate,
-			},
-		},
+	// Create RollingUpdate struct if maxUnavailable is provided OR if forced
+	if maxUnavailable != nil || forceRollingUpdate {
+		rollingUpdate := apps.RollingUpdateStatefulSetStrategy{
+			MaxUnavailable: maxUnavailable,
+		}
+		ss.Spec.UpdateStrategy.RollingUpdate = &rollingUpdate
 	}
+
+	return ss
 }
 
 func createOrdinalsWithStart(start int) *apps.StatefulSetOrdinals {
@@ -419,38 +600,133 @@ func TestDropStatefulSetDisabledFields(t *testing.T) {
 			expectedSS: generateStatefulSetWithMinReadySeconds(10),
 		},
 		{
+			name:                 "pods ready but not available due to minReadySeconds with maxUnavailable",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+		},
+		{
+			name:                 "pods available after minReadySeconds elapsed",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+		},
+		{
 			name:       "MaxUnavailable not enabled, field not used",
-			ss:         makeStatefulSetWithMaxUnavailable(nil),
+			ss:         makeStatefulSetWithMaxUnavailable(nil, nil, false),
 			oldSS:      nil,
-			expectedSS: makeStatefulSetWithMaxUnavailable(nil),
+			expectedSS: makeStatefulSetWithMaxUnavailable(nil, nil, false),
 		},
 		{
 			name:                 "MaxUnavailable not enabled, field used in new, not in old",
 			enableMaxUnavailable: false,
-			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(3)),
-			oldSS:                nil,
-			expectedSS:           makeStatefulSetWithMaxUnavailable(nil),
+			ss: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				false,
+			),
+			oldSS:      nil,
+			expectedSS: makeStatefulSetWithMaxUnavailable(nil, nil, true),
 		},
 		{
 			name:                 "MaxUnavailable not enabled, field used in old and new",
 			enableMaxUnavailable: false,
-			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(3)),
-			oldSS:                makeStatefulSetWithMaxUnavailable(ptr.To(3)),
-			expectedSS:           makeStatefulSetWithMaxUnavailable(ptr.To(3)),
+			ss: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				false,
+			),
 		},
 		{
 			name:                 "MaxUnavailable enabled, field used in new only",
 			enableMaxUnavailable: true,
-			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(3)),
-			oldSS:                nil,
-			expectedSS:           makeStatefulSetWithMaxUnavailable(ptr.To(3)),
+			ss: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				false,
+			),
+			oldSS: nil,
+			expectedSS: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				false,
+			),
 		},
 		{
 			name:                 "MaxUnavailable enabled, field used in both old and new",
 			enableMaxUnavailable: true,
-			ss:                   makeStatefulSetWithMaxUnavailable(ptr.To(1)),
-			oldSS:                makeStatefulSetWithMaxUnavailable(ptr.To(3)),
-			expectedSS:           makeStatefulSetWithMaxUnavailable(ptr.To(1)),
+			ss: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+		},
+		{
+			name:                 "MaxUnavailable enabled, percentage value in new",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.String, StrVal: "20%"},
+				false,
+			),
+			oldSS: nil,
+			expectedSS: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.String, StrVal: "20%"},
+				false,
+			),
+		},
+		{
+			name:                 "MaxUnavailable enabled, percentage value in old and new",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.String, StrVal: "20%"},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.String, StrVal: "20%"},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(nil,
+				&intstr.IntOrString{Type: intstr.String, StrVal: "20%"},
+				false,
+			),
 		},
 		{
 			name:       "set ordinals, ordinals in use in new only",
@@ -463,6 +739,101 @@ func TestDropStatefulSetDisabledFields(t *testing.T) {
 			ss:         makeStatefulSetWithStatefulSetOrdinals(createOrdinalsWithStart(2)),
 			oldSS:      makeStatefulSetWithStatefulSetOrdinals(createOrdinalsWithStart(1)),
 			expectedSS: makeStatefulSetWithStatefulSetOrdinals(createOrdinalsWithStart(2)),
+		},
+		{
+			name:                 "minReadySeconds and maxUnavailable enabled",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(15),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(15),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(15),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				false,
+			),
+		},
+		{
+			name:                 "zero minReadySeconds with maxUnavailable enabled",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(0),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(0),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(0),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+		},
+		{
+			name:                 "minReadySeconds change with maxUnavailable enabled",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(45),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(45),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+				false,
+			),
+		},
+		{
+			name:                 "minReadySeconds disabled with maxUnavailable disabled",
+			enableMaxUnavailable: false,
+			ss: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				nil,
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				nil,
+				true,
+			),
+		},
+		{
+			name:                 "transition from disabled to enabled maxUnavailable with minReadySeconds",
+			enableMaxUnavailable: true,
+			ss: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				false,
+			),
+			oldSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				nil,
+				false,
+			),
+			expectedSS: makeStatefulSetWithMaxUnavailable(
+				generateStatefulSetWithMinReadySeconds(30),
+				&intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+				false,
+			),
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Add more test cases for statefulset registry in case multiple cases for `maxUnavailable`.

#### What type of PR is this?

/kind feature
/sig apps
/triage accepted
/milestone v1.35

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/961

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
