### PR TITLE
test: De-flake TestReflectorNotStoppedOnSlowInitialization

### DIFF
--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -499,7 +499,7 @@ func TestReflectorNotStoppedOnSlowInitialization(t *testing.T) {
 
 	// Initialization should successfully finish.
 	fakeClock.Step(30 * time.Second)
-	deadlineCtx, deadlineCancel := context.WithTimeout(tCtx, time.Second)
+	deadlineCtx, deadlineCancel := context.WithTimeout(tCtx, 5*time.Second)
 	defer deadlineCancel()
 	if err := wait.PollUntilContextCancel(deadlineCtx, 10*time.Millisecond, false, reflectorInitialized); err != nil {
 		t.Errorf("reflector didn't iniailize correctly")


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/kind cleanup

**What this PR does / why we need it:**
This PR de-flakes the TestReflectorNotStoppedOnSlowInitialization unit test.

The TestReflectorNotStoppedOnSlowInitialization unit test was failing intermittently on the pull-kubernetes-unit-windows-master CI job.

The root cause was a race condition. The test uses a fake clock to simulate a long (120s) delay for an asynchronous operation. Immediately after the fake delay completed, it used a hard, 1-second real-time timeout to verify that the operation was finished. On heavily loaded CI environments, particularly on Windows, this 1-second timeout was not always sufficient, causing the test to fail.

This change increases the polling timeout to a more robust 5 seconds to account for CI environment variability.

**Which issue(s) this PR is related to:**
#133698

**Special notes for your reviewer:**
This is my first contribution to Kubernetes. Happy to make any changes needed!

**Does this PR introduce a user-facing change?**
```
Release-note
NONE

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
Docs

```
