### PR TITLE
DRA: Avoid unnecessary work in allocator

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator_test.go
@@ -18,6 +18,7 @@ package structured
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	resourceapi "k8s.io/api/resource/v1"
@@ -37,6 +38,16 @@ func TestAllocator(t *testing.T) {
 			slices []*resourceapi.ResourceSlice,
 			celCache *cel.Cache,
 		) (allocatortesting.Allocator, error) {
-			return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
+			allocator, err := NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
+			if err != nil {
+				return nil, err
+			}
+			// Return the allocator with the internal interface so the tests can
+			// check the channel for the allocator.
+			internalAllocator, ok := allocator.(internal.Allocator)
+			if !ok {
+				return nil, fmt.Errorf("allocator doesn't implement internal interface")
+			}
+			return internalAllocator, nil
 		})
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -84,6 +84,7 @@ const (
 	req1SubReq0 = "req-1/subReq-0"
 	req1SubReq1 = "req-1/subReq-1"
 	req2SubReq0 = "req-2/subReq-0"
+	req2SubReq1 = "req-2/subReq-1"
 	claim0      = "claim-0"
 	claim1      = "claim-1"
 	slice1      = "slice-1"
@@ -963,6 +964,15 @@ func TestAllocator(t *testing.T,
 		// Test case setting expectNumAllocateOneInvocations do not run against the "stable" variant of the allocator,
 		// which doesn't provide the stats and also falls over with excessive runtime for them.
 		expectNumAllocateOneInvocations int64
+
+		// expectNumAllocateOneInvocationsByChannel overrides expectNumAllocateOneInvocations with
+		// different values for specific implementations (e.g. "experimental").
+		//
+		// Ignored unless expectNumAllocateOneInvocations is also set.
+		// expectNumAllocateOneInvocations should contain the "best" result, so
+		// expectNumAllocateOneInvocationsByChannel is only needed as long as we have "worse"
+		// implementations.
+		expectNumAllocateOneInvocationsByChannel map[internal.AllocatorChannel]int64
 	}{
 
 		"empty": {},
@@ -6014,6 +6024,252 @@ func TestAllocator(t *testing.T,
 			),
 			node: node(node1, region1),
 		},
+		"check-combinations-within-single-request-single-pool-single-slice": {
+			claimsToAllocate: objects(claimWithRequests(claim0, nil,
+				request(req0, classA, 5),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, nil),
+				device(device2, nil, nil),
+				device(device3, nil, nil),
+				device(device4, nil, nil),
+			)),
+			node:                            node(node1, region1),
+			expectResults:                   nil,
+			expectNumAllocateOneInvocations: 16,
+			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
+				internal.Incubating: 65,
+			},
+		},
+		"check-combinations-within-single-request-single-pool-multiple-slices": {
+			claimsToAllocate: objects(claimWithRequests(claim0, nil,
+				request(req0, classA, 5),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+					device(device2, nil, nil),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device3, nil, nil),
+					device(device4, nil, nil),
+				),
+			),
+			node:                            node(node1, region1),
+			expectResults:                   nil,
+			expectNumAllocateOneInvocations: 16,
+			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
+				internal.Incubating: 65,
+			},
+		},
+		"check-combinations-within-single-request-multiple-pools-multiple-slices": {
+			claimsToAllocate: objects(claimWithRequests(claim0, nil,
+				request(req0, classA, 5),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device2, nil, nil),
+				),
+				sliceWithDevices(slice3, node1, pool2, driverA,
+					device(device3, nil, nil),
+					device(device4, nil, nil),
+				),
+			),
+			node:                            node(node1, region1),
+			expectResults:                   nil,
+			expectNumAllocateOneInvocations: 16,
+			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
+				internal.Incubating: 65,
+			},
+		},
+		"check-combinations-within-single-request-many-pools": {
+			claimsToAllocate: objects(claimWithRequests(claim0, nil,
+				request(req0, classA, 5),
+			)),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice2, node1, pool2, driverA,
+					device(device2, nil, nil),
+				),
+				sliceWithDevices(slice3, node1, pool3, driverA,
+					device(device3, nil, nil),
+				),
+				sliceWithDevices(slice4, node1, pool4, driverA,
+					device(device4, nil, nil),
+				),
+			),
+			node:                            node(node1, region1),
+			expectResults:                   nil,
+			expectNumAllocateOneInvocations: 16,
+			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
+				internal.Incubating: 65,
+			},
+		},
+		"check-combinations-with-backtracking": {
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				nil,
+				// req-1 needs two generic devices.
+				request(req1, classA, 2),
+				// req-2 needs a specific device.
+				request(req2, classA, 1, resourceapi.DeviceSelector{
+					CEL: &resourceapi.CELDeviceSelector{
+						Expression: fmt.Sprintf(`device.attributes["%s"].type == "X"`, driverA),
+					},
+				}),
+			)),
+			classes: objects(class(classA, driverA)),
+			// The order of devices is chosen such that the allocator
+			// will initially pick {device1, device2} for req1. This will fail
+			// because req-2 needs device1. The allocator has to
+			// backtrack. The correct solution is {device2, device3} for req-1
+			// and {device1} for req-2. The optimized allocator avoids
+			// testing {device2, device1} for req-1 and thus finds the solution
+			// faster.
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"type": {StringValue: ptr.To("X")},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"type": {StringValue: ptr.To("Y")},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"type": {StringValue: ptr.To("Y")},
+				}),
+			)),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req1, driverA, pool1, device2, false),
+				deviceAllocationResult(req1, driverA, pool1, device3, false),
+				deviceAllocationResult(req2, driverA, pool1, device1, false),
+			)},
+			expectNumAllocateOneInvocations: 12,
+			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
+				internal.Incubating: 14,
+			},
+		},
+		"check-combinations-with-backtracking-across-slices-and-pools": {
+			features: Features{
+				DeviceBindingAndStatus: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				nil,
+				// req-1 needs two generic devices.
+				request(req1, classA, 2),
+				// req-2 needs a specific device.
+				request(req2, classA, 1, resourceapi.DeviceSelector{
+					CEL: &resourceapi.CELDeviceSelector{
+						Expression: fmt.Sprintf(`device.attributes["%s"].type == "X"`, driverA),
+					},
+				}),
+			)),
+			classes: objects(class(classA, driverA)),
+			// The order of devices is chosen such that the allocator
+			// will initially pick {device1, device2} for req1. This will fail
+			// because req-2 needs device1. The allocator has to
+			// backtrack. The correct solution is {device2, device3} for req-1
+			// and {device1} for req-2. The optimized allocator avoids
+			// testing {device2, device1} for req-1 and thus finds the solution
+			// faster.
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"type": {StringValue: ptr.To("X")},
+					}),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"type": {StringValue: ptr.To("Y")},
+					}),
+				),
+				// Use a binding condition here to make sure pool2 is searched after pool1 when
+				// trying to allocate devices. This makes sure we see the same results every time.
+				sliceWithDevices(slice3, node1, pool2, driverA,
+					device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"type": {StringValue: ptr.To("Y")},
+					}).withBindingConditions([]string{"IsPrepare"}, []string{}),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req1, driverA, pool1, device2, false),
+				deviceRequestAllocationResultWithBindingConditions(req1, driverA, pool2, device3, []string{"IsPrepare"}, []string{}),
+				deviceAllocationResult(req2, driverA, pool1, device1, false),
+			)},
+			expectNumAllocateOneInvocations: 12,
+			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
+				internal.Incubating: 14,
+			},
+		},
+		"check-combinations-with-prioritized-list": {
+			features: Features{
+				PrioritizedList: true,
+			},
+			claimsToAllocate: objects(claim(claim0).withRequests(
+				// The first alternative can't be satisfied since there aren't enough devices
+				// of type Y, but the allocator will try all devices before finding out.
+				requestWithPrioritizedList(req1,
+					subRequest(subReq0, classA, 3, resourceapi.DeviceSelector{
+						CEL: &resourceapi.CELDeviceSelector{
+							Expression: fmt.Sprintf(`device.attributes["%s"].type == "Y"`, driverA),
+						},
+					}),
+					subRequest(subReq1, classA, 2),
+				),
+				// The first subrequest asks for too many devices, so the second
+				// have to be chosen.
+				requestWithPrioritizedList(req2,
+					subRequest(subReq0, classA, 2),
+					subRequest(subReq1, classA, 1, resourceapi.DeviceSelector{
+						CEL: &resourceapi.CELDeviceSelector{
+							Expression: fmt.Sprintf(`device.attributes["%s"].type == "X"`, driverA),
+						},
+					}),
+				),
+			)),
+			classes: objects(class(classA, driverA)),
+			// The order of devices is chosen such that the allocator
+			// will initially pick {device1, device2} for req1. This will fail
+			// because req-2 needs device1. The allocator has to
+			// backtrack. The correct solution is {device2, device3} for req-1
+			// and {device1} for req-2. The optimized allocator avoids
+			// testing {device2, device1} for req-1 and thus finds the solution
+			// faster.
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"type": {StringValue: ptr.To("X")},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"type": {StringValue: ptr.To("Y")},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"type": {StringValue: ptr.To("Y")},
+				}),
+			)),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req1SubReq1, driverA, pool1, device2, false),
+				deviceAllocationResult(req1SubReq1, driverA, pool1, device3, false),
+				deviceAllocationResult(req2SubReq1, driverA, pool1, device1, false),
+			)},
+			expectNumAllocateOneInvocations: 26,
+			expectNumAllocateOneInvocationsByChannel: map[internal.AllocatorChannel]int64{
+				internal.Incubating: 32,
+			},
+		},
 	}
 
 	for name, tc := range testcases {
@@ -6078,9 +6334,12 @@ func TestAllocator(t *testing.T,
 			g.Expect(slices).To(gomega.ConsistOf(tc.slices))
 			g.Expect(classLister.objs).To(gomega.ConsistOf(tc.classes))
 
-			if tc.expectNumAllocateOneInvocations > 0 {
+			if expectNumAllocateOneInvocations := tc.expectNumAllocateOneInvocations; expectNumAllocateOneInvocations > 0 {
 				stats := allocator.(internal.AllocatorExtended).GetStats()
-				g.Expect(stats.NumAllocateOneInvocations).To(gomega.Equal(tc.expectNumAllocateOneInvocations))
+				if override, ok := tc.expectNumAllocateOneInvocationsByChannel[allocator.Channel()]; ok {
+					expectNumAllocateOneInvocations = override
+				}
+				g.Expect(stats.NumAllocateOneInvocations).To(gomega.Equal(expectNumAllocateOneInvocations))
 			}
 		})
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -103,6 +103,10 @@ func NewAllocator(ctx context.Context,
 	}, nil
 }
 
