### PR TITLE
feat(validation-gen) enable declarative validation for resource.k8s.io DeviceClass

### DIFF
--- a/pkg/registry/resource/deviceclass/declarative_validation_test.go
+++ b/pkg/registry/resource/deviceclass/declarative_validation_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceclass
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/resource"
+	_ "k8s.io/kubernetes/pkg/apis/resource/install"
+)
+
+var apiVersions = []string{"v1", "v1beta1", "v1beta2"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "resource.k8s.io",
+				APIVersion: apiVersion,
+				Resource:   "deviceclasses",
+			})
+
+			strategy := Strategy
+
+			testCases := map[string]struct {
+				input        resource.DeviceClass
+				expectedErrs field.ErrorList
+			}{
+				"valid": {
+					input: mkDeviceClass(),
+				},
+				// TODO: Add more test cases
+			}
+
+			for k, tc := range testCases {
+				t.Run(k, func(t *testing.T) {
+					apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy.Validate, tc.expectedErrs)
+				})
+			}
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "resource.k8s.io",
+				APIVersion: apiVersion,
+				Resource:   "deviceclasses",
+			})
+
+			strategy := Strategy
+
+			testCases := map[string]struct {
+				old          resource.DeviceClass
+				update       resource.DeviceClass
+				expectedErrs field.ErrorList
+			}{
+				"valid no changes": {
+					old:    mkDeviceClass(),
+					update: mkDeviceClass(),
+				},
+				// TODO: Add more test cases
+			}
+
+			for k, tc := range testCases {
+				t.Run(k, func(t *testing.T) {
+					tc.old.ResourceVersion = "1"
+					tc.update.ResourceVersion = "1"
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy.ValidateUpdate, tc.expectedErrs)
+				})
+			}
+		})
+	}
+}
+
+// Helper function to create a DeviceClass with default values and optional mutators
+func mkDeviceClass(mutators ...func(*resource.DeviceClass)) resource.DeviceClass {
+	dc := resource.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-class",
+		},
+		Spec: resource.DeviceClassSpec{
+			Selectors: []resource.DeviceSelector{
+				{
+					CEL: &resource.CELDeviceSelector{
+						Expression: "device.driver == \"test.driver.io\"",
+					},
+				},
+			},
+			Config: []resource.DeviceClassConfiguration{
+				{
+					DeviceConfiguration: resource.DeviceConfiguration{
+						Opaque: &resource.OpaqueDeviceConfiguration{
+							Driver: "test.driver.io",
+							Parameters: runtime.RawExtension{
+								Raw: []byte(`{"key":"value"}`),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, mutate := range mutators {
+		mutate(&dc)
+	}
+	return dc
+}

--- a/pkg/registry/resource/deviceclass/strategy.go
+++ b/pkg/registry/resource/deviceclass/strategy.go
@@ -22,6 +22,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -50,7 +51,18 @@ func (deviceClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obj
 
 func (deviceClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	deviceClass := obj.(*resource.DeviceClass)
-	return validation.ValidateDeviceClass(deviceClass)
+	errorList := validation.ValidateDeviceClass(deviceClass)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation) {
+		takeover := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidationTakeover)
+		declarativeErrs := rest.ValidateDeclaratively(ctx, legacyscheme.Scheme, deviceClass, rest.WithTakeover(takeover))
+		validationIdentifier := "deviceclass_create"
+		rest.CompareDeclarativeErrorsAndEmitMismatches(ctx, errorList, declarativeErrs, takeover, validationIdentifier)
+		if takeover {
+			errorList = append(errorList.RemoveCoveredByDeclarative(), declarativeErrs...)
+		}
+	}
+	return errorList
 }
 
 func (deviceClassStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
@@ -77,8 +89,22 @@ func (deviceClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runtim
 }
 
 func (deviceClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	errorList := validation.ValidateDeviceClass(obj.(*resource.DeviceClass))
-	return append(errorList, validation.ValidateDeviceClassUpdate(obj.(*resource.DeviceClass), old.(*resource.DeviceClass))...)
+	newClass := obj.(*resource.DeviceClass)
+	oldClass := old.(*resource.DeviceClass)
+
+	errorList := validation.ValidateDeviceClass(newClass)
+	errorList = append(errorList, validation.ValidateDeviceClassUpdate(newClass, oldClass)...)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation) {
+		takeover := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidationTakeover)
+		declarativeErrs := rest.ValidateUpdateDeclaratively(ctx, legacyscheme.Scheme, newClass, oldClass, rest.WithTakeover(takeover))
+		validationIdentifier := "deviceclass_update"
+		rest.CompareDeclarativeErrorsAndEmitMismatches(ctx, errorList, declarativeErrs, takeover, validationIdentifier)
+		if takeover {
+			errorList = append(errorList.RemoveCoveredByDeclarative(), declarativeErrs...)
+		}
+	}
+	return errorList
 }
 
 func (deviceClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
**NOTE**: PR is dependant on https://github.com/kubernetes/kubernetes/pull/134072 for full declarative Validation functionality, wait until that merges to merge this

- Plumbs validation-gen for resource.k8s.io DeviceClass staging/src/k8s.io/api/resource/(v1,v1beta1,v1beta2)/types.go and 
- Introduces basic tests and template for declarative validation testing.

Which issue(s) this PR is related to:

#### Which issue(s) this PR is related to:
- https://github.com/kubernetes/enhancements/issues/5073
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- **This PR Does NOT migrate any validations**: validation rules migration would be introduced in separate PRs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```
