### PR TITLE
Support virtualized PCI device topology (e.g. Hyper-V) in resolving "resource.kubernetes.io/pcieRoot" device attribute

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
@@ -21,9 +21,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	resourceapi "k8s.io/api/resource/v1"
+)
+
+var (
+	pcieRootRegexp = regexp.MustCompile(`^pci[0-9a-f]{4}:[0-9a-f]{2}$`)
 )
 
 // GetPCIeRootAttributeByPCIBusID retrieves the PCIe Root Complex for a given PCI Bus ID.
@@ -69,8 +74,15 @@ func GetPCIeRootAttributeByPCIBusID(pciBusID string) (DeviceAttribute, error) {
 // So we can resolve the actual device path by reading the symlink at /sys/bus/pci/devices/<address>.
 //
 // For example, if the PCIAddress is "0000:04:1f.0",
+//
+// In typical physical machines, /sys/bus/pci/devices/0000:04:1f.0 points to
+// /sys/devices/pci0000:00/0000:00:1c.0/0000:04:00.0/0000:04:1f.0,
+// where "pci0000:00" is the PCIe Root.
+//
+// In some virtualized environments(e.g. Hyper-V), they have more complex device hierarchies such that
+// pcie devices are behind some virtual bus controllers(e.g. Hyper-V). In such cases,
 // /sys/bus/pci/devices/0000:04:1f.0 points to
-// /sys/devices/pci0000:00/...<intermediate PCI devices>.../0000:04:1f.0,
+// /sys/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/VMBUS:00/000000c1-0001-0000-3130-444532304235/pci0000:00/0000:04:1f.0
 // where "pci0000:00" is the PCIe Root.
 func resolvePCIeRoot(pciBusID string) (string, error) {
 	// e.g. /sys/bus/pci/devices/0000:04:1f.0
@@ -86,8 +98,8 @@ func resolvePCIeRoot(pciBusID string) (string, error) {
 		target = filepath.Join(filepath.Dir(sysBusPath), target)
 	}
 
-	// targetAbs must be /sys/devices/pci0000:00/...<intermediate PCI devices>.../0000:04:1f.0
-	devicePathPrefix := sysfs.devices("pci")
+	// targetAbs must be of the form /sys/devices/...<intermediate bus controllers>.../pci0000:00/...<intermediate PCI devices>.../0000:04:1f.0
+	devicePathPrefix := sysfs.devices("")
 	if !strings.HasPrefix(target, devicePathPrefix) {
 		return "", fmt.Errorf("symlink target for PCI Bus ID %s is invalid: it must start with %s: %s", pciBusID, devicePathPrefix, target)
 	}
@@ -95,8 +107,12 @@ func resolvePCIeRoot(pciBusID string) (string, error) {
 		return "", fmt.Errorf("symlink target for PCI Bus ID %s is invalid: it must end with %s: %s", pciBusID, pciBusID, target)
 	}
 
-	// We need to extract the PCIe Root part, which is the first part of the path after /sys/devices/.
-	pcieRootPart := strings.Split(strings.TrimPrefix(target, sysfs.devices("")+"/"), "/")[0]
+	// Extract the PCIe Root part(pciXXXX:YY), which is of the form pci<domain>:<bus> from the absolute target path.
+	targetAbsParts := strings.Split(strings.TrimPrefix(target, devicePathPrefix+"/"), "/")
+	pcieRootPartIdx := slices.IndexFunc(targetAbsParts, func(part string) bool { return pcieRootRegexp.MatchString(part) })
+	if pcieRootPartIdx == -1 {
+		return "", fmt.Errorf("failed to find PCIe Root Complex part (pciXXXX:YY) in the device path for PCI Bus ID %s: %s", pciBusID, target)
+	}
 
-	return pcieRootPart, nil
+	return targetAbsParts[pcieRootPartIdx], nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/575 reported
`k8s.io/dynamic-resource-allocation/deviceattribute.GetPCIeRootAttributeByPCIBusID` method fails resolving the `resource.kubernetes.io/pcieRoot` device attribute when the device path under `/sys/devices` is like:

```
/sys/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/VMBUS:00/000000c1-0001-0000-3130-444532304235/pci0001:00/0001:00:00.0
```

In such cases, there are intermediate bus controllers (Hyper-V in the above case) behind the PCI bus controllers.

This PR supports such cases in resolving ``resource.kubernetes.io/pcieRoot`` device attribute.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support virtualized pcie device topology (e.g. Hyper-V) in resolving "resource.kubernetes.io/pcieRoot" device attribute
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
