### PR TITLE
restore partial functionality of public func `AuditEventFrom` which was deleted by #129472

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/context.go
@@ -178,6 +178,25 @@ func (ac *AuditContext) LogRequestPatch(patch []byte) {
 	})
 }
 
+// GetEventUser returns a copy of the User associated with the audit Event.
+func (ac *AuditContext) GetEventUser() authnv1.UserInfo {
+	var val *authnv1.UserInfo
+	ac.visitEvent(func(ev *auditinternal.Event) {
+		val = ev.User.DeepCopy()
+	})
+	return *val
+}
+
+// GetEventImpersonatedUser returns a copy of the ImpersonatedUser associated with the audit Event,
+// or returns nil when there is no ImpersonatedUser.
+func (ac *AuditContext) GetEventImpersonatedUser() *authnv1.UserInfo {
+	var val *authnv1.UserInfo
+	ac.visitEvent(func(ev *auditinternal.Event) {
+		val = ev.ImpersonatedUser.DeepCopy()
+	})
+	return val
+}
+
 func (ac *AuditContext) GetEventAnnotation(key string) (string, bool) {
 	var val string
 	var ok bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

PR #129472 removed some important functionality which had been public for years. `func AuditEventFrom(ctx context.Context) *auditinternal.Event` could previously be used by other projects which use `k8s.io/apiserver` as a Go package in order to read the current audit event for the in-flight http request. While it makes sense that the audit event should not be mutated, which seems to be the spirit of the PR which removed the function, it was previously possible to read the fields of the audit event.

With that function now removed in v0.34.0, it seems to be impossible to read some of the information about the request which was previously available by reading the audit event. For example, it's no longer possible to determine if the current request is handling user impersonation, where it was previously possible by getting the audit event and looking at its `User` and `ImpersonatedUser` fields. (I know, that might be a weird thing for a project to need, but we've always used it.) This breaking API change hurts some users of `k8s.io/apiserver`, even though it does not effect Kubernetes itself.

~~This PR proposes to bring back the function with a new name but otherwise the same signature as before. The behavior is similar to the old function, except that it now returns a deep copy to prevent callers from mutating the context's underlying audit event.~~ Update after code review: This PR proposes to add new getters for the audit event's `User` and `ImpersonatedUser` fields. The getters return deep copies to prevent callers from mutating the context's underlying audit event. Aside from the new unit test, these new functions are not currently used in Kubernetes. They are intended for use by other projects, especially those which were previously using `AuditEventFrom` before its removal.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
