### PR TITLE
Automated cherry pick of #133513: Add missing conversion for timeoutForControlPlane

### DIFF
--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -380,6 +380,11 @@ func documentMapToInitConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 	// If ClusterConfiguration was given, populate it in the InitConfiguration struct
 	if clustercfg != nil {
 		initcfg.ClusterConfiguration = *clustercfg
+
+		// TODO: Workaround for missing v1beta3 ClusterConfiguration timeout conversion. Remove this conversion once the v1beta3 is removed
+		if clustercfg.APIServer.TimeoutForControlPlane.Duration != 0 && clustercfg.APIServer.TimeoutForControlPlane.Duration != kubeadmconstants.ControlPlaneComponentHealthCheckTimeout {
+			initcfg.Timeouts.ControlPlaneComponentHealthCheck.Duration = clustercfg.APIServer.TimeoutForControlPlane.Duration
+		}
 	} else {
 		// Populate the internal InitConfiguration.ClusterConfiguration with defaults
 		extclustercfg := &kubeadmapiv1.ClusterConfiguration{}


### PR DESCRIPTION
Cherry pick of #133513 on release-1.31.

#133513: Add missing conversion for timeoutForControlPlane

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fixed bug where v1beta3's ClusterConfiguration.APIServer.TimeoutForControlPlane is not respected in newer versions of kubeadm where v1beta4 is the default.
```