### PR TITLE
feat: promote mutating named port e2e test to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2079,6 +2079,19 @@
     Pod and the service must now have empty set of endpoints.
   release: v1.9
   file: test/e2e/network/service.go
+- testname: Service, should support named targetPorts that resolve to different ports
+    on different endpoints.
+  codename: '[sig-network] Services should support named targetPorts that resolve
+    to different ports on different endpoints [Conformance]'
+  description: Given a Service with a named targetPort and two backing pods, the Service
+    can be rolled out with an update to the pods that changes the named port, and
+    it MUST reach both endpoints at all points during the rollout. Update the Service
+    by recreating a new pod with the same port name and the different port number,
+    it MUST be able to forward traffic to both pods. Update the Service by recreating
+    a new pod with the same port name and number, it MUST be able to forward traffic
+    to both pods.
+  release: v1.35
+  file: test/e2e/network/service.go
 - testname: Endpoint resource lifecycle
   codename: '[sig-network] Services should test the lifecycle of an Endpoint [Conformance]'
   description: Create an endpoint, the endpoint MUST exist. The endpoint is updated

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -4286,7 +4286,14 @@ var _ = common.SIGDescribe("Services", func() {
 		checkServiceReachabilityFromExecPod(ctx, f.ClientSet, ns, service.Name, service.Spec.ClusterIP, port)
 	})
 
-	ginkgo.It("should support named targetPorts that resolve to different ports on different endpoints", func(ctx context.Context) {
+	/*
+		Release: v1.35
+		Testname: Service, should support named targetPorts that resolve to different ports on different endpoints.
+		Description: Given a Service with a named targetPort and two backing pods, the Service can be rolled out with an update to the pods that changes the named port, and it MUST reach both endpoints at all points during the rollout.
+		Update the Service by recreating a new pod with the same port name and the different port number, it MUST be able to forward traffic to both pods.
+		Update the Service by recreating a new pod with the same port name and number, it MUST be able to forward traffic to both pods.
+	*/
+	framework.ConformanceIt("should support named targetPorts that resolve to different ports on different endpoints", func(ctx context.Context) {
 		serviceName := "mutable-named-port"
 		ns := f.Namespace.Name
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig network
/sig testing
/sig architecture
/area conformance
/priority important-longterm
@kubernetes/sig-architecture-pr-reviews
@kubernetes/sig-network-pr-reviews 
@kubernetes/cncf-conformance-wg

#### What this PR does / why we need it:

Add help-wanted conformance test case for `service` resource

#### Which issue(s) this PR is related to:

[need a conformance test for named ports in Services #132954](https://github.com/kubernetes/kubernetes/issues/132954)

#### Special notes for your reviewer:

The previously added e2e test is proven without flakiness as screenshot listed below. The relevent link are:

- https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20master
- https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20nftables,%20master
- https://testgrid.k8s.io/sig-network-gce#gci-gce
- https://testgrid.k8s.io/sig-network-gce#kops-gce-networking-nftables

<img width="1440" height="695" alt="截屏2025-09-05 09 16 23" src="https://github.com/user-attachments/assets/ee7926fd-7fa3-4749-babc-a5aa2910ce41" />

<img width="1437" height="516" alt="截屏2025-09-05 09 20 45" src="https://github.com/user-attachments/assets/bb62748f-799f-4223-b02b-84ef25f2b286" />

<img width="1440" height="709" alt="截屏2025-09-05 09 43 28" src="https://github.com/user-attachments/assets/063142c3-f8c3-415c-b911-4b56cd447111" />

<img width="1440" height="754" alt="截屏2025-09-05 09 44 25" src="https://github.com/user-attachments/assets/5877d1bd-25d1-4b48-ae89-94b4f233d111" />


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
