### PR TITLE
refactor(cloud-provider): Use WaitForNamedCacheSyncWithContext

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -104,7 +104,7 @@ func (rc *RouteController) Run(ctx context.Context, syncPeriod time.Duration, co
 	controllerManagerMetrics.ControllerStarted("route")
 	defer controllerManagerMetrics.ControllerStopped("route")
 
-	if !cache.WaitForNamedCacheSync("route", ctx.Done(), rc.nodeListerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, rc.nodeListerSynced) {
 		return
 	}
 

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -237,7 +237,7 @@ func (c *Controller) Run(ctx context.Context, workers int, controllerManagerMetr
 	controllerManagerMetrics.ControllerStarted("service")
 	defer controllerManagerMetrics.ControllerStopped("service")
 
-	if !cache.WaitForNamedCacheSync("service", ctx.Done(), c.serviceListerSynced, c.nodeListerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.serviceListerSynced, c.nodeListerSynced) {
 		return
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR continues the effort to modernize controller startup logic by replacing `cache.WaitForNamedCacheSync` with `cache.WaitForNamedCacheSyncWithContext`.

This change is focused on the out-of-tree controllers in `staging/cloud-provider` where a `context.Context` was already available.

**Which issue(s) this PR fixes**:
Contributes to #126379

**Special notes for your reviewer**:
This PR contains the simple refactoring for the cloud provider controllers. As this touches cloud-provider specific code, it requires a review from SIG Cloud Provider.

/assign @kubernetes/sig-cloud-provider-pr-reviews

**Does this PR introduce a user-facing change?**:
```release-note
NONE```