### PR TITLE
scheduler_perf: wait for first consumer static volume

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -699,6 +699,7 @@ type createPodsOp struct {
 	// Optional
 	PersistentVolumeTemplatePath      *string
 	PersistentVolumeClaimTemplatePath *string
+	PersistentVolumeBound             *bool
 }
 
 func (cpo *createPodsOp) isValid(allowParameterization bool) error {
@@ -716,6 +717,9 @@ func (cpo *createPodsOp) isValid(allowParameterization bool) error {
 	}
 	if cpo.SteadyState && !allowParameterization && cpo.Duration.Duration <= 0 {
 		return errors.New("when creating pods in a steady state, the test duration must be > 0")
+	}
+	if (cpo.PersistentVolumeTemplatePath != nil) != (cpo.PersistentVolumeClaimTemplatePath != nil) {
+		return errors.New("persistentVolumeClaimTemplatePath and persistentVolumeTemplatePath must be specified together")
 	}
 	return nil
 }
@@ -2402,7 +2406,8 @@ func getPodStrategy(cpo *createPodsOp) (testutils.TestPodCreateStrategy, error) 
 	if err != nil {
 		return nil, err
 	}
-	return testutils.NewCreatePodWithPersistentVolumeStrategy(pvcTemplate, getCustomVolumeFactory(pvTemplate), podTemplate), nil
+	bindVolume := ptr.Deref(cpo.PersistentVolumeBound, true)
+	return testutils.NewCreatePodWithPersistentVolumeStrategy(pvcTemplate, getCustomVolumeFactory(pvTemplate), podTemplate, bindVolume), nil
 }
 
 type nodeTemplateFromFile string
@@ -2441,10 +2446,10 @@ func getPersistentVolumeClaimSpecFromFile(path *string) (*v1.PersistentVolumeCla
 	return persistentVolumeClaimSpec, nil
 }
 
