### PR TITLE
Fix minor inconsistencies in scheduler

### DIFF
--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -124,10 +124,6 @@ var ExpandedPluginsV1 = &config.Plugins{
 			// - This is a score coming from user preference.
 			{Name: names.NodeAffinity, Weight: 2},
 			{Name: names.NodeResourcesFit, Weight: 1},
-			// Weight is tripled because:
-			// - This is a score coming from user preference.
-			// - Usage of node tainting to group nodes in the cluster is increasing becoming a use-case
-			//	 for many user workloads
 			{Name: names.VolumeBinding, Weight: 1},
 			// Weight is doubled because:
 			// - This is a score coming from user preference.

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -1843,7 +1843,6 @@ func TestCustomOrdering(t *testing.T) {
 func TestPodEligibleToPreemptOthers(t *testing.T) {
 	tests := []struct {
 		name                string
-		fts                 feature.Features
 		pod                 *v1.Pod
 		pods                []*v1.Pod
 		nodes               []string

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -115,7 +115,7 @@ func (pl *CSILimits) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 		}
 	}
 
-	logger.V(5).Info("The deleted pod does not impact the scheduling of the unscheduled pod", "deletedPod", klog.KObj(pod), "pod", klog.KObj(deletedPod))
+	logger.V(5).Info("The deleted pod does not impact the scheduling of the unscheduled pod", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
 	return fwk.QueueSkip, nil
 }
 

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -367,13 +367,13 @@ type Plugin interface {
 }
 
 // PreEnqueuePlugin is an interface that must be implemented by "PreEnqueue" plugins.
-// These plugins are called prior to adding Pods to activeQ.
+// These plugins are called prior to adding Pods to activeQ or backoffQ.
 // Note: an preEnqueue plugin is expected to be lightweight and efficient, so it's not expected to
 // involve expensive calls like accessing external endpoints; otherwise it'd block other
 // Pods' enqueuing in event handlers.
 type PreEnqueuePlugin interface {
 	Plugin
-	// PreEnqueue is called prior to adding Pods to activeQ.
+	// PreEnqueue is called prior to adding Pods to activeQ or backoffQ.
 	PreEnqueue(ctx context.Context, p *v1.Pod) *Status
 }
 

--- a/test/integration/scheduler/queueing/former/queue_test.go
+++ b/test/integration/scheduler/queueing/former/queue_test.go
@@ -27,10 +27,10 @@ import (
 	"k8s.io/kubernetes/test/integration/scheduler/queueing"
 )
 
-// TestCoreResourceEnqueueWithQueueingHints verify Pods failed by in-tree default plugins can be
+// TestCoreResourceEnqueueWithoutQueueingHints verify Pods failed by in-tree default plugins can be
 // moved properly upon their registered events.
 // Here, we run only the test cases where the EnableSchedulingQueueHint is disabled.
-func TestCoreResourceEnqueueWithQueueingHints(t *testing.T) {
+func TestCoreResourceEnqueueWithoutQueueingHints(t *testing.T) {
 	for _, tt := range queueing.CoreResourceEnqueueTestCases {
 		if tt.EnableSchedulingQueueHint != nil && !tt.EnableSchedulingQueueHint.Has(false) {
 			continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR fixes some minor issues that I've encountered recently. These include:
- Invalid comment in default scheduler config used for testing
- Unused fields in DefaultPreemption plugin
- Incorrect pods logged by the NodeVolumeLimits plugin
- Outdated PreEnqueue comment
- Creating unnecessary test context when the other is available
- Invalid queueing test name with hints disabled

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
