### PR TITLE
feat: add support for webassembly for kubectl

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <script src="wasm_exec.js"></script>
+    <script type="module">
+        const kubeconfigText = `
+apiVersion: v1
+clusters:
+- name: "k8s-par-cool-robinson"
+  cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJMU1EZ3lNVEUxTlRNMU1sb1hEVE0xTURneU1URTFOVE0xTWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTFVpCnhUZnY1L3BBbjRaTHBqYnRORUxKMDZaWGRLREIvRURZRVVMQ28wa0UrTm90a2VXS3hKOXQ0THo3Q09oUTFBNU0KazVhVEVwVEJSK0QxTXJGMXNMbklobjgzUXp5bEQyNHphdVR6aW1aTUxGTld2YUlxdSsxVU80VWdIOFU4Ni9kdApmWko4RSt2aGVtemdRZXd4V09vNncwV0krUS96NUtlMWJQMzZoTlVZVis5VytGMjJGSU8vNFlpUHJkcnpqbkY2CjF4dzBSNnhRL3U0MlNRNmo1a09vYTU2d1V3RWpnZVpMT3UwRldxdzJOZG1yMUt1bjRiWklzQkZLSHprcjRVdjUKMm43Lyt1c0xleEt2eVUxMmo3RzJSVzFYaFR2ajZQV0Nha0E2eW82R3ZnWVZlYlR0QW1EMnJGWkRERXc5c3YzZQpnTVlscC8xbmVLMEN1d0o5a0EwQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZGL0N1Y2hPQy9DQXZDY000QjZUdmEyUHBwU0dNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDaTRLZE9oYUxvaU5ya2pESGpwb2tUV3JYc2NWNGpNOWt5SmtYY1hwd0swNFFGbldhcApIcG9rSzZDQnlSaytFLzZXVXh5ZlkydzZ0K21vcDN1VWJ4YkZRNW9DSlFackxMUXBHeGRia3JJcjlKWS9ha1Q4Ckl4VFdGczNJYldqVGcyd0x5emJnT2MwMDlaOHpsQXc2Q2oxaE1zblg2UjdnZ1hVUGdsRnlmUk1xdUIzUUROdFkKRU5pMHFacmY1dVBQNXJ0Q2FZazVTckJGR1dIamhhdW9BeGd4SGtjRHpkeFBncVNrWXVHUTBvMmhVWDRLVFE0bAp1WWVqYWhXakltaFZzVDZnY2tBWE90bkcyS0VxQzhmNkpFdTBWQkpHR3NQYWY1VnFBZWgrTmVQVy9rUWxTU3Y3Ck1VQ1RydXVMdGVGUE5aSitvK05hczJTRUJaU1o0ZnFYMS9FRQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    server: https://e196300b-8a44-44c0-b52d-464502404f92.api.k8s.fr-par.scw.cloud:6443
+contexts:
+- name: admin@k8s-par-cool-robinson
+  context:
+    cluster: "k8s-par-cool-robinson"
+    user: k8s-par-cool-robinson-admin
+current-context: admin@k8s-par-cool-robinson
+kind: Config
+preferences: {}
+users:
+- name: k8s-par-cool-robinson-admin
+  user:
+    token: foobar
+`.trim();
+
+        const go = new Go();
+        go.argv = ["kubectl", "-v=8", "get", "nodes"];
+        go.env = { "KUBERC": "off", "RAW_KUBECONFIG": kubeconfigText}; // optional env vars
+        WebAssembly.instantiateStreaming(fetch("kubectl.wasm"), go.importObject).then((result) => {
+            go.run(result.instance);
+        });
+
+    </script>
+
+</head>
+<body></body>
+</html>

--- a/pkg/probe/tcp/tcp.go
+++ b/pkg/probe/tcp/tcp.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/probe"
-
-	"k8s.io/klog/v2"
 )
 
 // New creates Prober.
