### PR TITLE
fix CI failure: update pod image using the same one

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -355,7 +355,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		checkDaemonSetPodsLabels(listDaemonPods(ctx, c, ns, label), firstHash)
 
 		ginkgo.By("Update daemon pods image.")
-		patch := getDaemonSetImagePatch(ds.Spec.Template.Spec.Containers[0].Name, AgnhostImage)
+		patch := getDaemonSetImagePatch(ds.Spec.Template.Spec.Containers[0].Name, PrevAgnhostImage)
 		ds, err = c.AppsV1().DaemonSets(ns).Patch(ctx, dsName, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:

https://testgrid.k8s.io/sig-release-master-informing#gce-cos-master-serial


#### Which issue(s) this PR is related to:
Fixes #133919 

```
Kubernetes e2e suite: [It] [sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete 
	5m4s { failed [FAILED] error waiting for controllerrevisions to be created: context deadline exceeded In [It] at: 
			k8s.io/kubernetes/test/e2e/apps/daemon_set.go:1245 @ 09/08/25 23:04:51.649 }
```

```
I0908 22:59:51.534332 11029 fixtures.go:136] Number of running nodes: 3, number of available pods: 3 in daemonset daemon-set
STEP: Update daemon pods image. - k8s.io/kubernetes/test/e2e/apps/daemon_set.go:357 @ 09/08/25 22:59:51.556
STEP: Check that daemon pods images aren't updated. - k8s.io/kubernetes/test/e2e/apps/daemon_set.go:362 @ 09/08/25 22:59:51.566
I0908 22:59:51.631364 11029 fixtures.go:90] DaemonSet pods can't tolerate node bootstrap-e2e-master with taints [{Key:node-role.kubernetes.io/control-plane Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
STEP: Check that daemon pods are still running on every node of the cluster. - k8s.io/kubernetes/test/e2e/apps/daemon_set.go:366 @ 09/08/25 22:59:51.631
I0908 22:59:51.637864 11029 fixtures.go:90] DaemonSet pods can't tolerate node bootstrap-e2e-master with taints [{Key:node-role.kubernetes.io/control-plane Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
I0908 22:59:51.643336 11029 fixtures.go:126] Number of nodes with available pods controlled by daemonset daemon-set: 3
I0908 22:59:51.643347 11029 fixtures.go:136] Number of running nodes: 3, number of available pods: 3 in daemonset daemon-set
I0908 22:59:51.653151 11029 daemon_set.go:1241] 1/2 controllerrevisions created.
I0908 22:59:52.655025 11029 daemon_set.go:1241] 1/2 controllerrevisions created.
I0908 22:59:53.654392 11029 daemon_set.go:1241] 1/2 controllerrevisions created.
```

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/compare/4786451d8...b50876736 failure happen after
 https://github.com/kubernetes/kubernetes/pull/132655 was merged.

#### Does this PR introduce a user-facing change?

```release-note
None
```
