### PR TITLE
Changed error message on hostPort conflicts to provide more details

### DIFF
--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -252,7 +252,7 @@ func TestGeneralPredicates(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "machine1"},
 				Status:     v1.NodeStatus{Capacity: makeResources(10, 20, 32, 0, 0, 0), Allocatable: makeAllocatableResources(10, 20, 32, 0, 0, 0)},
 			},
-			reasons: []PredicateFailureReason{&PredicateFailureError{nodeports.Name, "node(s) port conflict for the requested pod ports (/:123)"}},
+			reasons: []PredicateFailureReason{&PredicateFailureError{nodeports.Name, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:123,ContainerPort:0,Protocol:,HostIP:,})"}},
 			name:    "hostport conflict",
 		},
 		{

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -252,7 +252,7 @@ func TestGeneralPredicates(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "machine1"},
 				Status:     v1.NodeStatus{Capacity: makeResources(10, 20, 32, 0, 0, 0), Allocatable: makeAllocatableResources(10, 20, 32, 0, 0, 0)},
 			},
-			reasons: []PredicateFailureReason{&PredicateFailureError{nodeports.Name, nodeports.ErrReason}},
+			reasons: []PredicateFailureReason{&PredicateFailureError{nodeports.Name, "node(s) port conflict for the requested pod ports (/:123)"}},
 			name:    "hostport conflict",
 		},
 		{

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -252,7 +252,7 @@ func TestGeneralPredicates(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "machine1"},
 				Status:     v1.NodeStatus{Capacity: makeResources(10, 20, 32, 0, 0, 0), Allocatable: makeAllocatableResources(10, 20, 32, 0, 0, 0)},
 			},
-			reasons: []PredicateFailureReason{&PredicateFailureError{nodeports.Name, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:123,ContainerPort:0,Protocol:,HostIP:,})"}},
+			reasons: []PredicateFailureReason{&PredicateFailureError{nodeports.Name, "node(s) port conflict for the requested pod ports (/:123)"}},
 			name:    "hostport conflict",
 		},
 		{

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -778,8 +778,9 @@ func AdmissionCheck(pod *v1.Pod, nodeInfo *framework.NodeInfo, includeAllFailure
 			return admissionResults
 		}
 	}
