### PR TITLE
kubelet: Refactor ComputePodQOS by extracting resource-collection logic (no behavior change)

### DIFF
--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -121,6 +121,21 @@ func collectPodResources(pod *v1.Pod) (v1.ResourceList, v1.ResourceList, bool) {
 	return collectContainerLevelResources(pod)
 }
 
+func collectPodLevelResources(pod *v1.Pod) (v1.ResourceList, v1.ResourceList, bool) {
+	requests := v1.ResourceList{}
+	limits := v1.ResourceList{}
+
+	// process requests
+	processResourceList(requests, pod.Spec.Resources.Requests)
+	// process limits
+	processResourceList(limits, pod.Spec.Resources.Limits)
+
+	qosLimitResources := getQOSResources(pod.Spec.Resources.Limits)
+	isGuaranteed := qosLimitResources.HasAll(string(v1.ResourceMemory), string(v1.ResourceCPU))
+
+	return requests, limits, isGuaranteed
+}
+
 func collectContainerLevelResources(pod *v1.Pod) (v1.ResourceList, v1.ResourceList, bool) {
 	requests := v1.ResourceList{}
 	limits := v1.ResourceList{}
@@ -168,21 +183,6 @@ func collectContainerLevelResources(pod *v1.Pod) (v1.ResourceList, v1.ResourceLi
 			isGuaranteed = false
 		}
 	}
-
-	return requests, limits, isGuaranteed
-}
-
-func collectPodLevelResources(pod *v1.Pod) (v1.ResourceList, v1.ResourceList, bool) {
-	requests := v1.ResourceList{}
-	limits := v1.ResourceList{}
-
-	// process requests
-	processResourceList(requests, pod.Spec.Resources.Requests)
-	// process limits
-	processResourceList(limits, pod.Spec.Resources.Limits)
-
-	qosLimitResources := getQOSResources(pod.Spec.Resources.Limits)
-	isGuaranteed := qosLimitResources.HasAll(string(v1.ResourceMemory), string(v1.ResourceCPU))
 
 	return requests, limits, isGuaranteed
 }

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -118,12 +118,15 @@ func collectPodResources(pod *v1.Pod) (v1.ResourceList, v1.ResourceList, bool) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && pod.Spec.Resources != nil {
 		return collectPodLevelResources(pod)
 	}
+	return collectContainerLevelResources(pod)
+}
 
