### PR TITLE
[KEP-4330] add min-compatibility-version to control plane.

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -128,6 +128,7 @@ func TestAddFlags(t *testing.T) {
 		"--service-cluster-ip-range=192.168.128.0/17",
 		"--lease-reuse-duration-seconds=100",
 		"--emulated-version=test=1.31",
+		"--min-compatibility-version=test=1.29",
 		"--emulation-forward-compatible=true",
 		"--runtime-config-emulation-forward-compatible=true",
 		"--coordinated-leadership-lease-duration=10s",
@@ -357,5 +358,8 @@ func TestAddFlags(t *testing.T) {
 	testEffectiveVersion := s.GenericServerRunOptions.ComponentGlobalsRegistry.EffectiveVersionFor("test")
 	if testEffectiveVersion.EmulationVersion().String() != "1.31" {
 		t.Errorf("Got emulation version %s, wanted %s", testEffectiveVersion.EmulationVersion().String(), "1.31")
+	}
+	if testEffectiveVersion.MinCompatibilityVersion().String() != "1.29" {
+		t.Errorf("Got min compatibility version %s, wanted %s", testEffectiveVersion.MinCompatibilityVersion().String(), "1.29")
 	}
 }

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 	basecompatibility "k8s.io/component-base/compatibility"
+	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	zpagesfeatures "k8s.io/component-base/zpages/features"
@@ -198,6 +199,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		effectiveVersion = basecompatibility.NewEffectiveVersionFromString(instanceOptions.BinaryVersion, "", "")
 	}
 	effectiveVersion.SetEmulationVersion(featureGate.EmulationVersion())
+	effectiveVersion.SetMinCompatibilityVersion(featureGate.MinCompatibilityVersion())
 	componentGlobalsRegistry := basecompatibility.NewComponentGlobalsRegistry()
 	if err := componentGlobalsRegistry.Register(basecompatibility.DefaultKubeComponent, effectiveVersion, featureGate); err != nil {
 		return result, err
@@ -377,13 +379,17 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	// If the local ComponentGlobalsRegistry is changed by the flags,
 	// we need to copy the new feature values back to the DefaultFeatureGate because most feature checks still use the DefaultFeatureGate.
 	// We cannot directly use DefaultFeatureGate in ComponentGlobalsRegistry because the changes done by ComponentGlobalsRegistry.Set() will not be undone at the end of the test.
-	if !featureGate.EmulationVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.EmulationVersion()) {
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultMutableFeatureGate, effectiveVersion.EmulationVersion())
+	if !featureGate.EmulationVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.EmulationVersion()) || !featureGate.MinCompatibilityVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.MinCompatibilityVersion()) {
+		featuregatetesting.SetFeatureGateVersionsDuringTest(t, utilfeature.DefaultMutableFeatureGate, effectiveVersion.EmulationVersion(), effectiveVersion.MinCompatibilityVersion())
 	}
+	featureOverrides := map[featuregate.Feature]bool{}
 	for f := range utilfeature.DefaultMutableFeatureGate.GetAll() {
 		if featureGate.Enabled(f) != utilfeature.DefaultFeatureGate.Enabled(f) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, f, featureGate.Enabled(f))
+			featureOverrides[f] = featureGate.Enabled(f)
 		}
