### PR TITLE
DRAFT: WIP: Working on a test case

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -409,6 +409,9 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 
 		ginkgo.It("should report Memory pressure in PSI metrics", func(ctx context.Context) {
+			if !utilfeature.DefaultFeatureGate.Enabled(features.MemoryQoS) {
+				ginkgo.Skip("MemoryQoS feature gate is not enabled")
+			}
 			podName := "memory-pressure-pod"
 			ginkgo.By("Creating a pod to generate Memory pressure")
 			// Create a pod that generates memory pressure by continuously writing to files,
@@ -419,14 +422,14 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				// This command runs an infinite loop that uses `dd` to write 50MB files,
 				// cycling through 5 files to target 250MB of reclaimable file cache usage.
 				// This exceeds the 200MB memory limit, forcing the kernel to reclaim memory and generate pressure stalls.
-				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%4)); sleep 0.1; done",
+				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
 			}
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("210M"),
+					v1.ResourceMemory: resource.MustParse("250M"),
 				},
 				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("100M"),
+					v1.ResourceMemory: resource.MustParse("200M"),
 				},
 			}
 			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -416,17 +416,17 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			podSpec := getStressTestPod(podName, "memory-stress", []string{})
 			podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
 			podSpec.Spec.Containers[0].Args = []string{
-				// This command runs an infinite loop that uses `dd` to write 50MB files,
-				// cycling through 5 files to target 250MB of reclaimable file cache usage.
-				// This exceeds the 200MB memory limit, forcing the kernel to reclaim memory and generate pressure stalls.
-				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
+				// This command runs an infinite loop that uses `dd` to write 15MB files,
+				// cycling through 3 files to target 45MB of reclaimable file cache usage.
+				// This creates sustained memory pressure without triggering OOM kills.
+				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=15 &>/dev/null; i=$(((i+1)%3)); sleep 0.2; done",
 			}
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("200M"),
+					v1.ResourceMemory: resource.MustParse("250M"),
 				},
 				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("200M"),
+					v1.ResourceMemory: resource.MustParse("250M"),
 				},
 			}
 			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -419,14 +419,14 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				// This command runs an infinite loop that uses `dd` to write 50MB files,
 				// cycling through 5 files to target 250MB of reclaimable file cache usage.
 				// This exceeds the 200MB memory limit, forcing the kernel to reclaim memory and generate pressure stalls.
-				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
+				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%8)); sleep 0.3; done",
 			}
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("150M"),
+					v1.ResourceMemory: resource.MustParse("350M"),
 				},
 				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("150M"),
+					v1.ResourceMemory: resource.MustParse("350M"),
 				},
 			}
 			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -422,7 +422,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				// This command runs an infinite loop that uses `dd` to write 50MB files,
 				// cycling through 5 files to target 250MB of reclaimable file cache usage.
 				// This exceeds the 200MB memory limit, forcing the kernel to reclaim memory and generate pressure stalls.
-				"sleep 10; echo 218103808 > /sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/memory.high; i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
+				"sleep 10; i=0; while true; do find /sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice -type f -name \"memory.high\" -exec sh -c 'echo \"195103808\" | tee {} > /dev/null' \\;; dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%9)); sleep 0.1; done",
 			}
 			podSpec.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
 				{
@@ -444,7 +444,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			}
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("260M"),
+					v1.ResourceMemory: resource.MustParse("460M"),
 				},
 				Requests: v1.ResourceList{
 					v1.ResourceMemory: resource.MustParse("100M"),
@@ -464,7 +464,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 						"Memory": pressureDetected("full", 0.1),
 					}),
 				}))
