### PR TITLE
improve httpstream handshake error logging

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go
@@ -126,7 +126,7 @@ func createStreams(req *http.Request, w http.ResponseWriter, opts *Options, supp
 func createHTTPStreamStreams(req *http.Request, w http.ResponseWriter, opts *Options, supportedStreamProtocols []string, idleTimeout, streamCreationTimeout time.Duration) (*connectionContext, bool) {
 	protocol, err := httpstream.Handshake(req, w, supportedStreamProtocols)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		// Handshake writes the error to the client
 		return nil, false
 	}
 


### PR DESCRIPTION
Some tests are flaking in this function, having a better logged error will help to understand the cause.

Also modify the Handshake function to always write an http error,
otherwise we have inconsistencies in the codebase that is using the
function and since we are already passing the http writer it makes sense
to not just return an error and delegate the response to the caller.

/kind flake
```release-note
NONE
```

/sig api-machinery
/assign @liggitt @seans3 