### PR TITLE
test/e2e/node: add [NodeConformance] label to ConfigMap update test

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2126,6 +2126,12 @@
     ConfigMap must be deleted by Collection.
   release: v1.19
   file: test/e2e/common/node/configmap.go
+- testname: ConfigMap Update
+  codename: '[sig-node] ConfigMap should update ConfigMap successfully [NodeConformance]
+    [Conformance]'
+  description: Ensure that a ConfigMap object can be created and then updated successfully.
+  release: v1.32
+  file: test/e2e/common/node/configmap.go
 - testname: Pod Lifecycle, post start exec hook
   codename: '[sig-node] Container Lifecycle Hook when create a pod with lifecycle
     hook should execute poststart exec hook properly [NodeConformance] [Conformance]'

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -141,9 +141,9 @@ var _ = SIGDescribe("ConfigMap", func() {
 		gomega.Expect(err).To(gomega.HaveOccurred(), "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
 	})
 	/*
-	Release : v1.32
-	Testname: ConfigMap Update
-	Description: Ensure that a ConfigMap object can be created and then updated successfully.
+		Release : v1.32
+		Testname: ConfigMap Update
+		Description: Ensure that a ConfigMap object can be created and then updated successfully.
 	*/
 	framework.ConformanceIt("should update ConfigMap successfully", f.WithNodeConformance(), func(ctx context.Context) {
 		name := "configmap-test-" + string(uuid.NewUUID())

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -140,7 +140,11 @@ var _ = SIGDescribe("ConfigMap", func() {
 		configMap, err := newConfigMapWithEmptyKey(ctx, f)
 		gomega.Expect(err).To(gomega.HaveOccurred(), "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
 	})
-
+	/*
+	Release : v1.32
+	Testname: ConfigMap Update
+	Description: Ensure that a ConfigMap object can be created and then updated successfully.
+	*/
 	framework.ConformanceIt("should update ConfigMap successfully", f.WithNodeConformance(), func(ctx context.Context) {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -141,7 +141,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		gomega.Expect(err).To(gomega.HaveOccurred(), "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
 	})
 
-	ginkgo.It("should update ConfigMap successfully", func(ctx context.Context) {
+	framework.ConformanceIt("should update ConfigMap successfully", f.WithNodeConformance(), func(ctx context.Context) {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating ConfigMap %v/%v", f.Namespace.Name, configMap.Name))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node
/area conformance
/priority backlog

#### What this PR does / why we need it:

This PR picks up a small part of the work from the help-wanted issue kubernetes/test-infra#33827. It updates the ConfigMap update test in `test/e2e/common/node/configmap.go` to use `framework.ConformanceIt` with `f.WithNodeConformance()`.

- Ensures the test is properly marked as [NodeConformance].
- Removes it from the unlabeled test lane in TestGrid.
<img width="1168" height="592" alt="Screenshot 2025-09-15 001232" src="https://github.com/user-attachments/assets/65117003-5942-4b6a-8c44-9059726cf285" />
- Brings it in line with other ConfigMap tests in the same file, which are already part of the conformance suite.

#### Which issue(s) this PR is related to:

Ref: kubernetes/test-infra#33827


#### Special notes for your reviewer:

This is a small, incremental step towards cleaning up unlabeled tests so we can eventually drop the `*-unlabelled` TestGrid lane.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```