### PR TITLE
Remove the --pod-infra-container-image flag from kubeadm and cluster/gce

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1013,7 +1013,6 @@ function Start-WorkerServices {
   # otherwise kubelet and kube-proxy will not be able to run properly.
   $instance_name = "$(Get-InstanceMetadata 'name' | Out-String)"
   $default_kubelet_args = @(`
-      "--pod-infra-container-image=${env:INFRA_CONTAINER}",
       "--hostname-override=${instance_name}"
   )
 

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -75,18 +75,6 @@ func TestBuildKubeletArgs(t *testing.T) {
 				{Name: "register-with-taints", Value: "foo=bar:baz,key=val:eff"},
 			},
 		},
-		{
-			name: "pause image is set",
-			opts: kubeletFlagsOpts{
-				nodeRegOpts: &kubeadmapi.NodeRegistrationOptions{},
-				criSocket:   "unix:///var/run/containerd/containerd.sock",
-				pauseImage:  "registry.k8s.io/pause:ver",
-			},
-			expected: []kubeadmapi.Arg{
-				{Name: "container-runtime-endpoint", Value: "unix:///var/run/containerd/containerd.sock"},
-				{Name: "pod-infra-container-image", Value: "registry.k8s.io/pause:ver"},
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -200,14 +188,14 @@ func TestReadKubeadmFlags(t *testing.T) {
 	}{
 		{
 			name:          "valid kubeadm flags with container-runtime-endpoint",
-			fileContent:   `KUBELET_KUBEADM_ARGS="--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --pod-infra-container-image=registry.k8s.io/pause:1.0"`,
-			expectedValue: []string{"--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock", "--pod-infra-container-image=registry.k8s.io/pause:1.0"},
+			fileContent:   `KUBELET_KUBEADM_ARGS="--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock"`,
+			expectedValue: []string{"--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock"},
 			expectError:   false,
 		},
 		{
 			name:          "no container-runtime-endpoint found",
-			fileContent:   `KUBELET_KUBEADM_ARGS="--pod-infra-container-image=registry.k8s.io/pause:1.0"`,
-			expectedValue: []string{"--pod-infra-container-image=registry.k8s.io/pause:1.0"},
+			fileContent:   `KUBELET_KUBEADM_ARGS=""`,
+			expectedValue: nil,
 			expectError:   true,
 		},
 		{

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -175,6 +176,58 @@ func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, kubeletDir strin
 		err := dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletConfigurationFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, out)
 		if err != nil {
 			return errors.Wrap(err, "error printing kubelet configuration file on dryrun")
+		}
+	}
+	return nil
+}
+
+// RemoveKubeletArgsFromFile removes unwanted kubelet flags from the existing KubeletEnvFile file,
+// but first creates a backup of the existing file.
+func RemoveKubeletArgsFromFile(kubeletDir string, kubeConfigDir string, unwantedFlags []string, dryRun bool, out io.Writer) error {
+	// If there are no unwanted flags, do nothing.
+	if len(unwantedFlags) == 0 {
+		return nil
+	}
+
+	// For dry run mode, we can not access the real kubelet env file in the dry-run directory, so we only print the unwanted flags instead.
+	if dryRun {
+		_, _ = fmt.Fprintf(out, "[dryrun] Would remove unwanted kubelet flags %v from %s\n", unwantedFlags, kubeadmconstants.KubeletEnvFileName)
+		return nil
+	}
+
+	// Create a copy of the KubeletEnvFile in the /etc/kubernetes/tmp or kubeConfigDir.
+	backupDir, err := kubeadmconstants.CreateTempDir(kubeConfigDir, "kubeadm-kubelet-env")
+	if err != nil {
+		return err
+	}
+	klog.Warningf("Using temporary directory %s for kubelet env file. To override it set the environment variable %s",
+		backupDir, kubeadmconstants.EnvVarUpgradeDryRunDir)
+
+	src := filepath.Join(kubeletDir, kubeadmconstants.KubeletEnvFileName)
+	dest := filepath.Join(backupDir, kubeadmconstants.KubeletEnvFileName)
+
+	_, _ = fmt.Fprintf(out, "[upgrade] Backing up kubelet env file to %s\n", dest)
+	err = kubeadmutil.CopyFile(src, dest)
+	if err != nil {
+		return errors.Wrap(err, "error backing up the kubelet env file")
+	}
+
+	var kubeletFlags []kubeadmapi.Arg
+	command, err := kubeletphase.ReadKubeletDynamicEnvFile(src)
+	if err != nil {
+		return errors.Wrap(err, "error reading kubelet env file")
+	}
+	args := kubeadmutil.ArgumentsFromCommand(command)
+	for _, arg := range args {
+		if slices.Contains(unwantedFlags, arg.Name) {
+			continue
+		}
+		kubeletFlags = append(kubeletFlags, arg)
+	}
+	// Rewrite env file if needed
+	if len(args) != len(kubeletFlags) {
+		if err := kubeletphase.WriteKubeletArgsToFile(kubeletFlags, nil, kubeletDir); err != nil {
+			return errors.Wrap(err, "error writing kubelet env file")
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

 The `--pod-infra-container-image` flag is a nop flag.

#### Which issue(s) this PR is related to:

xref https://github.com/kubernetes/kubeadm/issues/3108

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: stoped applying the --pod-infra-container-image flag for the kubelet. The flag has been deprecated and no longer served a purpose in the kubelet as the logic was migrated to CRI. During upgrade, kubeadm will attempt to remove the flag from the file /var/lib/kubelet/kubeadm-flags.env.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
