### PR TITLE
Wait the readiness of pods for all the containers generate logs

### DIFF
--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -282,6 +282,9 @@ var _ = SIGDescribe("Kubectl logs", func() {
 					framework.Failf("Failed to wait for Deployment to complete: %v", err)
 				}
 
+				if err = e2epod.WaitForPodsRunningReady(ctx, c, ns, 2, framework.PodStartTimeout); err != nil {
+					framework.Failf("Failed to wait for Pods are running: %v", err)
+				}
 			})
 
 			ginkgo.AfterEach(func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
[Test](https://github.com/kubernetes/kubernetes/blob/597a684bb0653a607009e97299986763ebfde020/test/e2e/kubectl/logs.go#L322) creates 2 deployments with `--run-duration 3s` ([ref](https://github.com/kubernetes/kubernetes/blob/597a684bb0653a607009e97299986763ebfde020/test/e2e/kubectl/logs.go#L78)). After that test waits for the deployments are ready ([ref](https://github.com/kubernetes/kubernetes/blob/597a684bb0653a607009e97299986763ebfde020/test/e2e/kubectl/logs.go#L281)). However, in rare cases, `kubectl logs` is executed before container logs any data and causes the failure (as far as I can see, this didn't happen in kubernetes but happening in openshift in very slow environments).

In order to increase the reliability of the test, this PR waits for the readiness of the pods to guarantee that all logs are completed. 

#### Does this PR introduce a user-facing change?
```release-note
None
```