### PR TITLE
Codify feature gate dependencies

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -121,8 +121,9 @@ func TestNewControllerDescriptorsAlwaysReturnsDescriptorsForAllControllers(t *te
 
 	controllersWithoutFeatureGates := KnownControllers()
 
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllAlpha", true)
+	// AllBeta must be enabled before AllAlpha to resolve dependencies.
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllBeta", true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllAlpha", true)
 
 	controllersWithFeatureGates := KnownControllers()
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -2014,8 +2014,21 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 }
 
+// defaultKubernetesFeatureGateDependencies enumerates the dependencies of any feature gate that
+// depends on another. Dependencies ensure that a dependent feature gate can only be enabled if all
+// of its dependencies are also enabled, and ensures a feature at a higher stability level cannot
+// depend on a less stable feature.
+//
+// Entries are alphabetized.
+var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]featuregate.Feature{
+	InPlacePodVerticalScalingAllocatedStatus: {InPlacePodVerticalScaling},
+	InPlacePodVerticalScalingExclusiveCPUs:   {InPlacePodVerticalScaling},
+	InPlacePodVerticalScalingExclusiveMemory: {InPlacePodVerticalScaling, MemoryManager},
+}
+
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.AddVersioned(defaultVersionedKubernetesFeatureGates))
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.AddDependencies(defaultKubernetesFeatureGateDependencies))
 	runtime.Must(zpagesfeatures.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 
 	// Register all client-go features with kube's feature gate instance and make all client-go

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -59,6 +59,9 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration, featur
 	if err := localFeatureGate.SetFromMap(kc.FeatureGates); err != nil {
 		return err
 	}
+	if errs := localFeatureGate.Validate(); len(errs) > 0 {
+		allErrors = append(allErrors, errs...)
+	}
 
 	if kc.NodeLeaseDurationSeconds <= 0 {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: nodeLeaseDurationSeconds must be greater than 0"))


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Codify inter-feature gate dependencies.

This PR adds a new method `AddDependencies(features map[Feature][]Feature) error` to `MutableVersionedFeatureGate` to set explicit feature gate dependencies. Dependencies are validated according to these rules:

1. Validated at test time: A feature gate cannot depend on a feature with a lower stability level (only the latest version is checked).
2. Validated at runtime: A feature gate cannot be enabled if it depends on a disabled feature gate

This PR also adds dependencies to `kube_features.go` for `InPlacePodVerticalScaling`. This is probably not a comprehensive list of feature gate dependencies.

This PR also adds feature gate validation to Kubelet.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/133533

#### Special notes for your reviewer:

I would have prefered to declare dependencies in-line with the feature gate spec, but that would require changing the API for adding features since it currently takes a `map[Feature][]FeatureSpec`, and wrapping `[]FeatureSpec` in a struct would have been a larger change. I'm still open to this approach though.

#### Does this PR introduce a user-facing change?
```release-note
Action Required: Feature gate dependencies are now explicit, and validated at startup. A feature can no longer be enabled if it depends on a disabled feature. In particular, this means that `AllAlpha=true` will no longer work without enabling disabled-by-default beta features that are depended on (either with `AllBeta=true` or explicitly enumerating the disabled dependencies).
```

/sig architecture api-machinery cluster-lifecycle node