### PR TITLE
[failing-test] fix kubectl exec command in cmd test

### DIFF
--- a/test/cmd/exec.sh
+++ b/test/cmd/exec.sh
@@ -78,12 +78,12 @@ run_kubectl_exec_resource_name_tests() {
   kube::log::status "Testing kubectl exec TYPE/NAME COMMAND"
 
   ### Test execute invalid resource type
-  output_message=$(! kubectl exec foo/bar date 2>&1)
+  output_message=$(! kubectl exec foo/bar -- date 2>&1)
   # resource type foo should error since it's invalid
   kube::test::if_has_string "${output_message}" 'error:'
 
   ### Test execute non-existing resources
-  output_message=$(! kubectl exec deployments/bar date 2>&1)
+  output_message=$(! kubectl exec deployments/bar -- date 2>&1)
   # resource type foo should error since it doesn't exist
   kube::test::if_has_string "${output_message}" '"bar" not found'
 
@@ -92,7 +92,7 @@ run_kubectl_exec_resource_name_tests() {
   kubectl create -f hack/testdata/configmap.yaml
 
   ### Test execute non-implemented resources
-  output_message=$(! kubectl exec configmap/test-set-env-config date 2>&1)
+  output_message=$(! kubectl exec configmap/test-set-env-config -- date 2>&1)
   # resource type configmap should error since configmap not implemented to be attached
   kube::test::if_has_string "${output_message}" 'not implemented'
 
@@ -100,13 +100,13 @@ run_kubectl_exec_resource_name_tests() {
   # Just check the output, since test-cmd not run kubelet, pod never be assigned.
   # and not really can run `kubectl exec` command
 
-  output_message=$(! kubectl exec pods/test-pod date 2>&1)
+  output_message=$(! kubectl exec pods/test-pod -- date 2>&1)
   # POD test-pod is exists this is shouldn't have output not found
   kube::test::if_has_not_string "${output_message}" 'not found'
   # These must be pass the validate
   kube::test::if_has_not_string "${output_message}" 'pod, type/name or --filename must be specified'
 
-  output_message=$(! kubectl exec replicaset/frontend date 2>&1)
+  output_message=$(! kubectl exec replicaset/frontend -- date 2>&1)
   # Replicaset frontend is valid and exists will select the first pod.
   # and Shouldn't have output not found
   kube::test::if_has_not_string "${output_message}" 'not found'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 kubectl exec [POD] [COMMAND] is not supported anymore. we need to use exec [POD] -- [COMMAND] instead
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.
"N/A"
Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 "NONE" 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
