### PR TITLE
DRA e2e node: skipping resource health disabled test

### DIFF
--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
@@ -930,7 +931,16 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 
 	})
 
-	f.Context("Resource Health with Feature Gate Disabled", framework.WithLabel("[FeatureGate:ResourceHealthStatus:Disabled]"), f.WithSerial(), func() {
+	// This matches the "Resource Health" context above, except that it contains tests which need to run
+	// when the feature gate is disabled. This has to be checked at runtime because there is no generic
+	// way to filter out such tests in advance.
+	f.Context("Resource Health", f.WithSerial(), func() {
+
+		ginkgo.BeforeEach(func() {
+			if e2eskipper.IsFeatureGateEnabled(features.ResourceHealthStatus) {
+				e2eskipper.Skipf("feature %s is enabled", features.ResourceHealthStatus)
+			}
+		})
 
 		// Verifies that the Kubelet adds no health status to the Pod when the
 		// ResourceHealthStatus feature gate is disabled.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

`framework.WithLabel("[FeatureGate:ResourceHealthStatus:Disabled]")` has no effect unless a job explicitly uses it in a --label-filter, which is not what "generic" alpha/beta jobs are meant to do. The test therefore ran in the new dra-alpha-beta job and failed because it expected the feature to be off.

In addition, the square brackets got added twice (once via the string parameter, once by `framework.WithLabel`).

There is no generic way to filter out tests in advance which depend on feature gates to be turned off. In e2e_node tests the active feature gates can be checked at runtime, so this is what the test now does.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/133304#issuecomment-3239033244

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @Jpsassine 
/cc @pacoxu @bart0sh 