### PR TITLE
Drop StatefulSetAutoDeletePVC after the feature GA-ed in 1.32

### DIFF
--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -229,9 +229,12 @@ type StatefulSetSpec struct {
 	// +optional
 	MinReadySeconds int32
 
-	// PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
-	// the StatefulSet VolumeClaimTemplates. This requires the
-	// StatefulSetAutoDeletePVC feature gate to be enabled, which is beta and default on from 1.27.
+	// persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent
+	// volume claims created from volumeClaimTemplates. By default, all persistent
+	// volume claims are created as needed and retained until manually deleted. This
+	// policy allows the lifecycle to be altered, for example by deleting persistent
+	// volume claims when their stateful set is deleted, or when their pod is scaled
+	// down.
 	// +optional
 	PersistentVolumeClaimRetentionPolicy *StatefulSetPersistentVolumeClaimRetentionPolicy
 

--- a/pkg/apis/apps/v1/defaults.go
+++ b/pkg/apis/apps/v1/defaults.go
@@ -124,16 +124,14 @@ func SetDefaults_StatefulSet(obj *appsv1.StatefulSet) {
 		}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-		if obj.Spec.PersistentVolumeClaimRetentionPolicy == nil {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{}
-		}
-		if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted) == 0 {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted = appsv1.RetainPersistentVolumeClaimRetentionPolicyType
-		}
-		if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled) == 0 {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = appsv1.RetainPersistentVolumeClaimRetentionPolicyType
-		}
+	if obj.Spec.PersistentVolumeClaimRetentionPolicy == nil {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{}
+	}
+	if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted) == 0 {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted = appsv1.RetainPersistentVolumeClaimRetentionPolicyType
+	}
+	if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled) == 0 {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = appsv1.RetainPersistentVolumeClaimRetentionPolicyType
 	}
 
 	if obj.Spec.Replicas == nil {

--- a/pkg/apis/apps/v1beta1/defaults.go
+++ b/pkg/apis/apps/v1beta1/defaults.go
@@ -50,16 +50,14 @@ func SetDefaults_StatefulSet(obj *appsv1beta1.StatefulSet) {
 		}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-		if obj.Spec.PersistentVolumeClaimRetentionPolicy == nil {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy{}
-		}
-		if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted) == 0 {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted = appsv1beta1.RetainPersistentVolumeClaimRetentionPolicyType
-		}
-		if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled) == 0 {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = appsv1beta1.RetainPersistentVolumeClaimRetentionPolicyType
-		}
+	if obj.Spec.PersistentVolumeClaimRetentionPolicy == nil {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy{}
+	}
+	if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted) == 0 {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted = appsv1beta1.RetainPersistentVolumeClaimRetentionPolicyType
+	}
+	if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled) == 0 {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = appsv1beta1.RetainPersistentVolumeClaimRetentionPolicyType
 	}
 
 	if obj.Spec.Replicas == nil {

--- a/pkg/apis/apps/v1beta2/defaults.go
+++ b/pkg/apis/apps/v1beta2/defaults.go
@@ -81,16 +81,14 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 		}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-		if obj.Spec.PersistentVolumeClaimRetentionPolicy == nil {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{}
-		}
-		if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted) == 0 {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted = appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType
-		}
-		if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled) == 0 {
-			obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType
-		}
+	if obj.Spec.PersistentVolumeClaimRetentionPolicy == nil {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy = &appsv1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy{}
+	}
+	if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted) == 0 {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted = appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType
+	}
+	if len(obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled) == 0 {
+		obj.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled = appsv1beta2.RetainPersistentVolumeClaimRetentionPolicyType
 	}
 
 	if obj.Spec.Replicas == nil {

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -30,18 +30,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/version"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
 )
 
