### PR TITLE
lock DisableAllocatorDualWrite

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1231,7 +1231,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	DisableAllocatorDualWrite: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA}, // remove after MultiCIDRServiceAllocator is GA
+		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.GA},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove after MultiCIDRServiceAllocator is GA
 	},
 
 	DisableCPUQuotaWithExclusiveCPUs: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -427,6 +427,10 @@
     lockToDefault: false
     preRelease: GA
     version: "1.34"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.35"
 - name: DisableCPUQuotaWithExclusiveCPUs
   versionedSpecs:
   - default: true

--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -56,7 +56,7 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 					"--disable-admission-plugins=ServiceAccount",
 					fmt.Sprintf("--feature-gates=%s=%v,%s=%v", features.MultiCIDRServiceAllocator, enableMultiServiceCIDR, features.DisableAllocatorDualWrite, disableAllocatorDualWrite),
 				}
-				if !enableMultiServiceCIDR {
+				if !enableMultiServiceCIDR || !disableAllocatorDualWrite {
 					flags = append(flags, "--emulated-version=1.33")
 				}
 				s := kubeapiservertesting.StartTestServerOrDie(t,
@@ -303,7 +303,7 @@ func TestCreateServiceSingleStackIPv6(t *testing.T) {
 					"--disable-admission-plugins=ServiceAccount",
 					fmt.Sprintf("--feature-gates=%s=%v,%s=%v", features.MultiCIDRServiceAllocator, enableMultiServiceCIDR, features.DisableAllocatorDualWrite, disableAllocatorDualWrite),
 				}
-				if !enableMultiServiceCIDR {
+				if !enableMultiServiceCIDR || !disableAllocatorDualWrite {
 					flags = append(flags, "--emulated-version=1.33")
 				}
 				s := kubeapiservertesting.StartTestServerOrDie(t,
@@ -537,7 +537,7 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 					"--disable-admission-plugins=ServiceAccount",
 					fmt.Sprintf("--feature-gates=%s=%v,%s=%v", features.MultiCIDRServiceAllocator, enableMultiServiceCIDR, features.DisableAllocatorDualWrite, disableAllocatorDualWrite),
 				}
-				if !enableMultiServiceCIDR {
+				if !enableMultiServiceCIDR || !disableAllocatorDualWrite {
 					flags = append(flags, "--emulated-version=1.33")
 				}
 				s := kubeapiservertesting.StartTestServerOrDie(t,
@@ -819,7 +819,7 @@ func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 					"--disable-admission-plugins=ServiceAccount",
 					fmt.Sprintf("--feature-gates=%s=%v,%s=%v", features.MultiCIDRServiceAllocator, enableMultiServiceCIDR, features.DisableAllocatorDualWrite, disableAllocatorDualWrite),
 				}
-				if !enableMultiServiceCIDR {
+				if !enableMultiServiceCIDR || !disableAllocatorDualWrite {
 					flags = append(flags, "--emulated-version=1.33")
 				}
 				s := kubeapiservertesting.StartTestServerOrDie(t,


### PR DESCRIPTION

/kind cleanup

```release-note
NONE
```

Lock DisableAllocatorDualWrite to default after one release without reported bug.
After two versions running with the new allocators, 1.35 and 1.34 apiservers will no longer used the legacy bitmap allocators, so it will not be required to use the dual write

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1880
```
