### PR TITLE
Fix tests not using proper resource paths

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2427,7 +2427,7 @@ func TestStoreWatch(t *testing.T) {
 }
 
 func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheEnabled bool) (factory.DestroyFunc, *Store) {
-	podPrefix := "/pods"
+	podPrefix := "/pods/"
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	strategy := &testRESTStrategy{scheme, names.SimpleNameGenerator, true, false, true}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -258,7 +258,7 @@ func TestCacheWatcherStoppedOnDestroy(t *testing.T) {
 		t.Fatalf("unexpected error waiting for the cache to be ready")
 	}
 
-	w, err := cacher.Watch(context.Background(), "pods/ns", storage.ListOptions{ResourceVersion: "0", Predicate: storage.Everything})
+	w, err := cacher.Watch(context.Background(), "/pods/ns", storage.ListOptions{ResourceVersion: "0", Predicate: storage.Everything})
 	if err != nil {
 		t.Fatalf("Failed to create watch: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -303,7 +303,7 @@ func etcdListRequests(t *testing.T, ctx context.Context, store storage.Interface
 	key := rand.String(10)
 	listCtx := context.WithValue(ctx, storagetesting.RecorderContextKey, key)
 	listOut := &example.PodList{}
-	if err := store.GetList(listCtx, "/pods", opts, listOut); err != nil {
+	if err := store.GetList(listCtx, "/pods/", opts, listOut); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	return recorder.ListRequestForKey(key)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -950,7 +950,7 @@ func TestWatchCacheBypass(t *testing.T) {
 		}
 	}
 
-	_, err = delegator.Watch(context.TODO(), "pod/ns", storage.ListOptions{
+	_, err = delegator.Watch(context.TODO(), "/pods/ns", storage.ListOptions{
 		ResourceVersion: "0",
 		Predicate:       storage.Everything,
 	})
@@ -958,7 +958,7 @@ func TestWatchCacheBypass(t *testing.T) {
 		t.Errorf("Watch with RV=0 should be served from cache: %v", err)
 	}
 
-	_, err = delegator.Watch(context.TODO(), "pod/ns", storage.ListOptions{
+	_, err = delegator.Watch(context.TODO(), "/pods/ns", storage.ListOptions{
 		ResourceVersion: "",
 		Predicate:       storage.Everything,
 	})
@@ -1374,7 +1374,7 @@ func TestCacherDontMissEventsOnReinitialization(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			defer wg.Done()
-			w, err := cacher.Watch(ctx, "/pods", storage.ListOptions{ResourceVersion: "1", Predicate: storage.Everything})
+			w, err := cacher.Watch(ctx, "/pods/", storage.ListOptions{ResourceVersion: "1", Predicate: storage.Everything})
 			if err != nil {
 				// Watch failed to initialize (this most probably means that cacher
 				// already moved back to Pending state before watch initialized.
@@ -2680,7 +2680,7 @@ func BenchmarkCacher_GetList(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					result := &example.PodList{}
-					err = delegator.GetList(context.TODO(), "/pods", storage.ListOptions{
+					err = delegator.GetList(context.TODO(), "/pods/", storage.ListOptions{
 						Predicate:       pred,
 						Recursive:       true,
 						ResourceVersion: "12345",

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator_test.go
@@ -287,7 +287,7 @@ func TestConsistencyCheckerDigestMatches(t *testing.T) {
 
 	t.Log("Execute list to ensure cache is up to date")
 	outList := &example.PodList{}
-	err := store.cacher.GetList(ctx, "/pods", storage.ListOptions{ResourceVersion: resourceVersion, Recursive: true, Predicate: storage.Everything, ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan}, outList)
+	err := store.cacher.GetList(ctx, "/pods/", storage.ListOptions{ResourceVersion: resourceVersion, Recursive: true, Predicate: storage.Everything, ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan}, outList)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +295,7 @@ func TestConsistencyCheckerDigestMatches(t *testing.T) {
 		t.Errorf("Expect to get %d pods, got %d", storageWatchListPageSize+1, len(outList.Items))
 	}
 
-	checker := newConsistencyChecker("/pods", schema.GroupResource{}, store.cacher.newListFunc, store.cacher, store.storage)
+	checker := newConsistencyChecker("/pods/", schema.GroupResource{}, store.cacher.newListFunc, store.cacher, store.storage)
 	digest, err := checker.calculateDigests(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/lister_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/lister_watcher_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestCacherListerWatcher(t *testing.T) {
-	prefix := "/pods"
+	prefix := "/pods/"
 	fn := func() runtime.Object { return &example.PodList{} }
 	server, store := newEtcdTestStorage(t, prefix)
 	defer server.Terminate(t)
@@ -67,7 +67,7 @@ func TestCacherListerWatcher(t *testing.T) {
 }
 
 func TestCacherListerWatcherPagination(t *testing.T) {
-	prefix := "/pods"
+	prefix := "/pods/"
 	fn := func() runtime.Object { return &example.PodList{} }
 	server, store := newEtcdTestStorage(t, prefix)
 	defer server.Terminate(t)
@@ -130,7 +130,7 @@ func TestCacherListerWatcherPagination(t *testing.T) {
 func TestCacherListerWatcherListWatch(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
 
-	prefix := "/pods"
+	prefix := "/pods/"
 	fn := func() runtime.Object { return &example.PodList{} }
 	server, store := newEtcdTestStorage(t, prefix)
 	defer server.Terminate(t)
@@ -181,7 +181,7 @@ func TestCacherListerWatcherListWatch(t *testing.T) {
 func TestCacherListerWatcherWhenListWatchDisabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, false)
 
-	prefix := "/pods"
+	prefix := "/pods/"
 	fn := func() runtime.Object { return &example.PodList{} }
 	server, store := newEtcdTestStorage(t, prefix)
 	defer server.Terminate(t)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/linearized_read_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/linearized_read_test.go
@@ -37,7 +37,7 @@ func TestLinearizedReadRevisionInvariant(t *testing.T) {
 	// [1] https://etcd.io/docs/v3.5/learning/api_guarantees/#isolation-level-and-consistency-of-replicas
 	ctx, store, etcdClient := testSetup(t)
 
-	dir := "/pods"
+	dir := "/pods/"
 	key := dir + "/testkey"
 	out := &example.Pod{}
 	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", SelfLink: "testlink"}}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -615,7 +615,7 @@ func withDefaults(options *setupOptions) {
 	options.newFunc = newPod
 	options.newListFunc = newPodList
 	options.prefix = ""
-	options.resourcePrefix = "/pods"
+	options.resourcePrefix = "/pods/"
 	options.groupResource = schema.GroupResource{Resource: "pods"}
 	options.transformer = newTestTransformer()
 	options.leaseConfig = newTestLeaseManagerConfig()
@@ -1065,7 +1065,7 @@ func TestPrefixStats(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, store, c := testSetup(t, withPrefix("/registry"), withResourcePrefix("/pods"))
+			ctx, store, c := testSetup(t, withPrefix("/registry"), withResourcePrefix("/pods/"))
 			if tc.estimate {
 				err := store.EnableResourceSizeEstimation(store.getKeys)
 				if err != nil {
@@ -1094,7 +1094,7 @@ func TestPrefixStats(t *testing.T) {
 
 			listOut := &example.PodList{}
 			// Ignore error as decode is expected to fail
-			_ = store.GetList(ctx, "/pods", storage.ListOptions{Predicate: storage.Everything, Recursive: true}, listOut)
+			_ = store.GetList(ctx, "/pods/", storage.ListOptions{Predicate: storage.Everything, Recursive: true}, listOut)
 
 			gotStats, err := store.Stats(ctx)
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
@@ -57,7 +57,7 @@ func RunBenchmarkStoreListCreate(ctx context.Context, b *testing.B, store storag
 			panic(fmt.Sprintf("Unexpected error %s", err))
 		}
 		listOut := &example.PodList{}
-		err = store.GetList(ctx, "/pods", storage.ListOptions{
+		err = store.GetList(ctx, "/pods/", storage.ListOptions{
 			Recursive:            true,
 			ResourceVersion:      podOut.ResourceVersion,
 			ResourceVersionMatch: match,

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -681,14 +681,14 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 	}{
 		{
 			name:        "rejects invalid resource version",
-			prefix:      "/pods",
+			prefix:      "/pods/",
 			pred:        storage.Everything,
 			rv:          "abc",
 			expectError: true,
 		},
 		{
 			name:   "rejects resource version and continue token",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Label:    labels.Everything(),
 				Field:    fields.Everything(),
@@ -700,7 +700,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:             "rejects resource version set too high",
-			prefix:           "/pods",
+			prefix:           "/pods/",
 			pred:             storage.Everything,
 			rv:               strconv.FormatInt(math.MaxInt64, 10),
 			expectRVTooLarge: true,
@@ -1012,7 +1012,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "test List with filter returning only one item, ensure only a single page returned",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "barfoo"),
 				Label: labels.Everything(),
@@ -1023,7 +1023,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "test List with filter returning only one item, ensure only a single page returned with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "barfoo"),
 				Label: labels.Everything(),
@@ -1037,7 +1037,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "test List with filter returning only one item, covers the entire list",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "barfoo"),
 				Label: labels.Everything(),
@@ -1048,7 +1048,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "test List with filter returning only one item, covers the entire list with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "barfoo"),
 				Label: labels.Everything(),
@@ -1062,7 +1062,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "test List with filter returning only one item, covers the entire list, with resource version 0",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "barfoo"),
 				Label: labels.Everything(),
@@ -1074,7 +1074,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "test List with filter returning two items, more pages possible",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "bar"),
 				Label: labels.Everything(),
@@ -1085,7 +1085,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "test List with filter returning two items, more pages possible with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "bar"),
 				Label: labels.Everything(),
@@ -1098,7 +1098,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns two items split across multiple pages",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "foo"),
 				Label: labels.Everything(),
@@ -1108,7 +1108,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns two items split across multiple pages with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "foo"),
 				Label: labels.Everything(),
@@ -1120,7 +1120,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns one item for last page, ends on last item, not full",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field:    fields.OneTermEqualSelector("metadata.name", "foo"),
 				Label:    labels.Everything(),
@@ -1131,7 +1131,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns one item for last page, starts on last item, full",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field:    fields.OneTermEqualSelector("metadata.name", "foo"),
 				Label:    labels.Everything(),
@@ -1142,7 +1142,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns one item for last page, starts on last item, partial page",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field:    fields.OneTermEqualSelector("metadata.name", "foo"),
 				Label:    labels.Everything(),
@@ -1153,7 +1153,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns two items, page size equal to total list size",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "foo"),
 				Label: labels.Everything(),
@@ -1163,7 +1163,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns two items, page size equal to total list size with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "foo"),
 				Label: labels.Everything(),
@@ -1175,7 +1175,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns one item, page size equal to total list size",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "barfoo"),
 				Label: labels.Everything(),
@@ -1185,7 +1185,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "filter returns one item, page size equal to total list size with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "barfoo"),
 				Label: labels.Everything(),
@@ -1197,13 +1197,13 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:        "list all items",
-			prefix:      "/pods",
+			prefix:      "/pods/",
 			pred:        storage.Everything,
 			expectedOut: []example.Pod{*updatedPod, *createdPods[1], *createdPods[2], *createdPods[3], *createdPods[4]},
 		},
 		{
 			name:        "list all items with current resource version and match=NotOlderThan",
-			prefix:      "/pods",
+			prefix:      "/pods/",
 			pred:        storage.Everything,
 			rv:          list.ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchNotOlderThan,
@@ -1211,7 +1211,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "verify list returns updated version of object; filter returns one item, page size equal to total list size with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("spec.nodeName", "fakeNode"),
 				Label: labels.Everything(),
@@ -1223,7 +1223,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 		},
 		{
 			name:   "verify list does not return deleted object; filter for deleted object, page size equal to total list size with current resource version and match=NotOlderThan",
-			prefix: "/pods",
+			prefix: "/pods/",
 			pred: storage.SelectionPredicate{
 				Field: fields.OneTermEqualSelector("metadata.name", "baz"),
 				Label: labels.Everything(),
@@ -1909,7 +1909,7 @@ func seedMultiLevelData(ctx context.Context, store storage.Interface) (initialRV
 
 	// we want to figure out the resourceVersion before we create anything
 	initialList := &example.PodList{}
-	if err := store.GetList(ctx, "/pods", storage.ListOptions{Predicate: storage.Everything, Recursive: true}, initialList); err != nil {
+	if err := store.GetList(ctx, "/pods/", storage.ListOptions{Predicate: storage.Everything, Recursive: true}, initialList); err != nil {
 		return "", nil, nil, fmt.Errorf("failed to determine starting resourceVersion: %w", err)
 	}
 	initialRV = initialList.ResourceVersion
@@ -2283,7 +2283,7 @@ func RunTestListContinuation(ctx context.Context, t *testing.T, store storage.In
 		Predicate:       pred(1, ""),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get initial list: %v", err)
 	}
 	if len(out.Continue) == 0 {
@@ -2307,13 +2307,13 @@ func RunTestListContinuation(ctx context.Context, t *testing.T, store storage.In
 		Predicate:       pred(0, continueFromSecondItem),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get second page: %v", err)
 	}
 	if len(out.Continue) != 0 {
 		t.Fatalf("Unexpected continuation token set")
 	}
-	key, rv, err := storage.DecodeContinue(continueFromSecondItem, "/pods")
+	key, rv, err := storage.DecodeContinue(continueFromSecondItem, "/pods/")
 	t.Logf("continue token was %d %s %v", rv, key, err)
 	expectNoDiff(t, "incorrect second page", []example.Pod{*preset[1].storedObj, *preset[2].storedObj}, out.Items)
 	if out.ResourceVersion != currentRV {
@@ -2331,7 +2331,7 @@ func RunTestListContinuation(ctx context.Context, t *testing.T, store storage.In
 		Predicate:       pred(1, continueFromSecondItem),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get second page: %v", err)
 	}
 	if len(out.Continue) == 0 {
@@ -2354,7 +2354,7 @@ func RunTestListContinuation(ctx context.Context, t *testing.T, store storage.In
 		Predicate:       pred(1, continueFromThirdItem),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get second page: %v", err)
 	}
 	if len(out.Continue) != 0 {
@@ -2396,7 +2396,7 @@ func RunTestListPaginationRareObject(ctx context.Context, t *testing.T, store st
 		},
 		Recursive: true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get initial list: %v", err)
 	}
 	if len(out.Continue) != 0 {
@@ -2472,7 +2472,7 @@ func RunTestListContinuationWithFilter(ctx context.Context, t *testing.T, store 
 		Predicate:       pred(2, ""),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Errorf("Unable to get initial list: %v", err)
 	}
 	if len(out.Continue) == 0 {
@@ -2503,7 +2503,7 @@ func RunTestListContinuationWithFilter(ctx context.Context, t *testing.T, store 
 		Predicate:       pred(2, cont),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Errorf("Unable to get second page: %v", err)
 	}
 	if len(out.Continue) != 0 {
@@ -2578,7 +2578,7 @@ func RunTestListInconsistentContinuation(ctx context.Context, t *testing.T, stor
 		Predicate:       pred(1, ""),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get initial list: %v", err)
 	}
 	if len(out.Continue) == 0 {
@@ -2615,7 +2615,7 @@ func RunTestListInconsistentContinuation(ctx context.Context, t *testing.T, stor
 		Predicate:       pred(0, continueFromSecondItem),
 		Recursive:       true,
 	}
-	err := store.GetList(ctx, "/pods", options, out)
+	err := store.GetList(ctx, "/pods/", options, out)
 	if err == nil {
 		t.Fatalf("unexpected no error")
 	}
@@ -2637,7 +2637,7 @@ func RunTestListInconsistentContinuation(ctx context.Context, t *testing.T, stor
 		Predicate:       pred(1, inconsistentContinueFromSecondItem),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get second page: %v", err)
 	}
 	if len(out.Continue) == 0 {
@@ -2656,7 +2656,7 @@ func RunTestListInconsistentContinuation(ctx context.Context, t *testing.T, stor
 		Predicate:       pred(1, continueFromThirdItem),
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", options, out); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, out); err != nil {
 		t.Fatalf("Unable to get second page: %v", err)
 	}
 	if len(out.Continue) != 0 {
@@ -2730,7 +2730,7 @@ func RunTestListResourceVersionMatch(ctx context.Context, t *testing.T, store In
 		Predicate: predicate,
 		Recursive: true,
 	}
-	if err := store.GetList(ctx, "/pods", options, &result1); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, &result1); err != nil {
 		t.Fatalf("failed to list objects: %v", err)
 	}
 
@@ -2743,7 +2743,7 @@ func RunTestListResourceVersionMatch(ctx context.Context, t *testing.T, store In
 	}
 
 	result2 := example.PodList{}
-	if err := store.GetList(ctx, "/pods", options, &result2); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, &result2); err != nil {
 		t.Fatalf("failed to list objects: %v", err)
 	}
 
@@ -2753,7 +2753,7 @@ func RunTestListResourceVersionMatch(ctx context.Context, t *testing.T, store In
 	options.ResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
 
 	result3 := example.PodList{}
-	if err := store.GetList(ctx, "/pods", options, &result3); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, &result3); err != nil {
 		t.Fatalf("failed to list objects: %v", err)
 	}
 
@@ -2761,7 +2761,7 @@ func RunTestListResourceVersionMatch(ctx context.Context, t *testing.T, store In
 	options.ResourceVersionMatch = metav1.ResourceVersionMatchExact
 
 	result4 := example.PodList{}
-	if err := store.GetList(ctx, "/pods", options, &result4); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, &result4); err != nil {
 		t.Fatalf("failed to list objects: %v", err)
 	}
 
@@ -3175,7 +3175,7 @@ func RunTestTransformationFailure(ctx context.Context, t *testing.T, store Inter
 		Predicate: storage.Everything,
 		Recursive: true,
 	}
-	if err := store.GetList(ctx, "/pods", storageOpts, &got); !storage.IsInternalError(err) {
+	if err := store.GetList(ctx, "/pods/", storageOpts, &got); !storage.IsInternalError(err) {
 		t.Errorf("Unexpected error %v", err)
 	}
 
@@ -3256,7 +3256,7 @@ func RunTestStats(ctx context.Context, t *testing.T, store storage.Interface, co
 func assertStats(t *testing.T, store storage.Interface, sizeEnabled bool, expectStats storage.Stats) {
 	t.Helper()
 	// Execute consistent LIST to refresh state of cache.
-	err := store.GetList(t.Context(), "/pods", storage.ListOptions{Recursive: true, Predicate: storage.Everything}, &example.PodList{})
+	err := store.GetList(t.Context(), "/pods/", storage.ListOptions{Recursive: true, Predicate: storage.Everything}, &example.PodList{})
 	if err != nil {
 		t.Fatalf("GetList failed: %v", err)
 	}
@@ -3309,7 +3309,7 @@ func RunTestListPaging(ctx context.Context, t *testing.T, store storage.Interfac
 	for {
 		calls++
 		listOut := &example.PodList{}
-		err := store.GetList(ctx, "/pods", opts, listOut)
+		err := store.GetList(ctx, "/pods/", opts, listOut)
 		if err != nil {
 			t.Fatalf("Unexpected error %s", err)
 		}
@@ -3739,7 +3739,7 @@ func RunTestNamespaceScopedList(ctx context.Context, t *testing.T, store storage
 
 func RunTestCompactRevision(ctx context.Context, t *testing.T, store storage.Interface, increaseRV IncreaseRVFunc, compact Compaction) {
 	listOut := &example.PodList{}
-	if err := store.GetList(ctx, "/pods", storage.ListOptions{
+	if err := store.GetList(ctx, "/pods/", storage.ListOptions{
 		Predicate: storage.Everything,
 		Recursive: true,
 	}, listOut); err != nil {
@@ -3753,7 +3753,7 @@ func RunTestCompactRevision(ctx context.Context, t *testing.T, store storage.Int
 	if compactedRV >= int64(currentRV) {
 		t.Fatalf("Expected current RV not be compacted, current: %d, compacted: %d", currentRV, compactedRV)
 	}
-	if err := store.GetList(ctx, "/pods", storage.ListOptions{
+	if err := store.GetList(ctx, "/pods/", storage.ListOptions{
 		Predicate:            storage.Everything,
 		Recursive:            true,
 		ResourceVersion:      listOut.ResourceVersion,
@@ -3764,7 +3764,7 @@ func RunTestCompactRevision(ctx context.Context, t *testing.T, store storage.Int
 	increaseRV(ctx, t)
 	expectCompactedRV := currentRV + 1
 	compact(ctx, t, fmt.Sprintf("%d", expectCompactedRV))
-	if err := store.GetList(ctx, "/pods", storage.ListOptions{
+	if err := store.GetList(ctx, "/pods/", storage.ListOptions{
 		Predicate:            storage.Everything,
 		Recursive:            true,
 		ResourceVersion:      listOut.ResourceVersion,

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -383,7 +383,7 @@ func RunTestWatchError(ctx context.Context, t *testing.T, store InterfaceWithPre
 		Predicate:       storage.Everything,
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", storageOpts, list); err != nil {
+	if err := store.GetList(ctx, "/pods/", storageOpts, list); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -424,7 +424,7 @@ func RunTestWatchWithUnsafeDelete(ctx context.Context, t *testing.T, store Inter
 		Predicate:       storage.Everything,
 		Recursive:       true,
 	}
-	if err := store.GetList(ctx, "/pods", storageOpts, list); err != nil {
+	if err := store.GetList(ctx, "/pods/", storageOpts, list); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -493,7 +493,7 @@ func RunTestWatcherTimeout(ctx context.Context, t *testing.T, store storage.Inte
 		Predicate: storage.Everything,
 		Recursive: true,
 	}
-	if err := store.GetList(ctx, "/pods", options, &podList); err != nil {
+	if err := store.GetList(ctx, "/pods/", options, &podList); err != nil {
 		t.Fatalf("Failed to list pods: %v", err)
 	}
 	initialRV := podList.ResourceVersion
@@ -734,9 +734,9 @@ func RunTestClusterScopedWatch(ctx context.Context, t *testing.T, store storage.
 			ctx = genericapirequest.WithRequestInfo(ctx, requestInfo)
 			ctx = genericapirequest.WithNamespace(ctx, "")
 
-			watchKey := "/pods"
+			watchKey := "/pods/"
 			if tt.requestedName != "" {
-				watchKey += "/" + tt.requestedName
+				watchKey += tt.requestedName
 			}
 
 			predicate := CreatePodPredicate(tt.fieldSelector, false, tt.indexFields)
@@ -747,7 +747,7 @@ func RunTestClusterScopedWatch(ctx context.Context, t *testing.T, store storage.
 				Predicate:       predicate,
 				Recursive:       true,
 			}
-			if err := store.GetList(ctx, "/pods", opts, list); err != nil {
+			if err := store.GetList(ctx, "/pods/", opts, list); err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
@@ -1045,11 +1045,11 @@ func RunTestNamespaceScopedWatch(ctx context.Context, t *testing.T, store storag
 			ctx = genericapirequest.WithRequestInfo(ctx, requestInfo)
 			ctx = genericapirequest.WithNamespace(ctx, tt.requestedNamespace)
 
-			watchKey := "/pods"
+			watchKey := "/pods/"
 			if tt.requestedNamespace != "" {
-				watchKey += "/" + tt.requestedNamespace
+				watchKey += tt.requestedNamespace + "/"
 				if tt.requestedName != "" {
-					watchKey += "/" + tt.requestedName
+					watchKey += tt.requestedName
 				}
 			}
 
@@ -1061,7 +1061,7 @@ func RunTestNamespaceScopedWatch(ctx context.Context, t *testing.T, store storag
 				Predicate:       predicate,
 				Recursive:       true,
 			}
-			if err := store.GetList(ctx, "/pods", opts, list); err != nil {
+			if err := store.GetList(ctx, "/pods/", opts, list); err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
@@ -1189,7 +1189,7 @@ func RunTestOptionalWatchBookmarksWithCorrectResourceVersion(ctx context.Context
 		Predicate: storage.Everything,
 		Recursive: true,
 	}
-	if err := store.GetList(ctx, "/pods", storageOpts, list); err != nil {
+	if err := store.GetList(ctx, "/pods/", storageOpts, list); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	startRV := list.ResourceVersion
@@ -1283,7 +1283,7 @@ func RunTestOptionalWatchBookmarksWithCorrectResourceVersion(ctx context.Context
 func RunSendInitialEventsBackwardCompatibility(ctx context.Context, t *testing.T, store storage.Interface) {
 	opts := storage.ListOptions{Predicate: storage.Everything}
 	opts.SendInitialEvents = ptr.To(true)
-	w, err := store.Watch(ctx, "/pods", opts)
+	w, err := store.Watch(ctx, "/pods/", opts)
 	require.NoError(t, err)
 	w.Stop()
 }
@@ -1697,7 +1697,7 @@ func RunWatchListMatchSingle(ctx context.Context, t *testing.T, store storage.In
 	opts.SendInitialEvents = &trueVal
 	opts.Predicate.AllowWatchBookmarks = true
 
-	w, err := store.Watch(context.Background(), "/pods", opts)
+	w, err := store.Watch(context.Background(), "/pods/", opts)
 	require.NoError(t, err, "failed to create watch: %v")
 	defer w.Stop()
 
@@ -1750,7 +1750,7 @@ func RunWatchErrorIsBlockingFurtherEvents(ctx context.Context, t *testing.T, sto
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			w, err := store.Watch(ctx, "/pods", opts)
+			w, err := store.Watch(ctx, "/pods/", opts)
 			if err != nil {
 				t.Errorf("failed to create watch: %v", err)
 				return


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```

Adding requirement that both cache and storage key needs to include resourcePrefix ending with "/" like "/pods/".

Followup to https://github.com/kubernetes/kubernetes/pull/133871