### PR TITLE
fix(controller/podautoscaler): do not print panic when .status.lastScaleTime is not set

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -936,10 +936,14 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 			actionLabel = monitor.ActionLabelScaleDown
 		}
 	} else {
+		lastScaleTime := ""
+		if hpa.Status.LastScaleTime != nil {
+			lastScaleTime = hpa.Status.LastScaleTime.String()
+		}
 		logger.V(4).Info("Decided not to scale",
 			"scaleTarget", reference,
 			"desiredReplicas", desiredReplicas,
-			"lastScaleTime", hpa.Status.LastScaleTime)
+			"lastScaleTime", lastScaleTime)
 		desiredReplicas = currentReplicas
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When HPA's .status.lastScaleTime field is not set (set to nil) the controller can print the following log message:
```
I0826 14:17:40.979927 3887837 horizontal.go:939] "Decided not to scale" scaleTarget="ReplicationController/test-namespace/test-rc" desiredReplicas=0 lastScaleTime="<panic: runtime error: invalid memory address or nil pointer dereference>"
```

Even though the panic is just a cosmetic here it may give the impression something is wrong. Instead of printing a panic message print an empty value:

```
I0826 14:17:40.979927 3887837 horizontal.go:939] "Decided not to scale" scaleTarget="ReplicationController/test-namespace/test-rc" desiredReplicas=0 lastScaleTime=""
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The issue can be e.g. reproduced by decreasing the log level of the logged line to 0 and running `TestZeroReplicas` unit test:
```
$ go test -v k8s.io/kubernetes/pkg/controller/podautoscaler -run TestZeroReplicas
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