-func getCustomVolumeFactory(pvTemplate *v1.PersistentVolume) func(id int) *v1.PersistentVolume {
-	return func(id int) *v1.PersistentVolume {
+func getCustomVolumeFactory(pvTemplate *v1.PersistentVolume) func(namePrefix string, id int) *v1.PersistentVolume {
+	return func(namePrefix string, id int) *v1.PersistentVolume {
 		pv := pvTemplate.DeepCopy()
-		volumeID := fmt.Sprintf("vol-%d", id)
+		volumeID := fmt.Sprintf("%s-%d", namePrefix, id)
 		pv.ObjectMeta.Name = volumeID
 		pvs := pv.Spec.PersistentVolumeSource
 		if pvs.CSI != nil {

--- a/test/integration/scheduler_perf/volumes/performance-config.yaml
+++ b/test/integration/scheduler_perf/volumes/performance-config.yaml
@@ -269,6 +269,46 @@
       initPods: 5000
       measurePods: 5000
 
+- name: StaticDelayedBindingPVs
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: ../templates/node-default.yaml
+    nodeAllocatableStrategy:
+      nodeAllocatable:
+        attachable-volumes-csi-ebs.csi.aws.com: "39"
+      csiNodeAllocatable:
+        ebs.csi.aws.com:
+          count: 39
+  - opcode: createPods
+    countParam: $initPods
+    persistentVolumeTemplatePath: ../templates/pv-csi.yaml
+    persistentVolumeClaimTemplatePath: ../templates/pvc.yaml
+  - opcode: createPods
+    countParam: $measurePods
+    persistentVolumeTemplatePath: ../templates/pv-csi.yaml
+    persistentVolumeClaimTemplatePath: ../templates/pvc.yaml
+    persistentVolumeBound: false
+    collectMetrics: true
+  workloads:
+  - name: 5Nodes
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 100Nodes_500Pods
+    params:
+      initNodes: 100
+      initPods: 500
+      measurePods: 500
+  - name: 1000Nodes_5000Pods
+    labels: [performance]
+    params:
+      initNodes: 1000
+      initPods: 5000
+      measurePods: 5000
+
 - name: PreemptionPVs
   workloadTemplate:
   - opcode: createNodes

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -146,8 +146,12 @@ func CreateResourceClaimController(ctx context.Context, tb ktesting.TB, clientSe
 // TODO(mborsz): Use a real PV controller here.
 func StartFakePVController(ctx context.Context, clientSet clientset.Interface, informerFactory informers.SharedInformerFactory) {
 	pvInformer := informerFactory.Core().V1().PersistentVolumes()
+	queue := make(chan *v1.PersistentVolume, 30)
+	logger := klog.FromContext(ctx).WithName("fakePVController")
+	logger.V(1).Info("Using fake PV controller")
 
 	syncPV := func(obj *v1.PersistentVolume) {
+		logger.V(4).Info("Sync PV", "pv", obj.Name)
 		if obj.Spec.ClaimRef != nil {
 			claimRef := obj.Spec.ClaimRef
 			pvc, err := clientSet.CoreV1().PersistentVolumeClaims(claimRef.Namespace).Get(ctx, claimRef.Name, metav1.GetOptions{})
@@ -157,7 +161,7 @@ func StartFakePVController(ctx context.Context, clientSet clientset.Interface, i
 				// check is conservative and only ignores the "context canceled"
 				// error while shutting down.
 				if ctx.Err() == nil || !errors.Is(err, context.Canceled) {
-					klog.Errorf("error while getting %v/%v: %v", claimRef.Namespace, claimRef.Name, err)
+					logger.Error(err, "error while getting PVC", "pvc", klog.KRef(claimRef.Namespace, claimRef.Name))
 				}
 				return
 			}
@@ -169,22 +173,35 @@ func StartFakePVController(ctx context.Context, clientSet clientset.Interface, i
 				if err != nil {
 					if ctx.Err() == nil || !errors.Is(err, context.Canceled) {
 						// Shutting down, no need to record this.
-						klog.Errorf("error while updating %v/%v: %v", claimRef.Namespace, claimRef.Name, err)
+						logger.Error(err, "error while updating pvc", "pvc", klog.KObj(pvc))
 					}
 					return
 				}
+				logger.V(2).Info("pretend PV bound", "pvc", klog.KObj(pvc), "pv", klog.KObj(obj))
 			}
 		}
 	}
 
 	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			syncPV(obj.(*v1.PersistentVolume))
+			queue <- obj.(*v1.PersistentVolume)
 		},
 		UpdateFunc: func(_, obj interface{}) {
-			syncPV(obj.(*v1.PersistentVolume))
+			queue <- obj.(*v1.PersistentVolume)
 		},
 	})
+	for range 30 {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case pv := <-queue:
+					syncPV(pv)
+				}
+			}
+		}()
+	}
 }
 
 // CreateGCController creates a garbage controller and returns a run function

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	apps "k8s.io/api/apps/v1"
@@ -1188,22 +1189,17 @@ func CreatePod(ctx context.Context, client clientset.Interface, namespace string
 }
 
 func CreatePodWithPersistentVolume(ctx context.Context, client clientset.Interface, namespace string, claimTemplate *v1.PersistentVolumeClaim, factory volumeFactory, podTemplate PodTemplate, count int, bindVolume bool) error {
-	var createError error
-	lock := sync.Mutex{}
+	var createError atomic.Pointer[error]
+	saveErr := func(err error) {
+		createError.Store(&err)
+	}
 	createPodFunc := func(i int) {
 		pvcName := fmt.Sprintf("pvc-%d", i)
 		// pvc
 		pvc := claimTemplate.DeepCopy()
 		pvc.Name = pvcName
 		// pv
-		pv := factory(i)
-		// PVs are cluster-wide resources.
-		// Prepend a namespace to make the name globally unique.
-		pv.Name = fmt.Sprintf("%s-%s", namespace, pv.Name)
-		pvs := pv.Spec.PersistentVolumeSource
-		if pvs.CSI != nil {
-			pvs.CSI.VolumeHandle = pv.Name
-		}
+		pv := factory(namespace, i)
 		if bindVolume {
 			// bind pv to "pvc-$i"
 			pv.Spec.ClaimRef = &v1.ObjectReference{
@@ -1218,45 +1214,50 @@ func CreatePodWithPersistentVolume(ctx context.Context, client clientset.Interfa
 			pvc.Spec.VolumeName = pv.Name
 			pvc.Status.Phase = v1.ClaimBound
 		} else {
+			scName := "wait-for-first-consumer"
+			_, err := client.StorageV1().StorageClasses().Create(ctx, &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: scName,
+				},
+				Provisioner:       "example.com/provisioner",
+				VolumeBindingMode: ptr.To(storagev1.VolumeBindingWaitForFirstConsumer),
+			}, metav1.CreateOptions{})
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				saveErr(fmt.Errorf("error creating storage class: %w", err))
+				return
+			}
+
+			pvc.Spec.StorageClassName = &scName
+			pv.Spec.StorageClassName = scName
 			pv.Status.Phase = v1.VolumeAvailable
 		}
 
 		// Create PVC first as it's referenced by the PV when the `bindVolume` is true.
 		if err := CreatePersistentVolumeClaimWithRetries(client, namespace, pvc); err != nil {
-			lock.Lock()
-			defer lock.Unlock()
-			createError = fmt.Errorf("error creating PVC: %s", err)
+			saveErr(fmt.Errorf("error creating PVC: %w", err))
 			return
 		}
 
 		// We need to update statuses separately, as creating pv/pvc resets status to the default one.
 		if _, err := client.CoreV1().PersistentVolumeClaims(namespace).UpdateStatus(ctx, pvc, metav1.UpdateOptions{}); err != nil {
-			lock.Lock()
-			defer lock.Unlock()
-			createError = fmt.Errorf("error updating PVC status: %s", err)
+			saveErr(fmt.Errorf("error updating PVC status: %w", err))
 			return
 		}
 
 		if err := CreatePersistentVolumeWithRetries(client, pv); err != nil {
-			lock.Lock()
-			defer lock.Unlock()
-			createError = fmt.Errorf("error creating PV: %s", err)
+			saveErr(fmt.Errorf("error creating PV: %w", err))
 			return
 		}
 		// We need to update statuses separately, as creating pv/pvc resets status to the default one.
 		if _, err := client.CoreV1().PersistentVolumes().UpdateStatus(ctx, pv, metav1.UpdateOptions{}); err != nil {
-			lock.Lock()
-			defer lock.Unlock()
-			createError = fmt.Errorf("error updating PV status: %s", err)
+			saveErr(fmt.Errorf("error updating PV status: %w", err))
 			return
 		}
 
 		// pod
 		pod, err := podTemplate.GetPodTemplate(i, count)
 		if err != nil {
-			lock.Lock()
-			defer lock.Unlock()
-			createError = fmt.Errorf("error getting pod template: %s", err)
+			saveErr(fmt.Errorf("error getting pod template: %w", err))
 			return
 		}
 		pod = pod.DeepCopy()
@@ -1271,19 +1272,17 @@ func CreatePodWithPersistentVolume(ctx context.Context, client clientset.Interfa
 			},
 		}
 		if err := makeCreatePod(client, namespace, pod); err != nil {
-			lock.Lock()
-			defer lock.Unlock()
-			createError = err
+			saveErr(err)
 			return
 		}
 	}
 
