### PR TITLE
Add e2e test for MaxUnavailable StatefulSet RollingUpdate

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -50,9 +50,6 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
-
-	"k8s.io/utils/ptr"
-
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -64,6 +61,7 @@ import (
 	e2estatefulset "k8s.io/kubernetes/test/e2e/framework/statefulset"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -100,7 +98,7 @@ var httpProbe = &v1.Probe{
 
 // GCE Quota requirements: 3 pds, one per stateful pod manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
-var _ = SIGDescribe("StatefulSet", framework.WithFeatureGate(features.MaxUnavailableStatefulSet), func() {
+var _ = SIGDescribe("StatefulSet", func() {
 	f := framework.NewDefaultFramework("statefulset")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var ns string

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -568,7 +568,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			deletingPodForRollingUpdatePartitionTest(ctx, f, c, ns, ss)
 		})
 
-		f.It("should perform rolling updates with maxUnavailable", func(ctx context.Context) {
+		f.It("should perform rolling updates with maxUnavailable", framework.WithFeatureGate(features.MaxUnavailableStatefulSet), func(ctx context.Context) {
 			ginkgo.By("Creating a new StatefulSet")
 			ss := e2estatefulset.NewStatefulSet("ss-maxunavailable", ns, headlessSvcName, 5, nil, nil, labels)
 			setHTTPProbe(ss)

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -571,7 +571,7 @@ var _ = SIGDescribe("StatefulSet", framework.WithFeatureGate(features.MaxUnavail
 			deletingPodForRollingUpdatePartitionTest(ctx, f, c, ns, ss)
 		})
 
-		ginkgo.It("should perform rolling updates with maxUnavailable", func(ctx context.Context) {
+		f.It("should perform rolling updates with maxUnavailable", framework.WithFeatureGate(features.MaxUnavailableStatefulSet), func(ctx context.Context) {
 			ginkgo.By("Creating a new StatefulSet")
 			ss := e2estatefulset.NewStatefulSet("ss-maxunavailable", ns, headlessSvcName, 5, nil, nil, labels)
 			setHTTPProbe(ss)

--- a/test/e2e/apps/wait.go
+++ b/test/e2e/apps/wait.go
@@ -18,6 +18,7 @@ package apps
 
 import (
 	"context"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -45,7 +46,7 @@ func waitForPartitionedRollingUpdate(ctx context.Context, c clientset.Interface,
 			set.Namespace,
 			set.Name)
 	}
-	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, e2estatefulset.StatefulSetPoll, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		partition := int(*set.Spec.UpdateStrategy.RollingUpdate.Partition)
@@ -87,7 +88,7 @@ func waitForPartitionedRollingUpdate(ctx context.Context, c clientset.Interface,
 // waitForStatus waits for the StatefulSetStatus's ObservedGeneration to be greater than or equal to set's Generation.
 // The returned StatefulSet contains such a StatefulSetStatus
 func waitForStatus(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet) *appsv1.StatefulSet {
-	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, e2estatefulset.StatefulSetPoll, func(set2 *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
 		if set2.Status.ObservedGeneration >= set.Generation {
 			set = set2
 			return true, nil
@@ -99,7 +100,7 @@ func waitForStatus(ctx context.Context, c clientset.Interface, set *appsv1.State
 
 // waitForPodNames waits for the StatefulSet's pods to match expected names.
 func waitForPodNames(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet, expectedPodNames []string) {
-	e2estatefulset.WaitForState(ctx, c, set,
+	e2estatefulset.WaitForState(ctx, c, set, e2estatefulset.StatefulSetPoll,
 		func(intSet *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
 			if err := expectPodNames(pods, expectedPodNames); err != nil {
 				framework.Logf("Currently %v", err)
@@ -112,7 +113,7 @@ func waitForPodNames(ctx context.Context, c clientset.Interface, set *appsv1.Sta
 // waitForStatus waits for the StatefulSetStatus's CurrentReplicas to be equal to expectedReplicas
 // The returned StatefulSet contains such a StatefulSetStatus
 func waitForStatusCurrentReplicas(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet, expectedReplicas int32) *appsv1.StatefulSet {
-	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, e2estatefulset.StatefulSetPoll, func(set2 *appsv1.StatefulSet, pods *v1.PodList) (bool, error) {
 		if set2.Status.ObservedGeneration >= set.Generation && set2.Status.CurrentReplicas == expectedReplicas {
 			set = set2
 			return true, nil
@@ -125,7 +126,7 @@ func waitForStatusCurrentReplicas(ctx context.Context, c clientset.Interface, se
 // waitForPodNotReady waits for the Pod named podName in set to exist and to not have a Ready condition.
 func waitForPodNotReady(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet, podName string) (*appsv1.StatefulSet, *v1.PodList) {
 	var pods *v1.PodList
-	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, e2estatefulset.StatefulSetPoll, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		for i := range pods.Items {
@@ -148,7 +149,7 @@ func waitForRollingUpdate(ctx context.Context, c clientset.Interface, set *appsv
 			set.Name,
 			set.Spec.UpdateStrategy.Type)
 	}
-	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, e2estatefulset.StatefulSetPoll, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		if len(pods.Items) < int(*set.Spec.Replicas) {
@@ -187,7 +188,7 @@ func waitForMaxUnavailableRollingUpdate(ctx context.Context, c clientset.Interfa
 			set.Name,
 			set.Spec.UpdateStrategy.Type)
 	}
-	e2estatefulset.WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, time.Duration(1), func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		if len(pods.Items) < int(*set.Spec.Replicas) {

--- a/test/e2e/apps/wait.go
+++ b/test/e2e/apps/wait.go
@@ -188,7 +188,7 @@ func waitForMaxUnavailableRollingUpdate(ctx context.Context, c clientset.Interfa
 			set.Name,
 			set.Spec.UpdateStrategy.Type)
 	}
-	e2estatefulset.WaitForState(ctx, c, set, time.Duration(1), func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	e2estatefulset.WaitForState(ctx, c, set, 1*time.Second, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		if len(pods.Items) < int(*set.Spec.Replicas) {

--- a/test/e2e/framework/statefulset/wait.go
+++ b/test/e2e/framework/statefulset/wait.go
@@ -65,14 +65,8 @@ func WaitForRunning(ctx context.Context, c clientset.Interface, numPodsRunning, 
 }
 
 // WaitForState periodically polls for the ss and its pods until the until function returns either true or an error.
-// Optionally accepts a polling interval.
-func WaitForState(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, , pollInterval time.Duration, until func(*appsv1.StatefulSet, *v1.PodList) (bool, error)) {
-	interval := StatefulSetPoll
-	if len(pollInterval) > 0 {
-		interval = pollInterval[0]
-	}
-
-	pollErr := wait.PollUntilContextTimeout(ctx, interval, StatefulSetTimeout, true,
+func WaitForState(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, pollInterval time.Duration, until func(*appsv1.StatefulSet, *v1.PodList) (bool, error)) {
+	pollErr := wait.PollUntilContextTimeout(ctx, pollInterval, StatefulSetTimeout, true,
 		func(ctx context.Context) (bool, error) {
 			ssGet, err := c.AppsV1().StatefulSets(ss.Namespace).Get(ctx, ss.Name, metav1.GetOptions{})
 			if err != nil {
@@ -98,7 +92,7 @@ func WaitForRunningAndReady(ctx context.Context, c clientset.Interface, numState
 // WaitForPodReady waits for the Pod named podName in set to exist and have a Ready condition.
 func WaitForPodReady(ctx context.Context, c clientset.Interface, set *appsv1.StatefulSet, podName string) (*appsv1.StatefulSet, *v1.PodList) {
 	var pods *v1.PodList
-	WaitForState(ctx, c, set, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
+	WaitForState(ctx, c, set, StatefulSetPoll, func(set2 *appsv1.StatefulSet, pods2 *v1.PodList) (bool, error) {
 		set = set2
 		pods = pods2
 		for i := range pods.Items {

--- a/test/e2e/framework/statefulset/wait.go
+++ b/test/e2e/framework/statefulset/wait.go
@@ -66,7 +66,7 @@ func WaitForRunning(ctx context.Context, c clientset.Interface, numPodsRunning, 
 
 // WaitForState periodically polls for the ss and its pods until the until function returns either true or an error.
 // Optionally accepts a polling interval.
-func WaitForState(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, until func(*appsv1.StatefulSet, *v1.PodList) (bool, error), pollInterval ...time.Duration) {
+func WaitForState(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, , pollInterval time.Duration, until func(*appsv1.StatefulSet, *v1.PodList) (bool, error)) {
 	interval := StatefulSetPoll
 	if len(pollInterval) > 0 {
 		interval = pollInterval[0]


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig apps
/triage accepted
/milestone v1.35

#### What this PR does / why we need it:
Adds e2e test for StatefulSet `maxUnavailable` rolling updates and validates that the feature correctly limits concurrent pod updates during rolling updates.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/961

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
