### PR TITLE
feat: add impersonation information in webhook

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -37,6 +37,14 @@ import (
 	"k8s.io/apiserver/pkg/server/httplog"
 )
 
+// Impersonation extra keys constants
+const (
+	ImpersonatorOriginalUserExtraKey   = "impersonator.kubernetes.io/original-user"
+	ImpersonatorOriginalUIDExtraKey    = "impersonator.kubernetes.io/original-uid"
+	ImpersonatorOriginalGroupsExtraKey = "impersonator.kubernetes.io/original-groups"
+	ImpersonatorOriginalExtraKeyPrefix = "impersonator.kubernetes.io/original-extra-"
+)
+
 // WithImpersonation is a filter that will inspect and check requests that attempt to change the user.Info for their requests
 func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.NegotiatedSerializer) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -158,17 +166,17 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 		// Add original impersonator information
 		if requestor != nil {
 			if originalName := requestor.GetName(); originalName != "" {
-				userExtra["impersonator.kubernetes.io/original-user"] = []string{originalName}
+				userExtra[ImpersonatorOriginalUserExtraKey] = []string{originalName}
 			}
 			if originalUID := requestor.GetUID(); originalUID != "" {
-				userExtra["impersonator.kubernetes.io/original-uid"] = []string{originalUID}
+				userExtra[ImpersonatorOriginalUIDExtraKey] = []string{originalUID}
 			}
 			if originalGroups := requestor.GetGroups(); len(originalGroups) > 0 {
-				userExtra["impersonator.kubernetes.io/original-groups"] = originalGroups
+				userExtra[ImpersonatorOriginalGroupsExtraKey] = originalGroups
 			}
 			// Preserve original extra information with namespace prefix
 			for key, values := range requestor.GetExtra() {
-				prefixedKey := "impersonator.kubernetes.io/original-extra-" + key
+				prefixedKey := ImpersonatorOriginalExtraKeyPrefix + key
 				userExtra[prefixedKey] = values
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
@@ -192,7 +192,10 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:admin",
 				Groups: []string{"some-group", "system:authenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"wheel", "group-impersonater"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -252,7 +255,11 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:admin",
 				Groups: []string{"system:authenticated"},
-				Extra:  map[string][]string{"scopes": {"scope-a", "scope-b"}},
+				Extra: map[string][]string{
+					"scopes": {"scope-a", "scope-b"},
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"wheel", "extra-setter-scopes"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -267,7 +274,11 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:admin",
 				Groups: []string{"system:authenticated"},
-				Extra:  map[string][]string{"example.com/escapedᛄscopes": {"scope-a", "scope-b"}},
+				Extra: map[string][]string{
+					"example.com/escapedᛄscopes":                 {"scope-a", "scope-b"},
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"wheel", "escaped-scopes"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -282,7 +293,11 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:admin",
 				Groups: []string{"system:authenticated"},
-				Extra:  map[string][]string{"almost%zzpercent%xxencoded": {"scope-a", "scope-b"}},
+				Extra: map[string][]string{
+					"almost%zzpercent%xxencoded":                 {"scope-a", "scope-b"},
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"wheel", "almost-escaped-scopes"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -296,7 +311,10 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "tester",
 				Groups: []string{"system:authenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"regular-impersonater"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -324,7 +342,10 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:serviceaccount:foo:default",
 				Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo", "system:authenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"sa-impersonater"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -337,7 +358,9 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:anonymous",
 				Groups: []string{"system:unauthenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user": {"system:admin"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -351,7 +374,9 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "unknown",
 				Groups: []string{"system:unauthenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user": {"system:admin"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -365,7 +390,9 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "unknown",
 				Groups: []string{"system:authenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user": {"system:admin"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -380,7 +407,10 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:admin",
 				Groups: []string{"some-group", "system:authenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"wheel", "group-impersonater"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -393,7 +423,9 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:anonymous",
 				Groups: []string{"system:unauthenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user": {"system:admin"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -407,7 +439,9 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:anonymous",
 				Groups: []string{"system:unauthenticated"},
-				Extra:  map[string][]string{},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user": {"system:admin"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -424,8 +458,11 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name:   "tester",
 				Groups: []string{"system:authenticated"},
-				Extra:  map[string][]string{},
-				UID:    "some-uid",
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"everything-impersonater"},
+				},
+				UID: "some-uid",
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -461,7 +498,33 @@ func TestImpersonationFilter(t *testing.T) {
 				Name:   "tester",
 				Groups: []string{"system:authenticated"},
 				UID:    "some-uid",
-				Extra:  map[string][]string{"scopes": {"scope-a", "scope-b"}},
+				Extra: map[string][]string{
+					"scopes": {"scope-a", "scope-b"},
+					"impersonator.kubernetes.io/original-user":   {"dev"},
+					"impersonator.kubernetes.io/original-groups": {"everything-impersonater"},
+				},
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "impersonation-preserves-original-user-info",
+			user: &user.DefaultInfo{
+				Name:   "original-user",
+				Groups: []string{"everything-impersonater"},
+				UID:    "original-uid",
+				Extra:  map[string][]string{"original-key": {"original-value"}},
+			},
+			impersonationUser:   "impersonated-user",
+			impersonationGroups: []string{"impersonated-group"},
+			expectedUser: &user.DefaultInfo{
+				Name:   "impersonated-user",
+				Groups: []string{"impersonated-group", "system:authenticated"},
+				Extra: map[string][]string{
+					"impersonator.kubernetes.io/original-user":               {"original-user"},
+					"impersonator.kubernetes.io/original-uid":                {"original-uid"},
+					"impersonator.kubernetes.io/original-groups":             {"everything-impersonater"},
+					"impersonator.kubernetes.io/original-extra-original-key": {"original-value"},
+				},
 			},
 			expectedCode: http.StatusOK,
 		},

--- a/test/e2e/auth/selfsubjectreviews.go
+++ b/test/e2e/auth/selfsubjectreviews.go
@@ -130,12 +130,9 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 			gomega.Expect(config.Impersonate.UID).To(gomega.Equal(res.Status.UserInfo.UID))
 			gomega.Expect(config.Impersonate.Groups).To(gomega.Equal(res.Status.UserInfo.Groups))
 
-			extra := make(map[string][]string, len(res.Status.UserInfo.Extra))
-			for k, v := range res.Status.UserInfo.Extra {
-				extra[k] = v
+			for expectedKey, expectedValue := range config.Impersonate.Extra {
+				gomega.Expect(res.Status.UserInfo.Extra).To(gomega.HaveKeyWithValue(expectedKey, expectedValue))
 			}
-
-			gomega.Expect(config.Impersonate.Extra).To(gomega.Equal(extra))
 		}
 
 		ginkgo.By("creating SSR authentication/v1beta1")
@@ -153,12 +150,9 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 			gomega.Expect(config.Impersonate.UID).To(gomega.Equal(res.Status.UserInfo.UID))
 			gomega.Expect(config.Impersonate.Groups).To(gomega.Equal(res.Status.UserInfo.Groups))
 
-			extra := make(map[string][]string, len(res.Status.UserInfo.Extra))
-			for k, v := range res.Status.UserInfo.Extra {
-				extra[k] = v
+			for expectedKey, expectedValue := range config.Impersonate.Extra {
+				gomega.Expect(res.Status.UserInfo.Extra).To(gomega.HaveKeyWithValue(expectedKey, expectedValue))
 			}
-
-			gomega.Expect(config.Impersonate.Extra).To(gomega.Equal(extra))
 		}
 
 		ginkgo.By("creating SSR authentication/v1")
@@ -173,12 +167,9 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 			gomega.Expect(config.Impersonate.UID).To(gomega.Equal(res.Status.UserInfo.UID))
 			gomega.Expect(config.Impersonate.Groups).To(gomega.Equal(res.Status.UserInfo.Groups))
 
-			extra := make(map[string][]string, len(res.Status.UserInfo.Extra))
-			for k, v := range res.Status.UserInfo.Extra {
-				extra[k] = v
+			for expectedKey, expectedValue := range config.Impersonate.Extra {
+				gomega.Expect(res.Status.UserInfo.Extra).To(gomega.HaveKeyWithValue(expectedKey, expectedValue))
 			}
-
-			gomega.Expect(config.Impersonate.Extra).To(gomega.Equal(extra))
 		}
 	})
 })

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -60,6 +60,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/token/cache"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	unionauthz "k8s.io/apiserver/pkg/authorization/union"
+	"k8s.io/apiserver/pkg/endpoints/filters"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/apiserver/plugin/pkg/authenticator/token/webhook"
 	clientset "k8s.io/client-go/kubernetes"
@@ -992,14 +993,14 @@ func TestImpersonateWithUID(t *testing.T) {
 			Username:   "alice",
 			UID:        "1234",
 			Extra: map[string]certificatesv1.ExtraValue{
-				"impersonator.kubernetes.io/original-user":   {"system:apiserver"},
-				"impersonator.kubernetes.io/original-groups": {"system:authenticated", "system:masters"},
+				filters.ImpersonatorOriginalUserExtraKey:   {"system:apiserver"},
+				filters.ImpersonatorOriginalGroupsExtraKey: {"system:authenticated", "system:masters"},
 			},
 		}
 		actualCsrSpec := createdCsr.Spec
 
 		ignoreUIDFilter := func(k string, v any) bool {
-			return k == "impersonator.kubernetes.io/original-uid"
+			return k == filters.ImpersonatorOriginalUIDExtraKey
 		}
 
 		if diff := cmp.Diff(expectedCsrSpec, actualCsrSpec,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR enhances the impersonation mechanism in Kubernetes API server to preserve the original user context for admission webhooks. When a user impersonates another user, the original user's information (username, UID, groups, and extra fields) is now stored in the impersonated user's Extra field with namespaced keys.

This enables admission webhooks to:
- Make more informed authorization decisions based on the complete authentication chain
- Implement better audit trails by knowing who actually performed actions via impersonation  
- Enhance security by having visibility into the original requestor context
- Debug complex impersonation scenarios more effectively

The preserved information includes:
- `impersonator.kubernetes.io/original-user`: Original user name
- `impersonator.kubernetes.io/original-uid`: Original user UID  
- `impersonator.kubernetes.io/original-groups`: Original user groups
- `impersonator.kubernetes.io/original-extra-{key}`: Original extra fields (prefixed)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

- This change is additive-only and maintains full backward compatibility
- All existing tests have been updated to reflect the new behavior, demonstrating the scope of the change
- The implementation preserves existing security boundaries and authorization requirements
- No new API surfaces are introduced - this enriches existing admission webhook context
- The namespaced key format prevents conflicts with existing extra fields
- Original user information is only preserved during actual impersonation operations

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Admission webhooks now receive original user context when requests are made via impersonation. The impersonated user's Extra field contains the original user's identity information under namespaced keys (impersonator.kubernetes.io/original-*), enabling webhooks to make decisions based on the complete authentication chain.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