-			}, 2*time.Minute, 15*time.Second).Should(gomega.Succeed())
+			}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed())
 			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
 		})
 

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -381,7 +381,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		ginkgo.It("should report CPU pressure in PSI metrics", func(ctx context.Context) {
 			podName := "cpu-pressure-pod"
 			ginkgo.By("Creating a pod to generate CPU pressure")
-			podSpec := getStressTestPod(podName, "cpu-stress", []string{"stress", "--cpus", "1"})
+			podSpec := getStressTestPod(podName, "cpu-stress", []string{"stress", "--cpus", "2"})
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
 					v1.ResourceCPU: resource.MustParse("500m"),

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -381,7 +381,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		ginkgo.It("should report CPU pressure in PSI metrics", func(ctx context.Context) {
 			podName := "cpu-pressure-pod"
 			ginkgo.By("Creating a pod to generate CPU pressure")
-			podSpec := getStressTestPod(podName, "cpu-stress", []string{"stress", "--cpus", "2"})
+			podSpec := getStressTestPod(podName, "cpu-stress", []string{"stress", "--cpus", "1"})
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
 					v1.ResourceCPU: resource.MustParse("500m"),

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -481,7 +481,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				echo "Starting memory allocation stepping..."
 				step=1
 				while true; do
-					size_mb=$((step * 50))
+					size_mb=$((step * 500))
 					echo "Step $step: Allocating ${size_mb}MB"
 					# Use dd to create files of increasing size, keeping them in memory
 					dd if=/dev/zero of=/tmp/memfile_$step bs=1M count=$size_mb 2>/dev/null &
@@ -493,10 +493,10 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			// Guaranteed: requests = limits (set high enough to allow stepping)
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("500M"),
+					v1.ResourceMemory: resource.MustParse("5000M"),
 				},
 				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("500M"),
+					v1.ResourceMemory: resource.MustParse("5000M"),
 				},
 			}
 

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -409,116 +409,42 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 
 		ginkgo.It("should report Memory pressure in PSI metrics", func(ctx context.Context) {
-			var podsToDelete []*v1.Pod
-			defer func() {
-				// Clean up all pods
-				for _, pod := range podsToDelete {
-					framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
-				}
-			}()
-
-			ginkgo.By("Creating 10 BestEffort pods")
-			for i := 0; i < 10; i++ {
-				podName := fmt.Sprintf("besteffort-pod-%d", i)
-				podSpec := getStressTestPod(podName, "besteffort-container", []string{})
-				podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
-				podSpec.Spec.Containers[0].Args = []string{"sleep 3600"}
-				// BestEffort: no resource requests or limits
-				pod := e2epod.NewPodClient(f).Create(ctx, podSpec)
-				podsToDelete = append(podsToDelete, pod)
-			}
-
-			ginkgo.By("Creating 5 Burstable pods")
-			for i := 0; i < 5; i++ {
-				podName := fmt.Sprintf("burstable-pod-%d", i)
-				podSpec := getStressTestPod(podName, "burstable-container", []string{})
-				podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
-				podSpec.Spec.Containers[0].Args = []string{"sleep 3600"}
-				// Burstable: requests < limits
-				podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
-					Limits: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("200M"),
-					},
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("100M"),
-					},
-				}
-				pod := e2epod.NewPodClient(f).Create(ctx, podSpec)
-				podsToDelete = append(podsToDelete, pod)
-			}
-
-			ginkgo.By("Creating 5 Guaranteed pods")
-			for i := 0; i < 5; i++ {
-				podName := fmt.Sprintf("guaranteed-background-pod-%d", i)
-				podSpec := getStressTestPod(podName, "guaranteed-container", []string{})
-				podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
-				podSpec.Spec.Containers[0].Args = []string{"sleep 3600"}
-				// Guaranteed: requests = limits
-				podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
-					Limits: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("150M"),
-					},
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("150M"),
-					},
-				}
-				pod := e2epod.NewPodClient(f).Create(ctx, podSpec)
-				podsToDelete = append(podsToDelete, pod)
-			}
-
-			ginkgo.By("Waiting for all background pods to start")
-			for _, pod := range podsToDelete {
-				framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
-			}
-
-			ginkgo.By("Creating a Guaranteed pod with stepping memory usage")
-			memoryStepPodName := "guaranteed-memory-step-pod"
-			podSpec := getStressTestPod(memoryStepPodName, "memory-stress", []string{})
+			podName := "memory-pressure-pod"
+			ginkgo.By("Creating a pod to generate Memory pressure")
+			// Create a pod that generates memory pressure by continuously writing to files,
+			// forcing kernel page cache reclamation.
+			podSpec := getStressTestPod(podName, "memory-stress", []string{})
 			podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
 			podSpec.Spec.Containers[0].Args = []string{
-				// Memory stepping script: starts at 50MB, increases by 50MB every 5 seconds
-				`
-				echo "Starting memory allocation stepping..."
-				step=1
-				while true; do
-					size_mb=$((step * 500))
-					echo "Step $step: Allocating ${size_mb}MB"
-					# Use dd to create files of increasing size, keeping them in memory
-					dd if=/dev/zero of=/tmp/memfile_$step bs=1M count=$size_mb 2>/dev/null &
-					sleep 5
-					step=$((step + 1))
-				done
-				`,
+				// This command runs an infinite loop that uses `dd` to write 50MB files,
+				// cycling through 5 files to target 250MB of reclaimable file cache usage.
+				// This exceeds the 200MB memory limit, forcing the kernel to reclaim memory and generate pressure stalls.
+				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%4)); sleep 0.1; done",
 			}
