### PR TITLE
deflake e2e tests: Pod Level Resources Downward API

### DIFF
--- a/test/e2e/common/node/downwardapi.go
+++ b/test/e2e/common/node/downwardapi.go
@@ -458,6 +458,10 @@ var _ = SIGDescribe("Downward API", feature.PodLevelResources, framework.WithFea
 				},
 				Spec: v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("250m"),
+							v1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 						Limits: v1.ResourceList{
 							v1.ResourceCPU:    resource.MustParse("1250m"),
 							v1.ResourceMemory: resource.MustParse("64Mi"),
@@ -506,6 +510,10 @@ var _ = SIGDescribe("Downward API", feature.PodLevelResources, framework.WithFea
 				},
 				Spec: v1.PodSpec{
 					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("250m"),
+							v1.ResourceMemory: resource.MustParse("32Mi"),
+						},
 						Limits: v1.ResourceList{
 							v1.ResourceCPU: resource.MustParse("1250m"),
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

Pod Level Resources Downward API has two test cases.
https://github.com/kubernetes/kubernetes/blob/7d8551ad4e827f5f29447dc7b2f1f662a4fee050/test/e2e/common/node/downwardapi.go#L420-L576

In each test, a Pod is created with only CPU limits of 1250m specified. Since CPU limits are set, the CPU requests also default to 1250m. With a Node capacity of 2000m, two 1250m Pods cannot be scheduled, which appears to cause the `OutOfcpu` error.

```console
{ failed [FAILED] Told to stop trying after 2.006s.
pod "downward-api-2054fdc7-49b9-498a-b5cd-21f7a813d863" failed with status: 
    <v1.PodStatus>: 
        message: 'Pod was rejected: Node didn''t have enough resource: cpu, requested: 1250,
          used: 1250, capacity: 2000'
        observedGeneration: 1
        phase: Failed
        qosClass: Burstable
        reason: OutOfcpu
        startTime: "2025-09-11T08:36:32Z"
In [It] at: k8s.io/kubernetes/test/e2e/common/node/downwardapi.go:544 @ 09/11/25 08:36:34.465
}
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/134013

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
