### PR TITLE
Drop CronJobsScheduledAnnotation after the feature GA-ed in 1.32

### DIFF
--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -27,10 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
 )
 
@@ -245,19 +243,15 @@ func copyAnnotations(template *batchv1.JobTemplateSpec) labels.Set {
 // granularity of 1 minute for scheduling job.
 func getJobFromTemplate2(cj *batchv1.CronJob, scheduledTime time.Time) (*batchv1.Job, error) {
 	labels := copyLabels(&cj.Spec.JobTemplate)
-	annotations := copyAnnotations(&cj.Spec.JobTemplate)
 	// We want job names for a given nominal start time to have a deterministic name to avoid the same job being created twice
 	name := getJobName(cj, scheduledTime)
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.CronJobsScheduledAnnotation) {
-
-		timeZoneLocation, err := time.LoadLocation(ptr.Deref(cj.Spec.TimeZone, ""))
-		if err != nil {
-			return nil, err
-		}
-		// Append job creation timestamp to the cronJob annotations. The time will be in RFC3339 form.
-		annotations[batchv1.CronJobScheduledTimestampAnnotation] = scheduledTime.In(timeZoneLocation).Format(time.RFC3339)
+	annotations := copyAnnotations(&cj.Spec.JobTemplate)
+	timeZoneLocation, err := time.LoadLocation(ptr.Deref(cj.Spec.TimeZone, ""))
+	if err != nil {
+		return nil, err
 	}
+	// Append job creation timestamp to the cronJob annotations. The time will be in RFC3339 form.
+	annotations[batchv1.CronJobScheduledTimestampAnnotation] = scheduledTime.In(timeZoneLocation).Format(time.RFC3339)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -28,11 +28,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
 )
 
@@ -46,8 +43,6 @@ func TestGetJobFromTemplate2(t *testing.T) {
 		timeZoneCorrect = "Europe/Rome"
 		scheduledTime   = *topOfTheHour()
 	)
-
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CronJobsScheduledAnnotation, true)
 
 	cj := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -161,12 +161,6 @@ const (
 	// Enables coordinated leader election in the API server
 	CoordinatedLeaderElection featuregate.Feature = "CoordinatedLeaderElection"
 
-	// owner: @helayoty
-	// kep: https://kep.k8s.io/4026
-	//
-	// Set the scheduled time as an annotation in the job.
-	CronJobsScheduledAnnotation featuregate.Feature = "CronJobsScheduledAnnotation"
-
 	// owner: @ttakahashi21 @mkimuram
 	// kep: https://kep.k8s.io/3294
 	//
@@ -1182,11 +1176,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	ContainerStopSignals: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
-	},
-
-	CronJobsScheduledAnnotation: {
-		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.35
 	},
 
 	CrossNamespaceVolumeDataSource: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -345,16 +345,6 @@
     lockToDefault: true
     preRelease: GA
     version: "1.33"
-- name: CronJobsScheduledAnnotation
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.28"
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "1.32"
 - name: CrossNamespaceVolumeDataSource
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig apps

#### What this PR does / why we need it:
This cleans up `CronJobsScheduledAnnotation` feature gate after it was graduated to stable back in 1.32.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/4026

#### Special notes for your reviewer:
/assign @helayoty 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
