### PR TITLE
Standardize not found error message of kubectl scale

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -230,7 +230,7 @@ func (o *ScaleOptions) RunScale() error {
 
 	if len(infos) == 0 {
 		if infoErr != nil {
-			return fmt.Errorf("no objects passed to scale %w", infoErr)
+			return infoErr
 		}
 		return fmt.Errorf("no objects passed to scale")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig cli

#### What this PR does / why we need it:
Fix error message of `kubectl scale` when specified resource does not exist.
It is same behavior as some cmds(e.g. `kubectl get`,` kubectl describe`, `kubectl rollout restart`...)
```bash
Error from server (NotFound): <GroupResource> "<ResourceName>" not found
```

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubectl/issues/1770

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Previously, `kubectl scale` returned the error message `error: no objects passed to scale <GroupResource> "<ResourceName>" not found` when the specified resource did not exist. 
For consistency with other commands(e.g. `kubectl get`), it has been changed to just return `Error from server (NotFound): <GroupResource> "<ResourceName>" not found`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
