### PR TITLE
test/integration/apiserver: fix several data races

### DIFF
--- a/pkg/apis/scheduling/v1/helpers.go
+++ b/pkg/apis/scheduling/v1/helpers.go
@@ -43,16 +43,29 @@ var systemPriorityClasses = []*v1.PriorityClass{
 	},
 }
 
-// SystemPriorityClasses returns the list of system priority classes.
-// NOTE: be careful not to modify any of elements of the returned array directly.
+// SystemPriorityClasses returns a deep copy of the list of system priority classes.
+// If only the names are needed, use SystemPriorityClassNames().
 func SystemPriorityClasses() []*v1.PriorityClass {
-	return systemPriorityClasses
+	retval := make([]*v1.PriorityClass, 0, len(systemPriorityClasses))
+	for _, c := range systemPriorityClasses {
+		retval = append(retval, c.DeepCopy())
+	}
+	return retval
+}
+
+// SystemPriorityClassNames returns the names of system priority classes.
+func SystemPriorityClassNames() []string {
+	retval := make([]string, 0, len(systemPriorityClasses))
+	for _, c := range systemPriorityClasses {
+		retval = append(retval, c.Name)
+	}
+	return retval
 }
 
 // IsKnownSystemPriorityClass returns true if there's any of the system priority classes exactly
 // matches "name", "value", "globalDefault". otherwise it will return an error.
 func IsKnownSystemPriorityClass(name string, value int32, globalDefault bool) (bool, error) {
-	for _, spc := range SystemPriorityClasses() {
+	for _, spc := range systemPriorityClasses {
 		if spc.Name == name {
 			if spc.Value != value {
 				return false, fmt.Errorf("value of %v PriorityClass must be %v", spc.Name, spc.Value)

--- a/pkg/registry/scheduling/priorityclass/storage/storage.go
+++ b/pkg/registry/scheduling/priorityclass/storage/storage.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"context"
 	"errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,9 +71,9 @@ func (r *REST) ShortNames() []string {
 
 // Delete ensures that system priority classes are not deleted.
 func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	for _, spc := range schedulingapiv1.SystemPriorityClasses() {
-		if name == spc.Name {
-			return nil, false, apierrors.NewForbidden(scheduling.Resource("priorityclasses"), spc.Name, errors.New("this is a system priority class and cannot be deleted"))
+	for _, spcName := range schedulingapiv1.SystemPriorityClassNames() {
+		if name == spcName {
+			return nil, false, apierrors.NewForbidden(scheduling.Resource("priorityclasses"), spcName, errors.New("this is a system priority class and cannot be deleted"))
 		}
 	}
 

--- a/test/integration/apiserver/oidc/oidc_test.go
+++ b/test/integration/apiserver/oidc/oidc_test.go
@@ -34,7 +34,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -77,12 +76,6 @@ const (
 	defaultStubAccessToken  = "_fake_access_token_"
 
 	rsaKeyBitSize = 2048
-)
-
-var (
-	// testServerMutex serializes test server starts to prevent data races
-	// in admission plugin flag registration
-	testServerMutex sync.Mutex
 )
 
 var (
@@ -2011,15 +2004,12 @@ egressSelections:
 	}
 	customFlags = append(customFlags, "--authorization-mode=RBAC")
 
-	// Serialize test server starts to prevent data races in admission plugin flag registration
-	testServerMutex.Lock()
 	server, err := kubeapiserverapptesting.StartTestServer(
 		t,
 		kubeapiserverapptesting.NewDefaultTestServerOptions(),
 		customFlags,
 		framework.SharedEtcd(),
 	)
-	testServerMutex.Unlock()
 	require.NoError(t, err)
 
 	t.Cleanup(server.TearDownFn)

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -405,13 +405,13 @@ resources:
 // 7. when kms-plugin is down, no-op update for a pod should succeed and not result in RV change even once the DEK/seed is valid
 func TestKMSv2ProviderKeyIDStaleness(t *testing.T) {
 	t.Parallel()
+	// testKMSv2ProviderKeyIDStaleness modifies global state (kmsv2.NowFunc) and thus the following two tests
+	// have to run sequentially. No other test is allowed to change kmsv2.NowFunc.
 	t.Run("regular gcm", func(t *testing.T) {
-		t.Parallel()
 		kmsName := "kms-provider-key-id-stale-false"
 		testKMSv2ProviderKeyIDStaleness(t, kmsName, encryptionconfig.SetKDFForTests(kmsName, false))
 	})
 	t.Run("extended nonce gcm", func(t *testing.T) {
-		t.Parallel()
 		testKMSv2ProviderKeyIDStaleness(t, "kms-provider-key-id-stale-true", func() {})
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

https://testgrid.k8s.io/sig-testing-canaries#integration-race-master shows that test/integration/controlplane/transformation.transformation has a data race. Fixing that and running the tests locally revealed some more data races which hadn't shown up in the CI yet.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/133106
https://github.com/kubernetes/kubernetes/issues/133082
reverted by this PR and solved differently: https://github.com/kubernetes/kubernetes/pull/133086

#### Special notes for your reviewer:

See the individual commits for details.

cc @aramase @enj @aojea

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
