### PR TITLE
scheduler/assume_cache: read from both local and informer cache

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -193,7 +193,7 @@ func (c *claimTracker) Get(namespace, claimName string) (*resourceapi.ResourceCl
 func (c *claimTracker) List() ([]*resourceapi.ResourceClaim, error) {
 	var result []*resourceapi.ResourceClaim
 	// Probably not worth adding an index for?
-	objs := c.cache.List(nil)
+	objs := c.cache.List()
 	for _, obj := range objs {
 		claim, ok := obj.(*resourceapi.ResourceClaim)
 		if ok {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -2010,7 +2010,7 @@ func (tc *testContext) listAll(t *testing.T) (objects []metav1.Object) {
 func (tc *testContext) listAssumedClaims() ([]metav1.Object, []metav1.Object) {
 	var assumedClaims []metav1.Object
 	var sameClaims []metav1.Object
-	for _, obj := range tc.draManager.resourceClaimTracker.cache.List(nil) {
+	for _, obj := range tc.draManager.resourceClaimTracker.cache.List() {
 		claim := obj.(*resourceapi.ResourceClaim)
 		obj, _ := tc.draManager.resourceClaimTracker.cache.Get(claim.Namespace + "/" + claim.Name)
 		apiObj, _ := tc.draManager.resourceClaimTracker.cache.GetAPIObj(claim.Namespace + "/" + claim.Name)

--- a/pkg/scheduler/framework/plugins/volumebinding/assume_cache.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/assume_cache.go
@@ -73,11 +73,7 @@ func (c *PVAssumeCache) GetAPIPV(pvName string) (*v1.PersistentVolume, error) {
 }
 
 func (c *PVAssumeCache) ListPVs(storageClassName string) []*v1.PersistentVolume {
-	objs := c.List(&v1.PersistentVolume{
-		Spec: v1.PersistentVolumeSpec{
-			StorageClassName: storageClassName,
-		},
-	})
+	objs := c.ByIndex(storageClassName)
 	pvs := []*v1.PersistentVolume{}
 	for _, obj := range objs {
 		pv, ok := obj.(*v1.PersistentVolume)

--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -427,7 +427,6 @@ func (b *volumeBinder) AssumePodVolumes(logger klog.Logger, assumedPod *v1.Pod, 
 			b.revertAssumedPVs(newBindings)
 			return false, err
 		}
-		// TODO: can we assume every time?
 		if dirty {
 			err = b.pvCache.Assume(newPV)
 			if err != nil {

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -331,13 +331,9 @@ func (env *testEnv) updateVolumes(ctx context.Context, pvs []*v1.PersistentVolum
 	}
 	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (bool, error) {
 		for _, pv := range pvs {
-			obj, err := env.internalBinder.pvCache.GetAPIObj(pv.Name)
-			if obj == nil || err != nil {
+			pvInCache, err := env.internalBinder.pvCache.GetAPIPV(pv.Name)
+			if pvInCache == nil || err != nil {
 				return false, nil
-			}
-			pvInCache, ok := obj.(*v1.PersistentVolume)
-			if !ok {
-				return false, fmt.Errorf("PV %s invalid object", pvInCache.Name)
 			}
 			if versioner.CompareResourceVersion(pvInCache, pv) != 0 {
 				return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

AssumeCache and scheduler queue both receive events from informer. When a pod
is scheduling due to PV update event, the PVCache may be not updated yet
because it has not processed the relevant event.

Fix this by refactoring AssumeCache to only store the assumed objects that is
different from informer. When reading, read from both informer and local cache
to ensure we get the latest update.

AssumeCache now still listen events from informer, but only for cleaning up its
local cache.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #133872
Fixes #133611

#### Special notes for your reviewer:

DRA still needs to listen from AssumeCache because AssumeClaimAfterAPICall will
invoke handlers synchronously and ensure the allocatedDevices is updated before
removing the devices from inFlightAllocations.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix occasional schedule delay when the static PV is created
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
