### PR TITLE
Stop publishing resource capacity for disconnected plugins

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -271,16 +271,9 @@ func MachineInfo(nodeName string,
 			}
 
 			for _, removedResource := range removedDevicePlugins {
-				logger.V(2).Info("Set capacity for removed resource to 0 on device removal", "device", removedResource)
-				// Set the capacity of the removed resource to 0 instead of
-				// removing the resource from the node status. This is to indicate
-				// that the resource is managed by device plugin and had been
-				// registered before.
-				//
-				// This is required to differentiate the device plugin managed
-				// resources and the cluster-level resources, which are absent in
-				// node status.
-				node.Status.Capacity[v1.ResourceName(removedResource)] = *resource.NewQuantity(int64(0), resource.DecimalSI)
+				logger.V(2).Info("Delete capacity for removed resource on device removal", "device", removedResource)
+				// Delete capacity of the removed resource.
+				delete(node.Status.Capacity, v1.ResourceName(removedResource))
 			}
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.NodeSwap) && info.SwapCapacity != 0 {

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -748,7 +748,7 @@ func TestMachineInfo(t *testing.T) {
 			},
 		},
 		{
-			desc: "inactive device plugin resources should have their capacity set to 0",
+			desc: "inactive device plugin resources should have their capacity and allocatable removed",
 			node: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
@@ -770,13 +770,11 @@ func TestMachineInfo(t *testing.T) {
 						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
 						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-						"inactive":        *resource.NewQuantity(0, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
 						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
 						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-						"inactive":        *resource.NewQuantity(0, resource.BinarySI),
 					},
 				},
 			},

--- a/test/e2e_node/device_plugin_failures_test.go
+++ b/test/e2e_node/device_plugin_failures_test.go
@@ -283,7 +283,7 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		gomega.Eventually(getNodeResourceValues, nodeStatusUpdateTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 0}))
 	})
 
-	ginkgo.It("when ListAndWatch fails after provisioning devices, node allocatable will be set to zero and kubelet will not retry to list resources", func(ctx context.Context) {
+	ginkgo.It("when ListAndWatch fails after provisioning devices, node allocatable will be removed and kubelet will not retry to list resources", func(ctx context.Context) {
 		// randomizing so tests can run in parallel
 		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)
 		devices := []*kubeletdevicepluginv1beta1.Device{
@@ -320,11 +320,11 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		// however kubelet will not delete the resource and will keep the capacity
 		gomega.Eventually(getNodeResourceValues, nodeStatusUpdateTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 2}))
 
-		// after the graceful period devices capacity will reset to zero
-		gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout+1*time.Minute, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 0}))
+		// after the graceful period devices capacity will be removed
+		gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout+1*time.Minute, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: -1, Capacity: -1}))
 	})
 
-	ginkgo.It("when device plugin is stopped after provisioning devices, node allocatable will be set to zero", func(ctx context.Context) {
+	ginkgo.It("when device plugin is stopped after provisioning devices, node allocatable will be removed", func(ctx context.Context) {
 		// randomizing so tests can run in parallel
 		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)
 		devices := []*kubeletdevicepluginv1beta1.Device{
@@ -349,7 +349,7 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		// kubelet will mark all devices as unhealthy
 		gomega.Eventually(getNodeResourceValues, nodeStatusUpdateTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 2}))
 
-		// after the graceful period devices capacity will reset to zero
-		gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout+1*time.Minute, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 0}))
+		// after the graceful period devices capacity will be removed
+		gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout+1*time.Minute, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: -1, Capacity: -1}))
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

According to the [Device Plugins KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3573-device-plugin#healthcheck-and-failure-recovery) it's expected that Kubelet removes any devices that are owned by the failed device plugin from the node capacity. This is not the case currently as Kubelet keeps updating node status with zero values of the `Capacity` and `Allocatable` fields and never stops doing this. This is confusing for the users and also creates certain issues with [supporting extended resources for DRA](https://github.com/kubernetes/kubernetes/issues/133488).

This PR fixes this by deleting the `Capacity` and `Allocatable` of removed extended resources. This usually happens after a [graceful timeout of five minutes](https://github.com/kubernetes/kubernetes/blob/release-1.34/pkg/kubelet/cm/devicemanager/types.go#L116-L120), starting from device plugin disconnect or unregistration.

#### Which issue(s) this PR is related to:

Fixes: #33488

#### Special notes for your reviewer:

PTAL at what @ffromani [pointed out to 2 points](https://github.com/kubernetes/kubernetes/issues/133488#issuecomment-3216663394) we need to carefully discuss before deciding if we want to change this.

#### Does this PR introduce a user-facing change?

```release-note
device plugins: stop publishing resource capacity after pluigin disconnect.
```
