### PR TITLE
Automated cherry pick of #133573: fix: Update unit test to catch actual nil Labels case and fix functionality to handle nil Labels

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go
@@ -77,6 +77,9 @@ func (ll *LeaseLock) Update(ctx context.Context, ler LeaderElectionRecord) error
 	ll.lease.Spec = LeaderElectionRecordToLeaseSpec(&ler)
 
 	if ll.Labels != nil {
+		if ll.lease.Labels == nil {
+			ll.lease.Labels = map[string]string{}
+		}
 		// Only overwrite the labels that are specifically set
 		for k, v := range ll.Labels {
 			ll.lease.Labels[k] = v

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
@@ -266,7 +266,28 @@ func TestLeaseConversion(t *testing.T) {
 	}
 }
 
-func TestUpdateWithNilLabels(t *testing.T) {
+func TestUpdateWithNilLabelsOnLease(t *testing.T) {
+	setup()
+
+	// Create initial lease
+	if err := leaseLock.Create(context.Background(), testRecord); err != nil {
+		t.Fatalf("Failed to create lease: %v", err)
+	}
+	// Get the lease to initialize leaseLock.lease
+	if _, _, err := leaseLock.Get(context.Background()); err != nil {
+		t.Fatalf("Failed to get lease: %v", err)
+	}
+
+	leaseLock.Labels = map[string]string{"custom-key": "custom-val"}
+
+	// Update should succeed even with nil Labels on the lease itself
+	if err := leaseLock.Update(context.Background(), testRecord); err != nil {
+		t.Errorf("Update failed with nil Labels: %v", err)
+	}
+}
+
+
+func TestUpdateWithNilLabelsOnLeaseLock(t *testing.T) {
 	setup()
 
 	// Create initial lease
@@ -280,21 +301,7 @@ func TestUpdateWithNilLabels(t *testing.T) {
 
 	leaseLock.lease.Labels = map[string]string{"custom-key": "custom-val"}
 
-	// Update labels
-	lease, err := leaseLock.Client.Leases(testNamespace).Update(context.Background(), leaseLock.lease, metav1.UpdateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to update lease labels: %v", err)
-	}
-
-	val, exists := lease.Labels["custom-key"]
-	if !exists {
-		t.Error("Label was overidden on the lease")
-	}
-	if val != "custom-val" {
-		t.Errorf("Label value mismatch, got %q want %q", val, "custom-val")
-	}
-
-	// Update should succeed even with nil Labels
+	// Update should succeed even with nil Labels on the leaselock
 	if err := leaseLock.Update(context.Background(), testRecord); err != nil {
 		t.Errorf("Update failed with nil Labels: %v", err)
 	}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock_test.go
@@ -278,6 +278,8 @@ func TestUpdateWithNilLabelsOnLease(t *testing.T) {
 		t.Fatalf("Failed to get lease: %v", err)
 	}
 
+	leaseLock.lease.Labels = nil
+
 	leaseLock.Labels = map[string]string{"custom-key": "custom-val"}
 
 	// Update should succeed even with nil Labels on the lease itself
@@ -285,7 +287,6 @@ func TestUpdateWithNilLabelsOnLease(t *testing.T) {
 		t.Errorf("Update failed with nil Labels: %v", err)
 	}
 }
-
 
 func TestUpdateWithNilLabelsOnLeaseLock(t *testing.T) {
 	setup()
@@ -298,6 +299,8 @@ func TestUpdateWithNilLabelsOnLeaseLock(t *testing.T) {
 	if _, _, err := leaseLock.Get(context.Background()); err != nil {
 		t.Fatalf("Failed to get lease: %v", err)
 	}
+
+	leaseLock.Labels = nil
 
 	leaseLock.lease.Labels = map[string]string{"custom-key": "custom-val"}
 


### PR DESCRIPTION
Cherry pick of #133573 on release-1.34.

#133573: fix: Update unit test to catch actual nil Labels case and fix functionality to handle nil Labels

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```