### PR TITLE
Migrate kubelet/server to contextual logging

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1270,10 +1270,10 @@ func startKubelet(ctx context.Context, k kubelet.Bootstrap, podCfg *config.PodCo
 
 	// start the kubelet server
 	if enableServer {
-		go k.ListenAndServe(kubeCfg, kubeDeps.TLSOptions, kubeDeps.Auth, kubeDeps.TracerProvider)
+		go k.ListenAndServe(ctx, kubeCfg, kubeDeps.TLSOptions, kubeDeps.Auth, kubeDeps.TracerProvider)
 	}
 	if kubeCfg.ReadOnlyPort > 0 {
-		go k.ListenAndServeReadOnly(netutils.ParseIPSloppy(kubeCfg.Address), uint(kubeCfg.ReadOnlyPort), kubeDeps.TracerProvider)
+		go k.ListenAndServeReadOnly(ctx, netutils.ParseIPSloppy(kubeCfg.Address), uint(kubeCfg.ReadOnlyPort), kubeDeps.TracerProvider)
 	}
 	go k.ListenAndServePodResources(ctx)
 }

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -225,6 +225,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/cadvisor/.*
             contextual k8s.io/kubernetes/pkg/kubelet/config/.*
             contextual k8s.io/kubernetes/pkg/kubelet/oom/.*
+            contextual k8s.io/kubernetes/pkg/kubelet/server/.*
             contextual k8s.io/kubernetes/pkg/kubelet/status/.*
             contextual k8s.io/kubernetes/pkg/kubelet/sysctl/.*
             contextual k8s.io/kubernetes/pkg/kubelet/winstats/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -239,6 +239,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/cadvisor/.*
             contextual k8s.io/kubernetes/pkg/kubelet/config/.*
             contextual k8s.io/kubernetes/pkg/kubelet/oom/.*
+            contextual k8s.io/kubernetes/pkg/kubelet/server/.*
             contextual k8s.io/kubernetes/pkg/kubelet/status/.*
             contextual k8s.io/kubernetes/pkg/kubelet/sysctl/.*
             contextual k8s.io/kubernetes/pkg/kubelet/winstats/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -71,6 +71,7 @@ contextual k8s.io/kubernetes/pkg/kubelet/token/.*
 contextual k8s.io/kubernetes/pkg/kubelet/cadvisor/.*
 contextual k8s.io/kubernetes/pkg/kubelet/config/.*
 contextual k8s.io/kubernetes/pkg/kubelet/oom/.*