-	if !nodeports.Fits(pod, nodeInfo) {
-		admissionResults = append(admissionResults, AdmissionResult{Name: nodeports.Name, Reason: nodeports.ErrReason})
+	fits, portNotFittingMessage := nodeports.Fits(pod, nodeInfo)
+	if !fits {
+		admissionResults = append(admissionResults, AdmissionResult{Name: nodeports.Name, Reason: portNotFittingMessage})
 		if !includeAllFailures {
 			return admissionResults
 		}

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -778,9 +778,9 @@ func AdmissionCheck(pod *v1.Pod, nodeInfo *framework.NodeInfo, includeAllFailure
 			return admissionResults
 		}
 	}
-	fits, portNotFittingMessage := nodeports.Fits(pod, nodeInfo)
+	fits, err := nodeports.Fits(pod, nodeInfo)
 	if !fits {
-		admissionResults = append(admissionResults, AdmissionResult{Name: nodeports.Name, Reason: portNotFittingMessage})
+		admissionResults = append(admissionResults, AdmissionResult{Name: nodeports.Name, Reason: err.Error()})
 		if !includeAllFailures {
 			return admissionResults
 		}

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -711,7 +711,7 @@ func TestAdmissionCheck(t *testing.T) {
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("pod1").HostPort(80).Obj(),
 			},
-			wantAdmissionResults: [][]AdmissionResult{{nodeaffinityError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:80,ContainerPort:0,Protocol:,HostIP:,})"}}, {nodeaffinityError}},
+			wantAdmissionResults: [][]AdmissionResult{{nodeaffinityError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (/:80)"}}, {nodeaffinityError}},
 		},
 		{
 			name: "check PodOverhead and nodeAffinity, PodOverhead need fail quickly if includeAllFailures is false",
@@ -729,7 +729,7 @@ func TestAdmissionCheck(t *testing.T) {
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("pod1").HostPort(80).Node("fake-node").Obj(),
 			},
-			wantAdmissionResults: [][]AdmissionResult{{nodenameError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:80,ContainerPort:0,Protocol:,HostIP:,})"}}, {nodenameError}},
+			wantAdmissionResults: [][]AdmissionResult{{nodenameError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (/:80)"}}, {nodenameError}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -711,7 +711,7 @@ func TestAdmissionCheck(t *testing.T) {
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("pod1").HostPort(80).Obj(),
 			},
-			wantAdmissionResults: [][]AdmissionResult{{nodeaffinityError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (/:80)"}}, {nodeaffinityError}},
+			wantAdmissionResults: [][]AdmissionResult{{nodeaffinityError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:80,ContainerPort:0,Protocol:,HostIP:,})"}}, {nodeaffinityError}},
 		},
 		{
 			name: "check PodOverhead and nodeAffinity, PodOverhead need fail quickly if includeAllFailures is false",
@@ -729,7 +729,7 @@ func TestAdmissionCheck(t *testing.T) {
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("pod1").HostPort(80).Node("fake-node").Obj(),
 			},
-			wantAdmissionResults: [][]AdmissionResult{{nodenameError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (/:80)"}}, {nodenameError}},
+			wantAdmissionResults: [][]AdmissionResult{{nodenameError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:80,ContainerPort:0,Protocol:,HostIP:,})"}}, {nodenameError}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -695,7 +695,6 @@ func TestAddAllEventHandlers(t *testing.T) {
 func TestAdmissionCheck(t *testing.T) {
 	nodeaffinityError := AdmissionResult{Name: nodeaffinity.Name, Reason: nodeaffinity.ErrReasonPod}
 	nodenameError := AdmissionResult{Name: nodename.Name, Reason: nodename.ErrReason}
-	nodeportsError := AdmissionResult{Name: nodeports.Name, Reason: nodeports.ErrReason}
 	podOverheadError := AdmissionResult{InsufficientResource: &noderesources.InsufficientResource{ResourceName: v1.ResourceCPU, Reason: "Insufficient cpu", Requested: 2000, Used: 7000, Capacity: 8000}}
 	cpu := map[v1.ResourceName]string{v1.ResourceCPU: "8"}
 	tests := []struct {
@@ -712,7 +711,7 @@ func TestAdmissionCheck(t *testing.T) {
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("pod1").HostPort(80).Obj(),
 			},
-			wantAdmissionResults: [][]AdmissionResult{{nodeaffinityError, nodeportsError}, {nodeaffinityError}},
+			wantAdmissionResults: [][]AdmissionResult{{nodeaffinityError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (/:80)"}}, {nodeaffinityError}},
 		},
 		{
 			name: "check PodOverhead and nodeAffinity, PodOverhead need fail quickly if includeAllFailures is false",
@@ -730,7 +729,7 @@ func TestAdmissionCheck(t *testing.T) {
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("pod1").HostPort(80).Node("fake-node").Obj(),
 			},
-			wantAdmissionResults: [][]AdmissionResult{{nodenameError, nodeportsError}, {nodenameError}},
+			wantAdmissionResults: [][]AdmissionResult{{nodenameError, AdmissionResult{Name: nodeports.Name, Reason: "node(s) port conflict for the requested pod ports (/:80)"}}, {nodenameError}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -172,10 +172,9 @@ func (pl *NodePorts) Filter(ctx context.Context, cycleState fwk.CycleState, pod 
 }
 
 // Fits checks if the pod has any ports conflicting with nodeInfo's ports.
-// It returns true if there are no conflicts (which means that pod fits the node), otherwise false with the errMessage.
+// It returns true if there are no conflicts (which means that pod fits the node), otherwise false with the err message.
 func Fits(pod *v1.Pod, nodeInfo fwk.NodeInfo) (fits bool, err error) {
-	portFits, portConflictErr := fitsPorts(util.GetHostPorts(pod), nodeInfo.GetUsedPorts())
-	return portFits, portConflictErr
+	return fitsPorts(util.GetHostPorts(pod), nodeInfo.GetUsedPorts())
 }
 
 func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) (bool, error) {

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -18,6 +18,7 @@ package nodeports
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -174,9 +175,9 @@ func (pl *NodePorts) Filter(ctx context.Context, cycleState fwk.CycleState, pod 
 
 // Fits checks if the pod has any ports conflicting with nodeInfo's ports.
 // It returns true if there are no conflicts (which means that pod fits the node), otherwise false with the errMessage.
-func Fits(pod *v1.Pod, nodeInfo fwk.NodeInfo) (fits bool, errMessage string) {
+func Fits(pod *v1.Pod, nodeInfo fwk.NodeInfo) (fits bool, err error) {
 	portFits, portConflictErrMessage := fitsPorts(util.GetHostPorts(pod), nodeInfo.GetUsedPorts())
-	return portFits, portConflictErrMessage
+	return portFits, errors.New(portConflictErrMessage)
 }
 
 func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) (fits bool, errMessage string) {

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -183,7 +184,8 @@ func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) (fits 
 	// try to see whether portsInUse and wantPorts will conflict or not
 	for _, cp := range wantPorts {
 		if portsInUse.CheckConflict(cp.HostIP, string(cp.Protocol), cp.HostPort) {
-			errReason := fmt.Sprintf("node(s) port conflict for the requested pod ports (%s)", cp.String())
+			portNotFittingMessage := fmt.Sprintf("%s/%s:%s", string(cp.Protocol), cp.HostIP, strconv.Itoa(int(cp.HostPort)))
+			errReason := fmt.Sprintf("node(s) port conflict for the requested pod ports (%s)", portNotFittingMessage)
 			return false, errReason
 		}
 	}

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -180,7 +180,7 @@ func Fits(pod *v1.Pod, nodeInfo fwk.NodeInfo) (fits bool, err error) {
 	return portFits, errors.New(portConflictErrMessage)
 }
 
-func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) (fits bool, errMessage string) {
+func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) (bool, error) {
 	// try to see whether portsInUse and wantPorts will conflict or not
 	for _, cp := range wantPorts {
 		if portsInUse.CheckConflict(cp.HostIP, string(cp.Protocol), cp.HostPort) {

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -152,7 +152,7 @@ func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 		return fwk.QueueSkip, nil
 	}
 
-	logger.V(4).Info("the deleted pod and the target pod have common port(s), returning Queue as deleting this Pod may make the Pod schedulable", "port(s)", portNotFittingMessage, "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
+	logger.V(4).Info("the deleted pod and the target pod have common port(s), returning Queue as deleting this Pod may make the Pod schedulable", "msg", err.Error(), "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
 	return fwk.Queue, nil
 }
 

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -146,8 +146,8 @@ func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 	for _, p := range ports {
 		portsInUse.Add(p.HostIP, string(p.Protocol), p.HostPort)
 	}
-	portFits, portNotFittingMessage := fitsPorts(util.GetHostPorts(pod), portsInUse)
-	if portFits {
+	fits, err := fitsPorts(util.GetHostPorts(pod), portsInUse)
+	if fits {
 		logger.V(4).Info("the deleted pod and the target pod don't have any common port(s), returning QueueSkip as deleting this Pod won't make the Pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
 		return fwk.QueueSkip, nil
 	}

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -184,8 +183,7 @@ func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) (fits 
 	// try to see whether portsInUse and wantPorts will conflict or not
 	for _, cp := range wantPorts {
 		if portsInUse.CheckConflict(cp.HostIP, string(cp.Protocol), cp.HostPort) {
-			portNotFittingMessage := fmt.Sprintf("%s/%s:%s", string(cp.Protocol), cp.HostIP, strconv.Itoa(int(cp.HostPort)))
-			errReason := fmt.Sprintf("node(s) port conflict for the requested pod ports (%s)", portNotFittingMessage)
+			errReason := fmt.Sprintf("node(s) port conflict for the requested pod ports (%s)", cp.String())
 			return false, errReason
 		}
 	}

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -163,9 +163,9 @@ func (pl *NodePorts) Filter(ctx context.Context, cycleState fwk.CycleState, pod 
 		return fwk.AsStatus(err)
 	}
 
-	portFits, portConflictErr := fitsPorts(wantPorts, nodeInfo.GetUsedPorts())
-	if !portFits {
-		return fwk.NewStatus(fwk.Unschedulable, portConflictErr.Error())
+	fits, err := fitsPorts(wantPorts, nodeInfo.GetUsedPorts())
+	if !fits {
+		return fwk.NewStatus(fwk.Unschedulable, err.Error())
 	}
 
 	return nil

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -184,9 +184,7 @@ func fitsPorts(wantPorts []v1.ContainerPort, portsInUse fwk.HostPortInfo) (bool,
 	// try to see whether portsInUse and wantPorts will conflict or not
 	for _, cp := range wantPorts {
 		if portsInUse.CheckConflict(cp.HostIP, string(cp.Protocol), cp.HostPort) {
-			portNotFittingMessage := fmt.Sprintf("%s/%s:%s", string(cp.Protocol), cp.HostIP, strconv.Itoa(int(cp.HostPort)))
-			errReason := fmt.Sprintf("node(s) port conflict for the requested pod ports (%s)", portNotFittingMessage)
-			return false, errReason
+			return false, fmt.Errorf("node(s) port conflict for the requested pod ports (%s/%s:%d)", portStr, cp.Protocol, cp.HostIP, cp.HostPort)
 		}
 	}
 	return true, ""

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -77,14 +77,14 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "same udp port",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:UDP,HostIP:127.0.0.1,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8080)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			name:             "same tcp port",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:TCP,HostIP:127.0.0.1,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8080)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
@@ -103,35 +103,35 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "second udp port conflict",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:UDP,HostIP:127.0.0.1,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8080)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8081")),
 			name:             "first tcp port conflict",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:127.0.0.1,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8001)"),
 		},
 		{
 			pod: newPod("m1", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "first tcp port conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:0.0.0.0,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/0.0.0.0:8001)"),
 		},
 		{
 			pod: newPod("m1", "TCP/10.0.10.10/8001", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "TCP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:0.0.0.0,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/0.0.0.0:8001)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "second tcp port conflict to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:127.0.0.1,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8001)"),
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
@@ -144,7 +144,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001", "UDP/0.0.0.0/8001")),
 			name:             "UDP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:UDP,HostIP:127.0.0.1,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8001)"),
 		},
 		{
 			pod: st.MakePod().
@@ -172,7 +172,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "TCP hostPort conflict from sidecar initContainer",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:8001,Protocol:TCP,HostIP:,})"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/:8001)"),
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -77,14 +77,14 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "same udp port",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8080)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			name:             "same tcp port",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8080)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
@@ -103,35 +103,35 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "second udp port conflict",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8080)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8081")),
 			name:             "first tcp port conflict",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8001)"),
 		},
 		{
 			pod: newPod("m1", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "first tcp port conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/0.0.0.0:8001)"),
 		},
 		{
 			pod: newPod("m1", "TCP/10.0.10.10/8001", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "TCP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/0.0.0.0:8001)"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "second tcp port conflict to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8001)"),
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
@@ -144,7 +144,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001", "UDP/0.0.0.0/8001")),
 			name:             "UDP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8001)"),
 		},
 		{
 			pod: st.MakePod().
@@ -172,7 +172,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "TCP hostPort conflict from sidecar initContainer",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, ErrReason),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/:8001)"),
 		},
 	}
 
@@ -332,7 +332,8 @@ func TestFits(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			if Fits(test.pod, test.existing) != test.expect {
+			fits, _ := Fits(test.pod, test.existing)
+			if fits != test.expect {
 				t.Errorf("expected %t; got %t", test.expect, !test.expect)
 			}
 		})

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -77,14 +77,14 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "same udp port",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8080)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:UDP,HostIP:127.0.0.1,})"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			name:             "same tcp port",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8080)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:TCP,HostIP:127.0.0.1,})"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
@@ -103,35 +103,35 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			name:             "second udp port conflict",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8080)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:UDP,HostIP:127.0.0.1,})"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8080"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8081")),
 			name:             "first tcp port conflict",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8001)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:127.0.0.1,})"),
 		},
 		{
 			pod: newPod("m1", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "first tcp port conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/0.0.0.0:8001)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:0.0.0.0,})"),
 		},
 		{
 			pod: newPod("m1", "TCP/10.0.10.10/8001", "TCP/0.0.0.0/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			name:             "TCP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/0.0.0.0:8001)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:0.0.0.0,})"),
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001"),
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "second tcp port conflict to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/127.0.0.1:8001)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:TCP,HostIP:127.0.0.1,})"),
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
@@ -144,7 +144,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001", "UDP/0.0.0.0/8001")),
 			name:             "UDP hostPort conflict due to 0.0.0.0 hostIP",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (UDP/127.0.0.1:8001)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:0,Protocol:UDP,HostIP:127.0.0.1,})"),
 		},
 		{
 			pod: st.MakePod().
@@ -172,7 +172,7 @@ func TestNodePorts(t *testing.T) {
 			nodeInfo: framework.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			name:             "TCP hostPort conflict from sidecar initContainer",
-			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (TCP/:8001)"),
+			wantFilterStatus: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8001,ContainerPort:8001,Protocol:TCP,HostIP:,})"),
 		},
 	}
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1885,7 +1885,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 					NumAllNodes: 1,
 					Diagnosis: framework.Diagnosis{
 						NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
-							node.Name: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:,HostIP:,})").WithPlugin(nodeports.Name),
+							node.Name: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (/:8080)").WithPlugin(nodeports.Name),
 						}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 						UnschedulablePlugins: sets.New(nodeports.Name),
 					},

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1885,7 +1885,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 					NumAllNodes: 1,
 					Diagnosis: framework.Diagnosis{
 						NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
-							node.Name: fwk.NewStatus(fwk.Unschedulable, nodeports.ErrReason).WithPlugin(nodeports.Name),
+							node.Name: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (/:8080)").WithPlugin(nodeports.Name),
 						}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 						UnschedulablePlugins: sets.New(nodeports.Name),
 					},

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1885,7 +1885,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 					NumAllNodes: 1,
 					Diagnosis: framework.Diagnosis{
 						NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
-							node.Name: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (/:8080)").WithPlugin(nodeports.Name),
+							node.Name: fwk.NewStatus(fwk.Unschedulable, "node(s) port conflict for the requested pod ports (&ContainerPort{Name:,HostPort:8080,ContainerPort:0,Protocol:,HostIP:,})").WithPlugin(nodeports.Name),
 						}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
 						UnschedulablePlugins: sets.New(nodeports.Name),
 					},


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

I recently ran into the issue of having a hostPort conflict on a node and I had to manually investigate which port were conflicting. This PR removes this tedious work by printing the protocol, hostIP and port in conflict.

Before: `node(s) didn't have free ports for the requested pod ports`
After: `node(s) port conflict for the requested pod ports (TCP/0.0.0.0:8000)`

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:

All unit tests are passing locally.

#### Does this PR introduce a user-facing change?

```release-note
Changed error message on hostPort conflicts to provide more details.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
