### PR TITLE
Default to IfNotPresent if digest is included

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -70,26 +70,12 @@ func SetDefaults_Volume(obj *v1.Volume) {
 		}
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.ImageVolume) && obj.Image != nil && obj.Image.PullPolicy == "" {
-		// PullPolicy defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-		_, tag, _, _ := parsers.ParseImageName(obj.Image.Reference)
-		if tag == "latest" {
-			obj.Image.PullPolicy = v1.PullAlways
-		} else {
-			obj.Image.PullPolicy = v1.PullIfNotPresent
-		}
+		obj.Image.PullPolicy = defaultImagePullPolicy(obj.Image.Reference)
 	}
 }
 func SetDefaults_Container(obj *v1.Container) {
 	if obj.ImagePullPolicy == "" {
-		// Ignore error and assume it has been validated elsewhere
-		_, tag, _, _ := parsers.ParseImageName(obj.Image)
-
-		// Check image tag
-		if tag == "latest" {
-			obj.ImagePullPolicy = v1.PullAlways
-		} else {
-			obj.ImagePullPolicy = v1.PullIfNotPresent
-		}
+		obj.ImagePullPolicy = defaultImagePullPolicy(obj.Image)
 	}
 	if obj.TerminationMessagePath == "" {
 		obj.TerminationMessagePath = v1.TerminationMessagePathDefault
@@ -527,4 +513,16 @@ func defaultHugePagePodLimits(pod *v1.Pod) {
 	if len(podLims) > 0 {
 		pod.Spec.Resources.Limits = podLims
 	}
+}
+
+// defaultImagePullPolicy returns the default pull policy for the given image ref.
+// In most cases "PullIfNotPresent" is returned. The exception is if the "latest" tag
+// is used *and* an image digest is not provided.
+func defaultImagePullPolicy(ref string) v1.PullPolicy {
+	// Ignore parsing errors and assume the image reference has been validated elsewhere.
+	_, tag, digest, _ := parsers.ParseImageName(ref)
+	if tag == "latest" && digest == "" {
+		return v1.PullAlways
+	}
+	return v1.PullIfNotPresent
 }

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -2097,7 +2097,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 		validators []InitContainerValidator
 	}{
 		{
-			name: "imagePullIPolicy",
+			name: "imagePullIPolicy - latest",
 			rc: v1.ReplicationController{
 				Spec: v1.ReplicationControllerSpec{
 					Template: &v1.PodTemplateSpec{
@@ -3355,6 +3355,10 @@ func TestSetDefaults_Volume(t *testing.T) {
 			given:    &v1.Volume{VolumeSource: v1.VolumeSource{Image: &v1.ImageVolumeSource{Reference: "image:v1"}}},
 			expected: &v1.Volume{VolumeSource: v1.VolumeSource{Image: &v1.ImageVolumeSource{Reference: "image:v1", PullPolicy: v1.PullIfNotPresent}}},
 		},
+		"default image volume source pull policy is IfNotPresent if digest specified": {
+			given:    &v1.Volume{VolumeSource: v1.VolumeSource{Image: &v1.ImageVolumeSource{Reference: "image:latest@sha256:5e1e2bcac305958b27077ca136f35f0abae7cf38c9af678f7d220ed0cb51d4f8"}}},
+			expected: &v1.Volume{VolumeSource: v1.VolumeSource{Image: &v1.ImageVolumeSource{Reference: "image:latest@sha256:5e1e2bcac305958b27077ca136f35f0abae7cf38c9af678f7d220ed0cb51d4f8", PullPolicy: v1.PullIfNotPresent}}},
+		},
 		"default image volume source pull policy Always if 'latest' tag is used": {
 			given:    &v1.Volume{VolumeSource: v1.VolumeSource{Image: &v1.ImageVolumeSource{Reference: "image:latest"}}},
 			expected: &v1.Volume{VolumeSource: v1.VolumeSource{Image: &v1.ImageVolumeSource{Reference: "image:latest", PullPolicy: v1.PullAlways}}},
@@ -3368,6 +3372,52 @@ func TestSetDefaults_Volume(t *testing.T) {
 			corev1.SetDefaults_Volume(tc.given)
 			if !cmp.Equal(tc.given, tc.expected) {
 				t.Errorf("expected volume %+v, but got %+v", tc.expected, tc.given)
+			}
+		})
+	}
+}
+
+func TestSetDefaults_Container(t *testing.T) {
+	for desc, tc := range map[string]struct {
+		given, expected *v1.Container
+	}{
+		"default image pull policy is IfNotPresent": {
+			given: &v1.Container{Image: "image:v1"},
+			expected: &v1.Container{
+				Image:                    "image:v1",
+				ImagePullPolicy:          v1.PullIfNotPresent,
+				TerminationMessagePath:   v1.TerminationMessagePathDefault,
+				TerminationMessagePolicy: v1.TerminationMessageReadFile,
+			}},
+		"default image pull policy is Always if 'latest' tag is used": {
+			given: &v1.Container{Image: "image:latest"},
+			expected: &v1.Container{
+				Image:                    "image:latest",
+				ImagePullPolicy:          v1.PullAlways,
+				TerminationMessagePath:   v1.TerminationMessagePathDefault,
+				TerminationMessagePolicy: v1.TerminationMessageReadFile,
+			}},
+		"default image pull policy is Always if implicit 'latest' tag is used": {
+			given: &v1.Container{Image: "image"},
+			expected: &v1.Container{
+				Image:                    "image",
+				ImagePullPolicy:          v1.PullAlways,
+				TerminationMessagePath:   v1.TerminationMessagePathDefault,
+				TerminationMessagePolicy: v1.TerminationMessageReadFile,
+			}},
+		"default image pull policy is IfNotPresent if 'latest' tag is used with digest": {
+			given: &v1.Container{Image: "image:latest@sha256:5e1e2bcac305958b27077ca136f35f0abae7cf38c9af678f7d220ed0cb51d4f8"},
+			expected: &v1.Container{
+				Image:                    "image:latest@sha256:5e1e2bcac305958b27077ca136f35f0abae7cf38c9af678f7d220ed0cb51d4f8",
+				ImagePullPolicy:          v1.PullIfNotPresent,
+				TerminationMessagePath:   v1.TerminationMessagePathDefault,
+				TerminationMessagePolicy: v1.TerminationMessageReadFile,
+			}},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			corev1.SetDefaults_Container(tc.given)
+			if !cmp.Equal(tc.given, tc.expected) {
+				t.Errorf("expected container %+v, but got %+v", tc.expected, tc.given)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

When an ImagePullPolicy is not defined, a default value is set. The value is derived from the provided image reference. The `latest` tag is handled specially to account for the common use case of using such tag to track updates to images. In that case, it makes sense to continue setting the image pull policy to `Always`. However, if the image reference contains both a tag and a digest, that reference cannot point to a different image at a different time since the digest (immutable) takes precedence over the tag.

This commit changes the behavior to only set the pull policy to `Always` if the "latest" tag is used and the digest is *not* set.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed default ImagePullPolicy to `IfNotPresent` whenever the Image reference contains a digest, even if it use the "latest" tag.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
