### PR TITLE
Remove KUBECTL_OPENAPIV3_PATCH feature gate as the feature is stable

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -284,13 +284,11 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 	}
 
 	var openAPIV3Root openapi3.Root
-	if !cmdutil.OpenAPIV3Patch.IsDisabled() {
-		openAPIV3Client, err := f.OpenAPIV3Client()
-		if err == nil {
-			openAPIV3Root = openapi3.NewRoot(openAPIV3Client)
-		} else {
-			klog.V(4).Infof("warning: OpenAPI V3 Patch is enabled but is unable to be loaded. Will fall back to OpenAPI V2")
-		}
+	openAPIV3Client, err := f.OpenAPIV3Client()
+	if err == nil {
+		openAPIV3Root = openapi3.NewRoot(openAPIV3Client)
+	} else {
+		klog.V(4).Infof("warning: OpenAPI V3 Patch is enabled but is unable to be loaded. Will fall back to OpenAPI V2")
 	}
 
 	validationDirective, err := cmdutil.GetValidationDirective(cmd)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -642,13 +642,11 @@ func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 
 	if !o.ServerSideApply {
 		o.OpenAPIGetter = f
-		if !cmdutil.OpenAPIV3Patch.IsDisabled() {
-			openAPIV3Client, err := f.OpenAPIV3Client()
-			if err == nil {
-				o.OpenAPIV3Root = openapi3.NewRoot(openAPIV3Client)
-			} else {
-				klog.V(4).Infof("warning: OpenAPI V3 Patch is enabled but is unable to be loaded. Will fall back to OpenAPI V2")
-			}
+		openAPIV3Client, err := f.OpenAPIV3Client()
+		if err == nil {
+			o.OpenAPIV3Root = openapi3.NewRoot(openAPIV3Client)
+		} else {
+			klog.V(4).Infof("warning: OpenAPI V3 Patch is enabled but is unable to be loaded. Will fall back to OpenAPI V2")
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -437,12 +437,6 @@ const (
 	// Separate kubectl user preferences.
 	KubeRC FeatureGate = "KUBECTL_KUBERC"
 
-	// owner: @soltysh
-	// kep: https://kep.k8s.io/3515
-	//
-	// Improved kubectl apply --prune behavior.
-	OpenAPIV3Patch FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
-
 	// owner: @justinb
 	// kep: https://kep.k8s.io/3659
 	//


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Aggregated discovery has been promoted to GA in 1.30 (https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/3352-aggregated-discovery/kep.yaml). That means this functionality is locked to enable by default. 

This PR removes kubectl feature gate (i.e. `KUBECTL_OPENAPIV3_PATCH`) which is obsolete currently.

#### Does this PR introduce a user-facing change?
```release-note
Removing the KUBECTL_OPENAPIV3_PATCH environment variable entirely, since aggregated discovery has been stable from 1.30.
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/3352-aggregated-discovery/README.md
```