-	if count < 30 {
-		workqueue.ParallelizeUntil(ctx, count, count, createPodFunc)
-	} else {
-		workqueue.ParallelizeUntil(ctx, 30, count, createPodFunc)
+	workqueue.ParallelizeUntil(ctx, 30, count, createPodFunc)
+	var err error
+	if errp := createError.Load(); errp != nil {
+		err = *errp
 	}
-	return createError
+	return err
 }
 
 func NewCustomCreatePodStrategy(podTemplate PodTemplate) TestPodCreateStrategy {
@@ -1293,7 +1292,7 @@ func NewCustomCreatePodStrategy(podTemplate PodTemplate) TestPodCreateStrategy {
 }
 
 // volumeFactory creates an unique PersistentVolume for given integer.
-type volumeFactory func(uniqueID int) *v1.PersistentVolume
+type volumeFactory func(namePrefix string, uniqueID int) *v1.PersistentVolume
 
 // PodTemplate is responsible for creating a v1.Pod instance that is ready
 // to be sent to the API server.
@@ -1320,9 +1319,9 @@ func (s *staticPodTemplate) GetPodTemplate(index, count int) (*v1.Pod, error) {
 	return (*v1.Pod)(s), nil
 }
 
-func NewCreatePodWithPersistentVolumeStrategy(claimTemplate *v1.PersistentVolumeClaim, factory volumeFactory, podTemplate PodTemplate) TestPodCreateStrategy {
+func NewCreatePodWithPersistentVolumeStrategy(claimTemplate *v1.PersistentVolumeClaim, factory volumeFactory, podTemplate PodTemplate, bindVolume bool) TestPodCreateStrategy {
 	return func(ctx context.Context, client clientset.Interface, namespace string, podCount int) error {
-		return CreatePodWithPersistentVolume(ctx, client, namespace, claimTemplate, factory, podTemplate, podCount, true /* bindVolume */)
+		return CreatePodWithPersistentVolume(ctx, client, namespace, claimTemplate, factory, podTemplate, podCount, bindVolume)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add scheduler performance integration test for volumes with StorageClass WaitForFirstConsumer set to true, where scheduler is responsible for select which PV to bind to the PVCs used by pod.

The motivation is verifying the performance impact of https://github.com/kubernetes/kubernetes/pull/133929. But I think this is generally valuable. We plan to optimize this soon.

This was added in https://github.com/kubernetes/kubernetes/pull/88318, but removed in https://github.com/kubernetes/kubernetes/pull/109696. I'm trying to add it back.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
