### PR TITLE
Fix ClusterIP load balancer disappearing when InternalTrafficPolicy: Local is set.

### DIFF
--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -39,6 +39,8 @@ const (
 	epIpv6Address     = "192::3"
 	epIpAddressB      = "192.168.1.4"
 	epIpAddressRemote = "192.168.2.3"
+	epIpAddressLocal1 = "192.168.4.4"
+	epIpAddressLocal2 = "192.168.4.5"
 	epPaAddress       = "10.0.0.3"
 	protocol          = 6
 	internalPort      = 80

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1526,7 +1526,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		}
 
 		if !proxier.requiresUpdateLoadbalancer(svcInfo.hnsID, len(clusterIPEndpoints)) {
-			proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &svcInfo.hnsID, svcInfo.ClusterIP().String(), Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), hnsEndpoints, queriedLoadBalancers)
+			proxier.deleteExistingLoadBalancer(hns, svcInfo.winProxyOptimization, &svcInfo.hnsID, svcInfo.ClusterIP().String(), Enum(svcInfo.Protocol()), uint16(svcInfo.targetPort), uint16(svcInfo.Port()), clusterIPEndpoints, queriedLoadBalancers)
 			if len(clusterIPEndpoints) > 0 {
 
 				// If all endpoints are terminating, then no need to create Cluster IP LoadBalancer

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -48,15 +48,19 @@ import (
 const (
 	testNodeName      = "test-node"
 	testNetwork       = "TestNetwork"
-	ipAddress         = "10.0.0.1"
 	prefixLen         = 24
 	macAddress        = "00-11-22-33-44-55"
+	macAddressLocal1  = "00-11-22-33-44-56"
+	macAddressLocal2  = "00-11-22-33-44-57"
 	destinationPrefix = "192.168.2.0/24"
 	providerAddress   = "10.0.0.3"
 	guid              = "123ABC"
+	networkId         = "123ABC"
 	endpointGuid1     = "EPID-1"
 	loadbalancerGuid1 = "LBID-1"
-	endpointLocal     = "EP-LOCAL"
+	loadbalancerGuid2 = "LBID-2"
+	endpointLocal1    = "EP-LOCAL-1"
+	endpointLocal2    = "EP-LOCAL-2"
 	endpointGw        = "EP-GW"
 	epIpAddressGw     = "192.168.2.1"
 	epMacAddressGw    = "00-11-22-33-44-66"
@@ -411,6 +415,193 @@ func TestDsrNotAppliedToClusterTrafficPolicy(t *testing.T) {
 	if svcInfo.localTrafficDSR {
 		t.Errorf("Expected localTrafficDSR to be false for ExternalTrafficPolicy=Cluster, but got true")
 	}
+}
+
+// TestClusterIPSvcWithITPLocal tests the following scenarios for a ClusterIP service with InternalTrafficPolicy=Local:
+//  1. When a local endpoint is added to the service, the service should continue to use the local endpoints and existing loadbalancer.
+//     If no existing loadbalancer is present, a new loadbalancer should be created.
+//  2. When one more local endpoint is added to the service, the service should delete existing loadbalancer and create a new loadbalancer.
+//  3. When a remote endpoint is added to the service, the service should continue to use the local endpoints and existing loadbalancer,
+//     since it's a InternalTrafficPolicy=Local service.
+func TestClusterIPSvcWithITPLocal(t *testing.T) {
+	proxier := NewFakeProxier(t, "testhost", netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge", true)
+	if proxier == nil {
+		t.Fatal("Failed to create proxier")
+	}
+
+	svcIP := "10.20.30.41"
+	svcPort := 80
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	itpLocal := v1.ServiceInternalTrafficPolicyLocal
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.InternalTrafficPolicy = &itpLocal // Setting the InternalTrafficPolicy to Local
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+
+	populateEndpointSlices(proxier,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressLocal1}, // Local Endpoint 1
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	hcn := (proxier.hcn).(*fakehcn.HcnMock)
+	// Populating the endpoint to the cache, since it's a local endpoint and local endpoints are managed by CNI and not KubeProxy
+	// Populating here marks the endpoint to local
+	hcn.PopulateQueriedEndpoints(endpointLocal1, networkId, epIpAddressLocal1, macAddressLocal1, prefixLen)
+
+	proxier.setInitialized(true)
+
+	// Test 1: When a local endpoint is added to the service, the service should continue to use the local endpoints and existing loadbalancer.
+	// If no existing loadbalancer is present, a new loadbalancer should be created.
+	proxier.syncProxyRules()
+
+	ep := proxier.endpointsMap[svcPortName][0]
+	epInfo, ok := ep.(*endpointInfo)
+	assert.True(t, ok, fmt.Sprintf("Failed to cast endpointInfo %q", svcPortName.String()))
+	assert.NotEmpty(t, epInfo.hnsID, fmt.Sprintf("Expected HNS ID to be set for endpoint %s, but got empty value", epIpAddressRemote))
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	assert.Equal(t, svcInfo.hnsID, loadbalancerGuid1, fmt.Sprintf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1))
+	lb, err := proxier.hcn.GetLoadBalancerByID(loadbalancerGuid1)
+	assert.Equal(t, nil, err, fmt.Sprintf("Failed to fetch loadbalancer: %s. Error: %v", loadbalancerGuid1, err))
+	assert.NotNil(t, lb, "Loadbalancer object should not be nil")
+
+	// Test 2: When one more local endpoint is added to the service, the service should delete existing loadbalancer and create a new loadbalancer.
+
+	proxier.setInitialized(false)
+
+	proxier.OnEndpointSliceUpdate(
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{epIpAddressLocal1},
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressLocal1},
+				},
+				{
+					Addresses: []string{epIpAddressLocal2}, // Adding one more local endpoint
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}))
+
+	proxier.mu.Lock()
+	proxier.endpointSlicesSynced = true
+	proxier.mu.Unlock()
+
+	proxier.setInitialized(true)
+
+	// Creating the second local endpoint
+	hcn.PopulateQueriedEndpoints(endpointLocal2, networkId, epIpAddressLocal2, macAddressLocal2, prefixLen)
+	// Reinitiating the syncProxyRules to create new loadbalancer with the new local endpoint
+	proxier.syncProxyRules()
+	svc = proxier.svcPortMap[svcPortName]
+	svcInfo, ok = svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	assert.Equal(t, svcInfo.hnsID, loadbalancerGuid2, fmt.Sprintf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid2))
+	lb, err = proxier.hcn.GetLoadBalancerByID(loadbalancerGuid2)
+	assert.Equal(t, nil, err, fmt.Sprintf("Failed to fetch loadbalancer: %s. Error: %v", loadbalancerGuid2, err))
+	assert.NotNil(t, lb, "Loadbalancer object should not be nil")
+
+	lb, _ = proxier.hcn.GetLoadBalancerByID(loadbalancerGuid1)
+	assert.Nil(t, lb, fmt.Sprintf("Loadbalancer object should be nil: %s", loadbalancerGuid1))
+
+	// Test 3: When a remote endpoint is added to the service, the service should continue to use the local endpoints and existing loadbalancer,
+	// since it's a InternalTrafficPolicy=Local service.
+
+	proxier.setInitialized(false)
+
+	proxier.OnEndpointSliceUpdate(
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressLocal1},
+				},
+				{
+					Addresses: []string{epIpAddressLocal2},
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressLocal1},
+				},
+				{
+					Addresses: []string{epIpAddressLocal2}, // Adding one more local endpoint
+				},
+				{
+					Addresses: []string{epIpAddressRemote}, // Adding one more remote endpoint to the slice
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}))
+
+	proxier.mu.Lock()
+	proxier.endpointSlicesSynced = true
+	proxier.mu.Unlock()
+
+	proxier.setInitialized(true)
+
+	proxier.syncProxyRules()
+	svc = proxier.svcPortMap[svcPortName]
+	svcInfo, ok = svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	assert.Equal(t, svcInfo.hnsID, loadbalancerGuid2, fmt.Sprintf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid2))
+	lb, err = proxier.hcn.GetLoadBalancerByID(loadbalancerGuid2)
+	assert.Equal(t, nil, err, fmt.Sprintf("Failed to fetch loadbalancer: %s. Error: %v", loadbalancerGuid2, err))
+	assert.NotNil(t, lb, "Loadbalancer object should not be nil")
 }
 
 func TestSharedRemoteEndpointDelete(t *testing.T) {
@@ -1198,7 +1389,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 
 	hcn := (proxier.hcn).(*fakehcn.HcnMock)
 	proxier.rootHnsEndpointName = endpointGw
-	hcn.PopulateQueriedEndpoints(endpointLocal, guid, epIpAddressRemote, macAddress, prefixLen)
+	hcn.PopulateQueriedEndpoints(endpointLocal1, guid, epIpAddressRemote, macAddress, prefixLen)
 	hcn.PopulateQueriedEndpoints(endpointGw, guid, epIpAddressGw, epMacAddressGw, prefixLen)
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

During scale-up or scale-down, kube-proxy deletes the existing load balancer and creates a new one with an updated set of endpoints.
Before performing this, it verifies whether the new load balancer would have the same set of endpoints as the existing one using a cached value. If they match, the existing load balancer should remain in place and continue serving traffic.

The problem comes from how endpoints are validated from the cache. For a ClusterIP service with InternalTrafficPolicy=Local, kube-proxy checks all endpoint hash in the cache during deletion but only local endpoints hash during creation. This inconsistency causes the load balancer to be deleted unnecessarily, but not recreated and fetch the value from the cache, since the endpoint match check passes during creation.

The fix is to ensure kube-proxy checks only local endpoints consistently, both during deletion and creation.

#### Which issue(s) this PR is related to:
Fixes #133928 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
