### PR TITLE
Treat extended resources as inactive when allocatable is 0

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -758,10 +758,10 @@ func (pl *DynamicResources) filterExtendedResources(state *stateData, pod *v1.Po
 			continue
 		}
 
-		_, okScalar := nodeInfo.GetAllocatable().GetScalarResources()[rName]
+		allocatable, okScalar := nodeInfo.GetAllocatable().GetScalarResources()[rName]
 		_, okDynamic := state.draExtendedResource.resourceToDeviceClass[rName]
 		if okDynamic {
-			if okScalar {
+			if allocatable > 0 {
 				// node provides the resource via device plugin
 				extendedResources[rName] = 0
 			} else {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -158,8 +158,9 @@ var (
 	workerNode3      = &st.MakeNode().Name(node3Name).Label("kubernetes.io/hostname", node3Name).Node
 	workerNode3Slice = st.MakeResourceSlice(node3Name, driver).Device("instance-1", map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{attrName: {BoolValue: ptr.To(true)}}).Obj()
 
-	workerNodeWithExtendedResource = &st.MakeNode().Name(nodeName).Label("kubernetes.io/hostname", nodeName).Capacity(map[v1.ResourceName]string{v1.ResourceName(extendedResourceName): "1"}).Node
-	brokenSelector                 = resourceapi.DeviceSelector{
+	workerNodeWithExtendedResource                = &st.MakeNode().Name(nodeName).Label("kubernetes.io/hostname", nodeName).Capacity(map[v1.ResourceName]string{v1.ResourceName(extendedResourceName): "1"}).Node
+	workerNodeWithExtendedResourceZeroAllocatable = &st.MakeNode().Name(nodeName).Label("kubernetes.io/hostname", nodeName).Capacity(map[v1.ResourceName]string{v1.ResourceName(extendedResourceName): "0"}).Node
+	brokenSelector                                = resourceapi.DeviceSelector{
 		CEL: &resourceapi.CELDeviceSelector{
 			// Not set for workerNode.
 			Expression: fmt.Sprintf(`device.attributes["%s"].%s`, driver, attrName),
@@ -1422,6 +1423,38 @@ func TestPlugin(t *testing.T) {
 			pod:                                podWithExtendedResourceName,
 			classes:                            []*resourceapi.DeviceClass{deviceClassWithExtendResourceName},
 			want:                               want{},
+		},
+		"extended-resource-name-with-zero-allocatable": {
+			enableDRAExtendedResource: true,
+			nodes:                     []*v1.Node{workerNodeWithExtendedResourceZeroAllocatable},
+			pod:                       podWithExtendedResourceName,
+			classes:                   []*resourceapi.DeviceClass{deviceClassWithExtendResourceName},
+			objs:                      []apiruntime.Object{workerNodeSlice, podWithExtendedResourceName},
+			want: want{
+				reserve: result{
+					inFlightClaim: extendedResourceClaimNoName,
+				},
+				prebind: result{
+					assumedClaim: reserve(extendedResourceClaim, podWithExtendedResourceName),
+					added:        []metav1.Object{reserve(extendedResourceClaim, podWithExtendedResourceName)},
+				},
+				postbind: result{
+					assumedClaim: reserve(extendedResourceClaim, podWithExtendedResourceName),
+				},
+			},
+		},
+		"non-DRA-extended-resource-name-with-zero-allocatable": {
+			enableDRAExtendedResource: true,
+			nodes:                     []*v1.Node{workerNodeWithExtendedResourceZeroAllocatable},
+			pod:                       podWithExtendedResourceName,
+			classes:                   []*resourceapi.DeviceClass{deviceClass},
+			objs:                      []apiruntime.Object{workerNodeSlice, podWithExtendedResourceName},
+			want: want{
+				prefilter: result{
+					status: fwk.NewStatus(fwk.Skip),
+				},
+				prebindPreFlight: fwk.NewStatus(fwk.Skip),
+			},
 		},
 		"extended-resource-name-no-resource": {
 			enableDRAExtendedResource: true,

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -477,14 +477,15 @@ func haveAnyRequestedResourcesIncreased(pod *v1.Pod, originalNode, modifiedNode 
 		}
 
 		if opts.EnableDRAExtendedResource {
-			_, okScalar := modifiedNodeInfo.GetAllocatable().GetScalarResources()[rName]
+			allocatable := modifiedNodeInfo.GetAllocatable().GetScalarResources()[rName]
 			_, okDynamic := podRequest.resourceToDeviceClass[rName]
 
-			if (okDynamic || podRequest.resourceToDeviceClass == nil) && !okScalar {
+			if (okDynamic || podRequest.resourceToDeviceClass == nil) && allocatable == 0 {
 				// The extended resource request matches a device class or no device class mapping
-				// provided and it is not in the node's Allocatable (i.e. it is not provided
-				// by the node's device plugin), then leave it to the dynamicresources
-				// plugin to evaluate whether it can be satisfy by DRA resources.
+				// provided and node's Allocatable is 0 (i.e. it was never provided by the node's
+				// device plugin or it's not provided by the node's device plugin anymore),
+				// then leave it to the dynamicresources plugin to evaluate whether it can be
+				// satisfied by DRA resources.
 				return true
 			}
 		}
@@ -633,14 +634,15 @@ func fitsRequest(podRequest *preFilterState, nodeInfo fwk.NodeInfo, ignoredExten
 		}
 
 		if opts.EnableDRAExtendedResource {
-			_, okScalar := nodeInfo.GetAllocatable().GetScalarResources()[rName]
+			allocatable := nodeInfo.GetAllocatable().GetScalarResources()[rName]
 			_, okDynamic := podRequest.resourceToDeviceClass[rName]
 
-			if (okDynamic || podRequest.resourceToDeviceClass == nil) && !okScalar {
+			if (okDynamic || podRequest.resourceToDeviceClass == nil) && allocatable == 0 {
 				// The extended resource request matches a device class or no device class mapping
-				// provided and it is not in the node's Allocatable (i.e. it is not provided
-				// by the node's device plugin), then leave it to the dynamicresources
-				// plugin to evaluate whether it can be satisfy by DRA resources.
+				// provided and node's Allocatable is 0 (i.e. it was never provided by the node's
+				// device plugin or it's not provided by the node's device plugin anymore),
+				// then leave it to the dynamicresources plugin to evaluate whether it can be
+				// satisfied by DRA resources.
 				continue
 			}
 		}

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -677,6 +677,23 @@ func TestEnoughRequests(t *testing.T) {
 				},
 			},
 		},
+		{
+			draExtendedResourceEnabled: true,
+			pod: newResourcePod(
+				framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceDRA: 1}}),
+			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceDRA: 0}})),
+			name:                      "extended resource was backed by Device Plugin (Allocatable: 0)",
+			wantInsufficientResources: []InsufficientResource{},
+		},
+		{
+			draExtendedResourceEnabled: true,
+			pod: newResourcePod(
+				framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
+			nodeInfo:                  framework.NewNodeInfo(newResourcePod(framework.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
+			name:                      "extended resource was backed by Device Plugin (Allocatable: 0), nil resourceToDeviceClass",
+			nilResourceToDeviceClass:  true,
+			wantInsufficientResources: []InsufficientResource{},
+		},
 	}
 
 	for _, test := range enoughPodsTests {
@@ -1795,6 +1812,19 @@ func TestHaveAnyRequestedResourcesIncreased(t *testing.T) {
 				v1.ResourceCPU:              "1",
 				v1.ResourceMemory:           "2",
 				v1.ResourceEphemeralStorage: "1",
+			}).Obj(),
+			draExtendedResourceEnabled: true,
+			expected:                   true,
+		},
+		"requested-resources-dra-zero-capacity": {
+			pod: newResourcePod(framework.Resource{
+				ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1},
+			}),
+			originalNode: st.MakeNode().Capacity(map[v1.ResourceName]string{
+				extendedResourceA: "0",
+			}).Obj(),
+			modifiedNode: st.MakeNode().Capacity(map[v1.ResourceName]string{
+				extendedResourceA: "0",
 			}).Obj(),
 			draExtendedResourceEnabled: true,
 			expected:                   true,

--- a/test/e2e/dra/deploy_device_plugin.go
+++ b/test/e2e/dra/deploy_device_plugin.go
@@ -19,6 +19,7 @@ package dra
 import (
 	"context"
 
+	"github.com/onsi/ginkgo/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -32,6 +33,7 @@ import (
 // extended resource name (returned as result) and deploying it twice for the same nodes from different
 // tests would conflict.
 func deployDevicePlugin(ctx context.Context, f *framework.Framework, nodeNames []string) v1.ResourceName {
+	ginkgo.By("Deploy Device Plugin")
 	err := utils.CreateFromManifests(ctx, f, f.Namespace, func(item interface{}) error {
 		switch item := item.(type) {
 		case *appsv1.DaemonSet:

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -2291,6 +2291,54 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 				"fails",
 			)
 		})
+		f.It("process extended resources after device plugin uninstall", f.WithSerial(), func(ctx context.Context) {
+			resourceName := b.ExtendedResourceName(drautils.SingletonIndex)
+			extendedResourceName := deployDevicePlugin(ctx, f, nodes.NodeNames[0:1])
+			gomega.Expect(string(extendedResourceName)).To(gomega.Equal(resourceName))
+
+			getAllocatable := func() int {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodes.NodeNames[0], metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				for name, quantity := range node.Status.Allocatable {
+					if string(name) == resourceName {
+						return int(quantity.Value())
+					}
+				}
+				return -1
+			}
+			gomega.Eventually(ctx, getAllocatable).WithTimeout(f.Timeouts.PodStart).Should(gomega.Equal(2))
+
+			ginkgo.By("Uninstall Device Plugin")
+			err := f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).DeleteCollection(
+				ctx,
+				metav1.DeleteOptions{},
+				metav1.ListOptions{LabelSelector: "k8s-app=sample-device-plugin"},
+			)
+			framework.ExpectNoError(err, "uninstall device plugin")
+
+			ginkgo.By("Wait for NodeStatus.Allocatable = 0")
+			gomega.Eventually(ctx, getAllocatable).WithTimeout(f.Timeouts.PodDelete).Should(gomega.BeZero())
+
+			ginkgo.By("Create test pod")
+			pod := b.Pod()
+			pod.Spec.Containers[0].Name = "container0"
+			res := v1.ResourceList{
+				v1.ResourceName(resourceName): resource.MustParse("1"),
+			}
+			pod.Spec.Containers[0].Resources.Requests = res
+			pod.Spec.Containers[0].Resources.Limits = res
+
+			b.Create(ctx, b.Class(drautils.SingletonIndex), pod)
+
+			err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(err, "start pod")
+
+			ginkgo.By("Check that pod is processed by the DRA driver")
+			containerEnv := []string{
+				"container_0_request_0", "true",
+			}
+			drautils.TestContainerEnv(ctx, f, pod, pod.Spec.Containers[0].Name, false, containerEnv...)
+		})
 	})
 
 	framework.Context(f.WithFeatureGate(features.DRAExtendedResource), func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change updates scheduler and kubelet logic to treat device plugin resources with zero healthy devices(NodeStatus.Allocatable: 0) as inactive when the DRAExtendedResource feature is enabled. When a device plugin is disconnected or uninstalled, the resource is no longer considered a device plugin resource and can be processed by a DRA driver.

#### Which issue(s) this PR is related to:

Fixes: #133488

#### Special notes for your reviewer:

When device plugin is uninstalled, Kubelet keeps updating node status with the information about its resources, which makes current implementation of the DRA support for extended resources to consider those resources as mainained by
the device plugin. This PR changes this behaviour by allowing scheduling workloads to the nodes where NodeStatus.Allocatable is 0 and allowing Kubelet to admit them. This allows DRA to process such workloads.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/cc @yliaog @klueska @ffromani @pohly 

