### PR TITLE
DRA: Fix PrioritizedList scheduler perf test

### DIFF
--- a/test/integration/scheduler_perf/dra/prioritizedlist/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/prioritizedlist/performance-config.yaml
@@ -36,6 +36,8 @@
   - opcode: createAny
     templatePath: ../templates/deviceclass.yaml
   - opcode: createAny
+    templatePath: ../templates/deviceclass-no-devices.yaml
+  - opcode: createAny
     templatePath: ../templates/resourceclaim.yaml
     countParam: $initClaims
     namespace: init

--- a/test/integration/scheduler_perf/dra/templates/deviceclass-no-devices.yaml
+++ b/test/integration/scheduler_perf/dra/templates/deviceclass-no-devices.yaml
@@ -1,0 +1,8 @@
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: no-devices-class
+spec:
+  selectors:
+  - cel:
+      expression: device.driver == "no-such-driver.cdi.k8s.io"

--- a/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-first-available.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-first-available.yaml
@@ -9,6 +9,6 @@ spec:
       - name: req-0
         firstAvailable:
         - name: sub-0
-          deviceClassName: no-such-class
+          deviceClassName: no-devices-class
         - name: sub-1
           deviceClassName: test-class


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The test for the PrioritizedList feature in the scheduler perf tests creates ResourceClaims that references a non-existing DeviceClass. This means that none of the pods in the test actually end up getting scheduled. This change fixes the test so that the pods do get scheduled.

https://github.com/kubernetes/kubernetes/pull/133960 contains a change that will prevent these kind of tests from passing even though no pods get scheduled.


#### Which issue(s) this PR is related to:
Related-to: https://github.com/kubernetes/kubernetes/pull/133960

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
