### PR TITLE
Fix cacher resource prefix not having a "/" at the end in tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -513,7 +513,7 @@ type setupOptions struct {
 type setupOption func(*setupOptions)
 
 func withDefaults(options *setupOptions) {
-	prefix := "/pods"
+	prefix := "/pods/"
 
 	options.resourcePrefix = prefix
 	options.keyFunc = func(obj runtime.Object) (string, error) { return storage.NamespaceKeyFunc(prefix, obj) }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -64,7 +64,7 @@ import (
 )
 
 func newTestCacherWithoutSyncing(s storage.Interface, c clock.WithTicker) (*Cacher, storage.Versioner, error) {
-	prefix := "/pods"
+	prefix := "/pods/"
 	config := Config{
 		Storage:             s,
 		Versioner:           storage.APIObjectVersioner{},


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```
Followup to https://github.com/kubernetes/kubernetes/pull/133871

`NamespaceKeyFunc` and `NoNamespaceKeyFunc` are functions are the only functions assume that prefix has no "/" suffix. They are only used for tests, but because they are public we don't want to break them. Added a if statement to handle "/" suffix.

/cc @liggitt 
