### PR TITLE
featuregate: add freeze-on-first-read semantics

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -1905,3 +1905,81 @@ func TestAddVersioned(t *testing.T) {
 		})
 	}
 }
+
+func TestFrozenMode_BasicLifecycle(t *testing.T) {
+	feature := Feature("TestFeature")
+	ver := version.MustParseGeneric("1.20")
+
+	// Create frozen mode gate
+	fg := NewFeatureGateWithFreeze()
+
+	// Add a feature before freeze (should succeed)
+	if err := fg.Add(map[Feature]FeatureSpec{
+		feature: {Default: false, PreRelease: Alpha, Version: ver},
+	}); err != nil {
+		t.Fatalf("failed to add feature before freeze: %v", err)
+	}
+
+	// Override before freeze (should succeed)
+	if err := fg.OverrideDefault(feature, true); err != nil {
+		t.Fatalf("failed to override before freeze: %v", err)
+	}
+
+	// First read => should freeze
+	_ = fg.Enabled(feature)
+
+	// Now feature gate should be frozen
+	if !fg.frozen.Load() {
+		t.Fatalf("expected feature gate to be frozen after first read")
+	}
+
+	// Mutating methods must now fail
+	mutations := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Set", func() error { return fg.Set(fmt.Sprintf("%s=true", feature)) }},
+		{"SetFromMap", func() error { return fg.SetFromMap(map[string]bool{string(feature): false}) }},
+		{"Add", func() error {
+			return fg.Add(map[Feature]FeatureSpec{
+				Feature("AnotherFeature"): {Default: true, PreRelease: Alpha, Version: ver},
+			})
+		}},
+		{"OverrideDefault", func() error { return fg.OverrideDefault(feature, false) }},
+		{"OverrideDefaultAtVersion", func() error { return fg.OverrideDefaultAtVersion(feature, false, ver) }},
+		{"SetEmulationVersion", func() error { return fg.SetEmulationVersion(ver) }},
+		{"ResetFeatureValueToDefault", func() error { return fg.ResetFeatureValueToDefault(feature) }},
+	}
+
+	for _, m := range mutations {
+		if err := m.fn(); err == nil {
+			t.Errorf("%s should fail after frozen, but succeeded", m.name)
+		}
+	}
+}
+
+func TestFrozenMode_NonFrozenGateStillWorks(t *testing.T) {
+	feature := Feature("TestFeature")
+	ver := version.MustParseGeneric("1.20")
+
+	// Normal gate (not frozen on read)
+	fg := NewFeatureGate()
+
+	if err := fg.Add(map[Feature]FeatureSpec{
+		feature: {Default: false, PreRelease: Alpha, Version: ver},
+	}); err != nil {
+		t.Fatalf("failed to add feature: %v", err)
+	}
+
+	// Read should not freeze
+	_ = fg.Enabled(feature)
+
+	if fg.frozen.Load() {
+		t.Fatalf("expected non-frozen gate to remain unfrozen after read")
+	}
+
+	// Mutations must still succeed
+	if err := fg.OverrideDefault(feature, true); err != nil {
+		t.Errorf("OverrideDefault should work on non-frozen gate, got: %v", err)
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces freeze-on-first-read semantics to `featureGate`. 
- A new constructor `NewFeatureGateWithFreeze` creates a gate that allows configuration until the first `Enabled()` check.  
- first read, the gate is marked as frozen, and further mutation attempts are rejected.

This prepares the feature gate for safe test isolation and consistent behavior across components by clearly separating the configuration phase from the runtime (read-only) phase.

#### Which issue(s) this PR is related to:

part of #134009

#### Special notes for your reviewer:

- This PR does **not** modify the existing `NewFeatureGate` constructor.  
- The new `NewFeatureGateWithFreeze` constructor is opt-in and enables the frozen mode.  
- Existing callers remain unaffected and continue to work as before.  
- extending it with snapshot/restore functionality in a follow-up PR.  


```release-note
featuregate: add NewFeatureGateWithFreeze constructor enabling frozen-on-first-read semantics (mutations are disallowed after first read).
```