### PR TITLE
Stream test refactor

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/helpers_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	rcconstants "k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport"
+)
+
+// This file contains common helper functions, structs, and mocks used across the
+// proxy package's test files.
+
+// fakeTransport returns a new http.Transport for tests.
+func fakeTransport() (*http.Transport, error) {
+	cfg := &transport.Config{
+		TLS: transport.TLSConfig{
+			Insecure: true,
+			CAFile:   "",
+		},
+	}
+	rt, err := transport.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	t, ok := rt.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unknown transport type: %T", rt)
+	}
+	return t, nil
+}
+
+// streamContext encapsulates the structures necessary to communicate through
+// a SPDY connection, including the Reader/Writer streams.
+type streamContext struct {
+	conn         io.Closer
+	stdinStream  io.ReadCloser
+	stdoutStream io.WriteCloser
+	stderrStream io.WriteCloser
+	resizeStream io.ReadCloser
+	resizeChan   chan remotecommand.TerminalSize
+	writeStatus  func(status *apierrors.StatusError) error
+}
+
+type streamAndReply struct {
+	httpstream.Stream
+	replySent <-chan struct{}
+}
+
+// createSPDYServerStreams upgrades the passed HTTP request to a SPDY bi-directional streaming
+// connection with remote command streams defined in passed options. Returns a streamContext
+// structure containing the Reader/Writer streams to communicate through the SDPY connection.
+// Returns an error if unable to upgrade the HTTP connection to a SPDY connection.
+func createSPDYServerStreams(w http.ResponseWriter, req *http.Request, opts Options) (*streamContext, error) {
+	_, err := httpstream.Handshake(req, w, []string{rcconstants.StreamProtocolV4Name})
+	if err != nil {
+		return nil, err
+	}
+
+	upgrader := spdy.NewResponseUpgrader()
+	streamCh := make(chan streamAndReply)
+	conn := upgrader.UpgradeResponse(w, req, func(stream httpstream.Stream, replySent <-chan struct{}) error {
+		streamCh <- streamAndReply{Stream: stream, replySent: replySent}
+		return nil
+	})
+	ctx := &streamContext{
+		conn: conn,
+	}
+
+	// wait for stream
+	replyChan := make(chan struct{}, 5)
+	defer close(replyChan)
+	receivedStreams := 0
+	expectedStreams := 1 // expect at least the error stream
+	if opts.Stdout {
+		expectedStreams++
+	}
+	if opts.Stdin {
+		expectedStreams++
+	}
+	if opts.Stderr {
+		expectedStreams++
+	}
+	if opts.Tty {
+		expectedStreams++
+	}
+WaitForStreams:
+	for {
+		select {
+		case stream := <-streamCh:
+			streamType := stream.Headers().Get(v1.StreamType)
+			streamHandled := false
+			switch streamType {
+			case v1.StreamTypeError:
+				ctx.writeStatus = v4WriteStatusFunc(stream)
+				streamHandled = true
+			case v1.StreamTypeStdout:
+				if opts.Stdout {
+					ctx.stdoutStream = stream
+					streamHandled = true
+				}
+			case v1.StreamTypeStdin:
+				if opts.Stdin {
+					ctx.stdinStream = stream
+					streamHandled = true
+				}
+			case v1.StreamTypeStderr:
+				if opts.Stderr {
+					ctx.stderrStream = stream
+					streamHandled = true
+				}
+			case v1.StreamTypeResize:
+				if opts.Tty {
+					ctx.resizeStream = stream
+					streamHandled = true
+				}
+			}
+
+			if streamHandled {
+				replyChan <- struct{}{}
+			} else {
+				// This is a known but unexpected stream type, or an unknown one.
+				// We must reset it to signal the client we won't be using it.
+				stream.Reset() //nolint:errcheck
+			}
+		case <-replyChan:
+			receivedStreams++
+			if receivedStreams == expectedStreams {
+				break WaitForStreams
+			}
+		}
+	}
+
+	if ctx.resizeStream != nil {
+		ctx.resizeChan = make(chan remotecommand.TerminalSize)
+		go handleResizeEvents(req.Context(), ctx.resizeStream, ctx.resizeChan)
+	}
+
+	return ctx, nil
+}
+
+func v4WriteStatusFunc(stream io.Writer) func(status *apierrors.StatusError) error {
+	return func(status *apierrors.StatusError) error {
+		bs, err := json.Marshal(status.Status())
+		if err != nil {
+			return err
+		}
+		_, err = stream.Write(bs)
+		return err
+	}
+}
+
+// justQueueStream skips the usual stream validation before
+// queueing the stream on the stream channel.
+func justQueueStream(streams chan httpstream.Stream) func(httpstream.Stream, <-chan struct{}) error {
+	return func(stream httpstream.Stream, replySent <-chan struct{}) error {
+		streams <- stream
+		return nil
+	}
+}
+
+// mockConn implements "net.Conn" interface.
+var _ net.Conn = &mockConn{}
+
+type mockConn struct {
+	written       []byte
+	localAddr     *net.TCPAddr
+	remoteAddr    *net.TCPAddr
+	readDeadline  time.Time
+	writeDeadline time.Time
+	deadlineErr   error
+}
+
+func (mc *mockConn) Write(p []byte) (int, error) {
+	mc.written = append(mc.written, p...)
+	return len(p), nil
+}
+
+func (mc *mockConn) Read(p []byte) (int, error) { return 0, nil }
+func (mc *mockConn) Close() error               { return nil }
+func (mc *mockConn) LocalAddr() net.Addr        { return mc.localAddr }
+func (mc *mockConn) RemoteAddr() net.Addr       { return mc.remoteAddr }
+func (mc *mockConn) SetDeadline(t time.Time) error {
+	mc.SetReadDeadline(t)  //nolint:errcheck
+	mc.SetWriteDeadline(t) // nolint:errcheck
+	return mc.deadlineErr
+}
+func (mc *mockConn) SetReadDeadline(t time.Time) error  { mc.readDeadline = t; return mc.deadlineErr }
+func (mc *mockConn) SetWriteDeadline(t time.Time) error { mc.writeDeadline = t; return mc.deadlineErr }
+
+// mockResponseWriter implements "http.ResponseWriter" interface
+type mockResponseWriter struct {
+	header     http.Header
+	written    []byte
+	statusCode int
+}
+
+func (mrw *mockResponseWriter) Header() http.Header { return mrw.header }
+func (mrw *mockResponseWriter) Write(p []byte) (int, error) {
+	mrw.written = append(mrw.written, p...)
+	return len(p), nil
+}
+func (mrw *mockResponseWriter) WriteHeader(statusCode int) { mrw.statusCode = statusCode }
+
+// fakeResponder implements "rest.Responder" interface.
+var _ rest.Responder = &fakeResponder{}
+
+type fakeResponder struct{}
+
+func (fr *fakeResponder) Object(statusCode int, obj runtime.Object) {}
+func (fr *fakeResponder) Error(err error)                           {}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/main_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/main_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"k8s.io/apiserver/pkg/util/proxy/metrics"
+)
+
+// Shared test servers for the proxy package.
+var (
+	// spdyServer is the upstream SPDY server that the StreamTranslatorHandler connects to.
+	// It is shared across all tests in this package.
+	spdyServer *httptest.Server
+	// spdyServerMux is the router for the spdyServer. Tests register their specific handlers here.
+	spdyServerMux *http.ServeMux
+	spdyServerURL *url.URL
+
+	// streamTranslatorServer is the server that exposes the StreamTranslatorHandler.
+	// Test clients connect to this server. It is shared across all tests.
+	streamTranslatorServer *httptest.Server
+	// streamTranslatorServerMux is the router for the streamTranslatorServer.
+	// Tests register their specific StreamTranslatorHandler configurations here.
+	streamTranslatorServerMux *http.ServeMux
+	streamTranslatorServerURL *url.URL
+)
+
+// TestMain sets up the shared SPDY and StreamTranslator servers for the entire test suite.
+// This avoids the overhead of creating new servers for each test and eliminates race conditions
+// related to server startup and shutdown.
+func TestMain(m *testing.M) {
+	metrics.Register()
+
+	// Upstream SPDY server setup
+	spdyServerMux = http.NewServeMux()
+	spdyServer = httptest.NewServer(spdyServerMux)
+	var err error
+	spdyServerURL, err = url.Parse(spdyServer.URL)
+	if err != nil {
+		log.Fatalf("Failed to parse SPDY server URL: %v", err)
+	}
+
+	// StreamTranslator server setup
+	streamTranslatorServerMux = http.NewServeMux()
+	streamTranslatorServer = httptest.NewServer(streamTranslatorServerMux)
+	streamTranslatorServerURL, err = url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		log.Fatalf("Failed to parse StreamTranslator server URL: %v", err)
+	}
+
+	// Run tests
+	exitCode := m.Run()
+
+	// Teardown
+	spdyServer.Close()
+	streamTranslatorServer.Close()
+
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
### Refactor: Centralize Streaming Test Infrastructure for Stability

