### PR TITLE
Check for empty logsPath in container logs manager.

### DIFF
--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -167,7 +167,13 @@ func (c *containerLogManager) Clean(ctx context.Context, containerID string) err
 	if resp.GetStatus() == nil {
 		return fmt.Errorf("container status is nil for %q", containerID)
 	}
-	pattern := fmt.Sprintf("%s*", resp.GetStatus().GetLogPath())
+
+	logPath := resp.GetStatus().GetLogPath()
+	if logPath == "" || logPath == "/" {
+		return fmt.Errorf("invalid container logs path for %q: %q", containerID, logPath)
+	}
+
+	pattern := fmt.Sprintf("%s*", logPath)
 	logs, err := c.osInterface.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("failed to list all log files with pattern %q: %w", pattern, err)


### PR DESCRIPTION
#### What this PR does / why we need it:

If a bug or misconfiguration caused the container runtime to return a container with an empty logsPath, container logs manager will try to nuke the host root filesystem.

Obviously that's dangerous. Check for obviously bad paths and refuse to delete them.

A potential extension to this change could be refuse any log paths that Kubelet did not set (eg: /var/log/containers).

/kind bug


#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

```release-note
NONE
```
