### PR TITLE
Remove redundant experimental prefix in wait command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -124,7 +124,7 @@ func NewCmdWait(restClientGetter genericclioptions.RESTClientGetter, streams gen
 
 	cmd := &cobra.Command{
 		Use:     "wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=create|--for=delete|--for condition=available|--for=jsonpath='{}'[=value]]",
-		Short:   i18n.T("Experimental: Wait for a specific condition on one or many resources"),
+		Short:   i18n.T("Wait for a specific condition on one or many resources"),
 		Long:    waitLong,
 		Example: waitExample,
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Forgotten change in https://github.com/kubernetes/kubernetes/pull/133731

#### Does this PR introduce a user-facing change?
```release-note
Dropping the experimental prefix from kubectl wait command's short description, since kubectl wait command has been stable for a long time.
```
