### PR TITLE
DRA: Fix ConsumableCapacity scheduler perf test (simplified)

### DIFF
--- a/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-consumablecapacity.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-consumablecapacity.yaml
@@ -9,21 +9,12 @@ spec:
       - name: req-0
         exactly:
           deviceClassName: test-class
-          count: 2
           capacity:
             requests:
               memory: 40Gi
       - name: req-1
         exactly:
           deviceClassName: test-class
-          count: 2
           capacity:
             requests:
               memory: 40Gi
-      constraints:
-      - requests:
-        - req-0
-        distinctAttribute: dra.example.com/slice
-      - requests:
-        - req-1
-        matchAttribute: dra.example.com/slice

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-consumablecapacity.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-consumablecapacity.yaml
@@ -15,21 +15,9 @@ spec:
         operator: In
         values:
         - "true"
-  sharedCounters:
-  - name: counter-set
-    counters:
-      counter1:
-        value: "1"
-      counter2:
-        value: "1"
   devices:
   - name: shareable-device
     allowMultipleAllocations: true
-    attributes:
-      preallocate:
-        bool: false
-      dra.example.com/slice:
-        int: {{.Index}}
     capacity:
       memory:
         value: 80Gi
@@ -37,27 +25,3 @@ spec:
           default: 1Gi
           validRange:
             min: 1Gi
-  # 2 counter devices
-  - name: device-2-counters-1
-    allowMultipleAllocations: true
-    attributes:
-      preallocate:
-        bool: true
-      dra.example.com/slice:
-        int: {{.Index}}
-    capacity:
-      counters:
-        value: "2"
-      memory:
-        value: 80Gi
-        requestPolicy:
-          default: 1Gi
-          validRange:
-            min: 1Gi
-    consumesCounters:
-    - counterSet: counter-set
-      counters:
-        counter1:
-          value: "1"
-        counter2:
-          value: "1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The test for DRA Consumable Capacity failed when https://github.com/kubernetes/kubernetes/pull/133960 has been applied together with [suggested change](https://github.com/kubernetes/kubernetes/commit/3cf97b77c1a8589132d2a66939ecb5d71036ec52) that ensures the pod will be created even the flag is set and duration is zero.

The failure might relate to the bug report in https://github.com/kubernetes/kubernetes/issues/133705. To reduce complexity of the current test case, I simplify the test case by limit to single device and remove the counter reference from [Partitionable Device](https://github.com/kubernetes/enhancements/issues/4815) feature.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

KEP: https://github.com/kubernetes/enhancements/issues/5075
Related to: https://github.com/kubernetes/kubernetes/pull/133960

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