@@ -541,81 +537,65 @@ func TestStatefulPodControlClaimsMatchDeletionPolcy(t *testing.T) {
 func TestStatefulPodControlUpdatePodClaimForRetentionPolicy(t *testing.T) {
 	// All the update conditions are tested exhaustively in stateful_set_utils_test. This
 	// tests the wiring from the pod control to that method.
+	_, ctx := ktesting.NewTestContext(t)
+	testCases := []struct {
+		name      string
+		ownerRef  []metav1.OwnerReference
+		expectRef bool
+	}{
+		{
+			name:      "bare PVC",
+			expectRef: true,
+		},
+		{
+			name:      "PVC already controller",
+			ownerRef:  []metav1.OwnerReference{{Controller: ptr.To(true), Name: "foobar"}},
+			expectRef: false,
+		},
+	}
 
-	testFn := func(t *testing.T) {
-		_, ctx := ktesting.NewTestContext(t)
-		testCases := []struct {
-			name      string
-			ownerRef  []metav1.OwnerReference
-			expectRef bool
-		}{
-			{
-				name:      "bare PVC",
-				expectRef: true,
-			},
-			{
-				name:      "PVC already controller",
-				ownerRef:  []metav1.OwnerReference{{Controller: ptr.To(true), Name: "foobar"}},
-				expectRef: false,
-			},
+	for _, tc := range testCases {
+		fakeClient := &fake.Clientset{}
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		claimLister := corelisters.NewPersistentVolumeClaimLister(indexer)
+		fakeClient.AddReactor("update", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
+			update := action.(core.UpdateAction)
+			if err := indexer.Update(update.GetObject()); err != nil {
+				t.Fatalf("could not update index: %v", err)
+			}
+			return true, update.GetObject(), nil
+		})
+		set := newStatefulSet(3)
+		set.GetObjectMeta().SetUID("set-123")
+		pod0 := newStatefulSetPod(set, 0)
+		claims0 := getPersistentVolumeClaims(set, pod0)
+		for k := range claims0 {
+			claim := claims0[k]
+			if tc.ownerRef != nil {
+				claim.SetOwnerReferences(tc.ownerRef)
+			}
+			if err := indexer.Add(&claim); err != nil {
+				t.Errorf("Could not add claim %s: %v", k, err)
+			}
 		}
-
-		for _, tc := range testCases {
-			fakeClient := &fake.Clientset{}
-			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-			claimLister := corelisters.NewPersistentVolumeClaimLister(indexer)
-			fakeClient.AddReactor("update", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
-				update := action.(core.UpdateAction)
-				if err := indexer.Update(update.GetObject()); err != nil {
-					t.Fatalf("could not update index: %v", err)
-				}
-				return true, update.GetObject(), nil
-			})
-			set := newStatefulSet(3)
-			set.GetObjectMeta().SetUID("set-123")
-			pod0 := newStatefulSetPod(set, 0)
-			claims0 := getPersistentVolumeClaims(set, pod0)
-			for k := range claims0 {
-				claim := claims0[k]
-				if tc.ownerRef != nil {
-					claim.SetOwnerReferences(tc.ownerRef)
-				}
-				if err := indexer.Add(&claim); err != nil {
-					t.Errorf("Could not add claim %s: %v", k, err)
-				}
+		control := NewStatefulPodControl(fakeClient, nil, claimLister, &noopRecorder{})
+		set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+			WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
+		}
+		if err := control.UpdatePodClaimForRetentionPolicy(ctx, set, pod0); err != nil {
+			t.Errorf("Unexpected error for UpdatePodClaimForRetentionPolicy (retain), pod0: %v", err)
+		}
+		for k := range claims0 {
+			claim, err := claimLister.PersistentVolumeClaims(claims0[k].Namespace).Get(claims0[k].Name)
+			if err != nil {
+				t.Errorf("Unexpected error getting Claim %s/%s: %v", claim.Namespace, claim.Name, err)
 			}
-			control := NewStatefulPodControl(fakeClient, nil, claimLister, &noopRecorder{})
-			set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
-				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
-				WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
-			}
-			if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-				if err := control.UpdatePodClaimForRetentionPolicy(ctx, set, pod0); err != nil {
-					t.Errorf("Unexpected error for UpdatePodClaimForRetentionPolicy (retain), pod0: %v", err)
-				}
-			}
-			expectRef := tc.expectRef && utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC)
-			for k := range claims0 {
-				claim, err := claimLister.PersistentVolumeClaims(claims0[k].Namespace).Get(claims0[k].Name)
-				if err != nil {
-					t.Errorf("Unexpected error getting Claim %s/%s: %v", claim.Namespace, claim.Name, err)
-				}
-				if hasOwnerRef(claim, set) != expectRef {
-					t.Errorf("%s: Claim %s/%s bad set owner ref", tc.name, claim.Namespace, claim.Name)
-				}
+			if hasOwnerRef(claim, set) != tc.expectRef {
+				t.Errorf("%s: Claim %s/%s bad set owner ref", tc.name, claim.Namespace, claim.Name)
 			}
 		}
 	}
-	t.Run("StatefulSetAutoDeletePVCEnabled", func(t *testing.T) {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, true)
-		testFn(t)
-	})
-	t.Run("StatefulSetAutoDeletePVCDisabled", func(t *testing.T) {
-		// TODO: this will be removed in 1.35
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.31"))
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, false)
-		testFn(t)
-	})
 }
 
 func TestPodClaimIsStale(t *testing.T) {
@@ -730,66 +710,48 @@ func TestPodClaimIsStale(t *testing.T) {
 }
 
 func TestStatefulPodControlRetainDeletionPolicyUpdate(t *testing.T) {
-	testFn := func(t *testing.T) {
-		_, ctx := ktesting.NewTestContext(t)
-		recorder := record.NewFakeRecorder(10)
-		set := newStatefulSet(1)
-		set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
-			WhenDeleted: apps.RetainPersistentVolumeClaimRetentionPolicyType,
-			WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
-		}
-		pod := newStatefulSetPod(set, 0)
-		fakeClient := &fake.Clientset{}
-		podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-		podLister := corelisters.NewPodLister(podIndexer)
-		claimIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-		claimLister := corelisters.NewPersistentVolumeClaimLister(claimIndexer)
-		if err := podIndexer.Add(pod); err != nil {
-			t.Errorf("couldn't add %s to index: %v", pod.GetName(), err)
-		}
-		claims := getPersistentVolumeClaims(set, pod)
-		if len(claims) < 1 {
-			t.Errorf("Unexpected missing PVCs")
-		}
-		for k := range claims {
-			claim := claims[k]
-			// This ownerRef should be removed in the update.
-			claim.SetOwnerReferences(addControllerRef(claim.GetOwnerReferences(), set, controllerKind))
-			if err := claimIndexer.Add(&claim); err != nil {
-				t.Errorf("couldn't add %s to index: %v", claim.GetName(), err)
-			}
-		}
-		control := NewStatefulPodControl(fakeClient, podLister, claimLister, recorder)
-		if err := control.UpdateStatefulPod(ctx, set, pod); err != nil {
-			t.Errorf("Successful update returned an error: %s", err)
-		}
-		for k := range claims {
-			claim := claims[k]
-			if hasOwnerRef(&claim, set) {
-				t.Errorf("ownerRef not removed: %s/%s", claim.Namespace, claim.Name)
-			}
-		}
-		events := collectEvents(recorder.Events)
-		if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-			if eventCount := len(events); eventCount != 1 {
-				t.Errorf("delete failed: got %d events, but want 1", eventCount)
-			}
-		} else {
-			if len(events) != 0 {
-				t.Errorf("delete failed: expected no events, but got %v", events)
-			}
+	_, ctx := ktesting.NewTestContext(t)
+	recorder := record.NewFakeRecorder(10)
+	set := newStatefulSet(1)
+	set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+		WhenDeleted: apps.RetainPersistentVolumeClaimRetentionPolicyType,
+		WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
+	}
+	pod := newStatefulSetPod(set, 0)
+	fakeClient := &fake.Clientset{}
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	podLister := corelisters.NewPodLister(podIndexer)
+	claimIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	claimLister := corelisters.NewPersistentVolumeClaimLister(claimIndexer)
+	if err := podIndexer.Add(pod); err != nil {
+		t.Errorf("couldn't add %s to index: %v", pod.GetName(), err)
+	}
+	claims := getPersistentVolumeClaims(set, pod)
+	if len(claims) < 1 {
+		t.Errorf("Unexpected missing PVCs")
+	}
+	for k := range claims {
+		claim := claims[k]
+		// This ownerRef should be removed in the update.
+		claim.SetOwnerReferences(addControllerRef(claim.GetOwnerReferences(), set, controllerKind))
+		if err := claimIndexer.Add(&claim); err != nil {
+			t.Errorf("couldn't add %s to index: %v", claim.GetName(), err)
 		}
 	}
-	t.Run("StatefulSetAutoDeletePVCEnabled", func(t *testing.T) {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, true)
-		testFn(t)
-	})
-	t.Run("StatefulSetAutoDeletePVCDisabled", func(t *testing.T) {
-		// TODO: this will be removed in 1.35
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.31"))
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, false)
-		testFn(t)
-	})
+	control := NewStatefulPodControl(fakeClient, podLister, claimLister, recorder)
+	if err := control.UpdateStatefulPod(ctx, set, pod); err != nil {
+		t.Errorf("Successful update returned an error: %s", err)
+	}
+	for k := range claims {
+		claim := claims[k]
+		if hasOwnerRef(&claim, set) {
+			t.Errorf("ownerRef not removed: %s/%s", claim.Namespace, claim.Name)
+		}
+	}
+	events := collectEvents(recorder.Events)
+	if eventCount := len(events); eventCount != 1 {
+		t.Errorf("delete failed: got %d events, but want 1", eventCount)
+	}
 }
 
 func TestStatefulPodControlRetentionPolicyUpdate(t *testing.T) {

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -98,14 +98,7 @@ func setMinReadySeconds(set *apps.StatefulSet, minReadySeconds int32) *apps.Stat
 }
 
 func runTestOverPVCRetentionPolicies(t *testing.T, testName string, testFn func(*testing.T, *apps.StatefulSetPersistentVolumeClaimRetentionPolicy)) {
-	subtestName := "StatefulSetAutoDeletePVCDisabled"
-	if testName != "" {
-		subtestName = fmt.Sprintf("%s/%s", testName, subtestName)
-	}
-	t.Run(subtestName, func(t *testing.T) {
-		// TODO: this will be removed in 1.35
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, utilversion.MustParse("1.31"))
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, false)
+	t.Run(testName, func(t *testing.T) {
 		testFn(t, &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
 			WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
 			WhenDeleted: apps.RetainPersistentVolumeClaimRetentionPolicyType,
@@ -131,7 +124,7 @@ func runTestOverPVCRetentionPolicies(t *testing.T, testName string, testFn func(
 		// tests the case when no policy is set.
 		nil,
 	} {
-		subtestName := pvcDeletePolicyString(policy) + "/StatefulSetAutoDeletePVCEnabled"
+		subtestName := pvcDeletePolicyString(policy)
 		if testName != "" {
 			subtestName = fmt.Sprintf("%s/%s", testName, subtestName)
 		}
@@ -2929,7 +2922,7 @@ func checkClaimInvarients(set *apps.StatefulSet, pod *v1.Pod, claim *v1.Persiste
 		WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
 		WhenDeleted: apps.RetainPersistentVolumeClaimRetentionPolicyType,
 	}
-	if set.Spec.PersistentVolumeClaimRetentionPolicy != nil && utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
+	if set.Spec.PersistentVolumeClaimRetentionPolicy != nil {
 		policy = *set.Spec.PersistentVolumeClaimRetentionPolicy
 	}
 	claimShouldBeRetained := policy.WhenScaled == apps.RetainPersistentVolumeClaimRetentionPolicyType

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -936,11 +936,6 @@ const (
 	// Code can be removed in 1.35 without any consideration for emulated versions.
 	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes"
 
-	// owner: @mattcary
-	//
-	// Enables policies controlling deletion of PVCs created by a StatefulSet.
-	StatefulSetAutoDeletePVC featuregate.Feature = "StatefulSetAutoDeletePVC"
-
 	// owner: @cupnes
 	// kep: https://kep.k8s.io/4049
 	//
@@ -1747,12 +1742,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
-	},
-
-	StatefulSetAutoDeletePVC: {
-		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.32, remove in 1.35
 	},
 
 	StorageCapacityScoring: {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -9893,7 +9893,7 @@ func schema_k8sio_api_apps_v1beta1_StatefulSetSpec(ref common.ReferenceCallback)
 					},
 					"persistentVolumeClaimRetentionPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.",
+							Description: "persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down.",
 							Ref:         ref("k8s.io/api/apps/v1beta1.StatefulSetPersistentVolumeClaimRetentionPolicy"),
 						},
 					},
@@ -11607,7 +11607,7 @@ func schema_k8sio_api_apps_v1beta2_StatefulSetSpec(ref common.ReferenceCallback)
 					},
 					"persistentVolumeClaimRetentionPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.",
+							Description: "persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down.",
 							Ref:         ref("k8s.io/api/apps/v1beta2.StatefulSetPersistentVolumeClaimRetentionPolicy"),
 						},
 					},

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -118,11 +118,6 @@ func (statefulSetStrategy) PrepareForUpdate(ctx context.Context, obj, old runtim
 //	    newSvc.Spec.MyFeature = nil
 //	}
 func dropStatefulSetDisabledFields(newSS *apps.StatefulSet, oldSS *apps.StatefulSet) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-		if oldSS == nil || oldSS.Spec.PersistentVolumeClaimRetentionPolicy == nil {
-			newSS.Spec.PersistentVolumeClaimRetentionPolicy = nil
-		}
-	}
 	if !utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) && !maxUnavailableInUse(oldSS) {
 		if newSS.Spec.UpdateStrategy.RollingUpdate != nil {
 			newSS.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = nil

--- a/pkg/registry/apps/statefulset/strategy_test.go
+++ b/pkg/registry/apps/statefulset/strategy_test.go
@@ -187,8 +187,7 @@ func TestStatefulSetStrategy(t *testing.T) {
 		Status: apps.StatefulSetStatus{Replicas: 4},
 	}
 
-	t.Run("when StatefulSetAutoDeletePVC feature gate is enabled, PersistentVolumeClaimRetentionPolicy should be updated", func(t *testing.T) {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, true)
+	t.Run("PersistentVolumeClaimRetentionPolicy should be updated", func(t *testing.T) {
 		// Test creation
 		ps := &apps.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
@@ -227,8 +226,7 @@ func TestStatefulSetStrategy(t *testing.T) {
 			t.Errorf("expected PersistentVolumeClaimRetentionPolicy to be updated: %v", errs)
 		}
 	})
-	t.Run("when StatefulSetAutoDeletePVC feature gate is disabled, PersistentVolumeClaimRetentionPolicy should not be updated", func(t *testing.T) {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, true)
+	t.Run("PersistentVolumeClaimRetentionPolicy should not be updated", func(t *testing.T) {
 		// Test creation
 		ps := &apps.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
@@ -261,7 +259,7 @@ func TestStatefulSetStrategy(t *testing.T) {
 		Strategy.PrepareForUpdate(ctx, validPs, invalidPs)
 		errs = Strategy.ValidateUpdate(ctx, validPs, ps)
 		if len(errs) != 0 {
-			t.Errorf("should ignore updates to PersistentVolumeClaimRetentionPolicyType")
+			t.Errorf("unexpected failure with PersistentVolumeClaimRetentionPolicy: %v", errs)
 		}
 	})
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -396,13 +396,10 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 				rbacv1helpers.NewRule("get", "create", "delete", "update", "patch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "create", "delete", "update", "patch", "list", "watch").Groups(appsGroup).Resources("controllerrevisions").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "create", "list", "watch").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
+				rbacv1helpers.NewRule("update", "delete").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
+				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("pods/finalizers").RuleOrDie(),
 				eventsRule(),
 			},
-		}
-
-		if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
-			role.Rules = append(role.Rules, rbacv1helpers.NewRule("update", "delete").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie())
-			role.Rules = append(role.Rules, rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("pods/finalizers").RuleOrDie())
 		}
 
 		return role

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -1577,15 +1577,6 @@ items:
     - watch
   - apiGroups:
     - ""
-    - events.k8s.io
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
-  - apiGroups:
-    - ""
     resources:
     - persistentvolumeclaims
     verbs:
@@ -1596,6 +1587,15 @@ items:
     resources:
     - pods/finalizers
     verbs:
+    - update
+  - apiGroups:
+    - ""
+    - events.k8s.io
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
     - update
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -496,8 +496,12 @@ message StatefulSetSpec {
   // +optional
   optional int32 minReadySeconds = 9;
 
-  // PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
-  // the StatefulSet VolumeClaimTemplates.
+  // persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent
+  // volume claims created from volumeClaimTemplates. By default, all persistent
+  // volume claims are created as needed and retained until manually deleted. This
+  // policy allows the lifecycle to be altered, for example by deleting persistent
+  // volume claims when their stateful set is deleted, or when their pod is scaled
+  // down.
   // +optional
   optional StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy = 10;
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -294,8 +294,12 @@ type StatefulSetSpec struct {
 	// +optional
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,9,opt,name=minReadySeconds"`
 
-	// PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
-	// the StatefulSet VolumeClaimTemplates.
+	// persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent
+	// volume claims created from volumeClaimTemplates. By default, all persistent
+	// volume claims are created as needed and retained until manually deleted. This
+	// policy allows the lifecycle to be altered, for example by deleting persistent
+	// volume claims when their stateful set is deleted, or when their pod is scaled
+	// down.
 	// +optional
 	PersistentVolumeClaimRetentionPolicy *StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty" protobuf:"bytes,10,opt,name=persistentVolumeClaimRetentionPolicy"`
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
@@ -259,7 +259,7 @@ var map_StatefulSetSpec = map[string]string{
 	"updateStrategy":                       "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.",
 	"revisionHistoryLimit":                 "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
 	"minReadySeconds":                      "minReadySeconds is the minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-	"persistentVolumeClaimRetentionPolicy": "PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.",
+	"persistentVolumeClaimRetentionPolicy": "persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down.",
 	"ordinals":                             "ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a \"0\" index to the first replica and increments the index by one for each additional replica requested.",
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -795,8 +795,12 @@ message StatefulSetSpec {
   // +optional
   optional int32 minReadySeconds = 9;
 
-  // PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
-  // the StatefulSet VolumeClaimTemplates.
+  // persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent
+  // volume claims created from volumeClaimTemplates. By default, all persistent
+  // volume claims are created as needed and retained until manually deleted. This
+  // policy allows the lifecycle to be altered, for example by deleting persistent
+  // volume claims when their stateful set is deleted, or when their pod is scaled
+  // down.
   // +optional
   optional StatefulSetPersistentVolumeClaimRetentionPolicy persistentVolumeClaimRetentionPolicy = 10;
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -304,8 +304,12 @@ type StatefulSetSpec struct {
 	// +optional
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,9,opt,name=minReadySeconds"`
 
-	// PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
-	// the StatefulSet VolumeClaimTemplates.
+	// persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent
+	// volume claims created from volumeClaimTemplates. By default, all persistent
+	// volume claims are created as needed and retained until manually deleted. This
+	// policy allows the lifecycle to be altered, for example by deleting persistent
+	// volume claims when their stateful set is deleted, or when their pod is scaled
+	// down.
 	// +optional
 	PersistentVolumeClaimRetentionPolicy *StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty" protobuf:"bytes,10,opt,name=persistentVolumeClaimRetentionPolicy"`
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
@@ -384,7 +384,7 @@ var map_StatefulSetSpec = map[string]string{
 	"updateStrategy":                       "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.",
 	"revisionHistoryLimit":                 "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
 	"minReadySeconds":                      "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-	"persistentVolumeClaimRetentionPolicy": "PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.",
+	"persistentVolumeClaimRetentionPolicy": "persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down.",
 	"ordinals":                             "ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a \"0\" index to the first replica and increments the index by one for each additional replica requested.",
 }
 

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1619,20 +1619,6 @@
     lockToDefault: true
     preRelease: GA
     version: "1.32"
-- name: StatefulSetAutoDeletePVC
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "1.23"
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.27"
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "1.32"
 - name: StorageCapacityScoring
   versionedSpecs:
   - default: false

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -32,17 +32,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/statefulset"
 	"k8s.io/kubernetes/pkg/controlplane"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
@@ -470,8 +467,6 @@ func TestAutodeleteOwnerRefs(t *testing.T) {
 			expectSetOwnerRef: true,
 		},
 	}
-
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, true)
 
 	tCtx, closeFn, rm, informers, c := scSetup(t)
 	defer closeFn()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig apps

#### What this PR does / why we need it:
This cleans up `StatefulSetAutoDeletePVC` feature gate after it was graduated to stable back in 1.32.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/1847

#### Special notes for your reviewer:
/assign @mattcary @janetkuo 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
