### PR TITLE
Add completion to kubectl certificates command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -42,7 +42,7 @@ import (
 )
 
 // NewCmdCertificate returns `certificate` Cobra command
-func NewCmdCertificate(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
+func NewCmdCertificate(f genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 
 	validArgs := []string{"certificatesigningrequests"}
 
@@ -88,7 +88,7 @@ func NewCertificateOptions(ioStreams genericiooptions.IOStreams, operation strin
 }
 
 // Complete loads data from the command environment
-func (o *CertificateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (o *CertificateOptions) Complete(f genericclioptions.RESTClientGetter, cmd *cobra.Command, args []string) error {
 	o.csrNames = args
 	o.outputStyle = cmdutil.GetFlagString(cmd, "output")
 
@@ -125,7 +125,7 @@ func (o *CertificateOptions) Validate() error {
 }
 
 // NewCmdCertificateApprove returns the `certificate approve` Cobra command
-func NewCmdCertificateApprove(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
+func NewCmdCertificateApprove(f genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCertificateOptions(ioStreams, "approved")
 
 	cmd := &cobra.Command{
@@ -174,7 +174,7 @@ func (o *CertificateOptions) RunCertificateApprove(force bool) error {
 }
 
 // NewCmdCertificateDeny returns the `certificate deny` Cobra command
-func NewCmdCertificateDeny(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
+func NewCmdCertificateDeny(f genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCertificateOptions(ioStreams, "denied")
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
@@ -595,6 +595,7 @@ func setMockFactory(config api.Config) {
 
 func prepareCompletionTest() (*cmdtesting.TestFactory, *cobra.Command) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	SetFactoryForCompletion(tf)
 	defer tf.Cleanup()
 
 	streams, _, _, _ := genericiooptions.NewTestIOStreams()


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds completion to `kubectl certificates` and sub commands

#### Special notes for your reviewer:
Please let me know, if test cases for this kind of feature are required and if so where to put these. I manually tested the changes.

#### Does this PR introduce a user-facing change?
```release-note
Added completion for `kubectl certificates`
```