### PR TITLE
[KEP:4020] Peer-aggregated discovery

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -45,6 +45,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server/flagz"
 	serveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -63,7 +64,6 @@ import (
 	zpagesfeatures "k8s.io/component-base/zpages/features"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-aggregator/pkg/apiserver"
-	"k8s.io/kubernetes/pkg/features"
 	testutil "k8s.io/kubernetes/test/utils"
 	"k8s.io/kubernetes/test/utils/ktesting"
 
@@ -394,7 +394,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	utilfeature.DefaultMutableFeatureGate.AddMetrics()
 
 	if instanceOptions.EnableCertAuth {
-		if featureGate.Enabled(features.UnknownVersionInteroperabilityProxy) {
+		if featureGate.Enabled(genericfeatures.UnknownVersionInteroperabilityProxy) {
 			// TODO: set up a general clean up for testserver
 			if clientgotransport.DialerStopCh == wait.NeverStop {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Hour)

--- a/pkg/controlplane/apiserver/aggregator.go
+++ b/pkg/controlplane/apiserver/aggregator.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,6 +117,7 @@ func CreateAggregatorConfig(
 			ServiceResolver:           serviceResolver,
 			ProxyTransport:            proxyTransport,
 			RejectForwardingRedirects: commandOptions.AggregatorRejectForwardingRedirects,
+			PeerProxy:                 peerProxy,
 		},
 	}
 
@@ -129,6 +131,20 @@ func CreateAggregatorServer(aggregatorConfig aggregatorapiserver.CompletedConfig
 	aggregatorServer, err := aggregatorConfig.NewWithDelegate(delegateAPIServer)
 	if err != nil {
 		return nil, err
+	}
+
+	// Set informers for peer proxy handler to exclude CRD and APIService GVs
+	// from peer proxying and peer-aggregated discovery.
+	if aggregatorConfig.ExtraConfig.PeerProxy != nil {
+		if err := aggregatorConfig.ExtraConfig.PeerProxy.RegisterCRDInformerHandlers(crds.Informer(), crdExtractor); err != nil {
+			return nil, err
+		}
+		if err := aggregatorConfig.ExtraConfig.PeerProxy.RegisterAPIServiceInformerHandlers(
+			aggregatorServer.APIRegistrationInformers.Apiregistration().V1().APIServices().Informer(),
+			apiServiceExtractor,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	// create controllers for auto-registration
@@ -192,6 +208,38 @@ func CreateAggregatorServer(aggregatorConfig aggregatorapiserver.CompletedConfig
 	}
 
 	return aggregatorServer, nil
+}
+
+// crdExtractor extracts group-versions from CustomResourceDefinition objects
+// for use in the peer proxy exclusion filter.
+func crdExtractor(obj interface{}) []schema.GroupVersion {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		klog.Errorf("Expected CustomResourceDefinition but got %T", obj)
+		return nil
+	}
+	var gvs []schema.GroupVersion
+	for _, v := range crd.Spec.Versions {
+		gvs = append(gvs, schema.GroupVersion{Group: crd.Spec.Group, Version: v.Name})
+	}
+	return gvs
+}
+
+// apiServiceExtractor extracts group-versions from APIService objects
+// for use in the peer proxy exclusion filter. Only aggregated APIs
+// (those with a Service reference) are excluded.
+func apiServiceExtractor(obj interface{}) []schema.GroupVersion {
+	apiService, ok := obj.(*v1.APIService)
+	if !ok {
+		klog.Errorf("Expected APIService but got %T", obj)
+		return nil
+	}
+	// Only exclude if the APIService points to a service, implying it's an aggregated API
+	if apiService.Spec.Service == nil {
+		return nil
+	}
+	gv := schema.GroupVersion{Group: apiService.Spec.Group, Version: apiService.Spec.Version}
+	return []schema.GroupVersion{gv}
 }
 
 func makeAPIService(gv schema.GroupVersion, apiVersionPriorities map[schema.GroupVersion]APIServicePriority) *v1.APIService {

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -55,7 +55,6 @@ import (
 	controlplaneadmission "k8s.io/kubernetes/pkg/controlplane/apiserver/admission"
 	"k8s.io/kubernetes/pkg/controlplane/apiserver/options"
 	"k8s.io/kubernetes/pkg/controlplane/controller/clusterauthenticationtrust"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubeapiserver"
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 	rbacrest "k8s.io/kubernetes/pkg/registry/rbac/rest"
@@ -315,7 +314,7 @@ func CreateConfig(
 		},
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.UnknownVersionInteroperabilityProxy) {
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.UnknownVersionInteroperabilityProxy) {
 		var err error
 		config.PeerEndpointLeaseReconciler, err = CreatePeerEndpointLeaseReconciler(*genericConfig, storageFactory)
 		if err != nil {

--- a/pkg/controlplane/apiserver/options/validation.go
+++ b/pkg/controlplane/apiserver/options/validation.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	apiserverfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
 	"k8s.io/kubernetes/pkg/features"
@@ -72,7 +73,7 @@ func validateAPIPriorityAndFairness(options *Options) []error {
 
 func validateUnknownVersionInteroperabilityProxyFlags(options *Options) []error {
 	err := []error{}
-	if !utilfeature.DefaultFeatureGate.Enabled(features.UnknownVersionInteroperabilityProxy) {
+	if !utilfeature.DefaultFeatureGate.Enabled(apiserverfeatures.UnknownVersionInteroperabilityProxy) {
 		if options.PeerCAFile != "" {
 			err = append(err, fmt.Errorf("--peer-ca-file requires UnknownVersionInteroperabilityProxy feature to be turned on"))
 		}

--- a/pkg/controlplane/apiserver/options/validation_test.go
+++ b/pkg/controlplane/apiserver/options/validation_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	kubeapiserveradmission "k8s.io/apiserver/pkg/admission"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	basecompatibility "k8s.io/component-base/compatibility"
@@ -150,7 +151,7 @@ func TestValidateUnknownVersionInteroperabilityProxy(t *testing.T) {
 				PeerAdvertiseAddress: test.peerAdvertiseAddress,
 			}
 			if test.featureEnabled {
-				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.UnknownVersionInteroperabilityProxy, true)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.UnknownVersionInteroperabilityProxy, true)
 			}
 			var errMessageGot string
 			if errs := validateUnknownVersionInteroperabilityProxyFlags(options); len(errs) > 0 {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1032,11 +1032,6 @@ const (
 	// version of the RemoteCommand subprotocol that supports the "close" signal.
 	TranslateStreamCloseWebsocketRequests featuregate.Feature = "TranslateStreamCloseWebsocketRequests"
 
-	// owner: @richabanker
-	//
-	// Proxies client to an apiserver capable of serving the request in the event of version skew.
-	UnknownVersionInteroperabilityProxy featuregate.Feature = "UnknownVersionInteroperabilityProxy"
-
 	// owner: @HirazawaUi
 	// kep: https://kep.k8s.io/5607
 	//
@@ -1850,10 +1845,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
 	},
 
-	UnknownVersionInteroperabilityProxy: {
-		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
-	},
-
 	UserNamespacesHostNetworkSupport: {
 		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 	},
@@ -2084,6 +2075,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	genericfeatures.UnknownVersionInteroperabilityProxy: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	genericfeatures.WatchCacheInitializationPostStartHook: {
@@ -2425,8 +2420,6 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 
 	TranslateStreamCloseWebsocketRequests: {},
 
-	UnknownVersionInteroperabilityProxy: {},
-
 	UserNamespacesHostNetworkSupport: {UserNamespacesSupport},
 
 	UserNamespacesSupport: {},
@@ -2518,6 +2511,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	genericfeatures.TokenRequestServiceAccountUIDValidation: {},
 
 	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {},
+
+	genericfeatures.UnknownVersionInteroperabilityProxy: {genericfeatures.APIServerIdentity},
 
 	genericfeatures.WatchCacheInitializationPostStartHook: {},
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/sort/sort.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sort/sort.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sort
+
+import (
+	"container/heap"
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// MergePreservingRelativeOrder performs a topological consensus sort of items from multiple sources.
+// It merges multiple lists of strings into a single list, preserving the relative order of
+// elements within each source list.
+//
+// For any two items, if one appears before the other in any of the input lists,
+// that relative order will be preserved in the output. If no relative ordering is
+// defined between two items, they are sorted lexicographically.
+//
+// The function uses Kahn's algorithm for topological sorting with a min-heap to ensure
+// deterministic output. Items with no dependencies are processed in lexicographic order,
+// guaranteeing consistent results across multiple invocations with the same input.
+//
+// This function contains a shortcut optimization that returns an input list directly
+// if it already contains all unique items. This provides O(n) performance in the best case.
+//
+// Example:
+//   - Input: {{"a", "b", "c"}, {"b", "c"}} returns {"a", "b", "c"}
+//   - Input: {{"a", "c"}, {"b", "c"}} returns {"a", "b", "c"} (lexicographic tie-breaking)
+//   - Input: {{"a", "b"}, {"b", "a"}} returns error (cycle detected)
+//
+// Complexity: O(L*n + V*log(V) + E) where L is the number of lists, n is the average
+// list size, V is the number of unique items, and E is the number of precedence edges.
+//
+// This is useful for creating a stable, consistent ordering when merging data from
+// multiple sources that may have partial but not conflicting orderings.
+func MergePreservingRelativeOrder(inputLists [][]string) []string {
+	if len(inputLists) == 0 {
+		return nil
+	}
+
+	// Build a directed graph of precedence relationships
+	graph := make(map[string]*graphNode)
+	for _, list := range inputLists {
+		for i, item := range list {
+			node := getOrCreateNode(graph, item)
+
+			// Add edge from current item to next item in list
+			if i < len(list)-1 {
+				nextItem := list[i+1]
+				nextNode := getOrCreateNode(graph, nextItem)
+
+				// Only add edge if not already present (avoid incrementing in-degree multiple times)
+				if !node.outEdges.Has(nextItem) {
+					node.outEdges.Insert(nextItem)
+					nextNode.inDegree++
+				}
+			}
+		}
+	}
+
+	// Shortcut: if any input list contains all items (no duplicates), use it
+	allItems := sets.New[string]()
+	for name := range graph {
+		allItems.Insert(name)
+	}
+	for _, list := range inputLists {
+		if len(list) == allItems.Len() && isUnique(list) {
+			return list
+		}
+	}
+
+	// Perform topological sort using Kahn's algorithm with min-heap for determinism
+	result, err := topologicalSort(graph)
+	if err != nil {
+		// This should not happen with valid input, but if it does,
+		// fall back to lexicographic sort to provide some result
+		items := make([]string, 0, len(graph))
+		for name := range graph {
+			items = append(items, name)
+		}
+		sort.Strings(items)
+		return items
+	}
+
+	return result
+}
+
+// getOrCreateNode retrieves or creates a graph node for the given name
+func getOrCreateNode(graph map[string]*graphNode, name string) *graphNode {
+	if graph[name] == nil {
+		graph[name] = &graphNode{
+			outEdges: sets.New[string](),
+			inDegree: 0,
+		}
+	}
+	return graph[name]
+}
+
+// isUnique checks if a list contains no duplicate items
+func isUnique(list []string) bool {
+	seen := make(map[string]bool, len(list))
+	for _, item := range list {
+		if seen[item] {
+			return false
+		}
+		seen[item] = true
+	}
+	return true
+}
+
+// topologicalSort performs Kahn's algorithm with a min-heap for deterministic ordering
+func topologicalSort(graph map[string]*graphNode) ([]string, error) {
+	// Initialize min-heap with all nodes that have no incoming edges
+	pq := &stringMinHeap{}
+	heap.Init(pq)
+
+	for name, node := range graph {
+		if node.inDegree == 0 {
+			heap.Push(pq, name)
+		}
+	}
+
+	result := make([]string, 0, len(graph))
+
+	for pq.Len() > 0 {
+		// Pop item with lowest lexicographic value
+		current := heap.Pop(pq).(string)
+		result = append(result, current)
+
+		currentNode := graph[current]
+
+		// Reduce in-degree for all neighbors
+		for neighbor := range currentNode.outEdges {
+			neighborNode := graph[neighbor]
+			neighborNode.inDegree--
+
+			// If in-degree becomes 0, add to heap
+			if neighborNode.inDegree == 0 {
+				heap.Push(pq, neighbor)
+			}
+		}
+	}
+
+	// Check for cycles
+	if len(result) != len(graph) {
+		return nil, fmt.Errorf("cycle detected in precedence graph: sorted %d items but graph has %d items", len(result), len(graph))
+	}
+
+	return result, nil
+}
+
+// graphNode represents a node in the precedence graph
+type graphNode struct {
+	// Items that should come after this item
+	outEdges sets.Set[string]
+	// Number of items that should come before this item
+	inDegree int
+}
+
+// stringMinHeap implements heap.Interface for strings (min-heap with lexicographic ordering)
+type stringMinHeap []string
+
+func (h stringMinHeap) Len() int           { return len(h) }
+func (h stringMinHeap) Less(i, j int) bool { return h[i] < h[j] }
+func (h stringMinHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *stringMinHeap) Push(x interface{}) {
+	*h = append(*h, x.(string))
+}
+func (h *stringMinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/sort/sort_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sort/sort_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sort
+
+import (
+	"testing"
+)
+
+func TestSortDiscoveryGroupsTopo(t *testing.T) {
+	cases := []struct {
+		name  string
+		input [][]string
+		want  []string
+	}{
+		{
+			name: "consensus ordering",
+			input: [][]string{
+				{"A", "B", "C", "D"},
+				{"A", "B", "C", "D"},
+				{"A", "X", "Z", "D"},
+				{"Z", "Y"},
+				{"Q"},
+			},
+			want: []string{"A", "B", "C", "Q", "X", "Z", "D", "Y"},
+		},
+		{
+			name:  "empty input",
+			input: [][]string{},
+			want:  []string{},
+		},
+		{
+			name:  "single peer",
+			input: [][]string{{"foo", "bar", "baz"}},
+			want:  []string{"foo", "bar", "baz"},
+		},
+		{
+			name:  "conflicting orderings",
+			input: [][]string{{"A", "B"}, {"B", "A"}},
+			want:  []string{"A", "B"},
+		},
+		{
+			name:  "empty list merged with non-empty list",
+			input: [][]string{{}, {"A", "B", "C"}},
+			want:  []string{"A", "B", "C"},
+		},
+		{
+			name:  "multiple empty lists merged",
+			input: [][]string{{}, {}, {}},
+			want:  []string{},
+		},
+		{
+			name: "lexical tiebreak at beginning",
+			input: [][]string{
+				{"C", "D", "E"},
+				{"B", "D", "E"},
+				{"A", "D", "E"},
+			},
+			// A, B, C have no precedence constraints, so lexical order
+			want: []string{"A", "B", "C", "D", "E"},
+		},
+		{
+			name: "lexical tiebreak in middle",
+			input: [][]string{
+				{"A", "D", "E"},
+				{"A", "C", "E"},
+				{"A", "B", "E"},
+			},
+			// A comes first (consensus), then B, C, D (lexical), then E (consensus)
+			want: []string{"A", "B", "C", "D", "E"},
+		},
+		{
+			name: "conflicting orderings of 3 lists",
+			input: [][]string{
+				{"A", "B", "C"},
+				{"B", "C", "A"},
+				{"C", "A", "B"},
+			},
+			// Creates cycle: A->B, B->C, C->A
+			// Fallback to lexicographic sort
+			want: []string{"A", "B", "C"},
+		},
+		{
+			name: "conflicting ordering with different list lengths",
+			input: [][]string{
+				{"A", "B", "C", "D"},
+				{"B", "A"},
+				{"C", "D"},
+			},
+			// A->B->C->D from first list, but B->A from second
+			// Creates cycle between A and B
+			// Fallback to lexicographic sort
+			want: []string{"A", "B", "C", "D"},
+		},
+		{
+			name: "conflicting partial lists",
+			input: [][]string{
+				{"A", "B"},
+				{"C", "D"},
+				{"B", "A"},
+			},
+			// A->B from first, B->A from third (cycle)
+			// C->D is independent
+			// Fallback to lexicographic sort
+			want: []string{"A", "B", "C", "D"},
+		},
+		{
+			name: "cycle",
+			input: [][]string{
+				{"A", "B"},
+				{"B", "C"},
+				{"C", "A"},
+			},
+			// Creates cycle: A->B->C->A
+			// Fallback to lexicographic sort
+			want: []string{"A", "B", "C"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MergePreservingRelativeOrder(tc.input)
+			if len(got) != len(tc.want) {
+				t.Errorf("length mismatch:\n  got: %d\n  want: %d", len(got), len(tc.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("mismatch got: %v\n  want: %v", got, tc.want)
+					return
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/fake.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/fake.go
@@ -122,6 +122,18 @@ func (f *recorderResourceManager) SetGroupVersionPriority(gv metav1.GroupVersion
 	})
 }
 
+func (f *recorderResourceManager) SetPeerDiscoveryProvider(provider PeerDiscoveryProvider) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.Actions = append(f.Actions, recorderResourceManagerAction{
+		Type:    "SetPeerDiscoveryProvider",
+		Group:   "",
+		Version: "",
+		Value:   provider,
+	})
+}
+
 func (f *recorderResourceManager) AddGroupVersion(groupName string, value apidiscoveryv2.APIVersionDiscovery) {
 	f.lock.Lock()
 	defer f.lock.Unlock()

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/fake.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/fake.go
@@ -185,3 +185,7 @@ func (f *recorderResourceManager) ServeHTTP(http.ResponseWriter, *http.Request) 
 func (f *recorderResourceManager) WithSource(source Source) ResourceManager {
 	panic("unimplemented")
 }
+
+func (f *recorderResourceManager) AddInvalidationCallback(callback func()) {
+	panic("unimplemented")
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
@@ -85,6 +85,9 @@ type ResourceManager interface {
 	// The group from the least-numbered source is used
 	WithSource(source Source) ResourceManager
 
+	// AddInvalidationCallback adds a callback to be called when the discovery cache is invalidated.
+	AddInvalidationCallback(callback func())
+
 	http.Handler
 }
 
@@ -116,6 +119,10 @@ func (rm resourceManager) WithSource(source Source) ResourceManager {
 	}
 }
 
+func (rm resourceManager) AddInvalidationCallback(callback func()) {
+	rm.resourceDiscoveryManager.AddInvalidationCallback(callback)
+}
+
 type groupKey struct {
 	name string
 
@@ -138,14 +145,26 @@ type resourceDiscoveryManager struct {
 
 	// Writes protected by the lock.
 	// List of all apigroups & resources indexed by the resource manager
-	lock              sync.RWMutex
-	apiGroups         map[groupKey]*apidiscoveryv2.APIGroupDiscovery
-	versionPriorities map[groupVersionKey]priorityInfo
+	lock                 sync.RWMutex
+	apiGroups            map[groupKey]*apidiscoveryv2.APIGroupDiscovery
+	versionPriorities    map[groupVersionKey]priorityInfo
+	invalidationCallback atomic.Pointer[func()]
 }
 
 type priorityInfo struct {
 	GroupPriorityMinimum int
 	VersionPriority      int
+}
+
+func (rdm *resourceDiscoveryManager) AddInvalidationCallback(callback func()) {
+	rdm.invalidationCallback.Store(&callback)
+}
+
+func (rdm *resourceDiscoveryManager) invalidateCacheLocked() {
+	rdm.cache.Store(nil)
+	if callback := rdm.invalidationCallback.Load(); callback != nil {
+		(*callback)()
+	}
 }
 
 func NewResourceManager(path string) ResourceManager {
@@ -188,7 +207,7 @@ func (rdm *resourceDiscoveryManager) SetGroupVersionPriority(source Source, gv m
 		GroupPriorityMinimum: groupPriorityMinimum,
 		VersionPriority:      versionPriority,
 	}
-	rdm.cache.Store(nil)
+	rdm.invalidateCacheLocked()
 }
 
 func (rdm *resourceDiscoveryManager) SetGroups(source Source, groups []apidiscoveryv2.APIGroupDiscovery) {
@@ -196,7 +215,7 @@ func (rdm *resourceDiscoveryManager) SetGroups(source Source, groups []apidiscov
 	defer rdm.lock.Unlock()
 
 	rdm.apiGroups = nil
-	rdm.cache.Store(nil)
+	rdm.invalidateCacheLocked()
 
 	for _, group := range groups {
 		for _, version := range group.Versions {
@@ -297,7 +316,7 @@ func (rdm *resourceDiscoveryManager) addGroupVersionLocked(source Source, groupN
 	}
 
 	// Reset response document so it is recreated lazily
-	rdm.cache.Store(nil)
+	rdm.invalidateCacheLocked()
 }
 
 func (rdm *resourceDiscoveryManager) RemoveGroupVersion(source Source, apiGroup metav1.GroupVersion) {
@@ -338,7 +357,7 @@ func (rdm *resourceDiscoveryManager) RemoveGroupVersion(source Source, apiGroup 
 	}
 
 	// Reset response document so it is recreated lazily
-	rdm.cache.Store(nil)
+	rdm.invalidateCacheLocked()
 }
 
 func (rdm *resourceDiscoveryManager) RemoveGroup(source Source, groupName string) {
@@ -521,12 +540,22 @@ func (rdm *resourceDiscoveryManager) serveHTTP(resp http.ResponseWriter, req *ht
 	response := cache.cachedResponse
 	etag := cache.cachedResponseETag
 
-	mediaType, _, err := negotiation.NegotiateOutputMediaType(req, rdm.serializer, DiscoveryEndpointRestrictions)
+	writeDiscoveryResponse(&response, etag, rdm.serializer, resp, req)
+}
+
+func writeDiscoveryResponse(
+	resp *apidiscoveryv2.APIGroupDiscoveryList,
+	etag string,
+	serializer runtime.NegotiatedSerializer,
+	w http.ResponseWriter,
+	req *http.Request,
+) {
+	mediaType, _, err := negotiation.NegotiateOutputMediaType(req, serializer, DiscoveryEndpointRestrictions)
 	if err != nil {
 		// Should never happen. wrapper.go will only proxy requests to this
 		// handler if the media type passes DiscoveryEndpointRestrictions
 		utilruntime.HandleError(err)
-		resp.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	var targetGV schema.GroupVersion
@@ -534,40 +563,39 @@ func (rdm *resourceDiscoveryManager) serveHTTP(resp http.ResponseWriter, req *ht
 		(mediaType.Convert.GroupVersion() != apidiscoveryv2.SchemeGroupVersion &&
 			mediaType.Convert.GroupVersion() != apidiscoveryv2beta1.SchemeGroupVersion) {
 		utilruntime.HandleError(fmt.Errorf("expected aggregated discovery group version, got group: %s, version %s", mediaType.Convert.Group, mediaType.Convert.Version))
-		resp.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	if mediaType.Convert.GroupVersion() == apidiscoveryv2beta1.SchemeGroupVersion &&
 		utilfeature.DefaultFeatureGate.Enabled(genericfeatures.AggregatedDiscoveryRemoveBetaType) {
 		klog.Errorf("aggregated discovery version v2beta1 is removed. Please update to use v2")
-		resp.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-
 	targetGV = mediaType.Convert.GroupVersion()
 
 	if len(etag) > 0 {
 		// Use proper e-tag headers if one is available
 		ServeHTTPWithETag(
-			&response,
+			resp,
 			etag,
 			targetGV,
-			rdm.serializer,
-			resp,
+			serializer,
+			w,
 			req,
 		)
 	} else {
 		// Default to normal response in rare case etag is
 		// not cached with the object for some reason.
 		responsewriters.WriteObjectNegotiated(
-			rdm.serializer,
+			serializer,
 			DiscoveryEndpointRestrictions,
 			targetGV,
-			resp,
+			w,
 			req,
 			http.StatusOK,
-			&response,
+			resp,
 			true,
 		)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
@@ -490,7 +490,7 @@ func (rdm *resourceDiscoveryManager) fetchFromCache() *cachedGroupList {
 	}
 	etag, err := calculateETag(response)
 	if err != nil {
-		klog.Errorf("failed to calculate etag for discovery document: %s", etag)
+		klog.Errorf("failed to calculate etag for discovery document: %v", err)
 		etag = ""
 	}
 	cached := &cachedGroupList{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
@@ -134,7 +134,7 @@ func fetchPath(handler http.Handler, acceptPrefix string, path string, etag stri
 func fetchPathHelper(handler http.Handler, accept string, path string, etag string) (*http.Response, []byte) {
 	// Expect json-formatted apis group list
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(request.MethodGet, discoveryPath, nil)
+	req := httptest.NewRequest(request.MethodGet, path, nil)
 
 	// Ask for JSON response
 	req.Header.Set("Accept", accept)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/metrics.go
@@ -17,15 +17,47 @@ limitations under the License.
 package aggregated
 
 import (
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
 
+const subsystem = "aggregator_discovery"
+
 var (
 	regenerationCounter = metrics.NewCounter(
 		&metrics.CounterOpts{
-			Name:           "aggregator_discovery_aggregation_count_total",
+			Name:           "aggregation_count_total",
+			Subsystem:      subsystem,
 			Help:           "Counter of number of times discovery was aggregated",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	PeerAggregatedCacheHitsCounter = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           "peer_aggregated_cache_hits_total",
+			Subsystem:      subsystem,
+			Help:           "Counter of number of times discovery was served from peer-aggregated cache",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	PeerAggregatedCacheMissesCounter = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           "peer_aggregated_cache_misses_total",
+			Subsystem:      subsystem,
+			Help:           "Counter of number of times discovery was aggregated across all API servers",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	NoPeerDiscoveryRequestCounter = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           "nopeer_requests_total",
+			Subsystem:      subsystem,
+			Help:           "Counter of number of times no-peer (non peer-aggregated) discovery was requested",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
@@ -33,4 +65,9 @@ var (
 
 func init() {
 	legacyregistry.MustRegister(regenerationCounter)
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.UnknownVersionInteroperabilityProxy) {
+		legacyregistry.MustRegister(PeerAggregatedCacheHitsCounter)
+		legacyregistry.MustRegister(PeerAggregatedCacheMissesCounter)
+		legacyregistry.MustRegister(NoPeerDiscoveryRequestCounter)
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/metrics_test.go
@@ -25,7 +25,11 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
 
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
 	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 func formatExpectedMetrics(aggregationCount int) io.Reader {
@@ -85,5 +89,66 @@ func TestMetricsModified(t *testing.T) {
 	// If the discovery content has changed, reaggregation should be performed.
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, formatExpectedMetrics(2), interests...); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPeerAggregatedDiscoveryMetrics(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.UnknownVersionInteroperabilityProxy, true)
+	manager := discoveryendpoint.NewResourceManager("apis")
+	localGroup := newAPIGroup("local.example.com", "v1", "local-resource")
+	manager.AddGroupVersion(localGroup.Name, localGroup.Versions[0])
+	peerProvider := &mockPeerDiscoveryProvider{
+		resources: map[string][]apidiscoveryv2.APIGroupDiscovery{
+			"peer-server-1": {
+				newAPIGroup("peer.example.com", "v2", "peer-resource"),
+			},
+		},
+	}
+	peerAggregatedDiscoveryManager := discoveryendpoint.NewPeerAggregatedDiscoveryHandler("test-server", manager, peerProvider, "apis")
+	wrapped := discoveryendpoint.WrapAggregatedDiscoveryToHandler(manager, manager, peerAggregatedDiscoveryManager)
+
+	legacyregistry.MustRegister(discoveryendpoint.PeerAggregatedCacheHitsCounter)
+	legacyregistry.MustRegister(discoveryendpoint.PeerAggregatedCacheMissesCounter)
+	legacyregistry.MustRegister(discoveryendpoint.NoPeerDiscoveryRequestCounter)
+
+	// Make 3 peer-aggregated requests.
+	fetchPath(wrapped, "application/json", "/apis", "")
+	fetchPath(wrapped, "application/json;profile=foo", "/apis", "")
+	fetchPath(wrapped, "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList", "/apis", "")
+
+	// Make 2 no-peer discovery requests.
+	fetchPath(wrapped, "application/json;profile=nopeer", "/apis", "")
+	peerAggregatedDiscoveryManager.InvalidateCache()
+	fetchPath(wrapped, "application/json;profile=nopeer", "/apis", "")
+	peerAggregatedDiscoveryManager.InvalidateCache()
+
+	cacheHitsTotalMetric := `
+# HELP aggregator_discovery_peer_aggregated_cache_hits_total [ALPHA] Counter of number of times discovery was served from peer-aggregated cache
+# TYPE aggregator_discovery_peer_aggregated_cache_hits_total counter
+aggregator_discovery_peer_aggregated_cache_hits_total 2
+`
+
+	cacheMissesTotalMetric := `
+# HELP aggregator_discovery_peer_aggregated_cache_misses_total [ALPHA] Counter of number of times discovery was aggregated across all API servers
+# TYPE aggregator_discovery_peer_aggregated_cache_misses_total counter
+aggregator_discovery_peer_aggregated_cache_misses_total 1
+`
+
+	noPeerDiscoveryTotalMetric := `
+# HELP aggregator_discovery_nopeer_requests_total [ALPHA] Counter of number of times no-peer (non peer-aggregated) discovery was requested
+# TYPE aggregator_discovery_nopeer_requests_total counter
+aggregator_discovery_nopeer_requests_total 2
+`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(cacheHitsTotalMetric), "aggregator_discovery_peer_aggregated_cache_hits_total"); err != nil {
+		t.Errorf("unexpected metrics output: %v", err)
+	}
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(cacheMissesTotalMetric), "aggregator_discovery_peer_aggregated_cache_misses_total"); err != nil {
+		t.Errorf("unexpected metrics output: %v", err)
+	}
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(noPeerDiscoveryTotalMetric), "aggregator_discovery_nopeer_requests_total"); err != nil {
+		t.Errorf("unexpected metrics output: %v", err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/peer_aggregated_handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/peer_aggregated_handler.go
@@ -1,0 +1,495 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregated
+
+import (
+	"net/http"
+	"reflect"
+	"sort"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	utilsort "k8s.io/apimachinery/pkg/util/sort"
+)
+
+// PeerDiscoveryProvider defines an interface to get peer resources for peer-aggregated discovery.
+type PeerDiscoveryProvider interface {
+	GetPeerResources() map[string][]apidiscoveryv2.APIGroupDiscovery
+}
+
+// PeerAggregatedResourceManager defines the interface for managing peer-aggregated discovery resources
+// that combines both local and peer server resources.
+type PeerAggregatedResourceManager interface {
+	// InvalidateCache invalidates the peer-aggregated discovery caches
+	// This should be called when peer discovery data changes.
+	InvalidateCache()
+
+	// ServeHTTP handles peer-aggregated discovery HTTP requests.
+	http.Handler
+}
+
+type peerAggregatedDiscoveryHandler struct {
+	serverID              string
+	localResourceManager  ResourceManager
+	peerDiscoveryProvider PeerDiscoveryProvider
+	serializer            runtime.NegotiatedSerializer
+	cache                 atomic.Pointer[cachedGroupList]
+	serveHTTPFunc         func(http.ResponseWriter, *http.Request)
+}
+
+// NewPeerAggregatedDiscoveryHandler creates a new handler for peer-aggregated discovery.
+func NewPeerAggregatedDiscoveryHandler(serverID string, localDiscoveryProvider ResourceManager, peerDiscoveryProvider PeerDiscoveryProvider, path string) PeerAggregatedResourceManager {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(apidiscoveryv2.AddToScheme(scheme))
+	codecs := serializer.NewCodecFactory(scheme)
+
+	h := &peerAggregatedDiscoveryHandler{
+		serverID:              serverID,
+		localResourceManager:  localDiscoveryProvider,
+		peerDiscoveryProvider: peerDiscoveryProvider,
+		serializer:            codecs,
+	}
+
+	h.localResourceManager.AddInvalidationCallback(func() {
+		h.InvalidateCache()
+	})
+
+	// Instrumentation wrapper for serveHTTP
+	h.serveHTTPFunc = metrics.InstrumentHandlerFunc(request.MethodGet,
+		"", "", "", path, "", metrics.APIServerComponent, false, "",
+		h.serveHTTP)
+
+	return h
+}
+
+// InvalidateCache invalidates the peer-aggregated discovery caches.
+// This should be called when peer discovery data changes.
+func (h *peerAggregatedDiscoveryHandler) InvalidateCache() {
+	h.cache.Store(nil)
+	klog.V(4).Info("Invalidated peer-aggregated discovery caches")
+}
+
+func (h *peerAggregatedDiscoveryHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	h.serveHTTPFunc(resp, req)
+}
+
+func (h *peerAggregatedDiscoveryHandler) serveHTTP(resp http.ResponseWriter, req *http.Request) {
+	cache := h.fetchFromCache()
+	response := cache.cachedResponse
+	etag := cache.cachedResponseETag
+
+	writeDiscoveryResponse(&response, etag, h.serializer, resp, req)
+}
+
+func (h *peerAggregatedDiscoveryHandler) fetchFromCache() *cachedGroupList {
+	cacheLoad := h.cache.Load()
+	if cacheLoad != nil {
+		PeerAggregatedCacheHitsCounter.Inc()
+		return cacheLoad
+	}
+
+	PeerAggregatedCacheMissesCounter.Inc()
+
+	// Get local groups
+	var localGroups []apidiscoveryv2.APIGroupDiscovery
+	if rdm, ok := h.localResourceManager.(resourceManager); ok {
+		localCache := rdm.fetchFromCache()
+		if localCache != nil {
+			localGroups = localCache.cachedResponse.Items
+		}
+	}
+
+	// Get peer resources if provider is set
+	var mergedGroups []apidiscoveryv2.APIGroupDiscovery
+	if h.peerDiscoveryProvider != nil {
+		peerResources := h.peerDiscoveryProvider.GetPeerResources()
+		mergedGroups = h.mergeResources(localGroups, peerResources)
+	} else {
+		mergedGroups = localGroups
+	}
+
+	response := apidiscoveryv2.APIGroupDiscoveryList{
+		Items: mergedGroups,
+	}
+	etag, err := calculateETag(response)
+	if err != nil {
+		klog.Errorf("failed to calculate etag for discovery document: %v", err)
+		etag = ""
+	}
+
+	cached := &cachedGroupList{
+		cachedResponse:     response,
+		cachedResponseETag: etag,
+	}
+	h.cache.Store(cached)
+	return cached
+}
+
+// mergeResources merges local and peer APIGroupDiscovery lists, preserving relative order as much as possible.
+// localGroups is a list of APIGroupDiscovery objects from the local server.
+// peerGroupDiscovery is a map of peer server IDs to their APIGroupDiscovery lists.
+func (h *peerAggregatedDiscoveryHandler) mergeResources(
+	localGroups []apidiscoveryv2.APIGroupDiscovery,
+	peerGroupDiscovery map[string][]apidiscoveryv2.APIGroupDiscovery,
+) []apidiscoveryv2.APIGroupDiscovery {
+	discoveryByServerID := h.combineServerDiscoveryLists(localGroups, peerGroupDiscovery)
+	if len(discoveryByServerID) <= 1 {
+		// No merging or sorting needed.
+		return localGroups
+	}
+
+	mergedGroupMap := make(map[string]apidiscoveryv2.APIGroupDiscovery)
+	allGroupNames := make([][]string, 0, len(discoveryByServerID))
+	sortedServerIDs := sortServerIDs(discoveryByServerID)
+
+	// contentChanged tracks if any new groups/versions/resources were added in a peer.
+	contentChanged := false
+	// groupNameListsAreIdentical tracks if all peers have the exact same group names as local.
+	groupNameListsAreIdentical := true
+	localGroupNames := localGroupNames(localGroups)
+	for _, serverID := range sortedServerIDs {
+		discoveryGroups := discoveryByServerID[serverID]
+		groupNames, didThisServerMerge := h.processServerGroups(discoveryGroups, mergedGroupMap)
+		if didThisServerMerge {
+			contentChanged = true
+		}
+		allGroupNames = append(allGroupNames, groupNames)
+		// Check if this server's group order differs from local.
+		// 1. It catches simple re-orderings (e.g., ["g1", "g2"] vs ["g2", "g1"]).
+		// 2. It catches new or removed groups (e.g., ["g1"] vs ["g1", "g2"]).
+		// In either case, the list is not identical, and we must fall through
+		// to the full merge to ensure a deterministic result.
+		if !reflect.DeepEqual(localGroupNames, groupNames) {
+			groupNameListsAreIdentical = false
+		}
+	}
+
+	// Case 1: Total short-circuit.
+	// Nothing changed (no new content AND no order change).
+	if !contentChanged && groupNameListsAreIdentical {
+		return localGroups
+	}
+
+	var finalGroupOrder []string
+	// Case 2: Content changed, but group order didn't.
+	// We must return the new content, but we can skip the expensive sort.
+	if contentChanged && groupNameListsAreIdentical {
+		finalGroupOrder = localGroupNames
+	} else {
+		// Case 3: Group lists were different (new groups, different order, or both).
+		// We have no choice but to run the full topological sort.
+		finalGroupOrder = utilsort.MergePreservingRelativeOrder(allGroupNames)
+	}
+
+	return assembleGroups(mergedGroupMap, finalGroupOrder)
+}
+
+func (h *peerAggregatedDiscoveryHandler) processServerGroups(
+	discoveryGroups []apidiscoveryv2.APIGroupDiscovery,
+	mergedGroupMap map[string]apidiscoveryv2.APIGroupDiscovery,
+) (groupNames []string, contentMerged bool) {
+	groupNames = make([]string, 0, len(discoveryGroups))
+	contentMerged = false
+
+	for _, group := range discoveryGroups {
+		if existing, ok := mergedGroupMap[group.Name]; ok {
+			// Merge versions and resources.
+			mergedG, didMerge := mergeVersionsAcrossGroup(existing, group)
+			mergedGroupMap[group.Name] = mergedG
+			if didMerge {
+				contentMerged = true
+			}
+		} else {
+			mergedGroupMap[group.Name] = group
+		}
+		groupNames = append(groupNames, group.Name)
+	}
+
+	return groupNames, contentMerged
+}
+
+// mergeVersionsAcrossGroup merges two APIGroupDiscovery objects.
+// It returns a new merged object and a boolean indicating if the result differs from a.
+// The result may differ if any new versions/resources were added or if the order was different.
+func mergeVersionsAcrossGroup(a, b apidiscoveryv2.APIGroupDiscovery) (apidiscoveryv2.APIGroupDiscovery, bool) {
+	versionOrder := [][]string{}
+	mergedVersionMap := make(map[string]apidiscoveryv2.APIVersionDiscovery)
+
+	aVersionNames := make([]string, 0, len(a.Versions))
+	bVersionNames := make([]string, 0, len(b.Versions))
+	// This flag tracks if 'b' modified existing versions.
+	contentMerged := false
+
+	for _, v := range a.Versions {
+		aVersionNames = append(aVersionNames, v.Version)
+		mergedVersionMap[v.Version] = v
+	}
+	versionOrder = append(versionOrder, aVersionNames)
+
+	for _, v := range b.Versions {
+		bVersionNames = append(bVersionNames, v.Version)
+		if existing, ok := mergedVersionMap[v.Version]; !ok {
+			mergedVersionMap[v.Version] = v
+		} else {
+			// Version exists in both, must merge their resources
+			mergedV, didMerge := mergeResourcesAcrossVersion(existing, v)
+			mergedVersionMap[v.Version] = mergedV
+			if didMerge {
+				contentMerged = true
+			}
+		}
+	}
+	versionOrder = append(versionOrder, bVersionNames)
+
+	// Case 1: Total short-circuit.
+	// No new versions/resources were added and order is the same.
+	versionNamesAreIdentical := reflect.DeepEqual(aVersionNames, bVersionNames)
+	if !contentMerged && versionNamesAreIdentical {
+		return a, false
+	}
+
+	var finalVersionOrder []string
+	if versionNamesAreIdentical {
+		// Case 2: Content changed, but version order didn't.
+		// We can skip the expensive sort and just use the known order.
+		finalVersionOrder = aVersionNames
+	} else {
+		// Case 3: Version lists were different (new versions, different order, or both).
+		// Must perform topological sort.
+		finalVersionOrder = utilsort.MergePreservingRelativeOrder(versionOrder)
+	}
+
+	mergedVersions := orderedAPIVersionList(mergedVersionMap, finalVersionOrder)
+	return apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: *a.ObjectMeta.DeepCopy(),
+		TypeMeta:   a.TypeMeta,
+		Versions:   mergedVersions,
+	}, true
+}
+
+// mergeResourcesAcrossVersion merges two APIVersionDiscovery objects.
+// It returns a new merged object and a boolean indicating if the result differs from a.
+// The result may differ if any new resources were added or if the order was different.
+func mergeResourcesAcrossVersion(a, b apidiscoveryv2.APIVersionDiscovery) (apidiscoveryv2.APIVersionDiscovery, bool) {
+	resourceOrder := [][]string{}
+	mergedResourceMap := make(map[string]apidiscoveryv2.APIResourceDiscovery)
+
+	aResourceNames := make([]string, 0, len(a.Resources))
+	bResourceNames := make([]string, 0, len(b.Resources))
+	// This flag tracks if 'b' modified existing resources.
+	contentChanged := false
+
+	for _, r := range a.Resources {
+		aResourceNames = append(aResourceNames, r.Resource)
+		mergedResourceMap[r.Resource] = r
+	}
+	resourceOrder = append(resourceOrder, aResourceNames)
+
+	for _, r := range b.Resources {
+		bResourceNames = append(bResourceNames, r.Resource)
+		if existing, ok := mergedResourceMap[r.Resource]; !ok {
+			mergedResourceMap[r.Resource] = r
+		} else {
+			if reflect.DeepEqual(existing, r) {
+				continue
+			}
+			contentChanged = true
+			mergedR := mergeResourceCapabilities(existing, r)
+			mergedResourceMap[r.Resource] = mergedR
+		}
+	}
+	resourceOrder = append(resourceOrder, bResourceNames)
+
+	// Case 1: Total short-circuit.
+	// 'b' didn't add any new resources AND the resource order is the same.
+	resourceNameListIsIdentical := reflect.DeepEqual(aResourceNames, bResourceNames)
+	if !contentChanged && resourceNameListIsIdentical {
+		return a, false
+	}
+
+	var finalResourceOrder []string
+	if resourceNameListIsIdentical {
+		// Case 2: Content changed, but resource order didn't.
+		// We can skip the expensive sort and just use the known order.
+		finalResourceOrder = aResourceNames
+	} else {
+		// Case 3: Resource lists were different (new resources, different order, or both).
+		// Must perform topological sort.
+		finalResourceOrder = utilsort.MergePreservingRelativeOrder(resourceOrder)
+	}
+
+	mergedResources := orderedAPIResourceList(mergedResourceMap, finalResourceOrder)
+	return apidiscoveryv2.APIVersionDiscovery{
+		Version:   a.Version,
+		Resources: mergedResources,
+		Freshness: a.Freshness,
+	}, true
+}
+
+// mergeResourceCapabilities takes two resources and returns a new one
+// containing the union of their verbs and subresources.
+// The resulting slices are sorted to ensure the merge is deterministic.
+func mergeResourceCapabilities(a, b apidiscoveryv2.APIResourceDiscovery) apidiscoveryv2.APIResourceDiscovery {
+	// 1. Merge Verbs
+	verbSet := make(map[string]struct{})
+	for _, v := range a.Verbs {
+		verbSet[v] = struct{}{}
+	}
+	for _, v := range b.Verbs {
+		verbSet[v] = struct{}{}
+	}
+
+	var newVerbs []string
+	if len(verbSet) > 0 {
+		newVerbs = make([]string, 0, len(verbSet))
+		for v := range verbSet {
+			newVerbs = append(newVerbs, v)
+		}
+		// Sort for deterministic ETag
+		sort.Strings(newVerbs)
+	}
+
+	// 2. Merge Subresources
+	subresourceSet := make(map[string]apidiscoveryv2.APISubresourceDiscovery)
+	for _, s := range a.Subresources {
+		subresourceSet[s.Subresource] = s
+	}
+	for _, s := range b.Subresources {
+		subresourceSet[s.Subresource] = s
+	}
+
+	var newSubresources []apidiscoveryv2.APISubresourceDiscovery
+	if len(subresourceSet) > 0 {
+		newSubresources = make([]apidiscoveryv2.APISubresourceDiscovery, 0, len(subresourceSet))
+		for _, s := range subresourceSet {
+			newSubresources = append(newSubresources, s)
+		}
+		// Sort for deterministic ETag
+		sort.Slice(newSubresources, func(i, j int) bool {
+			return newSubresources[i].Subresource < newSubresources[j].Subresource
+		})
+	}
+
+	// 3. Return the new, merged object
+	// We prefer 'a's metadata (like ResponseKind) but 'b's could be used if 'a' is empty.
+	mergedResource := a
+	if len(mergedResource.Resource) == 0 {
+		mergedResource = b
+	}
+	mergedResource.Verbs = newVerbs
+	mergedResource.Subresources = newSubresources
+
+	return mergedResource
+}
+
+// assembleGroups builds the final slice from the merged map and ordered list.
+func assembleGroups(
+	groupMap map[string]apidiscoveryv2.APIGroupDiscovery,
+	orderedGroups []string,
+) []apidiscoveryv2.APIGroupDiscovery {
+	result := make([]apidiscoveryv2.APIGroupDiscovery, 0, len(orderedGroups))
+	for _, groupName := range orderedGroups {
+		if group, ok := groupMap[groupName]; ok {
+			result = append(result, group)
+		}
+	}
+	return result
+}
+
+// orderedAPIVersionList builds the final APIGroupDiscovery struct.
+func orderedAPIVersionList(
+	versionMap map[string]apidiscoveryv2.APIVersionDiscovery,
+	orderedVersions []string,
+) []apidiscoveryv2.APIVersionDiscovery {
+	mergedVersions := make([]apidiscoveryv2.APIVersionDiscovery, 0, len(orderedVersions))
+	for _, vName := range orderedVersions {
+		if v, ok := versionMap[vName]; ok {
+			mergedVersions = append(mergedVersions, v)
+			delete(versionMap, vName) // Avoid duplicates
+		}
+	}
+
+	return mergedVersions
+}
+
+// orderedAPIResourceList builds the final APIVersionDiscovery struct.
+func orderedAPIResourceList(
+	resourceMap map[string]apidiscoveryv2.APIResourceDiscovery,
+	orderedResources []string,
+) []apidiscoveryv2.APIResourceDiscovery {
+	mergedResources := make([]apidiscoveryv2.APIResourceDiscovery, 0, len(orderedResources))
+	for _, rName := range orderedResources {
+		if r, ok := resourceMap[rName]; ok {
+			mergedResources = append(mergedResources, r)
+			delete(resourceMap, rName)
+		}
+	}
+
+	return mergedResources
+}
+
+func (h *peerAggregatedDiscoveryHandler) combineServerDiscoveryLists(localGroups []apidiscoveryv2.APIGroupDiscovery, peerGroupDiscovery map[string][]apidiscoveryv2.APIGroupDiscovery,
+) map[string][]apidiscoveryv2.APIGroupDiscovery {
+	allServerLists := make(map[string][]apidiscoveryv2.APIGroupDiscovery, len(peerGroupDiscovery)+1)
+	allServerLists[h.serverID] = localGroups
+	for peerID, peerList := range peerGroupDiscovery {
+		allServerLists[peerID] = peerList
+	}
+	return allServerLists
+}
+
+func sortServerIDs(allServerLists map[string][]apidiscoveryv2.APIGroupDiscovery) []string {
+	allServerIDs := make([]string, 0, len(allServerLists))
+	for serverID := range allServerLists {
+		allServerIDs = append(allServerIDs, serverID)
+	}
+	sort.Strings(allServerIDs)
+	return allServerIDs
+}
+
+func localGroupNames(localGroups []apidiscoveryv2.APIGroupDiscovery) []string {
+	localGroupNames := make([]string, 0, len(localGroups))
+	for _, g := range localGroups {
+		localGroupNames = append(localGroupNames, g.Name)
+	}
+	return localGroupNames
+}
+
+// TestMergeResources is for testing only. It allows tests to call MergeResources without exporting peerAggregatedDiscoveryHandler.
+func TestMergeResources(serverID string, localGroups []apidiscoveryv2.APIGroupDiscovery, peerGroupDiscovery map[string][]apidiscoveryv2.APIGroupDiscovery) []apidiscoveryv2.APIGroupDiscovery {
+	h := &peerAggregatedDiscoveryHandler{serverID: serverID}
+	return h.mergeResources(localGroups, peerGroupDiscovery)
+}
+
+// TestFetchFromCache is for testing only. It allows tests to call fetchFromCache without exporting peerAggregatedDiscoveryHandler.
+// Returns the cached response and ETag.
+func TestFetchFromCache(serverID string, localResourceManager ResourceManager, peerDiscoveryProvider PeerDiscoveryProvider) (apidiscoveryv2.APIGroupDiscoveryList, string) {
+	h := &peerAggregatedDiscoveryHandler{
+		serverID:              serverID,
+		localResourceManager:  localResourceManager,
+		peerDiscoveryProvider: peerDiscoveryProvider,
+	}
+	cached := h.fetchFromCache()
+	return cached.cachedResponse, cached.cachedResponseETag
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/peer_aggregated_handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/peer_aggregated_handler_test.go
@@ -1,0 +1,490 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregated_test
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+func TestPeerAggregatedDiscovery(t *testing.T) {
+	manager := discoveryendpoint.NewResourceManager("apis")
+	localGroup := newAPIGroup("local.example.com", "v1", "local-resource")
+	manager.AddGroupVersion(localGroup.Name, localGroup.Versions[0])
+
+	peerProvider := &mockPeerDiscoveryProvider{
+		resources: map[string][]apidiscoveryv2.APIGroupDiscovery{
+			"peer-server-1": {
+				newAPIGroup("peer.example.com", "v2", "peer-resource"),
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                          string
+		enablePeerAggregatedDiscovery bool
+		acceptHeader                  string
+		peerProvider                  discoveryendpoint.PeerDiscoveryProvider
+		wantGroupNames                []string
+	}{
+		{
+			name:                          "Peer aggregated discovery disabled (should get local discovery)",
+			enablePeerAggregatedDiscovery: false,
+			acceptHeader:                  "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList;profile=nopeer",
+			wantGroupNames:                []string{"local.example.com"},
+		},
+		{
+			name:                          "Request without profile (should default to peer-aggregated)",
+			enablePeerAggregatedDiscovery: true,
+			acceptHeader:                  "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList",
+			peerProvider:                  peerProvider,
+			wantGroupNames:                []string{"local.example.com", "peer.example.com"},
+		},
+		{
+			name:                          "Request with unknown profile (should default to peer-aggregated)",
+			enablePeerAggregatedDiscovery: true,
+			acceptHeader:                  "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList;profile=foo",
+			peerProvider:                  peerProvider,
+			wantGroupNames:                []string{"local.example.com", "peer.example.com"},
+		},
+		{
+			name:                          "Request with profile=nopeer (should get no-peer discovery)",
+			enablePeerAggregatedDiscovery: true,
+			acceptHeader:                  "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList;profile=nopeer",
+			peerProvider:                  peerProvider,
+			wantGroupNames:                []string{"local.example.com"},
+		},
+		{
+			name:                          "Peer provider nil (should get local discovery)",
+			enablePeerAggregatedDiscovery: true,
+			acceptHeader:                  "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList",
+			peerProvider:                  nil,
+			wantGroupNames:                []string{"local.example.com"},
+		},
+		{
+			name:                          "Multiple peer resources (should return all)",
+			enablePeerAggregatedDiscovery: true,
+			acceptHeader:                  "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList",
+			peerProvider: &mockPeerDiscoveryProvider{
+				resources: map[string][]apidiscoveryv2.APIGroupDiscovery{
+					"peer-server-1": {
+						newAPIGroup("peer.example.com", "v2", "peer-resource"),
+					},
+					"peer-server-2": {
+						newAPIGroup("peer2.example.com", "v1", "peer2-resource"),
+					},
+				},
+			},
+			wantGroupNames: []string{
+				"local.example.com", "peer.example.com", "peer2.example.com",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.UnknownVersionInteroperabilityProxy, tc.enablePeerAggregatedDiscovery)
+
+			peerAggregatedDiscoveryManager := discoveryendpoint.NewPeerAggregatedDiscoveryHandler("test-server", manager, tc.peerProvider, "apis")
+			wrapped := discoveryendpoint.WrapAggregatedDiscoveryToHandler(manager, manager, peerAggregatedDiscoveryManager)
+
+			resp, _, decoded := fetchPath(wrapped, tc.acceptHeader, "/apis", "")
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NotNil(t, decoded)
+			gotGroupNames := make([]string, 0, len(decoded.Items))
+			for _, group := range decoded.Items {
+				gotGroupNames = append(gotGroupNames, group.Name)
+			}
+			assert.ElementsMatch(t, tc.wantGroupNames, gotGroupNames, "group names mismatch")
+		})
+	}
+}
+
+func TestPeerAggregatedDiscovery_ETagHandling(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.UnknownVersionInteroperabilityProxy, true)
+	manager := discoveryendpoint.NewResourceManager("apis")
+	localGroup := newAPIGroup("local.example.com", "v1", "local-resource")
+	manager.AddGroupVersion(localGroup.Name, localGroup.Versions[0])
+	peerProvider := &mockPeerDiscoveryProvider{
+		resources: map[string][]apidiscoveryv2.APIGroupDiscovery{
+			"peer-server-1": {
+				newAPIGroup("peer.example.com", "v2", "peer-resource"),
+			},
+		},
+	}
+
+	peerAggregatedDiscoveryManager := discoveryendpoint.NewPeerAggregatedDiscoveryHandler("test-server", manager, peerProvider, "apis")
+	wrapped := discoveryendpoint.WrapAggregatedDiscoveryToHandler(manager, manager, peerAggregatedDiscoveryManager)
+
+	// First request, get ETag
+	rr1 := &responseRecorder{header: make(http.Header)}
+	req1, _ := http.NewRequest(http.MethodGet, "/apis", nil)
+	req1.Header.Set("Accept", "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList")
+	wrapped.ServeHTTP(rr1, req1)
+	etag1 := rr1.header.Get("ETag")
+	assert.NotEmpty(t, etag1, "ETag should be set on first response")
+
+	// Second request, ETag should be the same (cache hit)
+	rr2 := &responseRecorder{header: make(http.Header)}
+	req2, _ := http.NewRequest(http.MethodGet, "/apis", nil)
+	req2.Header.Set("Accept", "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList")
+	wrapped.ServeHTTP(rr2, req2)
+	etag2 := rr2.header.Get("ETag")
+	assert.Equal(t, etag1, etag2, "ETag should be the same for cached response")
+
+	// Invalidate cache and add a new peer resource
+	peerAggregatedDiscoveryManager.InvalidateCache()
+	gvr := schema.GroupVersionResource{Group: "peer.example.com", Version: "v2", Resource: "peer-resource2"}
+	peerProvider.addResource("peer-server-3", gvr, newAPIGroup(gvr.Group, gvr.Version, "peer-resource2"))
+
+	// Third request, ETag should change
+	rr3 := &responseRecorder{header: make(http.Header)}
+	req3, _ := http.NewRequest(http.MethodGet, "/apis", nil)
+	req3.Header.Set("Accept", "application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList")
+	wrapped.ServeHTTP(rr3, req3)
+	etag3 := rr3.header.Get("ETag")
+	assert.NotEmpty(t, etag3, "ETag should be set after resource change")
+	assert.NotEqual(t, etag1, etag3, "ETag should change when resources change")
+}
+
+func TestFetchFromCache(t *testing.T) {
+	testCases := []struct {
+		name         string
+		localGroups  []apidiscoveryv2.APIGroupDiscovery
+		peerProvider discoveryendpoint.PeerDiscoveryProvider
+		wantGroups   []string
+	}{
+		{
+			name: "local only - no peer provider",
+			localGroups: []apidiscoveryv2.APIGroupDiscovery{
+				newAPIGroup("local.example.com", "v1", "local-resource"),
+			},
+			peerProvider: nil,
+			wantGroups:   []string{"local.example.com"},
+		},
+		{
+			name: "local and peer resources",
+			localGroups: []apidiscoveryv2.APIGroupDiscovery{
+				newAPIGroup("local.example.com", "v1", "local-resource"),
+			},
+			peerProvider: &mockPeerDiscoveryProvider{
+				resources: map[string][]apidiscoveryv2.APIGroupDiscovery{
+					"peer-server-1": {
+						newAPIGroup("peer1.example.com", "v1", "peer1-resource"),
+					},
+					"peer-server-2": {
+						newAPIGroup("peer2.example.com", "v1", "peer2-resource"),
+					},
+				},
+			},
+			wantGroups: []string{"local.example.com", "peer1.example.com", "peer2.example.com"},
+		},
+		{
+			name:        "no local resources, only peer",
+			localGroups: []apidiscoveryv2.APIGroupDiscovery{},
+			peerProvider: &mockPeerDiscoveryProvider{
+				resources: map[string][]apidiscoveryv2.APIGroupDiscovery{
+					"peer-server-1": {
+						newAPIGroup("peer.example.com", "v1", "peer-resource"),
+					},
+				},
+			},
+			wantGroups: []string{"peer.example.com"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := discoveryendpoint.NewResourceManager("apis")
+			for _, group := range tc.localGroups {
+				for _, version := range group.Versions {
+					manager.AddGroupVersion(group.Name, version)
+				}
+			}
+
+			response, etag := discoveryendpoint.TestFetchFromCache("test-server", manager, tc.peerProvider)
+			gotGroupNames := make([]string, 0, len(response.Items))
+			for _, group := range response.Items {
+				gotGroupNames = append(gotGroupNames, group.Name)
+			}
+
+			assert.ElementsMatch(t, tc.wantGroups, gotGroupNames, "group names mismatch")
+			assert.NotEmpty(t, etag, "ETag should be set")
+		})
+	}
+}
+
+func TestMergeResources(t *testing.T) {
+	r1 := apidiscoveryv2.APIResourceDiscovery{Resource: "r1"}
+	r2 := apidiscoveryv2.APIResourceDiscovery{Resource: "r2"}
+
+	v1r1 := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{r1}}
+	v1r2 := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{r2}}
+	v2r1 := apidiscoveryv2.APIVersionDiscovery{Version: "v2", Resources: []apidiscoveryv2.APIResourceDiscovery{r1}}
+
+	serverA := "serverA"
+	serverB := "serverB"
+
+	// Local versions/resources
+	g1v1r1 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid"},
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{v1r1},
+	}
+	g2v1r1 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g2", UID: "g2-uid"},
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{v1r1},
+	}
+
+	// Peer versions/resources
+	g1v1r2 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-peer-uid"}, // Different UID
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{v1r2},
+	}
+	g1v2r1 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-peer-uid"},
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{v2r1},
+	}
+
+	// g1v1r1 + g1v1r2 = g1v1(r1,r2)
+	g1v1r1r2Merged := apidiscoveryv2.APIGroupDiscovery{
+		// Meta is copied from first server in the sorted list of serverIDs
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid"}, // Meta from g1v1r1
+		Versions: []apidiscoveryv2.APIVersionDiscovery{
+			{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{r1, r2}},
+		},
+	}
+
+	// g1v1r1 + g1v2r1 = g1(v1r1, v2r1)
+	g1v1r1v2r1Merged := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid"}, // Meta from g1v1r1
+		Versions: []apidiscoveryv2.APIVersionDiscovery{
+			{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{r1}},
+			{Version: "v2", Resources: []apidiscoveryv2.APIResourceDiscovery{r1}},
+		},
+	}
+
+	// verbs test data
+	rVerbs1 := apidiscoveryv2.APIResourceDiscovery{Resource: "pods", Verbs: []string{"get", "list"}}
+	rVerbs2 := apidiscoveryv2.APIResourceDiscovery{Resource: "pods", Verbs: []string{"get", "watch"}}
+	rVerbsMerged := apidiscoveryv2.APIResourceDiscovery{Resource: "pods", Verbs: []string{"get", "list", "watch"}} // Verbs are sorted by helper
+
+	vVerbs1 := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{rVerbs1}}
+	vVerbs2 := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{rVerbs2}}
+	vVerbsMerged := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{rVerbsMerged}}
+
+	gVerbs1 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid-a"},
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{vVerbs1},
+	}
+	gVerbs2 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid-b"},
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{vVerbs2},
+	}
+	gVerbsMerged := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid-a"}, // Metadata from serverA (alphabetical first)
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{vVerbsMerged},
+	}
+
+	// subresource test data
+	rSub1 := apidiscoveryv2.APIResourceDiscovery{Resource: "pods", Subresources: []apidiscoveryv2.APISubresourceDiscovery{{Subresource: "status"}}}
+	rSub2 := apidiscoveryv2.APIResourceDiscovery{Resource: "pods", Subresources: []apidiscoveryv2.APISubresourceDiscovery{{Subresource: "log"}}}
+	rSubMerged := apidiscoveryv2.APIResourceDiscovery{Resource: "pods", Subresources: []apidiscoveryv2.APISubresourceDiscovery{{Subresource: "log"}, {Subresource: "status"}}} // Sorted by helper
+
+	vSub1 := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{rSub1}}
+	vSub2 := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{rSub2}}
+	vSubMerged := apidiscoveryv2.APIVersionDiscovery{Version: "v1", Resources: []apidiscoveryv2.APIResourceDiscovery{rSubMerged}}
+
+	gSub1 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid-a"},
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{vSub1},
+	}
+	gSub2 := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid-b"},
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{vSub2},
+	}
+	gSubMerged := apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", UID: "g1-uid-a"}, // Metadata from serverA
+		Versions:   []apidiscoveryv2.APIVersionDiscovery{vSubMerged},
+	}
+
+	tests := []struct {
+		name                 string
+		localServerID        string
+		localGroups          []apidiscoveryv2.APIGroupDiscovery
+		peerGroupDiscovery   map[string][]apidiscoveryv2.APIGroupDiscovery
+		wantResult           []apidiscoveryv2.APIGroupDiscovery
+		validateShortCircuit bool
+	}{
+		{
+			name:                 "no peers, just local resources",
+			localServerID:        serverA,
+			localGroups:          []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},
+			peerGroupDiscovery:   map[string][]apidiscoveryv2.APIGroupDiscovery{},
+			wantResult:           []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},
+			validateShortCircuit: true,
+		},
+		{
+			name:                 "peer adds no new g/v/r",
+			localServerID:        serverA,
+			localGroups:          []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},
+			peerGroupDiscovery:   map[string][]apidiscoveryv2.APIGroupDiscovery{"serverB": {g1v1r1, g2v1r1}},
+			wantResult:           []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},
+			validateShortCircuit: true,
+		},
+		{
+			name:               "peer adds a new resource to existing g/v",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{g1v1r1},
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{"serverB": {g1v1r2}},
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{g1v1r1r2Merged},
+		},
+		{
+			name:               "peer adds a new version to existing group",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{g1v1r1},
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{"serverB": {g1v2r1}},
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{g1v1r1v2r1Merged},
+		},
+		{
+			name:               "peer adds a completely new group",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{g1v1r1},
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{"serverB": {g2v1r1}},
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},
+		},
+		{
+			name:               "peer has same data but different group order",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},                         // g1, g2
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{"serverB": {g2v1r1, g1v1r1}}, // g2, g1
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},                         // Final order is [g1, g2] due to topo-sort
+		},
+		{
+			name:               "deterministic merge (Server A's view)",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{g1v1r1},                         // A has g1
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{"serverB": {g2v1r1}}, // B has g2
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},                 // Sorted order is [g1, g2]
+		},
+		{
+			name:               "deterministic merge (Server B's view)",
+			localServerID:      serverB,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{g2v1r1},                         // B has g2
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{"serverA": {g1v1r1}}, // A has g1
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{g1v1r1, g2v1r1},                 // Sorted order is [g1, g2]
+		},
+		{
+			name:               "peer adds a new verb to existing resource (triggers Case 2)",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{gVerbs1},
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{serverB: {gVerbs2}},
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{gVerbsMerged},
+		},
+		{
+			name:               "peer adds a new subresource to existing resource (triggers Case 2)",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{gSub1},
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{serverB: {gSub2}},
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{gSubMerged},
+		},
+		{
+			name:               "empty local, non-empty peer (triggers Case 3)",
+			localServerID:      serverA,
+			localGroups:        []apidiscoveryv2.APIGroupDiscovery{},
+			peerGroupDiscovery: map[string][]apidiscoveryv2.APIGroupDiscovery{serverB: {g1v1r1}},
+			wantResult:         []apidiscoveryv2.APIGroupDiscovery{g1v1r1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := discoveryendpoint.TestMergeResources(tt.localServerID, tt.localGroups, tt.peerGroupDiscovery)
+			if !reflect.DeepEqual(result, tt.wantResult) {
+				t.Errorf("mergeResources() mismatch (-want +got):\n%s", cmp.Diff(tt.wantResult, result))
+			}
+
+			// Test the short-circuit case specifically if requested
+			if tt.validateShortCircuit {
+				// reflect.ValueOf(slice).Pointer() gives the address of the underlying array.
+				// If the short-circuit worked, the result slice should be the *exact same*
+				// slice (same pointer) as localGroups, not just DeepEqual.
+				if reflect.ValueOf(result).Pointer() != reflect.ValueOf(tt.localGroups).Pointer() {
+					t.Errorf("Short-circuit failed: function returned a new slice instead of the original localGroups")
+				}
+			}
+		})
+	}
+}
+
+type mockPeerDiscoveryProvider struct {
+	resources map[string][]apidiscoveryv2.APIGroupDiscovery
+}
+
+// responseRecorder is a minimal http.ResponseWriter for testing status codes and headers
+type responseRecorder struct {
+	header     http.Header
+	statusCode int
+	body       strings.Builder
+}
+
+func (r *responseRecorder) Header() http.Header         { return r.header }
+func (r *responseRecorder) Write(b []byte) (int, error) { return r.body.Write(b) }
+func (r *responseRecorder) WriteHeader(statusCode int)  { r.statusCode = statusCode }
+
+func (m *mockPeerDiscoveryProvider) GetPeerResources() map[string][]apidiscoveryv2.APIGroupDiscovery {
+	return m.resources
+}
+
+func (m *mockPeerDiscoveryProvider) addResource(serverID string, gvr schema.GroupVersionResource, groupDiscovery apidiscoveryv2.APIGroupDiscovery) {
+	if m.resources == nil {
+		m.resources = make(map[string][]apidiscoveryv2.APIGroupDiscovery)
+	}
+
+	if _, exists := m.resources[serverID]; !exists {
+		m.resources[serverID] = []apidiscoveryv2.APIGroupDiscovery{}
+	}
+	m.resources[serverID] = append(m.resources[serverID], groupDiscovery)
+}
+
+func newAPIGroup(groupName, versionName, resourceName string) apidiscoveryv2.APIGroupDiscovery {
+	return apidiscoveryv2.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: groupName},
+		Versions: []apidiscoveryv2.APIVersionDiscovery{
+			{
+				Version: versionName,
+				Resources: []apidiscoveryv2.APIResourceDiscovery{
+					{Resource: resourceName},
+				},
+			},
+		},
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/wrapper.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/wrapper.go
@@ -28,18 +28,33 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 type WrappedHandler struct {
-	s          runtime.NegotiatedSerializer
-	handler    http.Handler
-	aggHandler http.Handler
+	s                     runtime.NegotiatedSerializer
+	handler               http.Handler
+	aggHandler            http.Handler
+	peerAggregatedHandler http.Handler
 }
 
 func (wrapped *WrappedHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	mediaType, _ := negotiation.NegotiateMediaTypeOptions(req.Header.Get("Accept"), wrapped.s.SupportedMediaTypes(), DiscoveryEndpointRestrictions)
 	// mediaType.Convert looks at the request accept headers and is used to control whether the discovery document will be aggregated.
+	mediaType, _ := negotiation.NegotiateMediaTypeOptions(req.Header.Get("Accept"), wrapped.s.SupportedMediaTypes(), DiscoveryEndpointRestrictions)
 	if IsAggregatedDiscoveryGVK(mediaType.Convert) {
+		if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.UnknownVersionInteroperabilityProxy) && mediaType.Convert.Version == "v2" {
+			if mediaType.Profile == "nopeer" {
+				NoPeerDiscoveryRequestCounter.Inc()
+				wrapped.aggHandler.ServeHTTP(resp, req)
+				return
+			}
+			if wrapped.peerAggregatedHandler != nil {
+				// Serve peer-aggregated discovery by default if provided.
+				wrapped.peerAggregatedHandler.ServeHTTP(resp, req)
+				return
+			}
+		}
 		wrapped.aggHandler.ServeHTTP(resp, req)
 		return
 	}
@@ -68,10 +83,15 @@ func (wrapped *WrappedHandler) GenerateWebService(prefix string, returnType inte
 // emit the aggregated discovery by passing in the aggregated
 // discovery type in content negotiation headers: eg: (Accept:
 // application/json;v=v2;g=apidiscovery.k8s.io;as=APIGroupDiscoveryList)
-func WrapAggregatedDiscoveryToHandler(handler http.Handler, aggHandler http.Handler) *WrappedHandler {
+//
+// If peerAggregatedHandler is non-nil, it will be used to serve peer-aggregated
+// discovery requests which aggregate discovery information from peer API servers.
+// To request a no-peer aggregation, the client must include the "profile=nopeer" parameter in the
+// Accept header eg: (Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList;profile=nopeer).
+func WrapAggregatedDiscoveryToHandler(handler, aggHandler, peerAggregatedHandler http.Handler) *WrappedHandler {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(apidiscoveryv2.AddToScheme(scheme))
 	utilruntime.Must(apidiscoveryv2beta1.AddToScheme(scheme))
 	codecs := serializer.NewCodecFactory(scheme)
-	return &WrappedHandler{codecs, handler, aggHandler}
+	return &WrappedHandler{codecs, handler, aggHandler, peerAggregatedHandler}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/wrapper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/wrapper_test.go
@@ -41,6 +41,8 @@ const aggregatedV2Beta1JSONAccept = jsonAccept + aggregatedV2Beta1AcceptSuffix
 const aggregatedV2Beta1ProtoAccept = protobufAccept + aggregatedV2Beta1AcceptSuffix
 const aggregatedJSONAccept = jsonAccept + aggregatedAcceptSuffix
 const aggregatedProtoAccept = protobufAccept + aggregatedAcceptSuffix
+const aggregatedNoPeerJSONAccept = jsonAccept + aggregatedAcceptSuffix + ";profile=nopeer"
+const aggregatedNoPeerProtoAccept = protobufAccept + aggregatedAcceptSuffix + ";profile=nopeer"
 
 func fetchPath(handler http.Handler, path, accept string) string {
 	w := httptest.NewRecorder()
@@ -50,7 +52,7 @@ func fetchPath(handler http.Handler, path, accept string) string {
 	req.Header.Set("Accept", accept)
 
 	handler.ServeHTTP(w, req)
-	return string(w.Body.Bytes())
+	return w.Body.String()
 }
 
 type fakeHTTPHandler struct {
@@ -64,12 +66,14 @@ func (f fakeHTTPHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 func TestAggregationEnabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.34"))
 	unaggregated := fakeHTTPHandler{data: "unaggregated"}
-	aggregated := fakeHTTPHandler{data: "aggregated"}
-	wrapped := WrapAggregatedDiscoveryToHandler(unaggregated, aggregated)
+	aggregated := fakeHTTPHandler{data: "nopeer-aggregated"}
+	peerAggregated := fakeHTTPHandler{data: "peer-aggregated"}
+	wrapped := WrapAggregatedDiscoveryToHandler(unaggregated, aggregated, peerAggregated)
 
 	testCases := []struct {
-		accept   string
-		expected string
+		accept               string
+		expected             string
+		enablePeerAggregated bool
 	}{
 		{
 			// Misconstructed/incorrect accept headers should be passed to the unaggregated handler to return an error
@@ -81,16 +85,16 @@ func TestAggregationEnabled(t *testing.T) {
 			expected: "unaggregated",
 		}, {
 			accept:   aggregatedV2Beta1JSONAccept,
-			expected: "aggregated",
+			expected: "nopeer-aggregated",
 		}, {
 			accept:   aggregatedV2Beta1ProtoAccept,
-			expected: "aggregated",
+			expected: "nopeer-aggregated",
 		}, {
 			accept:   aggregatedJSONAccept,
-			expected: "aggregated",
+			expected: "nopeer-aggregated",
 		}, {
 			accept:   aggregatedProtoAccept,
-			expected: "aggregated",
+			expected: "nopeer-aggregated",
 		}, {
 			accept:   jsonAccept,
 			expected: "unaggregated",
@@ -100,17 +104,47 @@ func TestAggregationEnabled(t *testing.T) {
 		}, {
 			// Server should return the first accepted type
 			accept:   aggregatedJSONAccept + "," + jsonAccept,
-			expected: "aggregated",
+			expected: "nopeer-aggregated",
 		}, {
 			// Server should return the first accepted type
 			accept:   aggregatedProtoAccept + "," + protobufAccept,
-			expected: "aggregated",
+			expected: "nopeer-aggregated",
+		},
+		// Peer Agg discovery cases.
+		// profile is not set (should default to peer-aggregated)
+		{
+			accept:               aggregatedJSONAccept,
+			expected:             "peer-aggregated",
+			enablePeerAggregated: true,
+		}, {
+			accept:               aggregatedProtoAccept,
+			expected:             "peer-aggregated",
+			enablePeerAggregated: true,
+		},
+		// profile=nopeer (should return no-peer)
+		{
+			accept:               aggregatedNoPeerJSONAccept,
+			expected:             "nopeer-aggregated",
+			enablePeerAggregated: true,
+		}, {
+			accept:               aggregatedNoPeerProtoAccept,
+			expected:             "nopeer-aggregated",
+			enablePeerAggregated: true,
+		},
+		// profile is set to something other than no-peer (should default to peer-aggregated)
+		{
+			accept:               aggregatedJSONAccept + ";profile=foo",
+			expected:             "peer-aggregated",
+			enablePeerAggregated: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		if tc.accept == aggregatedV2Beta1JSONAccept || tc.accept == aggregatedV2Beta1ProtoAccept {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AggregatedDiscoveryRemoveBetaType, false)
+		}
+		if tc.enablePeerAggregated {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.UnknownVersionInteroperabilityProxy, true)
 		}
 		body := fetchPath(wrapped, discoveryPath, tc.accept)
 		assert.Equal(t, tc.expected, body)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -168,6 +168,9 @@ type MediaTypeOptions struct {
 	// has set
 	Export bool
 
+	// profile controls the discovery profile (e.g., "local" for local (non peer-aggregated) discovery)
+	Profile string
+
 	// unrecognized is a list of all unrecognized keys
 	Unrecognized []string
 
@@ -226,6 +229,10 @@ func acceptMediaTypeOptions(params map[string]string, accepts *runtime.Serialize
 		// if specified, the pretty serializer will be used
 		case "pretty":
 			options.Pretty = v == "1"
+
+		// controls the discovery profile (eg local vs peer-aggregated)
+		case "profile":
+			options.Profile = v
 
 		default:
 			options.Unrecognized = append(options.Unrecognized, k)

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -274,6 +274,11 @@ const (
 	// clients.
 	UnauthenticatedHTTP2DOSMitigation featuregate.Feature = "UnauthenticatedHTTP2DOSMitigation"
 
+	// owner: @richabanker
+	//
+	// Proxies client to an apiserver capable of serving the request in the event of version skew.
+	UnknownVersionInteroperabilityProxy featuregate.Feature = "UnknownVersionInteroperabilityProxy"
+
 	// owner: @wojtek-t
 	//
 	// Enables post-start-hook for storage readiness
@@ -480,6 +485,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	UnauthenticatedHTTP2DOSMitigation: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	UnknownVersionInteroperabilityProxy: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	WatchCacheInitializationPostStartHook: {

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1129,7 +1129,7 @@ func installAPI(name string, s *GenericAPIServer, c *Config) {
 	routes.Version{Version: c.EffectiveVersion.Info()}.Install(s.Handler.GoRestfulContainer)
 
 	if c.EnableDiscovery {
-		wrapped := discoveryendpoint.WrapAggregatedDiscoveryToHandler(s.DiscoveryGroupManager, s.AggregatedDiscoveryGroupManager)
+		wrapped := discoveryendpoint.WrapAggregatedDiscoveryToHandler(s.DiscoveryGroupManager, s.AggregatedDiscoveryGroupManager, s.PeerAggregatedDiscoveryManager)
 		s.Handler.GoRestfulContainer.Add(wrapped.GenerateWebService("/apis", metav1.APIGroupList{}))
 	}
 	if c.FlowControl != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -155,6 +155,9 @@ type GenericAPIServer struct {
 	// AggregatedDiscoveryGroupManager serves /apis in an aggregated form.
 	AggregatedDiscoveryGroupManager discoveryendpoint.ResourceManager
 
+	// PeerAggregatedDiscoveryManager serves /apis aggregated from all peer apiservers.
+	PeerAggregatedDiscoveryManager discoveryendpoint.PeerAggregatedResourceManager
+
 	// AggregatedLegacyDiscoveryGroupManager serves /api in an aggregated form.
 	AggregatedLegacyDiscoveryGroupManager discoveryendpoint.ResourceManager
 
@@ -859,7 +862,8 @@ func (s *GenericAPIServer) InstallLegacyAPIGroup(apiPrefix string, apiGroupInfo 
 	// Install the version handler.
 	// Add a handler at /<apiPrefix> to enumerate the supported api versions.
 	legacyRootAPIHandler := discovery.NewLegacyRootAPIHandler(s.discoveryAddresses, s.Serializer, apiPrefix)
-	wrapped := discoveryendpoint.WrapAggregatedDiscoveryToHandler(legacyRootAPIHandler, s.AggregatedLegacyDiscoveryGroupManager)
+	// No peer-to-peer discovery for legacy API group.
+	wrapped := discoveryendpoint.WrapAggregatedDiscoveryToHandler(legacyRootAPIHandler, s.AggregatedLegacyDiscoveryGroupManager, s.AggregatedLegacyDiscoveryGroupManager)
 	s.Handler.GoRestfulContainer.Add(wrapped.GenerateWebService("/api", metav1.APIVersions{}))
 	s.registerStorageReadinessCheck("", apiGroupInfo)
 

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/exclusion_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/exclusion_filter.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peerproxy
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+)
+
+// GVExtractor is a function that extracts group-versions from an object.
+// It returns a slice of GroupVersions belonging to CRDs or aggregated APIs that
+// should be excluded from peer-discovery to avoid advertising stale CRDs/aggregated APIs
+// in peer-aggregated discovery that were deleted but still appear in a peer's discovery.
+type GVExtractor func(obj interface{}) []schema.GroupVersion
+
+// RegisterCRDInformerHandlers registers event handlers for CRD informer using a custom extractor.
+// The extractor function is responsible for extracting GroupVersions from CRD objects.
+func (h *peerProxyHandler) RegisterCRDInformerHandlers(crdInformer cache.SharedIndexInformer, extractor GVExtractor) error {
+	h.crdInformer = crdInformer
+	h.crdExtractor = extractor
+	_, err := h.crdInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			gvs := extractor(obj)
+			if gvs == nil {
+				return
+			}
+			h.addExcludedGVs(gvs)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			gvs := extractor(newObj)
+			if gvs == nil {
+				return
+			}
+			h.addExcludedGVs(gvs)
+		},
+		DeleteFunc: func(obj interface{}) {
+			// Handle tombstone objects
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			gvs := extractor(obj)
+			if gvs == nil {
+				return
+			}
+			for _, gv := range gvs {
+				h.gvDeletionQueue.Add(gv.String())
+			}
+		},
+	})
+	return err
+}
+
+// RegisterAPIServiceInformerHandlers registers event handlers for APIService informer using a custom extractor.
+// The extractor function is responsible for extracting GroupVersions from APIService objects
+// and determining if they represent aggregated APIs.
+func (h *peerProxyHandler) RegisterAPIServiceInformerHandlers(apiServiceInformer cache.SharedIndexInformer, extractor GVExtractor) error {
+	h.apiServiceInformer = apiServiceInformer
+	h.apiServiceExtractor = extractor
+	_, err := h.apiServiceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			gvs := extractor(obj)
+			if gvs == nil {
+				return
+			}
+			h.addExcludedGVs(gvs)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			gvs := extractor(newObj)
+			if gvs == nil {
+				return
+			}
+			h.addExcludedGVs(gvs)
+		},
+		DeleteFunc: func(obj interface{}) {
+			// Handle tombstone objects
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+
+			gvs := extractor(obj)
+			if gvs == nil {
+				return
+			}
+			for _, gv := range gvs {
+				h.gvDeletionQueue.Add(gv.String())
+			}
+		},
+	})
+	return err
+}
+
+// addExcludedGVs adds group-versions to the exclusion set, filters them from the peer discovery cache,
+// and triggers invalidation callbacks if the cache changed.
+func (h *peerProxyHandler) addExcludedGVs(gvs []schema.GroupVersion) {
+	if len(gvs) == 0 {
+		return
+	}
+
+	h.excludedGVsMu.Lock()
+	for _, gv := range gvs {
+		h.excludedGVs[gv] = nil
+	}
+	h.excludedGVsMu.Unlock()
+
+	// Load current peer cache and filter it
+	cache := h.peerDiscoveryInfoCache.Load()
+	if cache == nil {
+		return
+	}
+
+	cacheMap, ok := cache.(map[string]PeerDiscoveryCacheEntry)
+	if !ok {
+		klog.Warning("Invalid cache type in peerDiscoveryInfoCache")
+		return
+	}
+
+	// Always trigger filter and callbacks, to ensure late-appearing GVs are filtered.
+	if peerDiscovery, peerDiscoveryChanged := h.filterPeerDiscoveryCache(cacheMap); peerDiscoveryChanged {
+		h.storePeerDiscoveryCacheAndInvalidate(peerDiscovery)
+	}
+}
+
+// filterPeerDiscoveryCache filters the provided peer discovery cache,
+// excluding GVs in h.excludedGVs.
+func (h *peerProxyHandler) filterPeerDiscoveryCache(cacheMap map[string]PeerDiscoveryCacheEntry) (map[string]PeerDiscoveryCacheEntry, bool) {
+	h.excludedGVsMu.RLock()
+	if len(h.excludedGVs) == 0 {
+		// No exclusions, no filtering needed.
+		h.excludedGVsMu.RUnlock()
+		return cacheMap, false
+	}
+
+	excludedCloned := make(map[schema.GroupVersion]struct{}, len(h.excludedGVs))
+	for gv := range h.excludedGVs {
+		excludedCloned[gv] = struct{}{}
+	}
+	h.excludedGVsMu.RUnlock()
+
+	filtered := make(map[string]PeerDiscoveryCacheEntry, len(cacheMap))
+	peerDiscoveryChanged := false
+	for peerID, entry := range cacheMap {
+		newEntry, peerChanged := h.filterPeerCacheEntry(entry, excludedCloned)
+		filtered[peerID] = newEntry
+		if peerChanged {
+			peerDiscoveryChanged = true
+		}
+	}
+
+	return filtered, peerDiscoveryChanged
+}
+
+// filterPeerCacheEntry filters a single peer's cache entry for excluded groups.
+// Returns the filtered entry and whether any excluded group was present.
+func (h *peerProxyHandler) filterPeerCacheEntry(entry PeerDiscoveryCacheEntry, excluded map[schema.GroupVersion]struct{}) (PeerDiscoveryCacheEntry, bool) {
+	filteredGVRs := make(map[schema.GroupVersionResource]bool, len(entry.GVRs))
+	peerDiscoveryChanged := false
+
+	for existingGVR, v := range entry.GVRs {
+		gv := schema.GroupVersion{Group: existingGVR.Group, Version: existingGVR.Version}
+		if _, skip := excluded[gv]; skip {
+			peerDiscoveryChanged = true
+			continue
+		}
+		filteredGVRs[existingGVR] = v
+	}
+
+	if !peerDiscoveryChanged {
+		return entry, false
+	}
+
+	// Filter the group discovery list
+	filteredGroups := h.filterGroupDiscovery(entry.GroupDiscovery, excluded)
+	return PeerDiscoveryCacheEntry{
+		GVRs:           filteredGVRs,
+		GroupDiscovery: filteredGroups,
+	}, true
+}
+
+func (h *peerProxyHandler) filterGroupDiscovery(groupDiscoveries []apidiscoveryv2.APIGroupDiscovery, excluded map[schema.GroupVersion]struct{}) []apidiscoveryv2.APIGroupDiscovery {
+	var filteredDiscovery []apidiscoveryv2.APIGroupDiscovery
+	for _, groupDiscovery := range groupDiscoveries {
+		filteredGroup := apidiscoveryv2.APIGroupDiscovery{
+			ObjectMeta: groupDiscovery.ObjectMeta,
+		}
+
+		for _, version := range groupDiscovery.Versions {
+			gv := schema.GroupVersion{Group: groupDiscovery.Name, Version: version.Version}
+			if _, found := excluded[gv]; found {
+				// This version is excluded, skip it
+				continue
+			}
+			filteredGroup.Versions = append(filteredGroup.Versions, version)
+		}
+
+		// Only add the group to the final list if it still has any versions left
+		if len(filteredGroup.Versions) > 0 {
+			filteredDiscovery = append(filteredDiscovery, filteredGroup)
+		}
+	}
+	return filteredDiscovery
+}
+
+// RunGVDeletionWorkers starts workers to process GroupVersions from deleted CRDs and APIServices.
+// When a GV is processed, it is checked for usage by other resources. If no longer in use,
+// it is marked with a deletion timestamp, initiating a grace period. After this period,
+// the RunExcludedGVsReaper is responsible for removing the GV from the exclusion set.
+func (h *peerProxyHandler) RunGVDeletionWorkers(ctx context.Context, workers int) {
+	defer func() {
+		klog.Info("Shutting down GV deletion workers")
+		h.gvDeletionQueue.ShutDown()
+	}()
+	klog.Infof("Starting %d GV deletion worker(s)", workers)
+	for i := 0; i < workers; i++ {
+		go func(workerID int) {
+			for h.processNextGVDeletion() {
+				select {
+				case <-ctx.Done():
+					klog.Infof("GV deletion worker %d shutting down", workerID)
+					return
+				default:
+				}
+			}
+		}(i)
+	}
+
+	<-ctx.Done() // Wait till context is done to call deferred shutdown function
+}
+
+// processNextGVDeletion processes a single item from the GV deletion queue.
+func (h *peerProxyHandler) processNextGVDeletion() bool {
+	gvString, shutdown := h.gvDeletionQueue.Get()
+	if shutdown {
+		return false
+	}
+	defer h.gvDeletionQueue.Done(gvString)
+
+	gv, err := schema.ParseGroupVersion(gvString)
+	if err != nil {
+		klog.Errorf("Failed to parse GroupVersion %q: %v", gvString, err)
+		return true
+	}
+
+	h.markGVForDeletionIfUnused(gv)
+	return true
+}
+
+// markGVForDeletionIfUnused checks if a group-version is still in use.
+// If not, it marks it for deletion by setting a timestamp.
+func (h *peerProxyHandler) markGVForDeletionIfUnused(gv schema.GroupVersion) {
+	// Best-effort check if GV is still in use. This is racy - a new CRD/APIService could be
+	// created after this check completes and returns false.
+	if h.isGVUsed(gv) {
+		return
+	}
+
+	h.excludedGVsMu.Lock()
+	defer h.excludedGVsMu.Unlock()
+
+	// Only mark if it's currently active (nil timestamp)
+	if ts, exists := h.excludedGVs[gv]; exists && ts == nil {
+		now := time.Now()
+		h.excludedGVs[gv] = &now
+		klog.V(4).Infof("Marking group-version %q for deletion, grace period started", gv)
+	}
+}
+
+// isGVUsed checks the informer stores to see if any CRD or APIService
+// is still using the given group-version.
+//
+// This is necessary because multiple CRDs or aggregated APIs can share the same group-version,
+// but define different resources (kinds) or versions. Deleting one CRD or APIService
+// for a group-version does not mean the group-version is entirely gone—other CRDs or APIs in that group-version
+// may still exist. We must only remove a group-version from the exclusion set when there are
+// no remaining CRDs or APIService objects for that group-version, to ensure we do not prematurely
+// allow peer-aggregated discovery or proxying for APIs that are still served locally.
+func (h *peerProxyHandler) isGVUsed(gv schema.GroupVersion) bool {
+	// Check CRD informer store for the specific group-version
+	if h.crdInformer != nil && h.crdExtractor != nil {
+		crdList := h.crdInformer.GetStore().List()
+		for _, item := range crdList {
+			gvs := h.crdExtractor(item)
+			if gvs == nil {
+				continue
+			}
+			for _, extractedGV := range gvs {
+				if extractedGV == gv {
+					return true
+				}
+			}
+		}
+	}
+
+	// Check APIService informer store for the specific group-version
+	if h.apiServiceInformer != nil && h.apiServiceExtractor != nil {
+		apiSvcList := h.apiServiceInformer.GetStore().List()
+		for _, item := range apiSvcList {
+			gvs := h.apiServiceExtractor(item)
+			if gvs == nil {
+				continue
+			}
+			for _, extractedGV := range gvs {
+				if extractedGV == gv {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// RunExcludedGVsReaper starts a goroutine that periodically cleans up
+// excluded group-versions that have passed their grace period.
+func (h *peerProxyHandler) RunExcludedGVsReaper(stopCh <-chan struct{}) {
+	klog.Infof("Starting excluded group-versions reaper with %s interval", h.reaperCheckInterval)
+	ticker := time.NewTicker(h.reaperCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			h.reapExcludedGVs()
+		case <-stopCh:
+			klog.Info("Shutting down excluded group-versions reaper")
+			return
+		}
+	}
+}
+
+// reapExcludedGVs is the garbage collector function.
+// It removes group-versions from excludedGVs if their grace period has expired.
+func (h *peerProxyHandler) reapExcludedGVs() {
+	h.excludedGVsMu.Lock()
+	defer h.excludedGVsMu.Unlock()
+
+	now := time.Now()
+	for gv, deletionTime := range h.excludedGVs {
+		if deletionTime == nil {
+			// Still actively excluded
+			continue
+		}
+
+		if now.Sub(*deletionTime) > h.exclusionGracePeriod {
+			klog.V(4).Infof("Reaping excluded group-version %q (grace period expired)", gv)
+			delete(h.excludedGVs, gv)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/exclusion_filter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/exclusion_filter_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peerproxy
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFilteringLogic(t *testing.T) {
+	gvr := func(g, v, r string) schema.GroupVersionResource {
+		return schema.GroupVersionResource{Group: g, Version: v, Resource: r}
+	}
+	gv := func(g, v string) schema.GroupVersion {
+		return schema.GroupVersion{Group: g, Version: v}
+	}
+
+	testCases := []struct {
+		name               string
+		initialPeerCache   PeerDiscoveryCacheEntry
+		excludedGVs        map[schema.GroupVersion]struct{}
+		wantFilteredGVRs   map[schema.GroupVersionResource]bool
+		wantFilteredGroups []apidiscoveryv2.APIGroupDiscovery
+		wantChange         bool
+	}{
+		{
+			name: "no exclusions",
+			initialPeerCache: PeerDiscoveryCacheEntry{
+				GVRs: map[schema.GroupVersionResource]bool{gvr("apps", "v1", "deployments"): true},
+				GroupDiscovery: []apidiscoveryv2.APIGroupDiscovery{{
+					ObjectMeta: metav1.ObjectMeta{Name: "apps"},
+					Versions:   []apidiscoveryv2.APIVersionDiscovery{{Version: "v1"}},
+				}},
+			},
+			excludedGVs:      map[schema.GroupVersion]struct{}{},
+			wantFilteredGVRs: map[schema.GroupVersionResource]bool{gvr("apps", "v1", "deployments"): true},
+			wantFilteredGroups: []apidiscoveryv2.APIGroupDiscovery{{
+				ObjectMeta: metav1.ObjectMeta{Name: "apps"},
+				Versions:   []apidiscoveryv2.APIVersionDiscovery{{Version: "v1"}},
+			}},
+			wantChange: false,
+		},
+		{
+			name: "exclude one GV that exists",
+			initialPeerCache: PeerDiscoveryCacheEntry{
+				GVRs: map[schema.GroupVersionResource]bool{
+					gvr("apps", "v1", "deployments"):  true,
+					gvr("apps", "v1", "statefulsets"): true,
+					gvr("batch", "v1", "jobs"):        true,
+				},
+				GroupDiscovery: []apidiscoveryv2.APIGroupDiscovery{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "apps"},
+						Versions:   []apidiscoveryv2.APIVersionDiscovery{{Version: "v1"}},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "batch"},
+						Versions:   []apidiscoveryv2.APIVersionDiscovery{{Version: "v1"}},
+					},
+				},
+			},
+			excludedGVs: map[schema.GroupVersion]struct{}{
+				gv("apps", "v1"): {},
+			},
+			wantFilteredGVRs: map[schema.GroupVersionResource]bool{gvr("batch", "v1", "jobs"): true},
+			wantFilteredGroups: []apidiscoveryv2.APIGroupDiscovery{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "batch"},
+					Versions:   []apidiscoveryv2.APIVersionDiscovery{{Version: "v1"}},
+				},
+			},
+			wantChange: true,
+		},
+		{
+			name: "exclude a GV that does not exist",
+			initialPeerCache: PeerDiscoveryCacheEntry{
+				GVRs: map[schema.GroupVersionResource]bool{gvr("apps", "v1", "deployments"): true},
+				GroupDiscovery: []apidiscoveryv2.APIGroupDiscovery{{
+					ObjectMeta: metav1.ObjectMeta{Name: "apps"},
+					Versions:   []apidiscoveryv2.APIVersionDiscovery{{Version: "v1"}},
+				}},
+			},
+			excludedGVs: map[schema.GroupVersion]struct{}{
+				gv("foo", "v1"): {},
+			},
+			wantFilteredGVRs: map[schema.GroupVersionResource]bool{gvr("apps", "v1", "deployments"): true},
+			wantFilteredGroups: []apidiscoveryv2.APIGroupDiscovery{{
+				ObjectMeta: metav1.ObjectMeta{Name: "apps"},
+				Versions:   []apidiscoveryv2.APIVersionDiscovery{{Version: "v1"}},
+			}},
+			wantChange: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &peerProxyHandler{}
+			filteredEntry, changed := h.filterPeerCacheEntry(tc.initialPeerCache, tc.excludedGVs)
+
+			if changed != tc.wantChange {
+				t.Errorf("want change to be %v, got %v", tc.wantChange, changed)
+			}
+
+			if !reflect.DeepEqual(filteredEntry.GVRs, tc.wantFilteredGVRs) {
+				t.Errorf("filtered GVRs mismatch: got %v, want %v", filteredEntry.GVRs, tc.wantFilteredGVRs)
+			}
+
+			if !reflect.DeepEqual(filteredEntry.GroupDiscovery, tc.wantFilteredGroups) {
+				t.Errorf("filtered GroupDiscovery mismatch: got %v, want %v", filteredEntry.GroupDiscovery, tc.wantFilteredGroups)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/local_discovery.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/local_discovery.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peerproxy
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+// RunLocalDiscoveryCacheSync populated the localDiscoveryInfoCache and
+// starts a goroutine to periodically refresh the local discovery cache.
+func (h *peerProxyHandler) RunLocalDiscoveryCacheSync(stopCh <-chan struct{}) error {
+	klog.Info("localDiscoveryCacheInvalidation goroutine started")
+	// Populate the cache initially.
+	if err := h.populateLocalDiscoveryCache(); err != nil {
+		return fmt.Errorf("failed to populate initial local discovery cache: %w", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-h.localDiscoveryCacheTicker.C:
+				klog.V(4).Infof("Invalidating local discovery cache")
+				if err := h.populateLocalDiscoveryCache(); err != nil {
+					klog.Errorf("Failed to repopulate local discovery cache: %v", err)
+				}
+			case <-stopCh:
+				klog.Info("localDiscoveryCacheInvalidation goroutine received stop signal")
+				if h.localDiscoveryCacheTicker != nil {
+					h.localDiscoveryCacheTicker.Stop()
+					klog.Info("localDiscoveryCacheTicker stopped")
+				}
+				klog.Info("localDiscoveryCacheInvalidation goroutine exiting")
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (h *peerProxyHandler) populateLocalDiscoveryCache() error {
+	_, resourcesByGV, _, err := h.discoveryClient.GroupsAndMaybeResources()
+	if err != nil {
+		return fmt.Errorf("error getting API group resources from discovery: %w", err)
+	}
+
+	freshLocalDiscoveryResponse := map[schema.GroupVersionResource]bool{}
+	for gv, resources := range resourcesByGV {
+		for _, resource := range resources.APIResources {
+			gvr := gv.WithResource(resource.Name)
+			freshLocalDiscoveryResponse[gvr] = true
+		}
+	}
+
+	h.localDiscoveryInfoCache.Store(freshLocalDiscoveryResponse)
+	// Signal that the cache has been populated.
+	h.localDiscoveryInfoCachePopulatedOnce.Do(func() {
+		close(h.localDiscoveryInfoCachePopulated)
+	})
+	return nil
+}
+
+// shouldServeLocally checks if the requested resource is present in the local
+// discovery cache indicating the request can be served by this server.
+func (h *peerProxyHandler) shouldServeLocally(gvr schema.GroupVersionResource) bool {
+	cacheValue := h.localDiscoveryInfoCache.Load()
+	if cacheValue == nil {
+		return false
+	}
+
+	cache, ok := cacheValue.(map[schema.GroupVersionResource]bool)
+	if !ok {
+		klog.Warning("Invalid cache type in localDiscoveryInfoCache")
+		return false
+	}
+
+	exists, ok := cache[gvr]
+	if !ok {
+		klog.V(4).Infof("resource not found for %v in local discovery cache\n", gvr.GroupVersion())
+		return false
+	}
+
+	return exists
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/local_discovery_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/local_discovery_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peerproxy
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestShouldServeLocally_Table(t *testing.T) {
+	testCases := []struct {
+		name  string
+		cache map[schema.GroupVersionResource]bool
+		gvr   schema.GroupVersionResource
+		want  bool
+	}{
+		{
+			name:  "resource present and true",
+			cache: map[schema.GroupVersionResource]bool{{Group: "foo", Version: "v1", Resource: "bars"}: true},
+			gvr:   schema.GroupVersionResource{Group: "foo", Version: "v1", Resource: "bars"},
+			want:  true,
+		},
+		{
+			name:  "resource present and false",
+			cache: map[schema.GroupVersionResource]bool{{Group: "foo", Version: "v1", Resource: "bars"}: false},
+			gvr:   schema.GroupVersionResource{Group: "foo", Version: "v1", Resource: "bars"},
+			want:  false,
+		},
+		{
+			name:  "resource not present",
+			cache: map[schema.GroupVersionResource]bool{{Group: "foo", Version: "v1", Resource: "bars"}: true},
+			gvr:   schema.GroupVersionResource{Group: "foo", Version: "v1", Resource: "baz"},
+			want:  false,
+		},
+		{
+			name:  "empty cache",
+			cache: map[schema.GroupVersionResource]bool{},
+			gvr:   schema.GroupVersionResource{Group: "foo", Version: "v1", Resource: "bars"},
+			want:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &peerProxyHandler{}
+			h.localDiscoveryInfoCache.Store(tc.cache)
+			got := h.shouldServeLocally(tc.gvr)
+			if got != tc.want {
+				t.Errorf("shouldServeLocally(%v) = %v, want %v", tc.gvr, got, tc.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,25 +20,34 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
 	v1 "k8s.io/api/coordination/v1"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	responsewriterutil "k8s.io/apiserver/pkg/util/responsewriter"
 )
 
 const (
-	controllerName = "peer-discovery-cache-sync"
-	maxRetries     = 5
+	peerDiscoveryControllerName = "peer-discovery-cache-sync"
+	// maxRetries is the maximum number of retry attempts per lease, set to 20 to handle
+	// the race condition during API server startup where identity leases are created before
+	// endpoint leases. During initialization, peer discovery sync may attempt to fetch discovery
+	// from a peer before that peer has created its endpoint lease, resulting in "missing port in
+	// address" errors. With the default rate limiting (exponential backoff starting at 5ms),
+	// 20 retries per lease provides approximately 60-90 seconds of retry window, which is
+	// sufficient for both identity and endpoint leases to be established during normal startup.
+	maxRetries = 20
 )
 
 func (h *peerProxyHandler) RunPeerDiscoveryCacheSync(ctx context.Context, workers int) {
@@ -76,7 +85,7 @@ func (h *peerProxyHandler) processNextElectionItem(ctx context.Context) bool {
 	defer h.peerLeaseQueue.Done(key)
 
 	err := h.syncPeerDiscoveryCache(ctx)
-	h.handleErr(err, key)
+	h.handleSyncPeerDiscoveryCacheErr(err, key)
 	return true
 }
 
@@ -89,63 +98,95 @@ func (h *peerProxyHandler) syncPeerDiscoveryCache(ctx context.Context) error {
 		return err
 	}
 
-	newCache := map[string]map[schema.GroupVersionResource]bool{}
+	newCache := map[string]PeerDiscoveryCacheEntry{}
 	for _, l := range leases {
 		_, ok := h.isValidPeerIdentityLease(l)
 		if !ok {
 			continue
 		}
 
-		discoveryInfo, err := h.fetchNewDiscoveryFor(ctx, l.Name, *l.Spec.HolderIdentity)
+		discoveryEntry, err := h.fetchNewDiscoveryFor(ctx, l.Name)
 		if err != nil {
 			fetchDiscoveryErr = err
 		}
-
-		if discoveryInfo != nil {
-			newCache[l.Name] = discoveryInfo
+		// Only add if there is at least one GVR or group
+		if len(discoveryEntry.GVRs) > 0 || len(discoveryEntry.GroupDiscovery) > 0 {
+			newCache[l.Name] = discoveryEntry
 		}
 	}
 
-	// Overwrite cache with new contents.
-	h.peerDiscoveryInfoCache.Store(newCache)
+	// Apply exclusion filter to the cache.
+	if len(newCache) != 0 {
+		if filteredCache, peerDiscoveryChanged := h.filterPeerDiscoveryCache(newCache); peerDiscoveryChanged {
+			newCache = filteredCache
+		}
+	}
+
+	h.storePeerDiscoveryCacheAndInvalidate(newCache)
 	return fetchDiscoveryErr
 }
 
-func (h *peerProxyHandler) fetchNewDiscoveryFor(ctx context.Context, serverID string, holderIdentity string) (map[schema.GroupVersionResource]bool, error) {
+// storePeerDiscoveryCacheAndInvalidate stores the new peer discovery cache and always calls the invalidation callback if set.
+func (h *peerProxyHandler) storePeerDiscoveryCacheAndInvalidate(newCache map[string]PeerDiscoveryCacheEntry) {
+	h.peerDiscoveryInfoCache.Store(newCache)
+	if callback := h.cacheInvalidationCallback.Load(); callback != nil {
+		(*callback)()
+	}
+}
+
+func (h *peerProxyHandler) fetchNewDiscoveryFor(ctx context.Context, serverID string) (PeerDiscoveryCacheEntry, error) {
 	hostport, err := h.hostportInfo(serverID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get host port info from identity lease for server %s: %w", serverID, err)
+		return PeerDiscoveryCacheEntry{}, fmt.Errorf("failed to get host port info from identity lease for server %s: %w", serverID, err)
 	}
 
 	klog.V(4).Infof("Proxying an agg-discovery call from %s to %s", h.serverID, serverID)
-	servedResources := make(map[schema.GroupVersionResource]bool)
+	gvrMap := make(map[schema.GroupVersionResource]bool)
 	var discoveryErr error
 	var discoveryResponse *apidiscoveryv2.APIGroupDiscoveryList
 	discoveryPaths := []string{"/api", "/apis"}
+
+	// Use a slice to preserve order from the peer.
+	// Use a map to track seen groups to avoid duplicates.
+	groupList := make([]apidiscoveryv2.APIGroupDiscovery, 0)
+	seenGroups := make(map[string]struct{})
+
 	for _, path := range discoveryPaths {
 		discoveryResponse, discoveryErr = h.aggregateDiscovery(ctx, path, hostport)
-		if err != nil {
-			klog.ErrorS(err, "error querying discovery endpoint for serverID", "path", path, "serverID", serverID)
+		if discoveryErr != nil {
+			klog.ErrorS(discoveryErr, "error querying discovery endpoint for serverID", "path", path, "serverID", serverID)
 			continue
 		}
 
 		for _, groupDiscovery := range discoveryResponse.Items {
-			groupName := groupDiscovery.Name
-			if groupName == "" {
-				groupName = "core"
-			}
-
 			for _, version := range groupDiscovery.Versions {
 				for _, resource := range version.Resources {
-					gvr := schema.GroupVersionResource{Group: groupName, Version: version.Version, Resource: resource.Resource}
-					servedResources[gvr] = true
+					gvr := schema.GroupVersionResource{
+						Group:    groupDiscovery.Name,
+						Version:  version.Version,
+						Resource: resource.Resource,
+					}
+					gvrMap[gvr] = true
 				}
+			}
+			// Skip core/v1 group from peer-aggregated discovery since its not served from /apis.
+			// We still want to re-route core/v1 requests to the peer, but we don't want it
+			// to appear in the peer-aggregated discovery document.
+			if groupDiscovery.Name == "" {
+				continue
+			}
+			if _, ok := seenGroups[groupDiscovery.Name]; !ok {
+				groupList = append(groupList, groupDiscovery)
+				seenGroups[groupDiscovery.Name] = struct{}{}
 			}
 		}
 	}
 
 	klog.V(4).Infof("Agg discovery done successfully by %s for %s", h.serverID, serverID)
-	return servedResources, discoveryErr
+	return PeerDiscoveryCacheEntry{
+		GVRs:           gvrMap,
+		GroupDiscovery: groupList,
+	}, discoveryErr
 }
 
 func (h *peerProxyHandler) aggregateDiscovery(ctx context.Context, path string, hostport string) (*apidiscoveryv2.APIGroupDiscoveryList, error) {
@@ -163,7 +204,8 @@ func (h *peerProxyHandler) aggregateDiscovery(ctx context.Context, path string, 
 	ctx = apirequest.WithUser(ctx, apiServerUser)
 	req = req.WithContext(ctx)
 
-	req.Header.Add("Accept", discovery.AcceptV2)
+	// Fallback to V2 and V1 in that order if V2Local is not recognized.
+	req.Header.Add("Accept", discovery.AcceptV2NoPeer+","+discovery.AcceptV2+","+discovery.AcceptV1)
 
 	writer := responsewriterutil.NewInMemoryResponseWriter()
 	h.proxyRequestToDestinationAPIServer(req, writer, hostport)
@@ -179,8 +221,8 @@ func (h *peerProxyHandler) aggregateDiscovery(ctx context.Context, path string, 
 	return parsed, nil
 }
 
-// handleErr checks if an error happened and makes sure we will retry later.
-func (h *peerProxyHandler) handleErr(err error, key string) {
+// handleSyncPeerDiscoveryCacheErr checks if an error happened during peer discovery sync and makes sure we will retry later.
+func (h *peerProxyHandler) handleSyncPeerDiscoveryCacheErr(err error, key string) {
 	if err == nil {
 		h.peerLeaseQueue.Forget(key)
 		return
@@ -195,4 +237,75 @@ func (h *peerProxyHandler) handleErr(err error, key string) {
 	h.peerLeaseQueue.Forget(key)
 	utilruntime.HandleError(err)
 	klog.Infof("Dropping lease %s out of the queue: %v", key, err)
+}
+
+func (h *peerProxyHandler) isValidPeerIdentityLease(obj interface{}) (*v1.Lease, bool) {
+	lease, ok := obj.(*v1.Lease)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
+			return nil, false
+		}
+		if lease, ok = tombstone.Obj.(*v1.Lease); !ok {
+			utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
+			return nil, false
+		}
+	}
+
+	if lease == nil {
+		klog.Error(fmt.Errorf("nil lease object provided"))
+		return nil, false
+	}
+
+	if h.identityLeaseLabelSelector != nil && h.identityLeaseLabelSelector.String() != "" {
+		identityLeaseLabel := strings.Split(h.identityLeaseLabelSelector.String(), "=")
+		if len(identityLeaseLabel) != 2 {
+			klog.Errorf("invalid identityLeaseLabelSelector format: %s", h.identityLeaseLabelSelector.String())
+			return nil, false
+		}
+
+		if lease.Labels == nil || lease.Labels[identityLeaseLabel[0]] != identityLeaseLabel[1] {
+			klog.V(4).Infof("lease %s/%s does not match label selector: %s=%s", lease.Namespace, lease.Name, identityLeaseLabel[0], identityLeaseLabel[1])
+			return nil, false
+		}
+
+	}
+
+	// Ignore self.
+	if lease.Name == h.serverID {
+		return nil, false
+	}
+
+	if lease.Spec.HolderIdentity == nil {
+		klog.Error(fmt.Errorf("invalid lease object provided, missing holderIdentity in lease obj"))
+		return nil, false
+	}
+
+	return lease, true
+}
+
+func (h *peerProxyHandler) findServiceableByPeerFromPeerDiscoveryCache(gvr schema.GroupVersionResource) []string {
+	var serviceableByIDs []string
+	cache := h.peerDiscoveryInfoCache.Load()
+	if cache == nil {
+		return serviceableByIDs
+	}
+
+	cacheMap, ok := cache.(map[string]PeerDiscoveryCacheEntry)
+	if !ok {
+		klog.Warning("Invalid cache type in peerDiscoveryInfoCache")
+		return serviceableByIDs
+	}
+
+	for peerID, peerData := range cacheMap {
+		// Ignore local apiserver.
+		if peerID == h.serverID {
+			continue
+		}
+		if _, exists := peerData.GVRs[gvr]; exists {
+			serviceableByIDs = append(serviceableByIDs, peerID)
+		}
+	}
+	return serviceableByIDs
 }

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -60,11 +60,13 @@ const (
 	defaultBurst = 300
 
 	AcceptV1 = runtime.ContentTypeJSON
+	AcceptV1 = runtime.ContentTypeJSON
 	// Aggregated discovery content-type (v2beta1). NOTE: content-type parameters
 	// MUST be ordered (g, v, as) for server in "Accept" header (BUT we are resilient
 	// to ordering when comparing returned values in "Content-Type" header).
-	AcceptV2Beta1 = runtime.ContentTypeJSON + ";" + "g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList"
-	AcceptV2      = runtime.ContentTypeJSON + ";" + "g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList"
+	AcceptV2Beta1  = runtime.ContentTypeJSON + ";" + "g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList"
+	AcceptV2       = runtime.ContentTypeJSON + ";" + "g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList"
+	AcceptV2NoPeer = runtime.ContentTypeJSON + ";" + "g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList;profile=nopeer"
 	// Prioritize aggregated discovery by placing first in the order of discovery accept types.
 	acceptDiscoveryFormats = AcceptV2 + "," + AcceptV2Beta1 + "," + AcceptV1
 )
@@ -168,6 +170,11 @@ type DiscoveryClient struct {
 	LegacyPrefix string
 	// Forces the client to request only "unaggregated" (legacy) discovery.
 	UseLegacyDiscovery bool
+	// NoPeerDiscovery will request the "nopeer" profile of aggregated discovery.
+	// This allows a client to get just the discovery documents served by the single apiserver
+	// that it is talking to. This is useful for clients that need to understand the state
+	// of a single apiserver, for example, to validate that the apiserver is ready to serve traffic.
+	NoPeerDiscovery bool
 }
 
 var _ AggregatedDiscoveryInterface = &DiscoveryClient{}
@@ -241,10 +248,7 @@ func (d *DiscoveryClient) downloadLegacy() (
 	map[schema.GroupVersion]*metav1.APIResourceList,
 	map[schema.GroupVersion]error,
 	error) {
-	accept := acceptDiscoveryFormats
-	if d.UseLegacyDiscovery {
-		accept = AcceptV1
-	}
+	accept := selectDiscoveryAcceptHeader(d.UseLegacyDiscovery, d.NoPeerDiscovery)
 	var responseContentType string
 	body, err := d.restClient.Get().
 		AbsPath("/api").
@@ -307,10 +311,7 @@ func (d *DiscoveryClient) downloadAPIs() (
 	map[schema.GroupVersion]*metav1.APIResourceList,
 	map[schema.GroupVersion]error,
 	error) {
-	accept := acceptDiscoveryFormats
-	if d.UseLegacyDiscovery {
-		accept = AcceptV1
-	}
+	accept := selectDiscoveryAcceptHeader(d.UseLegacyDiscovery, d.NoPeerDiscovery)
 	var responseContentType string
 	body, err := d.restClient.Get().
 		AbsPath("/apis").
@@ -349,6 +350,16 @@ func (d *DiscoveryClient) downloadAPIs() (
 	}
 
 	return apiGroupList, resourcesByGV, failedGVs, nil
+}
+
+func selectDiscoveryAcceptHeader(useLegacy, nopeer bool) string {
+	if useLegacy {
+		return AcceptV1
+	}
+	if nopeer {
+		return AcceptV2NoPeer + "," + acceptDiscoveryFormats
+	}
+	return acceptDiscoveryFormats
 }
 
 // ContentTypeIsGVK checks of the content-type string is both

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -60,7 +60,6 @@ const (
 	defaultBurst = 300
 
 	AcceptV1 = runtime.ContentTypeJSON
-	AcceptV1 = runtime.ContentTypeJSON
 	// Aggregated discovery content-type (v2beta1). NOTE: content-type parameters
 	// MUST be ordered (g, v, as) for server in "Accept" header (BUT we are resilient
 	// to ordering when comparing returned values in "Content-Type" header).

--- a/test/integration/apiserver/discovery/peer_agg_discovery_test.go
+++ b/test/integration/apiserver/discovery/peer_agg_discovery_test.go
@@ -1,0 +1,386 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/test/integration/framework"
+
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	testutil "k8s.io/kubernetes/test/utils"
+)
+
+func TestPeerAggregatedDiscovery(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Enable feature gates for peer-aggregated discovery and peer proxy.
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.APIServerIdentity, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.UnknownVersionInteroperabilityProxy, true)
+
+	// Create shared etcd.
+	etcd := framework.SharedEtcd()
+
+	// Create certificates for aggregation and client-cert auth.
+	proxyCA, err := createProxyCertContent()
+	require.NoError(t, err)
+
+	// Start two API servers with different API configurations.
+	server.SetHostnameFuncForTests("test-server-a")
+	serverA := kubeapiservertesting.StartTestServerOrDie(t, &kubeapiservertesting.TestServerInstanceOptions{
+		EnableCertAuth: true,
+		ProxyCA:        &proxyCA,
+	}, []string{
+		"--runtime-config=apps/v1=false",
+	}, etcd)
+	t.Cleanup(serverA.TearDownFn)
+	clientA, err := kubernetes.NewForConfig(serverA.ClientConfig)
+	require.NoError(t, err)
+
+	server.SetHostnameFuncForTests("test-server-b")
+	serverB := kubeapiservertesting.StartTestServerOrDie(t, &kubeapiservertesting.TestServerInstanceOptions{
+		EnableCertAuth: true,
+		ProxyCA:        &proxyCA,
+	}, []string{
+		"--runtime-config=batch/v1=false",
+	}, etcd)
+	t.Cleanup(serverB.TearDownFn)
+
+	clientB, err := kubernetes.NewForConfig(serverB.ClientConfig)
+	require.NoError(t, err)
+
+	t.Run("CheckIdentityLeases", func(t *testing.T) {
+		// Check for identity leases in the kube-system namespace
+		leases, err := clientA.CoordinationV1().Leases("kube-system").List(ctx, metav1.ListOptions{
+			LabelSelector: "apiserver.kubernetes.io/identity=kube-apiserver",
+		})
+		if err != nil {
+			t.Logf("Failed to list identity leases: %v", err)
+		} else {
+			t.Logf("Found %d identity leases:", len(leases.Items))
+		}
+	})
+
+	t.Run("NoPeerDiscoveryWorks", func(t *testing.T) {
+		testNoPeerDiscovery(t, ctx, clientA, clientB)
+	})
+
+	t.Run("PeerAggregatedDiscoveryEndpoint", func(t *testing.T) {
+		testPeerAggregatedDiscoveryEndpoint(t, ctx, clientA, clientB)
+	})
+}
+
+func TestPeerAggregatedDiscoveryWithCRD(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Enable feature gates for peer-aggregated discovery and peer proxy.
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.APIServerIdentity, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.UnknownVersionInteroperabilityProxy, true)
+
+	// Create shared etcd.
+	etcd := framework.SharedEtcd()
+
+	// Create certificates for aggregation and client-cert auth.
+	proxyCA, err := createProxyCertContent()
+	require.NoError(t, err)
+
+	// Start two API servers with different API configurations.
+	server.SetHostnameFuncForTests("test-server-a")
+	serverA := kubeapiservertesting.StartTestServerOrDie(t, &kubeapiservertesting.TestServerInstanceOptions{
+		EnableCertAuth: true,
+		ProxyCA:        &proxyCA,
+	}, []string{
+		"--runtime-config=apps/v1=false",
+	}, etcd)
+	t.Cleanup(serverA.TearDownFn)
+	clientA, err := kubernetes.NewForConfig(serverA.ClientConfig)
+	require.NoError(t, err)
+	crdClientA, err := apiextensionsclient.NewForConfig(serverA.ClientConfig)
+	require.NoError(t, err)
+
+	server.SetHostnameFuncForTests("test-server-b")
+	serverB := kubeapiservertesting.StartTestServerOrDie(t, &kubeapiservertesting.TestServerInstanceOptions{
+		EnableCertAuth: true,
+		ProxyCA:        &proxyCA,
+	}, []string{
+		"--runtime-config=batch/v1=false",
+	}, etcd)
+	t.Cleanup(serverB.TearDownFn)
+
+	clientB, err := kubernetes.NewForConfig(serverB.ClientConfig)
+	require.NoError(t, err)
+	_, err = apiextensionsclient.NewForConfig(serverB.ClientConfig)
+	require.NoError(t, err)
+
+	// Create a new CRD in serverA
+	crdName := "foos.example.com"
+	crdSpec := makeCRDSpec("example.com", "Foo", false, []string{"v1"})
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: crdSpec,
+	}
+	_, err = crdClientA.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create CRD %s", crdName)
+
+	// Wait for peer-aggregated discovery to reflect the new group on both servers
+	for _, tc := range []struct {
+		name   string
+		client kubernetes.Interface
+	}{
+		{"serverA", clientA},
+		{"serverB", clientB},
+	} {
+		t.Run(tc.name+"_peeragg_with_crd", func(t *testing.T) {
+			testClientSet := testClientSet{kubeClientSet: tc.client}
+			testCtx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+			defer cancel()
+
+			err := WaitForPeerAggregatedDiscoveryWithCondition(testCtx, testClientSet, func(result apidiscoveryv2.APIGroupDiscoveryList) bool {
+				for _, group := range result.Items {
+					if group.Name == "example.com" {
+						return true
+					}
+				}
+				return false
+			})
+			require.NoError(t, err, "Peer-aggregated discovery did not show CRD group on %s", tc.name)
+			t.Logf("Peer-aggregated discovery on %s contains CRD group example.com", tc.name)
+		})
+	}
+
+	// Now delete the CRD and verify it gets removed from peer-aggregated discovery
+	t.Log("Deleting CRD from serverA...")
+	err = crdClientA.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crdName, metav1.DeleteOptions{})
+	require.NoError(t, err, "Failed to delete CRD %s", crdName)
+
+	// Wait for peer-aggregated discovery to reflect the deletion on both servers
+	// The CRD should be excluded from local discovery and therefore should NOT appear
+	// in peer-aggregated discovery from ANY peer.
+	for _, tc := range []struct {
+		name   string
+		client kubernetes.Interface
+	}{
+		{"serverA", clientA},
+		{"serverB", clientB},
+	} {
+		t.Run(tc.name+"_peeragg_without_crd", func(t *testing.T) {
+			testClientSet := testClientSet{kubeClientSet: tc.client}
+			testCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+			defer cancel()
+
+			// Wait for the CRD group to be removed from peer-aggregated discovery
+			// This validates:
+			// 1. The exclusion filter properly removes the CRD from local server's discovery
+			// 2. The grace period mechanism works (waits for peers to also see the deletion)
+			// 3. The peer-aggregated discovery doesn't show stale CRD data from any peer
+			err := WaitForPeerAggregatedDiscoveryWithCondition(testCtx, testClientSet, func(result apidiscoveryv2.APIGroupDiscoveryList) bool {
+				for _, group := range result.Items {
+					if group.Name == "example.com" {
+						// Still finding the group - not yet removed
+						return false
+					}
+				}
+				// Group not found - successfully removed
+				return true
+			})
+			require.NoError(t, err, "Peer-aggregated discovery should not show deleted CRD group on %s", tc.name)
+			t.Logf("Peer-aggregated discovery on %s correctly removed CRD group example.com after deletion", tc.name)
+		})
+	}
+
+	// Additionally verify that no-peer discovery also doesn't show the CRD
+	// This ensures the CRD is truly removed and not just filtered from peer-aggregated discovery
+	for _, tc := range []struct {
+		name   string
+		client kubernetes.Interface
+	}{
+		{"serverA", clientA},
+		{"serverB", clientB},
+	} {
+		t.Run(tc.name+"_nopeer_without_crd", func(t *testing.T) {
+			testClientSet := testClientSet{kubeClientSet: tc.client}
+
+			result, err := FetchNoPeerDiscovery(ctx, testClientSet)
+			require.NoError(t, err, "Should be able to fetch no-peer discovery from %s", tc.name)
+
+			hasCRDGroup := false
+			for _, group := range result.Items {
+				if group.Name == "example.com" {
+					hasCRDGroup = true
+					break
+				}
+			}
+			require.False(t, hasCRDGroup, "%s should NOT have example.com in no-peer discovery after CRD deletion", tc.name)
+			t.Logf("No-peer discovery on %s correctly does not show deleted CRD group", tc.name)
+		})
+	}
+}
+
+func testNoPeerDiscovery(t *testing.T, ctx context.Context, clientA, clientB kubernetes.Interface) {
+	testClientA := testClientSet{kubeClientSet: clientA}
+	testClientB := testClientSet{kubeClientSet: clientB}
+
+	// Verify serverA does NOT have apps/v1 in no-peer discovery (disabled via runtime-config)
+	resultA, err := FetchNoPeerDiscovery(ctx, testClientA)
+	require.NoError(t, err, "Should be able to fetch no-peer discovery from serverA")
+
+	hasAppsV1InA := false
+	for _, group := range resultA.Items {
+		if group.Name == "apps" {
+			for _, version := range group.Versions {
+				if version.Version == "v1" {
+					hasAppsV1InA = true
+					break
+				}
+			}
+		}
+	}
+	require.False(t, hasAppsV1InA, "ServerA should NOT have apps/v1 in no-peer discovery (disabled via runtime-config)")
+
+	// Verify serverB does NOT have batch/v1 in no-peer discovery (disabled via runtime-config)
+	resultB, err := FetchNoPeerDiscovery(ctx, testClientB)
+	require.NoError(t, err, "Should be able to fetch no-peer discovery from serverB")
+
+	hasBatchV1InB := false
+	for _, group := range resultB.Items {
+		if group.Name == "batch" {
+			for _, version := range group.Versions {
+				if version.Version == "v1" {
+					hasBatchV1InB = true
+					break
+				}
+			}
+		}
+	}
+	require.False(t, hasBatchV1InB, "ServerB should NOT have batch/v1 in no-peer discovery (disabled via runtime-config)")
+
+	// Verify serverA HAS batch/v1 in no-peer discovery (should be enabled by default)
+	hasBatchV1InA := false
+	var foundGroupsA []string
+	for _, group := range resultA.Items {
+		foundGroupsA = append(foundGroupsA, group.Name)
+		if group.Name == "batch" {
+			for _, version := range group.Versions {
+				if version.Version == "v1" {
+					hasBatchV1InA = true
+					break
+				}
+			}
+		}
+	}
+	t.Logf("ServerA no-peer discovery has groups: %v", foundGroupsA)
+	require.True(t, hasBatchV1InA, "ServerA should have batch/v1 in no-peer discovery (enabled by default)")
+
+	// Verify serverB HAS apps/v1 in no-peer discovery (should be enabled by default)
+	hasAppsV1InB := false
+	var foundGroupsB []string
+	for _, group := range resultB.Items {
+		foundGroupsB = append(foundGroupsB, group.Name)
+		if group.Name == "apps" {
+			for _, version := range group.Versions {
+				if version.Version == "v1" {
+					hasAppsV1InB = true
+					break
+				}
+			}
+		}
+	}
+	t.Logf("ServerB no-peer discovery has groups: %v", foundGroupsB)
+	require.True(t, hasAppsV1InB, "ServerB should have apps/v1 in no-peer discovery (enabled by default)")
+
+	t.Log("No-peer discovery validation complete:")
+	t.Log("  ServerA: has batch/v1, missing apps/v1 ✓")
+	t.Log("  ServerB: has apps/v1, missing batch/v1 ✓")
+}
+
+func testPeerAggregatedDiscoveryEndpoint(t *testing.T, ctx context.Context, clientA, clientB kubernetes.Interface) {
+	testCases := []struct {
+		name   string
+		client kubernetes.Interface
+	}{
+		{"serverA", clientA},
+		{"serverB", clientB},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s_peer_aggregated_discovery", tc.name), func(t *testing.T) {
+			testClientSet := testClientSet{kubeClientSet: tc.client}
+			testCtx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+			defer cancel()
+
+			// Wait for peer-aggregated discovery to contain both apps and batch groups.
+			err := WaitForPeerAggregatedDiscoveryWithCondition(testCtx, testClientSet, func(result apidiscoveryv2.APIGroupDiscoveryList) bool {
+				hasApps, hasBatch := false, false
+
+				for _, group := range result.Items {
+					if group.Name == "apps" {
+						hasApps = true
+					}
+					if group.Name == "batch" {
+						hasBatch = true
+					}
+				}
+
+				return hasApps && hasBatch
+			})
+
+			if err != nil {
+				t.Logf("Failed to get expected groups from %s after: %v", tc.name, err)
+			}
+
+			require.NoError(t, err, "Failed to get expected groups from %s within timeout", tc.name)
+			t.Logf("Successfully validated %s peer-aggregated discovery contains both apps and batch groups", tc.name)
+		})
+	}
+}
+
+func createProxyCertContent() (kubeapiservertesting.ProxyCA, error) {
+	result := kubeapiservertesting.ProxyCA{}
+	proxySigningKey, err := testutil.NewPrivateKey()
+	if err != nil {
+		return result, err
+	}
+	proxySigningCert, err := cert.NewSelfSignedCACert(cert.Config{CommonName: "front-proxy-ca"}, proxySigningKey)
+	if err != nil {
+		return result, err
+	}
+
+	result = kubeapiservertesting.ProxyCA{
+		ProxySigningCert: proxySigningCert,
+		ProxySigningKey:  proxySigningKey,
+	}
+	return result, nil
+}

--- a/test/integration/apiserver/peerproxy/peer_proxy_test.go
+++ b/test/integration/apiserver/peerproxy/peer_proxy_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/klog/v2"
 	kastesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
-	kubefeatures "k8s.io/kubernetes/pkg/features"
 
 	"k8s.io/kubernetes/test/integration/framework"
 	testutil "k8s.io/kubernetes/test/utils"
@@ -57,8 +56,8 @@ func TestPeerProxiedRequest(t *testing.T) {
 
 	// enable feature flags
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.APIServerIdentity:                       true,
-		kubefeatures.UnknownVersionInteroperabilityProxy: true,
+		features.APIServerIdentity:                   true,
+		features.UnknownVersionInteroperabilityProxy: true,
 	})
 
 	// create sharedetcd
@@ -120,8 +119,8 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 
 	// enable feature flags
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.APIServerIdentity:                       true,
-		kubefeatures.UnknownVersionInteroperabilityProxy: true,
+		features.APIServerIdentity:                   true,
+		features.UnknownVersionInteroperabilityProxy: true,
 	})
 
 	// create sharedetcd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Modifies agg-discovery response to include  resources served by all apiservers in an HA cluster if UnknownVersionInteroperabilityProxy feature gate is enabled. Also accepts a `profile=nopeer` Accept header to request the non peer-aggregated (local only) view of discovery.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/enhancements/issues/4020

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enhanced discovery response to support merged API groups/resources from all peer apiservers when UnknownVersionInteroperabilityProxy feature is enabled
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
