### PR TITLE
To prevent kubelet from evicting pods due to node affinity after a restart

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -686,6 +686,11 @@ const (
 	// resume work after restarts.
 	NominatedNodeNameForExpectation featuregate.Feature = "NominatedNodeNameForExpectation"
 
+	// owner: @HirazawaUi
+	//
+	// Kubelet will not evict pods due to node affinity after a restart.
+	NotEvictPodOnKubeletRestart featuregate.Feature = "NotEvictPodOnKubeletRestart"
+
 	// owner: @bwsalmon
 	// kep: https://kep.k8s.io/5598
 	//
@@ -1660,6 +1665,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 
+	NotEvictPodOnKubeletRestart: {
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
+	},
+
 	OpportunisticBatching: {
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
@@ -2422,6 +2431,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	NodeSwap: {},
 
 	NominatedNodeNameForExpectation: {},
+
+	NotEvictPodOnKubeletRestart: {},
 
 	OpportunisticBatching: {},
 

--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -72,6 +72,9 @@ type Manager interface {
 	// Returns the updated (or original) pod, and whether there was an allocation stored.
 	UpdatePodFromAllocation(pod *v1.Pod) (*v1.Pod, bool)
 
+	// IsPodAllocated returns true if the pod has been allocated resources.
+	IsPodAllocated(pod *v1.Pod) bool
+
 	// SetAllocatedResources checkpoints the resources allocated to a pod's containers.
 	SetAllocatedResources(allocatedPod *v1.Pod) error
 
@@ -473,6 +476,14 @@ func updatePodFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.
 		}
 	}
 	return pod, updated
+}
+
+func (m *manager) IsPodAllocated(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	_, ok := m.allocated.GetPodResourceInfo(pod.UID)
+	return ok
 }
 
 // SetAllocatedResources checkpoints the resources allocated to a pod's containers

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2466,7 +2466,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 		}, nil
 	}
 
-	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources)
+	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources, allocationManager.IsPodAllocated)
 	resizeHandler := NewPodResizesAdmitHandler(containerManager, runtime, allocationManager, logger)
 	allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{resizeHandler, predicateHandler})
 	return allocationManager

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1115,7 +1115,7 @@ func NewMainKubelet(ctx context.Context,
 	handlers = append(handlers, klet.containerManager.GetAllocateResourcesPodAdmitHandler())
 
 	criticalPodAdmissionHandler := preemption.NewCriticalPodAdmissionHandler(klet.getAllocatedPods, killPodNow(ctx, klet.podWorkers, kubeDeps.Recorder), kubeDeps.Recorder)
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources, klet.allocationManager.IsPodAllocated))
 	// apply functional Option's
 	for _, opt := range kubeDeps.Options {
 		opt(klet)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -425,7 +425,7 @@ func newTestKubeletWithImageList(
 	handlers = append(handlers, shutdownManager)
 
 	// Add this as cleanup predicate pod admitter
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources, kubelet.allocationManager.IsPodAllocated))
 
 	if !excludeAdmitHandlers {
 		kubelet.allocationManager.AddPodAdmitHandlers(handlers)
@@ -1264,7 +1264,7 @@ func TestHandlePluginResources(t *testing.T) {
 	}
 
 	// add updatePluginResourcesFunc to admission handler, to test it's behavior.
-	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc)})
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc, kl.allocationManager.IsPodAllocated)})
 
 	recorder := record.NewFakeRecorder(20)
 	nodeRef := &v1.ObjectReference{

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -102,17 +102,19 @@ type predicateAdmitHandler struct {
 	getNodeAnyWayFunc        getNodeAnyWayFuncType
 	pluginResourceUpdateFunc pluginResourceUpdateFuncType
 	admissionFailureHandler  AdmissionFailureHandler
+	isPodAllocatedFunc       func(pod *v1.Pod) bool
 }
 
 var _ PodAdmitHandler = &predicateAdmitHandler{}
 
 // NewPredicateAdmitHandler returns a PodAdmitHandler which is used to evaluates
 // if a pod can be admitted from the perspective of predicates.
-func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType) PodAdmitHandler {
+func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType, isPodAllocatedFunc func(pod *v1.Pod) bool) PodAdmitHandler {
 	return &predicateAdmitHandler{
 		getNodeAnyWayFunc,
 		pluginResourceUpdateFunc,
 		admissionFailureHandler,
+		isPodAllocatedFunc,
 	}
 }
 
