### PR TITLE
Remove GA feature gate ComponentSLIs

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/features/kube_features.go
+++ b/staging/src/k8s.io/component-base/metrics/features/kube_features.go
@@ -17,26 +17,11 @@ limitations under the License.
 package features
 
 import (
-	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
 
-const (
-	// owner: @logicalhan
-	// kep: https://kep.k8s.io/3466
-	ComponentSLIs featuregate.Feature = "ComponentSLIs"
-)
-
 func featureGates() map[featuregate.Feature]featuregate.VersionedSpecs {
-	return map[featuregate.Feature]featuregate.VersionedSpecs{
-		ComponentSLIs: {
-			{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
-			{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
-			// ComponentSLIs officially graduated to GA in v1.29 but the gate was not updated until v1.32.
-			// To support emulated versions, keep the gate until v1.35.
-			{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-		},
-	}
+	return map[featuregate.Feature]featuregate.VersionedSpecs{}
 }
 
 // AddFeatureGates adds all feature gates used by this package.

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -217,20 +217,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.32"
-- name: ComponentSLIs
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "1.26"
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.27"
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "1.32"
 - name: ComponentStatusz
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

re-do https://github.com/kubernetes/kubernetes/pull/127787

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

/assign @hankang @richabanker @Jefftree

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removed the `ComponentSLIs` feature gate, which had been promoted to stable as part of the Kubernetes 1.32 release.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
