### PR TITLE
Implement scoring for extended resources backed up by DRA

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -668,7 +668,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 		if err != nil {
 			return nil, statusError(logger, err)
 		}
-		features := allocatorFeatures(pl.fts)
+		features := AllocatorFeatures(pl.fts)
 		allocator, err := structured.NewAllocator(ctx, features, *allocatedState, pl.draManager.DeviceClasses(), slices, pl.celCache)
 		if err != nil {
 			return nil, statusError(logger, err)
@@ -680,7 +680,7 @@ func (pl *DynamicResources) PreFilter(ctx context.Context, state fwk.CycleState,
 	return nil, nil
 }
 
-func allocatorFeatures(fts feature.Features) structured.Features {
+func AllocatorFeatures(fts feature.Features) structured.Features {
 	return structured.Features{
 		AdminAccess:            fts.EnableDRAAdminAccess,
 		PrioritizedList:        fts.EnableDRAPrioritizedList,

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -3809,7 +3809,7 @@ func TestAllocatorSelection(t *testing.T) {
 			featureGate := utilfeature.DefaultFeatureGate.DeepCopy()
 			tCtx.ExpectNoError(featureGate.Set(tc.features), "set features")
 			fts := feature.NewSchedulerFeaturesFromGates(featureGate)
-			features := allocatorFeatures(fts)
+			features := AllocatorFeatures(fts)
 
 			// Slightly hacky: most arguments are not valid and the constructor
 			// is expected to not use them yet.

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -135,6 +135,7 @@ func NewBalancedAllocation(_ context.Context, baArgs runtime.Object, h fwk.Handl
 			Name:                            BalancedAllocationName,
 			enableInPlacePodVerticalScaling: fts.EnableInPlacePodVerticalScaling,
 			enablePodLevelResources:         fts.EnablePodLevelResources,
+			enableDRAExtendedResource:       fts.EnableDRAExtendedResource,
 			scorer:                          balancedResourceScorer,
 			useRequested:                    true,
 			resources:                       args.Resources,

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -21,11 +21,16 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/dynamic-resource-allocation/cel"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
+	resourceapi "k8s.io/api/resource/v1"
 	resourcehelper "k8s.io/component-helpers/resource"
+	"k8s.io/dynamic-resource-allocation/structured"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/extended"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
@@ -37,11 +42,15 @@ type resourceAllocationScorer struct {
 	Name                            string
 	enableInPlacePodVerticalScaling bool
 	enablePodLevelResources         bool
+	enableDRAExtendedResource       bool
 	// used to decide whether to use Requested or NonZeroRequested for
 	// cpu and memory.
 	useRequested bool
 	scorer       func(requested, allocable []int64) int64
 	resources    []config.ResourceSpec
+	draFeatures  structured.Features
+	draManager   fwk.SharedDRAManager
+	celCache     *cel.Cache
 }
 
 // score will use `scorer` function to calculate the score.
@@ -61,7 +70,7 @@ func (r *resourceAllocationScorer) score(
 	requested := make([]int64, len(r.resources))
 	allocatable := make([]int64, len(r.resources))
 	for i := range r.resources {
-		alloc, req := r.calculateResourceAllocatableRequest(logger, nodeInfo, v1.ResourceName(r.resources[i].Name), podRequests[i])
+		alloc, req := r.calculateResourceAllocatableRequest(ctx, nodeInfo, v1.ResourceName(r.resources[i].Name), podRequests[i])
 		// Only fill the extended resource entry when it's non-zero.
 		if alloc == 0 {
 			continue
@@ -86,7 +95,7 @@ func (r *resourceAllocationScorer) score(
 // - 1st param: quantity of allocatable resource on the node.
 // - 2nd param: aggregated quantity of requested resource on the node.
 // Note: if it's an extended resource, and the pod doesn't request it, (0, 0) is returned.
-func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(logger klog.Logger, nodeInfo fwk.NodeInfo, resource v1.ResourceName, podRequest int64) (int64, int64) {
+func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(ctx context.Context, nodeInfo fwk.NodeInfo, resource v1.ResourceName, podRequest int64) (int64, int64) {
 	requested := nodeInfo.GetNonZeroRequested()
 	if r.useRequested {
 		requested = nodeInfo.GetRequested()
@@ -105,11 +114,20 @@ func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(logger kl
 	case v1.ResourceEphemeralStorage:
 		return nodeInfo.GetAllocatable().GetEphemeralStorage(), (nodeInfo.GetRequested().GetEphemeralStorage() + podRequest)
 	default:
-		if _, exists := nodeInfo.GetAllocatable().GetScalarResources()[resource]; exists {
-			return nodeInfo.GetAllocatable().GetScalarResources()[resource], (nodeInfo.GetRequested().GetScalarResources()[resource] + podRequest)
+		allocatable, exists := nodeInfo.GetAllocatable().GetScalarResources()[resource]
+		if allocatable == 0 && r.enableDRAExtendedResource {
+			// Allocatable 0 means that this resource is not handled by device plugin.
+			// Calculate allocatable and requested for resources backed by DRA.
+			allocatable, allocated := r.calculateDRAExtendedResourceAllocatableRequest(ctx, nodeInfo.Node(), resource)
+			if allocatable > 0 {
+				return allocatable, allocated + podRequest
+			}
+		}
+		if exists {
+			return allocatable, (nodeInfo.GetRequested().GetScalarResources()[resource] + podRequest)
 		}
 	}
-	logger.V(10).Info("Requested resource is omitted for node score calculation", "resourceName", resource)
+	klog.FromContext(ctx).V(10).Info("Requested resource is omitted for node score calculation", "resourceName", resource)
 	return 0, 0
 }
 
@@ -154,4 +172,153 @@ func (r *resourceAllocationScorer) isBestEffortPod(podRequests []int64) bool {
 		}
 	}
 	return true
+}
+
+// calculateDRAExtendedResourceAllocatableRequest calculates allocatable and allocated
+// quantities for extended resources backed by DRA.
+func (r *resourceAllocationScorer) calculateDRAExtendedResourceAllocatableRequest(ctx context.Context, node *v1.Node, resource v1.ResourceName) (int64, int64) {
+	logger := klog.FromContext(ctx)
+	// Get device class mapping to find the device class for this resource
+	deviceClassMapping, err := extended.DeviceClassMapping(r.draManager)
+	if err != nil {
+		logger.Error(err, "Failed to get device class mapping for DRA extended resource scoring")
+		return 0, 0
+	}
+
+	deviceClassName, exists := deviceClassMapping[resource]
+	if !exists {
+		logger.Error(nil, "Extended resource not found in device class mapping", "resource", resource)
+		return 0, 0
+	}
+
+	deviceClass, err := r.draManager.DeviceClasses().Get(deviceClassName)
+	if err != nil {
+		logger.Error(err, "Failed to get device class for DRA extended resource scoring", "resource", resource, "deviceClass", deviceClassName)
+		return 0, 0
+	}
+
+	capacity, allocated, err := r.calculateDRAResourceTotals(ctx, node, deviceClass)
+	if err != nil {
+		logger.Error(err, "Failed to calculate DRA resource capacity and allocated", "node", node.Name, "resource", resource, "deviceClass", deviceClassName)
+		return 0, 0
+	}
+
+	logger.V(7).Info("DRA extended resource calculation", "node", node.Name, "resource", resource, "deviceClass", deviceClassName, "capacity", capacity, "allocated", allocated)
+	return capacity, allocated
+}
+
+// calculateDRAResourceTotals computes the total capacity and total allocated count of devices
+// matching the specified Device Class on the given node. It queries the DRA manager for resource
+// slices and allocated devices, filters devices by class and driver, and returns the counts.
+// Returns an error if resource information cannot be retrieved or if node matching fails.
+//
+// Parameters:
+//
+//	ctx         - context for cancellation and deadlines
+//	node        - the node to evaluate device resources on
+//	deviceClass - the device class to filter devices by
+//
+// Returns:
+//
+//	totalCapacity  - total number of devices matching the device class on the node
+//	totalAllocated - number of devices currently allocated from the matching set
+//	error          - any error encountered during processing
+func (r *resourceAllocationScorer) calculateDRAResourceTotals(ctx context.Context, node *v1.Node, deviceClass *resourceapi.DeviceClass) (int64, int64, error) {
+	allocatedState, err := r.draManager.ResourceClaims().GatherAllocatedState()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	resourceSlices, err := r.draManager.ResourceSlices().ListWithDeviceTaintRules()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var totalCapacity, totalAllocated int64
+	for _, slice := range resourceSlices {
+		driver := slice.Spec.Driver
+		pool := slice.Spec.Pool.Name
+		var devices []resourceapi.Device
+		// Handle per-device node selection vs slice-level node selection
+		if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
+			devices = []resourceapi.Device{}
+			// When per-device node selection is enabled, check each device individually
+			for _, device := range slice.Spec.Devices {
+				// Check if this specific device matches the node
+				deviceMatches, err := structured.NodeMatches(r.draFeatures, node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
+				if err != nil {
+					return 0, 0, err
+				}
+				if deviceMatches {
+					devices = append(devices, device)
+				}
+			}
+		} else {
+			// When per-device node selection is disabled, check slice-level node selection first
+			matches, err := structured.NodeMatches(r.draFeatures, node, ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false), slice.Spec.NodeSelector)
+			if err != nil {
+				return 0, 0, err
+			}
+			if !matches {
+				// Skip this slice as it doesn't match the node
+				continue
+			}
+			devices = slice.Spec.Devices
+		}
+		// Count devices that match the device class
+		for _, device := range devices {
+			matches, err := r.deviceMatchesClass(ctx, device, deviceClass, driver)
+			if err != nil {
+				return 0, 0, err
+			}
+			if matches {
+				totalCapacity++
+				// Count allocated devices (both fully allocated and partially consumed)
+				deviceID := structured.MakeDeviceID(driver, pool, device.Name)
+				if structured.IsDeviceAllocated(deviceID, allocatedState) {
+					totalAllocated++
+				}
+			}
+		}
+	}
+
+	return totalCapacity, totalAllocated, nil
+}
+
+// deviceMatchesClass checks if a device matches the selectors of a device class.
+// Note: This method assumes the device class has ExtendedResourceName set, as filtering
+// should be done by the caller to ensure we only process DRA resources meant for extended
+// resource scoring.
+func (r *resourceAllocationScorer) deviceMatchesClass(ctx context.Context, device resourceapi.Device, deviceClass *resourceapi.DeviceClass, driver string) (bool, error) {
+	// If no selectors are defined, all devices match
+	if len(deviceClass.Spec.Selectors) == 0 {
+		return true, nil
+	}
+
+	// All selectors must match for the device to be considered a match
+	for _, selector := range deviceClass.Spec.Selectors {
+		if selector.CEL == nil {
+			continue
+		}
+
+		// Use cached CEL compilation for performance
+		result := r.celCache.GetOrCompile(selector.CEL.Expression)
+		if result.Error != nil {
+			return false, result.Error
+		}
+
+		// Evaluate the expression against the device
+		celDevice := cel.Device{
+			Driver:     driver,
+			Attributes: device.Attributes,
+			Capacity:   device.Capacity,
+		}
+
+		matches, _, err := result.DeviceMatches(ctx, celDevice)
+		if err != nil || !matches {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -18,6 +18,8 @@ package noderesources
 
 import (
 	"context"
+	"strings"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,12 +32,21 @@ import (
 	"k8s.io/dynamic-resource-allocation/structured"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/extended"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 // scorer is decorator for resourceAllocationScorer
 type scorer func(args *config.NodeResourcesFitArgs) *resourceAllocationScorer
+
+// DRACaches holds various caches used for DRA-related computations
+type DRACaches struct {
+	// celCache is a cache for compiled CEL expressions used in device class selectors.
+	celCache *cel.Cache
+	// Cache for DeviceMatches results to avoid expensive repeated evaluations
+	deviceMatchCache sync.Map // map[deviceMatchCacheKey]bool
+	// Cache for NodeMatches results to avoid expensive repeated node selector evaluations
+	nodeMatchCache sync.Map // map[nodeMatchCacheKey]bool
+}
 
 // resourceAllocationScorer contains information to calculate resource allocation score.
 type resourceAllocationScorer struct {
@@ -50,7 +61,76 @@ type resourceAllocationScorer struct {
 	resources    []config.ResourceSpec
 	draFeatures  structured.Features
 	draManager   fwk.SharedDRAManager
-	celCache     *cel.Cache
+	// Caches for DRA-related computations
+	DRACaches
+}
+
+// buildNodeMatchCacheKey creates a string cache key for node matching results
+// Using a string key is significantly faster than struct keys with sync.Map
+func buildNodeMatchCacheKey(nodeName string, nodeNameToMatch string, allNodesMatch bool, nodeSelectorHash string) string {
+	// Pre-allocate sufficient capacity to avoid reallocation
+	var b strings.Builder
+	b.Grow(len(nodeName) + len(nodeNameToMatch) + len(nodeSelectorHash) + 4)
+
+	b.WriteString(nodeName)
+	b.WriteByte('|')
+	b.WriteString(nodeNameToMatch)
+	b.WriteByte('|')
+	if allNodesMatch {
+		b.WriteByte('1')
+	} else {
+		b.WriteByte('0')
+	}
+	b.WriteByte('|')
+	b.WriteString(nodeSelectorHash)
+
+	return b.String()
+}
+
+// buildDeviceMatchCacheKey creates a string cache key for device matching results
+// Using a string key is significantly faster than struct keys with sync.Map
+// This concatenates expression|driver|poolName|deviceName with pipe separators
+func buildDeviceMatchCacheKey(expression string, driver string, poolName string, deviceName string) string {
+	// Pre-allocate sufficient capacity to avoid reallocation
+	var b strings.Builder
+	b.Grow(len(expression) + len(driver) + len(poolName) + len(deviceName) + 3)
+
+	b.WriteString(expression)
+	b.WriteByte('|')
+	b.WriteString(driver)
+	b.WriteByte('|')
+	b.WriteString(poolName)
+	b.WriteByte('|')
+	b.WriteString(deviceName)
+
+	return b.String()
+}
+
+// nodeMatches is a cached wrapper around structured.NodeMatches
+func (r *resourceAllocationScorer) nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, nodeSelector *v1.NodeSelector) (bool, error) {
+
+	var nodeName string
+	if node != nil {
+		nodeName = node.Name
+	}
+
+	nodeSelectorStr := nodeSelector.String()
+	key := buildNodeMatchCacheKey(nodeName, nodeNameToMatch, allNodesMatch, nodeSelectorStr)
+
+	// Check cache first
+	if matches, ok := r.nodeMatchCache.Load(key); ok {
+		return matches.(bool), nil
+	}
+
+	// Call the original function
+	matches, err := structured.NodeMatches(r.draFeatures, node, nodeNameToMatch, allNodesMatch, nodeSelector)
+
+	// Cache the result (even if there was an error, to avoid repeated failures)
+	if err == nil {
+		r.nodeMatchCache.Store(key, matches)
+	}
+
+	return matches, err
 }
 
 // score will use `scorer` function to calculate the score.
@@ -58,7 +138,9 @@ func (r *resourceAllocationScorer) score(
 	ctx context.Context,
 	pod *v1.Pod,
 	nodeInfo fwk.NodeInfo,
-	podRequests []int64) (int64, *fwk.Status) {
+	podRequests []int64,
+	draPreScoreState *draPreScoreState,
+) (int64, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	node := nodeInfo.Node()
 
@@ -70,7 +152,7 @@ func (r *resourceAllocationScorer) score(
 	requested := make([]int64, len(r.resources))
 	allocatable := make([]int64, len(r.resources))
 	for i := range r.resources {
-		alloc, req := r.calculateResourceAllocatableRequest(ctx, nodeInfo, v1.ResourceName(r.resources[i].Name), podRequests[i])
+		alloc, req := r.calculateResourceAllocatableRequest(ctx, nodeInfo, v1.ResourceName(r.resources[i].Name), podRequests[i], draPreScoreState)
 		// Only fill the extended resource entry when it's non-zero.
 		if alloc == 0 {
 			continue
@@ -95,7 +177,13 @@ func (r *resourceAllocationScorer) score(
 // - 1st param: quantity of allocatable resource on the node.
 // - 2nd param: aggregated quantity of requested resource on the node.
 // Note: if it's an extended resource, and the pod doesn't request it, (0, 0) is returned.
-func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(ctx context.Context, nodeInfo fwk.NodeInfo, resource v1.ResourceName, podRequest int64) (int64, int64) {
+func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(
+	ctx context.Context,
+	nodeInfo fwk.NodeInfo,
+	resource v1.ResourceName,
+	podRequest int64,
+	draPreScoreState *draPreScoreState,
+) (int64, int64) {
 	requested := nodeInfo.GetNonZeroRequested()
 	if r.useRequested {
 		requested = nodeInfo.GetRequested()
@@ -115,10 +203,10 @@ func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(ctx conte
 		return nodeInfo.GetAllocatable().GetEphemeralStorage(), (nodeInfo.GetRequested().GetEphemeralStorage() + podRequest)
 	default:
 		allocatable, exists := nodeInfo.GetAllocatable().GetScalarResources()[resource]
-		if allocatable == 0 && r.enableDRAExtendedResource {
+		if allocatable == 0 && r.enableDRAExtendedResource && draPreScoreState != nil {
 			// Allocatable 0 means that this resource is not handled by device plugin.
 			// Calculate allocatable and requested for resources backed by DRA.
-			allocatable, allocated := r.calculateDRAExtendedResourceAllocatableRequest(ctx, nodeInfo.Node(), resource)
+			allocatable, allocated := r.calculateDRAExtendedResourceAllocatableRequest(ctx, nodeInfo.Node(), resource, draPreScoreState)
 			if allocatable > 0 {
 				return allocatable, allocated + podRequest
 			}
@@ -174,36 +262,63 @@ func (r *resourceAllocationScorer) isBestEffortPod(podRequests []int64) bool {
 	return true
 }
 
+// getDRAPreScoredParams returns the DRA allocated state and resource slices for DRA extended resource scoring.
+func getDRAPreScoredParams(draManager fwk.SharedDRAManager, resources []config.ResourceSpec) (*draPreScoreState, *fwk.Status) {
+	anyBackedByDRA := false
+	for _, resource := range resources {
+		resourceName := v1.ResourceName(resource.Name)
+		if !schedutil.IsDRAExtendedResourceName(resourceName) {
+			continue
+		}
+		deviceClass := draManager.DeviceClassResolver().GetDeviceClass(resourceName)
+		if deviceClass != nil {
+			anyBackedByDRA = true
+			break
+		}
+	}
+	// There's no point in returning DRA data as there are no resources backed by DRA.
+	if !anyBackedByDRA {
+		return nil, nil
+	}
+
+	allocatedState, err := draManager.ResourceClaims().GatherAllocatedState()
+	if err != nil {
+		return nil, fwk.AsStatus(err)
+	}
+	resourceSlices, err := draManager.ResourceSlices().ListWithDeviceTaintRules()
+	if err != nil {
+		return nil, fwk.AsStatus(err)
+	}
+
+	return &draPreScoreState{
+		allocatedState: allocatedState,
+		resourceSlices: resourceSlices,
+	}, nil
+}
+
 // calculateDRAExtendedResourceAllocatableRequest calculates allocatable and allocated
 // quantities for extended resources backed by DRA.
-func (r *resourceAllocationScorer) calculateDRAExtendedResourceAllocatableRequest(ctx context.Context, node *v1.Node, resource v1.ResourceName) (int64, int64) {
+func (r *resourceAllocationScorer) calculateDRAExtendedResourceAllocatableRequest(
+	ctx context.Context,
+	node *v1.Node,
+	resource v1.ResourceName,
+	draPreScoreState *draPreScoreState,
+) (int64, int64) {
 	logger := klog.FromContext(ctx)
-	// Get device class mapping to find the device class for this resource
-	deviceClassMapping, err := extended.DeviceClassMapping(r.draManager)
+	deviceClass := r.draManager.DeviceClassResolver().GetDeviceClass(resource)
+	if deviceClass == nil {
+		// This resource is not backed by DRA.
+		logger.V(7).Info("Extended resource not found in device class mapping", "resource", resource)
+		return 0, 0
+	}
+
+	capacity, allocated, err := r.calculateDRAResourceTotals(ctx, node, deviceClass, draPreScoreState.allocatedState, draPreScoreState.resourceSlices)
 	if err != nil {
-		logger.Error(err, "Failed to get device class mapping for DRA extended resource scoring")
+		logger.Error(err, "Failed to calculate DRA resource capacity and allocated", "node", node.Name, "resource", resource, "deviceClass", deviceClass.Name)
 		return 0, 0
 	}
 
-	deviceClassName, exists := deviceClassMapping[resource]
-	if !exists {
-		logger.Error(nil, "Extended resource not found in device class mapping", "resource", resource)
-		return 0, 0
-	}
-
-	deviceClass, err := r.draManager.DeviceClasses().Get(deviceClassName)
-	if err != nil {
-		logger.Error(err, "Failed to get device class for DRA extended resource scoring", "resource", resource, "deviceClass", deviceClassName)
-		return 0, 0
-	}
-
-	capacity, allocated, err := r.calculateDRAResourceTotals(ctx, node, deviceClass)
-	if err != nil {
-		logger.Error(err, "Failed to calculate DRA resource capacity and allocated", "node", node.Name, "resource", resource, "deviceClass", deviceClassName)
-		return 0, 0
-	}
-
-	logger.V(7).Info("DRA extended resource calculation", "node", node.Name, "resource", resource, "deviceClass", deviceClassName, "capacity", capacity, "allocated", allocated)
+	logger.V(7).Info("DRA extended resource calculation", "node", node.Name, "resource", resource, "deviceClass", deviceClass.Name, "capacity", capacity, "allocated", allocated)
 	return capacity, allocated
 }
 
@@ -223,60 +338,90 @@ func (r *resourceAllocationScorer) calculateDRAExtendedResourceAllocatableReques
 //	totalCapacity  - total number of devices matching the device class on the node
 //	totalAllocated - number of devices currently allocated from the matching set
 //	error          - any error encountered during processing
-func (r *resourceAllocationScorer) calculateDRAResourceTotals(ctx context.Context, node *v1.Node, deviceClass *resourceapi.DeviceClass) (int64, int64, error) {
-	allocatedState, err := r.draManager.ResourceClaims().GatherAllocatedState()
-	if err != nil {
-		return 0, 0, err
-	}
-
-	resourceSlices, err := r.draManager.ResourceSlices().ListWithDeviceTaintRules()
-	if err != nil {
-		return 0, 0, err
-	}
-
+func (r *resourceAllocationScorer) calculateDRAResourceTotals(ctx context.Context, node *v1.Node, deviceClass *resourceapi.DeviceClass, allocatedState *structured.AllocatedState, resourceSlices []*resourceapi.ResourceSlice,
+) (int64, int64, error) {
 	var totalCapacity, totalAllocated int64
+	nodeName := node.Name
+
 	for _, slice := range resourceSlices {
-		driver := slice.Spec.Driver
-		pool := slice.Spec.Pool.Name
+		// Early filtering: check if slice applies to this node
+		perDeviceNodeSelection := ptr.Deref(slice.Spec.PerDeviceNodeSelection, false)
+
 		var devices []resourceapi.Device
-		// Handle per-device node selection vs slice-level node selection
-		if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
-			devices = []resourceapi.Device{}
-			// When per-device node selection is enabled, check each device individually
+
+		if perDeviceNodeSelection {
+			// Per-device node selection: filter devices individually
+			devices = make([]resourceapi.Device, 0, len(slice.Spec.Devices))
 			for _, device := range slice.Spec.Devices {
-				// Check if this specific device matches the node
-				deviceMatches, err := structured.NodeMatches(r.draFeatures, node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
-				if err != nil {
-					return 0, 0, err
-				}
-				if deviceMatches {
+				deviceNodeName := ptr.Deref(device.NodeName, "")
+				deviceAllNodes := ptr.Deref(device.AllNodes, false)
+
+				// Fast path: check AllNodes or exact name match first
+				if deviceAllNodes || (deviceNodeName != "" && deviceNodeName == nodeName) {
 					devices = append(devices, device)
+					continue
+				}
+
+				// Slow path: only if we have a node selector
+				if device.NodeSelector != nil {
+					deviceMatches, err := r.nodeMatches(node, deviceNodeName, deviceAllNodes, device.NodeSelector)
+					if err != nil {
+						return 0, 0, err
+					}
+					if deviceMatches {
+						devices = append(devices, device)
+					}
 				}
 			}
 		} else {
-			// When per-device node selection is disabled, check slice-level node selection first
-			matches, err := structured.NodeMatches(r.draFeatures, node, ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false), slice.Spec.NodeSelector)
-			if err != nil {
-				return 0, 0, err
-			}
-			if !matches {
-				// Skip this slice as it doesn't match the node
+			// Slice-level node selection
+			sliceNodeName := ptr.Deref(slice.Spec.NodeName, "")
+			sliceAllNodes := ptr.Deref(slice.Spec.AllNodes, false)
+
+			// Fast path: check AllNodes or exact name match first
+			if !sliceAllNodes && sliceNodeName != nodeName && slice.Spec.NodeSelector != nil {
+				// Need to check node selector
+				matches, err := r.nodeMatches(node, sliceNodeName, sliceAllNodes, slice.Spec.NodeSelector)
+				if err != nil {
+					return 0, 0, err
+				}
+				if !matches {
+					continue // Skip this slice
+				}
+			} else if !sliceAllNodes && sliceNodeName != "" && sliceNodeName != nodeName {
+				// Node name specified but doesn't match
 				continue
 			}
+
 			devices = slice.Spec.Devices
 		}
-		// Count devices that match the device class
-		for _, device := range devices {
-			matches, err := r.deviceMatchesClass(ctx, device, deviceClass, driver)
-			if err != nil {
-				return 0, 0, err
-			}
-			if matches {
+
+		// Fast path for device class with no selectors
+		if len(deviceClass.Spec.Selectors) == 0 {
+			driver := slice.Spec.Driver
+			pool := slice.Spec.Pool.Name
+			for _, device := range devices {
 				totalCapacity++
-				// Count allocated devices (both fully allocated and partially consumed)
 				deviceID := structured.MakeDeviceID(driver, pool, device.Name)
 				if structured.IsDeviceAllocated(deviceID, allocatedState) {
 					totalAllocated++
+				}
+			}
+		} else {
+			// Slow path: check device class selectors
+			driver := slice.Spec.Driver
+			pool := slice.Spec.Pool.Name
+			for _, device := range devices {
+				matches, err := r.deviceMatchesClass(ctx, device, deviceClass, driver, pool)
+				if err != nil {
+					return 0, 0, err
+				}
+				if matches {
+					totalCapacity++
+					deviceID := structured.MakeDeviceID(driver, pool, device.Name)
+					if structured.IsDeviceAllocated(deviceID, allocatedState) {
+						totalAllocated++
+					}
 				}
 			}
 		}
@@ -289,16 +434,41 @@ func (r *resourceAllocationScorer) calculateDRAResourceTotals(ctx context.Contex
 // Note: This method assumes the device class has ExtendedResourceName set, as filtering
 // should be done by the caller to ensure we only process DRA resources meant for extended
 // resource scoring.
-func (r *resourceAllocationScorer) deviceMatchesClass(ctx context.Context, device resourceapi.Device, deviceClass *resourceapi.DeviceClass, driver string) (bool, error) {
+func (r *resourceAllocationScorer) deviceMatchesClass(ctx context.Context, device resourceapi.Device, deviceClass *resourceapi.DeviceClass, driver string, poolName string) (bool, error) {
 	// If no selectors are defined, all devices match
 	if len(deviceClass.Spec.Selectors) == 0 {
 		return true, nil
 	}
 
+	// Lazily create the CEL device only when needed (first CEL selector that's not cached)
+	var celDevice cel.Device
+	celDeviceCreated := false
+
 	// All selectors must match for the device to be considered a match
 	for _, selector := range deviceClass.Spec.Selectors {
 		if selector.CEL == nil {
 			continue
+		}
+
+		key := buildDeviceMatchCacheKey(selector.CEL.Expression, driver, poolName, device.Name)
+
+		// Check if result is already cached
+		if matches, ok := r.deviceMatchCache.Load(key); ok {
+			if !matches.(bool) {
+				return false, nil
+			}
+			continue // This selector matches, check the next one
+		}
+
+		// Cache miss - need to evaluate CEL expression
+		// Create CEL device if we haven't already
+		if !celDeviceCreated {
+			celDevice = cel.Device{
+				Driver:     driver,
+				Attributes: device.Attributes,
+				Capacity:   device.Capacity,
+			}
+			celDeviceCreated = true
 		}
 
 		// Use cached CEL compilation for performance
@@ -307,17 +477,13 @@ func (r *resourceAllocationScorer) deviceMatchesClass(ctx context.Context, devic
 			return false, result.Error
 		}
 
-		// Evaluate the expression against the device
-		celDevice := cel.Device{
-			Driver:     driver,
-			Attributes: device.Attributes,
-			Capacity:   device.Capacity,
-		}
-
 		matches, _, err := result.DeviceMatches(ctx, celDevice)
 		if err != nil || !matches {
-			return false, nil
+			return false, err
 		}
+
+		// Cache the result for future use
+		r.deviceMatchCache.Store(key, matches)
 	}
 
 	return true, nil

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -17,12 +17,29 @@ limitations under the License.
 package noderesources
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/dynamic-resource-allocation/cel"
+	"k8s.io/dynamic-resource-allocation/resourceslice/tracker"
+	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
+	"k8s.io/utils/ptr"
 )
 
 func TestResourceAllocationScorerCalculateRequests(t *testing.T) {
@@ -235,6 +252,334 @@ func TestResourceAllocationScorerCalculateRequests(t *testing.T) {
 					t.Errorf("expected %s = %d, got %d", n, exp, got)
 				}
 			}
+		})
+	}
+}
+
+func TestCalculateResourceAllocatableRequest(t *testing.T) {
+	// Initialize test variables
+	nodeName := "resource-node"
+	driverName := "test-driver"
+	testClaim := "test-claim"
+	explicitExtendedResource := v1.ResourceName(extendedResourceName)
+	implicitExtendedResource := v1.ResourceName(resourceapi.ResourceDeviceClassPrefix + deviceClassName)
+	celCache := cel.NewCache(10, cel.Features{EnableConsumableCapacity: true})
+	draFeatures := structured.Features{
+		AdminAccess:            true,
+		PrioritizedList:        true,
+		PartitionableDevices:   true,
+		DeviceTaints:           true,
+		DeviceBindingAndStatus: true,
+		ConsumableCapacity:     true,
+	}
+
+	// Define test cases
+	tests := map[string]struct {
+		enableDRAExtendedResource bool
+		node                      *v1.Node
+		extendedResource          v1.ResourceName
+		objects                   []apiruntime.Object
+		podRequest                int64
+		expectedAllocatable       int64
+		expectedRequested         int64
+	}{
+		"device-plugin-resource-feature-disabled": {
+			enableDRAExtendedResource: false,
+			node:                      st.MakeNode().Name(nodeName).Capacity(map[v1.ResourceName]string{explicitExtendedResource: "4"}).Obj(),
+			extendedResource:          explicitExtendedResource,
+			podRequest:                1,
+			expectedAllocatable:       4,
+			expectedRequested:         1,
+		},
+		"device-plugin-resource-feature-enabled": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Capacity(map[v1.ResourceName]string{explicitExtendedResource: "4"}).Obj(),
+			extendedResource:          explicitExtendedResource,
+			podRequest:                1,
+			expectedAllocatable:       4,
+			expectedRequested:         1,
+		},
+		"DRA-backed-resource-explicit": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Obj(),
+			extendedResource:          explicitExtendedResource,
+			objects: []apiruntime.Object{
+				deviceClassWithExtendResourceName,
+				st.MakeResourceSlice(nodeName, driverName).Device("device-1").Obj(),
+			},
+			podRequest:          1,
+			expectedAllocatable: 1,
+			expectedRequested:   1,
+		},
+		"DRA-backed-resource-implicit": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Obj(),
+			extendedResource:          implicitExtendedResource,
+			objects: []apiruntime.Object{
+				&resourceapi.DeviceClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: deviceClassName,
+					},
+				},
+				st.MakeResourceSlice(nodeName, driverName).Device("device-1").Obj(),
+			},
+			podRequest:          1,
+			expectedAllocatable: 1,
+			expectedRequested:   1,
+		},
+		"DRA-backed-resource-no-slices": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Obj(),
+			extendedResource:          explicitExtendedResource,
+			objects:                   []apiruntime.Object{deviceClassWithExtendResourceName},
+			podRequest:                1,
+			expectedAllocatable:       0,
+			expectedRequested:         0,
+		},
+		"DRA-backed-resource-with-allocated-device": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Obj(),
+			extendedResource:          explicitExtendedResource,
+			objects: []apiruntime.Object{
+				deviceClassWithExtendResourceName,
+				st.MakeResourceSlice(nodeName, driverName).Devices("device-1", "device-2").Obj(),
+				// Create a resource claim that fully allocates device-1
+				st.MakeResourceClaim().
+					Name(testClaim).
+					Request(deviceClassName).
+					Allocation(&resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{
+									Request: "req-1",
+									Driver:  driverName,
+									Pool:    nodeName,
+									Device:  "device-1",
+								},
+							},
+						},
+					}).
+					Obj(),
+			},
+			podRequest:          1,
+			expectedAllocatable: 2,
+			expectedRequested:   2, // 1 allocated + 1 requested
+		},
+		"DRA-backed-resource-with-shared-device-allocation": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Obj(),
+			extendedResource:          explicitExtendedResource,
+			objects: []apiruntime.Object{
+				deviceClassWithExtendResourceName,
+				st.MakeResourceSlice(nodeName, driverName).Devices("device-1", "device-2").Obj(),
+				// Create a resource claim with shared device allocation (consumable capacity)
+				st.MakeResourceClaim().
+					Name(testClaim).
+					Request(deviceClassName).
+					Allocation(&resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{
+									Request: "req-1",
+									Driver:  driverName,
+									Pool:    nodeName,
+									Device:  "device-1",
+									ShareID: ptr.To(types.UID("share-123")), // Shared device allocation
+								},
+							},
+						},
+					}).
+					Obj(),
+			},
+			podRequest:          1,
+			expectedAllocatable: 2,
+			expectedRequested:   2, // 1 allocated (shared) + 1 requested
+		},
+		"DRA-backed-resource-multiple-devices-mixed-allocation": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Obj(),
+			extendedResource:          explicitExtendedResource,
+			objects: []apiruntime.Object{
+				deviceClassWithExtendResourceName,
+				st.MakeResourceSlice(nodeName, driverName).Devices("device-1", "device-2", "device-3").Obj(),
+				// Mix of fully allocated and shared device allocations
+				st.MakeResourceClaim().
+					Name("test-claim-1").
+					Request(deviceClassName).
+					Allocation(&resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{
+									Request: "req-1",
+									Driver:  driverName,
+									Pool:    nodeName,
+									Device:  "device-1",
+									// No ShareID = fully allocated device
+								},
+							},
+						},
+					}).
+					Obj(),
+				st.MakeResourceClaim().
+					Name("test-claim-2").
+					Request(deviceClassName).
+					Allocation(&resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{
+									Request: "req-1",
+									Driver:  driverName,
+									Pool:    nodeName,
+									Device:  "device-2",
+									ShareID: ptr.To(types.UID("share-456")), // Shared device allocation
+								},
+							},
+						},
+					}).
+					Obj(),
+				// device-3 remains unallocated
+			},
+			podRequest:          1,
+			expectedAllocatable: 3,
+			expectedRequested:   3, // 2 allocated (1 full + 1 shared) + 1 requested
+		},
+		"DRA-backed-resource-with-per-device-node-selection": {
+			enableDRAExtendedResource: true,
+			node:                      st.MakeNode().Name(nodeName).Obj(),
+			extendedResource:          explicitExtendedResource,
+			objects: []apiruntime.Object{
+				&resourceapi.DeviceClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: deviceClassName,
+					},
+					Spec: resourceapi.DeviceClassSpec{
+						ExtendedResourceName: &extendedResourceName,
+						Selectors: []resourceapi.DeviceSelector{
+							{
+								CEL: &resourceapi.CELDeviceSelector{
+									// Realistic GPU selection: match test driver with at least 8GB memory and SOME- model
+									Expression: `device.driver == "test-driver" && device.capacity["test-driver"].memory.compareTo(quantity("8Gi")) >= 0 && device.attributes["test-driver"].model.startsWith("SOME-")`,
+								},
+							},
+						},
+					},
+				},
+				// Create a custom resource slice with per-device node selection
+				&resourceapi.ResourceSlice{
+					ObjectMeta: metav1.ObjectMeta{Name: "per-device-slice"},
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver:                 driverName, // Match the CEL expression driver
+						Pool:                   resourceapi.ResourcePool{Name: "per-device-pool", ResourceSliceCount: 1},
+						PerDeviceNodeSelection: ptr.To(true), // Enable per-device node selection
+						// Note: No NodeName, AllNodes, or NodeSelector at slice level when PerDeviceNodeSelection is true
+						Devices: []resourceapi.Device{
+							{
+								Name:     "device-1",
+								NodeName: ptr.To(nodeName), // This device matches the test node
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"model": {StringValue: ptr.To("SOME-XYZ")},
+								},
+								Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+									"memory": {Value: resource.MustParse("16Gi")}, // 16GB GPU - matches CEL (>= 8GB)
+								},
+							},
+							{
+								Name:     "device-2",
+								NodeName: ptr.To("other-node"), // This device matches a different node
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"model": {StringValue: ptr.To("SOME-ZYX")},
+								},
+								Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+									"memory": {Value: resource.MustParse("12Gi")}, // 12GB GPU - matches CEL (>= 8GB)
+								},
+							},
+							{
+								Name:     "device-3",
+								AllNodes: ptr.To(true), // This device matches all nodes
+								Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+									"model": {StringValue: ptr.To("SOME-XZY")},
+								},
+								Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+									"memory": {Value: resource.MustParse("24Gi")}, // 24GB GPU - matches CEL (>= 8GB)
+								},
+							},
+						},
+					},
+				},
+				// Create a resource claim that allocates gpu-1
+				st.MakeResourceClaim().
+					Name("test-claim").
+					Request(deviceClassName).
+					Allocation(&resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{
+									Request: "req-1",
+									Driver:  driverName,
+									Pool:    "per-device-pool",
+									Device:  "device-1",
+								},
+							},
+						},
+					}).
+					Obj(),
+			},
+			podRequest:          1,
+			expectedAllocatable: 2, // Only device-1 (matches test-node) and device-3 (matches all nodes)
+			expectedRequested:   2, // 1 allocated (device-1) + 1 requested
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// Setup environment, create required objects
+			logger, tCtx := ktesting.NewTestContext(t)
+			tCtx, cancel := context.WithCancel(tCtx)
+			defer cancel()
+
+			client := fake.NewClientset(tc.objects...)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			resourceSliceTrackerOpts := tracker.Options{
+				SliceInformer: informerFactory.Resource().V1().ResourceSlices(),
+				TaintInformer: informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+				ClassInformer: informerFactory.Resource().V1().DeviceClasses(),
+				KubeClient:    client,
+			}
+			resourceSliceTracker, err := tracker.StartTracker(tCtx, resourceSliceTrackerOpts)
+			require.NoError(t, err, "couldn't start resource slice tracker")
+			draManager := dynamicresources.NewDRAManager(
+				tCtx,
+				assumecache.NewAssumeCache(
+					logger,
+					informerFactory.Resource().V1().ResourceClaims().Informer(),
+					"resource claim",
+					"",
+					nil),
+				resourceSliceTracker,
+				informerFactory)
+
+			informerFactory.Start(tCtx.Done())
+			t.Cleanup(func() {
+				// Now we can wait for all goroutines to stop.
+				informerFactory.Shutdown()
+			})
+			informerFactory.WaitForCacheSync(tCtx.Done())
+
+			nodeInfo := framework.NewNodeInfo()
+			nodeInfo.SetNode(tc.node)
+
+			scorer := &resourceAllocationScorer{
+				enableDRAExtendedResource: tc.enableDRAExtendedResource,
+				draManager:                draManager,
+				draFeatures:               draFeatures,
+				celCache:                  celCache,
+			}
+
+			// Test calculateResourceAllocatableRequest API
+			allocatable, requested := scorer.calculateResourceAllocatableRequest(tCtx, nodeInfo, tc.extendedResource, tc.podRequest)
+			assert.Equal(t, tc.expectedAllocatable, allocatable)
+			assert.Equal(t, tc.expectedRequested, requested)
 		})
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -1148,7 +1148,7 @@ func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, 
 	}
 
 	if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
