### PR TITLE
kubeadm: graduate ControlPlaneKubeletLocalMode to GA

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeconfigphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
@@ -158,11 +157,9 @@ func runKubeConfigFile(kubeConfigFileName string) func(workflow.RunData) error {
 
 		initConfiguration := data.Cfg().DeepCopy()
 
-		if features.Enabled(cfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
-			if kubeConfigFileName == kubeadmconstants.KubeletKubeConfigFileName {
-				// Unset the ControlPlaneEndpoint so the creation falls back to the LocalAPIEndpoint for the kubelet's kubeconfig.
-				initConfiguration.ControlPlaneEndpoint = ""
-			}
+		if kubeConfigFileName == kubeadmconstants.KubeletKubeConfigFileName {
+			// Unset the ControlPlaneEndpoint so the creation falls back to the LocalAPIEndpoint for the kubelet's kubeconfig.
+			initConfiguration.ControlPlaneEndpoint = ""
 		}
 
 		// creates the KubeConfig file (or use existing)

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 	markcontrolplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markcontrolplane"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
@@ -83,32 +82,26 @@ func NewControlPlaneJoinPhase() workflow.Phase {
 func NewEtcdJoinPhase() workflow.Phase {
 	return workflow.Phase{
 		Name:          "etcd-join",
-		Short:         fmt.Sprintf("[EXPERIMENTAL] Join etcd for control plane nodes (only used when feature gate %s is enabled)", features.ControlPlaneKubeletLocalMode),
+		Short:         "Join etcd for control plane nodes",
 		Run:           runEtcdPhase,
 		Example:       etcdJoinExample,
 		InheritFlags:  getControlPlaneJoinPhaseFlags("etcd"),
 		ArgsValidator: cobra.NoArgs,
-		// TODO: unhide this phase once ControlPlaneKubeletLocalMode goes GA:
-		// https://github.com/kubernetes/enhancements/issues/4471
-		Hidden: true,
-		// Only run this phase as if `ControlPlaneKubeletLocalMode` is activated.
-		RunIf: func(c workflow.RunData) (bool, error) {
-			return checkFeatureState(c, features.ControlPlaneKubeletLocalMode, true)
-		},
 	}
 }
 
+// TODO: Deprecated. Remove once ControlPlaneKubeletLocalMode is removed in 1.36.
+// https://github.com/kubernetes/kubeadm/issues/2271
 func newEtcdLocalSubphase() workflow.Phase {
 	return workflow.Phase{
 		Name:          "etcd",
-		Short:         "Add a new local etcd member",
+		Short:         "[DEPRECATED] Add a new local etcd member. Deprecated in favor of 'etcd-join' and will be removed in 1.36",
 		Run:           runEtcdPhase,
 		InheritFlags:  getControlPlaneJoinPhaseFlags("etcd"),
 		ArgsValidator: cobra.NoArgs,
-		// Only run this phase as subphase of control-plane-join phase if
-		// `ControlPlaneKubeletLocalMode` is deactivated.
+		Hidden:        true,
 		RunIf: func(c workflow.RunData) (bool, error) {
-			return checkFeatureState(c, features.ControlPlaneKubeletLocalMode, false)
+			return false, nil
 		},
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -25,9 +25,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 )
 
 // JoinData is the interface to use for join phases.
@@ -46,18 +43,4 @@ type JoinData interface {
 	KubeletDir() string
 	ManifestDir() string
 	CertificateWriteDir() string
-}
-
-func checkFeatureState(c workflow.RunData, featureGate string, state bool) (bool, error) {
-	data, ok := c.(JoinData)
-	if !ok {
-		return false, errors.New("control-plane-join phase invoked with an invalid data struct")
-	}
-
-	cfg, err := data.InitCfg()
-	if err != nil {
-		return false, err
-	}
-
-	return state == features.Enabled(cfg.FeatureGates, featureGate), nil
 }

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -75,19 +75,12 @@ func NewKubeletStartPhase() workflow.Phase {
 func NewKubeletWaitBootstrapPhase() workflow.Phase {
 	return workflow.Phase{
 		Name:  "kubelet-wait-bootstrap",
-		Short: "[EXPERIMENTAL] Wait for the kubelet to bootstrap itself (only used when feature gate ControlPlaneKubeletLocalMode is enabled)",
+		Short: "Wait for the kubelet to bootstrap itself",
 		Run:   runKubeletWaitBootstrapPhase,
 		InheritFlags: []string{
 			options.CfgPath,
 			options.NodeCRISocket,
 			options.DryRun,
-		},
-		// TODO: unhide this phase once ControlPlaneKubeletLocalMode goes GA:
-		// https://github.com/kubernetes/enhancements/issues/4471
-		Hidden: true,
-		// Only run this phase as if `ControlPlaneKubeletLocalMode` is activated.
-		RunIf: func(c workflow.RunData) (bool, error) {
-			return checkFeatureState(c, features.ControlPlaneKubeletLocalMode, true)
 		},
 	}
 }
@@ -124,16 +117,6 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	}
 	bootstrapKubeConfigFile := filepath.Join(data.KubeConfigDir(), kubeadmconstants.KubeletBootstrapKubeConfigFileName)
 
-	// Do not delete the bootstrapKubeConfigFile at the end of this function when
-	// using ControlPlaneKubeletLocalMode. The KubeletWaitBootstrapPhase will delete
-	// it when the feature is enabled.
-	if !features.Enabled(initCfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
-		// Deletes the bootstrapKubeConfigFile, so the credential used for TLS bootstrap is removed from disk
-		defer func() {
-			_ = os.Remove(bootstrapKubeConfigFile)
-		}()
-	}
-
 	var client clientset.Interface
 	// If dry-use the client from joinData, else create a new bootstrap client
 	if data.DryRun() {
@@ -148,17 +131,15 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 		}
 	}
 
-	if features.Enabled(initCfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
-		// Set the server url to LocalAPIEndpoint if the feature gate is enabled so the config
-		// which gets passed to the kubelet forces it to talk to the local kube-apiserver.
-		if cfg.ControlPlane != nil {
-			for c, conf := range tlsBootstrapCfg.Clusters {
-				conf.Server, err = kubeadmutil.GetLocalAPIEndpoint(&cfg.ControlPlane.LocalAPIEndpoint)
-				if err != nil {
-					return errors.Wrapf(err, "could not get LocalAPIEndpoint when %s is enabled", features.ControlPlaneKubeletLocalMode)
-				}
-				tlsBootstrapCfg.Clusters[c] = conf
+	// Set the server url to LocalAPIEndpoint if the feature gate is enabled so the config
+	// which gets passed to the kubelet forces it to talk to the local kube-apiserver.
+	if cfg.ControlPlane != nil {
+		for c, conf := range tlsBootstrapCfg.Clusters {
+			conf.Server, err = kubeadmutil.GetLocalAPIEndpoint(&cfg.ControlPlane.LocalAPIEndpoint)
+			if err != nil {
+				return errors.Wrapf(err, "could not get LocalAPIEndpoint")
 			}
+			tlsBootstrapCfg.Clusters[c] = conf
 		}
 	}
 
@@ -251,13 +232,6 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	// Try to start the kubelet service in case it's inactive
 	fmt.Println("[kubelet-start] Starting the kubelet")
 	kubeletphase.TryStartKubelet()
-
-	// Run the same code as KubeletWaitBootstrapPhase would do if the ControlPlaneKubeletLocalMode feature gate is disabled.
-	if !features.Enabled(initCfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
-		if err := runKubeletWaitBootstrapPhase(c); err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -62,7 +62,7 @@ var InitFeatureGates = FeatureList{
 			" Once UserNamespacesSupport graduates to GA, kubeadm will start using it and RootlessControlPlane will be removed.",
 	},
 	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.GA, LockToDefault: true}},
-	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
+	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.GA, LockToDefault: true}},
 	NodeLocalCRISocket:               {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

graduates the FG to GA and locks it to true. note that unlike core k8s kubeadm locks FGs once they hit GA.
we might choose to not do this for certain cases, but this one was enabled by default in Beta too.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

xref https://github.com/kubernetes/kubeadm/issues/2271

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: graduate the kubeadm specific feature gate ControlPlaneKubeletLocalMode to GA and lock it to enabled by default. To opt-out manually from this desired default behavior you must patch the "server" field in the  /etc/kubernetes/kubelet.conf file. The subphase of "kubeadm join phase control-plane-join" called "etcd" is now deprecated, hidden and replaced by the subphase with identical functionality "etcd-join". "etcd" will be removed in a follow-up release. The subphase "kubelet-wait-bootstrap" of "kubeadm join" is no longer experimental and will always run.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4471
```