-	// note, ephemeral containers are not considered for QoS as they cannot define resources
+func collectContainerLevelResources(pod *v1.Pod) (v1.ResourceList, v1.ResourceList, bool) {
 	requests := v1.ResourceList{}
 	limits := v1.ResourceList{}
 	isGuaranteed := true
 
+	// note, ephemeral containers are not considered for QoS as they cannot define resources
 	allContainers := []v1.Container{}
 	allContainers = append(allContainers, pod.Spec.Containers...)
 	allContainers = append(allContainers, pod.Spec.InitContainers...)

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -88,8 +88,6 @@ func getQOSResources(list v1.ResourceList) sets.Set[string] {
 // A pod is besteffort if none of its containers have specified any requests or limits.
 // A pod is guaranteed only when requests and limits are specified for all the containers and they are equal.
 // A pod is burstable if limits and requests do not match across all containers.
-// TODO(ndixita): Refactor ComputePodQOS into smaller functions to make it more
-// readable and maintainable.
 func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 	requests, limits, isGuaranteed := collectPodResources(pod)
 	if len(requests) == 0 && len(limits) == 0 {

--- a/pkg/apis/core/v1/helper/qos/qos_test.go
+++ b/pkg/apis/core/v1/helper/qos/qos_test.go
@@ -32,22 +32,22 @@ import (
 
 func TestResourceListEqual(t *testing.T) {
 	tests := []struct {
-		name string
-		a    map[v1.ResourceName]string
-		b    map[v1.ResourceName]string
-		want bool
+		name     string
+		a        map[v1.ResourceName]string
+		b        map[v1.ResourceName]string
+		expected bool
 	}{
 		{
-			name: "both nil",
-			a:    nil,
-			b:    nil,
-			want: true,
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: true,
 		},
 		{
-			name: "nil vs empty map",
-			a:    nil,
-			b:    map[v1.ResourceName]string{},
-			want: true,
+			name:     "nil vs empty map",
+			a:        nil,
+			b:        map[v1.ResourceName]string{},
+			expected: true,
 		},
 		{
 			name: "identical keys and values",
@@ -59,7 +59,7 @@ func TestResourceListEqual(t *testing.T) {
 				v1.ResourceCPU:    "1",
 				v1.ResourceMemory: "1Gi",
 			},
-			want: true,
+			expected: true,
 		},
 		{
 			name: "different textual forms but equal quantities",
@@ -71,7 +71,7 @@ func TestResourceListEqual(t *testing.T) {
 				v1.ResourceCPU:    "1",
 				v1.ResourceMemory: "1Gi",
 			},
-			want: true,
+			expected: true,
 		},
 		{
 			name: "value differs",
@@ -83,15 +83,15 @@ func TestResourceListEqual(t *testing.T) {
 				v1.ResourceCPU:    "1",
 				v1.ResourceMemory: "1Gi",
 			},
-			want: false,
+			expected: false,
 		},
 		{
 			name: "missing key in b",
 			a: map[v1.ResourceName]string{
 				v1.ResourceMemory: "1Gi",
 			},
-			b:    map[v1.ResourceName]string{},
-			want: false,
+			b:        map[v1.ResourceName]string{},
+			expected: false,
 		},
 		{
 			name: "extra key in b",
@@ -102,16 +102,15 @@ func TestResourceListEqual(t *testing.T) {
 				v1.ResourceCPU:    "1",
 				v1.ResourceMemory: "1Gi",
 			},
-			want: false,
+			expected: false,
 		},
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got := resourceListEqual(mustResourceList(tc.a), mustResourceList(tc.b))
-			if got != tc.want {
-				t.Fatalf("resourceListEqual() = %v, want %v\n a=%v\n b=%v", got, tc.want, tc.a, tc.b)
+			actual := resourceListEqual(mustResourceList(tc.a), mustResourceList(tc.b))
+			if actual != tc.expected {
+				t.Errorf("resourceListEqual() = %v, expected %v\n a=%v\n b=%v", actual, tc.expected, tc.a, tc.b)
 			}
 		})
 	}

--- a/pkg/apis/core/v1/helper/qos/qos_test.go
+++ b/pkg/apis/core/v1/helper/qos/qos_test.go
@@ -397,7 +397,7 @@ func TestCollectContainerLevelResources(t *testing.T) {
 			// Requests sum : CPU 100m+300m+50m=450m, Mem 100Mi+400Mi+50Mi=550Mi
 			expectedReq: getResourceList("450m", "550Mi"),
 			// Limits sum : CPU 200m+800m+100m=1100m, Mem 200Mi+1000Mi+100Mi=1300Mi
-			expectedLim: getResourceList("1100m", "1300Mi"),
+			expectedLim:        getResourceList("1100m", "1300Mi"),
 			expectedGuaranteed: true,
 		},
 		{
@@ -445,7 +445,7 @@ func TestCollectContainerLevelResources(t *testing.T) {
 			// Requests sum : CPU 100m+300m+50m=450m, Mem 100Mi+100Mi+50Mi=250Mi
 			expectedReq: getResourceList("450m", "250Mi"),
 			// Limits sum : CPU 200m+0+50m=250m,  Mem 300Mi+300Mi+50Mi=650Mi
-			expectedLim: getResourceList("250m", "650Mi"),
+			expectedLim:        getResourceList("250m", "650Mi"),
 			expectedGuaranteed: false,
 		},
 		{

--- a/pkg/apis/core/v1/helper/qos/qos_test.go
+++ b/pkg/apis/core/v1/helper/qos/qos_test.go
@@ -317,6 +317,14 @@ func TestCollectPodLevelResources(t *testing.T) {
 			expectedLims:       getResourceList("", ""),
 			expectedGuaranteed: false,
 		},
+		{
+			name:               "no requests and limits -> not Guaranteed",
+			reqs:               getResourceList("", ""),
+			lims:               getResourceList("", ""),
+			expectedReqs:       getResourceList("", ""),
+			expectedLims:       getResourceList("", ""),
+			expectedGuaranteed: false,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/apis/core/v1/helper/qos/qos_test.go
+++ b/pkg/apis/core/v1/helper/qos/qos_test.go
@@ -30,6 +30,251 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
+func TestComputePodQOS(t *testing.T) {
+	testCases := []struct {
+		pod                      *v1.Pod
+		expected                 v1.PodQOSClass
+		podLevelResourcesEnabled bool
+	}{
+		{
+			pod: newPod("guaranteed", []v1.Container{
+				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
+			}),
+			expected: v1.PodQOSGuaranteed,
+		},
+		{
+			pod: newPod("guaranteed-guaranteed", []v1.Container{
+				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
+				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
+			}),
+			expected: v1.PodQOSGuaranteed,
+		},
+		{
+			pod: newPod("best-effort-best-effort", []v1.Container{
+				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+			}),
+			expected: v1.PodQOSBestEffort,
+		},
+		{
+			pod: newPod("best-effort", []v1.Container{
+				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+			}),
+			expected: v1.PodQOSBestEffort,
+		},
+		{
+			pod: newPod("best-effort-burstable", []v1.Container{
+				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+				newContainer("burstable", getResourceList("1", ""), getResourceList("2", "")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("best-effort-guaranteed", []v1.Container{
+				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+				newContainer("guaranteed", getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("burstable-cpu-guaranteed-memory", []v1.Container{
+				newContainer("burstable", getResourceList("", "100Mi"), getResourceList("", "100Mi")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("burstable-no-limits", []v1.Container{
+				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("", "")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("burstable-guaranteed", []v1.Container{
+				newContainer("burstable", getResourceList("1", "100Mi"), getResourceList("2", "100Mi")),
+				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("burstable-unbounded-but-requests-match-limits", []v1.Container{
+				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("200m", "200Mi")),
+				newContainer("burstable-unbounded", getResourceList("100m", "100Mi"), getResourceList("", "")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("burstable-1", []v1.Container{
+				newContainer("burstable", getResourceList("10m", "100Mi"), getResourceList("100m", "200Mi")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("burstable-2", []v1.Container{
+				newContainer("burstable", getResourceList("0", "0"), getResourceList("100m", "200Mi")),
+			}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPod("best-effort-hugepages", []v1.Container{
+				newContainer("best-effort", addResource("hugepages-2Mi", "1Gi", getResourceList("0", "0")), addResource("hugepages-2Mi", "1Gi", getResourceList("0", "0"))),
+			}),
+			expected: v1.PodQOSBestEffort,
+		},
+		{
+			pod: newPodWithInitContainers("init-container",
+				[]v1.Container{
+					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+				},
+				[]v1.Container{
+					newContainer("burstable", getResourceList("10m", "100Mi"), getResourceList("100m", "200Mi")),
+				}),
+			expected: v1.PodQOSBurstable,
+		},
+		{
+			pod: newPodWithResources(
+				"guaranteed-with-pod-level-resources",
+				[]v1.Container{
+					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+				},
+				getResourceRequirements(getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
+			),
+			expected:                 v1.PodQOSGuaranteed,
+			podLevelResourcesEnabled: true,
+		},
+		{
+			pod: newPodWithResources(
+				"guaranteed-with-pod-and-container-level-resources",
+				[]v1.Container{
+					newContainer("burstable", getResourceList("3m", "10Mi"), getResourceList("5m", "20Mi")),
+				},
+				getResourceRequirements(getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
+			),
+			expected:                 v1.PodQOSGuaranteed,
+			podLevelResourcesEnabled: true,
+		},
+		{
+			pod: newPodWithResources(
+				"burstable-with-pod-level-resources",
+				[]v1.Container{
+					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
+				},
+				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("20m", "50Mi")),
+			),
+			expected:                 v1.PodQOSBurstable,
+			podLevelResourcesEnabled: true,
+		},
+		{
+			pod: newPodWithResources(
+				"burstable-with-pod-and-container-level-resources",
+				[]v1.Container{
+					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("5m", "10Mi")),
+				},
+				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("20m", "50Mi")),
+			),
+			expected:                 v1.PodQOSBurstable,
+			podLevelResourcesEnabled: true,
+		},
+		{
+			pod: newPodWithResources(
+				"burstable-with-pod-and-container-level-requests",
+				[]v1.Container{
+					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("", "")),
+				},
+				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("", "")),
+			),
+			expected:                 v1.PodQOSBurstable,
+			podLevelResourcesEnabled: true,
+		},
+		{
+			pod: newPodWithResources(
+				"burstable-with-pod-and-container-level-resources-2",
+				[]v1.Container{
+					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("", "")),
+					newContainer("guaranteed", getResourceList("5m", "10Mi"), getResourceList("5m", "10Mi")),
+				},
+				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("5m", "")),
+			),
+			expected:                 v1.PodQOSBurstable,
+			podLevelResourcesEnabled: true,
+		},
+	}
+	for id, testCase := range testCases {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, testCase.podLevelResourcesEnabled)
+		if actual := ComputePodQOS(testCase.pod); testCase.expected != actual {
+			t.Errorf("[%d]: invalid qos pod %s, expected: %s, actual: %s", id, testCase.pod.Name, testCase.expected, actual)
+		}
+
+		// Convert v1.Pod to core.Pod, and then check against `core.helper.ComputePodQOS`.
+		pod := core.Pod{}
+		corev1.Convert_v1_Pod_To_core_Pod(testCase.pod, &pod, nil)
+
+		if actual := qos.ComputePodQOS(&pod); core.PodQOSClass(testCase.expected) != actual {
+			t.Errorf("[%d]: conversion invalid qos pod %s, expected: %s, actual: %s", id, testCase.pod.Name, testCase.expected, actual)
+		}
+	}
+}
+
+func getResourceList(cpu, memory string) v1.ResourceList {
+	res := v1.ResourceList{}
+	if cpu != "" {
+		res[v1.ResourceCPU] = resource.MustParse(cpu)
+	}
+	if memory != "" {
+		res[v1.ResourceMemory] = resource.MustParse(memory)
+	}
+	return res
+}
+
+func addResource(rName, value string, rl v1.ResourceList) v1.ResourceList {
+	rl[v1.ResourceName(rName)] = resource.MustParse(value)
+	return rl
+}
+
+func getResourceRequirements(requests, limits v1.ResourceList) *v1.ResourceRequirements {
+	res := v1.ResourceRequirements{}
+	res.Requests = requests
+	res.Limits = limits
+	return &res
+}
+
+func newContainer(name string, requests v1.ResourceList, limits v1.ResourceList) v1.Container {
+	return v1.Container{
+		Name:      name,
+		Resources: *(getResourceRequirements(requests, limits)),
+	}
+}
+
+func newPod(name string, containers []v1.Container) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			Containers: containers,
+		},
+	}
+}
+
+func newPodWithResources(name string, containers []v1.Container, podResources *v1.ResourceRequirements) *v1.Pod {
+	pod := newPod(name, containers)
+	if podResources != nil {
+		pod.Spec.Resources = podResources
+	}
+	return pod
+}
+
+func newPodWithInitContainers(name string, containers []v1.Container, initContainers []v1.Container) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			Containers:     containers,
+			InitContainers: initContainers,
+		},
+	}
+}
+
 func TestResourceListEqual(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -332,250 +577,5 @@ func TestCollectContainerLevelResources(t *testing.T) {
 				t.Errorf("isGuaranteed mismatch: actual=%v expected=%v", actualGuaranteed, tc.expectedGuaranteed)
 			}
 		})
-	}
-}
-
-func TestComputePodQOS(t *testing.T) {
-	testCases := []struct {
-		pod                      *v1.Pod
-		expected                 v1.PodQOSClass
-		podLevelResourcesEnabled bool
-	}{
-		{
-			pod: newPod("guaranteed", []v1.Container{
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-			}),
-			expected: v1.PodQOSGuaranteed,
-		},
-		{
-			pod: newPod("guaranteed-guaranteed", []v1.Container{
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-			}),
-			expected: v1.PodQOSGuaranteed,
-		},
-		{
-			pod: newPod("best-effort-best-effort", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBestEffort,
-		},
-		{
-			pod: newPod("best-effort", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBestEffort,
-		},
-		{
-			pod: newPod("best-effort-burstable", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				newContainer("burstable", getResourceList("1", ""), getResourceList("2", "")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("best-effort-guaranteed", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				newContainer("guaranteed", getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-cpu-guaranteed-memory", []v1.Container{
-				newContainer("burstable", getResourceList("", "100Mi"), getResourceList("", "100Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-no-limits", []v1.Container{
-				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-guaranteed", []v1.Container{
-				newContainer("burstable", getResourceList("1", "100Mi"), getResourceList("2", "100Mi")),
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-unbounded-but-requests-match-limits", []v1.Container{
-				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("200m", "200Mi")),
-				newContainer("burstable-unbounded", getResourceList("100m", "100Mi"), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-1", []v1.Container{
-				newContainer("burstable", getResourceList("10m", "100Mi"), getResourceList("100m", "200Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-2", []v1.Container{
-				newContainer("burstable", getResourceList("0", "0"), getResourceList("100m", "200Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("best-effort-hugepages", []v1.Container{
-				newContainer("best-effort", addResource("hugepages-2Mi", "1Gi", getResourceList("0", "0")), addResource("hugepages-2Mi", "1Gi", getResourceList("0", "0"))),
-			}),
-			expected: v1.PodQOSBestEffort,
-		},
-		{
-			pod: newPodWithInitContainers("init-container",
-				[]v1.Container{
-					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				},
-				[]v1.Container{
-					newContainer("burstable", getResourceList("10m", "100Mi"), getResourceList("100m", "200Mi")),
-				}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPodWithResources(
-				"guaranteed-with-pod-level-resources",
-				[]v1.Container{
-					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				},
-				getResourceRequirements(getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
-			),
-			expected:                 v1.PodQOSGuaranteed,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"guaranteed-with-pod-and-container-level-resources",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("3m", "10Mi"), getResourceList("5m", "20Mi")),
-				},
-				getResourceRequirements(getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
-			),
-			expected:                 v1.PodQOSGuaranteed,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-level-resources",
-				[]v1.Container{
-					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("20m", "50Mi")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-and-container-level-resources",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("5m", "10Mi")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("20m", "50Mi")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-and-container-level-requests",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("", "")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("", "")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-and-container-level-resources-2",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("", "")),
-					newContainer("guaranteed", getResourceList("5m", "10Mi"), getResourceList("5m", "10Mi")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("5m", "")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
-	}
-	for id, testCase := range testCases {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, testCase.podLevelResourcesEnabled)
-		if actual := ComputePodQOS(testCase.pod); testCase.expected != actual {
-			t.Errorf("[%d]: invalid qos pod %s, expected: %s, actual: %s", id, testCase.pod.Name, testCase.expected, actual)
-		}
-
-		// Convert v1.Pod to core.Pod, and then check against `core.helper.ComputePodQOS`.
-		pod := core.Pod{}
-		corev1.Convert_v1_Pod_To_core_Pod(testCase.pod, &pod, nil)
-
-		if actual := qos.ComputePodQOS(&pod); core.PodQOSClass(testCase.expected) != actual {
-			t.Errorf("[%d]: conversion invalid qos pod %s, expected: %s, actual: %s", id, testCase.pod.Name, testCase.expected, actual)
-		}
-	}
-}
-
-func getResourceList(cpu, memory string) v1.ResourceList {
-	res := v1.ResourceList{}
-	if cpu != "" {
-		res[v1.ResourceCPU] = resource.MustParse(cpu)
-	}
-	if memory != "" {
-		res[v1.ResourceMemory] = resource.MustParse(memory)
-	}
-	return res
-}
-
-func addResource(rName, value string, rl v1.ResourceList) v1.ResourceList {
-	rl[v1.ResourceName(rName)] = resource.MustParse(value)
-	return rl
-}
-
-func getResourceRequirements(requests, limits v1.ResourceList) *v1.ResourceRequirements {
-	res := v1.ResourceRequirements{}
-	res.Requests = requests
-	res.Limits = limits
-	return &res
-}
-
-func newContainer(name string, requests v1.ResourceList, limits v1.ResourceList) v1.Container {
-	return v1.Container{
-		Name:      name,
-		Resources: *(getResourceRequirements(requests, limits)),
-	}
-}
-
-func newPod(name string, containers []v1.Container) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.PodSpec{
-			Containers: containers,
-		},
-	}
-}
-
-func newPodWithResources(name string, containers []v1.Container, podResources *v1.ResourceRequirements) *v1.Pod {
-	pod := newPod(name, containers)
-	if podResources != nil {
-		pod.Spec.Resources = podResources
-	}
-	return pod
-}
-
-func newPodWithInitContainers(name string, containers []v1.Container, initContainers []v1.Container) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.PodSpec{
-			Containers:     containers,
-			InitContainers: initContainers,
-		},
 	}
 }

--- a/pkg/apis/core/v1/helper/qos/qos_test.go
+++ b/pkg/apis/core/v1/helper/qos/qos_test.go
@@ -480,6 +480,30 @@ func TestCollectContainerLevelResources(t *testing.T) {
 			expectedLim:        getResourceList("500m", "512Mi"),
 			expectedGuaranteed: true,
 		},
+		{
+			name: "non-QoS resources (hugepages) not considered; CPU+Mem limits exist -> Guaranteed",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						newContainer(
+							"c1",
+							addResource("hugepages-2Mi", "4Mi", getResourceList("250m", "256Mi")),
+							addResource("hugepages-2Mi", "4Mi", getResourceList("500m", "512Mi")),
+						),
+						newContainer(
+							"c2",
+							addResource("hugepages-1Gi", "2Gi", getResourceList("250m", "256Mi")),
+							addResource("hugepages-1Gi", "2Gi", getResourceList("500m", "512Mi")),
+						),
+					},
+				},
+			},
+			// requests sum: CPU 250m+250m=500m, Mem 256Mi+256Mi=512Mi
+			expectedReq: getResourceList("500m", "512Mi"),
+			// limits sum: CPU 500m+500m=1000m, Mem 512Mi+512Mi=1024Mi
+			expectedLim:        getResourceList("1000m", "1024Mi"),
+			expectedGuaranteed: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Refactors ComputePodQOS into smaller, focused helpers to improve readability and maintainability.
Motivated by the TODO from @ndixita.

Key benefits:
- Clear separation of concerns: collect inputs vs decide QoS
- Easier unit testing of edge cases (pod-level vs container-level, init containers, missing cpu/memory)
- Pure refactor with no semantic/behavioral changes

#### Which issue(s) this PR is related to:
Fixes #133685 

#### Special notes for your reviewer:
- Intentionally preserved the existing control flow in collectContainerLevelResources to stay consistent with current patterns (see b30e6c8b0e16100428e1925f6cefdd884a96cfb5).


#### Does this PR introduce a user-facing change?
```release-note
None
```
