### PR TITLE
node_e2e: fix kubelet configuration setup

### DIFF
--- a/test/e2e_node/container_restart_test.go
+++ b/test/e2e_node/container_restart_test.go
@@ -67,7 +67,10 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			initialConfig.CrashLoopBackOff.MaxContainerRestartPeriod = &metav1.Duration{Duration: time.Duration(30 * time.Second)}
-			initialConfig.FeatureGates = map[string]bool{"KubeletCrashLoopBackOffMax": true}
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
+			}
+			initialConfig.FeatureGates["KubeletCrashLoopBackOffMax"] = true
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -88,7 +91,10 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 	ginkgo.Context("Reduced default container restart backs off as expected", func() {
 
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-			initialConfig.FeatureGates = map[string]bool{"ReduceDefaultCrashLoopBackOffDecay": true}
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
+			}
+			initialConfig.FeatureGates["ReduceDefaultCrashLoopBackOffDecay"] = true
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -111,9 +117,12 @@ var _ = SIGDescribe("Container Restart", feature.CriProxy, framework.WithSerial(
 	ginkgo.Context("Lower node config container restart takes precedence", func() {
 
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-			initialConfig.FeatureGates = map[string]bool{"ReduceDefaultCrashLoopBackOffDecay": true}
 			initialConfig.CrashLoopBackOff.MaxContainerRestartPeriod = &metav1.Duration{Duration: time.Duration(1 * time.Second)}
-			initialConfig.FeatureGates = map[string]bool{"KubeletCrashLoopBackOffMax": true}
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
+			}
+			initialConfig.FeatureGates["ReduceDefaultCrashLoopBackOffDecay"] = true
+			initialConfig.FeatureGates["KubeletCrashLoopBackOffMax"] = true
 		})
 
 		ginkgo.BeforeEach(func() {

--- a/test/e2e_node/kubelet_config_dir_test.go
+++ b/test/e2e_node/kubelet_config_dir_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -28,6 +29,7 @@ import (
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/utils/cpuset"
 )
 
 var _ = SIGDescribe("Kubelet Config", framework.WithSlow(), framework.WithSerial(), framework.WithDisruptive(), feature.KubeletConfigDropInDir, func() {
@@ -137,6 +139,12 @@ featureGates:
 			initialConfig.ReadOnlyPort = int32(10257) // overridden by second file.
 			if initialConfig.SystemReserved == nil {
 				initialConfig.SystemReserved = map[string]string{}
+			}
+			if initialConfig.ReservedSystemCPUs != "" {
+				reservedCPUSet, err := cpuset.Parse(initialConfig.ReservedSystemCPUs)
+				if err == nil {
+					initialConfig.SystemReserved["cpu"] = strconv.Itoa(reservedCPUSet.Size())
+				}
 			}
 			initialConfig.SystemReserved["memory"] = "2Gi"
 			initialConfig.ClusterDNS = []string{"192.168.1.1", "192.168.1.5", "192.168.1.8"} // overridden by slice in second file.

--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -93,10 +93,11 @@ var _ = SIGDescribe("GracefulNodeShutdown", framework.WithSerial(), feature.Grac
 		)
 
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-			initialConfig.FeatureGates = map[string]bool{
-				string(features.GracefulNodeShutdown):                   true,
-				string(features.GracefulNodeShutdownBasedOnPodPriority): false,
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
 			}
+			initialConfig.FeatureGates[string(features.GracefulNodeShutdown)] = true
+			initialConfig.FeatureGates[string(features.GracefulNodeShutdownBasedOnPodPriority)] = false
 			initialConfig.ShutdownGracePeriod = metav1.Duration{Duration: nodeShutdownGracePeriod}
 		})
 
@@ -195,11 +196,13 @@ var _ = SIGDescribe("GracefulNodeShutdown", framework.WithSerial(), feature.Grac
 		)
 
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-			initialConfig.FeatureGates = map[string]bool{
-				string(features.GracefulNodeShutdown):                   true,
-				string(features.GracefulNodeShutdownBasedOnPodPriority): false,
-				string(features.PodReadyToStartContainersCondition):     true,
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
 			}
+			initialConfig.FeatureGates[string(features.GracefulNodeShutdown)] = true
+			initialConfig.FeatureGates[string(features.GracefulNodeShutdownBasedOnPodPriority)] = false
+			initialConfig.FeatureGates[string(features.PodReadyToStartContainersCondition)] = true
+
 			initialConfig.ShutdownGracePeriod = metav1.Duration{Duration: nodeShutdownGracePeriod}
 			initialConfig.ShutdownGracePeriodCriticalPods = metav1.Duration{Duration: nodeShutdownGracePeriodCriticalPods}
 		})
@@ -390,10 +393,12 @@ var _ = SIGDescribe("GracefulNodeShutdown", framework.WithSerial(), feature.Grac
 		)
 
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-			initialConfig.FeatureGates = map[string]bool{
-				string(features.GracefulNodeShutdown):                   true,
-				string(features.GracefulNodeShutdownBasedOnPodPriority): true,
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
 			}
+			initialConfig.FeatureGates[string(features.GracefulNodeShutdown)] = true
+			initialConfig.FeatureGates[string(features.GracefulNodeShutdownBasedOnPodPriority)] = true
+
 			initialConfig.ShutdownGracePeriodByPodPriority = []kubeletconfig.ShutdownGracePeriodByPodPriority{
 				{
 					Priority:                   scheduling.SystemCriticalPriority,

--- a/test/e2e_node/pod_conditions_test.go
+++ b/test/e2e_node/pod_conditions_test.go
@@ -50,9 +50,10 @@ var _ = SIGDescribe("Pod conditions managed by Kubelet", func() {
 
 	f.Context("including PodReadyToStartContainers condition", f.WithSerial(), feature.PodReadyToStartContainersCondition, func() {
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-			initialConfig.FeatureGates = map[string]bool{
-				string(features.PodReadyToStartContainersCondition): true,
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = map[string]bool{}
 			}
+			initialConfig.FeatureGates[string(features.PodReadyToStartContainersCondition)] = true
 		})
 		ginkgo.It("a pod without init containers should report all conditions set in expected order after the pod is up", runPodReadyConditionsTest(f, false, true))
 		ginkgo.It("a pod with init containers should report all conditions set in expected order after the pod is up", runPodReadyConditionsTest(f, true, true))


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
```
{ failed [FAILED] Merged kubelet config does not match the expected configuration.
Expected object to be comparable, diff:   &config.KubeletConfiguration{
  	... // 95 identical fields
  	AllowedUnsafeSysctls:    nil,
  	KernelMemcgNotification: true,
  	SystemReserved: map[string]string{
+ 		"cpu":    "1",
  		"memory": "2Gi",
  	},
  	KubeReserved:         nil,
  	SystemReservedCgroup: "",
  	... // 24 identical fields
```

#### Which issue(s) this PR is related to:

Fixes #133457 

#### Special notes for your reviewer:

follow up of https://github.com/kubernetes/kubernetes/pull/133955.
- fixed only `FeatureGates` merge problem

https://github.com/kubernetes/kubernetes/blob/1496b35a4a2928b087e0d7c82a6a69752bc34165/cmd/kubelet/app/server.go#L789-L805

#### Does this PR introduce a user-facing change?

```release-note
None
```
