### PR TITLE
Automated cherry pick of #133817: Disable collecting stats for resources not setting prefix to prevent error logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -186,7 +186,8 @@ func New(c *kubernetes.Client, compactor Compactor, codec runtime.Codec, newFunc
 		newListFunc:    newListFunc,
 		compactor:      compactor,
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
+	// Collecting stats requires properly set resourcePrefix to call getKeys.
+	if resourcePrefix != "" && utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
 		stats := newStatsCache(pathPrefix, s.getKeys)
 		s.stats = stats
 		w.stats = stats


### PR DESCRIPTION
Cherry pick of #133817 on release-1.34.

#133817: Disable collecting stats for resources not setting prefix to prevent error logs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-apiserver: Fixes a 1.34 regression with spurious "Error getting keys" log messages
```