### PR TITLE
DRA: scheduler_perf integration testing

### DIFF
--- a/test/integration/scheduler_perf/dra/consumablecapacity/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/consumablecapacity/performance-config.yaml
@@ -17,13 +17,13 @@
 # Combining `performance` and `short` selects suitable workloads for a local
 # before/after comparisons with benchstat.
 
-# SteadyStateClusterResourceClaimTemplateConsumableCapacity is a variant of
+# ConsumableCapacity is a variant of
 # SchedulingWithResourceClaimTemplate. It creates a single ResourceSlice that have two devices, 
 # one preallocate device slice and one basic device. Both allows multiple allocations and contain consumable capacity.
 # And, it creates a resource claim template with two requests.
 # Each requests half of this capacity for two count.
 # The first request checks distinctAttribute which the other checks matchAttribute.
-- name: SteadyStateClusterResourceClaimTemplateConsumableCapacity
+- name: ConsumableCapacity
   featureGates:
     DynamicResourceAllocation: true
     DRAConsumableCapacity: true
@@ -48,7 +48,7 @@
   - opcode: createPods
     namespace: test
     countParam: $measurePods
-    steadyState: true
+    steadyStateParam: $steadyState
     durationParam: $duration
     podTemplatePath: ../templates/pod-with-claim-template.yaml
     collectMetrics: true
@@ -60,7 +60,8 @@
       nodesWithoutDRA: 1
       resourceSlices: 1
       measurePods: 1
-      duration: 2s
+      steadyState: false
+      duration: 0s # unused
       maxClaimsPerNode: 2
   - name: fast_with_DRAPartitionableDevices
     featureGates:
@@ -72,7 +73,8 @@
       nodesWithoutDRA: 1
       resourceSlices: 1
       measurePods: 1
-      duration: 2s
+      steadyState: false
+      duration: 0s # unused
       maxClaimsPerNode: 2
   - name: 2000pods_100nodes
     params:
@@ -80,5 +82,6 @@
       nodesWithoutDRA: 0
       resourceSlices: 2000
       measurePods: 2000
+      steadyState: true
       duration: 10s
       maxClaimsPerNode: 20

--- a/test/integration/scheduler_perf/dra/devicetaints/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/devicetaints/performance-config.yaml
@@ -17,9 +17,9 @@
 # Combining `performance` and `short` selects suitable workloads for a local
 # before/after comparisons with benchstat.
 
-# SchedulingWithResourceClaimTemplateToleration is a variant of SchedulingWithResourceClaimTemplate
+# DeviceTaintToleration is a variant of SchedulingWithResourceClaimTemplate
 # with a claim template that tolerates the taint defined in a DeviceTaintRule.
-- name: SchedulingWithResourceClaimTemplateToleration
+- name: DeviceTaintToleration
   featureGates:
     DynamicResourceAllocation: true
     DRADeviceTaints: true

--- a/test/integration/scheduler_perf/dra/extendedresource/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/extendedresource/performance-config.yaml
@@ -17,8 +17,8 @@
 # Combining `performance` and `short` selects suitable workloads for a local
 # before/after comparisons with benchstat.
 
-# SchedulingWithExtendedResource uses pods with extended resources requests.
-- name: SchedulingWithExtendedResource
+# ExtendedResource uses pods with extended resources requests.
+- name: ExtendedResource
   featureGates:
     DynamicResourceAllocation: true
     DRAExtendedResource: true

--- a/test/integration/scheduler_perf/dra/partitionabledevices/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/partitionabledevices/performance-config.yaml
@@ -17,11 +17,11 @@
 # Combining `performance` and `short` selects suitable workloads for a local
 # before/after comparisons with benchstat.
 
-# SchedulingWithResourceClaimTemplatePartitionable is a variant of SchedulingWithResourceClaimTemplate.
+# Partitionable is a variant of SchedulingWithResourceClaimTemplate.
 # It creates ResourceSlices with partitionable devices and uses a claim template referenced
 # by the test pods. It includes allocated claims that consumes counters and it sets up the devices
 # such that the allocator will have to backtrack once in order to find a working solution.
-- name: SteadyStateClusterResourceClaimTemplatePartitionable
+- name: Partitionable
   featureGates:
     DynamicResourceAllocation: true
     DRAPartitionableDevices: true
@@ -48,7 +48,7 @@
   - opcode: createPods
     namespace: test
     countParam: $measurePods
-    steadyState: true
+    steadyStateParam: $steadyState
     durationParam: $duration
     podTemplatePath: ../templates/pod-with-claim-template.yaml
     collectMetrics: true
@@ -65,7 +65,8 @@
       resourceSlices: 10
       initClaims: 10
       measurePods: 10
-      duration: 2s
+      steadyState: false
+      duration: 0s # unused
   - name: fast_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
@@ -78,7 +79,8 @@
       resourceSlices: 10
       initClaims: 10
       measurePods: 10
-      duration: 2s
+      steadyState: false
+      duration: 0s # unused
   - name: 2000pods_100nodes
     params:
       nodesWithDRA: 100
@@ -86,13 +88,14 @@
       resourceSlices: 2000
       initClaims: 2000
       measurePods: 2000
+      steadyState: true
       duration: 10s
 
-# SchedulingWithResourceClaimTemplatePartitionableBacktracking is a variant of
+# PartitionableBacktracking is a variant of
 # SchedulingWithResourceClaimTemplate. It creates a single ResourceSlice and a
 # ResourceClaim that forces the allocator to backtrack multiple times in order
 # to find a solution.
