### PR TITLE
Optimize Event storage initialization to prevent multiple instances

### DIFF
--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -87,7 +87,7 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 		apiGroupInfo.NegotiatedSerializer = serializer.NewCodecFactory(legacyscheme.Scheme, opts...)
 	}
 
-	eventStorage, err := eventstore.NewREST(restOptionsGetter, uint64(c.EventTTL.Seconds()))
+	eventStorage, err := eventstore.GetOrCreateREST(restOptionsGetter, uint64(c.EventTTL.Seconds()))
 	if err != nil {
 		return genericapiserver.APIGroupInfo{}, err
 	}

--- a/pkg/registry/events/rest/storage_events.go
+++ b/pkg/registry/events/rest/storage_events.go
@@ -52,7 +52,7 @@ func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.API
 
 	// events
 	if resource := "events"; apiResourceConfigSource.ResourceEnabled(eventsapiv1.SchemeGroupVersion.WithResource(resource)) {
-		eventsStorage, err := eventstore.NewREST(restOptionsGetter, uint64(p.TTL.Seconds()))
+		eventsStorage, err := eventstore.GetOrCreateREST(restOptionsGetter, uint64(p.TTL.Seconds()))
 		if err != nil {
 			return storage, err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

prevents duplicate storage instances for events,as suggest in #133877

#### Which issue(s) this PR is related to:

Part of  #133877

#### Special notes for your reviewer:


```release-note
NONE
```