### PR TITLE
Increase port-forward broken connection detection client timeout

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -649,6 +649,10 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 			framework.ExpectNoError(err, "couldn't get http response from port-forward")
 			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "unexpected status code")
 
+			ginkgo.By("Close response body")
+			err = resp.Body.Close()
+			framework.ExpectNoError(err, "couldn't close response body")
+
 			ginkgo.By("Dialing the local port")
 			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cmd.port))
 			framework.ExpectNoError(err, "couldn't connect to port %d", cmd.port)
@@ -673,6 +677,10 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 			resp, err = client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
 			framework.ExpectNoError(err, "couldn't get http response from port-forward")
 			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "unexpected status code")
+
+			ginkgo.By("Close response body")
+			err = resp.Body.Close()
+			framework.ExpectNoError(err, "couldn't close response body")
 		})
 	})
 })

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -641,7 +641,9 @@ var _ = SIGDescribe("Kubectl Port forwarding", func() {
 
 			ginkgo.By("Send a http request to verify port-forward working")
 			client := http.Client{
-				Timeout: 15 * time.Second,
+				// As discussed in https://github.com/kubernetes/kubernetes/pull/133682#issuecomment-3228372990,
+				// 30 second should be sufficient to complete.
+				Timeout: 30 * time.Second,
 			}
 			resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", cmd.port))
 			framework.ExpectNoError(err, "couldn't get http response from port-forward")


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

`kubectl port-forward` command consists of plenty of legs between the client and the container runtime. That makes it difficult to determine the correct timeouts covering all cluster types. 

Consequently, `Kubectl Port forwarding Shutdown client connection while the remote stream is writing data to the port-forward connection port-forward should keep working after detect broken connection` fails intermittently (although it is rare) due to the fact that 15 second timeout is still insufficient for slow clusters to complete the flow. 

This PR increases the timeout of client to 30 seconds. That should have zero effect on the current passing CI jobs but it is supposed to fix it while running on the slow clusters.

It is difficult to say that whether this increase will fix this issue https://github.com/kubernetes/kubernetes/issues/132057 or not, though.

#### Does this PR introduce a user-facing change?
```release-note
None
```