This pull request refactors the streaming unit tests for the `staging/src/k8s.io/apiserver/pkg/util/proxy` package to improve stability, reduce code duplication, and adopt a more robust testing pattern.

#### Motivation

The tests in `streamtranslator_test.go` and `streamtunnel_test.go` each created and tore down their own `httptest` servers for individual test cases. This pattern can introduce flakiness due to race conditions in server startup/shutdown and potential resource leaks (e.g., leaving sockets in a `TIME_WAIT` state).

This refactoring centralizes the test server infrastructure, ensuring that servers are started only once for the entire package. This significantly reduces the risk of intermittent failures and creates a more reliable and maintainable test suite.

#### Changes

1.  **Centralized Test Setup:**
    *   A new `main_test.go` file now contains a single `TestMain` function that manages the lifecycle of shared `httptest` servers for the entire package.

2.  **Consolidated Test Helpers:**
    *   A new `helpers_test.go` file was created to consolidate common testing utilities, mocks, and helper functions that were previously duplicated across multiple files.

3.  **Refactored Test Files:**
    *   `streamtranslator_test.go` and `streamtunnel_test.go` were updated to use the shared servers and helpers, making the test cases themselves cleaner and more focused on their specific logic.

4.  **Improved Test Stability:**
    *   The `TestStreamTranslator_TTYResizeChannel` test was refactored to be more robust. The test validates TTY resize events and now uses a `sync.WaitGroup` to prevent a race condition where the test could finish before the server-side handler had processed all events. The number of events was also reduced from 10,000 to 1,000 to make the test less resource-intensive while still providing strong validation of the resize functionality.