+	}
+	if len(featureOverrides) > 0 {
+		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featureOverrides)
 	}
 	utilfeature.DefaultMutableFeatureGate.AddMetrics()
 

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -97,6 +97,7 @@ func StartTestServer(t *testing.T, ctx context.Context, customFlags []string) (r
 	featureGate := utilfeature.DefaultMutableFeatureGate.DeepCopy()
 	effectiveVersion := utilcompatibility.DefaultKubeEffectiveVersionForTest()
 	effectiveVersion.SetEmulationVersion(featureGate.EmulationVersion())
+	effectiveVersion.SetMinCompatibilityVersion(featureGate.MinCompatibilityVersion())
 	componentGlobalsRegistry := compatibility.NewComponentGlobalsRegistry()
 	if err := componentGlobalsRegistry.Register(compatibility.DefaultKubeComponent, effectiveVersion, featureGate); err != nil {
 		return result, err
@@ -116,8 +117,8 @@ func StartTestServer(t *testing.T, ctx context.Context, customFlags []string) (r
 	}
 	// If the local ComponentGlobalsRegistry is changed by the flags,
 	// we need to copy the new feature values back to the DefaultFeatureGate because most feature checks still use the DefaultFeatureGate.
-	if !featureGate.EmulationVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.EmulationVersion()) {
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultMutableFeatureGate, effectiveVersion.EmulationVersion())
+	if !featureGate.EmulationVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.EmulationVersion()) || !featureGate.MinCompatibilityVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.MinCompatibilityVersion()) {
+		featuregatetesting.SetFeatureGateVersionsDuringTest(t, utilfeature.DefaultMutableFeatureGate, effectiveVersion.EmulationVersion(), effectiveVersion.MinCompatibilityVersion())
 	}
 	featureOverrides := map[featuregate.Feature]bool{}
 	for f := range utilfeature.DefaultMutableFeatureGate.GetAll() {

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -98,6 +98,7 @@ func StartTestServer(t *testing.T, ctx context.Context, customFlags []string) (r
 	featureGate := utilfeature.DefaultMutableFeatureGate.DeepCopy()
 	effectiveVersion := utilcompatibility.DefaultKubeEffectiveVersionForTest()
 	effectiveVersion.SetEmulationVersion(featureGate.EmulationVersion())
+	effectiveVersion.SetMinCompatibilityVersion(featureGate.MinCompatibilityVersion())
 	componentGlobalsRegistry := compatibility.NewComponentGlobalsRegistry()
 	if err := componentGlobalsRegistry.Register(compatibility.DefaultKubeComponent, effectiveVersion, featureGate); err != nil {
 		return result, err
@@ -114,8 +115,8 @@ func StartTestServer(t *testing.T, ctx context.Context, customFlags []string) (r
 	}
 	// If the local ComponentGlobalsRegistry is changed by the flags,
 	// we need to copy the new feature values back to the DefaultFeatureGate because most feature checks still use the DefaultFeatureGate.
-	if !featureGate.EmulationVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.EmulationVersion()) {
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultMutableFeatureGate, effectiveVersion.EmulationVersion())
+	if !featureGate.EmulationVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.EmulationVersion()) || !featureGate.MinCompatibilityVersion().EqualTo(utilfeature.DefaultMutableFeatureGate.MinCompatibilityVersion()) {
+		featuregatetesting.SetFeatureGateVersionsDuringTest(t, utilfeature.DefaultMutableFeatureGate, effectiveVersion.EmulationVersion(), effectiveVersion.MinCompatibilityVersion())
 	}
 	featureOverrides := map[featuregate.Feature]bool{}
 	for f := range utilfeature.DefaultMutableFeatureGate.GetAll() {

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -123,6 +123,7 @@ func TestAddFlags(t *testing.T) {
 		"--storage-backend=etcd3",
 		"--lease-reuse-duration-seconds=100",
 		"--emulated-version=test=1.31",
+		"--min-compatibility-version=test=1.29",
 		"--coordinated-leadership-lease-duration=10s",
 		"--coordinated-leadership-renew-deadline=5s",
 		"--coordinated-leadership-retry-period=1s",
@@ -321,6 +322,9 @@ func TestAddFlags(t *testing.T) {
 	testEffectiveVersion := s.GenericServerRunOptions.ComponentGlobalsRegistry.EffectiveVersionFor("test")
 	if testEffectiveVersion.EmulationVersion().String() != "1.31" {
 		t.Errorf("Got emulation version %s, wanted %s", testEffectiveVersion.EmulationVersion().String(), "1.31")
+	}
+	if testEffectiveVersion.MinCompatibilityVersion().String() != "1.29" {
+		t.Errorf("Got min compatibility version %s, wanted %s", testEffectiveVersion.MinCompatibilityVersion().String(), "1.29")
 	}
 }
 

--- a/pkg/features/client_adapter_test.go
+++ b/pkg/features/client_adapter_test.go
@@ -80,7 +80,7 @@ func TestClientAdapterAdd(t *testing.T) {
 			t.Errorf("expected feature %q not found", name)
 			continue
 		}
-		if diff := cmp.Diff(actual, expected, cmpopts.IgnoreFields(featuregate.FeatureSpec{}, "Version")); diff != "" {
+		if diff := cmp.Diff(actual, expected, cmpopts.IgnoreFields(featuregate.FeatureSpec{}, "Version", "MinCompatibilityVersion")); diff != "" {
 			t.Errorf("expected feature %q spec %#v, got spec %#v", name, expected, actual)
 		}
 	}

--- a/staging/src/k8s.io/component-base/compatibility/registry.go
+++ b/staging/src/k8s.io/component-base/compatibility/registry.go
@@ -46,18 +46,12 @@ type ComponentGlobals struct {
 	effectiveVersion MutableEffectiveVersion
 	featureGate      featuregate.MutableVersionedFeatureGate
 
-	// emulationVersionMapping contains the mapping from the emulation version of this component
-	// to the emulation version of another component.
-	emulationVersionMapping map[string]VersionMapping
-	// dependentEmulationVersion stores whether or not this component's EmulationVersion is dependent through mapping on another component.
-	// If true, the emulation version cannot be set from the flag, or version mapping from another component.
-	dependentEmulationVersion bool
-	// minCompatibilityVersionMapping contains the mapping from the min compatibility version of this component
-	// to the min compatibility version of another component.
-	minCompatibilityVersionMapping map[string]VersionMapping
-	// dependentMinCompatibilityVersion stores whether or not this component's MinCompatibilityVersion is dependent through mapping on another component
-	// If true, the min compatibility version cannot be set from the flag, or version mapping from another component.
-	dependentMinCompatibilityVersion bool
+	// componentVersionMapping contains the mapping from the version of this component
+	// to the version of another component.
+	componentVersionMapping map[string]VersionMapping
+	// dependentComponentVersion stores whether or not this component's version is dependent through mapping on another component.
+	// If true, the emulation/minCompatibility version cannot be set from the flag, or version mapping from another component.
+	dependentComponentVersion bool
 }
 
 // ComponentGlobalsRegistry stores the global variables for different components for easy access, including feature gate and effective version of each component.
@@ -74,7 +68,7 @@ type ComponentGlobalsRegistry interface {
 	// ComponentGlobalsOrRegister would return the registered global variables for the component if it already exists in the registry.
 	// Otherwise, the provided variables would be registered under the component, and the same variables would be returned.
 	ComponentGlobalsOrRegister(component string, effectiveVersion MutableEffectiveVersion, featureGate featuregate.MutableVersionedFeatureGate) (MutableEffectiveVersion, featuregate.MutableVersionedFeatureGate)
-	// AddFlags adds flags of "--emulated-version" and "--feature-gates"
+	// AddFlags adds flags of "--emulated-version", "--min-compatibility-version" and "--feature-gates"
 	AddFlags(fs *pflag.FlagSet)
 	// Set sets the flags for all global variables for all components registered.
 	// A component's feature gate and effective version would not be updated until Set() is called.
@@ -85,12 +79,12 @@ type ComponentGlobalsRegistry interface {
 	Validate() []error
 	// Reset removes all stored ComponentGlobals, configurations, and version mappings.
 	Reset()
-	// SetEmulationVersionMapping sets the mapping from the emulation version of one component
-	// to the emulation version of another component.
-	// Once set, the emulation version of the toComponent will be determined by the emulation version of the fromComponent,
+	// SetVersionMapping sets the mapping from the emulation/minCompatibility version of one component
+	// to the emulation/minCompatibility version of another component.
+	// Once set, the emulation/minCompatibility version of the toComponent will be determined by the emulation/minCompatibility version of the fromComponent,
 	// and cannot be set from cmd flags anymore.
-	// For a given component, its emulation version can only depend on one other component, no multiple dependency is allowed.
-	SetEmulationVersionMapping(fromComponent, toComponent string, f VersionMapping) error
+	// For a given component, its emulation/minCompatibility version can only depend on one other component, no multiple dependency is allowed.
+	SetVersionMapping(fromComponent, toComponent string, f VersionMapping) error
 	// AddMetrics adds metrics for the emulation version of a component.
 	AddMetrics()
 }
@@ -100,11 +94,15 @@ type componentGlobalsRegistry struct {
 	mutex            sync.RWMutex
 	// emulationVersionConfig stores the list of component name to emulation version set from the flag.
 	// When the `--emulated-version` flag is parsed, it would not take effect until Set() is called,
-	// because the emulation version needs to be set before the feature gate is set.
+	// because we have to enforce of order of setting the emulation version first, then min compatibility version, and last the feature gate.
 	emulationVersionConfig []string
+	// minCompatibilityVersionConfig stores the list of component name to min compatibility version set from the flag.
+	// When the `--min-compatibility-version` flag is parsed, it would not take effect until Set() is called,
+	// because we have to enforce of order of setting the emulation version first, then min compatibility version, and last the feature gate.
+	minCompatibilityVersionConfig []string
 	// featureGatesConfig stores the map of component name to the list of feature gates set from the flag.
 	// When the `--feature-gates` flag is parsed, it would not take effect until Set() is called,
-	// because the emulation version needs to be set before the feature gate is set.
+	// because we have to enforce of order of setting the emulation version first, then min compatibility version, and last the feature gate.
 	featureGatesConfig map[string][]string
 	// featureGatesConfigFlags stores a pointer to the flag value, allowing other commands
 	// to append to the feature gates configuration rather than overwriting it
@@ -115,9 +113,10 @@ type componentGlobalsRegistry struct {
 
 func NewComponentGlobalsRegistry() *componentGlobalsRegistry {
 	return &componentGlobalsRegistry{
-		componentGlobals:       make(map[string]*ComponentGlobals),
-		emulationVersionConfig: nil,
-		featureGatesConfig:     nil,
+		componentGlobals:              make(map[string]*ComponentGlobals),
+		emulationVersionConfig:        nil,
+		minCompatibilityVersionConfig: nil,
+		featureGatesConfig:            nil,
 	}
 }
 
@@ -136,6 +135,7 @@ func (r *componentGlobalsRegistry) Reset() {
 	defer r.mutex.Unlock()
 	r.componentGlobals = make(map[string]*ComponentGlobals)
 	r.emulationVersionConfig = nil
+	r.minCompatibilityVersionConfig = nil
 	r.featureGatesConfig = nil
 	r.featureGatesConfigFlags = nil
 	r.set = false
@@ -166,15 +166,15 @@ func (r *componentGlobalsRegistry) unsafeRegister(component string, effectiveVer
 		return fmt.Errorf("component globals of %s already registered", component)
 	}
 	if featureGate != nil {
-		if err := featureGate.SetEmulationVersion(effectiveVersion.EmulationVersion()); err != nil {
+		if err := featureGate.SetEmulationVersionAndMinCompatibilityVersion(
+			effectiveVersion.EmulationVersion(), effectiveVersion.MinCompatibilityVersion()); err != nil {
 			return err
 		}
 	}
 	c := ComponentGlobals{
-		effectiveVersion:               effectiveVersion,
-		featureGate:                    featureGate,
-		emulationVersionMapping:        make(map[string]VersionMapping),
-		minCompatibilityVersionMapping: make(map[string]VersionMapping),
+		effectiveVersion:        effectiveVersion,
+		featureGate:             featureGate,
+		componentVersionMapping: make(map[string]VersionMapping),
 	}
 	r.componentGlobals[component] = &c
 	return nil
@@ -217,15 +217,12 @@ func (r *componentGlobalsRegistry) unsafeKnownFeatures() []string {
 func (r *componentGlobalsRegistry) unsafeVersionFlagOptions(isEmulation bool) []string {
 	var vs []string
 	for component, globals := range r.componentGlobals {
+		if globals.dependentComponentVersion {
+			continue
+		}
 		if isEmulation {
-			if globals.dependentEmulationVersion {
-				continue
-			}
 			vs = append(vs, fmt.Sprintf("%s=%s", component, globals.effectiveVersion.AllowedEmulationVersionRange()))
 		} else {
-			if globals.dependentMinCompatibilityVersion {
-				continue
-			}
 			vs = append(vs, fmt.Sprintf("%s=%s", component, globals.effectiveVersion.AllowedMinCompatibilityVersionRange()))
 		}
 	}
@@ -251,6 +248,16 @@ func (r *componentGlobalsRegistry) AddFlags(fs *pflag.FlagSet) {
 		"Version format could only be major.minor, for example: '--emulated-version=wardle=1.2,kube=1.31'.\nOptions are: "+strings.Join(r.unsafeVersionFlagOptions(true), ",")+
 		"\nIf the component is not specified, defaults to \"kube\"")
 
+	// min-compatibility-version is typically the minimal binary version of all control plane components the server expects to coexist with throughout the lifecycle of this server.
+	// If set to smaller than the server emulated version, the newest CEL features/libraries/parameters introduced after the min compatibility version would not be turned on,
+	// feature stages with a MinCompatibilityVersion higher than this value will be skipped, and the resource storage version will be set based on the min compatibility version.
+	// It can be set to equal to the binary version after all control plane components are upgraded, after which features with compatibility implications could be enabled, the newest CEL features/libraries/parameters would turned on, but rollbacks are no longer supported.
+	fs.StringSliceVar(&r.minCompatibilityVersionConfig, "min-compatibility-version", r.minCompatibilityVersionConfig, ""+
+		"The min version of control plane components the server should be compatible with.\n"+
+		"Must be less or equal to the emulated-version. Version format could only be major.minor, for example: '--min-compatibility-version=wardle=1.2,kube=1.31'.\n"+
+		"Options are: "+strings.Join(r.unsafeVersionFlagOptions(false), ",")+
+		"\nIf the component is not specified, defaults to \"kube\"")
+
 	if r.featureGatesConfigFlags == nil {
 		r.featureGatesConfigFlags = cliflag.NewColonSeparatedMultimapStringStringAllowDefaultEmptyKey(&r.featureGatesConfig)
 	}
@@ -264,9 +271,9 @@ type componentVersion struct {
 	ver       *version.Version
 }
 
-// getFullEmulationVersionConfig expands the given version config with version registered version mapping,
+// getFullVersionConfig expands the given version config with registered version mapping,
 // and returns the map of component to Version.
-func (r *componentGlobalsRegistry) getFullEmulationVersionConfig(
+func (r *componentGlobalsRegistry) getFullVersionConfig(
 	versionConfigMap map[string]*version.Version) (map[string]*version.Version, error) {
 	result := map[string]*version.Version{}
 	setQueue := []componentVersion{}
@@ -284,7 +291,7 @@ func (r *componentGlobalsRegistry) getFullEmulationVersionConfig(
 		}
 		setQueue = setQueue[1:]
 		result[cv.component] = cv.ver
-		for toComp, f := range r.componentGlobals[cv.component].emulationVersionMapping {
+		for toComp, f := range r.componentGlobals[cv.component].componentVersionMapping {
 			toVer := f(cv.ver)
 			if toVer == nil {
 				return result, fmt.Errorf("got nil version from mapping of %s=%s to component:%s", cv.component, cv.ver.String(), toComp)
@@ -350,15 +357,36 @@ func (r *componentGlobalsRegistry) Set() error {
 			return fmt.Errorf("component not registered: %s", comp)
 		}
 		// only components without any dependencies can be set from the flag.
-		if r.componentGlobals[comp].dependentEmulationVersion {
+		if r.componentGlobals[comp].dependentComponentVersion {
 			return fmt.Errorf("EmulationVersion of %s is set by mapping, cannot set it by flag", comp)
 		}
 	}
-	if emulationVersions, err := r.getFullEmulationVersionConfig(emulationVersionConfigMap); err != nil {
+	if emulationVersions, err := r.getFullVersionConfig(emulationVersionConfigMap); err != nil {
 		return err
 	} else {
 		for comp, ver := range emulationVersions {
 			r.componentGlobals[comp].effectiveVersion.SetEmulationVersion(ver)
+		}
+	}
+
+	minCompatibilityVersionConfigMap, err := toVersionMap(r.minCompatibilityVersionConfig)
+	if err != nil {
+		return err
+	}
+	for comp := range minCompatibilityVersionConfigMap {
+		if _, ok := r.componentGlobals[comp]; !ok {
+			return fmt.Errorf("component not registered: %s", comp)
+		}
+		// only components without any dependencies can be set from the flag.
+		if r.componentGlobals[comp].dependentComponentVersion {
+			return fmt.Errorf("MinCompatibilityVersion of %s is set by mapping, cannot set it by flag", comp)
+		}
+	}
+	if minCompatibilityVersions, err := r.getFullVersionConfig(minCompatibilityVersionConfigMap); err != nil {
+		return err
+	} else {
+		for comp, ver := range minCompatibilityVersions {
+			r.componentGlobals[comp].effectiveVersion.SetMinCompatibilityVersion(ver)
 		}
 	}
 	// Set feature gate emulation version before setting feature gate flag values.
@@ -366,8 +394,8 @@ func (r *componentGlobalsRegistry) Set() error {
 		if globals.featureGate == nil {
 			continue
 		}
-		klog.V(klogLevel).Infof("setting %s:feature gate emulation version to %s", comp, globals.effectiveVersion.EmulationVersion().String())
-		if err := globals.featureGate.SetEmulationVersion(globals.effectiveVersion.EmulationVersion()); err != nil {
+		klog.V(klogLevel).Infof("setting %s:feature gate emulation version to %s, min compatibility version to %s", comp, globals.effectiveVersion.EmulationVersion().String(), globals.effectiveVersion.MinCompatibilityVersion().String())
+		if err := globals.featureGate.SetEmulationVersionAndMinCompatibilityVersion(globals.effectiveVersion.EmulationVersion(), globals.effectiveVersion.MinCompatibilityVersion()); err != nil {
 			return err
 		}
 	}
@@ -426,7 +454,7 @@ func enabledAlphaFeatures(features map[featuregate.Feature]featuregate.FeatureSp
 	return enabled
 }
 
-func (r *componentGlobalsRegistry) SetEmulationVersionMapping(fromComponent, toComponent string, f VersionMapping) error {
+func (r *componentGlobalsRegistry) SetVersionMapping(fromComponent, toComponent string, f VersionMapping) error {
 	if f == nil {
 		return nil
 	}
@@ -440,19 +468,19 @@ func (r *componentGlobalsRegistry) SetEmulationVersionMapping(fromComponent, toC
 		return fmt.Errorf("component not registered: %s", toComponent)
 	}
 	// check multiple dependency
-	if r.componentGlobals[toComponent].dependentEmulationVersion {
+	if r.componentGlobals[toComponent].dependentComponentVersion {
 		return fmt.Errorf("mapping of %s already exists from another component", toComponent)
 	}
-	r.componentGlobals[toComponent].dependentEmulationVersion = true
+	r.componentGlobals[toComponent].dependentComponentVersion = true
 
-	versionMapping := r.componentGlobals[fromComponent].emulationVersionMapping
+	versionMapping := r.componentGlobals[fromComponent].componentVersionMapping
 	if _, ok := versionMapping[toComponent]; ok {
 		return fmt.Errorf("EmulationVersion from %s to %s already exists", fromComponent, toComponent)
 	}
 	versionMapping[toComponent] = f
 	klog.V(klogLevel).Infof("setting the default EmulationVersion of %s based on mapping from the default EmulationVersion of %s", toComponent, fromComponent)
 	defaultFromVersion := r.componentGlobals[fromComponent].effectiveVersion.EmulationVersion()
-	emulationVersions, err := r.getFullEmulationVersionConfig(map[string]*version.Version{fromComponent: defaultFromVersion})
+	emulationVersions, err := r.getFullVersionConfig(map[string]*version.Version{fromComponent: defaultFromVersion})
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -721,6 +721,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 	const testLockedFalseGate Feature = "TestLockedFalse"
 	const testAlphaGateNoVersion Feature = "TestAlphaNoVersion"
 	const testBetaGateNoVersion Feature = "TestBetaNoVersion"
+	const testCompatibilityGate Feature = "TestCompatibility"
 
 	tests := []struct {
 		arg        string
@@ -738,6 +739,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -750,20 +752,11 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    true,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "fooBarBaz=true",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "fooBarBaz=true",
 			parseError: "unrecognized feature gate: fooBarBaz",
 		},
 		{
@@ -777,6 +770,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -790,6 +784,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: true,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -803,21 +798,12 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 			parseError: "invalid value of AllAlpha",
 		},
 		{
-			arg: "AllAlpha=false,TestAlpha=true,TestAlphaNoVersion=true",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: true,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "AllAlpha=false,TestAlpha=true,TestAlphaNoVersion=true",
 			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
 		},
 		{
@@ -831,34 +817,15 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: true,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "TestAlpha=true,TestAlphaNoVersion=true,AllAlpha=false",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: true,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "TestAlpha=true,TestAlphaNoVersion=true,AllAlpha=false",
 			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
 		},
 		{
-			arg: "AllAlpha=true,TestAlpha=false,TestAlphaNoVersion=false",
-			expect: map[Feature]bool{
-				allAlphaGate:           true,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           true,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "AllAlpha=true,TestAlpha=false,TestAlphaNoVersion=false",
 			parseError: "cannot set feature gate TestAlpha to false, feature is PreAlpha at emulated version 1.28",
 		},
 		{
@@ -872,20 +839,11 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
-			arg: "TestAlpha=false,TestAlphaNoVersion=false,AllAlpha=true",
-			expect: map[Feature]bool{
-				allAlphaGate:           true,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           true,
-				testLockedFalseGate:    false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "TestAlpha=false,TestAlphaNoVersion=false,AllAlpha=true",
 			parseError: "cannot set feature gate TestAlpha to false, feature is PreAlpha at emulated version 1.28",
 		},
 		{
@@ -899,6 +857,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  false,
 			},
 		},
 
@@ -913,6 +872,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -926,19 +886,11 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  true,
 			},
 		},
 		{
-			arg: "AllBeta=banana",
-			expect: map[Feature]bool{
-				allAlphaGate:           false,
-				allBetaGate:            false,
-				testGAGate:             false,
-				testAlphaGate:          false,
-				testBetaGate:           false,
-				testAlphaGateNoVersion: false,
-				testBetaGateNoVersion:  false,
-			},
+			arg:        "AllBeta=banana",
 			parseError: "invalid value of AllBeta",
 		},
 		{
@@ -952,6 +904,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -965,6 +918,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  true,
+				testCompatibilityGate:  false,
 			},
 		},
 		{
@@ -978,6 +932,7 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  true,
 			},
 		},
 		{
@@ -991,21 +946,26 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  true,
 			},
 		},
 		{
-			arg: "TestAlpha=true,AllBeta=false",
+			arg:        "TestAlpha=true,AllBeta=false",
+			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
+		},
+		{
+			arg: "TestCompatibility=true",
 			expect: map[Feature]bool{
 				allAlphaGate:           false,
 				allBetaGate:            false,
 				testGAGate:             false,
-				testAlphaGate:          true,
+				testAlphaGate:          false,
 				testBetaGate:           false,
 				testLockedFalseGate:    false,
 				testAlphaGateNoVersion: false,
 				testBetaGateNoVersion:  false,
+				testCompatibilityGate:  true,
 			},
-			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
 		},
 	}
 	for i, test := range tests {
@@ -1031,6 +991,11 @@ func TestVersionedFeatureGateFlag(t *testing.T) {
 				testLockedFalseGate: {
 					{Version: version.MustParse("1.28"), Default: false, PreRelease: GA},
 					{Version: version.MustParse("1.29"), Default: false, PreRelease: GA, LockToDefault: true},
+				},
+				testCompatibilityGate: {
+					{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.28")},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: GA, LockToDefault: true},
 				},
 			})
 			require.NoError(t, err)
@@ -1181,6 +1146,8 @@ func TestVersionedFeatureGateKnownFeatures(t *testing.T) {
 		testPreAlphaGate            Feature = "TestPreAlpha"
 		testAlphaGate               Feature = "TestAlpha"
 		testBetaGate                Feature = "TestBeta"
+		testFastBetaGate            Feature = "TestFastBeta"
+		testLatestFastBetaGate      Feature = "TestLatestFastBeta"
 		testGAGate                  Feature = "TestGA"
 		testDeprecatedGate          Feature = "TestDeprecated"
 		testGAGateNoVersion         Feature = "TestGANoVersion"
@@ -1206,6 +1173,14 @@ func TestVersionedFeatureGateKnownFeatures(t *testing.T) {
 		testBetaGate: {
 			{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
 		},
+		testFastBetaGate: {
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.28")},
+		},
+		testLatestFastBetaGate: {
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+		},
 		testDeprecatedGate: {
 			{Version: version.MustParse("1.26"), Default: false, PreRelease: Alpha},
 			{Version: version.MustParse("1.28"), Default: true, PreRelease: Deprecated},
@@ -1225,12 +1200,106 @@ func TestVersionedFeatureGateKnownFeatures(t *testing.T) {
 	assert.NotContains(t, known, testPreAlphaGate)
 	assert.Contains(t, known, testAlphaGate)
 	assert.Contains(t, known, testBetaGate)
+	assert.Contains(t, known, "TestFastBeta=true|false (BETA - default=true) if --min-compatibility-version>=1.28")
+	assert.NotContains(t, known, testLatestFastBetaGate)
 	assert.NotContains(t, known, testGAGate)
 	assert.NotContains(t, known, testDeprecatedGate)
 	assert.Contains(t, known, testAlphaGateNoVersion)
 	assert.Contains(t, known, testBetaGateNoVersion)
 	assert.NotContains(t, known, testGAGateNoVersion)
 	assert.NotContains(t, known, testDeprecatedGateNoVersion)
+}
+
+func TestVersionedFeatureGateKnownFeaturesWithMinCompatVersion(t *testing.T) {
+	// gates for testing
+	const (
+		testPreAlphaGate            Feature = "TestPreAlpha"
+		testAlphaGate               Feature = "TestAlpha"
+		testBetaGate                Feature = "TestBeta"
+		testFastBetaGate            Feature = "TestFastBeta"
+		testLatestFastBetaGate      Feature = "TestLatestFastBeta"
+		testGAGate                  Feature = "TestGA"
+		testDeprecatedGate          Feature = "TestDeprecated"
+		testGAGateNoVersion         Feature = "TestGANoVersion"
+		testAlphaGateNoVersion      Feature = "TestAlphaNoVersion"
+		testBetaGateNoVersion       Feature = "TestBetaNoVersion"
+		testDeprecatedGateNoVersion Feature = "TestDeprecatedNoVersion"
+	)
+	// Don't parse the flag, assert defaults are used.
+	f := NewVersionedFeatureGate(version.MustParse("1.29"))
+	err := f.AddVersioned(map[Feature]VersionedSpecs{
+		testGAGate: {
+			{Version: version.MustParse("1.26"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.26"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.26")},
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: GA},
+		},
+		testPreAlphaGate: {
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+		},
+		testAlphaGate: {
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+		},
+		testBetaGate: {
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+		},
+		testFastBetaGate: {
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.28")},
+		},
+		testLatestFastBetaGate: {
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+		},
+		testDeprecatedGate: {
+			{Version: version.MustParse("1.26"), Default: false, PreRelease: Alpha},
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: Deprecated},
+		},
+	})
+	require.NoError(t, err)
+	err = f.Add(map[Feature]FeatureSpec{
+		testAlphaGateNoVersion:      {Default: false, PreRelease: Alpha},
+		testBetaGateNoVersion:       {Default: false, PreRelease: Beta},
+		testGAGateNoVersion:         {Default: false, PreRelease: GA},
+		testDeprecatedGateNoVersion: {Default: false, PreRelease: Deprecated},
+	})
+	require.NoError(t, err)
+
+	knownExpected := []string{
+		"AllAlpha=true|false (ALPHA - default=false)",
+		"AllBeta=true|false (BETA - default=false)",
+		"TestAlpha=true|false (ALPHA - default=false)",
+		"TestAlphaNoVersion=true|false (ALPHA - default=false)",
+		"TestBeta=true|false (BETA - default=false)",
+		"TestBetaNoVersion=true|false (BETA - default=false)",
+		"TestFastBeta=true|false (BETA - default=true)",
+		"TestLatestFastBeta=true|false (BETA - default=false), or TestLatestFastBeta=true|false (BETA - default=true) if --min-compatibility-version>=1.29",
+		"TestPreAlpha=true|false (ALPHA - default=false)",
+	}
+	assert.ElementsMatch(t, f.KnownFeatures(), knownExpected)
+
+	require.NoError(t, f.SetEmulationVersionAndMinCompatibilityVersion(version.MustParse("1.28"), version.MustParse("1.28")))
+	knownExpected = []string{
+		"AllAlpha=true|false (ALPHA - default=false)",
+		"AllBeta=true|false (BETA - default=false)",
+		"TestAlpha=true|false (ALPHA - default=false)",
+		"TestAlphaNoVersion=true|false (ALPHA - default=false)",
+		"TestBeta=true|false (BETA - default=false)",
+		"TestBetaNoVersion=true|false (BETA - default=false)",
+		"TestFastBeta=true|false (BETA - default=true)",
+	}
+	assert.ElementsMatch(t, f.KnownFeatures(), knownExpected)
+
+	require.NoError(t, f.SetEmulationVersionAndMinCompatibilityVersion(version.MustParse("1.28"), version.MustParse("1.26")))
+	knownExpected = []string{
+		"AllAlpha=true|false (ALPHA - default=false)",
+		"AllBeta=true|false (BETA - default=false)",
+		"TestAlpha=true|false (ALPHA - default=false)",
+		"TestAlphaNoVersion=true|false (ALPHA - default=false)",
+		"TestBeta=true|false (BETA - default=false)",
+		"TestBetaNoVersion=true|false (BETA - default=false)",
+		"TestFastBeta=true|false (BETA - default=false), or TestFastBeta=true|false (BETA - default=true) if --min-compatibility-version>=1.28",
+	}
+	assert.ElementsMatch(t, f.KnownFeatures(), knownExpected)
 }
 
 func TestVersionedFeatureGateMetrics(t *testing.T) {
@@ -1311,11 +1380,11 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
 		if err := f.AddVersioned(map[Feature]VersionedSpecs{
 			"TestFeature1": {
-				{Version: version.MustParse("1.28"), Default: true},
+				{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta},
 			},
 			"TestFeature2": {
-				{Version: version.MustParse("1.26"), Default: false},
-				{Version: version.MustParse("1.29"), Default: false},
+				{Version: version.MustParse("1.26"), Default: false, PreRelease: Alpha},
+				{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
 			},
 		}); err != nil {
 			t.Fatal(err)
@@ -1527,47 +1596,148 @@ func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
 	})
 }
 
-func TestFeatureSpecAtEmulationVersion(t *testing.T) {
+func TestFeatureGateMinCompatibilityVersion(t *testing.T) {
+	const testCompatGateA Feature = "TestCompatA"
+	const testCompatGateB Feature = "TestCompatB"
+	const testCompatGateC Feature = "TestCompatC"
+
+	f := NewVersionedFeatureGateWithMinCompatibility(version.MustParse("1.30"), version.MustParse("1.27"))
+	err := f.AddVersioned(map[Feature]VersionedSpecs{
+		testCompatGateA: {
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+			{Version: version.MustParse("1.30"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.30"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.30")},
+		},
+		testCompatGateB: {
+			{Version: version.MustParse("1.30"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.30"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.30")},
+		},
+		testCompatGateC: {
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.28")},
+			{Version: version.MustParse("1.30"), Default: true, PreRelease: GA, LockToDefault: true},
+		},
+	})
+	require.NoError(t, err)
+
+	// KnownFeatures should show min-compatibility-version requirement.
+	knownExpected := []string{
+		"AllAlpha=true|false (ALPHA - default=false)",
+		"AllBeta=true|false (BETA - default=false)",
+		"TestCompatA=true|false (BETA - default=false), or TestCompatA=true|false (BETA - default=true) if --min-compatibility-version>=1.30",
+		"TestCompatB=true|false (BETA - default=false), or TestCompatB=true|false (BETA - default=true) if --min-compatibility-version>=1.30",
+		"TestCompatC=true|false (BETA - default=false)",
+	}
+	assert.ElementsMatch(t, f.KnownFeatures(), knownExpected)
+
+	// Gate is Alpha min compat version is 1.29, feature's is 1.30. Feature should be disabled.
+	assert.False(t, f.Enabled(testCompatGateA), "TestCompatA should be disabled at Alpha stage")
+	assert.False(t, f.Enabled(testCompatGateB), "TestCompatB should be disabled when its min compat version is too high")
+	assert.False(t, f.Enabled(testCompatGateC), "TestCompatC should be disabled when its min compat version is too high")
+	// Trying to override TestCompatA default should work.
+	require.NoError(t, f.OverrideDefault(testCompatGateA, true))
+	assert.True(t, f.Enabled(testCompatGateA), "TestCompatA should be enabled after overriding default")
+	// Trying to enable TestCompatA should work.
+	require.NoError(t, f.Set(string(testCompatGateA)+"=false"))
+	assert.False(t, f.Enabled(testCompatGateA), "TestCompatA should be enabled after setting it explicitly")
+	// Trying to override TestCompatB, TestCompatC default should fail.
+	require.NoError(t, f.OverrideDefault(testCompatGateB, false))
+	require.NoError(t, f.OverrideDefault(testCompatGateC, false))
+	// Trying to enable TestCompatB, TestCompatC should work.
+	require.NoError(t, f.Set(string(testCompatGateB)+"=true"))
+	require.NoError(t, f.Set(string(testCompatGateC)+"=true"))
+
+	// reset the feature gate first so no overrides or raw flags are carried over.
+	f = f.DeepCopyAndReset().(*featureGate)
+	// Now, update the gate's min compat version.
+	require.NoError(t, f.SetEmulationVersionAndMinCompatibilityVersion(version.MustParse("1.30"), version.MustParse("1.30")))
+	// KnownFeatures should not show the min-compatibility-version requirement anymore.
+	knownExpected = []string{
+		"AllAlpha=true|false (ALPHA - default=false)",
+		"AllBeta=true|false (BETA - default=false)",
+		"TestCompatA=true|false (BETA - default=true)",
+		"TestCompatB=true|false (BETA - default=true)",
+	}
+	assert.ElementsMatch(t, f.KnownFeatures(), knownExpected)
+
+	// Feature should now be enabled by default.
+	assert.True(t, f.Enabled(testCompatGateA), "TestCompatA should be Beta and enabled when its min compat version is met")
+	assert.True(t, f.Enabled(testCompatGateB), "TestCompatB should be enabled when its min compat version is met")
+	assert.True(t, f.Enabled(testCompatGateC), "TestCompatC should be enabled when its min compat version is met")
+
+	// Trying to disable feature should succeed.
+	require.NoError(t, f.Set(string(testCompatGateA)+"=false"))
+	assert.False(t, f.Enabled(testCompatGateA), "feature should be disabled")
+	require.NoError(t, f.Set(string(testCompatGateB)+"=false"))
+	assert.False(t, f.Enabled(testCompatGateB), "feature should be disabled")
+
+	require.NoError(t, f.ResetFeatureValueToDefault(testCompatGateB))
+	assert.True(t, f.Enabled(testCompatGateB), "feature should be enabled after resetting to default")
+	// Trying to override default should now succeed.
+	require.NoError(t, f.OverrideDefault(testCompatGateB, false))
+	assert.False(t, f.Enabled(testCompatGateB), "feature should be disabled by default after override default to false")
+	// Trying to override GA default should fail.
+	require.Error(t, f.OverrideDefault(testCompatGateC, false))
+	require.Error(t, f.Set(string(testCompatGateC)+"=false"))
+}
+
+func TestFeatureSpecAtEmulationAndMinCompatVersion(t *testing.T) {
 	specs := VersionedSpecs{
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
-		{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
-		{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.25")},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: GA, MinCompatibilityVersion: version.MustParse("1.25")},
 	}
 	sort.Sort(specs)
 	tests := []struct {
-		cVersion string
-		expect   FeatureSpec
+		emuVer       *version.Version
+		minCompatVer *version.Version
+		expect       FeatureSpec
 	}{
 		{
-			cVersion: "1.30",
-			expect:   FeatureSpec{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+			emuVer: version.MustParse("1.30"),
+			expect: FeatureSpec{Version: version.MustParse("1.29"), Default: true, PreRelease: GA, MinCompatibilityVersion: version.MustParse("1.25")},
 		},
 		{
-			cVersion: "1.29",
-			expect:   FeatureSpec{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+			emuVer: version.MustParse("1.29"),
+			expect: FeatureSpec{Version: version.MustParse("1.29"), Default: true, PreRelease: GA, MinCompatibilityVersion: version.MustParse("1.25")},
 		},
 		{
-			cVersion: "1.28",
-			expect:   FeatureSpec{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+			emuVer: version.MustParse("1.28"),
+			expect: FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.25")},
 		},
 		{
-			cVersion: "1.27",
-			expect:   FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+			emuVer: version.MustParse("1.26"),
+			expect: FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.25")},
 		},
 		{
-			cVersion: "1.25",
-			expect:   FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+			emuVer:       version.MustParse("1.25"),
+			minCompatVer: version.MustParse("1.25"),
+			expect:       FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.25")},
 		},
 		{
-			cVersion: "1.24",
-			expect:   FeatureSpec{Version: version.MajorMinor(0, 0), Default: false, PreRelease: PreAlpha},
+			emuVer: version.MustParse("1.25"),
+			expect: FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+		},
+		{
+			emuVer: version.MustParse("1.24"),
+			expect: FeatureSpec{Version: version.MajorMinor(0, 0), Default: false, PreRelease: PreAlpha},
+		},
+		{
+			emuVer:       version.MustParse("1.26"),
+			minCompatVer: version.MustParse("1.23"),
+			expect:       FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+		},
+		{
+			emuVer:       version.MustParse("1.29"),
+			minCompatVer: version.MustParse("1.23"),
+			expect:       FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("featureSpecAtEmulationVersion for emulationVersion %s", test.cVersion), func(t *testing.T) {
-			result := featureSpecAtEmulationVersion(specs, version.MustParse(test.cVersion))
+		t.Run(fmt.Sprintf("featureSpecAtEmulationVersion for emulationVersion %s", test.emuVer), func(t *testing.T) {
+			result := featureSpecAtEmulationAndMinCompatVersion(specs, test.emuVer, test.minCompatVer)
 			if !reflect.DeepEqual(*result, test.expect) {
-				t.Errorf("%d: featureSpecAtEmulationVersion(, %s) Expected %v, Got %v", i, test.cVersion, test.expect, result)
+				t.Errorf("%d: featureSpecAtEmulationVersion(, %s) Expected %v, Got %v", i, test.emuVer, test.expect, result)
 			}
 		})
 	}
@@ -1884,6 +2054,191 @@ func TestAddVersioned(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "patch min compat version",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.30"), Default: false, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.30.1")},
+				},
+			},
+		},
+		{
+			name: "Alpha to GA",
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.30"), Default: true, PreRelease: GA},
+				},
+			},
+		},
+		{
+			name: "GA with default false",
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.30"), Default: false, PreRelease: GA},
+				},
+			},
+		},
+		{
+			name: "Beta to Deprecated",
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.30"), Default: false, PreRelease: Deprecated},
+				},
+			},
+		},
+		{
+			name: "Alpha to Deprecated",
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.30"), Default: false, PreRelease: Deprecated},
+				},
+			},
+		},
+		{
+			name:        "MinCompatibilityVersion > Version",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.30")},
+				},
+			},
+		},
+		{
+			name:        "decreasing minCompatibilityVersion",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Alpha, MinCompatibilityVersion: version.MustParse("1.28")},
+					{Version: version.MustParse("1.30"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.30"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.27")},
+				},
+			},
+		},
+		{
+			name:        "transition without stability change",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.30"), Default: false, PreRelease: Alpha},
+				},
+			},
+		},
+		{
+			name:        "resurrect from locked",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: GA, LockToDefault: true},
+					{Version: version.MustParse("1.30"), Default: true, PreRelease: GA, LockToDefault: false},
+				},
+			},
+		},
+		{
+			name:        "no version provided",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Default: false, PreRelease: Alpha},
+				},
+			},
+		},
+		{
+			name:        "direct to Beta with minCompatibilityVersion, no preceding entry",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+				},
+			},
+		},
+		{
+			name: "direct to Beta with minCompatibilityVersion",
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+				},
+			},
+		},
+		{
+			name:        "minCompatibilityVersion greater than version",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.30")},
+				},
+			},
+		},
+		{
+			name: "same version with different minCompatibilityVersion",
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+					{Version: version.MustParse("1.30"), Default: true, PreRelease: GA},
+				},
+			},
+		},
+		{
+			name:        "different version with different minCompatibilityVersion",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+					{Version: version.MustParse("1.30"), Default: true, PreRelease: GA},
+				},
+			},
+		},
+		{
+			name:        "same version with different stability",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+					{Version: version.MustParse("1.30"), Default: true, PreRelease: GA},
+				},
+			},
+		},
+		{
+			name:        "same version with different lockToDefault",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, LockToDefault: true, MinCompatibilityVersion: version.MustParse("1.29")},
+				},
+			},
+		},
+		{
+			name:        "only minCompatibilityVersion different",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha, MinCompatibilityVersion: version.MustParse("1.29")},
+				},
+			},
+		},
+		{
+			name:        "multiple entries for the same version and minCompatibilityVersion",
+			expectError: true,
+			features: map[Feature]VersionedSpecs{
+				testAGate: {
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha, MinCompatibilityVersion: version.MustParse("1.29")},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta, MinCompatibilityVersion: version.MustParse("1.29")},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("AddVersioned-%s", test.name), func(t *testing.T) {
@@ -2023,7 +2378,7 @@ func TestAddDependencies(t *testing.T) {
 			name: "invalid: stability inversion at later version",
 			features: map[Feature]VersionedSpecs{
 				fA: {{Version: v129, PreRelease: Alpha}, {Version: v130, PreRelease: Beta}},
-				fB: {{Version: v129, PreRelease: Alpha}, {Version: v130, PreRelease: Alpha}},
+				fB: {{Version: v129, PreRelease: Alpha}, {Version: v130, PreRelease: Alpha, Default: true}},
 			},
 			newDeps:     map[Feature][]Feature{fA: {fB}},
 			expectedErr: "BETA feature FeatureA cannot depend on ALPHA feature FeatureB at version 1.30",

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -160,7 +160,7 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 
 	// Set the emulation version mapping from the "Wardle" component to the kube component.
 	// This ensures that the emulation version of the latter is determined by the emulation version of the former.
-	utilruntime.Must(defaults.ComponentGlobalsRegistry.SetEmulationVersionMapping(apiserver.WardleComponentName, basecompatibility.DefaultKubeComponent, WardleVersionToKubeVersion))
+	utilruntime.Must(defaults.ComponentGlobalsRegistry.SetVersionMapping(apiserver.WardleComponentName, basecompatibility.DefaultKubeComponent, WardleVersionToKubeVersion))
 
 	defaults.ComponentGlobalsRegistry.AddFlags(flags)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adding the --min-compatibility-version part of [KEP-4330](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/4330-compatibility-versions?rgh-link-date=2025-04-18T19%3A45%3A43Z)

The biggest change is adding `MinCompatibilityVersion` field in feature spec, which allows setting the feature at different stages based on the server --min-compatibility-version. The usage of MinCompatibilityVersion for CEL and storage version is already in place. 

This PR also exposes the `--min-compatibility-version` flag in apiserver, kcm and scheduler. 

The `MinCompatibilityVersion` feature unlocks the option to accelerate the adoption of some features that can be accelerated if there is no backward compatibility concerns. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/4330

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new `--min-compatibility-version` command line setting for kube-apiserver, kube-controller-manager and kube-scheduler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4330
```
