### PR TITLE
Explicitly set TerminationGracePeriodSeconds for mirror pod

### DIFF
--- a/test/e2e_node/mirror_pod_grace_period_test.go
+++ b/test/e2e_node/mirror_pod_grace_period_test.go
@@ -36,6 +36,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 )
 
 var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
@@ -344,6 +345,7 @@ var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 
 func createStaticPodWithGracePeriod(dir, name, namespace string) error {
 	podSpec := v1.PodSpec{
+		TerminationGracePeriodSeconds: ptr.To(int64(20)),
 		Containers: []v1.Container{{
 			Name:    "m-test",
 			Image:   imageutils.GetE2EImage(imageutils.BusyBox),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

This PR is to fix the failing test by explicitly setting the TerminationGracePeriodSeconds for mirror pod.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test
#### What this PR does / why we need it:
Mirror pod [Test](https://github.com/kubernetes/kubernetes/blob/4e907fad15d41b09a51060d5ff02a90111d5b25f/test/e2e_node/mirror_pod_grace_period_test.go#L164) expects the TerminationGracePeriodSeconds to be 20s as per the test [comments](https://github.com/kubernetes/kubernetes/blob/4e907fad15d41b09a51060d5ff02a90111d5b25f/test/e2e_node/mirror_pod_grace_period_test.go#L273-L277) but in 
 the PR https://github.com/kubernetes/kubernetes/pull/132198 it has been removed causing the test failure.

#### Which issue(s) this PR is related to: https://github.com/kubernetes/kubernetes/issues/116998
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #https://github.com/kubernetes/kubernetes/issues/116998
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
