### PR TITLE
gocritic: using EqualFold and double wrapped filepath.Join

### DIFF
--- a/cluster/gce/gci/configure_helper_test.go
+++ b/cluster/gce/gci/configure_helper_test.go
@@ -99,7 +99,7 @@ func (c *ManifestTestCase) mustCopyAuxFromTemplate() {
 }
 
 func (c *ManifestTestCase) mustCreateManifestDstDir() {
-	p := filepath.Join(filepath.Join(c.kubeHome, "etc", "kubernetes", "manifests"))
+	p := filepath.Join(c.kubeHome, "etc", "kubernetes", "manifests")
 	if err := os.MkdirAll(p, os.ModePerm); err != nil {
 		c.t.Fatalf("Failed to create designation folder for kube-apiserver.manifest: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
@@ -45,7 +45,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 		return nil, false, nil
 	}
 	parts := strings.SplitN(auth, " ", 3)
-	if len(parts) < 2 || strings.ToLower(parts[0]) != "bearer" {
+	if len(parts) < 2 || !strings.EqualFold(parts[0], "bearer") {
 		return nil, false, nil
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
@@ -64,7 +64,7 @@ func getAuthMethods(req *http.Request) string {
 
 	auth := strings.TrimSpace(req.Header.Get("Authorization"))
 	parts := strings.Split(auth, " ")
-	if len(parts) > 1 && strings.ToLower(parts[0]) == "bearer" {
+	if len(parts) > 1 && strings.EqualFold(parts[0], "bearer") {
 		authMethods = append(authMethods, "bearer")
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -791,7 +791,7 @@ func cleanVerb(verb, suggestedVerb string, request *http.Request, requestInfo *r
 
 // getVerbIfWatch additionally ensures that GET or List would be transformed to WATCH
 func getVerbIfWatch(req *http.Request) string {
-	if strings.ToUpper(req.Method) == MethodGet || strings.ToUpper(req.Method) == request.MethodList {
+	if strings.EqualFold(req.Method, MethodGet) || strings.EqualFold(req.Method, request.MethodList) {
 		// see apimachinery/pkg/runtime/conversion.go Convert_Slice_string_To_bool
 		if values := req.URL.Query()["watch"]; len(values) > 0 {
 			if value := strings.ToLower(values[0]); value != "0" && value != "false" {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -322,7 +322,7 @@ func (o *WaitOptions) RunWait() error {
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), o.Timeout)
 	defer cancel()
 
-	if strings.ToLower(o.ForCondition) == "create" {
+	if strings.EqualFold(o.ForCondition, "create") {
 		// TODO(soltysh): this is not ideal solution, because we're polling every .5s,
 		// and we have to use ResourceFinder, which contains the resource name.
 		// In the long run, we should expose resource information from ResourceFinder,
@@ -367,7 +367,7 @@ func (o *WaitOptions) RunWait() error {
 		return err
 	}
 	visitor := o.ResourceFinder.Do()
-	isForDelete := strings.ToLower(o.ForCondition) == "delete"
+	isForDelete := strings.EqualFold(o.ForCondition, "delete")
 	if visitor, ok := visitor.(*resource.Result); ok && isForDelete {
 		visitor.IgnoreErrors(apierrors.IsNotFound)
 	}


### PR DESCRIPTION

What type of PR is this?

/kind cleanup

What this PR does / why we need it:

Fix gocritic issues by using `strings.EqualFold` for comparison and removing double wrapped `filepath.Join`
related to https://github.com/kubernetes/kubernetes/issues/131475

Which issue(s) this PR fixes:

#131475 

Special notes for your reviewer:

> NONE

Does this PR introduce a user-facing change?:

> NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

> NONE

