### PR TITLE
Drop experimental prefix from kubectl wait command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -46,7 +46,7 @@ import (
 
 var (
 	waitLong = templates.LongDesc(i18n.T(`
-		Experimental: Wait for a specific condition on one or many resources.
+		Wait for a specific condition on one or many resources.
 
 		The command takes multiple resources and waits until the specified condition
 		is seen in the Status field of every given resource.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

`kubectl wait` command has been around for a long time. I think, it is time to mark it as stable by removing `Experimental` prefix from the description.

#### Does this PR introduce a user-facing change?
```release-note
Removing Experimental prefix from the description of kubectl wait to emphasize that it is stable.
```