### PR TITLE
Put the nfacct e2e test back under the "KubeProxy" label

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -255,13 +255,8 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 			framework.Failf("no valid conntrack entry for port %d on node %s: %v", testDaemonTCPPort, serverNodeInfo.nodeIP, err)
 		}
 	})
-})
 
-var _ = common.SIGDescribe("KubeProxyNFAcct", feature.KubeProxyNFAcct, func() {
-	fr := framework.NewDefaultFramework("kube-proxy-nfacct")
-	fr.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-
-	ginkgo.It("should update metric for tracking accepted packets destined for localhost nodeports", func(ctx context.Context) {
+	framework.It("should update metric for tracking accepted packets destined for localhost nodeports", feature.KubeProxyNFAcct, func(ctx context.Context) {
 		if framework.TestContext.ClusterIsIPv6() {
 			e2eskipper.Skipf("test requires IPv4 cluster")
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
#131490 fixed up some problems with the nfacct test, but also moved it out from under the "KubeProxy" label, making it harder for someone to "skip all kube-proxy-specific tests". It doesn't need its own separate "label" anyway, since it now has a feature tag as well for people who need to skip that test specifically.

#### Which issue(s) this PR is related to:
Fixes #133950

#### Special notes for your reviewer:
@aojea and I discussed and he was actually OK with changing the Fail here back to a Skip, but then I noticed the fact that that change also corresponded to losing the previous tag, so I think just fixing that (and not making it auto-skip) is fine.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/priority important-soon
/triage accepted