#### Test Coverage

The test coverage for the package was analyzed before and after the refactoring. The coverage remains unchanged at **83.0%**, confirming that no test coverage was lost during the refactoring.

*   **Coverage Before:** `83.0% of statements`
*   **Coverage After:** `83.0% of statements`

#### Verification

The stability of the new shared server infrastructure was verified through extensive stress testing. The tests for both the stream translator and the tunneling handler were run repeatedly to ensure no flaky behavior was introduced by the refactoring.

*   **Parallel Race Detection:** The tests were first run in parallel with the race detector to catch any potential concurrency issues.
    ```sh
    go test -race -v -count=1 -parallel=20 ./staging/src/k8s.io/apiserver/pkg/util/proxy
    ```

*   **Stress Test for Translator Handler:** The translator tests were run under load to validate their stability. The `stress` tool executes the test binary in a tight loop and only reports failures.
```
$ go test -c -o proxy.test .
$ stress -p 4 ./proxy.test -test.run ^TestStreamTranslator_
5s: 12 runs so far, 0 failures
10s: 28 runs so far, 0 failures
15s: 44 runs so far, 0 failures
20s: 60 runs so far, 0 failures
25s: 75 runs so far, 0 failures
30s: 88 runs so far, 0 failures
...
23m55s: 4389 runs so far, 0 failures
24m0s: 4402 runs so far, 0 failures
24m5s: 4417 runs so far, 0 failures
24m10s: 4433 runs so far, 0 failures
24m15s: 4449 runs so far, 0 failures
24m20s: 4465 runs so far, 0 failures
# STOPPED HERE...No Failures
```

*   **Stress Test for Tunneling Handler:** The tunneling handler tests were also run under load to ensure they are robust.
 ```sh
$ go test -c -o proxy.test
$ stress -p 4 ./proxy.test -test.run ^TestTunnelingHandler_
 5s: 332 runs so far, 0 failures
 10s: 668 runs so far, 0 failures
 15s: 1005 runs so far, 0 failures
 20s: 1337 runs so far, 0 failures
 25s: 1681 runs so far, 0 failures
...
40m30s: 165116 runs so far, 0 failures
40m35s: 165457 runs so far, 0 failures
40m40s: 165795 runs so far, 0 failures
40m45s: 166132 runs so far, 0 failures
40m50s: 166474 runs so far, 0 failures
# STOPPED HERE...No Failures
```

All tests passed consistently under these conditions, demonstrating the stability and correctness of the refactored test suite.

/kind cleanup


```release-note
NONE
```
