### PR TITLE
build: discourage expanding dependency on rsync, eliminate some unnecessary filters

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -707,7 +707,6 @@ function kube::build::copy_output() {
     --filter='+ /vendor/' \
     --filter='+ /staging/***/Godeps/**' \
     --filter='+ /_output/dockerized/bin/**' \
-    --filter='- /_output/dockerized/go/**' \
     --filter='+ zz_generated.*' \
     --filter='+ generated.proto' \
     --filter='+ *.pb.go' \

--- a/build/common.sh
+++ b/build/common.sh
@@ -677,6 +677,8 @@ function kube::build::sync_to_container() {
   # are hidden from rsync so they will be deleted in the target container if
   # they exist. This will allow them to be re-created in the container if
   # necessary.
+  # PLEASE DO NOT ADD TO THIS
+  # https://github.com/kubernetes/kubernetes/issues/112862
   kube::build::rsync \
     --delete \
     --filter='- /_tmp/' \
@@ -701,6 +703,8 @@ function kube::build::copy_output() {
   #
   # We are looking to copy out all of the built binaries along with various
   # generated files.
+  # PLEASE DO NOT ADD TO THIS
+  # https://github.com/kubernetes/kubernetes/issues/112862
   kube::build::rsync \
     --prune-empty-dirs \
     --filter='- /_temp/' \

--- a/build/common.sh
+++ b/build/common.sh
@@ -709,7 +709,6 @@ function kube::build::copy_output() {
     --prune-empty-dirs \
     --filter='- /_temp/' \
     --filter='+ /vendor/' \
-    --filter='+ /staging/***/Godeps/**' \
     --filter='+ /_output/dockerized/bin/**' \
     --filter='+ zz_generated.*' \
     --filter='+ generated.proto' \

--- a/hack/lib/verify-generated.sh
+++ b/hack/lib/verify-generated.sh
@@ -39,7 +39,7 @@ kube::verify::generated() {
 
     _tmpdir="$(kube::realpath "$(mktemp -d -t "verify-generated-$(basename "$1").XXXXXX")")"
     git worktree add -f -q "${_tmpdir}" HEAD
-    kube::util::trap_add "git worktree remove -f ${_tmpdir}" EXIT
+    kube::util::trap_add "git worktree remove -f ${_tmpdir:?}; rm -rf ${_tmpdir:?}" EXIT
     cd "${_tmpdir}"
 
     # Update generated files.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

- Adds a note discouraging further expansion of the build rsync filters
- Removes unnecessary rsync filters / fixes codegen cleanup ref: https://github.com/kubernetes/kubernetes/pull/125272#discussion_r1624768041

See: https://github.com/kubernetes/kubernetes/issues/112862

Ideally we could drop the rsync from the build and just use a volume mount, volume mount performance is better on macOS these days and the rsync steps add a lot of complexity and expense to the builds.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing release