### PR TITLE
Propagate valid non-controller ownerReferences from PodTemplateSpec to Pods

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1064,6 +1064,10 @@ const (
 	//
 	// Enables support for joining Windows containers to a hosts' network namespace.
 	WindowsHostNetwork featuregate.Feature = "WindowsHostNetwork"
+	// owner: @itzPranshul
+	//
+	// Enables propagation of valid non-controller ownerReferences
+	PropagatePodTemplateOwnerRefs featuregate.Feature = "PropagatePodTemplateOwnerRefs"
 )
 
 // defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
@@ -1077,6 +1081,11 @@ const (
 //
 // Entries are alphabetized.
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+
+	PropagatePodTemplateOwnerRefs: {
+        {Version:    version.MustParse("1.35"), Default: false,PreRelease: featuregate.Alpha,},
+    },
+
 	AllowDNSOnlyNodeCSR: {
 		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Deprecated},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR introduces the `PropagatePodTemplateOwnerRefs` feature gate to optionally propagate valid non-controller ownerReferences from PodTemplateSpec into Pods.

Rules for propagation:
- Skip ownerReferences where `controller=true` (only the controller sets this).
- Skip ownerReferences with an empty UID (invalid).
- Propagate all other valid non-controller ownerReferences.

Feature gate is disabled by default(alpha).
Unit tests added


#### Which issue(s) this PR is related to:
Fixes  #133974


#### Special notes for your reviewer:
The feature is guarded entirely by a feature gate, so existing clusters are unaffected unless the gate is enabled.


#### Does this PR introduce a user-facing change?
Yes. This PR introduces the `PropagatePodTemplateOwnerRefs` feature gate, which allows Pods created from PodTemplateSpecs to inherit valid non-controller ownerReferences.



```release-note (feature-gate): 
The `PropagatePodTemplateOwnerRefs` feature gate allows Pods created from a PodTemplateSpec
to inherit valid non-controller ownerReferences. This feature is alpha and disabled by default.
```