@@ -181,7 +183,13 @@ func (w *predicateAdmitHandler) Admit(ctx context.Context, attrs *PodAdmitAttrib
 	// the Resource Class API in the future.
 	podWithoutMissingExtendedResources := removeMissingExtendedResources(admitPod, nodeInfo)
 
-	reasons := w.generalFilter(ctx, podWithoutMissingExtendedResources, nodeInfo)
+	var skipIgnorableChecks bool
+	if utilfeature.DefaultFeatureGate.Enabled(features.NotEvictPodOnKubeletRestart) &&
+		admitPod.Status.StartTime != nil && w.isPodAllocatedFunc(admitPod) {
+		skipIgnorableChecks = true
+	}
+
+	reasons := w.generalFilter(ctx, podWithoutMissingExtendedResources, nodeInfo, skipIgnorableChecks)
 	fit := len(reasons) == 0
 	if !fit {
 		reasons, err = w.admissionFailureHandler.HandleAdmissionFailure(ctx, admitPod, reasons)
@@ -200,12 +208,11 @@ func (w *predicateAdmitHandler) Admit(ctx context.Context, attrs *PodAdmitAttrib
 		var reason string
 		var message string
 		if len(reasons) == 0 {
-			message = fmt.Sprint("GeneralPredicates failed due to unknown reason, which is unexpected.")
 			logger.Info("Failed to admit pod: GeneralPredicates failed due to unknown reason, which is unexpected", "pod", klog.KObj(admitPod))
 			return PodAdmitResult{
 				Admit:   fit,
 				Reason:  UnknownReason,
-				Message: message,
+				Message: "GeneralPredicates failed due to unknown reason, which is unexpected.",
 			}
 		}
 		// If there are failed predicates, we only return the first one as a reason.
@@ -247,10 +254,10 @@ func (w *predicateAdmitHandler) Admit(ctx context.Context, attrs *PodAdmitAttrib
 }
 
 // generalFilter checks a group of filterings that the kubelet cares about.
-func (w *predicateAdmitHandler) generalFilter(ctx context.Context, pod *v1.Pod, nodeInfo *schedulerframework.NodeInfo) []PredicateFailureReason {
+func (w *predicateAdmitHandler) generalFilter(ctx context.Context, pod *v1.Pod, nodeInfo *schedulerframework.NodeInfo, skipIgnorableChecks bool) []PredicateFailureReason {
 	logger := klog.FromContext(ctx)
 
-	reasons := generalFilter(logger, pod, nodeInfo)
+	reasons := generalFilter(logger, pod, nodeInfo, skipIgnorableChecks)
 	for _, r := range reasons {
 		if r.GetReason() != nodeaffinity.ErrReasonPod {
 			return reasons
@@ -266,7 +273,7 @@ func (w *predicateAdmitHandler) generalFilter(ctx context.Context, pod *v1.Pod, 
 			return reasons
 		}
 		nodeInfo.SetNode(node)
-		reasons = generalFilter(logger, pod, nodeInfo)
+		reasons = generalFilter(logger, pod, nodeInfo, skipIgnorableChecks)
 	}
 
 	return reasons
@@ -429,7 +436,7 @@ func (e *PredicateFailureError) GetReason() string {
 }
 
 // generalFilter checks a group of filterings that the kubelet cares about.
-func generalFilter(logger klog.Logger, pod *v1.Pod, nodeInfo *schedulerframework.NodeInfo) []PredicateFailureReason {
+func generalFilter(logger klog.Logger, pod *v1.Pod, nodeInfo *schedulerframework.NodeInfo, skipIgnorableChecks bool) []PredicateFailureReason {
 	admissionResults := scheduler.AdmissionCheck(pod, nodeInfo, true)
 	var reasons []PredicateFailureReason
 	for _, r := range admissionResults {
@@ -441,12 +448,15 @@ func generalFilter(logger klog.Logger, pod *v1.Pod, nodeInfo *schedulerframework
 				Capacity:     r.InsufficientResource.Capacity,
 			})
 		} else {
+			if skipIgnorableChecks && r.Reason == nodeaffinity.ErrReasonPod {
+				continue
+			}
 			reasons = append(reasons, &PredicateFailureError{r.Name, r.Reason})
 		}
 	}
 
 	// Check taint/toleration except for static pods
-	if !types.IsStaticPod(pod) {
+	if !skipIgnorableChecks && !types.IsStaticPod(pod) {
 		_, isUntolerated := corev1.FindMatchingUntoleratedTaint(logger, nodeInfo.Node().Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
 			// Kubelet is only interested in the NoExecute taint.
 			return t.Effect == v1.TaintEffectNoExecute

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -294,12 +294,13 @@ func newPodWithPort(hostPorts ...int) *v1.Pod {
 
 func TestGeneralPredicates(t *testing.T) {
 	resourceTests := []struct {
-		pod        *v1.Pod
-		nodeInfo   *schedulerframework.NodeInfo
-		cachedNode *v1.Node
-		syncNode   *v1.Node
-		name       string
-		reasons    []PredicateFailureReason
+		pod                 *v1.Pod
+		nodeInfo            *schedulerframework.NodeInfo
+		cachedNode          *v1.Node
+		syncNode            *v1.Node
+		name                string
+		skipIgnorableChecks bool
+		reasons             []PredicateFailureReason
 	}{
 		{
 			pod: &v1.Pod{},
@@ -624,6 +625,96 @@ func TestGeneralPredicates(t *testing.T) {
 			},
 			name: "node affinity failure on fresh node, but not the cached one",
 		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						types.ConfigSourceAnnotationKey: types.FileSource,
+					},
+				},
+				Spec: v1.PodSpec{
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: v1.NodeSelectorOpExists,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeInfo: schedulerframework.NewNodeInfo(),
+			cachedNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "machine1"},
+				Spec:       v1.NodeSpec{},
+				Status:     v1.NodeStatus{Capacity: makeResources(10, 20, 32, 0, 0, 0), Allocatable: makeAllocatableResources(10, 20, 32, 0, 0, 0)},
+			},
+			syncNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "machine1"},
+				Spec:       v1.NodeSpec{},
+				Status:     v1.NodeStatus{Capacity: makeResources(10, 20, 32, 0, 0, 0), Allocatable: makeAllocatableResources(10, 20, 32, 0, 0, 0)},
+			},
+			name:                "node affinity failure but skip ignorable checks",
+			skipIgnorableChecks: true,
+			reasons:             nil,
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						types.ConfigSourceAnnotationKey: types.FileSource,
+					},
+				},
+				Spec: v1.PodSpec{
+					NodeName: "some-node-name",
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      "foo",
+												Operator: v1.NodeSelectorOpExists,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodeInfo: schedulerframework.NewNodeInfo(),
+			cachedNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "machine1"},
+				Spec:       v1.NodeSpec{},
+				Status:     v1.NodeStatus{Capacity: makeResources(10, 20, 32, 0, 0, 0), Allocatable: makeAllocatableResources(10, 20, 32, 0, 0, 0)},
+			},
+			syncNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "machine1",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   v1.NodeSpec{},
+				Status: v1.NodeStatus{Capacity: makeResources(10, 20, 32, 0, 0, 0), Allocatable: makeAllocatableResources(10, 20, 32, 0, 0, 0)},
+			},
+			skipIgnorableChecks: true,
+			name:                "node affinity failure on cached node and node name doesn't match but skip ignorable checks",
+			reasons: []PredicateFailureReason{
+				&PredicateFailureError{nodename.Name, nodename.ErrReason},
+			},
+		},
 	}
 	for _, test := range resourceTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -634,7 +725,7 @@ func TestGeneralPredicates(t *testing.T) {
 				}
 				return test.syncNode, nil
 			}}
