### PR TITLE
Fix OWNERS_ALIASES entry for SIG Docs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -463,11 +463,22 @@ aliases:
     - MadhavJivrajani
     - mfahlandt
     - Priyankasaggu11929
+  # See https://github.com/kubernetes/org/blob/main/OWNERS_ALIASES
+  # for the authoritative list of SIG Docs leads, or look for
+  # https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES
+  # for the list that this was derived from. SIG Docs' leads can
+  # confirm modifications here.
   sig-docs-approvers:
-    - jimangel
-    - kbhawkey
-    - onlydole
-    - sftim
+    - dipesh-rawat
+    - divya-mohan0209
+    - katcosgrove
+    - lmktfy
+    - natalisucks
+    - nate-double-u
+    - reylejano
+    - salaxander
+    - SayakMukhopadhyay
+    - tengqm
   sig-node-api-reviewers:
     - dchen1107
     - derekwaynecarr


### PR DESCRIPTION
/kind cleanup

/sig docs

It does what the PR title says. Updated based on the current list of website admins from https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES ([permalink](https://github.com/kubernetes/website/blob/16aa332f28b9f34f9f37c5b45fecc78c38598882/OWNERS_ALIASES)).

```release-note
NONE
```