### PR TITLE
Update base image to fedora:39 for volume/rbd test container

### DIFF
--- a/test/images/volume/rbd/BASEIMAGE
+++ b/test/images/volume/rbd/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=fedora:38
-linux/arm64=arm64v8/fedora:38
-linux/ppc64le=ppc64le/fedora:38
-linux/s390x=s390x/fedora:38
+linux/amd64=fedora:39
+linux/arm64=arm64v8/fedora:39
+linux/ppc64le=ppc64le/fedora:39
+linux/s390x=s390x/fedora:39


### PR DESCRIPTION
Update base image to fedora:39 for volume/rbd test container

This PR updates the base image used by the `volume/rbd` test container from `fedora:38` to `fedora:39` across all supported platforms.

The change is isolated to the `BASEIMAGE` file and ensures compatibility with the latest Fedora release while maintaining reproducibility.

Ref: [Issue #131874](https://github.com/kubernetes/kubernetes/issues/131874)

```release-note
NONE
```