-- name: SteadyStateClusterResourceClaimTemplatePartitionableBacktracking
+- name: PartitionableBacktracking
   featureGates:
     DynamicResourceAllocation: true
     DRAPartitionableDevices: true
@@ -113,8 +116,6 @@
   - opcode: createPods
     namespace: test
     countParam: $measurePods
-    steadyState: true
-    durationParam: $duration
     podTemplatePath: ../templates/pod-with-claim-template.yaml
     collectMetrics: true
   workloads:
@@ -129,7 +130,6 @@
       nodesWithoutDRA: 1
       resourceSlices: 1
       measurePods: 1
-      duration: 2s
   - name: fast_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
@@ -141,4 +141,3 @@
       nodesWithoutDRA: 1
       resourceSlices: 1
       measurePods: 1
-      duration: 2s

--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -192,30 +192,6 @@
     podTemplatePath: templates/pod-with-claim-template.yaml
     collectMetrics: true
   workloads:
-  - name: fast
-    featureGates:
-      SchedulerQueueingHints: false
-    labels: [integration-test, short]
-    params:
-      # This testcase runs through all code paths without
-      # taking too long overall.
-      nodesWithDRA: 1
-      nodesWithoutDRA: 1
-      initClaims: 0
-      maxClaimsPerNode: 10
-      duration: 2s
-  - name: fast_QueueingHintsEnabled
-    featureGates:
-      SchedulerQueueingHints: true
-    labels: [integration-test, short]
-    params:
-      # This testcase runs through all code paths without
-      # taking too long overall.
-      nodesWithDRA: 1
-      nodesWithoutDRA: 1
-      initClaims: 0
-      maxClaimsPerNode: 10
-      duration: 2s
   - name: empty_100nodes
     params:
       nodesWithDRA: 100

--- a/test/integration/scheduler_perf/dra/prioritizedlist/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/prioritizedlist/performance-config.yaml
@@ -17,9 +17,9 @@
 # Combining `performance` and `short` selects suitable workloads for a local
 # before/after comparisons with benchstat.
 
-# SteadyStateResourceClaimTemplateFirstAvailable is a variant of SteadyStateResourceClaimTemplate
+# FirstAvailable is a variant of SchedulingWithResourceClaimTemplate
 # with a claim template that uses the "firstAvailable" subrequests, aka DRAPrioritizedList.
-- name: SteadyStateClusterResourceClaimTemplateFirstAvailable
+- name: FirstAvailable
   featureGates:
     DynamicResourceAllocation: true
     DRAPrioritizedList: true
@@ -49,8 +49,6 @@
   - opcode: createPods
     namespace: test
     count: 10
-    steadyState: true
-    durationParam: $duration
     podTemplatePath: ../templates/pod-with-claim-template.yaml
     collectMetrics: true
   workloads:
@@ -65,7 +63,6 @@
       nodesWithoutDRA: 1
       initClaims: 0
       maxClaimsPerNode: 10
-      duration: 2s
   - name: fast_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
@@ -77,4 +74,3 @@
       nodesWithoutDRA: 1
       initClaims: 0
       maxClaimsPerNode: 10
-      duration: 2s

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -672,6 +672,8 @@ type createPodsOp struct {
 	// the namespace, so use different namespaces for pods that
 	// are supposed to be kept running.
 	SteadyState bool
+	// Template parameter for SteadyState.
+	SteadyStateParam string
 	// How long to keep the cluster in a steady state.
 	Duration metav1.Duration
 	// Template parameter for Duration.
@@ -711,6 +713,9 @@ func (cpo *createPodsOp) isValid(allowParameterization bool) error {
 	if cpo.SkipWaitToCompletion && cpo.SteadyState {
 		return errors.New("skipWaitToCompletion and steadyState cannot be true at the same time")
 	}
+	if cpo.SteadyState && !allowParameterization && cpo.Duration.Duration <= 0 {
+		return errors.New("when creating pods in a steady state, the test duration must be > 0")
+	}
 	return nil
 }
 
@@ -733,6 +738,13 @@ func (cpo createPodsOp) patchParams(w *workload) (realOp, error) {
 		}
 		if cpo.Duration.Duration, err = time.ParseDuration(durationStr); err != nil {
 			return nil, fmt.Errorf("parsing duration parameter %s: %w", cpo.DurationParam, err)
+		}
+	}
+	if cpo.SteadyStateParam != "" {
+		var err error
+		cpo.SteadyState, err = getParam[bool](w.Params, cpo.SteadyStateParam[1:])
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &cpo, (&cpo).isValid(false)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The steady-state pod scheduling is less suitable for integration tests because the duration is either short (making the test potentially flaky if nothing gets scheduled yet due to the time constraint) or long (making the test run too long). It is more useful for benchmark testcase because of the bounded runtime.

This PR
- adds a sanity check which fails a test if no pod got scheduled (first commit)
- cleans up workload definitions to avoid steady-state where it makes no sense (second commit)

S single workload definition can now be used in both modes: when the duration is zero, pod scheduling falls back to scheduling all pods (i.e. the non-steady-state approach).
    
Workload definitions get updated accordingly. While at it, their names get simplified and some (in the case of the main DRA config) redundant testcases get removed.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

test/integration/scheduler_perf/dra/consumablecapacity is known to not pass because pod scheduling fails. This needs to be fixed before this PR can be merge.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @sunya-ch  @macsko 