### PR TITLE
Naive/trivial wait.Until -> wait.UntilWithContext conversions

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -440,7 +440,7 @@ func serveHealthz(ctx context.Context, hz *healthcheck.ProxyHealthServer, errCh 
 		return
 	}
 
-	fn := func() {
+	fn := func(ctx context.Context) {
 		err := hz.Run(ctx)
 		if err != nil {
 			logger.Error(err, "Healthz server failed")
@@ -454,7 +454,7 @@ func serveHealthz(ctx context.Context, hz *healthcheck.ProxyHealthServer, errCh 
 			logger.Error(nil, "Healthz server returned without error")
 		}
 	}
-	go wait.Until(fn, 5*time.Second, ctx.Done())
+	go wait.UntilWithContext(ctx, fn, 5*time.Second)
 }
 
 func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyconfig.ProxyMode, enableProfiling bool, flagzReader flagz.Reader, errCh chan error) {
@@ -489,7 +489,7 @@ func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyco
 		statusz.Install(proxyMux, kubeProxy, statusz.NewRegistry(compatibility.DefaultBuildEffectiveVersion()))
 	}
 
-	fn := func() {
+	fn := func(ctx context.Context) {
 		var err error
 		defer func() {
 			if err != nil {
@@ -516,7 +516,7 @@ func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyco
 		}
 
 	}
-	go wait.Until(fn, 5*time.Second, wait.NeverStop)
+	go wait.UntilWithContext(ctx, fn, 5*time.Second)
 }
 
 // Run runs the specified ProxyServer.  This should never exit (unless CleanupAndExit is set).

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -910,12 +910,12 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 	if s.HealthzPort > 0 {
 		mux := http.NewServeMux()
 		healthz.InstallHandler(mux)
-		go wait.Until(func() {
+		go wait.UntilWithContext(ctx, func(ctx context.Context) {
 			err := http.ListenAndServe(net.JoinHostPort(s.HealthzBindAddress, strconv.Itoa(int(s.HealthzPort))), mux)
 			if err != nil {
 				logger.Error(err, "Failed to start healthz server")
 			}
-		}, 5*time.Second, wait.NeverStop)
+		}, 5*time.Second)
 	}
 
 	// If systemd is used, notify it that we have started

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -319,7 +319,7 @@ func (dsc *DaemonSetsController) Run(ctx context.Context, workers int) {
 		go wait.UntilWithContext(ctx, dsc.runNodeUpdateWorker, time.Second)
 	}
 
-	go wait.Until(dsc.failedPodsBackoff.GC, BackoffGCInterval, ctx.Done())
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { dsc.failedPodsBackoff.GC() }, BackoffGCInterval)
 
 	<-ctx.Done()
 }

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -473,7 +473,7 @@ func (dc *DisruptionController) Run(ctx context.Context) {
 	}
 
 	go wait.UntilWithContext(ctx, dc.worker, time.Second)
-	go wait.Until(dc.recheckWorker, time.Second, ctx.Done())
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { dc.recheckWorker() }, time.Second)
 	go wait.UntilWithContext(ctx, dc.stalePodDisruptionWorker, time.Second)
 
 	<-ctx.Done()

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -287,10 +287,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	logger.V(2).Info("Starting service queue worker threads", "total", workers)
 	for i := 0; i < workers; i++ {
-		go wait.Until(func() { c.serviceQueueWorker(logger) }, c.workerLoopPeriod, ctx.Done())
+		go wait.UntilWithContext(ctx, func(ctx context.Context) { c.serviceQueueWorker(logger) }, c.workerLoopPeriod)
 	}
 	logger.V(2).Info("Starting topology queue worker threads", "total", 1)
-	go wait.Until(func() { c.topologyQueueWorker(logger) }, c.workerLoopPeriod, ctx.Done())
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { c.topologyQueueWorker(logger) }, c.workerLoopPeriod)
 
 	<-ctx.Done()
 }

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -233,7 +233,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	logger.V(2).Info("Starting worker threads", "total", workers)
 	for i := 0; i < workers; i++ {
-		go wait.Until(func() { c.worker(logger) }, c.workerLoopPeriod, ctx.Done())
+		go wait.UntilWithContext(ctx, func(ctx context.Context) { c.worker(logger) }, c.workerLoopPeriod)
 	}
 
 	<-ctx.Done()

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -159,7 +159,7 @@ func (gc *GarbageCollector) Run(ctx context.Context, workers int, initialSyncTim
 	// gc workers
 	for i := 0; i < workers; i++ {
 		go wait.UntilWithContext(ctx, gc.runAttemptToDeleteWorker, 1*time.Second)
-		go wait.Until(func() { gc.runAttemptToOrphanWorker(logger) }, 1*time.Second, ctx.Done())
+		go wait.UntilWithContext(ctx, func(ctx context.Context) { gc.runAttemptToOrphanWorker(logger) }, 1*time.Second)
 	}
 
 	<-ctx.Done()

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -360,7 +360,7 @@ func (gb *GraphBuilder) Run(ctx context.Context) {
 	// Start monitors and begin change processing until the stop channel is
 	// closed.
 	gb.startMonitors(logger)
-	wait.Until(func() { gb.runProcessGraphChanges(logger) }, 1*time.Second, ctx.Done())
+	wait.UntilWithContext(ctx, func(ctx context.Context) { gb.runProcessGraphChanges(logger) }, 1*time.Second)
 
 	// Stop any running monitors.
 	gb.monitorLock.Lock()

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -314,7 +314,7 @@ func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
 
 	ctrl.initializeCaches(logger, ctrl.volumeLister, ctrl.claimLister)
 
-	go wait.Until(func() { ctrl.resync(ctx) }, ctrl.resyncPeriod, ctx.Done())
+	go wait.UntilWithContext(ctx, ctrl.resync, ctrl.resyncPeriod)
 	go wait.UntilWithContext(ctx, ctrl.volumeWorker, time.Second)
 	go wait.UntilWithContext(ctx, ctrl.claimWorker, time.Second)
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -636,8 +636,8 @@ func TestSchedulerGuaranteeNonNilNodeInSchedulingCycle(t *testing.T) {
 	// 1) One is responsible for deleting several nodes in each round;
 	// 2) Another is creating several pods in each round to trigger scheduling;
 	// Those two goroutines will stop until ctx.Done() is called, which means all waiting pods are scheduled at least once.
-	go wait.Until(deleteNodesOneRound, 10*time.Millisecond, ctx.Done())
-	go wait.Until(createPodsOneRound, 9*time.Millisecond, ctx.Done())
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { deleteNodesOneRound() }, 10*time.Millisecond)
+	go wait.UntilWithContext(ctx, func(ctx context.Context) { createPodsOneRound() }, 9*time.Millisecond)
 
 	// Capture the events to wait all pods to be scheduled at least once.
 	allWaitSchedulingPods := sets.New[string]()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Contributes to the effort to change various methods to versions which perform contextual logging, as described in #126379 by swapping out some uses of `wait.Until` with `wait.UntilWithContext`.

#### Which issue(s) this PR is related to:

Contributes to #126379

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
