### PR TITLE
refactor(controller): Use context-aware WaitForNamedCacheSync in resourcequota and HPA tests

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	metricsclient "k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	cmapi "k8s.io/metrics/pkg/apis/custom_metrics/v1beta2"
 	emapi "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -341,6 +342,9 @@ func (tc *replicaCalcTestCase) prepareTestClient(t *testing.T) (*fake.Clientset,
 }
 
 func (tc *replicaCalcTestCase) runTest(t *testing.T) {
+	// Create the special test-aware context.
+	tCtx := ktesting.Init(t)
+
 	testClient, testMetricsClient, testCMClient, testEMClient := tc.prepareTestClient(t)
 	metricsClient := metricsclient.NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient)
 
@@ -349,11 +353,15 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 
 	replicaCalc := NewReplicaCalculator(metricsClient, informer.Lister(), defaultTestingCPUInitializationPeriod, defaultTestingDelayOfInitialReadinessStatus)
 
-	stop := make(chan struct{})
-	defer close(stop)
-	informerFactory.Start(stop)
-	if !cache.WaitForNamedCacheSync("HPA", stop, informer.Informer().HasSynced) {
-		return
+	// Use the test context's Done() channel to manage the informer's lifecycle.
+	informerFactory.Start(tCtx.Done())
+
+	// Create a new context specifically for the cache sync operation with a timeout.
+	syncCtx, cancel := context.WithTimeout(tCtx, 10*time.Second)
+	defer cancel()
+
+	if !cache.WaitForNamedCacheSyncWithContext(syncCtx, informer.Informer().HasSynced) {
+		tCtx.Fatal("Failed to sync informer cache within the 10s timeout")
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
@@ -368,7 +376,7 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	}
 
 	if tc.resource != nil {
-		outReplicas, outUtilization, outRawValue, outTimestamp, err := replicaCalc.GetResourceReplicas(context.TODO(), tc.currentReplicas, tc.resource.targetUtilization, tc.resource.name, tolerances, testNamespace, selector, tc.container)
+		outReplicas, outUtilization, outRawValue, outTimestamp, err := replicaCalc.GetResourceReplicas(tCtx, tc.currentReplicas, tc.resource.targetUtilization, tc.resource.name, tolerances, testNamespace, selector, tc.container)
 
 		if tc.expectedError != nil {
 			require.Error(t, err, "there should be an error calculating the replica count")

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -489,14 +489,17 @@ func (rq *Controller) Sync(ctx context.Context, discoveryFunc NamespacedResource
 		// this protects us from deadlocks where available resources changed and one of our informer caches will never fill.
 		// informers keep attempting to sync in the background, so retrying doesn't interrupt them.
 		// the call to resyncMonitors on the reattempt will no-op for resources that still exist.
-		if rq.quotaMonitor != nil &&
-			!cache.WaitForNamedCacheSync(
-				"resource quota",
-				waitForStopOrTimeout(ctx.Done(), period),
+		if rq.quotaMonitor != nil {
+			syncCtx, cancel := context.WithTimeout(ctx, period)
+			defer cancel()
+
+			if !cache.WaitForNamedCacheSyncWithContext(
+				syncCtx,
 				func() bool { return rq.quotaMonitor.IsSynced(ctx) },
 			) {
-			utilruntime.HandleError(fmt.Errorf("timed out waiting for quota monitor sync"))
-			return
+				utilruntime.HandleError(fmt.Errorf("timed out waiting for quota monitor sync"))
+				return
+			}
 		}
 
 		logger.V(2).Info("synced quota controller")
@@ -518,19 +521,6 @@ func printDiff(oldResources, newResources map[schema.GroupVersionResource]struct
 		}
 	}
 	return fmt.Sprintf("added: %v, removed: %v", added.List(), removed.List())
-}
-
-// waitForStopOrTimeout returns a stop channel that closes when the provided stop channel closes or when the specified timeout is reached
-func waitForStopOrTimeout(stopCh <-chan struct{}, timeout time.Duration) <-chan struct{} {
-	stopChWithTimeout := make(chan struct{})
-	go func() {
-		defer close(stopChWithTimeout)
-		select {
-		case <-stopCh:
-		case <-time.After(timeout):
-		}
-	}()
-	return stopChWithTimeout
 }
 
 // resyncMonitors starts or stops quota monitors as needed to ensure that all


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
refactor(controller): Use context-aware WaitForNamedCacheSync in resourcequota and HPA tests

#### Which issue(s) this PR is related to:
Contributes to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
NONE
```