### PR TITLE
Add http2 server side PING frames to kube-apiserver with flags

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/pflag"
 	noopoteltrace "go.opentelemetry.io/otel/trace/noop"
-
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -115,6 +114,8 @@ func TestAddFlags(t *testing.T) {
 		"--etcd-certfile=/var/run/kubernetes/etcdce.crt",
 		"--etcd-cafile=/var/run/kubernetes/etcdca.crt",
 		"--http2-max-streams-per-connection=42",
+		"--http2-read-idle-timeout=48s",
+		"--http2-ping-timeout=13s",
 		"--kubelet-read-only-port=10255",
 		"--kubelet-timeout=5s",
 		"--kubelet-client-certificate=/var/run/kubernetes/ceserver.crt",
@@ -202,6 +203,8 @@ func TestAddFlags(t *testing.T) {
 				},
 				HTTP2MaxStreamsPerConnection: 42,
 				Required:                     true,
+				HTTP2ReadIdleTimeout:         48 * time.Second,
+				HTTP2PingTimeout:             13 * time.Second,
 			}).WithLoopback(),
 			EventTTL: 1 * time.Hour,
 			Audit: &apiserveroptions.AuditOptions{

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -116,6 +116,8 @@ func TestAddFlags(t *testing.T) {
 		"--etcd-certfile=/var/run/kubernetes/etcdce.crt",
 		"--etcd-cafile=/var/run/kubernetes/etcdca.crt",
 		"--http2-max-streams-per-connection=42",
+		"--http2-read-idle-timeout=48s",
+		"--http2-ping-timeout=13s",
 		"--tracing-config-file=/var/run/kubernetes/tracing_config.yaml",
 		"--proxy-client-cert-file=/var/run/kubernetes/proxy.crt",
 		"--proxy-client-key-file=/var/run/kubernetes/proxy.key",
@@ -192,6 +194,8 @@ func TestAddFlags(t *testing.T) {
 			},
 			HTTP2MaxStreamsPerConnection: 42,
 			Required:                     true,
+			HTTP2ReadIdleTimeout:         48 * time.Second,
+			HTTP2PingTimeout:             13 * time.Second,
 		}).WithLoopback(),
 		EventTTL: 1 * time.Hour,
 		Audit: &apiserveroptions.AuditOptions{

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -371,12 +371,12 @@ type SecureServingInfo struct {
 	// DisableHTTP2 indicates that http2 should not be enabled.
 	DisableHTTP2 bool
 
-	// ReadIdleTimeout is the timeout after which a health check using a ping
+	// HTTP2ReadIdleTimeout is the timeout after which a health check using a ping
 	// frame will be carried out if no frame is received on the connection.
 	// If zero, no health check is performed.
 	HTTP2ReadIdleTimeout time.Duration
 
-	// PingTimeout is the timeout after which the connection will be closed
+	// HTTP2PingTimeout is the timeout after which the connection will be closed
 	// if a response to a ping is not received.
 	// If zero, a default of 15 seconds is used.
 	HTTP2PingTimeout time.Duration

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -370,6 +370,16 @@ type SecureServingInfo struct {
 
 	// DisableHTTP2 indicates that http2 should not be enabled.
 	DisableHTTP2 bool
+
+	// ReadIdleTimeout is the timeout after which a health check using a ping
+	// frame will be carried out if no frame is received on the connection.
+	// If zero, no health check is performed.
+	HTTP2ReadIdleTimeout time.Duration
+
+	// PingTimeout is the timeout after which the connection will be closed
+	// if a response to a ping is not received.
+	// If zero, a default of 15 seconds is used.
+	HTTP2PingTimeout time.Duration
 }
 
 type AuthenticationInfo struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -73,22 +73,22 @@ type SecureServingOptions struct {
 	// A value of zero means to use the default provided by golang's HTTP/2 support.
 	HTTP2MaxStreamsPerConnection int
 
+	// HTTP2ReadIdleTimeout is the timeout after which a health check using a ping
+	// frame will be carried out if no frame is received on the connection.
+	// If zero, no health check is performed.
+	HTTP2ReadIdleTimeout time.Duration
+
+	// HTTP2PingTimeout is the timeout after which the connection will be closed
+	// if a response to a ping is not received.
+	// If zero, a default of 15 seconds is used.
+	HTTP2PingTimeout time.Duration
+
 	// PermitPortSharing controls if SO_REUSEPORT is used when binding the port, which allows
 	// more than one instance to bind on the same address and port.
 	PermitPortSharing bool
 
 	// PermitAddressSharing controls if SO_REUSEADDR is used when binding the port.
 	PermitAddressSharing bool
-
-	// ReadIdleTimeout is the timeout after which a health check using a ping
-	// frame will be carried out if no frame is received on the connection.
-	// If zero, no health check is performed.
-	HTTP2ReadIdleTimeout time.Duration
-
-	// PingTimeout is the timeout after which the connection will be closed
-	// if a response to a ping is not received.
-	// If zero, a default of 15 seconds is used.
-	HTTP2PingTimeout time.Duration
 }
 
 type CertKey struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -231,12 +231,12 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 			"for the kernel to release sockets in TIME_WAIT state. [default=false]")
 
 	fs.DurationVar(&s.HTTP2ReadIdleTimeout, "http2-read-idle-timeout", s.HTTP2ReadIdleTimeout,
-		"The duration that server waits until server sends PING frame to client."+
+		"The duration that server waits until server sends PING frame to client. "+
 			"Zero means to use golang's default.")
 
 	fs.DurationVar(&s.HTTP2PingTimeout, "http2-ping-timeout", s.HTTP2PingTimeout,
-		"The duration to wait for sent PING request's response from server to client."+
-			"After the duration, if no response received connection will be closed."+
+		"The duration to wait for sent PING request's response from server to client. "+
+			"After the duration, if no response received connection will be closed. "+
 			"Zero means to use golang's default, has no effect without --http2-read-idle-timeout")
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -195,6 +195,15 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 			http2Options.MaxConcurrentStreams = 100
 		}
 
