### PR TITLE
avoid resyncing about bound pv and pvc in resync method

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -610,7 +610,9 @@ func (ctrl *PersistentVolumeController) resync(ctx context.Context) {
 		return
 	}
 	for _, pvc := range pvcs {
-		ctrl.enqueueWork(ctx, ctrl.claimQueue, pvc)
+		if pvc.Status.Phase != v1.ClaimBound {
+			ctrl.enqueueWork(ctx, ctrl.claimQueue, pvc)
+		}
 	}
 
 	pvs, err := ctrl.volumeLister.List(labels.NewSelector())
@@ -619,7 +621,9 @@ func (ctrl *PersistentVolumeController) resync(ctx context.Context) {
 		return
 	}
 	for _, pv := range pvs {
-		ctrl.enqueueWork(ctx, ctrl.volumeQueue, pv)
+		if pv.Status.Phase != v1.VolumeBound {
+			ctrl.enqueueWork(ctx, ctrl.volumeQueue, pv)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When the Kubernetes cluster manages a lot of PVs and PVCs, the claimQueue and volumeQueue lengths become so long that it results in a continuous backlog.
To avoid the queue length being long, I changed the code to enqueue PVs and PVCs when their status is not bound in the resync method.

#### Which issue(s) this PR is related to:
Fixes #118225
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