-			reasons := w.generalFilter(context.Background(), test.pod, test.nodeInfo)
+			reasons := w.generalFilter(context.Background(), test.pod, test.nodeInfo, test.skipIgnorableChecks)
 			if diff := cmp.Diff(test.reasons, reasons); diff != "" {
 				t.Errorf("unexpected failure reasons (-want, +got):\n%s", diff)
 			}

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1239,6 +1239,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.35"
+- name: NotEvictPodOnKubeletRestart
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.35"
 - name: OpenAPIEnums
   versionedSpecs:
   - default: false

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kubeletstatsv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
@@ -38,6 +39,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -1423,3 +1425,121 @@ func getMemhogPodWithPodLevelResources(podName string, podLevelRes v1.ResourceRe
 
 	return pod
 }
+
+var _ = SIGDescribe("NodeAffinityEviction", framework.WithSerial(), framework.WithDisruptive(), framework.WithFeatureGate(features.NotEvictPodOnKubeletRestart), func() {
+	f := framework.NewDefaultFramework("node-affinity-eviction-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("when a pod has node affinity with IgnoredDuringExecution", func() {
+		var nodeName string
+		var labelKey string
+		var labelValue string
+		var anotherLabelValue string
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			nodeName = framework.TestContext.NodeName
+			labelKey = "e2e-node-affinity-eviction-test"
+			labelValue = "true"
+			anotherLabelValue = "false"
+
+			ginkgo.By(fmt.Sprintf("Adding label %s=%s to node %s", labelKey, labelValue, nodeName))
+			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, nodeName, labelKey, labelValue)
+			gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				if node.Labels == nil {
+					return "", nil
+				}
+				return node.Labels[labelKey], nil
+			}, time.Minute, time.Second).Should(gomega.Equal(labelValue))
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			ginkgo.By(fmt.Sprintf("Removing label %s from node %s", labelKey, nodeName))
+			e2enode.RemoveLabelOffNode(f.ClientSet, nodeName, labelKey)
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+				if err != nil {
+					return true
+				}
+				if node.Labels == nil {
+					return true
+				}
+				_, hasLabel := node.Labels[labelKey]
+				return !hasLabel
+			}, time.Minute, time.Second).Should(gomega.BeTrueBecause("node should contain label"))
+		})
+
+		ginkgo.It("should not be evicted when node labels change and kubelet is restarted", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-with-node-affinity",
+				},
+				Spec: v1.PodSpec{
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      labelKey,
+												Operator: v1.NodeSelectorOpIn,
+												Values:   []string{labelValue},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "pause",
+							Image: imageutils.GetPauseImageName(),
+						},
+					},
+				},
+			}
+
+			ginkgo.By("Creating a pod with node affinity")
+			podClient := e2epod.NewPodClient(f)
+			p := podClient.CreateSync(ctx, pod)
+
+			ginkgo.By("Waiting for the pod to be running")
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, p)
+			framework.ExpectNoError(err, "waiting for pod to be running")
+
+			ginkgo.By(fmt.Sprintf("Updating label on node %s to %s=%s", nodeName, labelKey, anotherLabelValue))
+			e2enode.AddOrUpdateLabelOnNode(f.ClientSet, nodeName, labelKey, anotherLabelValue)
+			gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
+				node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				if node.Labels == nil {
+					return "", nil
+				}
+				return node.Labels[labelKey], nil
+			}, time.Minute, time.Second).Should(gomega.Equal(anotherLabelValue))
+
+			ginkgo.By("Restarting Kubelet")
+			restartKubelet(ctx, true)
+
+			ginkgo.By("Verifying the pod is not evicted and continues running")
+			gomega.Consistently(ctx, func() error {
+				p, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				if p.Status.Phase != v1.PodRunning {
+					return fmt.Errorf("pod is not running")
+				}
+				if p.Spec.NodeName != nodeName {
+					return fmt.Errorf("expected node name to be %s, got %s", nodeName, p.Spec.NodeName)
+				}
+				return nil
+			}, 20*time.Second, 1*time.Second).Should(gomega.Succeed())
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After kubelet restarts, we should not evict pods running on the node due to node affinity issues. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #124586

#### Special notes for your reviewer:
To address this, we need to handle the following three scenarios:
1. Kubelet is running normally and receives a new pod. It determines whether the pod can be admitted. This is the most common scenario. When kubelet sees a brand-new pod, its StartTime should be nil, so we will skip this logic and follow the same admission process as before.

2. Kubelet restarts. In this case, we should not disrupt the pod's state due to node affinity or other issues. This requires us to determine whether the container already exists on the node (this needs to be distinguished from a node restart; otherwise, we only need to check if the pod has already started on the current node). If the container already exists on the current node and kubelet sees the pod, it needs to determine whether the pod can be admitted. At this point, we will skip node affinity-related admission checks.

3. Node restart. In this scenario, kubelet needs to re-evaluate whether the pod can be admitted, as the container's state has already been disrupted regardless. We need to treat it as if kubelet is seeing the pod for the first time.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the `NotEvictPodOnKubeletRestart` feature gate, which is enabled by default. When enabled, kubelet restarts will not evict pods due to node affinity changes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
