### PR TITLE
Omit value type from validation rule failures

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -494,10 +494,8 @@ func (s *Validator) validateExpressions(ctx context.Context, fldPath *field.Path
 		}
 
 		value := obj
-		if ok {
+		if sts.Type == "object" || sts.Type == "array" {
 			value = field.OmitValueType{}
-		} else if sts.Type == "object" || sts.Type == "array" {
-			value = sts.Type
 		}
 
 		addErr(fieldErrorForReason(currentFldPath, value, detail, rule.Reason))

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -2363,7 +2363,7 @@ func TestValidationExpressionsAtSchemaLevels(t *testing.T) {
 			schema: objectTypePtr(map[string]schema.Structural{
 				"f/2": withRule(objectType(map[string]schema.Structural{"m": integerType}), "self.m == 2"),
 			}),
-			errors: []string{"Invalid value: \"object\": failed rule: self.m == 2"},
+			errors: []string{"Invalid value: failed rule: self.m == 2"},
 		},
 		// unescapable field names that are not accessed by the CEL rule are allowed and should not impact CEL rule validation
 		{name: "invalid rule under unescapable field name",
@@ -2397,7 +2397,7 @@ func TestValidationExpressionsAtSchemaLevels(t *testing.T) {
 			schema: objectTypePtr(map[string]schema.Structural{
 				"a@b": withRule(objectType(map[string]schema.Structural{"m": integerType}), "self.m == 2"),
 			}),
-			errors: []string{"Invalid value: \"object\": failed rule: self.m == 2"},
+			errors: []string{"Invalid value: failed rule: self.m == 2"},
 		},
 		{name: "matchExpressions - 'values' must be specified when 'operator' is 'In' or 'NotIn'",
 			obj: map[string]interface{}{
@@ -4295,7 +4295,7 @@ func TestRatcheting(t *testing.T) {
 				bar: invalid
 			`),
 			errors: []string{
-				`root.foo: Invalid value: "object": gotta be baz`,
+				`root.foo: Invalid value: gotta be baz`,
 			},
 		},
 		{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/test/example/apiexports_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/test/example/apiexports_test.go
@@ -35,7 +35,7 @@ func TestAPIExportPermissionClaimCELValidation(t *testing.T) {
 			name:    "nothing is set",
 			current: map[string]interface{}{},
 			wantErrs: []string{
-				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: \"object\": either \"all\" or \"resourceSelector\" must be set",
+				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: either \"all\" or \"resourceSelector\" must be set",
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestAPIExportPermissionClaimCELValidation(t *testing.T) {
 				},
 			},
 			wantErrs: []string{
-				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: \"object\": either \"all\" or \"resourceSelector\" must be set",
+				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: either \"all\" or \"resourceSelector\" must be set",
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestAPIExportPermissionClaimCELValidation(t *testing.T) {
 				"resourceSelector": nil,
 			},
 			wantErrs: []string{
-				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: \"object\": either \"all\" or \"resourceSelector\" must be set",
+				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: either \"all\" or \"resourceSelector\" must be set",
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestAPIExportPermissionClaimCELValidation(t *testing.T) {
 				"resourceSelector": []interface{}{},
 			},
 			wantErrs: []string{
-				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: \"object\": either \"all\" or \"resourceSelector\" must be set",
+				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: either \"all\" or \"resourceSelector\" must be set",
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestAPIExportPermissionClaimCELValidation(t *testing.T) {
 				"resourceSelector": nil,
 			},
 			wantErrs: []string{
-				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: \"object\": either \"all\" or \"resourceSelector\" must be set",
+				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: either \"all\" or \"resourceSelector\" must be set",
 			},
 		},
 		{
@@ -113,7 +113,7 @@ func TestAPIExportPermissionClaimCELValidation(t *testing.T) {
 				"resourceSelector": []interface{}{},
 			},
 			wantErrs: []string{
-				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: \"object\": either \"all\" or \"resourceSelector\" must be set",
+				"openAPIV3Schema.properties.spec.properties.permissionClaims.items: Invalid value: either \"all\" or \"resourceSelector\" must be set",
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestResourceSelectorCELValidation(t *testing.T) {
 				"namespace": nil,
 			},
 			wantErrs: []string{
-				"openAPIV3Schema.properties.spec.properties.permissionClaims.items.properties.resourceSelector.items: Invalid value: \"object\": at least one field must be set",
+				"openAPIV3Schema.properties.spec.properties.permissionClaims.items.properties.resourceSelector.items: Invalid value: at least one field must be set",
 			},
 		},
 		{


### PR DESCRIPTION
This updates kubernetes/kubernetes#132798 to show simple values and NO types. This also reverts the logic that omits values when there is a message expression, so we can discuss that behavior further.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Correct CEL validation messages to match this discussion: https://github.com/kubernetes/kubernetes/issues/132528#issuecomment-3243021475

#### Which issue(s) this PR is related to:

- #132528

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#132798 includes the correct release note for this change.

```release-note
NONE
```
