### PR TITLE
apiserver/peerproxy: avoid shadowing math/rand with local variable\n\…

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler.go
@@ -177,8 +177,8 @@ func (h *peerProxyHandler) WrapHandler(handler http.Handler) http.Handler {
 			return
 		}
 
-		rand := rand.Intn(len(peerEndpoints))
-		peerEndpoint := peerEndpoints[rand]
+		endpointIndex := rand.Intn(len(peerEndpoints))
+		peerEndpoint := peerEndpoints[endpointIndex]
 		h.proxyRequestToDestinationAPIServer(r, w, peerEndpoint)
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area apiserver
/sig api-machinery

#### What this PR does / why we need it:
This PR renames a local variable named `rand` to `endpointIndex` in `staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler.go` to avoid shadowing the imported `math/rand` package when selecting a random peer endpoint. The behavior is unchanged; this improves readability and prevents future confusion.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
- Purely internal rename, no functional changes.
- Keeps current behavior of random selection intact.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
