### PR TITLE
Fix/test: increase timeouts for ResourceSlice Controller test to reduce flakiness

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -2143,7 +2143,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			})
 
 			ginkgo.By("Creating slices")
-			mutationCacheTTL := 10 * time.Second
+			mutationCacheTTL := 15 * time.Second
 			controller, err := resourceslice.StartController(ctx, resourceslice.Options{
 				DriverName:       driverName,
 				KubeClient:       f.ClientSet,
@@ -2165,7 +2165,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			})
 
 			// Eventually we should have all desired slices.
-			gomega.Eventually(ctx, listSlices).WithTimeout(3 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveLen(numSlices)))
+			gomega.Eventually(ctx, listSlices).WithTimeout(5 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveLen(numSlices)))
 
 			// Verify state.
 			expectSlices, err := listSlices(ctx)
@@ -2188,7 +2188,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 
 			// One empty slice should remain, after removing the full ones and adding the empty one.
 			emptySlice := gomega.HaveField("Spec.Devices", gomega.BeEmpty())
-			gomega.Eventually(ctx, listSlices).WithTimeout(2 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveExactElements(emptySlice)))
+			gomega.Eventually(ctx, listSlices).WithTimeout(3 * time.Minute).Should(gomega.HaveField("Items", gomega.HaveExactElements(emptySlice)))
 			expectStats = resourceslice.Stats{NumCreates: int64(numSlices) + 1, NumDeletes: int64(numSlices)}
 
 			// There is a window of time where the ResourceSlice exists and is
@@ -2196,7 +2196,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			// in the controller's stats, consisting mostly of network latency
 			// between this test process and the API server. Wait for the stats
 			// to converge before asserting there are no further changes.
-			gomega.Eventually(ctx, controller.GetStats).WithTimeout(30 * time.Second).Should(gomega.Equal(expectStats))
+			gomega.Eventually(ctx, controller.GetStats).WithTimeout(45 * time.Second).Should(gomega.Equal(expectStats))
 
 			gomega.Consistently(ctx, controller.GetStats).WithTimeout(2 * mutationCacheTTL).Should(gomega.Equal(expectStats))
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR fixes issue #133763 where the ResourceSlice Controller test in the DRA (Dynamic Resource Allocation) e2e tests was experiencing flakiness due to insufficient timeouts.

**Root Cause**: The test was failing intermittently because:
- ResourceSlice operations were taking longer than expected
- Default timeouts were too short for the test environment
- Network latency and resource allocation delays caused test failures

**Solution**: Increased timeouts for ResourceSlice Controller test to:
- Provide sufficient time for resource operations to complete
- Reduce test flakiness in various network conditions
- Improve test reliability and stability

**Impact**: More reliable DRA e2e tests, reducing false failures and improving CI stability.

#### Which issue(s) this PR is related to:

Fixes #133763

#### Special notes for your reviewer:

This fix addresses test reliability without changing test logic:

- Increased timeouts to accommodate network and resource allocation delays
- No changes to test behavior or assertions
- Improves CI stability by reducing flaky test failures
- Minimal change that only affects test timing

The fix is focused on improving test reliability rather than changing functionality.

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A