### PR TITLE
scheduler: fix data race in cache.finishBinding

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
@@ -392,8 +392,8 @@ func (cache *cacheImpl) finishBinding(logger klog.Logger, pod *v1.Pod, now time.
 		return err
 	}
 
-	cache.mu.RLock()
-	defer cache.mu.RUnlock()
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
 
 	logger.V(5).Info("Finished binding for pod, can be expired", "podKey", key, "pod", klog.KObj(pod))
 	currState, ok := cache.podStates[key]


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a data race in the scheduler cache when `finishBinding` is invoked concurrently.  
Currently, `finishBinding` modifies the pod state while holding only an `RLock`, which leads to unsafe concurrent writes.  
This can be detected by running tests with the `-race` flag.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The race occurs when multiple goroutines call  `finishBinding` concurrently.
- The issue does not usually appear in existing unit tests because they run serially.
- The fix changes the read lock (`RLock`) to a write lock (`Lock`) to ensure thread safety.

#### Does this PR introduce a user-facing change?

```release-note
Fix a data race in the scheduler cache when `finishBinding` is executed concurrently.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
