### PR TITLE
refactor: Use WaitForNamedCacheSyncWithContext in core components

### DIFF
--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
@@ -463,7 +463,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	go c.kubeSystemConfigMapInformer.Run(ctx.Done())
 
 	// wait for your secondary caches to fill before starting your work
-	if !cache.WaitForNamedCacheSync("cluster_authentication_trust_controller", ctx.Done(), c.preRunCaches...) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.preRunCaches...) {
 		return
 	}
 

--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -88,7 +88,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		}
 	}()
 
-	if !cache.WaitForNamedCacheSync(controllerName, ctx.Done(), c.leaseRegistration.HasSynced, c.leaseCandidateRegistration.HasSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.leaseRegistration.HasSynced, c.leaseCandidateRegistration.HasSynced) {
 		return
 	}
 

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -81,7 +81,7 @@ func newNodeManager(ctx context.Context, client clientset.Interface, resyncInter
 
 	// initialize the informer and wait for cache sync
 	thisNodeInformerFactory.Start(wait.NeverStop)
-	if !cache.WaitForNamedCacheSync("node informer cache", ctx.Done(), nodeInformer.Informer().HasSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, nodeInformer.Informer().HasSynced) {
 		return nil, fmt.Errorf("can not sync node informer")
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -145,7 +145,7 @@ func (s *policySource[P, B, E]) Run(ctx context.Context) error {
 
 	// Wait for initial cache sync of policies and informers before reconciling
 	// any
-	if !cache.WaitForNamedCacheSync(fmt.Sprintf("%T", s), ctx.Done(), s.UpstreamHasSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, s.UpstreamHasSynced) {
 		err := ctx.Err()
 		if err == nil {
 			err = fmt.Errorf("initial cache sync for %T failed", s)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller.go
@@ -174,7 +174,7 @@ func (c *controller[T]) Run(ctx context.Context) error {
 
 	// Wait for initial cache list to complete before beginning to reconcile
 	// objects.
-	if !cache.WaitForNamedCacheSync(c.options.Name, ctx.Done(), c.informer.HasSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.informer.HasSynced) {
 		// ctx cancelled during cache sync. return early
 		err := ctx.Err()
 		if err == nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
@@ -183,7 +183,7 @@ func (c *RequestHeaderAuthRequestController) Run(ctx context.Context, workers in
 	go c.configmapInformer.Run(ctx.Done())
 
 	// wait for caches to fill before starting your work
-	if !cache.WaitForNamedCacheSync(c.name, ctx.Done(), c.configmapInformerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.configmapInformerSynced) {
 		return
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
@@ -209,7 +209,7 @@ func (c *ConfigMapCAController) Run(ctx context.Context, workers int) {
 	go c.configMapInformer.Run(ctx.Done())
 
 	// wait for your secondary caches to fill before starting your work
-	if !cache.WaitForNamedCacheSync(c.name, ctx.Done(), c.preRunCaches...) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.preRunCaches...) {
 		return
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR is part of the ongoing effort to modernize controller startup logic. It replaces several usages of the legacy `cache.WaitForNamedCacheSync` function with the modern, context-aware `cache.WaitForNamedCacheSyncWithContext` variant.

This change is limited to core components in `kube-apiserver` and `kube-proxy` where a `context.Context` was already available, making this a straightforward and low-risk refactoring.

**Which issue(s) this PR fixes**:
Contributes to #126379

**Special notes for your reviewer**:
```
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```