### PR TITLE
Automated cherry pick of #134054: fix incorrect warning whenever headless service is created/updated

### DIFF
--- a/pkg/api/service/warnings.go
+++ b/pkg/api/service/warnings.go
@@ -48,7 +48,7 @@ func GetWarningsForService(service, oldService *api.Service) []string {
 		if len(service.Spec.ExternalIPs) > 0 {
 			warnings = append(warnings, "spec.externalIPs is ignored for headless services")
 		}
-		if service.Spec.SessionAffinity != "" {
+		if service.Spec.SessionAffinity != api.ServiceAffinityNone {
 			warnings = append(warnings, "spec.SessionAffinity is ignored for headless services")
 		}
 	}

--- a/pkg/api/service/warnings_test.go
+++ b/pkg/api/service/warnings_test.go
@@ -62,6 +62,7 @@ func TestGetWarningsForService(t *testing.T) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
 			s.Spec.LoadBalancerIP = "1.2.3.4"
+			s.Spec.SessionAffinity = api.ServiceAffinityNone // default value
 		},
 		numWarnings: 1,
 	}, {
@@ -70,10 +71,11 @@ func TestGetWarningsForService(t *testing.T) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
 			s.Spec.ExternalIPs = []string{"1.2.3.4"}
+			s.Spec.SessionAffinity = api.ServiceAffinityNone // default value
 		},
 		numWarnings: 1,
 	}, {
-		name: "SessionAffinity set when headless service",
+		name: "SessionAffinity Client IP set when headless service",
 		tweakSvc: func(s *api.Service) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
@@ -81,16 +83,25 @@ func TestGetWarningsForService(t *testing.T) {
 		},
 		numWarnings: 1,
 	}, {
-		name: "ExternalIPs, LoadBalancerIP and SessionAffinity set when headless service",
+		name: "SessionAffinity None set when headless service",
 		tweakSvc: func(s *api.Service) {
 			s.Spec.Type = api.ServiceTypeClusterIP
 			s.Spec.ClusterIP = api.ClusterIPNone
-			s.Spec.ExternalIPs = []string{"1.2.3.4"}
-			s.Spec.LoadBalancerIP = "1.2.3.4"
-			s.Spec.SessionAffinity = api.ServiceAffinityClientIP
+			s.Spec.SessionAffinity = api.ServiceAffinityNone
 		},
-		numWarnings: 3,
-	}}
+		numWarnings: 0,
+	},
+		{
+			name: "ExternalIPs, LoadBalancerIP and SessionAffinity set when headless service",
+			tweakSvc: func(s *api.Service) {
+				s.Spec.Type = api.ServiceTypeClusterIP
+				s.Spec.ClusterIP = api.ClusterIPNone
+				s.Spec.ExternalIPs = []string{"1.2.3.4"}
+				s.Spec.LoadBalancerIP = "1.2.3.4"
+				s.Spec.SessionAffinity = api.ServiceAffinityClientIP
+			},
+			numWarnings: 3,
+		}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #134054 on release-1.34.

#134054: fix incorrect warning whenever headless service is created/updated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
remove incorrectly printed warning for SessionAffinity whenever a headless service is creater or updated
```