### PR TITLE
Fix kubelet certificate reload when connecting by IP address

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -920,6 +920,13 @@ func NewMainKubelet(ctx context.Context,
 				}
 				return cert, nil
 			}
+
+			// GetCertificate is only preferred over the certificate files by
+			// Golang TLS if the ClientHelloInfo.ServerName is set, which it is
+			// not when connecting to a host by IP address. Clear the files to
+			// force the use of GetCertificate.
+			kubeDeps.TLSOptions.CertFile = ""
+			kubeDeps.TLSOptions.KeyFile = ""
 		}
 	}
 

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -194,9 +194,6 @@ func ListenAndServeKubeletServer(
 
 	if tlsOptions != nil {
 		s.TLSConfig = tlsOptions.Config
-		// Passing empty strings as the cert and key files means no
-		// cert/keys are specified and GetCertificate in the TLSConfig
-		// should be called instead.
 		if err := s.ListenAndServeTLS(tlsOptions.CertFile, tlsOptions.KeyFile); err != nil {
 			logger.Error(err, "Failed to listen and serve")
 			os.Exit(1)

--- a/test/e2e_node/kubelet_tls_test.go
+++ b/test/e2e_node/kubelet_tls_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/pkg/cluster/ports"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func createCertAndKeyFiles(certDir string) (string, string, error) {
+	cert, key, err := cert.GenerateSelfSignedCertKey(
+		"localhost",
+		[]net.IP{{127, 0, 0, 1}},
+		[]string{"localhost"},
+	)
+	if err != nil {
+		return "", "", nil
+	}
+
+	certPath := filepath.Join(certDir, "kubelet.cert")
+	keyPath := filepath.Join(certDir, "kubelet.key")
+	if err = os.WriteFile(certPath, cert, os.FileMode(0644)); err != nil {
+		return "", "", err
+	}
+
+	if err = os.WriteFile(keyPath, key, os.FileMode(0600)); err != nil {
+		return "", "", err
+	}
+
+	return certPath, keyPath, nil
+}
+
+func getCert(addr string) (*x509.Certificate, error) {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	return conn.ConnectionState().PeerCertificates[0], nil
+}
+
+var _ = SIGDescribe("KubletTLS", framework.WithSerial(), framework.WithNodeConformance(), func() {
+	f := framework.NewDefaultFramework("kubelet-tls-test")
+
+	ginkgo.Context("certificate reload", func() {
+		var tempDir string
+
+		t := ginkgo.GinkgoT()
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			tempDir = t.TempDir()
+			cfg, err := getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func(ctx context.Context, cfg *kubeletconfig.KubeletConfiguration) {
+				updateKubeletConfig(ctx, f, cfg, true)
+			}, cfg.DeepCopy())
+
+			certPath, keyPath, err := createCertAndKeyFiles(tempDir)
+			framework.ExpectNoError(err)
+
+			cfg.TLSCertFile = certPath
+			cfg.TLSPrivateKeyFile = keyPath
+			updateKubeletConfig(ctx, f, cfg, true)
+		})
+
+		ginkgo.It("should reload certificates from disk", func(ctx context.Context) {
+			addr := fmt.Sprintf("127.0.0.1:%d", ports.KubeletPort)
+			oldCert, err := getCert(addr)
+			framework.ExpectNoError(err)
+
+			_, _, err = createCertAndKeyFiles(tempDir)
+			framework.ExpectNoError(err)
+
+			gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
+				newCert, err := getCert(addr)
+				if err != nil {
+					return true, err
+				}
+
+				return newCert.Equal(oldCert), nil
+			}).Should(gomega.BeFalseBecause("new certificate should be loaded"))
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

Note the issue is tagged as a feature, but certificate reloading for the kubelet was previously added in #124574, so I think this is better described as a bug.

#### What this PR does / why we need it:

Currently, the certificate reloading functions from the `ReloadKubeletServerCertificateFile` are not called. A clearer description is in [this issue comment](https://github.com/kubernetes/kubernetes/issues/133001#issuecomment-3209843823), but the summary is that `http.Server` does not call `GetCertificate` if certificate paths were passed to `ListenAndServeTLS` and the client connects by IP (and therefore does not use SNI).

#### Which issue(s) this PR is related to:

Fixes #133001 

#### Special notes for your reviewer:

I'm struggling to find a good way to test for the presence/absence of this bug, because `ListenAndServeKubeletServer` calls `os.Exit(1)` if the HTTPS server exits. There is also no easy way to shutdown the HTTPS server, or to pick a random port to serve on (for parallel testing).

I'm happy to refactor this code to allow testing, but would like to get a maintainer/reviewer's opinion on how to best do this - should it be an e2e test, or I change the function to `CreateKubeletServer`, and return the server for testing?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: fixed reloading of kubelet server certificate files when they are changed on disk, and kubelet is dialed by IP address instead of DNS/hostname
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A