### PR TITLE
KEP-3926: implement dry-run support for unsafe corrupt object deletion

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -376,9 +376,6 @@ func ValidateIgnoreStoreReadError(fldPath *field.Path, options *metav1.DeleteOpt
 		return allErrs
 	}
 
-	if len(options.DryRun) > 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, true, "cannot be set together with .dryRun"))
-	}
 	if options.PropagationPolicy != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, true, "cannot be set together with .propagationPolicy"))
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
@@ -129,7 +129,6 @@ func TestInvalidDryRun(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestValidateDeleteOptionsWithIgnoreStoreReadError(t *testing.T) {
@@ -180,7 +179,6 @@ func TestValidateDeleteOptionsWithIgnoreStoreReadError(t *testing.T) {
 				Preconditions:      &metav1.Preconditions{},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(fieldPath, true, "cannot be set together with .dryRun"),
 				field.Invalid(fieldPath, true, "cannot be set together with .propagationPolicy"),
 				field.Invalid(fieldPath, true, "cannot be set together with .gracePeriodSeconds"),
 				field.Invalid(fieldPath, true, "cannot be set together with .preconditions"),
@@ -197,7 +195,6 @@ func TestValidateDeleteOptionsWithIgnoreStoreReadError(t *testing.T) {
 				Preconditions:      &metav1.Preconditions{},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(fieldPath, true, "cannot be set together with .dryRun"),
 				field.Invalid(fieldPath, true, "cannot be set together with .orphanDependents"),
 				field.Invalid(fieldPath, true, "cannot be set together with .gracePeriodSeconds"),
 				field.Invalid(fieldPath, true, "cannot be set together with .preconditions"),
@@ -209,6 +206,24 @@ func TestValidateDeleteOptionsWithIgnoreStoreReadError(t *testing.T) {
 				IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To[bool](false),
 			},
 			expectedErrors: field.ErrorList{},
+		},
+		{
+			name: "option is true, dry-run is set (should be allowed)",
+			opts: metav1.DeleteOptions{
+				IgnoreStoreReadErrorWithClusterBreakingPotential: new(true),
+				DryRun: []string{"All"},
+			},
+			expectedErrors: field.ErrorList{},
+		},
+		{
+			name: "option is true, dry-run is set to an invalid value",
+			opts: metav1.DeleteOptions{
+				IgnoreStoreReadErrorWithClusterBreakingPotential: new(true),
+				DryRun: []string{"Invalid"},
+			},
+			expectedErrors: field.ErrorList{
+				field.NotSupported(field.NewPath("dryRun"), []string{"Invalid"}, []string{"All"}),
+			},
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go
@@ -23,10 +23,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	storeerr "k8s.io/apiserver/pkg/storage/errors"
+	"k8s.io/apiserver/pkg/util/dryrun"
 
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -51,6 +53,27 @@ func NewCorruptObjectDeleter(store *Store) rest.GracefulDeleter {
 type corruptObjectDeleter struct {
 	store *Store
 }
+
+// errUnsafeDeleteDryRun is a sentinel error returned by the deletion validator
+// on dry run requests. The etcd3 store calls the validator only after the
+// corruption check, and before it executes the delete:
+//
+//	getState(key, expectTransformOrDecodeError=true)
+//	    key not found          -> KeyNotFoundError, validator never runs
+//	    decodes cleanly        -> InvalidObjError, validator never runs
+//	    transform/decode fails -> validateDeletion, then OptimisticDelete
+//
+// Getting this error back means the object is corrupt at the latest revision
+// and the delete would have gone through.
+var errUnsafeDeleteDryRun = errors.New("aborting unsafe delete, dry run requested")
+
+// errUnsafeDeleteDryRunBypassed indicates the storage deleted the object
+// without calling the deletion validator on a dry run request. This MUST
+// NEVER happen with ANY storage.Interface implementation. The validator is
+// the same parameter that carries delete admission for regular deletion
+// requests, see Store.Delete. A backend that triggers this error has a bug
+// that allows object deletion without running delete admission.
+var errUnsafeDeleteDryRunBypassed = errors.New("storage deleted the object despite the dry run request")
 
 // Delete performs an unsafe deletion of the given resource from the storage.
 //
@@ -81,6 +104,26 @@ func (d *corruptObjectDeleter) Delete(ctx context.Context, name string, deleteVa
 	//  b) skip admission validation, rest.ValidateAllObjectFunc will "admit everything"
 	var nilPreconditions *storage.Preconditions = nil
 	var nilCachedExistingObject runtime.Object = nil
+	if dryrun.IsDryRun(opts.DryRun) {
+		err := storageBackend.Delete(
+			ctx, key, out, nilPreconditions,
+			func(context.Context, runtime.Object) error { return errUnsafeDeleteDryRun },
+			nilCachedExistingObject, storageOpts,
+		)
+		switch {
+		case errors.Is(err, errUnsafeDeleteDryRun):
+			// the object is corrupt at the latest revision, the
+			// delete would have proceeded
+			return nil, true, nil
+		case err == nil:
+			// Should never happen. Indicates a critical bug in the
+			// storage.Interface implementation, see errUnsafeDeleteDryRunBypassed
+			utilruntime.HandleErrorWithContext(ctx, errUnsafeDeleteDryRunBypassed, "The storage bypassed delete admission on a dry run request", "object", klog.KRef(genericapirequest.NamespaceValue(ctx), name))
+			return nil, false, apierrors.NewInternalError(errUnsafeDeleteDryRunBypassed)
+		default:
+			return nil, false, storeerr.InterpretDeleteError(err, qualifiedResource, name)
+		}
+	}
 	if err := storageBackend.Delete(ctx, key, out, nilPreconditions, rest.ValidateAllObjectFunc, nilCachedExistingObject, storageOpts); err != nil {
 		return nil, false, storeerr.InterpretDeleteError(err, qualifiedResource, name)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter.go
@@ -55,8 +55,9 @@ type corruptObjectDeleter struct {
 }
 
 // errUnsafeDeleteDryRun is a sentinel error returned by the deletion validator
-// on dry run requests. The etcd3 store calls the validator only after the
-// corruption check, and before it executes the delete:
+// on dry run requests. Calling the validation function before the delete
+// transaction is a system-wide invariant: it is how delete admission runs for
+// every delete in Kubernetes. No storage implementation can skip it.
 //
 //	getState(key, expectTransformOrDecodeError=true)
 //	    key not found          -> KeyNotFoundError, validator never runs
@@ -92,10 +93,16 @@ func (d *corruptObjectDeleter) Delete(ctx context.Context, name string, deleteVa
 		return nil, false, err
 	}
 	qualifiedResource := d.store.qualifiedResourceFromContext(ctx)
-	// use the storage implementation directly, bypass the dryRun layer
+	// Bypass the DryRunnableStorage layer as it was never designed to
+	// deal with corrupt objects (its dry run simulation is Get + decode).
+	// The call below must always land in the etcd3 store, see Delete in
+	// https://github.com/kubernetes/kubernetes/blob/6a5cc912a3c2a2c241fe05abea563079bf574abd/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L336-L354
 	storageBackend := d.store.Storage.Storage
 	klog.FromContext(ctx).V(1).Info("Going to perform unsafe object deletion", "object", klog.KRef(genericapirequest.NamespaceValue(ctx), name))
 	out := d.store.NewFunc()
+	// ExpectTransformOrDecodeError forces a live read from etcd and makes
+	// the delete fail unless the object is corrupt: not found and
+	// decodable objects return errors.
 	storageOpts := storage.DeleteOptions{ExpectTransformOrDecodeError: true}
 	// we don't have the old object in the cache, neither can it be
 	// retrieved from the storage and decoded into an object

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/corrupt_obj_deleter_test.go
@@ -33,10 +33,14 @@ import (
 )
 
 // fakeStorage is a test double for storage.Interface that intercepts Delete calls, records the
-// arguments, and returns a pre-configured error.
+// arguments, and returns a pre-configured error. By default it mimics the etcd3 store handling
+// a corrupt object: the deletion validator runs after the corruption check and before the
+// delete, a validator error aborts the delete. With bypassValidator set, it simulates a buggy
+// backend that deletes without consulting the deletion validator.
 type fakeStorage struct {
 	storage.Interface
-	deleteErr error
+	deleteErr       error
+	bypassValidator bool
 
 	deleteCalled            bool
 	key                     string
@@ -51,13 +55,21 @@ func (s *fakeStorage) Delete(ctx context.Context, key string, out runtime.Object
 	s.expectTransformOrDecode = opts.ExpectTransformOrDecodeError
 	s.preconditions = preconditions
 	s.cachedExistingObject = cachedExistingObject
-	return s.deleteErr
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	if s.bypassValidator {
+		return nil
+	}
+	// the object is nil for a corrupt object, it cannot be decoded
+	return deleteValidation(ctx, nil)
 }
 
 func TestCorruptObjectDeleterDelete(t *testing.T) {
 	for _, test := range []struct {
 		name               string
 		deleteErr          error
+		bypassValidator    bool
 		opts               *metav1.DeleteOptions
 		expectDeleteCalled bool
 		wantDeleted        bool
@@ -100,10 +112,38 @@ func TestCorruptObjectDeleterDelete(t *testing.T) {
 			expectDeleteCalled: true,
 			wantErr:            errors.IsNotFound,
 		},
+		{
+			name:               "option true, dry run, object not decodable, store honors the validator",
+			opts:               &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: new(true), DryRun: []string{"All"}},
+			expectDeleteCalled: true,
+			wantDeleted:        true,
+			wantErr:            func(err error) bool { return err == nil },
+		},
+		{
+			name:               "option true, dry run, object decodable, store returns InvalidObj",
+			opts:               &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: new(true), DryRun: []string{"All"}},
+			deleteErr:          storage.NewInvalidObjError("/pods/foo", "object is decodable"),
+			expectDeleteCalled: true,
+			wantErr:            errors.IsConflict,
+		},
+		{
+			name:               "option true, dry run, object not found, store returns NotFound",
+			opts:               &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: new(true), DryRun: []string{"All"}},
+			deleteErr:          storage.NewKeyNotFoundError("/pods/foo", 0),
+			expectDeleteCalled: true,
+			wantErr:            errors.IsNotFound,
+		},
+		{
+			name:               "option true, dry run, store deletes without invoking the validator",
+			opts:               &metav1.DeleteOptions{IgnoreStoreReadErrorWithClusterBreakingPotential: new(true), DryRun: []string{"All"}},
+			bypassValidator:    true,
+			expectDeleteCalled: true,
+			wantErr:            errors.IsInternalError,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
-			fs := &fakeStorage{deleteErr: test.deleteErr}
+			fs := &fakeStorage{deleteErr: test.deleteErr, bypassValidator: test.bypassValidator}
 			const podPrefix = "/pods/"
 			store := &Store{
 				NewFunc:                   func() runtime.Object { return &example.Pod{} },
@@ -120,6 +160,10 @@ func TestCorruptObjectDeleterDelete(t *testing.T) {
 			}
 			deleter := NewCorruptObjectDeleter(store)
 
+			// the unsafe deleter must ignore the caller's admission validator, it
+			// passes its own validator to the storage instead: admit-everything for
+			// a regular delete, a hardcoded-fail sentinel for dry run. This func
+			// fails the test if the deleter ever wires admission back in.
 			obj, deleted, err := deleter.Delete(ctx, "foo", func(context.Context, runtime.Object) error {
 				t.Fatal("caller-provided admission was invoked")
 				return nil

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -334,7 +334,15 @@ func TestAllowUnsafeMalformedObjectDeletionFeature(t *testing.T) {
 				t.Errorf("unexpected failure when etting the secret from the cache: %v", err)
 			}
 
-			// l) let's try the normal deletion flow, we expect an error
+			withDryRun := func(opts metav1.DeleteOptions) metav1.DeleteOptions {
+				opts.DryRun = []string{metav1.DryRunAll}
+
+				return opts
+			}
+
+			// l) let's try the normal deletion flow with/without dry run, we expect an error
+			err = test.restClient.CoreV1().Secrets(testNamespace).Delete(context.Background(), secretCorrupt, withDryRun(metav1.DeleteOptions{}))
+			tc.corrupObjDeletWithoutOption.verify(t, err)
 			err = test.restClient.CoreV1().Secrets(testNamespace).Delete(context.Background(), secretCorrupt, metav1.DeleteOptions{})
 			tc.corrupObjDeletWithoutOption.verify(t, err)
 
@@ -344,6 +352,9 @@ func TestAllowUnsafeMalformedObjectDeletionFeature(t *testing.T) {
 			options := metav1.DeleteOptions{
 				IgnoreStoreReadErrorWithClusterBreakingPotential: ptr.To(true),
 			}
+			dryRunOptions := withDryRun(options)
+			err = test.restClient.CoreV1().Secrets(testNamespace).Delete(context.Background(), secretCorrupt, dryRunOptions)
+			tc.corrupObjDeleteWithOption.verify(t, err)
 			err = test.restClient.CoreV1().Secrets(testNamespace).Delete(context.Background(), secretCorrupt, options)
 			tc.corrupObjDeleteWithOption.verify(t, err)
 
@@ -351,6 +362,12 @@ func TestAllowUnsafeMalformedObjectDeletionFeature(t *testing.T) {
 			permitUserToDoVerbOnSecret(t, adminClient, testUser, testNamespace, []string{"unsafe-delete-ignore-read-errors"})
 
 			// o) let's try to do unsafe delete again
+			err = test.restClient.CoreV1().Secrets(testNamespace).Delete(context.Background(), secretCorrupt, dryRunOptions)
+			tc.corrupObjDeleteWithOptionAndPrivilege.verify(t, err)
+			// the dry run must not delete the object, the GET should fail
+			// with the same error as before any delete attempt
+			_, err = test.restClient.CoreV1().Secrets(testNamespace).Get(context.Background(), secretCorrupt, metav1.GetOptions{})
+			tc.corruptObjGetPreDelete.verify(t, err)
 			err = test.restClient.CoreV1().Secrets(testNamespace).Delete(context.Background(), secretCorrupt, options)
 			tc.corrupObjDeleteWithOptionAndPrivilege.verify(t, err)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR implements dry-run support for the unsafe corrupt object deletion feature introduced in KEP-3926.

This enhancement allows administrators to safely test corrupt object deletion operations before executing them, providing an important safety mechanism for this potentially cluster-breaking operation.

#### Which issue(s) this PR fixes:
 
Fixes #

#### Special notes for your reviewer:

This builds upon the existing unsafe deletion functionality from #127513. The dry-run implementation follows Kubernetes' standard dry-run patterns and maintains backward compatibility.

Key changes:

- Removed validation restriction in that blocked dry-run with unsafe deletion options
- Enhanced `corrupt_obj_deleter.go` to handle dry-run requests appropriately
- Added comprehensive test coverage for dry-run scenarios in integration tests

#### Does this PR introduce a user-facing change?

This feature is feature-gated by `AllowUnsafeMalformedObjectDeletion`:

```release-note
The unsafe corrupt object deletion feature now supports dry-run mode, allowing administrators to test deletion operations safely before execution.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/pull/3927