### PR TITLE
pick one device class deterministically when there are more than one

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -2708,16 +2708,36 @@ func Test_createDeviceRequests(t *testing.T) {
 		v1.ResourceName(extendedResourceName):          1,
 		v1.ResourceName(extendedResourceName + "init"): 2,
 	}
-	devMap := map[v1.ResourceName]string{
-		v1.ResourceName(extendedResourceName): "class",
+	devMap := map[v1.ResourceName]*resourceapi.DeviceClass{
+		v1.ResourceName(extendedResourceName): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class",
+			},
+		},
 	}
-	devMap2 := map[v1.ResourceName]string{
-		v1.ResourceName(extendedResourceName):       "class",
-		v1.ResourceName(extendedResourceName + "1"): "class1",
+	devMap2 := map[v1.ResourceName]*resourceapi.DeviceClass{
+		v1.ResourceName(extendedResourceName): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class",
+			},
+		},
+		v1.ResourceName(extendedResourceName + "1"): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class1",
+			},
+		},
 	}
-	devMapInit := map[v1.ResourceName]string{
-		v1.ResourceName(extendedResourceName):          "class",
-		v1.ResourceName(extendedResourceName + "init"): "classInit",
+	devMapInit := map[v1.ResourceName]*resourceapi.DeviceClass{
+		v1.ResourceName(extendedResourceName): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class",
+			},
+		},
+		v1.ResourceName(extendedResourceName + "init"): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "classInit",
+			},
+		},
 	}
 	devReq := resourceapi.DeviceRequest{
 		Name: "container-0-request-0",
@@ -2763,7 +2783,7 @@ func Test_createDeviceRequests(t *testing.T) {
 	testcases := map[string]struct {
 		pod                *v1.Pod
 		extendedResources  map[v1.ResourceName]int64
-		deviceClassMapping map[v1.ResourceName]string
+		deviceClassMapping map[v1.ResourceName]*resourceapi.DeviceClass
 		wantDeviceRequests []resourceapi.DeviceRequest
 	}{
 		"nil": {

--- a/pkg/scheduler/framework/plugins/dynamicresources/extended/util.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extended/util.go
@@ -22,17 +22,45 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 )
 
-func DeviceClassMapping(draManager fwk.SharedDRAManager) (map[v1.ResourceName]string, error) {
+// deviceClassCmp returns true when classi is created later than classj, or
+// when they are created at the same time, classi's Name is lexicographically sorted before classj's Name.
+// This helps the transition of extended resource name from one device class to another.
+func deviceClassCmp(classi, classj *resourceapi.DeviceClass) bool {
+	if classi.CreationTimestamp.Equal(&classj.CreationTimestamp) {
+		return classi.Name < classj.Name
+	}
+	return classj.CreationTimestamp.Before(&classi.CreationTimestamp)
+}
+
+func preferableClass(newClass *resourceapi.DeviceClass, mapping map[v1.ResourceName]*resourceapi.DeviceClass, name v1.ResourceName) *resourceapi.DeviceClass {
+	if class, ok := mapping[name]; ok {
+		if deviceClassCmp(newClass, class) {
+			return newClass
+		}
+		return class
+	}
+	return newClass
+}
+
+// DeviceClassMapping creates the mapping of extended resource name to device class name.
+// It always includes the implicit extended resource name for each device class.
+// The device class MUST NOT BE modified.
+func DeviceClassMapping(draManager fwk.SharedDRAManager) (map[v1.ResourceName]*resourceapi.DeviceClass, error) {
 	classes, err := draManager.DeviceClasses().List()
-	extendedResources := make(map[v1.ResourceName]string, len(classes))
 	if err != nil {
 		return nil, err
 	}
+	mapping := make(map[v1.ResourceName]*resourceapi.DeviceClass, len(classes))
 	for _, c := range classes {
+		// implicit extended resource name
+		name := v1.ResourceName(resourceapi.ResourceDeviceClassPrefix + c.Name)
+		mapping[name] = c
+
+		// explicit extended resource name, if any
 		if c.Spec.ExtendedResourceName != nil {
-			extendedResources[v1.ResourceName(*c.Spec.ExtendedResourceName)] = c.Name
+			name = v1.ResourceName(*c.Spec.ExtendedResourceName)
+			mapping[name] = preferableClass(c, mapping, name)
 		}
-		extendedResources[v1.ResourceName(resourceapi.ResourceDeviceClassPrefix+c.Name)] = c.Name
 	}
-	return extendedResources, nil
+	return mapping, nil
 }

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -106,7 +107,7 @@ func (f *Fit) ScoreExtensions() fwk.ScoreExtensions {
 type preFilterState struct {
 	framework.Resource
 	// resourceToDeviceClass holds the mapping of extended resource to device class name.
-	resourceToDeviceClass map[v1.ResourceName]string
+	resourceToDeviceClass map[v1.ResourceName]*resourceapi.DeviceClass
 }
 
 // Clone the prefilter state.
@@ -254,7 +255,7 @@ func withDeviceClass(result *preFilterState, draManager fwk.SharedDRAManager) *f
 		result.resourceToDeviceClass = resourceToDeviceClass
 		if len(resourceToDeviceClass) == 0 {
 			// ensure it is empty map, not nil.
-			result.resourceToDeviceClass = make(map[v1.ResourceName]string, 0)
+			result.resourceToDeviceClass = make(map[v1.ResourceName]*resourceapi.DeviceClass, 0)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
pick one device class deterministically when there are more than one

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/133693

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
pick one device class deterministically for extended resource when there are more than one

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
