### PR TITLE
scheduler-perf: fix data race in createPodsSteadily

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -2059,6 +2059,8 @@ func createPodsSteadily(tCtx ktesting.TContext, namespace string, podInformer co
 				return
 			}
 
+			mutex.Lock()
+			defer mutex.Unlock()
 			existingPods--
 			if pod.Spec.NodeName != "" {
 				runningPods--


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

A mutex lock around decrementing runningPods was missing, leading to a data race report in ci-kubernetes-integration-race-master:

WARNING: DATA RACE
Read at 0x00c001bd20a8 by goroutine 95696:
  k8s.io/kubernetes/test/integration/scheduler_perf.createPodsSteadily.func7()
      /home/prow/go/src/k8s.io/kubernetes/test/integration/scheduler_perf/scheduler_perf.go:2133 +0x238
  ...

Previous write at 0x00c001bd20a8 by goroutine 101407:
  k8s.io/kubernetes/test/integration/scheduler_perf.createPodsSteadily.func5()
      /home/prow/go/src/k8s.io/kubernetes/test/integration/scheduler_perf/scheduler_perf.go:2064 +0x1a4
  ...

#### Which issue(s) this PR is related to:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-race-master/1963103542197620736

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @macsko 