### PR TITLE
Add ObjectMeta validation for PDB

### DIFF
--- a/pkg/apis/policy/validation/validation.go
+++ b/pkg/apis/policy/validation/validation.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 
 	policyapiv1beta1 "k8s.io/api/policy/v1beta1"
+	genericvalidation "k8s.io/apimachinery/pkg/api/validation"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -41,7 +42,8 @@ type PodDisruptionBudgetValidationOptions struct {
 // ValidatePodDisruptionBudget validates a PodDisruptionBudget and returns an ErrorList
 // with any errors.
 func ValidatePodDisruptionBudget(pdb *policy.PodDisruptionBudget, opts PodDisruptionBudgetValidationOptions) field.ErrorList {
-	allErrs := ValidatePodDisruptionBudgetSpec(pdb.Spec, opts, field.NewPath("spec"))
+	allErrs := genericvalidation.ValidateObjectMeta(&pdb.ObjectMeta, true, genericvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+	allErrs = append(allErrs, ValidatePodDisruptionBudgetSpec(pdb.Spec, opts, field.NewPath("spec"))...)
 	return allErrs
 }
 

--- a/pkg/apis/policy/validation/validation_test.go
+++ b/pkg/apis/policy/validation/validation_test.go
@@ -94,6 +94,60 @@ func TestValidateMinAvailablePodAndMaxUnavailableDisruptionBudgetSpec(t *testing
 	}
 }
 
+func TestValidatePodDisruptionBudget(t *testing.T) {
+	tests := []struct {
+		name      string
+		pdb       *policy.PodDisruptionBudget
+		expectErr bool
+	}{
+		{
+			name: "valid PodDisruptionBudget with valid metadata",
+			pdb: &policy.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-pdb",
+					Namespace: "default",
+				},
+				Spec: policy.PodDisruptionBudgetSpec{},
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid PodDisruptionBudget with invalid name",
+			pdb: &policy.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-pdb",
+					Namespace: "==invalid_Namespace==",
+				},
+				Spec: policy.PodDisruptionBudgetSpec{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid PodDisruptionBudget with invalid namespace",
+			pdb: &policy.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalidPdb++",
+					Namespace: "valid-ns",
+				},
+				Spec: policy.PodDisruptionBudgetSpec{},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := ValidatePodDisruptionBudget(tc.pdb, PodDisruptionBudgetValidationOptions{false})
+			if len(errs) == 0 && tc.expectErr {
+				t.Errorf("unexpected success for %v", tc.pdb)
+			}
+			if len(errs) != 0 && !tc.expectErr {
+				t.Errorf("unexpected failure: %v for %v", errs, tc.pdb)
+			}
+		})
+	}
+}
+
 func TestValidateUnhealthyPodEvictionPolicyDisruptionBudgetSpec(t *testing.T) {
 	c1 := intstr.FromString("10%")
 	alwaysAllowPolicy := policy.AlwaysAllow


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
There is no ObjectMeta validation for `PodDisruptionBudget` resources currently. That means users can create PDBs with arbitrary names (e.g. `invalid++`). This seems not ideal to allow anything for resources in kubernetes (unless it is intentional). So this PR adds validation for ObjectMeta of `PodDisruptionBudget` which will prohibit invalid names, namespaces, etc.

#### Does this PR introduce a user-facing change?
```release-note
By adding objectmeta validation for PDB, users will not be able to create PDBs with invalid names
```
