### PR TITLE
add ProgressDeadlineSeconds is MaxInt32 condition

### DIFF
--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -667,7 +668,7 @@ func ValidateDeploymentSpec(spec, oldSpec *apps.DeploymentSpec, fldPath *field.P
 	}
 	if spec.ProgressDeadlineSeconds != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.ProgressDeadlineSeconds), fldPath.Child("progressDeadlineSeconds"))...)
-		if *spec.ProgressDeadlineSeconds <= spec.MinReadySeconds {
+		if *spec.ProgressDeadlineSeconds != math.MaxInt32 && *spec.ProgressDeadlineSeconds <= spec.MinReadySeconds {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("progressDeadlineSeconds"), spec.ProgressDeadlineSeconds, "must be greater than minReadySeconds"))
 		}
 	}


### PR DESCRIPTION

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
when Deployment spec progressDeadlineSeconds equal math.MaxInt32, there is no need to check minReadySeconds should less than progressDeadlineSeconds.


#### Which issue(s) this PR is related to:

Fixes #133830
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
