### PR TITLE
Automated cherry pick of #132456: nftables short-circuit local traffic to external addresses

### DIFF
--- a/pkg/proxy/nftables/README.md
+++ b/pkg/proxy/nftables/README.md
@@ -131,7 +131,7 @@ by setting appropriate `priority` values for your base chains. In particular:
     will will see masqueraded source IPs for some traffic.)
 
   - Traffic to services with no endpoints will be dropped or rejected from a chain with
-    `type filter`, `priority dstnat-10`, and any of `hook input`, `hook output`, or `hook
+    `type filter`, `priority filter`, and any of `hook input`, `hook output`, or `hook
     forward`.
 
 Note that the use of `mark` to indicate what traffic needs to be masqueraded is *not*

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -68,7 +68,6 @@ const (
 	filterInputChain             = "filter-input"
 	filterForwardChain           = "filter-forward"
 	filterOutputChain            = "filter-output"
-	filterOutputPostDNATChain    = "filter-output-post-dnat"
 	natPreroutingChain           = "nat-prerouting"
 	natOutputChain               = "nat-output"
 	natPostroutingChain          = "nat-postrouting"
@@ -401,9 +400,6 @@ var nftablesBaseChains = []nftablesBaseChain{
 	{filterForwardChain, knftables.FilterType, knftables.ForwardHook, knftables.FilterPriority},
 	{filterOutputChain, knftables.FilterType, knftables.OutputHook, knftables.FilterPriority},
 
-	// filter base chain (post-dnat priority)
-	{filterOutputPostDNATChain, knftables.FilterType, knftables.OutputHook, knftables.DNATPriority + "+10"},
-
 	// nat base chains (dnat priority)
 	{natPreroutingChain, knftables.NATType, knftables.PreroutingHook, knftables.DNATPriority},
 	{natOutputChain, knftables.NATType, knftables.OutputHook, knftables.DNATPriority},
@@ -436,7 +432,7 @@ var nftablesJumpChains = []nftablesJumpChain{
 	{masqueradingChain, natPostroutingChain, ""},
 
 	{clusterIPsCheckChain, filterForwardChain, "ct state new"},
-	{clusterIPsCheckChain, filterOutputPostDNATChain, "ct state new"},
+	{clusterIPsCheckChain, filterOutputChain, "ct state new"},
 }
 
 // ensureChain adds commands to tx to ensure that chain exists and doesn't contain

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -165,7 +165,6 @@ var baseRules = dedent.Dedent(`
 	add chain ip kube-proxy filter-forward { type filter hook forward priority 0 ; }
 	add chain ip kube-proxy filter-input { type filter hook input priority 0 ; }
 	add chain ip kube-proxy filter-output { type filter hook output priority 0 ; }
-	add chain ip kube-proxy filter-output-post-dnat { type filter hook output priority -90 ; }
 	add chain ip kube-proxy firewall-check
 	add chain ip kube-proxy mark-for-masquerade
 	add chain ip kube-proxy masquerading
@@ -186,7 +185,7 @@ var baseRules = dedent.Dedent(`
 	add rule ip kube-proxy filter-input ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-output ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-output-pre-dnat ct state new jump firewall-check
-	add rule ip kube-proxy filter-output-post-dnat ct state new jump cluster-ips-check
+	add rule ip kube-proxy filter-output ct state new jump cluster-ips-check
 	add rule ip kube-proxy firewall-check ip daddr . meta l4proto . th dport vmap @firewall-ips
 	add rule ip kube-proxy mark-for-masquerade mark set mark or 0x4000
 	add rule ip kube-proxy masquerading mark and 0x4000 == 0 return

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -160,10 +160,11 @@ var baseRules = dedent.Dedent(`
 	add map ip kube-proxy service-nodeports { type inet_proto . inet_service : verdict ; comment "NodePort traffic" ; }
 
 	add chain ip kube-proxy cluster-ips-check
-	add chain ip kube-proxy filter-prerouting { type filter hook prerouting priority -110 ; }
-	add chain ip kube-proxy filter-forward { type filter hook forward priority -110 ; }
-	add chain ip kube-proxy filter-input { type filter hook input priority -110 ; }
-	add chain ip kube-proxy filter-output { type filter hook output priority -110 ; }
+	add chain ip kube-proxy filter-prerouting-pre-dnat { type filter hook prerouting priority -110 ; }
+	add chain ip kube-proxy filter-output-pre-dnat { type filter hook output priority -110 ; }
+	add chain ip kube-proxy filter-forward { type filter hook forward priority 0 ; }
+	add chain ip kube-proxy filter-input { type filter hook input priority 0 ; }
+	add chain ip kube-proxy filter-output { type filter hook output priority 0 ; }
 	add chain ip kube-proxy filter-output-post-dnat { type filter hook output priority -90 ; }
 	add chain ip kube-proxy firewall-check
 	add chain ip kube-proxy mark-for-masquerade
@@ -178,13 +179,13 @@ var baseRules = dedent.Dedent(`
 
 	add rule ip kube-proxy cluster-ips-check ip daddr @cluster-ips reject comment "Reject traffic to invalid ports of ClusterIPs"
 	add rule ip kube-proxy cluster-ips-check ip daddr { 172.30.0.0/16 } drop comment "Drop traffic to unallocated ClusterIPs"
-	add rule ip kube-proxy filter-prerouting ct state new jump firewall-check
+	add rule ip kube-proxy filter-prerouting-pre-dnat ct state new jump firewall-check
 	add rule ip kube-proxy filter-forward ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-forward ct state new jump cluster-ips-check
 	add rule ip kube-proxy filter-input ct state new jump nodeport-endpoints-check
 	add rule ip kube-proxy filter-input ct state new jump service-endpoints-check
 	add rule ip kube-proxy filter-output ct state new jump service-endpoints-check
-	add rule ip kube-proxy filter-output ct state new jump firewall-check
+	add rule ip kube-proxy filter-output-pre-dnat ct state new jump firewall-check
 	add rule ip kube-proxy filter-output-post-dnat ct state new jump cluster-ips-check
 	add rule ip kube-proxy firewall-check ip daddr . meta l4proto . th dport vmap @firewall-ips
 	add rule ip kube-proxy mark-for-masquerade mark set mark or 0x4000


### PR DESCRIPTION
Cherry pick of #132456 on release-1.33.

#132456: nftables short-circuit local traffic to external addresses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-proxy in nftables mode now allows pods on nodes without local service endpoints to access LoadBalancer Service ExternalIPs (with `externalTrafficPolicy: Local`). Previously, such traffic was dropped. This change brings nftables mode in line with iptables and IPVS modes, allowing traffic to be forwarded to available endpoints elsewhere in the cluster.
```