### PR TITLE
add fieldSelector for VolumeAttachment

### DIFF
--- a/pkg/apis/storage/v1/conversion.go
+++ b/pkg/apis/storage/v1/conversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func addConversionFuncs(scheme *runtime.Scheme) error {
+	// Add field conversion funcs.
+	if err := AddFieldLabelConversionsForVolumeAttachment(scheme); err != nil {
+		return err
+	}
+	return nil
+}
+
+func AddFieldLabelConversionsForVolumeAttachment(scheme *runtime.Scheme) error {
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("VolumeAttachment"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name",
+				"spec.nodeName",
+				"spec.attacher",
+				"spec.persistentVolumeName":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+}

--- a/pkg/apis/storage/v1/register.go
+++ b/pkg/apis/storage/v1/register.go
@@ -41,5 +41,5 @@ func init() {
 	// We only register manually written functions here. The registration of the
 	// generated functions takes place in the generated files. The separation
 	// makes the code compile even when the generated files are missing.
-	localSchemeBuilder.Register(addDefaultingFuncs)
+	localSchemeBuilder.Register(addDefaultingFuncs, addConversionFuncs)
 }

--- a/pkg/registry/storage/volumeattachment/storage/storage.go
+++ b/pkg/registry/storage/volumeattachment/storage/storage.go
@@ -48,6 +48,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (*VolumeAttachmentStorage,
 	store := &genericregistry.Store{
 		NewFunc:                   func() runtime.Object { return &storageapi.VolumeAttachment{} },
 		NewListFunc:               func() runtime.Object { return &storageapi.VolumeAttachmentList{} },
+		PredicateFunc:             volumeattachment.Matcher,
 		DefaultQualifiedResource:  storageapi.Resource("volumeattachments"),
 		SingularQualifiedResource: storageapi.Resource("volumeattachment"),
 

--- a/pkg/registry/storage/volumeattachment/strategy_test.go
+++ b/pkg/registry/storage/volumeattachment/strategy_test.go
@@ -24,6 +24,8 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/util/feature"
@@ -31,6 +33,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/ptr"
 )
 
 func getValidVolumeAttachment(name string) *storage.VolumeAttachment {
@@ -340,6 +343,139 @@ func TestVolumeAttachmentValidation(t *testing.T) {
 			}
 			if len(err) == 0 && test.expectError {
 				t.Errorf("Validation of object unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestMatchVolumeAttachment(t *testing.T) {
+	testCases := []struct {
+		name          string
+		in            *storage.VolumeAttachment
+		fieldSelector fields.Selector
+		expectMatch   bool
+	}{
+		{
+			name: "match on name",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.name=test"),
+			expectMatch:   true,
+		},
+		{
+			name: "no match on name",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.name=nomatch"),
+			expectMatch:   false,
+		},
+		{
+			name: "match on node name",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{NodeName: "node1"},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.nodeName=node1"),
+			expectMatch:   true,
+		},
+		{
+			name: "no match on node name",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{NodeName: "node2"},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.nodeName=node1"),
+			expectMatch:   false,
+		},
+		{
+			name: "match on persistent volume name",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{Source: storage.VolumeAttachmentSource{
+					PersistentVolumeName: ptr.To("pvc-00000000-0000-0000-0000-000000000000")}},
+			},
+			fieldSelector: fields.OneTermEqualSelector("spec.persistentVolumeName", "pvc-00000000-0000-0000-0000-000000000000"),
+			expectMatch:   true,
+		},
+		{
+			name: "no match on persistent volume name",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{Source: storage.VolumeAttachmentSource{
+					PersistentVolumeName: ptr.To("pvc-00000000-0000-0000-0000-000000000000")}},
+			},
+			fieldSelector: fields.OneTermEqualSelector("spec.persistentVolumeName", "pvc-00000000-0000-0000-0000-000000000001"),
+			expectMatch:   false,
+		},
+		{
+			name: "no match on persistent volume name not exist",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{Source: storage.VolumeAttachmentSource{
+					PersistentVolumeName: nil}},
+			},
+			fieldSelector: fields.OneTermEqualSelector("spec.persistentVolumeName", "pvc-00000000-0000-0000-0000-000000000000"),
+			expectMatch:   false,
+		},
+		{
+			name: "match on attacher",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{Attacher: "attach"},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.attacher=attach"),
+			expectMatch:   true,
+		},
+		{
+			name: "no match on attacher",
+			in: &storage.VolumeAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+				Spec: storage.VolumeAttachmentSpec{Attacher: "attach"},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.attacher=attach1"),
+			expectMatch:   false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := Matcher(labels.Everything(), testCase.fieldSelector)
+			result, err := m.Matches(testCase.in)
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+			if result != testCase.expectMatch {
+				t.Errorf("Result %v, Expected %v, Selector: %v, VolumeAttachment: %v", result, testCase.expectMatch, testCase.fieldSelector.String(), testCase.in)
 			}
 		})
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Added fieldSelector for VolumeAttachment to include fields `spec.nodeName`, `spec.attacher`, and `spec.persistentVolumeName`.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added field selector support for VolumeAttachment, allowing field-level selection for the fields `.spec.nodeName`, `.spec.attacher`, and `.spec.persistentVolumeName`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
