### PR TITLE
Automated cherry pick of #133890: kubelet/metrics: fix multiple Register call

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -317,7 +317,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		if err != nil {
 			return nil, err
 		}
-		metrics.Register(cm.draManager.NewMetricsCollector())
+		metrics.RegisterCollectors(cm.draManager.NewMetricsCollector())
 	}
 	cm.kubeClient = kubeClient
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1631,7 +1631,8 @@ func (kl *Kubelet) StartGarbageCollection() {
 // Note that the modules here must not depend on modules that are not initialized here.
 func (kl *Kubelet) initializeModules(ctx context.Context) error {
 	// Prometheus metrics.
-	metrics.Register(
+	metrics.Register()
+	metrics.RegisterCollectors(
 		collectors.NewVolumeStatsCollector(kl),
 		collectors.NewLogMetricsCollector(kl.StatsProvider.ListPodStats),
 	)

--- a/pkg/kubelet/metrics/collectors/volume_stats.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats.go
@@ -107,7 +107,7 @@ func (collector *volumeStatsCollector) CollectWithStability(ch chan<- metrics.Me
 		lv = append([]string{pvcRef.Namespace, pvcRef.Name}, lv...)
 		ch <- metrics.NewLazyConstMetric(desc, metrics.GaugeValue, v, lv...)
 	}
-	allPVCs := sets.Set[string]{}
+	allPVCs := sets.Set[stats.PVCReference]{}
 	for _, podStat := range podStats {
 		if podStat.VolumeStats == nil {
 			continue
@@ -118,8 +118,7 @@ func (collector *volumeStatsCollector) CollectWithStability(ch chan<- metrics.Me
 				// ignore if no PVC reference
 				continue
 			}
-			pvcUniqStr := pvcRef.Namespace + "/" + pvcRef.Name
-			if allPVCs.Has(pvcUniqStr) {
+			if allPVCs.Has(*pvcRef) {
 				// ignore if already collected
 				continue
 			}
@@ -132,7 +131,7 @@ func (collector *volumeStatsCollector) CollectWithStability(ch chan<- metrics.Me
 			if volumeStat.VolumeHealthStats != nil {
 				addGauge(volumeStatsHealthAbnormalDesc, pvcRef, convertBoolToFloat64(volumeStat.VolumeHealthStats.Abnormal))
 			}
-			allPVCs.Insert(pvcUniqStr)
+			allPVCs.Insert(*pvcRef)
 		}
 	}
 }

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -1274,9 +1274,7 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(OrphanPodCleanedVolumes)
 		legacyregistry.MustRegister(OrphanPodCleanedVolumesErrors)
 
-		for _, collector := range collectors {
-			legacyregistry.CustomMustRegister(collector)
-		}
+		legacyregistry.CustomMustRegister(collectors...)
 
 		if utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdown) &&
 			utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdownBasedOnPodPriority) {

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -1194,7 +1194,7 @@ var (
 var registerMetrics sync.Once
 
 // Register registers all metrics.
-func Register(collectors ...metrics.StableCollector) {
+func Register() {
 	// Register the metrics.
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(FirstNetworkPodStartSLIDuration)
@@ -1274,8 +1274,6 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(OrphanPodCleanedVolumes)
 		legacyregistry.MustRegister(OrphanPodCleanedVolumesErrors)
 
-		legacyregistry.CustomMustRegister(collectors...)
-
 		if utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdown) &&
 			utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdownBasedOnPodPriority) {
 			legacyregistry.MustRegister(GracefulShutdownStartTime)
@@ -1310,6 +1308,10 @@ func Register(collectors ...metrics.StableCollector) {
 			legacyregistry.MustRegister(PodDeferredAcceptedResizes)
 		}
 	})
+}
+
+func RegisterCollectors(collectors ...metrics.StableCollector) {
+	legacyregistry.CustomMustRegister(collectors...)
 }
 
 // GetGather returns the gatherer. It used by test case outside current package.

--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -125,7 +125,7 @@ func (s *volumeStatCalculator) calcAndStoreStats() {
 	}
 
 	// Get volume specs for the pod - key'd by volume name
-	volumesSpec := make(map[string]v1.Volume)
+	volumesSpec := make(map[string]v1.Volume, len(s.pod.Spec.Volumes))
 	for _, v := range s.pod.Spec.Volumes {
 		volumesSpec[v.Name] = v
 	}


### PR DESCRIPTION
Cherry pick of #133890 on release-1.34.

#133890: kubelet/metrics: fix multiple Register call

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a 1.34 regression causing missing kubelet_volume_stats_* metrics
```