### PR TITLE
Improve remote availability controller probing.

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
@@ -19,6 +19,7 @@ package remote
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -294,9 +295,16 @@ func (c *AvailableConditionController) sync(key string) error {
 	// actually try to hit the discovery endpoint when it isn't local and when we're routing as a service.
 	if apiService.Spec.Service != nil && c.serviceResolver != nil {
 		attempts := 5
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		results := make(chan error, attempts)
 		for i := 0; i < attempts; i++ {
 			go func() {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(100 * time.Millisecond * time.Duration(i)): // Delay the second and following attempts slightly.
+				}
 				discoveryURL, err := c.serviceResolver.ResolveEndpoint(apiService.Spec.Service.Namespace, apiService.Spec.Service.Name, *apiService.Spec.Service.Port)
 				if err != nil {
 					results <- err
@@ -321,16 +329,26 @@ func (c *AvailableConditionController) sync(key string) error {
 					// setting the system-masters identity ensures that we will always have access rights
 					transport.SetAuthProxyHeaders(newReq, "system:kube-aggregator", "", []string{"system:masters"}, nil)
 					resp, err := discoveryClient.Do(newReq)
+					errToSend := err
 					if resp != nil {
-						resp.Body.Close()
-						// we should always been in the 200s or 300s
+						// We should always be in the 200s or 300s.
 						if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-							errCh <- fmt.Errorf("bad status from %v: %d", discoveryURL, resp.StatusCode)
-							return
+							errToSend = fmt.Errorf("bad status from %v: %d", discoveryURL, resp.StatusCode)
+						}
+						// Drain the response to avoid spammy errors in the aggregated server's logs.
+						if _, err := io.ReadAll(resp.Body); err != nil {
+							if errToSend == nil {
+								errToSend = fmt.Errorf("failed to read body: %w", err)
+							}
+						}
+						if err := resp.Body.Close(); err != nil {
+							if errToSend == nil {
+								errToSend = fmt.Errorf("failed to close body: %w", err)
+							}
 						}
 					}
 
-					errCh <- err
+					errCh <- errToSend
 				}()
 
 				select {
@@ -356,6 +374,7 @@ func (c *AvailableConditionController) sync(key string) error {
 			lastError = <-results
 			// if we had at least one success, we are successful overall and we can return now
 			if lastError == nil {
+				cancel() // Cancel remaining requests.
 				break
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

When probing the health of an aggregated API server, the kube API server:

- Closes the response body from those requests without reading it. (It is only interested in the status code.)
- Fires off 5 requests in parallel.

Closing the body without reading the response results in the TCP connection being closed abruptly (as far as the aggregated API server is concerned).  Since most aggregated API servers (including the one used in Calico) are based on the kube API machinery, they inherit the "timeout or abort" handler, which logs "timeout or abort while handling ...." errors when the client closes the connection in this way (and when the body is large enough to still be being written when the connection is closed).

This PR:

- Reads the body to avoid spammy errors about closed connections in the aggregated API server.
- Staggers requests slightly to avoid spamming 5 requests when one would be enough.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #133644

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The API server now reads the response body when probing the health of aggregated API servers rather than only checking the status code. This prevents aggregated API servers from seeing abrupt TCP socket closures from these requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
