### PR TITLE
Remove use of pkg/scheduler/framework.NodeInfo in node_ports.go

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -136,15 +136,13 @@ func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 		return fwk.QueueSkip, nil
 	}
 
-	// Construct a fake NodeInfo that only has the deleted Pod.
-	// If we can schedule `pod` to this fake node, it means that `pod` and the deleted pod don't have any common port(s).
+	// Verify that `pod` and the deleted pod don't have any common port(s).
 	// So, deleting that pod couldn't make `pod` schedulable.
-	usedPorts := make(fwk.HostPortInfo, len(ports))
+	portsInUse := make(fwk.HostPortInfo, len(ports))
 	for _, p := range ports {
-		usedPorts.Add(p.HostIP, string(p.Protocol), p.HostPort)
+		portsInUse.Add(p.HostIP, string(p.Protocol), p.HostPort)
 	}
-	nodeInfo := framework.NodeInfo{UsedPorts: usedPorts}
-	if Fits(pod, &nodeInfo) {
+	if fitsPorts(util.GetHostPorts(pod), portsInUse) {
 		logger.V(4).Info("the deleted pod and the target pod don't have any common port(s), returning QueueSkip as deleting this Pod won't make the Pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
 		return fwk.QueueSkip, nil
 	}
@@ -160,7 +158,7 @@ func (pl *NodePorts) Filter(ctx context.Context, cycleState fwk.CycleState, pod 
 		return fwk.AsStatus(err)
 	}
 
-	fits := fitsPorts(wantPorts, nodeInfo)
+	fits := fitsPorts(wantPorts, nodeInfo.GetUsedPorts())
 	if !fits {
 		return fwk.NewStatus(fwk.Unschedulable, ErrReason)
 	}
@@ -168,16 +166,16 @@ func (pl *NodePorts) Filter(ctx context.Context, cycleState fwk.CycleState, pod 
 	return nil
 }
 
-// Fits checks if the pod fits the node.
+// Fits checks if the pod has any ports conflicting with nodeInfo's ports.
+// It returns true if there are no conflicts (which means that pod fits the node), otherwise false.
 func Fits(pod *v1.Pod, nodeInfo fwk.NodeInfo) bool {
-	return fitsPorts(util.GetHostPorts(pod), nodeInfo)
+	return fitsPorts(util.GetHostPorts(pod), nodeInfo.GetUsedPorts())
 }
 
-func fitsPorts(wantPorts []v1.ContainerPort, nodeInfo fwk.NodeInfo) bool {
-	// try to see whether existingPorts and wantPorts will conflict or not
-	existingPorts := nodeInfo.GetUsedPorts()
+func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) bool {
+	// try to see whether portsInUse and wantPorts will conflict or not
 	for _, cp := range wantPorts {
-		if existingPorts.CheckConflict(cp.HostIP, string(cp.Protocol), cp.HostPort) {
+		if portsInUse.CheckConflict(cp.HostIP, string(cp.Protocol), cp.HostPort) {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR removes the use of `pkg/scheduler/framework.NodeInfo` from `pkg/scheduler/framework/plugins/nodeports/node_ports.go`. After this PR and https://github.com/kubernetes/kubernetes/pull/133172 are merged, node_ports.go will not depend on `pkg/scheduler/framework` anymore.

#### Which issue(s) this PR is related to:
Part of #89930
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