-			// Guaranteed: requests = limits (set high enough to allow stepping)
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("5000M"),
+					v1.ResourceMemory: resource.MustParse("210M"),
 				},
 				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("5000M"),
+					v1.ResourceMemory: resource.MustParse("100M"),
 				},
 			}
+			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)
 
-			memoryStepPod := e2epod.NewPodClient(f).Create(ctx, podSpec)
-			podsToDelete = append(podsToDelete, memoryStepPod)
+			ginkgo.By("Waiting for the pod to start")
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
 
-			ginkgo.By("Waiting for memory stepping pod to start")
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, memoryStepPod))
-
-			ginkgo.By("Monitoring for memory pressure on the stepping pod")
+			ginkgo.By("Validating that Memory PSI metrics reflect pressure")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
-				// Check if memory pressure is detected on the stepping pod
 				summary, err := getNodeSummary(ctx)
 				framework.ExpectNoError(err)
 				g.Expect(summary.Pods).To(gstruct.MatchElements(summaryObjectID, gstruct.IgnoreExtras, gstruct.Elements{
-					fmt.Sprintf("%s::%s", f.Namespace.Name, memoryStepPodName): gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					fmt.Sprintf("%s::%s", f.Namespace.Name, podName): gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 						"Memory": pressureDetected("full", 0.1),
 					}),
 				}))
-			}, 5*time.Minute, 10*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("Memory pressure detected on the stepping guaranteed pod")
+			}, 2*time.Minute, 15*time.Second).Should(gomega.Succeed())
+			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
 		})
 
 		ginkgo.It("should report I/O pressure in PSI metrics", func(ctx context.Context) {

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -416,17 +416,17 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			podSpec := getStressTestPod(podName, "memory-stress", []string{})
 			podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
 			podSpec.Spec.Containers[0].Args = []string{
-				// This command runs an infinite loop that uses `dd` to write 15MB files,
-				// cycling through 3 files to target 45MB of reclaimable file cache usage.
-				// This creates sustained memory pressure without triggering OOM kills.
-				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=15 &>/dev/null; i=$(((i+1)%3)); sleep 0.2; done",
+				// This command runs an infinite loop that uses `dd` to write 50MB files,
+				// cycling through 5 files to target 250MB of reclaimable file cache usage.
+				// This exceeds the 200MB memory limit, forcing the kernel to reclaim memory and generate pressure stalls.
+				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
 			}
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("250M"),
+					v1.ResourceMemory: resource.MustParse("150M"),
 				},
 				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("250M"),
+					v1.ResourceMemory: resource.MustParse("150M"),
 				},
 			}
 			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -426,10 +426,10 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			}
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("250M"),
+					v1.ResourceMemory: resource.MustParse("260M"),
 				},
 				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("200M"),
+					v1.ResourceMemory: resource.MustParse("100M"),
 				},
 			}
 			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR address the issue with Memory pressure. 
When running the test in Fedora with cri-o runtime, the process was getting killed with OOM before the PSI metrics are generated.

TODO: Update more details post testing

#### Which issue(s) this PR is related to:
Fixes #134141
https://github.com/kubernetes/kubernetes/issues/134141
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
