### PR TITLE
cleanup: replace manual signal handling with SetupSignalContext

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -147,13 +147,7 @@ func runCommand(cmd *cobra.Command, opts *options.Options, registryOptions ...Op
 	}
 	cliflag.PrintFlags(cmd.Flags())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		stopCh := server.SetupSignalHandler()
-		<-stopCh
-		cancel()
-	}()
+	ctx := server.SetupSignalContext()
 
 	cc, sched, err := Setup(ctx, opts, registryOptions...)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/signal.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/signal.go
@@ -38,11 +38,15 @@ func SetupSignalHandler() <-chan struct{} {
 // Only one of SetupSignalContext and SetupSignalHandler should be called, and only can
 // be called once.
 func SetupSignalContext() context.Context {
+	return SetupSignalContextFrom(context.Background())
+}
+
+func SetupSignalContextFrom(ctx context.Context) context.Context {
 	close(onlyOneSignalHandler) // panics when called twice
 
 	shutdownHandler = make(chan os.Signal, 2)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	signal.Notify(shutdownHandler, shutdownSignals...)
 	go func() {
 		<-shutdownHandler

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -88,13 +88,7 @@ func runServer(ctx context.Context, opts *options.Options) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		stopCh := apiserver.SetupSignalHandler()
-		<-stopCh
-		cancel()
-	}()
+	ctx = apiserver.SetupSignalContextFrom(ctx)
 
 	return server.Start(ctx)
 }


### PR DESCRIPTION
The `apiserver/pkg/server/signal.go` already implements identical functionality, let's use it directly.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR streamlines signal handling in kube-scheduler and pod-security-admission webhook using SetupSignalContext for cleaner, more maintainable code.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```