### PR TITLE
Disable collecting stats for resources not setting prefix to prevent error logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -186,7 +186,8 @@ func New(c *kubernetes.Client, compactor Compactor, codec runtime.Codec, newFunc
 		newListFunc:    newListFunc,
 		compactor:      compactor,
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
+	// Collecting stats requires properly set resourcePrefix to call getKeys.
+	if resourcePrefix != "" && utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
 		stats := newStatsCache(pathPrefix, s.getKeys)
 		s.stats = stats
 		w.stats = stats


### PR DESCRIPTION
/kind bug

```release-note
kube-apiserver: Fixes a 1.34 regression with spurious "Error getting keys" log messages
```

Fixes https://github.com/kubernetes/kubernetes/issues/133787