### PR TITLE
Automated cherry pick of #133771: Fix completion of resource names

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
@@ -325,10 +325,12 @@ func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cm
 	o.Verbs = []string{"get"}
 	// TODO:Should set --request-timeout=5s
 
-	o.Complete(restClientGetter, cmd, nil)
+	if err := o.Complete(restClientGetter, cmd, nil); err != nil {
+		return []string{}
+	}
 
 	// Ignore errors as the output may still be valid
-	o.RunAPIResources()
+	_ = o.RunAPIResources()
 
 	// Resources can be a comma-separated list.  The last element is then
 	// the one we should complete.  For example if toComplete=="pods,secre"

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
@@ -319,13 +319,13 @@ func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cm
 	streams := genericiooptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: io.Discard}
 	o := apiresources.NewAPIResourceOptions(streams)
 
-	o.Complete(restClientGetter, cmd, nil)
-
 	// Get the list of resources
 	o.PrintFlags.OutputFormat = ptr.To("name")
 	o.Cached = true
 	o.Verbs = []string{"get"}
 	// TODO:Should set --request-timeout=5s
+
+	o.Complete(restClientGetter, cmd, nil)
 
 	// Ignore errors as the output may still be valid
 	o.RunAPIResources()


### PR DESCRIPTION
Cherry pick of #133771 on release-1.34.

#133771: Fix completion of resource names

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a 1.34 regression causing broken shell completion for api resources.
```