### PR TITLE
Drop unused tests, after KEP-3335 graduated to GA

### DIFF
--- a/pkg/registry/apps/statefulset/strategy_test.go
+++ b/pkg/registry/apps/statefulset/strategy_test.go
@@ -331,15 +331,6 @@ func TestStatefulSetStatusStrategy(t *testing.T) {
 	}
 }
 
-// generateStatefulSetWithMinReadySeconds generates a StatefulSet with min values
-func generateStatefulSetWithMinReadySeconds(minReadySeconds int32) *apps.StatefulSet {
-	return &apps.StatefulSet{
-		Spec: apps.StatefulSetSpec{
-			MinReadySeconds: minReadySeconds,
-		},
-	}
-}
-
 func makeStatefulSetWithMaxUnavailable(maxUnavailable *int) *apps.StatefulSet {
 	rollingUpdate := apps.RollingUpdateStatefulSetStrategy{}
 	if maxUnavailable != nil {
@@ -368,24 +359,6 @@ func TestDropStatefulSetDisabledFields(t *testing.T) {
 		oldSS                *apps.StatefulSet
 		expectedSS           *apps.StatefulSet
 	}{
-		{
-			name:       "set minReadySeconds, no update",
-			ss:         generateStatefulSetWithMinReadySeconds(10),
-			oldSS:      generateStatefulSetWithMinReadySeconds(20),
-			expectedSS: generateStatefulSetWithMinReadySeconds(10),
-		},
-		{
-			name:       "set minReadySeconds, oldSS field set to nil",
-			ss:         generateStatefulSetWithMinReadySeconds(10),
-			oldSS:      nil,
-			expectedSS: generateStatefulSetWithMinReadySeconds(10),
-		},
-		{
-			name:       "set minReadySeconds, oldSS field is set to 0",
-			ss:         generateStatefulSetWithMinReadySeconds(10),
-			oldSS:      generateStatefulSetWithMinReadySeconds(0),
-			expectedSS: generateStatefulSetWithMinReadySeconds(10),
-		},
 		{
 			name:       "MaxUnavailable not enabled, field not used",
 			ss:         makeStatefulSetWithMaxUnavailable(nil),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig apps

#### What this PR does / why we need it:
This drops tests which are not needed since [KEP-3335](https://github.com/kubernetes/enhancements/issues/3335) graduated to GA already in 1.31 (first commit) and [KEP-2599](https://github.com/kubernetes/enhancements/issues/2599) graduated to GA in 1.25.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/3335
KEP: https://github.com/kubernetes/enhancements/issues/2599

#### Special notes for your reviewer:
/assign @janetkuo 
/assign @deads2k 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
