### PR TITLE
Fix completion of resource names

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
@@ -325,10 +325,12 @@ func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cm
 	o.Verbs = []string{"get"}
 	// TODO:Should set --request-timeout=5s
 
-	o.Complete(restClientGetter, cmd, nil)
+	if err := o.Complete(restClientGetter, cmd, nil); err != nil {
+		return []string{}
+	}
 
 	// Ignore errors as the output may still be valid
-	o.RunAPIResources()
+	_ = o.RunAPIResources()
 
 	// Resources can be a comma-separated list.  The last element is then
 	// the one we should complete.  For example if toComplete=="pods,secre"

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
@@ -319,13 +319,13 @@ func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cm
 	streams := genericiooptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: io.Discard}
 	o := apiresources.NewAPIResourceOptions(streams)
 
-	o.Complete(restClientGetter, cmd, nil)
-
 	// Get the list of resources
 	o.PrintFlags.OutputFormat = ptr.To("name")
 	o.Cached = true
 	o.Verbs = []string{"get"}
 	// TODO:Should set --request-timeout=5s
+
+	o.Complete(restClientGetter, cmd, nil)
 
 	// Ignore errors as the output may still be valid
 	o.RunAPIResources()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixed the shell completion for api resources that got broken in #132604

For API resources, the output format is now used by the `Complete()` function, so the format must be set before invoking said function.

The commit also adds unit tests for this scenario, which fails before the fix.

Before the PR:
```
$ kubectl __complete get add
addons                                       k3s.cattle.io/v1                       true    Addon
:4
Completion ended with directive: ShellCompDirectiveNoFileComp

# Which leads to a broken shell completion:
$ kubectl get add<TAB>
$ kubectl get addons\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ k3s.cattle.io/v1\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ true\ \ \ \ Addon
```
With the PR:
```
$ /tmp/kubectl __complete get add
addons.k3s.cattle.io
:4
Completion ended with directive: ShellCompDirectiveNoFileComp

$ /tmp/kubectl get add<TAB>
$ /tmp/kubectl get addons.k3s.cattle.io
```
#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1775

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Only in the fact that shell completion for resource names will work again.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a 1.34 regression causing broken shell completion for api resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
