### PR TITLE
Disable too short scheduler_perf workloads

### DIFF
--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -151,8 +151,10 @@ The test cases labeled as `short` are executed in pull-kubernetes-integration jo
 | ci-kubernetes-integration-master | integration-test       |
 | pull-kubernetes-integration      | integration-test,short |
 | ci-benchmark-scheduler-perf      | performance            |
+| pull-kubernetes-scheduler-perf   | performance            |
 
 See the comment on [./misc/performance-config.yaml](./misc/performance-config.yaml) for the details.
+Workloads without any labels are good for local usage, because they run faster than performance ones.
 
 ## Scheduling throughput thresholds
 

--- a/test/integration/scheduler_perf/affinity/performance-config.yaml
+++ b/test/integration/scheduler_perf/affinity/performance-config.yaml
@@ -50,13 +50,11 @@
       initPods: 1
       measurePods: 4
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 100
       measurePods: 400
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 1000
@@ -117,7 +115,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -180,13 +177,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance]
     params:
       initNodes: 5000
       initPods: 5000
@@ -243,7 +238,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -305,13 +299,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 5000
@@ -387,13 +379,11 @@
       initPods: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 200
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance]
     params:
       initNodes: 5000
       initPods: 2000
@@ -460,7 +450,6 @@
       initNamespaces: 2
       measurePods: 6
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
@@ -537,7 +526,6 @@
       initNamespaces: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
@@ -617,7 +605,6 @@
       initNamespaces: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
@@ -694,14 +681,12 @@
       initNamespaces: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
       initNamespaces: 10
       measurePods: 100
   - name: 5000Nodes
-    labels: [performance]
     params:
       initNodes: 5000
       initPodsPerNamespace: 50

--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -55,13 +55,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 1000
@@ -278,7 +276,6 @@
       initPods: 20
       measurePods: 5
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 2000
@@ -369,13 +366,11 @@
       initPods: 1
       measurePods: 10
   - name: 500Nodes/10Init/1kPods
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 10
       measurePods: 1000
   - name: 5kNodes/100Init/1kPods
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 100
@@ -468,12 +463,10 @@
       initNodes: 10
       measurePods: 100
   - name: 1000Nodes
-    labels: [performance, short]
     params:
       initNodes: 1000
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       measurePods: 2000
@@ -604,7 +597,6 @@
   - name: 1000Node_1000DeletingPods
     featureGates:
       SchedulerQueueingHints: false
-    labels: [performance, short]
     params:
       initNodes: 1000
       deletingPods: 1000
@@ -612,11 +604,26 @@
   - name: 1000Node_1000DeletingPods_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
-    labels: [performance, short]
     params:
       initNodes: 1000
       deletingPods: 1000
       measurePods: 1000
+  - name: 5000Node_5000DeletingPods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    params:
+      initNodes: 5000
+      deletingPods: 5000
+      measurePods: 5000
+  - name: 5000Node_5000DeletingPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
+    params:
+      initNodes: 5000
+      deletingPods: 5000
+      measurePods: 5000
 
 ## SchedulingWithExtendedResource uses pods with extended resources requests.
 - name: SchedulingWithExtendedResource
@@ -657,7 +664,6 @@
   - name: 500pods_500nodes
     featureGates:
       DRAExtendedResource: false
-    labels: [performance, short]
     params:
       nodesWithExtendedResource: 500
       nodesWithoutExtendedResource: 0
@@ -665,7 +671,6 @@
   - name: 500pods_500nodes_DRAExtendedResourceEnabled
     featureGates:
       DRAExtendedResource: true
-    labels: [performance, short]
     params:
       nodesWithExtendedResource: 500
       nodesWithoutExtendedResource: 0

--- a/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
+++ b/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
@@ -50,7 +50,6 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 1000
@@ -113,7 +112,6 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 1000
@@ -182,7 +180,6 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 1000
@@ -241,7 +238,6 @@
       normalNodes: 4
       measurePods: 4
   - name: 500Nodes
-    labels: [performance, short]
     params:
       taintNodes: 100
       normalNodes: 400

--- a/test/integration/scheduler_perf/volumes/performance-config.yaml
+++ b/test/integration/scheduler_perf/volumes/performance-config.yaml
@@ -45,13 +45,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 5000
@@ -106,7 +104,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -176,7 +173,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -244,7 +240,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Smaller scheduler_perf workloads run too quickly to get any relevant results from them. Since we have larger workloads, the smaller ones can be disabled, which will shorten the duration of the tests. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
