### PR TITLE
Automated cherry pick of #134024: fix: use iifname for input interface name matches

### DIFF
--- a/pkg/proxy/util/localdetector.go
+++ b/pkg/proxy/util/localdetector.go
@@ -98,8 +98,8 @@ func NewDetectLocalByBridgeInterface(interfaceName string) LocalTrafficDetector 
 	return &detectLocal{
 		ifLocal:       []string{"-i", interfaceName},
 		ifNotLocal:    []string{"!", "-i", interfaceName},
-		ifLocalNFT:    []string{"iif", interfaceName},
-		ifNotLocalNFT: []string{"iif", "!=", interfaceName},
+		ifLocalNFT:    []string{"iifname", interfaceName},
+		ifNotLocalNFT: []string{"iifname", "!=", interfaceName},
 	}
 }
 
@@ -110,7 +110,7 @@ func NewDetectLocalByInterfaceNamePrefix(interfacePrefix string) LocalTrafficDet
 	return &detectLocal{
 		ifLocal:       []string{"-i", interfacePrefix + "+"},
 		ifNotLocal:    []string{"!", "-i", interfacePrefix + "+"},
-		ifLocalNFT:    []string{"iif", interfacePrefix + "*"},
-		ifNotLocalNFT: []string{"iif", "!=", interfacePrefix + "*"},
+		ifLocalNFT:    []string{"iifname", interfacePrefix + "*"},
+		ifNotLocalNFT: []string{"iifname", "!=", interfacePrefix + "*"},
 	}
 }

--- a/pkg/proxy/util/localdetector_test.go
+++ b/pkg/proxy/util/localdetector_test.go
@@ -105,6 +105,37 @@ func TestDetectLocalByBridgeInterface(t *testing.T) {
 	}
 }
 
+func TestDetectLocalNFTByBridgeInterface(t *testing.T) {
+	cases := []struct {
+		ifaceName               string
+		expectedJumpIfOutput    []string
+		expectedJumpIfNotOutput []string
+	}{
+		{
+			ifaceName:               "eth0",
+			expectedJumpIfOutput:    []string{"iifname", "eth0"},
+			expectedJumpIfNotOutput: []string{"iifname", "!=", "eth0"},
+		},
+	}
+	for _, c := range cases {
+		localDetector := NewDetectLocalByBridgeInterface(c.ifaceName)
+		if !localDetector.IsImplemented() {
+			t.Error("DetectLocalByBridgeInterface returns false for IsImplemented")
+		}
+
+		ifLocal := localDetector.IfLocalNFT()
+		ifNotLocal := localDetector.IfNotLocalNFT()
+
+		if !reflect.DeepEqual(ifLocal, c.expectedJumpIfOutput) {
+			t.Errorf("IfLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfOutput, ifLocal)
+		}
+
+		if !reflect.DeepEqual(ifNotLocal, c.expectedJumpIfNotOutput) {
+			t.Errorf("IfNotLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfNotOutput, ifNotLocal)
+		}
+	}
+}
+
 func TestDetectLocalByInterfaceNamePrefix(t *testing.T) {
 	cases := []struct {
 		ifacePrefix             string
@@ -134,6 +165,39 @@ func TestDetectLocalByInterfaceNamePrefix(t *testing.T) {
 
 		if !reflect.DeepEqual(ifNotLocal, c.expectedJumpIfNotOutput) {
 			t.Errorf("IfNotLocal, expected: '%v', but got: '%v'", c.expectedJumpIfNotOutput, ifNotLocal)
+		}
+	}
+}
+
+func TestDetectLocalNFTByInterfaceNamePrefix(t *testing.T) {
+	cases := []struct {
+		ifacePrefix             string
+		chain                   string
+		args                    []string
+		expectedJumpIfOutput    []string
+		expectedJumpIfNotOutput []string
+	}{
+		{
+			ifacePrefix:             "eth",
+			expectedJumpIfOutput:    []string{"iifname", "eth*"},
+			expectedJumpIfNotOutput: []string{"iifname", "!=", "eth*"},
+		},
+	}
+	for _, c := range cases {
+		localDetector := NewDetectLocalByInterfaceNamePrefix(c.ifacePrefix)
+		if !localDetector.IsImplemented() {
+			t.Error("DetectLocalByInterfaceNamePrefix returns false for IsImplemented")
+		}
+
+		ifLocal := localDetector.IfLocalNFT()
+		ifNotLocal := localDetector.IfNotLocalNFT()
+
+		if !reflect.DeepEqual(ifLocal, c.expectedJumpIfOutput) {
+			t.Errorf("IfLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfOutput, ifLocal)
+		}
+
+		if !reflect.DeepEqual(ifNotLocal, c.expectedJumpIfNotOutput) {
+			t.Errorf("IfNotLocalNFT, expected: '%v', but got: '%v'", c.expectedJumpIfNotOutput, ifNotLocal)
 		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #134024 on release-1.33.

#134024: fix: use iifname for input interface name matches

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a bug in kube-proxy nftables mode (GA as of 1.33) that fails to determine if traffic originates from a local source on the node. The issue was caused by using the wrong meta `iif` instead of `iifname` for name based matches.
```