### PR TITLE
Fix KMS integration test: remove existing socket before starting mock plugin

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/testing/v1beta1/kms_plugin_mock.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/testing/v1beta1/kms_plugin_mock.go
@@ -69,6 +69,8 @@ func NewBase64Plugin(t *testing.T, socketPath string) *Base64Plugin {
 		socketPath: socketPath,
 	}
 
+	// Make sure we don't have a leftover socket.
+	_ = os.Remove(socketPath)
 	kmsapi.RegisterKeyManagementServiceServer(server, result)
 	if err := result.start(); err != nil {
 		t.Fatalf("failed to start KMS plugin, err: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Ensure KMS plugin socket is removed before starting mock in 'encrypt all resources' test
I noticed that if this test fails for some reason and if you re-run the test, it would fail with "address already in use".
This PR ensures that the socket file is removed before starting the mock plugin

