### PR TITLE
Fix DRAConsumableCapacity to schedule more than one devices

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -4458,7 +4458,7 @@ func TestAllocator(t *testing.T,
 
 			expectResults: []any{}, // default max requestPolicy is 4, should not allocate even though 6 < 10
 		},
-		"consumable-capacity-multi-allocatable-device-with-some-remaining-consumable-capacity": {
+		"consumable-capacity-multi-allocatable-device-with-allocated-capacity-use-remaining": {
 			features: Features{
 				ConsumableCapacity: true,
 			},
@@ -4482,6 +4482,34 @@ func TestAllocator(t *testing.T,
 				allocationResult(
 					localNodeSelector(node1),
 					deviceRequestAllocationResult(req0, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
+				),
+			},
+		},
+		"consumable-capacity-multi-allocatable-device-with-allocated-capacity-next-device": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0, "", classA).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(two))),
+			),
+			allocatedCapacityDevices: map[DeviceID]ConsumedCapacity{
+				MakeDeviceID(driverA, pool1, device1): {
+					capacity0: ptr.To(two),
+				},
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrap(
+				slice(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
+					device(device2, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
+				),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceRequestAllocationResult(req0, driverA, pool1, device2).withConsumedCapacity(&fixedShareID, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
 			},
 		},
@@ -4711,8 +4739,13 @@ func TestAllocator(t *testing.T,
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
 			),
-			node:          node(node1, region1),
-			expectResults: []any{},
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceRequestAllocationResult(req0, driverA, pool1, device2).withConsumedCapacity(&fixedShareID, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}),
+				),
+			},
 		},
 		"consumable-capacity-dedicated-device-with-consumable-capacity-request": {
 			features: Features{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -534,7 +534,8 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 						}
 						if alloc.features.ConsumableCapacity {
 							// Next validate whether resource request over capacity
-							success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, deviceIndex)
+							device := slice.Spec.Devices[deviceIndex]
+							success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
 							if err != nil {
 								alloc.logger.V(7).Info("Skip comparing device capacity request",
 									"device", device, "request", requestData.request.name(), "err", err)
@@ -999,7 +1000,8 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 				}
 				if alloc.features.ConsumableCapacity {
 					// Next validate whether resource request over capacity
-					success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, deviceIndex)
+					device := slice.Spec.Devices[deviceIndex]
+					success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
 					if err != nil {
 						alloc.logger.V(7).Info("Skip comparing device capacity request",
 							"device", deviceID, "request", requestData.request.name(), "err", err)
@@ -1110,13 +1112,14 @@ func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, 
 
 }
 
-// CmpRequestOverCapacity checks whether a device with remaining resources is consumable by the request.
+// CmpRequestOverCapacity checks if the given device has sufficient remaining capacity
+// to satisfy the resource request.
 // Return true if success.
-func (alloc *allocator) CmpRequestOverCapacity(request requestAccessor, slice *draapi.ResourceSlice, deviceIndex int) (bool, error) {
-	deviceID := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: slice.Spec.Devices[deviceIndex].Name}
+func (alloc *allocator) CmpRequestOverCapacity(request requestAccessor, slice *draapi.ResourceSlice, device draapi.Device) (bool, error) {
+	deviceID := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: device.Name}
 	allocatingCapacity := alloc.allocatingCapacity[deviceID]
-	allowMultipleAllocations := slice.Spec.Devices[deviceIndex].AllowMultipleAllocations
-	capacities := slice.Spec.Devices[deviceIndex].Capacity
+	allowMultipleAllocations := device.AllowMultipleAllocations
+	capacities := device.Capacity
 	if allocatedCapacity, found := alloc.allocatedState.AggregatedCapacity[deviceID]; found {
 		return CmpRequestOverCapacity(allocatedCapacity, request.capacities(), allowMultipleAllocations, capacities, allocatingCapacity)
 	}
@@ -1169,6 +1172,11 @@ func (alloc *allocator) selectorsMatch(r requestIndices, device *draapi.Device, 
 
 // allocateDevice checks device availability and constraints for one
 // candidate. The device must be selectable.
+//
+// r identifies the request for which allocation is attempted.
+// The device is the candidate under consideration.
+// If "must" is true, then it is okay (but not required) to return an error which describes in more detail why allocation wasn't possible.
+// This is used when the caller wants exactly this device and will give up if it cannot allocate it.
 //
 // If that candidate works out okay, the shared state gets updated
 // as if that candidate had been allocated. If allocation cannot continue later
@@ -1266,7 +1274,7 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	var shareID *types.UID
 	if alloc.features.ConsumableCapacity {
 		// Validate whether resource request over capacity
-		success, err := alloc.CmpRequestOverCapacity(requestData.request, device.slice, r.deviceIndex)
+		success, err := alloc.CmpRequestOverCapacity(requestData.request, device.slice, *device.Device)
 		if err != nil {
 			alloc.logger.V(7).Info("Failed to compare device capacity request",
 				"device", device, "request", requestData.request.name(), "err", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

- Define a new function in experimental module in `/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental` for fixing the follow line where `r.deviceIndex` is misused.

https://github.com/kubernetes/kubernetes/blob/091f87c10bc3532041b77a783a5f832de5506dc8/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go#L1269

- Add new unit test case

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #133705

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Fixed a bug that prevents schedule next pod when using DRAConsumableCapacity feature. (#133705, @sunya-ch)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5075-dra-consumable-capacity
```
