### PR TITLE
WIP: Add recognized CRD formats: int32, int64, float, and double

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
@@ -58,6 +58,10 @@ var supportedVersionedFormats = []versionedFormats{
 			"date",         // a date string like "2006-01-02" as defined by full-date in RFC3339
 			"duration",     // a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format
 			"datetime",     // a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339
+			"float",        // a number with a Golang type of float32
+			"double",       // a number with a Golang type of float64
+			"int32",        // a number with a Golang type of int32
+			"int64",        // a number with a Golang type of int64
 		),
 	},
 	{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
@@ -165,6 +165,12 @@ func TestGetUnrecognizedFormats(t *testing.T) {
 			expectedFormats:      []string{"unknown-format"},
 		},
 		{
+			name:                 "recognizes int32 at version 1.0",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "int32"}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{},
+		},
+		{
 			name:                 "recognized format with normalization",
 			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "k8s-short-name"}},
 			compatibilityVersion: version.MajorMinor(1, 34),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
In 179551a7cb3, warnings are returned for unrecognized CRD formats, however int32, int64, float, and double were not being recognized, conflicting with existing behavior and docs.

Adds them as supported since v1.0 and a unit test to cover int32.

#### Which issue(s) this PR is related to:
Fixes #133880

#### Special notes for your reviewer:
I'm a relatively new contributor in this space, so please let me know if I should change/improve anything, no matter how small - I don't mind! I mentioned this on the original issue as well, but I'm not sure if there are other types that are intended to also be acceptable.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds int32, int64, float, and double as recognized formats within CustomResourceDefinitions to remove a misleading warning that these were unrecognized formats.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```