### PR TITLE
fix incorrect warning whenever headless service is created/updated

### DIFF
--- a/pkg/api/service/warnings.go
+++ b/pkg/api/service/warnings.go
@@ -48,7 +48,7 @@ func GetWarningsForService(service, oldService *api.Service) []string {
 		if len(service.Spec.ExternalIPs) > 0 {
 			warnings = append(warnings, "spec.externalIPs is ignored for headless services")
 		}
-		if service.Spec.SessionAffinity != "" {
+		if service.Spec.SessionAffinity != api.ServiceAffinityNone {
 			warnings = append(warnings, "spec.SessionAffinity is ignored for headless services")
 		}
 	}

--- a/pkg/api/service/warnings_test.go
+++ b/pkg/api/service/warnings_test.go
@@ -62,6 +62,7 @@ func TestGetWarningsForService(t *testing.T) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
 			s.Spec.LoadBalancerIP = "1.2.3.4"
+			s.Spec.SessionAffinity = api.ServiceAffinityNone // default value
 		},
 		numWarnings: 1,
 	}, {
@@ -70,10 +71,11 @@ func TestGetWarningsForService(t *testing.T) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
 			s.Spec.ExternalIPs = []string{"1.2.3.4"}
+			s.Spec.SessionAffinity = api.ServiceAffinityNone // default value
 		},
 		numWarnings: 1,
 	}, {
-		name: "SessionAffinity set when headless service",
+		name: "SessionAffinity Client IP set when headless service",
 		tweakSvc: func(s *api.Service) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
@@ -81,16 +83,25 @@ func TestGetWarningsForService(t *testing.T) {
 		},
 		numWarnings: 1,
 	}, {
-		name: "ExternalIPs, LoadBalancerIP and SessionAffinity set when headless service",
+		name: "SessionAffinity None set when headless service",
 		tweakSvc: func(s *api.Service) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
-			s.Spec.ExternalIPs = []string{"1.2.3.4"}
-			s.Spec.LoadBalancerIP = "1.2.3.4"
-			s.Spec.SessionAffinity = api.ServiceAffinityClientIP
+			s.Spec.SessionAffinity = api.ServiceAffinityNone
 		},
-		numWarnings: 3,
-	}}
+		numWarnings: 0,
+	},
+		{
+			name: "ExternalIPs, LoadBalancerIP and SessionAffinity set when headless service",
+			tweakSvc: func(s *api.Service) {
+				s.Spec.Type = api.ServiceTypeClusterIP
+				s.Spec.ClusterIP = api.ClusterIPNone
+				s.Spec.ExternalIPs = []string{"1.2.3.4"}
+				s.Spec.LoadBalancerIP = "1.2.3.4"
+				s.Spec.SessionAffinity = api.ServiceAffinityClientIP
+			},
+			numWarnings: 3,
+		}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes: https://github.com/kubernetes/kubernetes/issues/134040

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
remove incorrectly printed warning for SessionAffinity whenever a headless service is creater or updated
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