+func (a *Allocator) Channel() internal.AllocatorChannel {
+	return internal.Incubating
+}
+
 func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resourceapi.ResourceClaim) (finalResult []resourceapi.AllocationResult, finalErr error) {
 	alloc := &allocator{
 		Allocator:            a,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -94,6 +94,10 @@ func NewAllocator(ctx context.Context,
 	}, nil
 }
 
+func (a *Allocator) Channel() internal.AllocatorChannel {
+	return internal.Stable
+}
+
 func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resourceapi.ResourceClaim) (finalResult []resourceapi.AllocationResult, finalErr error) {
 	alloc := &allocator{
 		Allocator:            a,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
@@ -41,6 +41,7 @@ type DeviceClassLister interface {
 // This interface is also broader than the public one.
 type Allocator interface {
 	Allocate(ctx context.Context, node *v1.Node, claims []*resourceapi.ResourceClaim) (finalResult []resourceapi.AllocationResult, finalErr error)
+	Channel() AllocatorChannel
 }
 
 // AllocatorExtended is an optional interface. Not all variants implement it.
@@ -56,6 +57,14 @@ type Stats struct {
 	// got called.
 	NumAllocateOneInvocations int64
 }
+
+type AllocatorChannel string
+
+const (
+	Experimental = "experimental"
+	Stable       = "stable"
+	Incubating   = "incubating"
+)
 
 // Features control optional functionality during ResourceClaim allocation.
 // Each entry must correspond to at least one control flow change. Entries can

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -151,7 +151,9 @@ func TestDRA(t *testing.T) {
 			features: map[featuregate.Feature]bool{},
 			f: func(tCtx ktesting.TContext) {
 				tCtx.Run("Pod", func(tCtx ktesting.TContext) { testPod(tCtx, true) })
-				tCtx.Run("FilterTimeout", testFilterTimeout)
+				// Number of devices per slice is chosen so that Filter takes a few seconds:
+				// without a timeout, the test doesn't run too long, but long enough that a short timeout triggers.
+				tCtx.Run("FilterTimeout", func(tCtx ktesting.TContext) { testFilterTimeout(tCtx, 9) })
 			},
 		},
 		"GA": {
@@ -238,6 +240,10 @@ func TestDRA(t *testing.T) {
 				tCtx.Run("EvictClusterWithRule", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, true) })
 				tCtx.Run("EvictClusterWithSlices", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, false) })
 				tCtx.Run("InvalidResourceSlices", testInvalidResourceSlices)
+				// Number of devices per slice is chosen so that Filter takes a few seconds: The allocator
+				// in the experimental channel has an improvement that requires a higher number here than
+				// in the incubating and stable channels.
+				tCtx.Run("FilterTimeout", func(tCtx ktesting.TContext) { testFilterTimeout(tCtx, 20) })
 			},
 		},
 	} {
@@ -511,13 +517,9 @@ func testAdminAccess(tCtx ktesting.TContext, adminAccessEnabled bool) {
 // testFilterTimeout covers the scheduler plugin's filter timeout configuration and behavior.
 //
 // It runs the scheduler with non-standard settings and thus cannot run in parallel.
-func testFilterTimeout(tCtx ktesting.TContext) {
+func testFilterTimeout(tCtx ktesting.TContext, devicesPerSlice int) {
 	namespace := createTestNamespace(tCtx, nil)
 	class, driverName := createTestClass(tCtx, namespace)
-	// Chosen so that Filter takes a few seconds:
-	// without a timeout, the test doesn't run too long,
-	// but long enough that a short timeout triggers.
-	devicesPerSlice := 9
 	deviceNames := make([]string, devicesPerSlice)
 	for i := 0; i < devicesPerSlice; i++ {
 		deviceNames[i] = fmt.Sprintf("dev-%d", i)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds an optimization to the DRA allocator that prevents it from trying all permutations of devices within a single request and instead just tries all combinations. The order of the devices within a request does not matter, so just trying the combinations is sufficient.

#### Which issue(s) this PR is related to:

Related-to: https://github.com/kubernetes/kubernetes/issues/131730

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
