### PR TITLE
kubeadm: fix KUBEADM_UPGRADE_DRYRUN_DIR not honored in upgrade phase when writing kubelet config files

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -351,11 +351,11 @@ func newInitData(cmd *cobra.Command, args []string, initOptions *initOptions, ou
 		return nil, err
 	}
 
-	// if dry running creates a temporary folder for saving kubeadm generated files
+	// If dry running creates a temporary directory for saving kubeadm generated files.
 	dryRunDir := ""
 	if initOptions.dryRun || cfg.DryRun {
 		if dryRunDir, err = kubeadmconstants.GetDryRunDir(kubeadmconstants.EnvVarInitDryRunDir, "kubeadm-init-dryrun", klog.Warningf); err != nil {
-			return nil, errors.Wrap(err, "couldn't create a temporary directory")
+			return nil, errors.Wrap(err, "could not create a temporary directory")
 		}
 	}
 
@@ -475,7 +475,7 @@ func (d *initData) KubeConfig() (*clientcmdapi.Config, error) {
 	return d.kubeconfig, nil
 }
 
-// KubeConfigDir returns the path of the Kubernetes configuration folder or the temporary folder path in case of DryRun.
+// KubeConfigDir returns the Kubernetes configuration directory or the temporary directory if DryRun is true.
 func (d *initData) KubeConfigDir() string {
 	if d.dryRun {
 		return d.dryRunDir
@@ -491,7 +491,7 @@ func (d *initData) KubeConfigPath() string {
 	return d.kubeconfigPath
 }
 
-// ManifestDir returns the path where manifest should be stored or the temporary folder path in case of DryRun.
+// ManifestDir returns the path where manifest should be stored or the temporary directory if DryRun is true.
 func (d *initData) ManifestDir() string {
 	if d.dryRun {
 		return d.dryRunDir
@@ -499,7 +499,7 @@ func (d *initData) ManifestDir() string {
 	return kubeadmconstants.GetStaticPodDirectory()
 }
 
-// KubeletDir returns path of the kubelet configuration folder or the temporary folder in case of DryRun.
+// KubeletDir returns the kubelet configuration directory or the temporary directory if DryRun is true.
 func (d *initData) KubeletDir() string {
 	if d.dryRun {
 		return d.dryRunDir

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -355,7 +355,7 @@ func newInitData(cmd *cobra.Command, args []string, initOptions *initOptions, ou
 	dryRunDir := ""
 	if initOptions.dryRun || cfg.DryRun {
 		if dryRunDir, err = kubeadmconstants.GetDryRunDir(kubeadmconstants.EnvVarInitDryRunDir, "kubeadm-init-dryrun", klog.Warningf); err != nil {
-			return nil, errors.Wrap(err, "could not create a temporary directory")
+			return nil, errors.Wrap(err, "could not create a temporary directory on dryrun")
 		}
 	}
 

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -467,7 +467,7 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 	dryRunDir := ""
 	if opt.dryRun || cfg.DryRun {
 		if dryRunDir, err = kubeadmconstants.GetDryRunDir(kubeadmconstants.EnvVarJoinDryRunDir, "kubeadm-join-dryrun", klog.Warningf); err != nil {
-			return nil, errors.Wrap(err, "could not create a temporary directory")
+			return nil, errors.Wrap(err, "could not create a temporary directory on dryrun")
 		}
 	}
 

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -463,11 +463,11 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 		}
 	}
 
-	// if dry running, creates a temporary folder to save kubeadm generated files
+	// If dry running creates a temporary directory for saving kubeadm generated files.
 	dryRunDir := ""
 	if opt.dryRun || cfg.DryRun {
 		if dryRunDir, err = kubeadmconstants.GetDryRunDir(kubeadmconstants.EnvVarJoinDryRunDir, "kubeadm-join-dryrun", klog.Warningf); err != nil {
-			return nil, errors.Wrap(err, "couldn't create a temporary directory on dryrun")
+			return nil, errors.Wrap(err, "could not create a temporary directory")
 		}
 	}
 
@@ -500,7 +500,7 @@ func (j *joinData) DryRun() bool {
 	return j.dryRun
 }
 
-// KubeConfigDir returns the path of the Kubernetes configuration folder or the temporary folder path in case of DryRun.
+// KubeConfigDir returns the Kubernetes configuration directory or the temporary directory if DryRun is true.
 func (j *joinData) KubeConfigDir() string {
 	if j.dryRun {
 		return j.dryRunDir
@@ -508,7 +508,7 @@ func (j *joinData) KubeConfigDir() string {
 	return kubeadmconstants.KubernetesDir
 }
 
-// KubeletDir returns the path of the kubelet configuration folder or the temporary folder in case of DryRun.
+// KubeletDir returns the kubelet configuration directory or the temporary directory if DryRun is true.
 func (j *joinData) KubeletDir() string {
 	if j.dryRun {
 		return j.dryRunDir
@@ -516,7 +516,7 @@ func (j *joinData) KubeletDir() string {
 	return kubeadmconstants.KubeletRunDirectory
 }
 
-// ManifestDir returns the path where manifest should be stored or the temporary folder path in case of DryRun.
+// ManifestDir returns the path where manifest should be stored or the temporary directory if DryRun is true.
 func (j *joinData) ManifestDir() string {
 	if j.dryRun {
 		return j.dryRunDir
@@ -524,7 +524,7 @@ func (j *joinData) ManifestDir() string {
 	return kubeadmconstants.GetStaticPodDirectory()
 }
 
-// CertificateWriteDir returns the path where certs should be stored or the temporary folder path in case of DryRun.
+// CertificateWriteDir returns the path where certs should be stored or the temporary directory if DryRun is true.
 func (j *joinData) CertificateWriteDir() string {
 	if j.dryRun {
 		return j.dryRunDir

--- a/cmd/kubeadm/app/cmd/phases/upgrade/apply/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/apply/data_test.go
@@ -45,3 +45,5 @@ func (t *testData) SessionIsInteractive() bool              { return false }
 func (t *testData) AllowExperimentalUpgrades() bool         { return false }
 func (t *testData) AllowRCUpgrades() bool                   { return false }
 func (t *testData) ForceUpgrade() bool                      { return false }
+func (t *testData) KubeConfigDir() string                   { return "" }
+func (t *testData) KubeletDir() string                      { return "" }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/data.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/data.go
@@ -38,4 +38,6 @@ type Data interface {
 	IgnorePreflightErrors() sets.Set[string]
 	PatchesDir() string
 	OutputWriter() io.Writer
+	KubeConfigDir() string
+	KubeletDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/data_test.go
@@ -41,3 +41,5 @@ func (t *testData) Client() clientset.Interface             { return nil }
 func (t *testData) IgnorePreflightErrors() sets.Set[string] { return nil }
 func (t *testData) PatchesDir() string                      { return "" }
 func (t *testData) OutputWriter() io.Writer                 { return nil }
+func (t *testData) KubeConfigDir() string                   { return "" }
+func (t *testData) KubeletDir() string                      { return "" }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/kubeletconfig.go
@@ -29,10 +29,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 )
 
-const (
-	kubeletConfigDir = ""
-)
-
 var (
 	kubeletConfigLongDesc = cmdutil.LongDesc(`
 		Upgrade the kubelet configuration for this node by downloading it from the kubelet-config ConfigMap stored in the cluster
@@ -65,7 +61,7 @@ func runKubeletConfigPhase(c workflow.RunData) error {
 	// Write the configuration for the kubelet down to disk and print the generated manifests instead of dry-running.
 	// If not dry-running, the kubelet config file will be backed up to the /etc/kubernetes/tmp/ dir, so that it could be
 	// recovered if anything goes wrong.
-	err := upgrade.WriteKubeletConfigFiles(data.InitCfg(), kubeletConfigDir, data.PatchesDir(), data.DryRun(), data.OutputWriter())
+	err := upgrade.WriteKubeletConfigFiles(data.InitCfg(), data.KubeletDir(), data.KubeConfigDir(), data.PatchesDir(), data.DryRun(), data.OutputWriter())
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/data_test.go
@@ -42,3 +42,5 @@ func (t *testData) IgnorePreflightErrors() sets.Set[string] { return nil }
 func (t *testData) PatchesDir() string                      { return "" }
 func (t *testData) KubeConfigPath() string                  { return "" }
 func (t *testData) OutputWriter() io.Writer                 { return nil }
+func (t *testData) KubeConfigDir() string                   { return "" }
+func (t *testData) KubeletDir() string                      { return "" }

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -63,6 +63,7 @@ type applyData struct {
 	nonInteractiveMode        bool
 	force                     bool
 	dryRun                    bool
+	dryRunDir                 string
 	etcdUpgrade               bool
 	renewCerts                bool
 	allowExperimentalUpgrades bool
@@ -195,6 +196,14 @@ func newApplyData(cmd *cobra.Command, args []string, applyFlags *applyFlags) (*a
 		return nil, cmdutil.TypeMismatchErr("dryRun", "bool")
 	}
 
+	// If dry running creates a temporary directory for saving kubeadm generated files.
+	dryRunDir := ""
+	if *dryRun {
+		if dryRunDir, err = constants.GetDryRunDir(constants.EnvVarUpgradeDryRunDir, "kubeadm-upgrade-apply-dryrun", klog.Warningf); err != nil {
+			return nil, errors.Wrap(err, "could not create a temporary directory")
+		}
+	}
+
 	etcdUpgrade, ok := cmdutil.ValueFromFlagsOrConfig(cmd.Flags(), options.EtcdUpgrade, upgradeCfg.Apply.EtcdUpgrade, &applyFlags.etcdUpgrade).(*bool)
 	if !ok {
 		return nil, cmdutil.TypeMismatchErr("etcdUpgrade", "bool")
@@ -270,6 +279,7 @@ func newApplyData(cmd *cobra.Command, args []string, applyFlags *applyFlags) (*a
 		nonInteractiveMode:        applyFlags.nonInteractiveMode,
 		force:                     *force,
 		dryRun:                    *dryRun,
+		dryRunDir:                 dryRunDir,
 		etcdUpgrade:               *etcdUpgrade,
 		renewCerts:                *renewCerts,
 		allowExperimentalUpgrades: *allowExperimentalUpgrades,
@@ -353,4 +363,20 @@ func (d *applyData) ForceUpgrade() bool {
 func (d *applyData) IsControlPlaneNode() bool {
 	// `kubeadm upgrade apply` should always be executed on a control-plane node
 	return true
+}
+
+// KubeConfigDir returns the Kubernetes configuration directory or the temporary directory if DryRun is true.
+func (j *applyData) KubeConfigDir() string {
+	if j.dryRun {
+		return j.dryRunDir
+	}
+	return constants.KubernetesDir
+}
+
+// KubeletDir returns the kubelet configuration directory or the temporary directory if DryRun is true.
+func (j *applyData) KubeletDir() string {
+	if j.dryRun {
+		return j.dryRunDir
+	}
+	return constants.KubeletRunDirectory
 }

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -200,7 +200,7 @@ func newApplyData(cmd *cobra.Command, args []string, applyFlags *applyFlags) (*a
 	dryRunDir := ""
 	if *dryRun {
 		if dryRunDir, err = constants.GetDryRunDir(constants.EnvVarUpgradeDryRunDir, "kubeadm-upgrade-apply-dryrun", klog.Warningf); err != nil {
-			return nil, errors.Wrap(err, "could not create a temporary directory")
+			return nil, errors.Wrap(err, "could not create a temporary directory on dryrun")
 		}
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -196,7 +196,7 @@ func newNodeData(cmd *cobra.Command, nodeOptions *nodeOptions, out io.Writer) (*
 	dryRunDir := ""
 	if *dryRun {
 		if dryRunDir, err = constants.GetDryRunDir(constants.EnvVarUpgradeDryRunDir, "kubeadm-upgrade-node-dryrun", klog.Warningf); err != nil {
-			return nil, errors.Wrap(err, "couldn't create a temporary directory on dryrun")
+			return nil, errors.Wrap(err, "could not create a temporary directory on dryrun")
 		}
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -64,6 +64,7 @@ type nodeData struct {
 	etcdUpgrade           bool
 	renewCerts            bool
 	dryRun                bool
+	dryRunDir             string
 	cfg                   *kubeadmapi.UpgradeConfiguration
 	initCfg               *kubeadmapi.InitConfiguration
 	isControlPlaneNode    bool
@@ -191,6 +192,14 @@ func newNodeData(cmd *cobra.Command, nodeOptions *nodeOptions, out io.Writer) (*
 		return nil, cmdutil.TypeMismatchErr("dryRun", "bool")
 	}
 
+	// If dry running creates a temporary directory for saving kubeadm generated files.
+	dryRunDir := ""
+	if *dryRun {
+		if dryRunDir, err = constants.GetDryRunDir(constants.EnvVarUpgradeDryRunDir, "kubeadm-upgrade-node-dryrun", klog.Warningf); err != nil {
+			return nil, errors.Wrap(err, "couldn't create a temporary directory")
+		}
+	}
+
 	printer := &output.TextPrinter{}
 	client, err := getClient(nodeOptions.kubeConfigPath, *dryRun, printer)
 	if err != nil {
@@ -222,6 +231,7 @@ func newNodeData(cmd *cobra.Command, nodeOptions *nodeOptions, out io.Writer) (*
 	return &nodeData{
 		cfg:                   upgradeCfg,
 		dryRun:                *dryRun,
+		dryRunDir:             dryRunDir,
 		initCfg:               initCfg,
 		client:                client,
 		isControlPlaneNode:    isControlPlaneNode,
@@ -286,4 +296,20 @@ func (d *nodeData) KubeConfigPath() string {
 
 func (d *nodeData) OutputWriter() io.Writer {
 	return d.outputWriter
+}
+
+// KubeConfigDir returns the Kubernetes configuration directory or the temporary directory if DryRun is true.
+func (j *nodeData) KubeConfigDir() string {
+	if j.dryRun {
+		return j.dryRunDir
+	}
+	return constants.KubernetesDir
+}
+
+// KubeletDir returns the kubelet configuration directory or the temporary directory if DryRun is true.
+func (j *nodeData) KubeletDir() string {
+	if j.dryRun {
+		return j.dryRunDir
+	}
+	return constants.KubeletRunDirectory
 }

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -196,7 +196,7 @@ func newNodeData(cmd *cobra.Command, nodeOptions *nodeOptions, out io.Writer) (*
 	dryRunDir := ""
 	if *dryRun {
 		if dryRunDir, err = constants.GetDryRunDir(constants.EnvVarUpgradeDryRunDir, "kubeadm-upgrade-node-dryrun", klog.Warningf); err != nil {
-			return nil, errors.Wrap(err, "couldn't create a temporary directory")
+			return nil, errors.Wrap(err, "couldn't create a temporary directory on dryrun")
 		}
 	}
 

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -95,21 +95,9 @@ func UnupgradedControlPlaneInstances(client clientset.Interface, nodeName string
 }
 
 // WriteKubeletConfigFiles writes the kubelet config file to disk, but first creates a backup of any existing one.
-func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, kubeletConfigDir string, patchesDir string, dryRun bool, out io.Writer) error {
-	var (
-		err        error
-		kubeletDir = kubeadmconstants.KubeletRunDirectory
-	)
-	// If dry-running, this will return a directory under /etc/kubernetes/tmp or kubeletConfigDir.
-	if dryRun {
-		kubeletDir, err = kubeadmconstants.CreateTempDir(kubeletConfigDir, "kubeadm-upgrade-dryrun")
-	}
-	if err != nil {
-		// The error here should never occur in reality, would only be thrown if /tmp doesn't exist on the machine.
-		return err
-	}
-	// Create a copy of the kubelet config file in the /etc/kubernetes/tmp or kubeletConfigDir.
-	backupDir, err := kubeadmconstants.CreateTempDir(kubeletConfigDir, "kubeadm-kubelet-config")
+func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, kubeletDir string, kubeConfigDir string, patchesDir string, dryRun bool, out io.Writer) error {
+	// Create a copy of the kubelet config file in the /etc/kubernetes/tmp or kubeConfigDir.
+	backupDir, err := kubeadmconstants.CreateTimestampDir(kubeConfigDir, "kubeadm-kubelet-config")
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -108,13 +108,13 @@ func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, kubeletDir strin
 	dest := filepath.Join(backupDir, kubeadmconstants.KubeletConfigurationFileName)
 
 	if !dryRun {
-		fmt.Printf("[upgrade] Backing up kubelet config file to %s\n", dest)
+		_, _ = fmt.Fprintf(out, "[upgrade] Backing up kubelet config file to %s\n", dest)
 		err := kubeadmutil.CopyFile(src, dest)
 		if err != nil {
 			return errors.Wrap(err, "error backing up the kubelet config file")
 		}
 	} else {
-		fmt.Printf("[dryrun] Would back up kubelet config file to %s\n", dest)
+		_, _ = fmt.Fprintf(out, "[dryrun] Would back up kubelet config file to %s\n", dest)
 	}
 
 	if features.Enabled(cfg.FeatureGates, features.NodeLocalCRISocket) {
@@ -142,7 +142,7 @@ func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, kubeletDir strin
 					}
 				}
 			} else if dryRun {
-				fmt.Fprintf(os.Stdout, "[dryrun] would read the flag --container-runtime-endpoint value from %q, which is missing. "+
+				_, _ = fmt.Fprintf(out, "[dryrun] would read the flag --container-runtime-endpoint value from %q, which is missing. "+
 					"Using default socket %q instead", kubeadmconstants.KubeletEnvFileName, kubeadmconstants.DefaultCRISocket)
 				containerRuntimeEndpoint = kubeadmconstants.DefaultCRISocket
 			} else {
@@ -158,7 +158,7 @@ func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, kubeletDir strin
 			}
 
 			if dryRun { // Print what contents would be written
-				err = dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletInstanceConfigurationFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, os.Stdout)
+				err = dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletInstanceConfigurationFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, out)
 				if err != nil {
 					return errors.Wrap(err, "error printing kubelet instance configuration file on dryrun")
 				}
@@ -172,7 +172,7 @@ func WriteKubeletConfigFiles(cfg *kubeadmapi.InitConfiguration, kubeletDir strin
 	}
 
 	if dryRun { // Print what contents would be written
-		err := dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletConfigurationFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, os.Stdout)
+		err := dryrunutil.PrintDryRunFile(kubeadmconstants.KubeletConfigurationFileName, kubeletDir, kubeadmconstants.KubeletRunDirectory, out)
 		if err != nil {
 			return errors.Wrap(err, "error printing kubelet configuration file on dryrun")
 		}

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_test.go
@@ -142,7 +142,7 @@ func TestWriteKubeletConfigFiles(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		err := WriteKubeletConfigFiles(tc.cfg, tempDir, tc.patchesDir, true, os.Stdout)
+		err := WriteKubeletConfigFiles(tc.cfg, tempDir, tempDir, tc.patchesDir, true, os.Stdout)
 		if (err != nil) != tc.expectedError {
 			t.Fatalf("expected error: %v, got: %v, error: %v", tc.expectedError, err != nil, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/126776 refactorred the dry run logic for kubeadm but the `WriteKubeletConfigFiles` function doesn't honor the KUBEADM_UPGRADE_DRYRUN_DIR environment variable.

And this PR will make it easier to write unit tests for https://github.com/kubernetes/kubernetes/pull/133778.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix KUBEADM_UPGRADE_DRYRUN_DIR not honored in upgrade phase when writing kubelet config files
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