+contextual k8s.io/kubernetes/pkg/kubelet/server/.*
 contextual k8s.io/kubernetes/pkg/kubelet/status/.*
 contextual k8s.io/kubernetes/pkg/kubelet/sysctl/.*
 contextual k8s.io/kubernetes/pkg/kubelet/winstats/.*

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -206,7 +206,7 @@ func newTestKubeletWithImageList(
 	excludeAdmitHandlers bool,
 	enableResizing bool,
 ) *TestKubelet {
-	logger, _ := ktesting.NewTestContext(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	fakeRuntime := &containertest.FakeRuntime{
 		ImageList: imageList,
@@ -336,7 +336,7 @@ func newTestKubeletWithImageList(
 	)
 	kubelet.allocationManager.SetContainerRuntime(fakeRuntime)
 	volumeStatsAggPeriod := time.Second * 10
-	kubelet.resourceAnalyzer = serverstats.NewResourceAnalyzer(kubelet, volumeStatsAggPeriod, kubelet.recorder)
+	kubelet.resourceAnalyzer = serverstats.NewResourceAnalyzer(tCtx, kubelet, volumeStatsAggPeriod, kubelet.recorder)
 
 	fakeHostStatsProvider := stats.NewFakeHostStatsProvider(&containertest.FakeOS{})
 

--- a/pkg/kubelet/server/auth.go
+++ b/pkg/kubelet/server/auth.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -76,8 +77,8 @@ func isSubpath(subpath, path string) bool {
 //	/healthz/* 		=> verb=<api verb from request>, resource=nodes, name=<node name>, subresource(s)=healthz,proxy
 //	/configz 		=> verb=<api verb from request>, resource=nodes, name=<node name>, subresource(s)=configz,proxy
 //	/flagz 		    => verb=<api verb from request>, resource=nodes, name=<node name>, subresource(s)=configz,proxy
-func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http.Request) []authorizer.Attributes {
-
+func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(ctx context.Context, u user.Info, r *http.Request) []authorizer.Attributes {
+	logger := klog.FromContext(ctx)
 	apiVerb := ""
 	switch r.Method {
 	case "POST":
@@ -145,7 +146,7 @@ func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 		attrs = append(attrs, attr)
 	}
 
-	klog.V(5).InfoS("Node request attributes", "user", attrs[0].GetUser().GetName(), "verb", attrs[0].GetVerb(), "resource", attrs[0].GetResource(), "subresource(s)", subresources)
+	logger.V(5).Info("Node request attributes", "user", attrs[0].GetUser().GetName(), "verb", attrs[0].GetVerb(), "resource", attrs[0].GetResource(), "subresource(s)", subresources)
 
 	return attrs
 }

--- a/pkg/kubelet/server/auth_test.go
+++ b/pkg/kubelet/server/auth_test.go
@@ -27,6 +27,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestIsSubPath(t *testing.T) {
@@ -64,6 +65,7 @@ func TestIsSubPath(t *testing.T) {
 }
 
 func TestGetRequestAttributes(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	for _, fineGrained := range []bool{false, true} {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletFineGrainedAuthz, fineGrained)
 		for _, test := range AuthzTestCases(fineGrained) {
@@ -72,7 +74,7 @@ func TestGetRequestAttributes(t *testing.T) {
 
 				req, err := http.NewRequest(test.Method, "https://localhost:1234"+test.Path, nil)
 				require.NoError(t, err)
-				attrs := getter.GetRequestAttributes(AuthzTestUser(), req)
+				attrs := getter.GetRequestAttributes(tCtx, AuthzTestUser(), req)
 
 				test.AssertAttributes(t, attrs)
 			})

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -54,6 +54,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	// Do some initialization to decode the query parameters correctly.
 	"k8s.io/apiserver/pkg/server/healthz"
@@ -280,15 +281,15 @@ func (fk *fakeKubelet) ListVolumesForPod(podUID types.UID) (map[string]volume.Vo
 func (*fakeKubelet) ListBlockVolumesForPod(podUID types.UID) (map[string]volume.BlockVolume, bool) {
 	return map[string]volume.BlockVolume{}, true
 }
-func (*fakeKubelet) RootFsStats() (*statsapi.FsStats, error)                     { return nil, nil }
-func (*fakeKubelet) ListPodStats(_ context.Context) ([]statsapi.PodStats, error) { return nil, nil }
-func (*fakeKubelet) ListPodStatsAndUpdateCPUNanoCoreUsage(_ context.Context) ([]statsapi.PodStats, error) {
+func (*fakeKubelet) RootFsStats() (*statsapi.FsStats, error)                   { return nil, nil }
+func (*fakeKubelet) ListPodStats(context.Context) ([]statsapi.PodStats, error) { return nil, nil }
+func (*fakeKubelet) ListPodStatsAndUpdateCPUNanoCoreUsage(context.Context) ([]statsapi.PodStats, error) {
 	return nil, nil
 }
-func (*fakeKubelet) ListPodCPUAndMemoryStats(_ context.Context) ([]statsapi.PodStats, error) {
+func (*fakeKubelet) ListPodCPUAndMemoryStats(context.Context) ([]statsapi.PodStats, error) {
 	return nil, nil
 }
-func (*fakeKubelet) ImageFsStats(_ context.Context) (*statsapi.FsStats, *statsapi.FsStats, error) {
+func (*fakeKubelet) ImageFsStats(context.Context) (*statsapi.FsStats, *statsapi.FsStats, error) {
 	return nil, nil, nil
 }
 func (*fakeKubelet) RlimitStats() (*statsapi.RlimitStats, error) { return nil, nil }
@@ -308,7 +309,7 @@ type fakeAuth struct {
 func (f *fakeAuth) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	return f.authenticateFunc(req)
 }
-func (f *fakeAuth) GetRequestAttributes(u user.Info, req *http.Request) []authorizer.Attributes {
+func (f *fakeAuth) GetRequestAttributes(ctx context.Context, u user.Info, req *http.Request) []authorizer.Attributes {
 	return f.attributesFunc(u, req)
 }
 func (f *fakeAuth) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
@@ -322,21 +323,21 @@ type serverTestFramework struct {
 	testHTTPServer  *httptest.Server
 }
 
-func newServerTest() *serverTestFramework {
-	return newServerTestWithDebug(true, nil)
+func newServerTest(ctx context.Context) *serverTestFramework {
+	return newServerTestWithDebug(ctx, true, nil)
 }
 
-func newServerTestWithDebug(enableDebugging bool, streamingServer streaming.Server) *serverTestFramework {
+func newServerTestWithDebug(ctx context.Context, enableDebugging bool, streamingServer streaming.Server) *serverTestFramework {
 	kubeCfg := &kubeletconfiginternal.KubeletConfiguration{
 		EnableDebuggingHandlers: enableDebugging,
 		EnableSystemLogHandler:  enableDebugging,
 		EnableProfilingHandler:  enableDebugging,
 		EnableDebugFlagsHandler: enableDebugging,
 	}
-	return newServerTestWithDebuggingHandlers(kubeCfg, streamingServer)
+	return newServerTestWithDebuggingHandlers(ctx, kubeCfg, streamingServer)
 }
 
-func newServerTestWithDebuggingHandlers(kubeCfg *kubeletconfiginternal.KubeletConfiguration, streamingServer streaming.Server) *serverTestFramework {
+func newServerTestWithDebuggingHandlers(ctx context.Context, kubeCfg *kubeletconfiginternal.KubeletConfiguration, streamingServer streaming.Server) *serverTestFramework {
 
 	fw := &serverTestFramework{}
 	fw.fakeKubelet = &fakeKubelet{
@@ -364,8 +365,9 @@ func newServerTestWithDebuggingHandlers(kubeCfg *kubeletconfiginternal.KubeletCo
 		},
 	}
 	server := NewServer(
+		ctx,
 		fw.fakeKubelet,
-		stats.NewResourceAnalyzer(fw.fakeKubelet, time.Minute, &record.FakeRecorder{}),
+		stats.NewResourceAnalyzer(ctx, fw.fakeKubelet, time.Minute, &record.FakeRecorder{}),
 		[]healthz.HealthChecker{},
 		flagz.NamedFlagSetsReader{},
 		fw.fakeAuth,
@@ -385,7 +387,8 @@ func getPodName(name, namespace string) string {
 }
 
 func TestServeLogs(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	content := string(`<pre><a href="kubelet.log">kubelet.log</a><a href="google.log">google.log</a></pre>`)
@@ -414,7 +417,8 @@ func TestServeLogs(t *testing.T) {
 }
 
 func TestServeRunInContainer(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 	output := "foo bar"
 	podNamespace := "other"
@@ -455,7 +459,8 @@ func TestServeRunInContainer(t *testing.T) {
 }
 
 func TestServeRunInContainerWithUID(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 	output := "foo bar"
 	podNamespace := "other"
@@ -498,7 +503,8 @@ func TestServeRunInContainerWithUID(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	assertHealthIsOk(t, fw.testHTTPServer.URL+"/healthz")
@@ -516,9 +522,10 @@ func assertHealthFails(t *testing.T, httpURL string, expectedErrorCode int) {
 }
 
 func TestStatusz(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, zpagesfeatures.ComponentStatusz, true)
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	req, err := http.NewRequest(http.MethodGet, fw.testHTTPServer.URL+"/statusz", nil)
@@ -552,7 +559,8 @@ func TestStatusz(t *testing.T) {
 
 // Ensure all registered handlers & services have an associated testcase.
 func TestAuthzCoverage(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	for _, fineGrained := range []bool{false, true} {
@@ -597,7 +605,8 @@ func TestAuthzCoverage(t *testing.T) {
 }
 
 func TestInstallAuthNotRequiredHandlers(t *testing.T) {
-	fw := newServerTestWithDebug(false, nil)
+	tCtx := ktesting.Init(t)
+	fw := newServerTestWithDebug(tCtx, false, nil)
 	defer fw.testHTTPServer.Close()
 
 	// No new handlers should be added to this list.
@@ -663,12 +672,13 @@ func TestInstallAuthNotRequiredHandlers(t *testing.T) {
 }
 
 func TestAuthFilters(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// Enable features.ContainerCheckpoint during test
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ContainerCheckpoint, true)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, zpagesfeatures.ComponentStatusz, true)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, zpagesfeatures.ComponentFlagz, true)
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	attributesGetter := NewNodeAuthorizerAttributesGetter(authzTestNodeName)
@@ -692,7 +702,7 @@ func TestAuthFilters(t *testing.T) {
 				fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) []authorizer.Attributes {
 					calledAttributes = true
 					require.Equal(t, expectedUser, u)
-					attrs := attributesGetter.GetRequestAttributes(u, req)
+					attrs := attributesGetter.GetRequestAttributes(tCtx, u, req)
 					tc.AssertAttributes(t, attrs)
 					return attrs
 				}
@@ -718,6 +728,7 @@ func TestAuthFilters(t *testing.T) {
 }
 
 func TestAuthenticationError(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		expectedUser       = &user.DefaultInfo{Name: "test"}
 		expectedAttributes = []authorizer.Attributes{&authorizer.AttributesRecord{User: expectedUser}}
@@ -727,7 +738,7 @@ func TestAuthenticationError(t *testing.T) {
 		calledAttributes   = false
 	)
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 	fw.fakeAuth.authenticateFunc = func(req *http.Request) (*authenticator.Response, bool, error) {
 		calledAuthenticate = true
@@ -756,6 +767,7 @@ func TestAuthenticationError(t *testing.T) {
 }
 
 func TestAuthenticationFailure(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		expectedUser       = &user.DefaultInfo{Name: "test"}
 		expectedAttributes = []authorizer.Attributes{&authorizer.AttributesRecord{User: expectedUser}}
@@ -765,7 +777,7 @@ func TestAuthenticationFailure(t *testing.T) {
 		calledAttributes   = false
 	)
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 	fw.fakeAuth.authenticateFunc = func(req *http.Request) (*authenticator.Response, bool, error) {
 		calledAuthenticate = true
@@ -794,6 +806,7 @@ func TestAuthenticationFailure(t *testing.T) {
 }
 
 func TestAuthorizationSuccess(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	var (
 		expectedUser       = &user.DefaultInfo{Name: "test"}
 		expectedAttributes = []authorizer.Attributes{&authorizer.AttributesRecord{User: expectedUser}}
@@ -803,7 +816,7 @@ func TestAuthorizationSuccess(t *testing.T) {
 		calledAttributes   = false
 	)
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 	fw.fakeAuth.authenticateFunc = func(req *http.Request) (*authenticator.Response, bool, error) {
 		calledAuthenticate = true
@@ -832,7 +845,8 @@ func TestAuthorizationSuccess(t *testing.T) {
 }
 
 func TestSyncLoopCheck(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	fw.fakeKubelet.resyncInterval = time.Minute
@@ -902,7 +916,8 @@ func setGetContainerLogsFunc(fw *serverTestFramework, t *testing.T, expectedPodN
 }
 
 func TestContainerLogs(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	tests := map[string]struct {
@@ -956,7 +971,8 @@ func TestContainerLogs(t *testing.T) {
 }
 
 func TestContainerLogsWithInvalidTail(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 	output := "foo bar"
 	podNamespace := "other"
@@ -976,6 +992,7 @@ func TestContainerLogsWithInvalidTail(t *testing.T) {
 }
 
 func TestContainerLogsWithSeparateStream(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLogsQuerySplitStreams, true)
 
 	type logEntry struct {
@@ -983,7 +1000,7 @@ func TestContainerLogsWithSeparateStream(t *testing.T) {
 		msg    string
 	}
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	var (
@@ -1190,6 +1207,7 @@ func TestContainerLogsWithSeparateStream(t *testing.T) {
 }
 
 func TestCheckpointContainer(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	podNamespace := "other"
 	podName := "foo"
 	expectedContainerName := "baz"
@@ -1198,7 +1216,7 @@ func TestCheckpointContainer(t *testing.T) {
 		// Enable features.ContainerCheckpoint during test
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ContainerCheckpoint, featureGate)
 
-		fw := newServerTest()
+		fw := newServerTest(tCtx)
 		// GetPodByName() should always fail
 		fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
 			return nil, false
@@ -1291,10 +1309,11 @@ func makeReq(t *testing.T, method, url, clientProtocol string) *http.Request {
 }
 
 func TestServeExecInContainerIdleTimeout(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	ss, err := newTestStreamingServer(100 * time.Millisecond)
 	require.NoError(t, err)
 	defer ss.testHTTPServer.Close()
-	fw := newServerTestWithDebug(true, ss)
+	fw := newServerTestWithDebug(tCtx, true, ss)
 	defer fw.testHTTPServer.Close()
 
 	podNamespace := "other"
@@ -1331,6 +1350,7 @@ func TestServeExecInContainerIdleTimeout(t *testing.T) {
 }
 
 func testExecAttach(t *testing.T, verb string) {
+	tCtx := ktesting.Init(t)
 	tests := map[string]struct {
 		stdin              bool
 		stdout             bool
@@ -1354,7 +1374,7 @@ func testExecAttach(t *testing.T, verb string) {
 			ss, err := newTestStreamingServer(0)
 			require.NoError(t, err)
 			defer ss.testHTTPServer.Close()
-			fw := newServerTestWithDebug(true, ss)
+			fw := newServerTestWithDebug(tCtx, true, ss)
 			defer fw.testHTTPServer.Close()
 			fmt.Println(desc)
 
@@ -1550,10 +1570,11 @@ func TestServeAttachContainer(t *testing.T) {
 }
 
 func TestServePortForwardIdleTimeout(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	ss, err := newTestStreamingServer(100 * time.Millisecond)
 	require.NoError(t, err)
 	defer ss.testHTTPServer.Close()
-	fw := newServerTestWithDebug(true, ss)
+	fw := newServerTestWithDebug(tCtx, true, ss)
 	defer fw.testHTTPServer.Close()
 
 	podNamespace := "other"
@@ -1587,6 +1608,7 @@ func TestServePortForwardIdleTimeout(t *testing.T) {
 }
 
 func TestServePortForward(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tests := map[string]struct {
 		port          string
 		uid           bool
@@ -1615,7 +1637,7 @@ func TestServePortForward(t *testing.T) {
 			ss, err := newTestStreamingServer(0)
 			require.NoError(t, err)
 			defer ss.testHTTPServer.Close()
-			fw := newServerTestWithDebug(true, ss)
+			fw := newServerTestWithDebug(tCtx, true, ss)
 			defer fw.testHTTPServer.Close()
 
 			portForwardFuncDone := make(chan struct{})
@@ -1713,6 +1735,7 @@ func TestServePortForward(t *testing.T) {
 }
 
 func TestMetricBuckets(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, zpagesfeatures.ComponentStatusz, true)
 
 	tests := map[string]struct {
@@ -1752,7 +1775,7 @@ func TestMetricBuckets(t *testing.T) {
 		"invalid path starting with good": {url: "/healthzjunk", bucket: "other"},
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, zpagesfeatures.ComponentFlagz, true)
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	for _, test := range tests {
@@ -1763,6 +1786,7 @@ func TestMetricBuckets(t *testing.T) {
 }
 
 func TestMetricMethodBuckets(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tests := map[string]struct {
 		method string
 		bucket string
@@ -1772,7 +1796,7 @@ func TestMetricMethodBuckets(t *testing.T) {
 		"invalid method": {method: "WEIRD", bucket: "other"},
 	}
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	for _, test := range tests {
@@ -1783,6 +1807,7 @@ func TestMetricMethodBuckets(t *testing.T) {
 }
 
 func TestDebuggingDisabledHandlers(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// for backward compatibility even if enablesystemLogHandler or enableProfilingHandler is set but not
 	// enableDebuggingHandler then /logs, /pprof and /flags shouldn't be served.
 	kubeCfg := &kubeletconfiginternal.KubeletConfiguration{
@@ -1791,7 +1816,7 @@ func TestDebuggingDisabledHandlers(t *testing.T) {
 		EnableDebugFlagsHandler: true,
 		EnableProfilingHandler:  true,
 	}
-	fw := newServerTestWithDebuggingHandlers(kubeCfg, nil)
+	fw := newServerTestWithDebuggingHandlers(tCtx, kubeCfg, nil)
 	defer fw.testHTTPServer.Close()
 
 	paths := []string{
@@ -1806,10 +1831,11 @@ func TestDebuggingDisabledHandlers(t *testing.T) {
 }
 
 func TestDisablingLogAndProfilingHandler(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	kubeCfg := &kubeletconfiginternal.KubeletConfiguration{
 		EnableDebuggingHandlers: true,
 	}
-	fw := newServerTestWithDebuggingHandlers(kubeCfg, nil)
+	fw := newServerTestWithDebuggingHandlers(tCtx, kubeCfg, nil)
 	defer fw.testHTTPServer.Close()
 
 	// verify debug endpoints are disabled
@@ -1819,7 +1845,8 @@ func TestDisablingLogAndProfilingHandler(t *testing.T) {
 }
 
 func TestFailedParseParamsSummaryHandler(t *testing.T) {
-	fw := newServerTest()
+	tCtx := ktesting.Init(t)
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	resp, err := http.Post(fw.testHTTPServer.URL+"/stats/summary", "invalid/content/type", nil)
@@ -1869,10 +1896,11 @@ func TestTrimURLPath(t *testing.T) {
 }
 
 func TestFineGrainedAuthz(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// Enable features.ContainerCheckpoint during test
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletFineGrainedAuthz, true)
 
-	fw := newServerTest()
+	fw := newServerTest(tCtx)
 	defer fw.testHTTPServer.Close()
 
 	attributesGetter := NewNodeAuthorizerAttributesGetter(authzTestNodeName)
@@ -1944,7 +1972,7 @@ func TestFineGrainedAuthz(t *testing.T) {
 			}
 			fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) []authorizer.Attributes {
 				calledAttributes = true
-				attrs := attributesGetter.GetRequestAttributes(u, req)
+				attrs := attributesGetter.GetRequestAttributes(tCtx, u, req)
 				var gotSubresources []string
 				for _, attr := range attrs {
 					gotSubresources = append(gotSubresources, attr.GetSubresource())
@@ -1973,11 +2001,12 @@ func TestFineGrainedAuthz(t *testing.T) {
 }
 
 func TestNewServerRegistersMetricsSLIsEndpointTwice(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	host := &fakeKubelet{}
-	resourceAnalyzer := stats.NewResourceAnalyzer(nil, time.Minute, &record.FakeRecorder{})
+	resourceAnalyzer := stats.NewResourceAnalyzer(tCtx, nil, time.Minute, &record.FakeRecorder{})
 
-	server1 := NewServer(host, resourceAnalyzer, []healthz.HealthChecker{}, flagz.NamedFlagSetsReader{}, nil, nil)
-	server2 := NewServer(host, resourceAnalyzer, []healthz.HealthChecker{}, flagz.NamedFlagSetsReader{}, nil, nil)
+	server1 := NewServer(tCtx, host, resourceAnalyzer, []healthz.HealthChecker{}, flagz.NamedFlagSetsReader{}, nil, nil)
+	server2 := NewServer(tCtx, host, resourceAnalyzer, []healthz.HealthChecker{}, flagz.NamedFlagSetsReader{}, nil, nil)
 
 	// Check if both servers registered the /metrics/slis endpoint
 	assert.Contains(t, server1.restfulCont.RegisteredHandlePaths(), "/metrics/slis", "First server should register /metrics/slis")

--- a/pkg/kubelet/server/server_websocket_test.go
+++ b/pkg/kubelet/server/server_websocket_test.go
@@ -30,6 +30,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubelet/pkg/cri/streaming/portforward"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const (
@@ -38,6 +39,7 @@ const (
 )
 
 func TestServeWSPortForward(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	tests := map[string]struct {
 		port          string
 		uid           bool
@@ -66,7 +68,7 @@ func TestServeWSPortForward(t *testing.T) {
 			ss, err := newTestStreamingServer(0)
 			require.NoError(t, err)
 			defer ss.testHTTPServer.Close()
-			fw := newServerTestWithDebug(true, ss)
+			fw := newServerTestWithDebug(tCtx, true, ss)
 			defer fw.testHTTPServer.Close()
 
 			portForwardFuncDone := make(chan struct{})
@@ -150,6 +152,7 @@ func TestServeWSPortForward(t *testing.T) {
 }
 
 func TestServeWSMultiplePortForward(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	portsText := []string{"7000,8000", "9000"}
 	ports := []uint16{7000, 8000, 9000}
 	podNamespace := "other"
@@ -158,7 +161,7 @@ func TestServeWSMultiplePortForward(t *testing.T) {
 	ss, err := newTestStreamingServer(0)
 	require.NoError(t, err)
 	defer ss.testHTTPServer.Close()
-	fw := newServerTestWithDebug(true, ss)
+	fw := newServerTestWithDebug(tCtx, true, ss)
 	defer fw.testHTTPServer.Close()
 
 	portForwardWG := sync.WaitGroup{}

--- a/pkg/kubelet/server/stats/resource_analyzer.go
+++ b/pkg/kubelet/server/stats/resource_analyzer.go
@@ -17,13 +17,15 @@ limitations under the License.
 package stats
 
 import (
-	"k8s.io/client-go/tools/record"
+	"context"
 	"time"
+
+	"k8s.io/client-go/tools/record"
 )
 
 // ResourceAnalyzer provides statistics on node resource consumption
 type ResourceAnalyzer interface {
-	Start()
+	Start(context.Context)
 
 	fsResourceAnalyzerInterface
 	SummaryProvider
@@ -38,13 +40,13 @@ type resourceAnalyzer struct {
 var _ ResourceAnalyzer = &resourceAnalyzer{}
 
 // NewResourceAnalyzer returns a new ResourceAnalyzer
-func NewResourceAnalyzer(statsProvider Provider, calVolumeFrequency time.Duration, eventRecorder record.EventRecorder) ResourceAnalyzer {
+func NewResourceAnalyzer(ctx context.Context, statsProvider Provider, calVolumeFrequency time.Duration, eventRecorder record.EventRecorder) ResourceAnalyzer {
 	fsAnalyzer := newFsResourceAnalyzer(statsProvider, calVolumeFrequency, eventRecorder)
-	summaryProvider := NewSummaryProvider(statsProvider)
+	summaryProvider := NewSummaryProvider(ctx, statsProvider)
 	return &resourceAnalyzer{fsAnalyzer, summaryProvider}
 }
 
 // Start starts background functions necessary for the ResourceAnalyzer to function
-func (ra *resourceAnalyzer) Start() {
-	ra.fsResourceAnalyzer.Start()
+func (ra *resourceAnalyzer) Start(ctx context.Context) {
+	ra.fsResourceAnalyzer.Start(ctx)
 }

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -53,12 +53,13 @@ var _ SummaryProvider = &summaryProviderImpl{}
 
 // NewSummaryProvider returns a SummaryProvider using the stats provided by the
 // specified statsProvider.
-func NewSummaryProvider(statsProvider Provider) SummaryProvider {
+func NewSummaryProvider(ctx context.Context, statsProvider Provider) SummaryProvider {
+	logger := klog.FromContext(ctx)
 	kubeletCreationTime := metav1.Now()
 	bootTime, err := util.GetBootTime()
 	if err != nil {
 		// bootTime will be zero if we encounter an error getting the boot time.
-		klog.InfoS("Error getting system boot time. Node metrics will have an incorrect start time", "err", err)
+		logger.Info("Error getting system boot time. Node metrics will have an incorrect start time", "err", err)
 	}
 
 	return &summaryProviderImpl{
@@ -113,7 +114,7 @@ func (sp *summaryProviderImpl) Get(ctx context.Context, updateStats bool) (*stat
 		Fs:               rootFsStats,
 		Runtime:          &statsapi.RuntimeStats{ContainerFs: containerFsStats, ImageFs: imageFsStats},
 		Rlimit:           rlimit,
-		SystemContainers: sp.GetSystemContainersStats(nodeConfig, podStats, updateStats),
+		SystemContainers: sp.GetSystemContainersStats(ctx, nodeConfig, podStats, updateStats),
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
 		nodeStats.IO = rootStats.IO
@@ -149,7 +150,7 @@ func (sp *summaryProviderImpl) GetCPUAndMemoryStats(ctx context.Context) (*stats
 		Memory:           rootStats.Memory,
 		Swap:             rootStats.Swap,
 		StartTime:        rootStats.StartTime,
-		SystemContainers: sp.GetSystemContainersCPUAndMemoryStats(nodeConfig, podStats, false),
+		SystemContainers: sp.GetSystemContainersCPUAndMemoryStats(ctx, nodeConfig, podStats, false),
 	}
 	summary := statsapi.Summary{
 		Node: nodeStats,

--- a/pkg/kubelet/server/stats/summary_sys_containers.go
+++ b/pkg/kubelet/server/stats/summary_sys_containers.go
@@ -20,6 +20,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"errors"
 
 	"k8s.io/klog/v2"
@@ -30,7 +31,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 )
 
-func (sp *summaryProviderImpl) GetSystemContainersStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+func (sp *summaryProviderImpl) GetSystemContainersStats(ctx context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+	logger := klog.FromContext(ctx)
 	systemContainers := map[string]struct {
 		name             string
 		forceStatsUpdate bool
@@ -48,7 +50,7 @@ func (sp *summaryProviderImpl) GetSystemContainersStats(nodeConfig cm.NodeConfig
 		}
 		s, _, err := sp.provider.GetCgroupStats(cont.name, cont.forceStatsUpdate)
 		if err != nil {
-			klog.ErrorS(err, "Failed to get system container stats", "containerName", cont.name)
+			logger.Error(err, "Failed to get system container stats", "containerName", cont.name)
 			continue
 		}
 		// System containers don't have a filesystem associated with them.
@@ -65,7 +67,8 @@ func (sp *summaryProviderImpl) GetSystemContainersStats(nodeConfig cm.NodeConfig
 	return stats
 }
 
-func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(ctx context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+	logger := klog.FromContext(ctx)
 	systemContainers := map[string]struct {
 		name             string
 		forceStatsUpdate bool
@@ -84,9 +87,9 @@ func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(nodeConfig c
 		s, err := sp.provider.GetCgroupCPUAndMemoryStats(cont.name, cont.forceStatsUpdate)
 		if err != nil {
 			if errors.Is(err, cadvisormemory.ErrDataNotFound) {
-				klog.V(4).InfoS("cgroup stats not found in memory cache", "containerName", cont.name)
+				logger.V(4).Info("cgroup stats not found in memory cache", "containerName", cont.name)
 			} else {
-				klog.ErrorS(err, "Failed to get system container stats", "containerName", cont.name)
+				logger.Error(err, "Failed to get system container stats", "containerName", cont.name)
 			}
 			continue
 		}

--- a/pkg/kubelet/server/stats/summary_sys_containers_windows.go
+++ b/pkg/kubelet/server/stats/summary_sys_containers_windows.go
@@ -20,6 +20,7 @@ limitations under the License.
 package stats
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,13 +30,13 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/winstats"
 )
 
-func (sp *summaryProviderImpl) GetSystemContainersStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+func (sp *summaryProviderImpl) GetSystemContainersStats(_ context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
 	stats = append(stats, sp.getSystemPodsCPUAndMemoryStats(nodeConfig, podStats, updateStats))
 	stats = append(stats, sp.getSystemWindowsGlobalmemoryStats())
 	return stats
 }
 
-func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(_ context.Context, nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
 	stats = append(stats, sp.getSystemPodsCPUAndMemoryStats(nodeConfig, podStats, updateStats))
 	stats = append(stats, sp.getSystemWindowsGlobalmemoryStats())
 	return stats

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -288,7 +288,7 @@ func TestSummaryProviderGetCPUAndMemoryStats(t *testing.T) {
 	mockStatsProvider.EXPECT().GetCgroupCPUAndMemoryStats("/kubelet", false).Return(cgroupStatsMap["/kubelet"].cs, nil)
 	mockStatsProvider.EXPECT().GetCgroupCPUAndMemoryStats("/kubepods", false).Return(cgroupStatsMap["/pods"].cs, nil)
 
-	provider := NewSummaryProvider(mockStatsProvider)
+	provider := NewSummaryProvider(ctx, mockStatsProvider)
 	summary, err := provider.GetCPUAndMemoryStats(ctx)
 	assert.NoError(err)
 

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	statstest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const (
@@ -104,6 +105,7 @@ var (
 )
 
 func TestPVCRef(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	// Setup mock stats provider
 	mockStats := statstest.NewMockProvider(t)
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}, vol3: &fakeVolume{}}
@@ -118,7 +120,7 @@ func TestPVCRef(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats()
+	statsCalculator.calcAndStoreStats(logger)
 	vs, _ := statsCalculator.GetLatest()
 
 	assert.Len(t, append(vs.EphemeralVolumes, vs.PersistentVolumes...), 4)
@@ -161,6 +163,7 @@ func TestPVCRef(t *testing.T) {
 }
 
 func TestNormalVolumeEvent(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	mockStats := statstest.NewMockProvider(t)
 
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}}
@@ -175,7 +178,7 @@ func TestNormalVolumeEvent(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats()
+	statsCalculator.calcAndStoreStats(logger)
 
 	event, err := WatchEvent(eventStore)
 	assert.Error(t, err)
@@ -183,6 +186,7 @@ func TestNormalVolumeEvent(t *testing.T) {
 }
 
 func TestAbnormalVolumeEvent(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIVolumeHealth, true)
 
 	// Setup mock stats provider
@@ -203,7 +207,7 @@ func TestAbnormalVolumeEvent(t *testing.T) {
 		volumeCondition.Abnormal = true
 	}
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats()
+	statsCalculator.calcAndStoreStats(logger)
 
 	event, err := WatchEvent(eventStore)
 	assert.NoError(t, err)

--- a/pkg/kubelet/stats/provider_test.go
+++ b/pkg/kubelet/stats/provider_test.go
@@ -617,7 +617,7 @@ type fakeResourceAnalyzer struct {
 	podVolumeStats serverstats.PodVolumeStats
 }
 
-func (o *fakeResourceAnalyzer) Start()                                               {}
+func (o *fakeResourceAnalyzer) Start(context.Context)                                {}
 func (o *fakeResourceAnalyzer) Get(context.Context, bool) (*statsapi.Summary, error) { return nil, nil }
 func (o *fakeResourceAnalyzer) GetCPUAndMemoryStats(context.Context) (*statsapi.Summary, error) {
 	return nil, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrate pkg/kubelet/server to contextual logging.
This is a continuation of https://github.com/kubernetes/kubernetes/pull/130367

#### Which issue(s) this PR is related to:

Ref: https://github.com/kubernetes/kubernetes/issues/130069

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/cc @SergeyKanzhelev @dims