### PR TITLE
WIP: Add validation for integer and number types

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestRegistryFormats(t *testing.T) {
-	for _, sf := range supportedVersionedFormats {
+	for _, sf := range supportedStringVersionedFormats {
 		for f := range sf.formats {
 			if !strfmt.Default.ContainsName(f) {
 				t.Errorf("expected format %q in strfmt default registry", f)
@@ -201,22 +201,34 @@ func TestGetUnrecognizedFormats(t *testing.T) {
 			expectedFormats:      []string{},
 		},
 		{
-			name:                 "unrecognized format for integer type is not reported",
-			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "unknown-format", Type: []string{"integer"}}},
+			name:                 "recognized int32 format for integer type",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "int32", Type: []string{"integer"}}},
 			compatibilityVersion: version.MajorMinor(1, 0),
 			expectedFormats:      []string{},
 		},
 		{
-			name:                 "unrecognized format for string,null type is not reported",
+			name:                 "recognized double format for number type",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "double", Type: []string{"number"}}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{},
+		},
+		{
+			name:                 "unrecognized float format for integer type",
+			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "float", Type: []string{"integer"}}},
+			compatibilityVersion: version.MajorMinor(1, 0),
+			expectedFormats:      []string{"float"},
+		},
+		{
+			name:                 "unrecognized format for string,null type is reported",
 			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "unknown-format", Type: []string{"string", "null"}}},
 			compatibilityVersion: version.MajorMinor(1, 0),
-			expectedFormats:      []string{},
+			expectedFormats:      []string{"unknown-format"},
 		},
 		{
-			name:                 "unrecognized format for no type is not reported",
+			name:                 "unrecognized format for no type is reported",
 			schema:               &spec.Schema{SchemaProps: spec.SchemaProps{Format: "unknown-format"}},
 			compatibilityVersion: version.MajorMinor(1, 0),
-			expectedFormats:      []string{},
+			expectedFormats:      []string{"unknown-format"},
 		},
 	}
 
@@ -234,7 +246,7 @@ func TestGetUnrecognizedFormats(t *testing.T) {
 			expectedSet := sets.New(tc.expectedFormats...)
 
 			if !gotSet.Equal(expectedSet) {
-				t.Errorf("expected unrecognized formats %v, got %v", tc.expectedFormats, got)
+				t.Errorf("expected unrecognized formats %v, got %v", expectedSet, gotSet)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In 179551a, warnings are returned for unrecognized CRD formats, however int32, int64, float, and double were not being recognized, conflicting with existing behavior. Later in 4e200ca, warnings were restricted to only type=string.

This commit adds validation to types integer and number and returns warnings when formats are not supported.

#### Which issue(s) this PR is related to:
Fixes #133880

#### Special notes for your reviewer:
Specifically, this PR address part 2 of [this comment on the issue](https://github.com/kubernetes/kubernetes/issues/133880#issuecomment-3255436197).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added validation for CustomResourceDefinition schema around recognized formats for type=integer and type=number. The recognized formats are int32, int64, uint32, and uint64 for type=integer and float32, float64, float, and double for type=number. In 1.34, CustomResourceDefinition schema validation was previously added for type=string. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
