### PR TITLE
drop utiliptables.NewDualStack, which is too confusing

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -404,7 +404,7 @@ var iptablesCleanupOnlyChains = []iptablesJumpChain{}
 // CleanupLeftovers removes all iptables rules and chains created by the Proxier
 // It returns true if an error was encountered. Errors are logged.
 func CleanupLeftovers(ctx context.Context) (encounteredError bool) {
-	ipts, _ := utiliptables.NewDualStack()
+	ipts := utiliptables.NewBestEffort()
 	for _, ipt := range ipts {
 		encounteredError = cleanupLeftoversForFamily(ctx, ipt) || encounteredError
 	}

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -706,7 +706,7 @@ func CleanupLeftovers(ctx context.Context) (encounteredError bool) {
 		return false
 	}
 
-	ipts, _ := utiliptables.NewDualStack()
+	ipts := utiliptables.NewBestEffort()
 	ipsetInterface := utilipset.New()
 	ipvsInterface := utilipvs.New()
 

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -329,7 +329,7 @@ func TestNewDualStack(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fexec := fakeExecForCommands(tc.commands)
-			runners, err := newDualStackInternal(fexec)
+			runners := newDualStackInternal(fexec)
 
 			if tc.ipv4 && runners[v1.IPv4Protocol] == nil {
 				t.Errorf("Expected ipv4 runner, got nil")
@@ -340,12 +340,6 @@ func TestNewDualStack(t *testing.T) {
 				t.Errorf("Expected ipv6 runner, got nil")
 			} else if !tc.ipv6 && runners[v1.IPv6Protocol] != nil {
 				t.Errorf("Expected no ipv6 runner, got one")
-			}
-
-			if len(runners) == 2 && err != nil {
-				t.Errorf("Got 2 runners but also an error (%v)", err)
-			} else if len(runners) != 2 && err == nil {
-				t.Errorf("Got %d runners but no error", len(runners))
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
This is a followup to #133695. And #132170. `utiliptables.NewDualStack` is just too confusing for its own good. And it turns out we really only need it in one place anyway, so let's just do what we need to do inline there and save us from misusing the function again.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/area kube-proxy
/priority important-soon
/triage accepted
