### PR TITLE
storagebackend/factory: Simplify etcd health check

### DIFF
--- a/pkg/controlplane/apiserver/config_test.go
+++ b/pkg/controlplane/apiserver/config_test.go
@@ -46,6 +46,10 @@ func TestBuildGenericConfig(t *testing.T) {
 	s.BindPort = ln.Addr().(*net.TCPAddr).Port
 	opts.SecureServing = s
 
+	// Configure an etcd endpoint to avoid immediate errors.
+	// In this case it doesn't matter the endpoint actually doesn't exist.
+	opts.Etcd.StorageConfig.Transport.ServerList = []string{"http://example.com:2379"}
+
 	completedOptions, err := opts.Complete(context.TODO(), nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to complete apiserver options: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -361,6 +361,13 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 				EncryptionProviderConfigFilepath:        tc.encryptionConfigPath,
 				EncryptionProviderConfigAutomaticReload: tc.reload,
 				SkipHealthEndpoints:                     tc.skipHealth,
+				// We need to configure an etcd endpoint, even though there is no server there,
+				// otherwise we get an immediate error when applying options.
+				StorageConfig: storagebackend.Config{
+					Transport: storagebackend.TransportConfig{
+						ServerList: []string{"http://example.com:2379"},
+					},
+				},
 			}
 			if err := etcdOptions.ApplyTo(serverConfig); err != nil {
 				t.Fatalf("Failed to add healthz error: %v", err)
@@ -434,7 +441,17 @@ func TestReadinessCheck(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			serverConfig := server.NewConfig(codecs)
-			etcdOptions := &EtcdOptions{SkipHealthEndpoints: tc.skipHealth, EtcdServersOverrides: tc.etcdServersOverrides}
+			etcdOptions := &EtcdOptions{
+				SkipHealthEndpoints:  tc.skipHealth,
+				EtcdServersOverrides: tc.etcdServersOverrides,
+				// We need to configure an etcd endpoint, even though there is no server there,
+				// otherwise we get an immediate error when applying options.
+				StorageConfig: storagebackend.Config{
+					Transport: storagebackend.TransportConfig{
+						ServerList: []string{"http://example.com:2379"},
+					},
+				},
+			}
 			if err := etcdOptions.ApplyTo(serverConfig); err != nil {
 				t.Fatalf("Failed to add healthz error: %v", err)
 			}
@@ -465,7 +482,15 @@ func healthChecksAreEqual(t *testing.T, want []string, healthChecks []healthz.He
 
 func TestRestOptionsStorageObjectCountTracker(t *testing.T) {
 	serverConfig := server.NewConfig(codecs)
-	etcdOptions := &EtcdOptions{}
+	etcdOptions := &EtcdOptions{
+		// We need to configure an etcd endpoint, even though there is no server there,
+		// otherwise we get an immediate error when applying options.
+		StorageConfig: storagebackend.Config{
+			Transport: storagebackend.TransportConfig{
+				ServerList: []string{"http://example.com:2379"},
+			},
+		},
+	}
 	if err := etcdOptions.ApplyTo(serverConfig); err != nil {
 		t.Fatalf("Failed to apply etcd options error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -18,6 +18,7 @@ package factory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -151,69 +152,48 @@ func (a *atomicLastError) Load() error {
 }
 
 func newETCD3Check(c storagebackend.Config, timeout time.Duration, stopCh <-chan struct{}) (func() error, error) {
-	// constructing the etcd v3 client blocks and times out if etcd is not available.
-	// retry in a loop in the background until we successfully create the client, storing the client or error encountered
-
-	lock := sync.RWMutex{}
-	var prober *etcd3ProberMonitor
-	clientErr := fmt.Errorf("etcd client connection not yet established")
-
-	go wait.PollImmediateUntil(time.Second, func() (bool, error) {
-		lock.Lock()
-		defer lock.Unlock()
-		newProber, err := newETCD3ProberMonitor(c)
-		// Ensure that server is already not shutting down.
-		select {
-		case <-stopCh:
-			if err == nil {
-				newProber.Close()
-			}
-			return true, nil
-		default:
-		}
-		if err != nil {
-			clientErr = err
-			return false, nil
-		}
-		prober = newProber
-		clientErr = nil
-		return true, nil
-	}, stopCh)
+	// Create a new prober monitor.
+	prober, err := newETCD3ProberMonitor(c)
+	if err != nil {
+		return nil, err
+	}
 
 	// Close the client on shutdown.
+	var (
+		lock     sync.RWMutex
+		probeErr error
+	)
 	go func() {
 		defer utilruntime.HandleCrash()
 		<-stopCh
 
 		lock.Lock()
 		defer lock.Unlock()
-		if prober != nil {
-			prober.Close()
-			clientErr = fmt.Errorf("server is shutting down")
-		}
+		_ = prober.Close()
+		probeErr = errors.New("server is shutting down")
 	}()
 
-	// limit to a request every half of the configured timeout with a maximum burst of one
-	// rate limited requests will receive the last request sent error (note: not the last received response)
+	// Limit to a request every half of the configured timeout with a maximum burst of one.
+	// Rate limited requests will receive the last received response.
 	limiter := rate.NewLimiter(rate.Every(timeout/2), 1)
-	// initial state is the clientErr
-	lastError := &atomicLastError{err: fmt.Errorf("etcd client connection not yet established")}
+	lastError := &atomicLastError{err: errors.New("etcd client connection not yet established")}
 
 	return func() error {
-		// Given that client is closed on shutdown we hold the lock for
-		// the entire period of healthcheck call to ensure that client will
-		// not be closed during healthcheck.
-		// Given that healthchecks has a 2s timeout, worst case of blocking
-		// shutdown for additional 2s seems acceptable.
+		// Hold the lock to make sure the prober is not closed during the health check.
+		// Given that there is a 2s timeout, the worst case of blocking shutdown for additional 2s seems acceptable.
 		lock.RLock()
 		defer lock.RUnlock()
 
-		if clientErr != nil {
-			return clientErr
+		// Return the guard error object when set.
+		if probeErr != nil {
+			return probeErr
 		}
+
+		// Check the rate limit.
 		if limiter.Allow() == false {
 			return lastError.Load()
 		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		now := time.Now()
@@ -224,7 +204,7 @@ func newETCD3Check(c storagebackend.Config, timeout time.Duration, stopCh <-chan
 }
 
 func newETCD3ProberMonitor(c storagebackend.Config) (*etcd3ProberMonitor, error) {
-	client, err := newETCD3Client(c.Transport)
+	client, err := newETCD3Client(c.Transport, false)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +263,7 @@ func (t *etcd3ProberMonitor) Monitor(ctx context.Context) (metrics.StorageMetric
 	}, nil
 }
 
-var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
+var newETCD3Client = func(c storagebackend.TransportConfig, blockUntilConnected bool) (*kubernetes.Client, error) {
 	tlsInfo := transport.TLSInfo{
 		CertFile:      c.CertFile,
 		KeyFile:       c.KeyFile,
@@ -307,7 +287,6 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
 		}
 	}
 	dialOptions := []grpc.DialOption{
-		grpc.WithBlock(), // block until the underlying connection is up
 		// use chained interceptors so that the default (retry and backoff) interceptors are added.
 		// otherwise they will be overwritten by the metric interceptor.
 		//
@@ -315,6 +294,10 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
 		// which seems to be what we want as the metrics will be collected on each attempt (retry)
 		grpc.WithChainUnaryInterceptor(grpcprom.UnaryClientInterceptor),
 		grpc.WithChainStreamInterceptor(grpcprom.StreamClientInterceptor),
+	}
+	if blockUntilConnected {
+		// nolint:staticcheck // Ignore WithBlock being deprecated.
+		dialOptions = append(dialOptions, grpc.WithBlock())
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
 		tracingOpts := []otelgrpc.Option{
@@ -385,7 +368,7 @@ func startCompactorOnce(c storagebackend.TransportConfig, interval time.Duration
 	}
 	key := fmt.Sprintf("%v", c) // gives: {[server1 server2] keyFile certFile caFile}
 	if compactor, foundBefore := compactors[key]; !foundBefore || compactor.interval > interval {
-		client, err := newETCD3Client(c)
+		client, err := newETCD3Client(c, true)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -429,7 +412,7 @@ func newETCD3Storage(c storagebackend.ConfigForResource, newFunc, newListFunc fu
 		return nil, nil, err
 	}
 
-	client, err := newETCD3Client(c.Transport)
+	client, err := newETCD3Client(c.Transport, true)
 	if err != nil {
 		stopCompactor()
 		return nil, nil, err

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -112,7 +112,7 @@ func TestCreateHealthcheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ready := make(chan struct{})
 			tc.cfg.Transport.ServerList = client.Endpoints()
-			newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
+			newETCD3Client = func(_ storagebackend.TransportConfig, _ bool) (*kubernetes.Client, error) {
 				defer close(ready)
 				dummyKV := mockKV{
 					get: func(ctx context.Context) (*clientv3.GetResponse, error) {
@@ -212,7 +212,7 @@ func TestCreateReadycheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ready := make(chan struct{})
 			tc.cfg.Transport.ServerList = client.Endpoints()
-			newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
+			newETCD3Client = func(_ storagebackend.TransportConfig, _ bool) (*kubernetes.Client, error) {
 				defer close(ready)
 				dummyKV := mockKV{
 					get: func(ctx context.Context) (*clientv3.GetResponse, error) {
@@ -278,7 +278,7 @@ func TestRateLimitHealthcheck(t *testing.T) {
 			ready := make(chan struct{})
 
 			var counter uint64
-			newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
+			newETCD3Client = func(_ storagebackend.TransportConfig, _ bool) (*kubernetes.Client, error) {
 				defer close(ready)
 				dummyKV := mockKV{
 					get: func(ctx context.Context) (*clientv3.GetResponse, error) {
@@ -374,7 +374,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	signal := make(chan struct{})
 
 	var counter uint64
-	newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
+	newETCD3Client = func(_ storagebackend.TransportConfig, _ bool) (*kubernetes.Client, error) {
 		defer close(ready)
 		dummyKV := mockKV{
 			get: func(ctx context.Context) (*clientv3.GetResponse, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The function is unnecessarily complex just because the gRPC client is
initialized with `grpc.WithBlock()`, which is unnecessary in this case
since there is anyway a health check request sent to etcd, which times
out in case the connection is not established yet.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A