+		// use the overridden HTTP2ReadIdleTimeout value, without HTTP2ReadIdleTimeout HTTP2PingTimeout has no usage
+		if s.HTTP2ReadIdleTimeout > 0 {
+			http2Options.ReadIdleTimeout = s.HTTP2ReadIdleTimeout
+
+			if s.HTTP2PingTimeout > 0 {
+				http2Options.PingTimeout = s.HTTP2PingTimeout
+			}
+		}
+
 		// increase the connection buffer size from the 1MB default to handle the specified number of concurrent streams
 		http2Options.MaxUploadBufferPerConnection = http2Options.MaxUploadBufferPerStream * int32(http2Options.MaxConcurrentStreams)
 		// apply settings to the server


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig network
/sig api-machinery

#### What this PR does / why we need it:

This PR adds http2 pings to the server side of kube-apiserver. In issue #127632, @aojea explained exactly why it's needed, quoting him:

> We are already setting by default the http2 ping frames mechanism for clients with great success
but adding it server side, will allow us improve our reliability extending this capabilities to all clients that are connected to the apiserver

#### Which issue(s) this PR is related to:
Fixes #127632

#### Special notes for your reviewer:

We can discuss:
- The default values for the new flags. I used Golang's default values.
- Docstrings of the new flags that repeated in `SecureServingInfo` and `SecureServingOptions`. Currently it's copy pasted from Golang's docstrings.

Also, this issue had no `good-first-issue` or `help-wanted` labels. If maintainers don't have time to review it, or if it requires special attention that would create extra overhead because I'm a novice Kubernetes contributor, I can close the PR. That said, I am willing to put in the effort to improve it if it's acceptable.

To save reviewer's time, I've commented important sections from [RFC 7540](https://datatracker.ietf.org/doc/html/rfc7540#section-6.7).

> PING frames can be sent from any endpoint.

As mentioned in the issue, we can ping from server -> client.

(=== out of context for this pr === start)

> In addition to the frame header, PING frames MUST contain 8 octets of
   opaque data in the payload.  A sender can include any value it
   chooses and use those octets in any fashion

Currently Golang's http2 library does not allow sending a custom payload, thus it's not usable for us. We can discuss utilizing these 8 bytes, in another issue if you wish. I can open a PR to Go to add this feature if there's a k8s need.

What k8s can utilize from this, if we add "ping handler" to Go:
- We can give `http2_ping_rtt_seconds` like metrics: initiator (apiserver for our use case) puts timestamp, and other side puts same buffer again (may be good Go default). A dead-simple RTT metric.
- Another thing is http2 errors, currently we can't use them, but in the future we can use the [`http2.Server.CountError`](https://pkg.go.dev/golang.org/x/net/http2#Server.CountError) function to expose prometheus metrics for http2 related things, we can also give ping timeouts.

(=== out of context for this pr === end)

> PING responses SHOULD be given higher priority than any other frame.

As a down side, these PING frames will consume some bandwidth. But not that much, looked at the package at Wireshark it's 95 bytes total (including frame). So even with 80_000 active http2 connections to apiserver, it would **less than 1Mib/s**.

#### Does this PR introduce a user-facing change?

```release-note
Added `--http2-read-idle-timeout` and `--http2-ping-timeout` kube-apiserver flags. With these flags kube-apiserver can utilize server side http2 pings to detect broken connections.
```
