### PR TITLE
Added CgroupV1 Feature label to summary_tests when querying /stats/summary under pressure

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -99,6 +99,10 @@ var (
 	// Testing critical pod admission
 	CriticalPod = framework.WithFeature(framework.ValidFeatures.Add("CriticalPod"))
 
+	//OWNER: sig-node
+	//Testing critical for cgroupv1 test suites
+	CgroupV1 = framework.WithFeature(framework.ValidFeatures.Add("CgroupV1"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	CustomMetricsAutoscaling = framework.WithFeature(framework.ValidFeatures.Add("CustomMetricsAutoscaling"))
 

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -368,7 +368,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 	})
 
-	framework.Context("when querying /stats/summary under pressure", feature.KubeletPSI, framework.WithSerial(), func() {
+	framework.Context("when querying /stats/summary under pressure", feature.KubeletPSI, framework.WithSerial(), feature.CgroupV1, func() {
 		ginkgo.BeforeEach(func() {
 			if !utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
 				ginkgo.Skip("KubeletPSI feature gate is not enabled")

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -368,7 +368,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 	})
 
-	framework.Context("when querying /stats/summary under pressure", feature.KubeletPSI, framework.WithSerial(), feature.CgroupV1, func() {
+	framework.Context("when querying /stats/summary under pressure", feature.KubeletPSI, framework.WithSerial(), func() {
 		ginkgo.BeforeEach(func() {
 			if !utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
 				ginkgo.Skip("KubeletPSI feature gate is not enabled")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind feature
/kind failing-test

#### What this PR does / why we need it:

This change introduces a new feature label, `CgroupV1`, to the node e2e test suite, specifically in `summary_test.go`. The label is registered in `feature.go` and applied to relevant test contexts to enable targeted test selection and filtering for environments using cgroup v1.  
By labeling these tests, we ensure they are only run in compatible environments and can be easily targeted by test-infra jobs. Mainly the `pull-kubernetes-node-kubelet-serial-crio-cgroupv1` test job is in mind to fix. 

A follow-up PR in the test-infra repo will update the --focus-regex to filter and run these tests using the new feature label.


#### Which issue(s) this PR is related to:
Alternate solution as recommended in [this comment](https://github.com/kubernetes/kubernetes/pull/134079#discussion_r2354434424) in PR #134079 
This is still a follow-up to the investigation in https://github.com/kubernetes/kubernetes/issues/133456#issuecomment-3287284474,
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Needs the test-infra PR merged to work. Intended behavior is to skip this test suite since it is intended for cgroupv1
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
[from test-infra] Issue35211: Have explicit cgroupv1 jobs and cgroupv2 jobs
[#35211](https://github.com/kubernetes/test-infra/issues/35211) may be related

