### PR TITLE
fix: use iifname for input interface name matches

### DIFF
--- a/pkg/proxy/util/localdetector.go
+++ b/pkg/proxy/util/localdetector.go
@@ -98,8 +98,8 @@ func NewDetectLocalByBridgeInterface(interfaceName string) LocalTrafficDetector 
 	return &detectLocal{
 		ifLocal:       []string{"-i", interfaceName},
 		ifNotLocal:    []string{"!", "-i", interfaceName},
-		ifLocalNFT:    []string{"iif", interfaceName},
-		ifNotLocalNFT: []string{"iif", "!=", interfaceName},
+		ifLocalNFT:    []string{"iifname", interfaceName},
+		ifNotLocalNFT: []string{"iifname", "!=", interfaceName},
 	}
 }
 
@@ -110,7 +110,7 @@ func NewDetectLocalByInterfaceNamePrefix(interfacePrefix string) LocalTrafficDet
 	return &detectLocal{
 		ifLocal:       []string{"-i", interfacePrefix + "+"},
 		ifNotLocal:    []string{"!", "-i", interfacePrefix + "+"},
-		ifLocalNFT:    []string{"iif", interfacePrefix + "*"},
-		ifNotLocalNFT: []string{"iif", "!=", interfacePrefix + "*"},
+		ifLocalNFT:    []string{"iifname", interfacePrefix + "*"},
+		ifNotLocalNFT: []string{"iifname", "!=", interfacePrefix + "*"},
 	}
 }

--- a/pkg/proxy/util/localdetector_test.go
+++ b/pkg/proxy/util/localdetector_test.go
@@ -105,6 +105,37 @@ func TestDetectLocalByBridgeInterface(t *testing.T) {
 	}
 }
 
+func TestDetectLocalNFTByBridgeInterface(t *testing.T) {
+	cases := []struct {
+		ifaceName               string
+		expectedJumpIfOutput    []string
+		expectedJumpIfNotOutput []string
+	}{
+		{
+			ifaceName:               "eth0",
+			expectedJumpIfOutput:    []string{"iifname", "eth0"},
+			expectedJumpIfNotOutput: []string{"iifname", "!=", "eth0"},
+		},
+	}
+	for _, c := range cases {
+		localDetector := NewDetectLocalByBridgeInterface(c.ifaceName)
+		if !localDetector.IsImplemented() {
+			t.Error("DetectLocalByBridgeInterface returns false for IsImplemented")
+		}
+
+		ifLocal := localDetector.IfLocalNFT()
+		ifNotLocal := localDetector.IfNotLocalNFT()
+
+		if !reflect.DeepEqual(ifLocal, c.expectedJumpIfOutput) {
+			t.Errorf("IfLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfOutput, ifLocal)
+		}
+
+		if !reflect.DeepEqual(ifNotLocal, c.expectedJumpIfNotOutput) {
+			t.Errorf("IfNotLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfNotOutput, ifNotLocal)
+		}
+	}
+}
+
 func TestDetectLocalByInterfaceNamePrefix(t *testing.T) {
 	cases := []struct {
 		ifacePrefix             string
@@ -134,6 +165,39 @@ func TestDetectLocalByInterfaceNamePrefix(t *testing.T) {
 
 		if !reflect.DeepEqual(ifNotLocal, c.expectedJumpIfNotOutput) {
 			t.Errorf("IfNotLocal, expected: '%v', but got: '%v'", c.expectedJumpIfNotOutput, ifNotLocal)
+		}
+	}
+}
+
+func TestDetectLocalNFTByInterfaceNamePrefix(t *testing.T) {
+	cases := []struct {
+		ifacePrefix             string
+		chain                   string
+		args                    []string
+		expectedJumpIfOutput    []string
+		expectedJumpIfNotOutput []string
+	}{
+		{
+			ifacePrefix:             "eth",
+			expectedJumpIfOutput:    []string{"iifname", "eth*"},
+			expectedJumpIfNotOutput: []string{"iifname", "!=", "eth*"},
+		},
+	}
+	for _, c := range cases {
+		localDetector := NewDetectLocalByInterfaceNamePrefix(c.ifacePrefix)
+		if !localDetector.IsImplemented() {
+			t.Error("DetectLocalByInterfaceNamePrefix returns false for IsImplemented")
+		}
+
+		ifLocal := localDetector.IfLocalNFT()
+		ifNotLocal := localDetector.IfNotLocalNFT()
+
+		if !reflect.DeepEqual(ifLocal, c.expectedJumpIfOutput) {
+			t.Errorf("IfLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfOutput, ifLocal)
+		}
+
+		if !reflect.DeepEqual(ifNotLocal, c.expectedJumpIfNotOutput) {
+			t.Errorf("IfNotLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfNotOutput, ifNotLocal)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes a bug in the nftables support of kube-proxy. An example error without this fix. Notice that `iif` was mistakenly used instead of `iifname` in that.

```
I0911 16:35:49.542259       1 proxier.go:1840] "Reloading service nftables data" ipFamily="IPv4" numServices=5 numEndpoints=8
E0911 16:35:49.547707       1 proxier.go:1851] "nftables sync failed" err=<
	/dev/stdin:72:109-112: Error: Interface does not exist
	add rule ip kube-proxy service-2QRHZV4L-default/kubernetes/tcp/https ip daddr 10.0.0.1 tcp dport 443 iif != azv* jump mark-for-masquerade
	                                                                                                            ^^^^
	/dev/stdin:84:109-112: Error: Interface does not exist
	add rule ip kube-proxy service-FY5PMXPG-kube-system/kube-dns/udp/dns ip daddr 10.0.0.10 udp dport 53 iif != azv* jump mark-for-masquerade
	                                                                                                            ^^^^
	/dev/stdin:97:113-116: Error: Interface does not exist
	add rule ip kube-proxy service-NWBZK7IH-kube-system/kube-dns/tcp/dns-tcp ip daddr 10.0.0.10 tcp dport 53 iif != azv* jump mark-for-masquerade
	                                                                                                                ^^^^
	/dev/stdin:111:129-132: Error: Interface does not exist
	add rule ip kube-proxy service-EZ4UY2LR-calico-system/calico-typha/tcp/calico-typha ip daddr 10.0.172.152 tcp dport 5473 iif != azv* jump mark-for-masquerade
	                                                                                                                                ^^^^
 > ipFamily="IPv4"
I0911 16:35:49.547728       1 proxier.go:1204] "Sync failed" ipFamily="IPv4" retryingTime="30s"
```

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/3866-nftables-proxy/README.md

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in kube-proxy nftables mode (GA as of 1.33) that fails to determine if traffic originates from a local source on the node. The issue was caused by using the wrong meta `iif` instead of `iifname` for name based matches.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
