### PR TITLE
Replace deprecated sets.String with sets.Set[string] in apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/config.go
@@ -108,7 +108,7 @@ func ReadAdmissionConfiguration(pluginNames []string, configFilePath string, con
 	// in order to preserve backwards compatibility, we set plugins that
 	// previously read input from a non-versioned file configuration to the
 	// current input file.
-	legacyPluginsWithUnversionedConfig := sets.NewString("ImagePolicyWebhook", "PodNodeSelector")
+	legacyPluginsWithUnversionedConfig := sets.New[string]("ImagePolicyWebhook", "PodNodeSelector")
 	externalConfig := &apiserverv1.AdmissionConfiguration{}
 	for _, pluginName := range pluginNames {
 		if legacyPluginsWithUnversionedConfig.Has(pluginName) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/handler.go
@@ -34,7 +34,7 @@ type ReadyFunc func() bool
 // Handler is a base for admission control handlers that
 // support a predefined set of operations
 type Handler struct {
-	operations sets.String
+	operations sets.Set[string]
 	readyFunc  ReadyFunc
 }
 
@@ -46,7 +46,7 @@ func (h *Handler) Handles(operation Operation) bool {
 // NewHandler creates a new base handler that handles the passed
 // in operations
 func NewHandler(ops ...Operation) *Handler {
-	operations := sets.NewString()
+	operations := sets.New[string]()
 	for _, op := range ops {
 		operations.Insert(string(op))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -49,7 +49,7 @@ func newHandlerForTest(c clientset.Interface) (*Lifecycle, informers.SharedInfor
 // newHandlerForTestWithClock returns a configured handler for testing.
 func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (*Lifecycle, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(c, 5*time.Minute)
-	handler, err := newLifecycleWithClock(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem), cacheClock)
+	handler, err := newLifecycleWithClock(sets.New[string](metav1.NamespaceDefault, metav1.NamespaceSystem), cacheClock)
 	if err != nil {
 		return nil, f, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -65,7 +65,7 @@ type quotaEvaluator struct {
 	workLock   sync.Mutex
 	work       map[string][]*admissionWaiter
 	dirtyWork  map[string][]*admissionWaiter
-	inProgress sets.String
+	inProgress sets.Set[string]
 
 	// controls the run method so that we can cleanly conform to the Evaluator interface
 	workers int
@@ -125,7 +125,7 @@ func NewQuotaEvaluator(quotaAccessor QuotaAccessor, ignoredResources map[schema.
 		queue:      workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[string]{Name: "admission_quota_controller"}),
 		work:       map[string][]*admissionWaiter{},
 		dirtyWork:  map[string][]*admissionWaiter{},
-		inProgress: sets.String{},
+		inProgress: sets.Set[string]{},
 
 		workers: workers,
 		stopCh:  stopCh,

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/reinvocationcontext.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/reinvocationcontext.go
@@ -27,9 +27,9 @@ type webhookReinvokeContext struct {
 	lastWebhookOutput runtime.Object
 	// previouslyInvokedReinvocableWebhooks holds the set of webhooks that have been invoked and
 	// should be reinvoked if a later mutation occurs
-	previouslyInvokedReinvocableWebhooks sets.String
+	previouslyInvokedReinvocableWebhooks sets.Set[string]
 	// reinvokeWebhooks holds the set of webhooks that should be reinvoked
-	reinvokeWebhooks sets.String
+	reinvokeWebhooks sets.Set[string]
 }
 
 func (rc *webhookReinvokeContext) ShouldReinvokeWebhook(webhook string) bool {
@@ -50,7 +50,7 @@ func (rc *webhookReinvokeContext) SetLastWebhookInvocationOutput(object runtime.
 
 func (rc *webhookReinvokeContext) AddReinvocableWebhookToPreviouslyInvoked(webhook string) {
 	if rc.previouslyInvokedReinvocableWebhooks == nil {
-		rc.previouslyInvokedReinvocableWebhooks = sets.NewString()
+		rc.previouslyInvokedReinvocableWebhooks = sets.New[string]()
 	}
 	rc.previouslyInvokedReinvocableWebhooks.Insert(webhook)
 }
@@ -58,11 +58,11 @@ func (rc *webhookReinvokeContext) AddReinvocableWebhookToPreviouslyInvoked(webho
 func (rc *webhookReinvokeContext) RequireReinvokingPreviouslyInvokedPlugins() {
 	if len(rc.previouslyInvokedReinvocableWebhooks) > 0 {
 		if rc.reinvokeWebhooks == nil {
-			rc.reinvokeWebhooks = sets.NewString()
+			rc.reinvokeWebhooks = sets.New[string]()
 		}
 		for s := range rc.previouslyInvokedReinvocableWebhooks {
 			rc.reinvokeWebhooks.Insert(s)
 		}
-		rc.previouslyInvokedReinvocableWebhooks = sets.NewString()
+		rc.previouslyInvokedReinvocableWebhooks = sets.New[string]()
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/rules/rules_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/rules/rules_test.go
@@ -396,11 +396,11 @@ func TestScope(t *testing.T) {
 			noMatch: attrList(),
 		},
 	}
-	keys := sets.NewString()
+	keys := sets.New[string]()
 	for name := range table {
 		keys.Insert(name)
 	}
-	for _, name := range keys.List() {
+	for _, name := range sets.List(keys) {
 		tt := table[name]
 		for i, m := range tt.match {
 			t.Run(fmt.Sprintf("%s_match_%d", name, i), func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
   Continue the work started in #133923 to replace all usages of deprecated `sets.String` type with the recommended `sets.Set[string]` in apiserver admission subsystem.

  This PR focuses specifically on the admission controller components, updating 7 files in
  `staging/src/k8s.io/apiserver/pkg/admission/` to use the modern generic `sets.Set[string]` type instead of the
  deprecated `sets.String`. This change modernizes the codebase while maintaining API functionality.

Breaking Changes:
  This PR contains breaking changes to exported APIs in the following files:
  - `staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go`: `NewLifecycle` function signature

#### Which issue(s) this PR is related to:

  Related to #133935
  Follows up on #133923 (admission subsystem portion)
#### Special notes for your reviewer:
  This PR is part of a larger effort to modernize the Kubernetes codebase by replacing deprecated `sets.String` with the new generic `sets.Set[string]` type. 
  All existing tests have been updated and continue to pass with no functional changes.

#### Does this PR introduce a user-facing change?

```release-note
  Replace deprecated sets.String with sets.Set[string] in apiserver admission subsystem. This is a breaking change for consumers of the NewLifecycle function.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
