### PR TITLE
refactor(controller): Use WithContext variants in cloud node controllers

### DIFF
--- a/cmd/kube-controller-manager/names/controller_names.go
+++ b/cmd/kube-controller-manager/names/controller_names.go
@@ -36,7 +36,6 @@ package names
 //     2.1. [TODO] logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
 //     2.2. [TODO] emitted events should have an EventSource.Component set to the controller name (usually when initializing an EventRecorder)
 //     2.3. [TODO] registering ControllerManagerMetrics with ControllerStarted and ControllerStopped
-//     2.4. [TODO] calling WaitForNamedCacheSync
 //  3. defining controller options for "--help" command or generated documentation
 //     3.1. controller name should be used to create a pflag.FlagSet when registering controller options (the name is rendered in a controller flag group header) in options.KubeControllerManagerOptions
 //     3.2. when defined flag's help mentions a controller name

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -183,7 +183,7 @@ func (r *rangeAllocator) Run(ctx context.Context) {
 	logger.Info("Starting range CIDR allocator")
 	defer logger.Info("Shutting down range CIDR allocator")
 
-	if !cache.WaitForNamedCacheSync("cidrallocator", ctx.Done(), r.nodesSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, r.nodesSynced) {
 		return
 	}
 

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -141,7 +141,7 @@ func (nc *Controller) Run(ctx context.Context) {
 	klog.FromContext(ctx).Info("Starting ipam controller")
 	defer klog.FromContext(ctx).Info("Shutting down ipam controller")
 
-	if !cache.WaitForNamedCacheSync("node", ctx.Done(), nc.nodeInformerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, nc.nodeInformerSynced) {
 		return
 	}
 

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -464,7 +464,7 @@ func (nc *Controller) Run(ctx context.Context) {
 	logger.Info("Starting node controller")
 	defer logger.Info("Shutting down node controller")
 
-	if !cache.WaitForNamedCacheSync("taint", ctx.Done(), nc.leaseInformerSynced, nc.nodeInformerSynced, nc.podInformerSynced, nc.daemonSetInformerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, nc.leaseInformerSynced, nc.nodeInformerSynced, nc.podInformerSynced, nc.daemonSetInformerSynced) {
 		return
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR refactors the `node-lifecycle` and `node-ipam` controllers to use a `context.Context` for cancellation, replacing the legacy `stopCh` pattern.

This is a follow-up to the work in #133985. As requested by @atiratree in that PR, these controllers have been separated into a dedicated pull request because they can also be run by the legacy Cloud Controller Manager (CCM).

**Which issue(s) this PR fixes**:
Contributes to #126379

**Special notes for your reviewer**:
This PR specifically addresses the feedback from #133985 to isolate the cloud-controller changes.

I understand from the previous review that the CCM's legacy startup logic does not populate the controller name in the context. This change knowingly proceeds with the refactoring to at least unify the cancellation and shutdown logic around `context.Context`, even though the contextual logs will be less detailed when these controllers are run in a CCM.

As suggested, this PR needs a review from someone on SIG Cloud Provider to double-check this approach.

/cc @atiratree
/assign @kubernetes/sig-cloud-provider-pr-reviews

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```