-		matches, err := nodeMatches(alloc.node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
+		matches, err := NodeMatches(alloc.node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
 		if err != nil {
 			return false, err
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, nodeSelector *v1.NodeSelector) (bool, error) {
+func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, nodeSelector *v1.NodeSelector) (bool, error) {
 	switch {
 	case nodeNameToMatch != "":
 		return node != nil && node.Name == nodeNameToMatch, nil
@@ -61,7 +61,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 		}
 
 		if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
-			match, err := nodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
+			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
 			}
@@ -80,7 +80,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 			}
 		} else if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
 			for _, device := range slice.Spec.Devices {
-				match, err := nodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
+				match, err := NodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
 				if err != nil {
 					return nil, fmt.Errorf("failed to perform node selection for device %s in slice %s: %w",
 						device.String(), slice.Name, err)

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -1017,7 +1017,7 @@ func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, 
 	}
 
 	if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
-		matches, err := nodeMatches(alloc.node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
+		matches, err := NodeMatches(alloc.node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
 		if err != nil {
 			return false, err
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, nodeSelector *v1.NodeSelector) (bool, error) {
+func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, nodeSelector *v1.NodeSelector) (bool, error) {
 	switch {
 	case nodeNameToMatch != "":
 		return node != nil && node.Name == nodeNameToMatch, nil
@@ -60,7 +60,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 		}
 
 		if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
-			match, err := nodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
+			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
 			}
@@ -71,7 +71,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 			}
 		} else if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
 			for _, device := range slice.Spec.Devices {
-				match, err := nodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
+				match, err := NodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
 				if err != nil {
 					return nil, fmt.Errorf("failed to perform node selection for device %s in slice %s: %w",
 						device.String(), slice.Name, err)

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -926,7 +926,7 @@ func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, 
 	}
 
 	if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
-		matches, err := nodeMatches(alloc.node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
+		matches, err := NodeMatches(alloc.node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
 		if err != nil {
 			return false, err
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, nodeSelector *v1.NodeSelector) (bool, error) {
+func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, nodeSelector *v1.NodeSelector) (bool, error) {
 	switch {
 	case nodeNameToMatch != "":
 		return node != nil && node.Name == nodeNameToMatch, nil
@@ -60,7 +60,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 		}
 
 		if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
-			match, err := nodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
+			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
 			}
@@ -71,7 +71,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 			}
 		} else if ptr.Deref(slice.Spec.PerDeviceNodeSelection, false) {
 			for _, device := range slice.Spec.Devices {
-				match, err := nodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
+				match, err := NodeMatches(node, ptr.Deref(device.NodeName, ""), ptr.Deref(device.AllNodes, false), device.NodeSelector)
 				if err != nil {
 					return nil, fmt.Errorf("failed to perform node selection for device %s in slice %s: %w",
 						device.String(), slice.Name, err)

--- a/test/integration/scheduler_perf/dra/extendedresource/scoring/extendedresource_scoring_test.go
+++ b/test/integration/scheduler_perf/dra/extendedresource/scoring/extendedresource_scoring_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extendedresourcescoring
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/dynamic-resource-allocation/structured"
+	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
+)
+
+func TestMain(m *testing.M) {
+	if err := perf.InitTests(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	m.Run()
+}
+
+func TestSchedulerPerf(t *testing.T) {
+	// Verify correct behavior with all available allocators for this feature.
+	for _, allocatorName := range []string{"experimental"} {
+		t.Run(allocatorName, func(t *testing.T) {
+			structured.EnableAllocators(allocatorName)
+			defer structured.EnableAllocators()
+
+			perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+		})
+	}
+}
+
+func BenchmarkPerfScheduling(b *testing.B) {
+	// Restrict benchmarking to the allocator for this feature
+	// to ensure that we do not accidentally pick something else.
+	structured.EnableAllocators("experimental")
+	defer structured.EnableAllocators()
+
+	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra_extendedresource_scoring", nil)
+}

--- a/test/integration/scheduler_perf/dra/extendedresource/scoring/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/extendedresource/scoring/performance-config.yaml
@@ -1,0 +1,84 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration specifically for testing DRA extended resource scoring performance.
+# This config ensures that multiple nodes can satisfy each pod's extended resource
+# requirements, forcing the scheduler to use scoring to choose between nodes.
+
+
+# ExtendedResourceScoring uses pods with extended resources that can be satisfied
+# by multiple nodes, triggering scoring competition to test the DRA scoring implementation.
+- name: ExtendedResourceScoring
+  featureGates:
+    DynamicResourceAllocation: true
+    DRAExtendedResource: true
+  schedulerConfigPath: scheduler-config.yaml
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $nodesWithoutDRA
+  - opcode: createNodes
+    nodeTemplatePath: ../../templates/node-with-dra-test-driver.yaml
+    countParam: $nodesWithDRA
+  - opcode: createResourceDriver
+    driverName: test-driver.cdi.k8s.io
+    nodes: scheduler-perf-dra-*
+    maxClaimsPerNodeParam: $maxClaimsPerNode
+  - opcode: createAny
+    templatePath: ../../templates/deviceclass-extended-resource-scoring.yaml
+    countParam: $classes
+  - opcode: createPods
+    namespace: init
+    countParam: $initPods
+    podTemplatePath: ../../templates/pod-with-extended-resource-scoring.yaml
+  - opcode: createPods
+    namespace: test
+    countParam: $measurePods
+    podTemplatePath: ../../templates/pod-with-extended-resource-scoring.yaml
+    collectMetrics: true
+  workloads:
+  - name: fast
+    featureGates:
+      DRAExtendedResource: true
+    labels: [integration-test, short]
+    params:
+      # Use fewer classes than nodes to ensure multiple nodes can satisfy
+      # each pod's extended resource requirements, forcing scoring competition.
+      classes: 2
+      nodesWithDRA: 3
+      nodesWithoutDRA: 1
+      initPods: 0
+      measurePods: 10
+      maxClaimsPerNode: 10
+  - name: 2000pods_200nodes
+    featureGates:
+      DRAExtendedResource: true
+    labels: [integration-test, performance]
+    params:
+      classes: 10
+      nodesWithDRA: 200
+      nodesWithoutDRA: 0
+      initPods: 0
+      measurePods: 2000
+      maxClaimsPerNode: 20
+  - name: 5000pods_500nodes
+    featureGates:
+      DRAExtendedResource: true
+    labels: [integration-test, performance]
+    params:
+      classes: 20
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initPods: 0
+      measurePods: 5000
+      maxClaimsPerNode: 20

--- a/test/integration/scheduler_perf/dra/extendedresource/scoring/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/extendedresource/scoring/performance-config.yaml
@@ -1,21 +1,25 @@
-# Copyright 2025 The Kubernetes Authors.
+# The following labels are used in this file. (listed in ascending order of the number of covered test cases)
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# - integration-test: test cases to run as the integration test, usually to spot some issues in the scheduler implementation or scheduler-perf itself.
+# - performance: test cases to run in the performance test.
+# - short: supplemental label for the above two labels (must not used alone), which literally means short execution time test cases.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# Specifically, the CIs use labels like the following:
+# - `ci-kubernetes-integration-master` (`integration-test`): Test cases are chosen based on a tradeoff between code coverage and overall runtime. 
+# It basically covers all test cases but with their smallest workload. 
+# - `pull-kubernetes-integration` (`integration-test`,`short`): Test cases are chosen so that they should take less than total 5 min to complete.
+# - `ci-benchmark-scheduler-perf` (`performance`): Long enough test cases are chosen (ideally, longer than 10 seconds) 
+# to provide meaningful samples for the pod scheduling rate.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Also, `performance`+`short` isn't used in the CIs, but it's used to test the performance test locally.
+# (Sometimes, the test cases with `integration-test` are too small to spot issues.)
+#
+# Combining `performance` and `short` selects suitable workloads for a local
+# before/after comparisons with benchstat.
 
-# Configuration specifically for testing DRA extended resource scoring performance.
-# This config ensures that multiple nodes can satisfy each pod's extended resource
+# This config is specific for testing DRA extended resource scoring performance.
+# It ensures that multiple nodes can satisfy each pod's extended resource
 # requirements, forcing the scheduler to use scoring to choose between nodes.
-
 
 # ExtendedResourceScoring uses pods with extended resources that can be satisfied
 # by multiple nodes, triggering scoring competition to test the DRA scoring implementation.

--- a/test/integration/scheduler_perf/dra/extendedresource/scoring/scheduler-config.yaml
+++ b/test/integration/scheduler_perf/dra/extendedresource/scoring/scheduler-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+profiles:
+- schedulerName: default-scheduler
+  pluginConfig:
+  - name: NodeResourcesFit
+    args:
+      scoringStrategy:
+        type: LeastAllocated
+        resources:
+        - name: cpu
+          weight: 1
+        - name: memory
+          weight: 1
+        - name: example.com/gpu
+          weight: 1

--- a/test/integration/scheduler_perf/dra/templates/deviceclass-extended-resource-scoring.yaml
+++ b/test/integration/scheduler_perf/dra/templates/deviceclass-extended-resource-scoring.yaml
@@ -1,0 +1,11 @@
+apiVersion: resource.k8s.io/v1beta2
+kind: DeviceClass
+metadata:
+  name: scoring-test-class-{{.Index}}
+spec:
+  selectors:
+  - cel:
+      expression: device.driver == "test-driver.cdi.k8s.io"
+  # All device classes expose the same extended resource name
+  # This allows multiple nodes to satisfy the same pod's extended resource request
+  extendedResourceName: example.com/gpu

--- a/test/integration/scheduler_perf/dra/templates/pod-with-extended-resource-scoring.yaml
+++ b/test/integration/scheduler_perf/dra/templates/pod-with-extended-resource-scoring.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: scoring-test-pod-{{.Index}}
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.9
+    name: pause
+    resources:
+      requests:
+        # All pods request the same extended resource
+        # This forces the scheduler to choose between multiple nodes
+        example.com/gpu: 1
+      limits:
+        example.com/gpu: 1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently, the scheduler only scores extended resources provided via device plugins. Extended resources backed by DRA are ignored in scoring, which makes the behavior inconsistent with the existing scheduling model:

For device-plugin backed extended resources, allocatable and requested values are included in node scoring.

For DRA-backed extended resources, the same requests are currently excluded.

This effectively breaks backward compatibility for workloads that migrate from device-plugin extended resources to DRA-backed ones. Instead of preserving consistent placement decisions, the scheduler would treat these resources as if they don’t matter at all, leading to incompatible scheduling decisions.

This gap must be closed for DRA extended resources to graduate to Beta.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/133669

#### Special notes for your reviewer:

##### High level technical details of the implementation:

The implementation calculates total number of available devices (capacity/allocatable) and requested(already allocated + requested by pod) amount of devices for extended resources backed by DRA for a node. For backward compatibility, device plugin resources are still handled first; DRA-backed extended resources are considered only when `Allocatable` value for extended resource is 0. 

The computed (capacity, allocated + podRequest) values are fed back into the existing scoring logic, just like for CPU, memory, or device plugin resources.

`SharedDraManager` is used to get information about device classes, resource slices and resource claims to simplify the implementation and avoid duplicating dynamicresources APIs.

Capacity is calculated by counting devices that belong to the resource slices on the node that match the resource device class. Allocated is calculated by counting already allocated devices returned by dra manager ResourceClaims().ListAllAllocatedDevices() API and filtering out devices from other nodes and device classes.

Device filtering honors node selectors and CEL-based match expressions from the DeviceClass.

#### Does this PR introduce a user-facing change?

```release-note
Implement scoring for DRA-backed extended resources
```