### PR TITLE
[client-go] [cli-runtime] [133916]: fix config override logic when override provides ClientKey, ClientCertificate

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -170,9 +170,11 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	// bind auth info flag values to overrides
 	if f.CertFile != nil {
 		overrides.AuthInfo.ClientCertificate = *f.CertFile
+		overrides.AuthInfo.ClientCertificateData = nil
 	}
 	if f.KeyFile != nil {
 		overrides.AuthInfo.ClientKey = *f.KeyFile
+		overrides.AuthInfo.ClientKeyData = nil
 	}
 	if f.BearerToken != nil {
 		overrides.AuthInfo.Token = *f.BearerToken

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -178,6 +178,7 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 	}
 	if f.BearerToken != nil {
 		overrides.AuthInfo.Token = *f.BearerToken
+		overrides.AuthInfo.TokenFile = ""
 	}
 	if f.Impersonate != nil {
 		overrides.AuthInfo.Impersonate = *f.Impersonate

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -533,6 +533,19 @@ func (config *DirectClientConfig) getAuthInfo() (clientcmdapi.AuthInfo, error) {
 		if err := merge(mergedAuthInfo, &config.overrides.AuthInfo); err != nil {
 			return clientcmdapi.AuthInfo{}, err
 		}
+
+		// Handle ClientKey/ClientKeyData conflict: if override sets ClientKey, also use override's ClientKeyData
+		// otherwise if original config has ClientKeyData set,
+		// validation returns error "client-key-data and client-key are both specified <user-name>"
+		if len(config.overrides.AuthInfo.ClientKey) > 0 {
+			mergedAuthInfo.ClientKeyData = config.overrides.AuthInfo.ClientKeyData
+		}
+		// Handle ClientCertificate/ClientCertificateData conflict, if override sets ClientCertificate, also use override's ClientCertificateData
+		// otherwise if original config has ClientCertificateData set,
+		// validation returns error "client-cert-data and client-cert are both specified <user-name>"
+		if len(config.overrides.AuthInfo.ClientCertificate) > 0 {
+			mergedAuthInfo.ClientCertificateData = config.overrides.AuthInfo.ClientCertificateData
+		}
 	}
 
 	return *mergedAuthInfo, nil

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -537,13 +537,15 @@ func (config *DirectClientConfig) getAuthInfo() (clientcmdapi.AuthInfo, error) {
 		// Handle ClientKey/ClientKeyData conflict: if override sets ClientKey, also use override's ClientKeyData
 		// otherwise if original config has ClientKeyData set,
 		// validation returns error "client-key-data and client-key are both specified <user-name>"
-		if len(config.overrides.AuthInfo.ClientKey) > 0 {
+		if len(config.overrides.AuthInfo.ClientKey) > 0 || len(config.overrides.AuthInfo.ClientKeyData) > 0 {
+			mergedAuthInfo.ClientKey = config.overrides.AuthInfo.ClientKey
 			mergedAuthInfo.ClientKeyData = config.overrides.AuthInfo.ClientKeyData
 		}
 		// Handle ClientCertificate/ClientCertificateData conflict, if override sets ClientCertificate, also use override's ClientCertificateData
 		// otherwise if original config has ClientCertificateData set,
 		// validation returns error "client-cert-data and client-cert are both specified <user-name>"
-		if len(config.overrides.AuthInfo.ClientCertificate) > 0 {
+		if len(config.overrides.AuthInfo.ClientCertificate) > 0 || len(config.overrides.AuthInfo.ClientCertificateData) > 0 {
+			mergedAuthInfo.ClientCertificate = config.overrides.AuthInfo.ClientCertificate
 			mergedAuthInfo.ClientCertificateData = config.overrides.AuthInfo.ClientCertificateData
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -1224,74 +1224,164 @@ func TestMergeRawConfigDoOverride(t *testing.T) {
 }
 
 func TestClientCertOverrideData(t *testing.T) {
-	// Test that when overrides contain cert/key file paths, the corresponding
-	// data fields are properly handled to avoid validation conflicts
-	// in particular code in DirectClientConfig::getAuthInfo
+	// Test that when overrides contain cert/key file paths or data fields,
+	// the corresponding fields are properly handled to avoid validation conflicts
+	// in particular code in DirectClientConfig::getAuthInfo.
+	// This covers both scenarios: overrides with file paths (which clear data fields)
+	// and overrides with data fields (which clear file paths).
 
-	certFile, err := os.CreateTemp("", "test-client-*.crt")
-	if err != nil {
-		t.Fatalf("Failed to create temp cert file: %v", err)
-	}
-	defer utiltesting.CloseAndRemove(t, certFile)
+	testCases := []struct {
+		name        string
+		description string
+		setupTest   func(t *testing.T) (*clientcmdapi.Config, *ConfigOverrides, func())
+		validate    func(t *testing.T, authInfo *clientcmdapi.AuthInfo)
+	}{
+		{
+			name:        "override-with-file-paths",
+			description: "Test override with cert/key file paths",
+			setupTest: func(t *testing.T) (*clientcmdapi.Config, *ConfigOverrides, func()) {
+				certFile, err := os.CreateTemp("", "test-client-*.crt")
+				if err != nil {
+					t.Fatalf("Failed to create temp cert file: %v", err)
+				}
 
-	keyFile, err := os.CreateTemp("", "test-client-*.key")
-	if err != nil {
-		t.Fatalf("Failed to create temp key file: %v", err)
-	}
-	defer utiltesting.CloseAndRemove(t, keyFile)
+				keyFile, err := os.CreateTemp("", "test-client-*.key")
+				if err != nil {
+					t.Fatalf("Failed to create temp key file: %v", err)
+				}
 
-	if err := os.WriteFile(certFile.Name(), []byte("dummy-cert-content"), 0600); err != nil {
-		t.Fatalf("Failed to write cert file: %v", err)
-	}
-	if err := os.WriteFile(keyFile.Name(), []byte("dummy-key-content"), 0600); err != nil {
-		t.Fatalf("Failed to write key file: %v", err)
-	}
+				if err := os.WriteFile(certFile.Name(), []byte("dummy-cert-content"), 0600); err != nil {
+					t.Fatalf("Failed to write cert file: %v", err)
+				}
+				if err := os.WriteFile(keyFile.Name(), []byte("dummy-key-content"), 0600); err != nil {
+					t.Fatalf("Failed to write key file: %v", err)
+				}
 
-	baseConfig := clientcmdapi.Config{
-		Clusters: map[string]*clientcmdapi.Cluster{
-			"test-cluster": {
-				Server:                   "https://example.com:6443",
-				CertificateAuthorityData: []byte("fake-ca-data"),
+				baseConfig := clientcmdapi.Config{
+					Clusters: map[string]*clientcmdapi.Cluster{
+						"test-cluster": {
+							Server:                   "https://example.com:6443",
+							CertificateAuthorityData: []byte("fake-ca-data"),
+						},
+					},
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test-user": {
+							ClientCertificateData: []byte("base-cert-data"),
+							ClientKeyData:         []byte("base-key-data"),
+						},
+					},
+					Contexts: map[string]*clientcmdapi.Context{
+						"test-context": {
+							Cluster:  "test-cluster",
+							AuthInfo: "test-user",
+						},
+					},
+					CurrentContext: "test-context",
+				}
+
+				overrides := &ConfigOverrides{
+					AuthInfo: clientcmdapi.AuthInfo{
+						ClientCertificate:     certFile.Name(),
+						ClientCertificateData: nil,
+						ClientKey:             keyFile.Name(),
+						ClientKeyData:         nil,
+					},
+				}
+
+				cleanup := func() {
+					utiltesting.CloseAndRemove(t, certFile)
+					utiltesting.CloseAndRemove(t, keyFile)
+				}
+
+				return &baseConfig, overrides, cleanup
+			},
+			validate: func(t *testing.T, authInfo *clientcmdapi.AuthInfo) {
+				if authInfo.ClientCertificate == "" {
+					t.Errorf("Expected ClientCertificate file path to be set")
+				}
+				if authInfo.ClientKey == "" {
+					t.Errorf("Expected ClientKey file path to be set")
+				}
+				if authInfo.ClientCertificateData != nil {
+					t.Errorf("Expected ClientCertificateData to be nil when file path is used")
+				}
+				if authInfo.ClientKeyData != nil {
+					t.Errorf("Expected ClientKeyData to be nil when file path is used")
+				}
 			},
 		},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"test-user": {
-				ClientCertificateData: []byte("base-cert-data"),
-				ClientKeyData:         []byte("base-key-data"),
+		{
+			name:        "override-with-data-fields",
+			description: "Test override with cert/key data fields",
+			setupTest: func(t *testing.T) (*clientcmdapi.Config, *ConfigOverrides, func()) {
+				baseConfig := clientcmdapi.Config{
+					Clusters: map[string]*clientcmdapi.Cluster{
+						"test-cluster": {
+							Server:                   "https://example.com:6443",
+							CertificateAuthorityData: []byte("fake-ca-data"),
+						},
+					},
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test-user": {
+							ClientCertificate: "/path/to/base-cert.pem",
+							ClientKey:         "/path/to/base-key.pem",
+						},
+					},
+					Contexts: map[string]*clientcmdapi.Context{
+						"test-context": {
+							Cluster:  "test-cluster",
+							AuthInfo: "test-user",
+						},
+					},
+					CurrentContext: "test-context",
+				}
+
+				overrides := &ConfigOverrides{
+					AuthInfo: clientcmdapi.AuthInfo{
+						ClientCertificate:     "",
+						ClientCertificateData: []byte("override-cert-data"),
+						ClientKey:             "",
+						ClientKeyData:         []byte("override-key-data"),
+					},
+				}
+
+				return &baseConfig, overrides, func() {}
+			},
+			validate: func(t *testing.T, authInfo *clientcmdapi.AuthInfo) {
+				if authInfo.ClientCertificate != "" {
+					t.Errorf("Expected ClientCertificate file path to be empty when data is used")
+				}
+				if authInfo.ClientKey != "" {
+					t.Errorf("Expected ClientKey file path to be empty when data is used")
+				}
+				if string(authInfo.ClientCertificateData) != "override-cert-data" {
+					t.Errorf("Expected ClientCertificateData to be 'override-cert-data', got %s", string(authInfo.ClientCertificateData))
+				}
+				if string(authInfo.ClientKeyData) != "override-key-data" {
+					t.Errorf("Expected ClientKeyData to be 'override-key-data', got %s", string(authInfo.ClientKeyData))
+				}
 			},
 		},
-		Contexts: map[string]*clientcmdapi.Context{
-			"test-context": {
-				Cluster:  "test-cluster",
-				AuthInfo: "test-user",
-			},
-		},
-		CurrentContext: "test-context",
 	}
 
-	overrides := &ConfigOverrides{
-		AuthInfo: clientcmdapi.AuthInfo{
-			ClientCertificate:     certFile.Name(),
-			ClientCertificateData: nil,
-			ClientKey:             keyFile.Name(),
-			ClientKeyData:         nil,
-		},
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseConfig, overrides, cleanup := tc.setupTest(t)
+			defer cleanup()
+
+			clientConfig := NewNonInteractiveClientConfig(*baseConfig, "test-context", overrides, nil)
+
+			mergedConfig, err := clientConfig.MergedRawConfig()
+			if err != nil {
+				t.Fatalf("MergedRawConfig() failed: %v", err)
+			}
+
+			authInfo := mergedConfig.AuthInfos["test-user"]
+			if authInfo == nil {
+				t.Fatalf("Expected AuthInfo 'test-user' not found")
+			}
+
+			tc.validate(t, authInfo)
+		})
 	}
-
-	clientConfig := NewNonInteractiveClientConfig(baseConfig, "test-context", overrides, nil)
-
-	mergedConfig, err := clientConfig.MergedRawConfig()
-	if err != nil {
-		t.Fatalf("MergedRawConfig() failed: %v", err)
-	}
-
-	authInfo := mergedConfig.AuthInfos["test-user"]
-	if authInfo == nil {
-		t.Fatalf("Expected AuthInfo 'test-user' not found")
-	}
-
-	matchStringArg(certFile.Name(), authInfo.ClientCertificate, t)
-	matchStringArg(keyFile.Name(), authInfo.ClientKey, t)
-	matchByteArg(nil, authInfo.ClientCertificateData, t)
-	matchByteArg(nil, authInfo.ClientKeyData, t)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This pr fixes validation error when ConfigFlags has CertFile and (or) KeyFile and original config also contains CertFileData and (or) KeyFileData. 

#### Which issue(s) this PR is related to:

Fixes  #133916 

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:


Set in `config_flags.go`  `ClientKeyData` to nil if `KeyFile` is set, `ClientCertificateData` to nil if `CertFile` is set. 
 `ConfigFlags` only allows to set KeyFile and CertFile not corresponding data fields. 

Add in `client_config.go` explicit set to `mergedAuthInfo` of `ClientKey`, `ClientKeyData`, and 'ClientCertificate', `ClientCertificateData` if one of them are present in overrides,  as if they are empty they are not processed during call to merge function.  

I think there is a similar approach in `client_config.go` for InsecureSkipTLSVerify and CertificateAuthority fields [line 571](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go#L571) as they also should not be both populated. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed validation error when ConfigFlags has CertFile and (or) KeyFile and original config also contains CertFileData and (or) KeyFileData. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
