### PR TITLE
Fix/kubectl: add request-level timeout to prevent delete hanging

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -203,6 +203,24 @@ func (m *Helper) DeleteWithOptions(namespace, name string, options *metav1.Delet
 		Get()
 }
 
+// DeleteWithOptionsWithContext performs a DELETE request with the given context for timeout control
+func (m *Helper) DeleteWithOptionsWithContext(ctx context.Context, namespace, name string, options *metav1.DeleteOptions) (runtime.Object, error) {
+	if options == nil {
+		options = &metav1.DeleteOptions{}
+	}
+	if m.ServerDryRun {
+		options.DryRun = []string{metav1.DryRunAll}
+	}
+
+	return m.RESTClient.Delete().
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(m.Resource).
+		Name(name).
+		Body(options).
+		Do(ctx).
+		Get()
+}
+
 func (m *Helper) Create(namespace string, modify bool, obj runtime.Object) (runtime.Object, error) {
 	return m.CreateWithOptions(namespace, modify, obj, nil)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -492,7 +492,8 @@ func (o *DeleteOptions) deleteResource(info *resource.Info, deleteOptions *metav
 	deleteResponse, err := resource.
 		NewHelper(info.Client, info.Mapping).
 		DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
-		DeleteWithOptionsWithContext(ctx, info.Namespace, info.Name, deleteOptions)
+		WithContext(ctx).
+		DeleteWithOptions(info.Namespace, info.Name, deleteOptions)
 	if err != nil {
 		// Check if the error is due to timeout
 		if ctx.Err() == context.DeadlineExceeded {

--- a/staging/src/k8s.io/kubectl/pkg/rawhttp/raw.go
+++ b/staging/src/k8s.io/kubectl/pkg/rawhttp/raw.go
@@ -47,8 +47,18 @@ func RawDelete(restClient *rest.RESTClient, streams genericiooptions.IOStreams, 
 	return raw(restClient, streams, url, filename, "DELETE")
 }
 
+// RawDeleteWithContext uses the REST client to DELETE content with a context
+func RawDeleteWithContext(ctx context.Context, restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, filename string) error {
+	return rawWithContext(ctx, restClient, streams, url, filename, "DELETE")
+}
+
 // raw makes a simple HTTP request to the provided path on the server using the default credentials.
 func raw(restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, filename, requestType string) error {
+	return rawWithContext(context.Background(), restClient, streams, url, filename, requestType)
+}
+
+// rawWithContext makes a simple HTTP request to the provided path on the server using the default credentials with context for timeout control.
+func rawWithContext(ctx context.Context, restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, filename, requestType string) error {
 	var data io.Reader
 	switch {
 	case len(filename) == 0:
@@ -81,7 +91,7 @@ func raw(restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, f
 		return fmt.Errorf("unknown requestType: %q", requestType)
 	}
 
-	stream, err := request.Stream(context.TODO())
+	stream, err := request.Stream(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR introduces context support for delete operations in `kubectl` by allowing `Helper` methods to accept a context through a new `WithContext()` helper. This avoids duplicating methods like `DeleteWithOptionsWithContext` and provides a cleaner, consistent approach for passing context to all operations.

#### Which issue(s) this PR is related to:

follow-up to #133808 
may Fix kubernetes/kubectl#1779

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```