### PR TITLE
DRA: allocator selection

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -164,23 +164,13 @@ type nodeAllocation struct {
 
 // DynamicResources is a plugin that ensures that ResourceClaims are allocated.
 type DynamicResources struct {
-	enabled                       bool
-	enableAdminAccess             bool
-	enablePrioritizedList         bool
-	enableSchedulingQueueHint     bool
-	enablePartitionableDevices    bool
-	enableDeviceTaints            bool
-	enableDeviceBindingConditions bool
-	enableDeviceStatus            bool
-	enableExtendedResource        bool
-	enableFilterTimeout           bool
-	filterTimeout                 time.Duration
-	enableConsumableCapacity      bool
-
-	fh         fwk.Handle
-	clientset  kubernetes.Interface
-	celCache   *cel.Cache
-	draManager fwk.SharedDRAManager
+	enabled       bool
+	fts           feature.Features
+	filterTimeout time.Duration
+	fh            fwk.Handle
+	clientset     kubernetes.Interface
+	celCache      *cel.Cache
+	draManager    fwk.SharedDRAManager
 }
 
 // New initializes a new plugin and returns it.
@@ -199,25 +189,16 @@ func New(ctx context.Context, plArgs runtime.Object, fh fwk.Handle, fts feature.
 	}
 
 	pl := &DynamicResources{
-		enabled:                       true,
-		enableAdminAccess:             fts.EnableDRAAdminAccess,
-		enableDeviceTaints:            fts.EnableDRADeviceTaints,
-		enablePrioritizedList:         fts.EnableDRAPrioritizedList,
-		enableFilterTimeout:           fts.EnableDRASchedulerFilterTimeout,
-		enableSchedulingQueueHint:     fts.EnableSchedulingQueueHint,
-		enablePartitionableDevices:    fts.EnablePartitionableDevices,
-		enableExtendedResource:        fts.EnableDRAExtendedResource,
-		enableConsumableCapacity:      fts.EnableConsumableCapacity,
-		filterTimeout:                 ptr.Deref(args.FilterTimeout, metav1.Duration{}).Duration,
-		enableDeviceBindingConditions: fts.EnableDRADeviceBindingConditions,
-		enableDeviceStatus:            fts.EnableDRAResourceClaimDeviceStatus,
+		enabled:       true,
+		fts:           fts,
+		filterTimeout: ptr.Deref(args.FilterTimeout, metav1.Duration{}).Duration,
 
 		fh:        fh,
 		clientset: fh.ClientSet(),
 		// This is a LRU cache for compiled CEL expressions. The most
 		// recent 10 of them get reused across different scheduling
 		// cycles.
-		celCache:   cel.NewCache(10, cel.Features{EnableConsumableCapacity: fts.EnableConsumableCapacity}),
+		celCache:   cel.NewCache(10, cel.Features{EnableConsumableCapacity: fts.EnableDRAConsumableCapacity}),
 		draManager: fh.SharedDRAManager(),
 	}
 
@@ -251,7 +232,7 @@ func (pl *DynamicResources) EventsToRegister(_ context.Context) ([]fwk.ClusterEv
 	// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
 	// See: https://github.com/kubernetes/kubernetes/issues/109437
 	nodeActionType := fwk.Add | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeAllocatable
-	if pl.enableSchedulingQueueHint {
+	if pl.fts.EnableSchedulingQueueHint {
 		// When QHint is enabled, the problematic preCheck is already removed, and we can remove UpdateNodeTaint.
 		nodeActionType = fwk.Add | fwk.UpdateNodeLabel | fwk.UpdateNodeAllocatable
 	}
@@ -476,7 +457,7 @@ func findExtendedResourceClaim(pod *v1.Pod, resourceClaims []*resourceapi.Resour
 // It returns the special ResourceClaim and an error status. It returns nil for both
 // if the feature is disabled or not required for the Pod.
 func (pl *DynamicResources) preFilterExtendedResources(pod *v1.Pod, logger klog.Logger, s *stateData) (*resourceapi.ResourceClaim, *fwk.Status) {
-	if !pl.enableExtendedResource {
+	if !pl.fts.EnableDRAExtendedResource {
 		return nil, nil
 	}
 
@@ -628,7 +609,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 						return nil, status
 					}
 				case len(request.FirstAvailable) > 0:
-					if !pl.enablePrioritizedList {
+					if !pl.fts.EnableDRAPrioritizedList {
 						return nil, statusUnschedulable(logger, fmt.Sprintf("resource claim %s, request %s: has subrequests, but the DRAPrioritizedList feature is disabled", klog.KObj(claim), request.Name))
 					}
 					for _, subRequest := range request.FirstAvailable {
@@ -666,7 +647,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 		// or currently their allocation is in-flight. This does not change
 		// during filtering, so we can determine that once.
 		var allocatedState *structured.AllocatedState
-		if pl.enableConsumableCapacity {
+		if pl.fts.EnableDRAConsumableCapacity {
 			allocatedState, err = pl.draManager.ResourceClaims().GatherAllocatedState()
 			if err != nil {
 				return nil, statusError(logger, err)
@@ -689,15 +670,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 		if err != nil {
 			return nil, statusError(logger, err)
 		}
-		features := structured.Features{
-			AdminAccess:          pl.enableAdminAccess,
-			PrioritizedList:      pl.enablePrioritizedList,
-			PartitionableDevices: pl.enablePartitionableDevices,
-			DeviceTaints:         pl.enableDeviceTaints,
-			DeviceBinding:        pl.enableDeviceBindingConditions,
-			DeviceStatus:         pl.enableDeviceStatus,
-			ConsumableCapacity:   pl.enableConsumableCapacity,
-		}
+		features := allocatorFeatures(pl.fts)
 		allocator, err := structured.NewAllocator(ctx, features, *allocatedState, pl.draManager.DeviceClasses(), slices, pl.celCache)
 		if err != nil {
 			return nil, statusError(logger, err)
@@ -707,6 +680,18 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 	}
 	s.claims = claims
 	return nil, nil
+}
+
+func allocatorFeatures(fts feature.Features) structured.Features {
+	return structured.Features{
+		AdminAccess:          fts.EnableDRAAdminAccess,
+		PrioritizedList:      fts.EnableDRAPrioritizedList,
+		PartitionableDevices: fts.EnableDRAPartitionableDevices,
+		DeviceTaints:         fts.EnableDRADeviceTaints,
+		DeviceBinding:        fts.EnableDRADeviceBindingConditions,
+		DeviceStatus:         fts.EnableDRAResourceClaimDeviceStatus,
+		ConsumableCapacity:   fts.EnableDRAConsumableCapacity,
+	}
 }
 
 func (pl *DynamicResources) validateDeviceClass(logger klog.Logger, deviceClassName, requestName string) *fwk.Status {
@@ -937,7 +922,7 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 		}
 
 		// The claim is allocated, check whether it is ready for binding.
-		if pl.enableDeviceBindingConditions && pl.enableDeviceStatus {
+		if pl.fts.EnableDRADeviceBindingConditions && pl.fts.EnableDRAResourceClaimDeviceStatus {
 			ready, err := pl.isClaimReadyForBinding(claim)
 			// If the claim is not ready yet (ready false, no error) and binding has timed out
 			// or binding has failed (err non-nil), then the scheduler should consider deallocating this
@@ -957,7 +942,7 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 		}
 
 		// Apply timeout to the operation?
-		if pl.enableFilterTimeout && pl.filterTimeout > 0 {
+		if pl.fts.EnableDRASchedulerFilterTimeout && pl.filterTimeout > 0 {
 			c, cancel := context.WithTimeout(allocCtx, pl.filterTimeout)
 			defer cancel()
 			allocCtx = c
@@ -1326,7 +1311,7 @@ func (pl *DynamicResources) PreBind(ctx context.Context, cs fwk.CycleState, pod 
 		}
 	}
 
-	if !pl.enableDeviceBindingConditions || !pl.enableDeviceStatus {
+	if !pl.fts.EnableDRADeviceBindingConditions || !pl.fts.EnableDRAResourceClaimDeviceStatus {
 		// If we don't have binding conditions, we can return early.
 		// The claim is now reserved for the pod and the scheduler can proceed with binding.
 		return nil
@@ -1558,7 +1543,7 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, ind
 		// preconditions. The apiserver will tell us with a
 		// non-conflict error if this isn't possible.
 		claim.Status.ReservedFor = append(claim.Status.ReservedFor, resourceapi.ResourceClaimConsumerReference{Resource: "pods", Name: pod.Name, UID: pod.UID})
-		if pl.enableDeviceBindingConditions && pl.enableDeviceStatus && claim.Status.Allocation.AllocationTimestamp == nil {
+		if pl.fts.EnableDRADeviceBindingConditions && pl.fts.EnableDRAResourceClaimDeviceStatus && claim.Status.Allocation.AllocationTimestamp == nil {
 			claim.Status.Allocation.AllocationTimestamp = &metav1.Time{Time: time.Now()}
 		}
 		updatedClaim, err := pl.clientset.ResourceV1().ResourceClaims(claim.Namespace).UpdateStatus(ctx, claim, metav1.UpdateOptions{})
@@ -1638,7 +1623,7 @@ func (pl *DynamicResources) isClaimReadyForBinding(claim *resourceapi.ResourceCl
 // It returns true if the binding timeout is reached.
 // It returns false if the binding timeout is not reached.
 func (pl *DynamicResources) isClaimTimeout(claim *resourceapi.ResourceClaim) bool {
-	if !pl.enableDeviceBindingConditions || !pl.enableDeviceStatus {
+	if !pl.fts.EnableDRADeviceBindingConditions || !pl.fts.EnableDRAResourceClaimDeviceStatus {
 		return false
 	}
 	if claim.Status.Allocation == nil || claim.Status.Allocation.AllocationTimestamp == nil {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -684,13 +684,12 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 
 func allocatorFeatures(fts feature.Features) structured.Features {
 	return structured.Features{
-		AdminAccess:          fts.EnableDRAAdminAccess,
-		PrioritizedList:      fts.EnableDRAPrioritizedList,
-		PartitionableDevices: fts.EnableDRAPartitionableDevices,
-		DeviceTaints:         fts.EnableDRADeviceTaints,
-		DeviceBinding:        fts.EnableDRADeviceBindingConditions,
-		DeviceStatus:         fts.EnableDRAResourceClaimDeviceStatus,
-		ConsumableCapacity:   fts.EnableDRAConsumableCapacity,
+		AdminAccess:            fts.EnableDRAAdminAccess,
+		PrioritizedList:        fts.EnableDRAPrioritizedList,
+		PartitionableDevices:   fts.EnableDRAPartitionableDevices,
+		DeviceTaints:           fts.EnableDRADeviceTaints,
+		DeviceBindingAndStatus: fts.EnableDRADeviceBindingConditions && fts.EnableDRAResourceClaimDeviceStatus,
+		ConsumableCapacity:     fts.EnableDRAConsumableCapacity,
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -38,12 +39,14 @@ import (
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	cgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
+	"k8s.io/dynamic-resource-allocation/structured"
 	kubeschedulerconfigv1 "k8s.io/kube-scheduler/config/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -2754,6 +2757,54 @@ func Test_createRequestMappings(t *testing.T) {
 				if r.ResourceName != gotReqMappings[i].ResourceName {
 					t.Fatalf("different resource name, want %#v, got %#v", r, gotReqMappings[i])
 				}
+			}
+		})
+	}
+}
+
+// TestAllocatorSelection covers the selection of a structured allocation implementation
+// based on actual Kubernetes feature gates. This test lives here instead of
+// k8s.io/dynamic-resource-allocation/structured because that code has no access
+// to feature gate definitions.
+func TestAllocatorSelection(t *testing.T) {
+	for name, tc := range map[string]struct {
+		features             string
+		expectImplementation string
+	}{
+		// The most conservative implementation: only used when explicitly asking
+		// for the most stable Kubernetes (no alpha or beta features).
+		"only-GA": {
+			features:             "AllAlpha=false,AllBeta=false",
+			expectImplementation: "stable",
+		},
+
+		// By default, some beta features are on and the incubating implementation
+		// is used.
+		"default": {
+			features:             "",
+			expectImplementation: "incubating",
+		},
+
+		// Alpha features need the experimental implementation.
+		"alpha": {
+			features:             "AllAlpha=true,AllBeta=true",
+			expectImplementation: "experimental",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			featureGate := utilfeature.DefaultFeatureGate.DeepCopy()
+			tCtx.ExpectNoError(featureGate.Set(tc.features), "set features")
+			fts := feature.NewSchedulerFeaturesFromGates(featureGate)
+			features := allocatorFeatures(fts)
+
+			// Slightly hacky: most arguments are not valid and the constructor
+			// is expected to not use them yet.
+			allocator, err := structured.NewAllocator(tCtx, features, structured.AllocatedState{}, nil, nil, nil)
+			tCtx.ExpectNoError(err, "create allocator")
+			allocatorType := fmt.Sprintf("%T", allocator)
+			if !strings.Contains(allocatorType, tc.expectImplementation) {
+				tCtx.Fatalf("Expected allocator implementation %q, got %s", tc.expectImplementation, allocatorType)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -28,8 +28,10 @@ type Features struct {
 	EnableDRAExtendedResource                    bool
 	EnableDRAPrioritizedList                     bool
 	EnableDRAAdminAccess                         bool
+	EnableDRAConsumableCapacity                  bool
 	EnableDRADeviceTaints                        bool
 	EnableDRADeviceBindingConditions             bool
+	EnableDRAPartitionableDevices                bool
 	EnableDRAResourceClaimDeviceStatus           bool
 	EnableDRASchedulerFilterTimeout              bool
 	EnableDynamicResourceAllocation              bool
@@ -42,9 +44,7 @@ type Features struct {
 	EnableSchedulingQueueHint                    bool
 	EnableAsyncPreemption                        bool
 	EnablePodLevelResources                      bool
-	EnablePartitionableDevices                   bool
 	EnableStorageCapacityScoring                 bool
-	EnableConsumableCapacity                     bool
 }
 
 // NewSchedulerFeaturesFromGates copies the current state of the feature gates into the struct.
@@ -53,7 +53,7 @@ func NewSchedulerFeaturesFromGates(featureGate featuregate.FeatureGate) Features
 		EnableDRAExtendedResource:                    featureGate.Enabled(features.DRAExtendedResource),
 		EnableDRAPrioritizedList:                     featureGate.Enabled(features.DRAPrioritizedList),
 		EnableDRAAdminAccess:                         featureGate.Enabled(features.DRAAdminAccess),
-		EnableConsumableCapacity:                     featureGate.Enabled(features.DRAConsumableCapacity),
+		EnableDRAConsumableCapacity:                  featureGate.Enabled(features.DRAConsumableCapacity),
 		EnableDRADeviceTaints:                        featureGate.Enabled(features.DRADeviceTaints),
 		EnableDRASchedulerFilterTimeout:              featureGate.Enabled(features.DRASchedulerFilterTimeout),
 		EnableDRAResourceClaimDeviceStatus:           featureGate.Enabled(features.DRAResourceClaimDeviceStatus),
@@ -68,7 +68,7 @@ func NewSchedulerFeaturesFromGates(featureGate featuregate.FeatureGate) Features
 		EnableSchedulingQueueHint:                    featureGate.Enabled(features.SchedulerQueueingHints),
 		EnableAsyncPreemption:                        featureGate.Enabled(features.SchedulerAsyncPreemption),
 		EnablePodLevelResources:                      featureGate.Enabled(features.PodLevelResources),
-		EnablePartitionableDevices:                   featureGate.Enabled(features.DRAPartitionableDevices),
+		EnableDRAPartitionableDevices:                featureGate.Enabled(features.DRAPartitionableDevices),
 		EnableStorageCapacityScoring:                 featureGate.Enabled(features.StorageCapacityScoring),
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/README.md
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/README.md
@@ -1,0 +1,28 @@
+The allocator code exists in three variants which get picked depending on which
+features are enabled:
+- stable: for a "GA only" feature configuration, minimal changes going forward
+- incubating: the default implementation, adds support for beta features
+- experimental: under active development, including alpha features
+
+This structure serves as a safety net because experimental changes cannot break
+more stable Kubernetes configurations, something that happened already once
+despite careful reviews.
+
+The goal is to rotate the implementations wholesale instead of copying
+individual code chunks, i.e. at some point "incubating" replaces "stable",
+"experimental" replaces "incubating", and "experimental" becomes a copy of
+"incubating" until new changes get added to it again.
+
+Ideally changes should be limited to "experimental", but sometimes changes have
+to be applied the same way across different variants, for example bug fixes
+or changes to the package API.
+
+Tests are shared between all implementations, with test cases applied depending
+on what features they require. Further testing is covered by
+test/integration/scheduler_perf. When promoting implementations, the selection
+of implementations which support certain features there needs to be
+updated. For example `[]string{"experimental"}` in `TestSchedulerPerf` of
+`test/integration/scheduler_perf/dra/consumablecapacity/consumablecapacity_test.go`
+will eventually become `[]string{"incubating", "experimental"}`. The explicit
+selection of the implementation for benchmarking in
+`EnableAllocators("experimental")` then becomes `EnableAllocators("incubating")`.

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -3802,8 +3802,7 @@ func TestAllocator(t *testing.T,
 		},
 		"device-binding-conditions": {
 			features: Features{
-				DeviceBinding: true,
-				DeviceStatus:  true,
+				DeviceBindingAndStatus: true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 1))),
@@ -3825,8 +3824,7 @@ func TestAllocator(t *testing.T,
 		},
 		"binding-conditions-multiple-devices": {
 			features: Features{
-				DeviceBinding: true,
-				DeviceStatus:  true,
+				DeviceBindingAndStatus: true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil,
@@ -3854,34 +3852,7 @@ func TestAllocator(t *testing.T,
 		},
 		"binding-conditions-without-feature-gate": {
 			features: Features{
-				DeviceBinding: false,
-				DeviceStatus:  false,
-			},
-			claimsToAllocate: objects(
-				claimWithRequests(claim0, nil, request(req0, classA, 1))),
-			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
-				device(device1, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}))),
-			node:          node(node1, region1),
-			expectResults: nil,
-		},
-		"device-binding-conditions-without-binding-conditions-feature-gate": {
-			features: Features{
-				DeviceBinding: false,
-				DeviceStatus:  true,
-			},
-			claimsToAllocate: objects(
-				claimWithRequests(claim0, nil, request(req0, classA, 1))),
-			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
-				device(device1, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}))),
-			node:          node(node1, region1),
-			expectResults: nil,
-		},
-		"device-binding-conditions-without-device-status-feature-gate": {
-			features: Features{
-				DeviceBinding: true,
-				DeviceStatus:  false,
+				DeviceBindingAndStatus: false,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 1))),
@@ -3893,8 +3864,7 @@ func TestAllocator(t *testing.T,
 		},
 		"node-restriction": {
 			features: Features{
-				DeviceBinding: true,
-				DeviceStatus:  true,
+				DeviceBindingAndStatus: true,
 			},
 			claimsToAllocate: objects(claim(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
@@ -3908,9 +3878,8 @@ func TestAllocator(t *testing.T,
 		},
 		"partitionable-devices-with-binding-conditions": {
 			features: Features{
-				PartitionableDevices: true,
-				DeviceBinding:        true,
-				DeviceStatus:         true,
+				PartitionableDevices:   true,
+				DeviceBindingAndStatus: true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 1)),
@@ -3945,9 +3914,8 @@ func TestAllocator(t *testing.T,
 		},
 		"partitionable-devices-with-binding-conditions-multiple": {
 			features: Features{
-				PartitionableDevices: true,
-				DeviceBinding:        true,
-				DeviceStatus:         true,
+				PartitionableDevices:   true,
+				DeviceBindingAndStatus: true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil,
@@ -3992,9 +3960,8 @@ func TestAllocator(t *testing.T,
 		},
 		"partitionable-devices-with-binding-conditions-some-devices-no-conditions": {
 			features: Features{
-				PartitionableDevices: true,
-				DeviceBinding:        true,
-				DeviceStatus:         true,
+				PartitionableDevices:   true,
+				DeviceBindingAndStatus: true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil,
@@ -4046,9 +4013,8 @@ func TestAllocator(t *testing.T,
 		},
 		"partitionable-devices-with-binding-conditions-multi-slices": {
 			features: Features{
-				PartitionableDevices: true,
-				DeviceBinding:        true,
-				DeviceStatus:         true,
+				PartitionableDevices:   true,
+				DeviceBindingAndStatus: true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 2)),
@@ -4096,10 +4062,9 @@ func TestAllocator(t *testing.T,
 		},
 		"partitionable-devices-with-binding-conditions-and-taints": {
 			features: Features{
-				PartitionableDevices: true,
-				DeviceBinding:        true,
-				DeviceStatus:         true,
-				DeviceTaints:         true,
+				PartitionableDevices:   true,
+				DeviceBindingAndStatus: true,
+				DeviceTaints:           true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 2)),
@@ -4136,10 +4101,9 @@ func TestAllocator(t *testing.T,
 		},
 		"partitionable-devices-with-binding-conditions-and-taints-tolerated": {
 			features: Features{
-				PartitionableDevices: true,
-				DeviceBinding:        true,
-				DeviceStatus:         true,
-				DeviceTaints:         true,
+				PartitionableDevices:   true,
+				DeviceBindingAndStatus: true,
+				DeviceTaints:           true,
 			},
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 2)).withTolerations(resourceapi.DeviceToleration{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -76,13 +76,12 @@ func NewConsumedCapacityCollection() ConsumedCapacityCollection {
 // making this the variant that is used when any of those
 // are enabled.
 var SupportedFeatures = internal.Features{
-	AdminAccess:          true,
-	PrioritizedList:      true,
-	PartitionableDevices: true,
-	DeviceTaints:         true,
-	DeviceBinding:        true,
-	DeviceStatus:         true,
-	ConsumableCapacity:   true,
+	AdminAccess:            true,
+	PrioritizedList:        true,
+	PartitionableDevices:   true,
+	DeviceTaints:           true,
+	DeviceBindingAndStatus: true,
+	ConsumableCapacity:     true,
 }
 
 type Allocator struct {
@@ -374,14 +373,14 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 			// Performance optimization: skip the for loop if the feature is off.
 			// Not needed for correctness because if the feature is off, the selected
 			// device should not have binding conditions.
-			if a.features.DeviceBinding {
+			if a.features.DeviceBindingAndStatus {
 				allocationResult.Devices.Results[i].BindingConditions = internal.BindingConditions
 				allocationResult.Devices.Results[i].BindingFailureConditions = internal.BindingFailureConditions
 			}
 			// Performance optimization: skip the for loop if the feature is off.
 			// Not needed for correctness because if the feature is off, the selected
 			// device should not have binding conditions.
-			if a.features.DeviceBinding {
+			if a.features.DeviceBindingAndStatus {
 				allocationResult.Devices.Results[i].BindingConditions = internal.BindingConditions
 				allocationResult.Devices.Results[i].BindingFailureConditions = internal.BindingFailureConditions
 			}
@@ -1060,7 +1059,7 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 // isSelectable checks whether a device satisfies the request and class selectors.
 func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, slice *draapi.ResourceSlice, deviceIndex int) (bool, error) {
 	device := &slice.Spec.Devices[deviceIndex]
-	if (!alloc.features.DeviceBinding || !alloc.features.DeviceStatus) &&
+	if !alloc.features.DeviceBindingAndStatus &&
 		len(device.BindingConditions) > 0 {
 		// Devices with binding conditions are not supported, feature is off.
 		return false, nil

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -930,7 +930,7 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 // isSelectable checks whether a device satisfies the request and class selectors.
 func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, slice *draapi.ResourceSlice, deviceIndex int) (bool, error) {
 	device := &slice.Spec.Devices[deviceIndex]
-	if (!alloc.features.DeviceBinding || !alloc.features.DeviceStatus) &&
+	if !alloc.features.DeviceBindingAndStatus &&
 		len(device.BindingConditions) > 0 {
 		// Devices with binding conditions are not supported, feature is off.
 		return false, nil

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -865,7 +865,7 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 // isSelectable checks whether a device satisfies the request and class selectors.
 func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, slice *draapi.ResourceSlice, deviceIndex int) (bool, error) {
 	device := &slice.Spec.Devices[deviceIndex]
-	if (!alloc.features.DeviceBinding || !alloc.features.DeviceStatus) &&
+	if !alloc.features.DeviceBindingAndStatus &&
 		len(device.BindingConditions) > 0 {
 		// Devices with binding conditions are not supported, feature is off.
 		return false, nil

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
@@ -52,17 +52,23 @@ type Stats struct {
 	NumAllocateOneInvocations int64
 }
 
-// Features contains all feature gates that may influence the behavior of ResourceClaim allocation.
+// Features control optional functionality during ResourceClaim allocation.
+// Each entry must correspond to at least one control flow change. Entries can
+// be removed when the control flow change is no longer necessary (= feature is
+// considered stable and always enabled).
+//
+// This often corresponds to feature gates, but not always: if a KEP implementation
+// depends on a set of feature gates, then a single entry here should control whether
+// that implementation is active.
 type Features struct {
 	// Sorted alphabetically. When adding a new entry, also extend Set and FeaturesAll.
 
-	AdminAccess          bool
-	ConsumableCapacity   bool
-	DeviceBinding        bool
-	DeviceStatus         bool
-	DeviceTaints         bool
-	PartitionableDevices bool
-	PrioritizedList      bool
+	AdminAccess            bool
+	ConsumableCapacity     bool
+	DeviceBindingAndStatus bool
+	DeviceTaints           bool
+	PartitionableDevices   bool
+	PrioritizedList        bool
 }
 
 // Set returns all features which are set to true.
@@ -88,21 +94,17 @@ func (f Features) Set() sets.Set[string] {
 	if f.PrioritizedList {
 		enabled.Insert("DRAPrioritizedList")
 	}
-	if f.DeviceBinding {
-		enabled.Insert("DRADeviceBindingConditions")
-	}
-	if f.DeviceStatus {
-		enabled.Insert("DRAResourceClaimDeviceStatus")
+	if f.DeviceBindingAndStatus {
+		enabled.Insert("DRADeviceBindingConditions+DRAResourceClaimDeviceStatus")
 	}
 	return enabled
 }
 
 var FeaturesAll = Features{
-	AdminAccess:          true,
-	ConsumableCapacity:   true,
-	DeviceBinding:        true,
-	DeviceStatus:         true,
-	DeviceTaints:         true,
-	PartitionableDevices: true,
-	PrioritizedList:      true,
+	AdminAccess:            true,
+	ConsumableCapacity:     true,
+	DeviceBindingAndStatus: true,
+	DeviceTaints:           true,
+	PartitionableDevices:   true,
+	PrioritizedList:        true,
 }

--- a/test/integration/scheduler_perf/dra/consumablecapacity/consumablecapacity_test.go
+++ b/test/integration/scheduler_perf/dra/consumablecapacity/consumablecapacity_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/dynamic-resource-allocation/structured"
 	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
 )
 
@@ -35,9 +36,22 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchedulerPerf(t *testing.T) {
-	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+	// Verify correct behavior with all available allocators for this feature.
+	for _, allocatorName := range []string{"experimental"} {
+		t.Run(allocatorName, func(t *testing.T) {
+			structured.EnableAllocators(allocatorName)
+			defer structured.EnableAllocators()
+
+			perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+		})
+	}
 }
 
 func BenchmarkPerfScheduling(b *testing.B) {
+	// Restrict benchmarking to the allocator for this feature
+	// to ensure that we do not accidentally pick something else.
+	structured.EnableAllocators("experimental")
+	defer structured.EnableAllocators()
+
 	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra_consumablecapacity", nil)
 }

--- a/test/integration/scheduler_perf/dra/extendedresource/extendedresource_test.go
+++ b/test/integration/scheduler_perf/dra/extendedresource/extendedresource_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/dynamic-resource-allocation/structured"
 	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
 )
 
@@ -35,9 +36,22 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchedulerPerf(t *testing.T) {
-	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+	// Verify correct behavior with all available allocators for this feature.
+	for _, allocatorName := range []string{"experimental"} {
+		t.Run(allocatorName, func(t *testing.T) {
+			structured.EnableAllocators(allocatorName)
+			defer structured.EnableAllocators()
+
+			perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+		})
+	}
 }
 
 func BenchmarkPerfScheduling(b *testing.B) {
+	// Restrict benchmarking to the allocator for this feature
+	// to ensure that we do not accidentally pick something else.
+	structured.EnableAllocators("experimental")
+	defer structured.EnableAllocators()
+
 	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra_extendedresource", nil)
 }

--- a/test/integration/scheduler_perf/dra/partitionabledevices/partitionabledevices_test.go
+++ b/test/integration/scheduler_perf/dra/partitionabledevices/partitionabledevices_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/dynamic-resource-allocation/structured"
 	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
 )
 
@@ -35,9 +36,22 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchedulerPerf(t *testing.T) {
-	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+	// Verify correct behavior with all available allocators for this feature.
+	for _, allocatorName := range []string{"experimental"} {
+		t.Run(allocatorName, func(t *testing.T) {
+			structured.EnableAllocators(allocatorName)
+			defer structured.EnableAllocators()
+
+			perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+		})
+	}
 }
 
 func BenchmarkPerfScheduling(b *testing.B) {
+	// Restrict benchmarking to the allocator for this feature
+	// to ensure that we do not accidentally pick something else.
+	structured.EnableAllocators("experimental")
+	defer structured.EnableAllocators()
+
 	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra_partitionabledevices", nil)
 }

--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -27,8 +27,6 @@
 - name: PublishResourceSlices
   featureGates:
     DynamicResourceAllocation: true
-    DRAPrioritizedList: false
-    DRAAdminAccess: false
   workloadTemplate:
   - opcode: createNodes
     countParam: $nodesWithoutDRA
@@ -315,7 +313,6 @@
 - name: SchedulingWithResourceClaim
   featureGates:
     DynamicResourceAllocation: true
-    # SchedulerQueueingHints: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $nodesWithoutDRA

--- a/test/integration/scheduler_perf/dra/prioritizedlist/prioritizedlist_test.go
+++ b/test/integration/scheduler_perf/dra/prioritizedlist/prioritizedlist_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/dynamic-resource-allocation/structured"
 	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
 )
 
@@ -35,9 +36,22 @@ func TestMain(m *testing.M) {
 }
 
 func TestSchedulerPerf(t *testing.T) {
-	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+	// Verify correct behavior with all available allocators for this feature.
+	for _, allocatorName := range []string{"incubating", "experimental"} {
+		t.Run(allocatorName, func(t *testing.T) {
+			structured.EnableAllocators(allocatorName)
+			defer structured.EnableAllocators()
+
+			perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+		})
+	}
 }
 
 func BenchmarkPerfScheduling(b *testing.B) {
+	// Restrict benchmarking to the allocator for this feature
+	// to ensure that we do not accidentally pick something else.
+	structured.EnableAllocators("incubating")
+	defer structured.EnableAllocators()
+
 	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra_prioritizedlist", nil)
 }

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1115,8 +1115,11 @@ func setupTestCase(t testing.TB, tc *testCase, featureGates map[featuregate.Feat
 	if qhEnabled, exists := featureGates[features.SchedulerQueueingHints]; exists && !qhEnabled {
 		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
 	}
-	for feature, flag := range featureGates {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature, flag)
+
+	// Iterate by sorted feature name, to make it deterministic and put AllAlpha/Beta first to enable
+	// overriding that choice.
+	for _, name := range slices.Sorted(maps.Keys(featureGates)) {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, name, featureGates[name])
 	}
 
 	// 30 minutes should be plenty enough even for the 5000-node tests.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In 1.34, the default feature gate selection picked the "experimental" allocator implementation when it should have used the "incubating" allocator. No harm came from that because the experimental allocator has all the necessary if checks to disable the extra code and no bugs were introduced when implementing it, but it means that our safety net wasn't there when we expected it to be.
    
The reason is that the "DRAResourceClaimDeviceStatus" feature gate is on by default and was only listed as supported by the experimental implementation. This could be fixed by listing it as supported also by the otherimplementation, but that would be a bit odd because there is nothing to support for it (the reason why this was missed in 1.34!). Instead, the allocator features are now only indirectly related to feature gates, with a single boolean controlling the implementation of binding conditions.

This PR includes this fix and add tests. It also cleans up feature gate handling in scheduler_perf.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Depends on https://github.com/kubernetes/kubernetes/pull/133960 (first two commits).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @mortent 