### PR TITLE
kube-proxy: log but don't exit if ipv4 or ipv6 is not available

### DIFF
--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -90,18 +90,17 @@ func (s *ProxyServer) platformCheckSupported(ctx context.Context) (ipv4Supported
 
 	if isIPTablesBased(s.Config.Mode) {
 		// Check for the iptables and ip6tables binaries.
-		var ipts map[v1.IPFamily]utiliptables.Interface
-		ipts, err = utiliptables.NewDualStack()
+		ipts, errDS := utiliptables.NewDualStack()
 
 		ipv4Supported = ipts[v1.IPv4Protocol] != nil
 		ipv6Supported = ipts[v1.IPv6Protocol] != nil
 
 		if !ipv4Supported && !ipv6Supported {
-			err = fmt.Errorf("iptables is not available on this host : %w", err)
+			err = fmt.Errorf("iptables is not available on this host : %w", errDS)
 		} else if !ipv4Supported {
-			logger.Info("No iptables support for family", "ipFamily", v1.IPv4Protocol, "error", err)
+			logger.Info("No iptables support for family", "ipFamily", v1.IPv4Protocol, "error", errDS)
 		} else if !ipv6Supported {
-			logger.Info("No iptables support for family", "ipFamily", v1.IPv6Protocol, "error", err)
+			logger.Info("No iptables support for family", "ipFamily", v1.IPv6Protocol, "error", errDS)
 		}
 	} else {
 		// The nft CLI always supports both families.


### PR DESCRIPTION
/kind bug
/kind regression

```release-note
Fixed regression introduced in v1.34.0-alpha.1 where the kube-proxy fails to start on an IP single-stack networking environment.
```

### What this PR does / why we need it:

similar to https://github.com/kubernetes/kubernetes/pull/132170, https://github.com/kubernetes/kubernetes/pull/131534 was not supposed to change kube-proxy's behavior, but instead of just logging, it will error out and exit if either ipv4 or ipv6 are unavailable

this pr aims to restore the original kube-proxy behavior and log but not exit if ipv4 or ipv6 are not available

### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/133694