### PR TITLE
Fix typos in help for kubectl create clusterrole

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -51,10 +51,10 @@ var (
 		# Create a cluster role named "foo" with SubResource specified
 		kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
 
-		# Create a cluster role name "foo" with NonResourceURL specified
-		kubectl create clusterrole "foo" --verb=get --non-resource-url=/logs/*
+		# Create a cluster role named "foo" with NonResourceURL specified
+		kubectl create clusterrole foo --verb=get --non-resource-url=/logs/*
 
-		# Create a cluster role name "monitoring" with AggregationRule specified
+		# Create a cluster role named "monitoring" with AggregationRule specified
 		kubectl create clusterrole monitoring --aggregation-rule="rbac.example.com/aggregate-to-monitoring=true"`))
 
 	// Valid nonResource verb list for validation.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Correction of a view typos in the command line help for `kubectl create clusterrole`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```