### PR TITLE
[WIP] add trace logs to port-forward related code

### DIFF
--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -235,7 +235,7 @@ func (r *PortForwardREST) ConnectMethods() []string {
 
 // Connect returns a handler for the pod portforward proxy
 func (r *PortForwardREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	opTrace := utiltrace.New("PortForwardREST.Connect", Field{Key: "name", Value: name})
+	opTrace := utiltrace.New("PortForwardREST.Connect", utiltrace.Field{Key: "name", Value: name})
 	ctx = utiltrace.ContextWithTrace(ctx, opTrace)
 	defer opTrace.Log()
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	utiltrace "k8s.io/utils/trace"
 
 	"github.com/mxk/go-flowrate/flowrate"
 
@@ -211,6 +212,9 @@ func proxyRedirectsforRootPath(path string, w http.ResponseWriter, req *http.Req
 
 // ServeHTTP handles the proxy request
 func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	opTrace := utiltrace.New("UpgradeAwareHandler.ServeHTTP")
+	defer opTrace.Log()
+
 	if h.tryUpgrade(w, req) {
 		return
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtunnel.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtunnel.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apiserver/pkg/util/proxy/metrics"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/klog/v2"
+	utiltrace "k8s.io/utils/trace"
 )
 
 // TunnelingHandler is a handler which tunnels SPDY through WebSockets.
@@ -60,6 +61,9 @@ func NewTunnelingHandler(upgradeHandler http.Handler) *TunnelingHandler {
 // case the upstream upgrade fails, we delegate communication to the passed
 // in "w" ResponseWriter.
 func (h *TunnelingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	opTrace := utiltrace.New("TunnelingHandler.ServeHTTP")
+	defer opTrace.Log()
+
 	klog.V(4).Infoln("TunnelingHandler ServeHTTP")
 
 	spdyProtocols := spdyProtocolsFromWebsocketProtocols(req)

--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/portforward/websocket.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/portforward/websocket.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+	utiltrace "k8s.io/utils/trace"
 )
 
 const (
@@ -95,6 +96,9 @@ func BuildV4Options(ports []int32) (*V4Options, error) {
 // ERROR n+1). The associated port is written to each stream as a unsigned 16
 // bit integer in little endian format.
 func handleWebSocketStreams(req *http.Request, w http.ResponseWriter, portForwarder PortForwarder, podName string, uid types.UID, opts *V4Options, supportedPortForwardProtocols []string, idleTimeout, streamCreationTimeout time.Duration) error {
+	opTrace := utiltrace.New("handleWebSocketStreams")
+	defer opTrace.Log()
+
 	channels := make([]wsstream.ChannelType, 0, len(opts.Ports)*2)
 	for i := 0; i < len(opts.Ports); i++ {
 		channels = append(channels, wsstream.ReadWriteChannel, wsstream.WriteChannel)

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -247,7 +247,7 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	// by the port-forward command. We don't want to hard code the port as we have no
 	// way of guaranteeing we can pick one that isn't in use, particularly on Jenkins.
 	framework.Logf("starting port-forward command and streaming output")
-	portOutput, _, err := framework.StartCmdAndStreamOutput(cmd)
+	portOutput, portStderr, err := framework.StartCmdAndStreamOutput(cmd)
 	if err != nil {
 		framework.Failf("Failed to start port-forward command: %v", err)
 	}
@@ -268,6 +268,15 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	listenPort, err := strconv.Atoi(match[2])
 	if err != nil {
 		framework.Failf("Error converting %s to an int: %v", match[2], err)
+	}
+
+	framework.Logf("port-forward stdout:")
+	framework.Logf(string(buf))
+
+	framework.Logf("port-forward stderr:")
+	stderrBuf := make([]byte, 128)
+	if _, err = portStderr.Read(stderrBuf); err != nil {
+		framework.Logf("failed to read port-forward stderr: %s", err)
 	}
 
 	return &portForwardCommand{

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -252,7 +252,6 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 		framework.Failf("Failed to start port-forward command: %v", err)
 	}
 
-	var n int
 	var buf []byte
 
 	framework.Logf("reading from `kubectl port-forward` command's stdout")
@@ -273,8 +272,9 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	}
 
 	go func() {
-		if stderrBuf, stderrErr := io.ReadAll(portStderr); stderrErr != nil {
-			framework.Failf("Failed to read from kubectl port-forward stderr: %v", err)
+		stderrBuf, stderrErr := io.ReadAll(portStderr)
+		if stderrErr != nil {
+			framework.Failf("Failed to read from kubectl port-forward stderr: %v", stderrErr)
 		}
 		framework.Logf("stderr: %s", string(stderrBuf))
 	}()


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

Adds trace logs to port-forward code in kubectl, kubelet and apiserver.
This might help us understading and troubleshooting e2e test failures in port-forwarding related tests, such as the ones observed in #132057.

#### Which issue(s) this PR is related to:

#132057

#### Special notes for your reviewer:
We might want to make trace logging conditional to time taken by using `opTrace.LogIfLong` instead of `opTrace.Log`.
I have not started with that because I plan to run this code a few times in CI to observe what component takes the longest to respond.
If/when we switch to `LogIfLong`, what would we consider long? The e2e test started timing out after 10 seconds, and was increased to 15 and then recently to 25. But we do not know if the delay is coming from a single component.

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