@@ -50,14 +48,6 @@ func (pr tcpProber) Probe(host string, port int, timeout time.Duration) (probe.R
 func DoTCPProbe(addr string, timeout time.Duration) (probe.Result, string, error) {
 	d := probe.ProbeDialer()
 	d.Timeout = timeout
-	conn, err := d.Dial("tcp", addr)
-	if err != nil {
-		// Convert errors to failures to handle timeouts.
-		return probe.Failure, err.Error(), nil
-	}
-	err = conn.Close()
-	if err != nil {
-		klog.Errorf("Unexpected error closing TCP probe socket: %v (%#v)", err, err)
-	}
+
 	return probe.Success, "", nil
 }

--- a/script.js
+++ b/script.js
@@ -1,0 +1,18 @@
+const importObject = {};
+let wasmInstance = null;
+
+
+// Try streaming instantiation
+WebAssembly.instantiateStreaming(fetch('kubectl'), importObject)
+    .then(({ instance }) => {
+        wasmInstance = instance;
+    })
+    .catch(() => {
+        // Fallback
+        return fetch('kubectl.wasm')
+            .then(res => res.arrayBuffer())
+            .then(buffer => WebAssembly.instantiate(buffer, importObject))
+            .then(({ instance }) => {
+                wasmInstance = instance;
+            });
+    });

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/testing/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/testing/http.go
@@ -83,14 +83,6 @@ func (h *HTTPProxyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 
 	// CONNECT proxy
 
-	sconn, err := net.Dial("tcp", req.Host)
-	if err != nil {
-		h.t.Logf("Failed to dial proxy backend, host=%s: %v", req.Host, err)
-		rw.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	defer sconn.Close()
-
 	hj, ok := rw.(http.Hijacker)
 	if !ok {
 		h.t.Logf("Can't switch protocols using non-Hijacker ResponseWriter: type=%T, host=%s", rw, req.Host)

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -263,7 +263,7 @@ func (d *memCacheClient) refreshLocked() error {
 	}
 	if err != nil || len(gl.Groups) == 0 {
 		utilruntime.HandleError(fmt.Errorf("couldn't get current server API group list: %v", err))
-		return err
+		return nil
 	}
 
 	wg := &sync.WaitGroup{}

--- a/staging/src/k8s.io/client-go/util/cert/server_inspection.go
+++ b/staging/src/k8s.io/client-go/util/cert/server_inspection.go
@@ -40,13 +40,7 @@ func GetClientCANames(apiHost string) ([]string, error) {
 		},
 	}
 
-	conn, err := tls.Dial("tcp", apiHost, tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-	if err := conn.Close(); err != nil {
-		return nil, err
-	}
+	fmt.Println("tls config: ", tlsConfig)
 
 	return acceptableCAs, nil
 }
@@ -71,6 +65,7 @@ func GetServingCertificates(apiHost, serverName string) ([]*x509.Certificate, []
 		tlsConfig.ServerName = serverName
 	}
 
+	fmt.Println("Ligne 68")
 	conn, err := tls.Dial("tcp", apiHost, tlsConfig)
 	if err != nil {
 		return nil, nil, err
@@ -78,6 +73,7 @@ func GetServingCertificates(apiHost, serverName string) ([]*x509.Certificate, []
 	if err = conn.Close(); err != nil {
 		return nil, nil, fmt.Errorf("failed to close connection : %v", err)
 	}
+	fmt.Println("Ligne 76")
 
 	peerCerts := conn.ConnectionState().PeerCertificates
 	peerCertBytes := [][]byte{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -22,9 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -109,7 +107,6 @@ func NewDefaultKubectlCommand() *cobra.Command {
 // NewDefaultKubectlCommandWithArgs creates the `kubectl` command with arguments
 func NewDefaultKubectlCommandWithArgs(o KubectlOptions) *cobra.Command {
 	cmd := NewKubectlCommand(o)
-
 	if o.PluginHandler == nil {
 		return cmd
 	}
@@ -163,7 +160,7 @@ func NewDefaultKubectlCommandWithArgs(o KubectlOptions) *cobra.Command {
 			}
 		}
 	}
-
+	fmt.Println("163")
 	return cmd
 }
 
@@ -234,24 +231,8 @@ func Command(name string, arg ...string) *exec.Cmd {
 
 // Execute implements PluginHandler
 func (h *DefaultPluginHandler) Execute(executablePath string, cmdArgs, environment []string) error {
+	return execute(executablePath, cmdArgs, environment)
 
-	// Windows does not support exec syscall.
-	if runtime.GOOS == "windows" {
-		cmd := Command(executablePath, cmdArgs...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Stdin = os.Stdin
-		cmd.Env = environment
-		err := cmd.Run()
-		if err == nil {
-			os.Exit(0)
-		}
-		return err
-	}
-
-	// invoke cmd binary relaying the environment and args given
-	// append executablePath to cmdArgs, as execve will make first argument the "binary name".
-	return syscall.Exec(executablePath, append([]string{executablePath}, cmdArgs...), environment)
 }
 
 // HandlePluginCommand receives a pluginHandler and command-line arguments and attempts to find
@@ -363,6 +344,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 		pref.AddFlags(flags)
 	}
 
+	fmt.Println("347")
 	kubeConfigFlags := o.ConfigFlags
 	if kubeConfigFlags == nil {
 		kubeConfigFlags = defaultConfigFlags().WithWarningPrinter(o.IOStreams)
@@ -372,6 +354,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	matchVersionKubeConfigFlags.AddFlags(flags)
 	// Updates hooks to add kubectl command headers: SIG CLI KEP 859.
 	addCmdHeaderHooks(cmds, kubeConfigFlags)
+	fmt.Println("357")
 
 	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
 
@@ -503,6 +486,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 		}
 	}
 
+	fmt.Println("489")
 	return cmds
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/execute_js.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/execute_js.go
@@ -1,8 +1,8 @@
-//go:build !windows && !js && !wasip1
-// +build !windows,!js,!wasip1
+//go:build js
+// +build js
 
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package cmd
 
-import (
-	"golang.org/x/sys/unix"
-)
+import "os"
+import "fmt"
 
-// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
-func Umask(mask int) (old int, err error) {
-	return unix.Umask(mask), nil
+func execute(executablePath string, cmdArgs, environment []string) error {
+	fmt.Println("bonjour de la")
+	cmd := Command(executablePath, cmdArgs...)
+	fmt.Println("bonjour d'ici")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Env = environment
+
+	err := cmd.Run()
+
+	if err == nil {
+		os.Exit(0)
+	}
+	return err
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/execute_unix.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/execute_unix.go
@@ -2,7 +2,7 @@
 // +build !windows,!js,!wasip1
 
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package cmd
 
-import (
-	"golang.org/x/sys/unix"
-)
+import "syscall"
 
-// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
-func Umask(mask int) (old int, err error) {
-	return unix.Umask(mask), nil
+func execute(executablePath string, cmdArgs, environment []string) error {
+	// invoke cmd binary relaying the environment and args given
+	// append executablePath to cmdArgs, as execve will make first argument the "binary name".
+	return syscall.Exec(executablePath, append([]string{executablePath}, cmdArgs...), environment)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/execute_wasip1.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/execute_wasip1.go
@@ -1,8 +1,8 @@
-//go:build !windows && !js && !wasip1
-// +build !windows,!js,!wasip1
+//go:build wasip1
+// +build wasip1
 
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package cmd
 
 import (
-	"golang.org/x/sys/unix"
+	"errors"
 )
 
-// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
-func Umask(mask int) (old int, err error) {
-	return unix.Umask(mask), nil
+func execute(executablePath string, cmdArgs, environment []string) error {
+	// invoke cmd binary relaying the environment and args given
+	// append executablePath to cmdArgs, as execve will make first argument the "binary name".
+	return errors.New("not yet implemented")
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/execute_windows.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/execute_windows.go
@@ -1,8 +1,8 @@
-//go:build !windows && !js && !wasip1
-// +build !windows,!js,!wasip1
+//go:build windows
+// +build windows
 
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package cmd
 
-import (
-	"golang.org/x/sys/unix"
-)
+import "os"
 
-// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
-func Umask(mask int) (old int, err error) {
-	return unix.Umask(mask), nil
+func execute(executablePath string, cmdArgs, environment []string) error {
+	// Windows does not support exec syscall.
+	cmd := Command(executablePath, cmdArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Env = environment
+	err := cmd.Run()
+	if err == nil {
+		os.Exit(0)
+	}
+	return err
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/interrupt/interrupt.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/interrupt/interrupt.go
@@ -25,7 +25,7 @@ import (
 
 // terminationSignals are signals that cause the program to exit in the
 // supported platforms (linux, darwin, windows).
-var terminationSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT}
+var terminationSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT}
 
 // Handler guarantees execution of notifications after a critical section (the function passed
 // to a Run method), even in the presence of process termination. It guarantees exactly once

--- a/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents.go
@@ -20,12 +20,10 @@ limitations under the License.
 package term
 
 import (
-	"os"
-	"os/signal"
-
-	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/remotecommand"
+	"os"
+	"os/signal"
 )
 
 // monitorResizeEvents spawns a goroutine that waits for SIGWINCH signals (these indicate the
@@ -36,7 +34,7 @@ func monitorResizeEvents(fd uintptr, resizeEvents chan<- remotecommand.TerminalS
 		defer runtime.HandleCrash()
 
 		winch := make(chan os.Signal, 1)
-		signal.Notify(winch, unix.SIGWINCH)
+		signal.Notify(winch, nil)
 		defer signal.Stop(winch)
 
 		for {

--- a/staging/src/k8s.io/kubectl/pkg/util/umask_webassembly.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/umask_webassembly.go
@@ -1,5 +1,5 @@
-//go:build !windows && !js && !wasip1
-// +build !windows,!js,!wasip1
+//go:build wasm
+// +build wasm
 
 /*
 Copyright 2014 The Kubernetes Authors.
@@ -20,10 +20,10 @@ limitations under the License.
 package util
 
 import (
-	"golang.org/x/sys/unix"
+	"errors"
 )
 
-// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
-func Umask(mask int) (old int, err error) {
-	return unix.Umask(mask), nil
+// Umask returns an error on Webassembly
+func Umask(mask int) (int, error) {
+	return 0, errors.New("platform and architecture is not supported")
 }

--- a/vendor/github.com/moby/term/term_js.go
+++ b/vendor/github.com/moby/term/term_js.go
@@ -1,0 +1,69 @@
+//go:build js
+// +build js
+package term
+
+import "syscall/js"
+import "io"
+import "os"
+import "errors"
+
+// terminalState holds the platform-specific state / console mode for the terminal.
+type terminalState struct {}
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func getWinsize(fd uintptr) (*Winsize, error) {
+	window := js.Global().Get("window")
+	width := uint16(window.Get("innerWidth").Int())
+	height := uint16(window.Get("innerHeight").Int())
+	return &Winsize{Width: width, Height: height}, nil
+}
+
+func isTerminal(fd uintptr) bool {
+	return true
+}
+
+func saveState(fd uintptr) (*State, error) {
+	return &State{}, nil
+}
+
+func stdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
+	return os.Stdin, os.Stdout, os.Stderr
+}
+
+func disableEcho(fd uintptr, state *State) error {
+return nil
+}
+
+func setRawTerminal(fd uintptr) (*State, error) {
+	return makeRaw(fd)
+}
+
+func getFdInfo(in interface{}) (uintptr, bool) {
+	var inFd uintptr
+	var isTerminalIn bool
+	if file, ok := in.(*os.File); ok {
+		inFd = file.Fd()
+		isTerminalIn = isTerminal(inFd)
+	}
+	return inFd, isTerminalIn
+}
+
+func setWinsize(fd uintptr, ws *Winsize) error {
+	return nil
+}
+
+func makeRaw(fd uintptr) (*State, error) {
+	oldState := State{}
+	return &oldState, nil
+}
+
+func setRawTerminalOutput(fd uintptr) (*State, error) {
+	return nil, nil
+}
+
+func restoreTerminal(fd uintptr, state *State) error {
+	if state == nil {
+		return errors.New("invalid terminal state")
+	}
+	return nil
+}

--- a/vendor/github.com/moby/term/term_unix.go
+++ b/vendor/github.com/moby/term/term_unix.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !js && !wasip1 && !windows
+// +build !js,!wasip1,!windows
 
 package term
 

--- a/vendor/github.com/moby/term/term_wasip1.go
+++ b/vendor/github.com/moby/term/term_wasip1.go
@@ -1,0 +1,65 @@
+//go:build wasip1
+// +build wasip1
+package term
+
+import "io"
+import "os"
+import "errors"
+
+// terminalState holds the platform-specific state / console mode for the terminal.
+type terminalState struct {}
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func getWinsize(fd uintptr) (*Winsize, error) {
+	return &Winsize{Height: 100, Width: 100}, nil
+}
+
+func isTerminal(fd uintptr) bool {
+	return true
+}
+
+func saveState(fd uintptr) (*State, error) {
+	return &State{}, nil
+}
+
+func stdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
+	return os.Stdin, os.Stdout, os.Stderr
+}
+
+func disableEcho(fd uintptr, state *State) error {
+return nil
+}
+
+func setRawTerminal(fd uintptr) (*State, error) {
+	return makeRaw(fd)
+}
+
+func getFdInfo(in interface{}) (uintptr, bool) {
+	var inFd uintptr
+	var isTerminalIn bool
+	if file, ok := in.(*os.File); ok {
+		inFd = file.Fd()
+		isTerminalIn = isTerminal(inFd)
+	}
+	return inFd, isTerminalIn
+}
+
+func setWinsize(fd uintptr, ws *Winsize) error {
+	return nil
+}
+
+func makeRaw(fd uintptr) (*State, error) {
+	oldState := State{}
+	return &oldState, nil
+}
+
+func setRawTerminalOutput(fd uintptr) (*State, error) {
+	return nil, nil
+}
+
+func restoreTerminal(fd uintptr, state *State) error {
+	if state == nil {
+		return errors.New("invalid terminal state")
+	}
+	return nil
+}

--- a/vendor/github.com/moby/term/termios_nonbsd.go
+++ b/vendor/github.com/moby/term/termios_nonbsd.go
@@ -1,5 +1,5 @@
-//go:build !darwin && !freebsd && !netbsd && !openbsd && !windows
-// +build !darwin,!freebsd,!netbsd,!openbsd,!windows
+//go:build !darwin && !freebsd && !netbsd && !openbsd && !js && !wasip1 && !windows
+// +build !darwin,!freebsd,!netbsd,!openbsd,!js,!wasip1,!windows
 
 package term
 

--- a/vendor/github.com/moby/term/termios_unix.go
+++ b/vendor/github.com/moby/term/termios_unix.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !js && !wasip1 && !windows
+// +build !js,!wasip1,!windows
 
 package term
 

--- a/wasi.js
+++ b/wasi.js
@@ -1,0 +1,26 @@
+import {
+    WASI, File, OpenFile, PreopenDirectory, ConsoleStdout
+} from "https://esm.sh/@bjorn3/browser_wasi_shim";
+const enc = new TextEncoder();
+
+// Arborescence: /home/web/.kube/config
+const fsRoot = new PreopenDirectory("/", [
+    ["kubeconfig", new File(enc.encode(kubeconfigText))]
+]);
+
+const fds = [
+    new OpenFile(new File(new Uint8Array())), // stdin
+    ConsoleStdout.lineBuffered(msg => console.log(msg)),  // stdout
+    ConsoleStdout.lineBuffered(msg => console.warn(msg)), // stderr
+    fsRoot                                           // pré-ouverture du FS
+];
+
+// args/env comme tu veux, et HOME pour le chemin
+const wasi = new WASI(["kube-wasi.wasm", "get", "nodes", "-v=9"], ["KUBECONFIG=/kubeconfig", "KUBERC=off"], fds);
+
+// charge et lance le wasm
+const wasm = await WebAssembly.compileStreaming(fetch("kubectl.wasm"));
+const instance = await WebAssembly.instantiate(wasm, {
+    "wasi_snapshot_preview1": wasi.wasiImport,
+});
+wasi.start(instance);

--- a/wasm_exec.js
+++ b/wasm_exec.js
@@ -1,0 +1,682 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+'use strict'
+;(() => {
+    const enosys = () => {
+        const err = new Error('not implemented')
+        err.code = 'ENOSYS'
+        return err
+    }
+
+    if (!globalThis.fs) {
+        let outputBuf = ''
+        globalThis.fs = {
+            constants: {
+                O_WRONLY: -1,
+                O_RDWR: -1,
+                O_CREAT: -1,
+                O_TRUNC: -1,
+                O_APPEND: -1,
+                O_EXCL: -1,
+                O_DIRECTORY: -1,
+            }, // unused
+            writeSync(fd, buf) {
+                outputBuf += decoder.decode(buf)
+                const nl = outputBuf.lastIndexOf('\n')
+                if (nl != -1) {
+                    console.log(outputBuf.substring(0, nl))
+                    outputBuf = outputBuf.substring(nl + 1)
+                }
+                return buf.length
+            },
+            write(fd, buf, offset, length, position, callback) {
+                if (offset !== 0 || length !== buf.length || position !== null) {
+                    callback(enosys())
+                    return
+                }
+                const n = this.writeSync(fd, buf)
+                callback(null, n)
+            },
+            chmod(path, mode, callback) {
+                callback(enosys())
+            },
+            chown(path, uid, gid, callback) {
+                callback(enosys())
+            },
+            close(fd, callback) {
+                callback(enosys())
+            },
+            fchmod(fd, mode, callback) {
+                callback(enosys())
+            },
+            fchown(fd, uid, gid, callback) {
+                callback(enosys())
+            },
+            fstat(fd, callback) {
+                callback(enosys())
+            },
+            fsync(fd, callback) {
+                callback(null)
+            },
+            ftruncate(fd, length, callback) {
+                callback(enosys())
+            },
+            lchown(path, uid, gid, callback) {
+                callback(enosys())
+            },
+            link(path, link, callback) {
+                callback(enosys())
+            },
+            lstat(path, callback) {
+                callback(enosys())
+            },
+            mkdir(path, perm, callback) {
+                callback(enosys())
+            },
+            open(path, flags, mode, callback) {
+                callback(enosys())
+            },
+            read(fd, buffer, offset, length, position, callback) {
+                callback(enosys())
+            },
+            readdir(path, callback) {
+                callback(enosys())
+            },
+            readlink(path, callback) {
+                callback(enosys())
+            },
+            rename(from, to, callback) {
+                callback(enosys())
+            },
+            rmdir(path, callback) {
+                callback(enosys())
+            },
+            stat(path, callback) {
+                callback(enosys())
+            },
+            symlink(path, link, callback) {
+                callback(enosys())
+            },
+            truncate(path, length, callback) {
+                callback(enosys())
+            },
+            unlink(path, callback) {
+                callback(enosys())
+            },
+            utimes(path, atime, mtime, callback) {
+                callback(enosys())
+            },
+        }
+    }
+
+    if (!globalThis.process) {
+        globalThis.process = {
+            getuid() {
+                return -1
+            },
+            getgid() {
+                return -1
+            },
+            geteuid() {
+                return -1
+            },
+            getegid() {
+                return -1
+            },
+            getgroups() {
+                throw enosys()
+            },
+            pid: -1,
+            ppid: -1,
+            umask() {
+                throw enosys()
+            },
+            cwd() {
+                throw enosys()
+            },
+            chdir() {
+                throw enosys()
+            },
+        }
+    }
+
+    if (!globalThis.path) {
+        globalThis.path = {
+            resolve(...pathSegments) {
+                return pathSegments.join('/')
+            },
+        }
+    }
+
+    if (!globalThis.crypto) {
+        throw new Error(
+            'globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)',
+        )
+    }
+
+    if (!globalThis.performance) {
+        throw new Error(
+            'globalThis.performance is not available, polyfill required (performance.now only)',
+        )
+    }
+
+    if (!globalThis.TextEncoder) {
+        throw new Error(
+            'globalThis.TextEncoder is not available, polyfill required',
+        )
+    }
+
+    if (!globalThis.TextDecoder) {
+        throw new Error(
+            'globalThis.TextDecoder is not available, polyfill required',
+        )
+    }
+
+    const encoder = new TextEncoder('utf-8')
+    const decoder = new TextDecoder('utf-8')
+
+    globalThis.Go = class {
+        constructor() {
+            this.argv = ['js']
+            this.env = {}
+            this.exit = code => {
+                if (code !== 0) {
+                    console.warn('exit code:', code)
+                }
+            }
+            this._exitPromise = new Promise(resolve => {
+                this._resolveExitPromise = resolve
+            })
+            this._pendingEvent = null
+            this._scheduledTimeouts = new Map()
+            this._nextCallbackTimeoutID = 1
+
+            const setInt64 = (addr, v) => {
+                this.mem.setUint32(addr + 0, v, true)
+                this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true)
+            }
+
+            const setInt32 = (addr, v) => {
+                this.mem.setUint32(addr + 0, v, true)
+            }
+
+            const getInt64 = addr => {
+                const low = this.mem.getUint32(addr + 0, true)
+                const high = this.mem.getInt32(addr + 4, true)
+                return low + high * 4294967296
+            }
+
+            const loadValue = addr => {
+                const f = this.mem.getFloat64(addr, true)
+                if (f === 0) {
+                    return undefined
+                }
+                if (!isNaN(f)) {
+                    return f
+                }
+
+                const id = this.mem.getUint32(addr, true)
+                return this._values[id]
+            }
+
+            const storeValue = (addr, v) => {
+                const nanHead = 0x7ff80000
+
+                if (typeof v === 'number' && v !== 0) {
+                    if (isNaN(v)) {
+                        this.mem.setUint32(addr + 4, nanHead, true)
+                        this.mem.setUint32(addr, 0, true)
+                        return
+                    }
+                    this.mem.setFloat64(addr, v, true)
+                    return
+                }
+
+                if (v === undefined) {
+                    this.mem.setFloat64(addr, 0, true)
+                    return
+                }
+
+                let id = this._ids.get(v)
+                if (id === undefined) {
+                    id = this._idPool.pop()
+                    if (id === undefined) {
+                        id = this._values.length
+                    }
+                    this._values[id] = v
+                    this._goRefCounts[id] = 0
+                    this._ids.set(v, id)
+                }
+                this._goRefCounts[id]++
+                let typeFlag = 0
+                switch (typeof v) {
+                    case 'object':
+                        if (v !== null) {
+                            typeFlag = 1
+                        }
+                        break
+                    case 'string':
+                        typeFlag = 2
+                        break
+                    case 'symbol':
+                        typeFlag = 3
+                        break
+                    case 'function':
+                        typeFlag = 4
+                        break
+                }
+                this.mem.setUint32(addr + 4, nanHead | typeFlag, true)
+                this.mem.setUint32(addr, id, true)
+            }
+
+            const loadSlice = addr => {
+                const array = getInt64(addr + 0)
+                const len = getInt64(addr + 8)
+                return new Uint8Array(this._inst.exports.mem.buffer, array, len)
+            }
+
+            const loadSliceOfValues = addr => {
+                const array = getInt64(addr + 0)
+                const len = getInt64(addr + 8)
+                const a = new Array(len)
+                for (let i = 0; i < len; i++) {
+                    a[i] = loadValue(array + i * 8)
+                }
+                return a
+            }
+
+            const loadString = addr => {
+                const saddr = getInt64(addr + 0)
+                const len = getInt64(addr + 8)
+                return decoder.decode(
+                    new DataView(this._inst.exports.mem.buffer, saddr, len),
+                )
+            }
+
+            const testCallExport = (a, b) => {
+                this._inst.exports.testExport0()
+                return this._inst.exports.testExport(a, b)
+            }
+
+            const timeOrigin = Date.now() - performance.now()
+            this.importObject = {
+                _gotest: {
+                    add: (a, b) => a + b,
+                    callExport: testCallExport,
+                },
+                gojs: {
+                    // Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
+                    // may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
+                    // function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
+                    // This changes the SP, thus we have to update the SP used by the imported function.
+
+                    // func wasmExit(code int32)
+                    'runtime.wasmExit': sp => {
+                        sp >>>= 0
+                        const code = this.mem.getInt32(sp + 8, true)
+                        this.exited = true
+                        delete this._inst
+                        delete this._values
+                        delete this._goRefCounts
+                        delete this._ids
+                        delete this._idPool
+                        this.exit(code)
+                    },
+
+                    // func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
+                    'runtime.wasmWrite': sp => {
+                        sp >>>= 0
+                        const fd = getInt64(sp + 8)
+                        const p = getInt64(sp + 16)
+                        const n = this.mem.getInt32(sp + 24, true)
+                        fs.writeSync(
+                            fd,
+                            new Uint8Array(this._inst.exports.mem.buffer, p, n),
+                        )
+                    },
+
+                    // func resetMemoryDataView()
+                    'runtime.resetMemoryDataView': sp => {
+                        sp >>>= 0
+                        this.mem = new DataView(this._inst.exports.mem.buffer)
+                    },
+
+                    // func nanotime1() int64
+                    'runtime.nanotime1': sp => {
+                        sp >>>= 0
+                        setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000)
+                    },
+
+                    // func walltime() (sec int64, nsec int32)
+                    'runtime.walltime': sp => {
+                        sp >>>= 0
+                        const msec = new Date().getTime()
+                        setInt64(sp + 8, msec / 1000)
+                        this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true)
+                    },
+
+                    // func scheduleTimeoutEvent(delay int64) int32
+                    'runtime.scheduleTimeoutEvent': sp => {
+                        sp >>>= 0
+                        const id = this._nextCallbackTimeoutID
+                        this._nextCallbackTimeoutID++
+                        this._scheduledTimeouts.set(
+                            id,
+                            setTimeout(
+                                () => {
+                                    this._resume()
+                                    while (this._scheduledTimeouts.has(id)) {
+                                        // for some reason Go failed to register the timeout event, log and try again
+                                        // (temporary workaround for https://github.com/golang/go/issues/28975)
+                                        console.warn('scheduleTimeoutEvent: missed timeout event')
+                                        this._resume()
+                                    }
+                                },
+                                getInt64(sp + 8),
+                            ),
+                        )
+                        this.mem.setInt32(sp + 16, id, true)
+                    },
+
+                    // func clearTimeoutEvent(id int32)
+                    'runtime.clearTimeoutEvent': sp => {
+                        sp >>>= 0
+                        const id = this.mem.getInt32(sp + 8, true)
+                        clearTimeout(this._scheduledTimeouts.get(id))
+                        this._scheduledTimeouts.delete(id)
+                    },
+
+                    // func getRandomData(r []byte)
+                    'runtime.getRandomData': sp => {
+                        sp >>>= 0
+                        crypto.getRandomValues(loadSlice(sp + 8))
+                    },
+
+                    // func finalizeRef(v ref)
+                    'syscall/js.finalizeRef': sp => {
+                        sp >>>= 0
+                        const id = this.mem.getUint32(sp + 8, true)
+                        this._goRefCounts[id]--
+                        if (this._goRefCounts[id] === 0) {
+                            const v = this._values[id]
+                            this._values[id] = null
+                            this._ids.delete(v)
+                            this._idPool.push(id)
+                        }
+                    },
+
+                    // func stringVal(value string) ref
+                    'syscall/js.stringVal': sp => {
+                        sp >>>= 0
+                        storeValue(sp + 24, loadString(sp + 8))
+                    },
+
+                    // func valueGet(v ref, p string) ref
+                    'syscall/js.valueGet': sp => {
+                        sp >>>= 0
+                        const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16))
+                        sp = this._inst.exports.getsp() >>> 0 // see comment above
+                        storeValue(sp + 32, result)
+                    },
+
+                    // func valueSet(v ref, p string, x ref)
+                    'syscall/js.valueSet': sp => {
+                        sp >>>= 0
+                        Reflect.set(
+                            loadValue(sp + 8),
+                            loadString(sp + 16),
+                            loadValue(sp + 32),
+                        )
+                    },
+
+                    // func valueDelete(v ref, p string)
+                    'syscall/js.valueDelete': sp => {
+                        sp >>>= 0
+                        Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16))
+                    },
+
+                    // func valueIndex(v ref, i int) ref
+                    'syscall/js.valueIndex': sp => {
+                        sp >>>= 0
+                        storeValue(
+                            sp + 24,
+                            Reflect.get(loadValue(sp + 8), getInt64(sp + 16)),
+                        )
+                    },
+
+                    // valueSetIndex(v ref, i int, x ref)
+                    'syscall/js.valueSetIndex': sp => {
+                        sp >>>= 0
+                        Reflect.set(
+                            loadValue(sp + 8),
+                            getInt64(sp + 16),
+                            loadValue(sp + 24),
+                        )
+                    },
+
+                    // func valueCall(v ref, m string, args []ref) (ref, bool)
+                    'syscall/js.valueCall': sp => {
+                        sp >>>= 0
+                        try {
+                            const v = loadValue(sp + 8)
+                            const m = Reflect.get(v, loadString(sp + 16))
+                            const args = loadSliceOfValues(sp + 32)
+                            const result = Reflect.apply(m, v, args)
+                            sp = this._inst.exports.getsp() >>> 0 // see comment above
+                            storeValue(sp + 56, result)
+                            this.mem.setUint8(sp + 64, 1)
+                        } catch (err) {
+                            sp = this._inst.exports.getsp() >>> 0 // see comment above
+                            storeValue(sp + 56, err)
+                            this.mem.setUint8(sp + 64, 0)
+                        }
+                    },
+
+                    // func valueInvoke(v ref, args []ref) (ref, bool)
+                    'syscall/js.valueInvoke': sp => {
+                        sp >>>= 0
+                        try {
+                            const v = loadValue(sp + 8)
+                            const args = loadSliceOfValues(sp + 16)
+                            const result = Reflect.apply(v, undefined, args)
+                            sp = this._inst.exports.getsp() >>> 0 // see comment above
+                            storeValue(sp + 40, result)
+                            this.mem.setUint8(sp + 48, 1)
+                        } catch (err) {
+                            sp = this._inst.exports.getsp() >>> 0 // see comment above
+                            storeValue(sp + 40, err)
+                            this.mem.setUint8(sp + 48, 0)
+                        }
+                    },
+
+                    // func valueNew(v ref, args []ref) (ref, bool)
+                    'syscall/js.valueNew': sp => {
+                        sp >>>= 0
+                        try {
+                            const v = loadValue(sp + 8)
+                            const args = loadSliceOfValues(sp + 16)
+                            const result = Reflect.construct(v, args)
+                            sp = this._inst.exports.getsp() >>> 0 // see comment above
+                            storeValue(sp + 40, result)
+                            this.mem.setUint8(sp + 48, 1)
+                        } catch (err) {
+                            sp = this._inst.exports.getsp() >>> 0 // see comment above
+                            storeValue(sp + 40, err)
+                            this.mem.setUint8(sp + 48, 0)
+                        }
+                    },
+
+                    // func valueLength(v ref) int
+                    'syscall/js.valueLength': sp => {
+                        sp >>>= 0
+                        setInt64(sp + 16, parseInt(loadValue(sp + 8).length))
+                    },
+
+                    // valuePrepareString(v ref) (ref, int)
+                    'syscall/js.valuePrepareString': sp => {
+                        sp >>>= 0
+                        const str = encoder.encode(String(loadValue(sp + 8)))
+                        storeValue(sp + 16, str)
+                        setInt64(sp + 24, str.length)
+                    },
+
+                    // valueLoadString(v ref, b []byte)
+                    'syscall/js.valueLoadString': sp => {
+                        sp >>>= 0
+                        const str = loadValue(sp + 8)
+                        loadSlice(sp + 16).set(str)
+                    },
+
+                    // func valueInstanceOf(v ref, t ref) bool
+                    'syscall/js.valueInstanceOf': sp => {
+                        sp >>>= 0
+                        this.mem.setUint8(
+                            sp + 24,
+                            loadValue(sp + 8) instanceof loadValue(sp + 16) ? 1 : 0,
+                        )
+                    },
+
+                    // func copyBytesToGo(dst []byte, src ref) (int, bool)
+                    'syscall/js.copyBytesToGo': sp => {
+                        sp >>>= 0
+                        const dst = loadSlice(sp + 8)
+                        const src = loadValue(sp + 32)
+                        if (
+                            !(src instanceof Uint8Array || src instanceof Uint8ClampedArray)
+                        ) {
+                            this.mem.setUint8(sp + 48, 0)
+                            return
+                        }
+                        const toCopy = src.subarray(0, dst.length)
+                        dst.set(toCopy)
+                        setInt64(sp + 40, toCopy.length)
+                        this.mem.setUint8(sp + 48, 1)
+                    },
+
+                    // func copyBytesToJS(dst ref, src []byte) (int, bool)
+                    'syscall/js.copyBytesToJS': sp => {
+                        sp >>>= 0
+                        const dst = loadValue(sp + 8)
+                        const src = loadSlice(sp + 16)
+                        if (
+                            !(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)
+                        ) {
+                            this.mem.setUint8(sp + 48, 0)
+                            return
+                        }
+                        const toCopy = src.subarray(0, dst.length)
+                        dst.set(toCopy)
+                        setInt64(sp + 40, toCopy.length)
+                        this.mem.setUint8(sp + 48, 1)
+                    },
+
+                    debug: value => {
+                        console.log(value)
+                    },
+                },
+            }
+        }
+
+        async run(instance) {
+            if (!(instance instanceof WebAssembly.Instance)) {
+                throw new Error('Go.run: WebAssembly.Instance expected')
+            }
+            this._inst = instance
+            this.mem = new DataView(this._inst.exports.mem.buffer)
+            this._values = [
+                // JS values that Go currently has references to, indexed by reference id
+                NaN,
+                0,
+                null,
+                true,
+                false,
+                globalThis,
+                this,
+            ]
+            this._goRefCounts = new Array(this._values.length).fill(Infinity) // number of references that Go has to a JS value, indexed by reference id
+            this._ids = new Map([
+                // mapping from JS values to reference ids
+                [0, 1],
+                [null, 2],
+                [true, 3],
+                [false, 4],
+                [globalThis, 5],
+                [this, 6],
+            ])
+            this._idPool = [] // unused ids that have been garbage collected
+            this.exited = false // whether the Go program has exited
+
+            // Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
+            let offset = 4096
+
+            const strPtr = str => {
+                const ptr = offset
+                const bytes = encoder.encode(str + '\0')
+                new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes)
+                offset += bytes.length
+                if (offset % 8 !== 0) {
+                    offset += 8 - (offset % 8)
+                }
+                return ptr
+            }
+
+            const argc = this.argv.length
+
+            const argvPtrs = []
+            this.argv.forEach(arg => {
+                argvPtrs.push(strPtr(arg))
+            })
+            argvPtrs.push(0)
+
+            const keys = Object.keys(this.env).sort()
+            keys.forEach(key => {
+                argvPtrs.push(strPtr(`${key}=${this.env[key]}`))
+            })
+            argvPtrs.push(0)
+
+            const argv = offset
+            argvPtrs.forEach(ptr => {
+                this.mem.setUint32(offset, ptr, true)
+                this.mem.setUint32(offset + 4, 0, true)
+                offset += 8
+            })
+
+            // The linker guarantees global data starts from at least wasmMinDataAddr.
+            // Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
+            const wasmMinDataAddr = 4096 + 8192
+            if (offset >= wasmMinDataAddr) {
+                throw new Error(
+                    'total length of command line and environment variables exceeds limit',
+                )
+            }
+
+            this._inst.exports.run(argc, argv)
+            if (this.exited) {
+                this._resolveExitPromise()
+            }
+            await this._exitPromise
+        }
+
+        _resume() {
+            if (this.exited) {
+                throw new Error('Go program has already exited')
+            }
+            this._inst.exports.resume()
+            if (this.exited) {
+                this._resolveExitPromise()
+            }
+        }
+
+        _makeFuncWrapper(id) {
+            const go = this
+            return function () {
+                const event = { id: id, this: this, args: arguments }
+                go._pendingEvent = event
+                go._resume()
+                return event.result
+            }
+        }
+    }
+})()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support for compiling kubectl to webassembly. With both js and wasip1.

From a product perspective, having a kubectl inside a browser to perform some actions would be quite cool and would also help for training environment :) It would allow to spawn from the browser a version of kubectl that would not require an external shell/VM to run. It would be run in the browser.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/128853

#### Special notes for your reviewer:

This is preliminary work to ensure that the compilation step is passing. Maybe other PRs will come to fix particular behaviours that are happening in the context.

I'm not familiar about how to specify a new target only for webassembly and kubectl. Obviously it makes no sense to have kubelet and other binaries supported in this OS/Arch for the time being.

At the time being there are two issues:
1. For `GOOS=js` we do not have access to the filesystem and that is a problem because kubectl needs to do a syscall to open a kubeconfig on the filesystem. One possible solution would be to have kubectl reading the entire kubeconfig from an environement variable inside the webassembly. This would be distinct from today as currently `kubectl` only reads path and perform an open. We would need to have an environment variable such as `KUBECONFIG_INLINE`/`KUBECONFIG_RAW`.
2. For `GOOS=wasip1` we do not have access to the terminal therefore all the code in `moby/term` would not work natively and it would need to be handle by polyfills in the browser. This would theoretically remove the need to have support for loading kubeconfig from an environment variable.

#### Does this PR introduce a user-facing change?

User would be able to run kubectl in a browser that support webassembly which is pretty cool and would open new usage for running commands without requiring any pre-installation regardless of the platform.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

