### PR TITLE
Replace JitterUntil with JitterUntilWithContext

### DIFF
--- a/pkg/kubelet/server/stats/fs_resource_analyzer.go
+++ b/pkg/kubelet/server/stats/fs_resource_analyzer.go
@@ -67,19 +67,19 @@ func (s *fsResourceAnalyzer) Start(ctx context.Context) {
 			return
 		}
 		logger.Info("Starting FS ResourceAnalyzer")
-		go wait.Forever(func() { s.updateCachedPodVolumeStats(logger) }, s.calcPeriod)
+		go wait.Forever(func() { s.updateCachedPodVolumeStats(ctx) }, s.calcPeriod)
 	})
 }
 
 // updateCachedPodVolumeStats calculates and caches the PodVolumeStats for every Pod known to the kubelet.
-func (s *fsResourceAnalyzer) updateCachedPodVolumeStats(logger klog.Logger) {
+func (s *fsResourceAnalyzer) updateCachedPodVolumeStats(ctx context.Context) {
 	oldCache := s.cachedVolumeStats.Load().(statCache)
 	newCache := make(statCache)
 
 	// Copy existing entries to new map, creating/starting new entries for pods missing from the cache
 	for _, pod := range s.statsProvider.GetPods() {
 		if value, found := oldCache[pod.GetUID()]; !found {
-			newCache[pod.GetUID()] = newVolumeStatCalculator(s.statsProvider, s.calcPeriod, pod, s.eventRecorder).StartOnce(logger)
+			newCache[pod.GetUID()] = newVolumeStatCalculator(ctx, s.statsProvider, s.calcPeriod, pod, s.eventRecorder).StartOnce()
 		} else {
 			newCache[pod.GetUID()] = value
 		}

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -105,7 +105,7 @@ var (
 )
 
 func TestPVCRef(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	// Setup mock stats provider
 	mockStats := statstest.NewMockProvider(t)
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}, vol3: &fakeVolume{}}
@@ -119,7 +119,7 @@ func TestPVCRef(t *testing.T) {
 	}
 
 	// Calculate stats for pod
-	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
+	statsCalculator := newVolumeStatCalculator(ctx, mockStats, time.Minute, fakePod, &fakeEventRecorder)
 	statsCalculator.calcAndStoreStats(logger)
 	vs, _ := statsCalculator.GetLatest()
 
@@ -163,7 +163,7 @@ func TestPVCRef(t *testing.T) {
 }
 
 func TestNormalVolumeEvent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	mockStats := statstest.NewMockProvider(t)
 
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}}
@@ -177,7 +177,7 @@ func TestNormalVolumeEvent(t *testing.T) {
 	}
 
 	// Calculate stats for pod
-	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
+	statsCalculator := newVolumeStatCalculator(ctx, mockStats, time.Minute, fakePod, &fakeEventRecorder)
 	statsCalculator.calcAndStoreStats(logger)
 
 	event, err := WatchEvent(eventStore)
@@ -186,7 +186,7 @@ func TestNormalVolumeEvent(t *testing.T) {
 }
 
 func TestAbnormalVolumeEvent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIVolumeHealth, true)
 
 	// Setup mock stats provider
@@ -206,7 +206,7 @@ func TestAbnormalVolumeEvent(t *testing.T) {
 		volumeCondition.Message = "The target path of the volume doesn't exist"
 		volumeCondition.Abnormal = true
 	}
-	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
+	statsCalculator := newVolumeStatCalculator(ctx, mockStats, time.Minute, fakePod, &fakeEventRecorder)
 	statsCalculator.calcAndStoreStats(logger)
 
 	event, err := WatchEvent(eventStore)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Replace JitterUntil with JitterUntilWithContext for contextual logging.

#### Which issue(s) this PR is related to:

Related #126379

#### Special notes for your reviewer:

When I read the KEP, I noticed that the stopChannel should be removed; however, I'm unsure if the direction of my changes is correct. If it's wrong, please point it out.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
