### PR TITLE
Enhance MutableVersionedFeatureGate with freeze-on-first-read and Snapshot/Restore support

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -269,11 +269,11 @@ type featureGate struct {
 	queriedFeatures         atomic.Value
 	emulationVersion        atomic.Pointer[version.Version]
 	minCompatibilityVersion atomic.Pointer[version.Version]
-	// freezeOnRead indicates whether this feature gate should automatically
-	// transition into "frozen mode" after the first read (via Enabled).
-	frozen atomic.Bool
 	// frozen is atomically set to true when the first read (Enabled call) occurs
 	// if freezeOnRead is true. Once frozen, the gate becomes immutable.
+	frozen atomic.Bool
+	// freezeOnRead indicates whether this feature gate should automatically
+	// transition into "frozen mode" after the first read (via Enabled).
 	freezeOnRead bool
 }
 
@@ -341,9 +341,7 @@ func (f *featureGate) Restore(state FeatureGateState) error {
 
 	f.closed = state.Closed
 
-	if !f.frozen.Load() {
-		f.frozen.Store(state.Frozen)
-	}
+	f.frozen.Store(state.Frozen)
 
 	return nil
 }
@@ -420,7 +418,7 @@ func NewFeatureGate() *featureGate {
 // after the first call to Enabled(). Once frozen, all mutation methods will
 // reject further writes. This enforces a strict "configuration phase"
 // (before the first read) followed by a "runtime phase" (after first read).
-func NewFeatureGateWithFreeze() *featureGate {
+func NewFeatureGateWithFreezeForTest() *featureGate {
 	fg := NewFeatureGate()
 	fg.freezeOnRead = true
 	return fg

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -2583,7 +2583,7 @@ func TestFrozenMode_BasicLifecycle(t *testing.T) {
 	ver := version.MustParseGeneric("1.20")
 
 	// Create frozen mode gate
-	fg := NewFeatureGateWithFreeze()
+	fg := NewFeatureGateWithFreezeForTest()
 
 	// Add a feature before freeze (should succeed)
 	if err := fg.Add(map[Feature]FeatureSpec{
@@ -2684,7 +2684,7 @@ func TestFeatureGateSnapshotRestore(t *testing.T) {
 }
 
 func TestFeatureGateSnapshotRestoreFrozen(t *testing.T) {
-	fg := NewFeatureGateWithFreeze()
+	fg := NewFeatureGateWithFreezeForTest()
 	fg.AddVersioned(map[Feature]VersionedSpecs{
 		"FrozenFeature": {{Default: false, PreRelease: Alpha, Version: version.MustParse("1.0")}},
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
This PR significantly enhances the safety and testability of the `MutableVersionedFeatureGate` by introducing two related features: **freeze-on-first-read semantics** and **state Snapshot/Restore functionality**.

* **Freeze-on-First-Read:** A new constructor, `NewFeatureGateWithFreezeForTest`, is introduced. After the first call to `Enabled()`, the gate is marked as frozen, and further mutation attempts are rejected. This clearly separates the configuration phase from the immutable runtime phase, preventing accidental runtime modification.
*  **Snapshot and Restore:** Adds `Snapshot()` and `Restore(state FeatureGateState)` methods to `MutableVersionedFeatureGate`. This enables capturing and restoring the complete internal state of a feature gate instance.

**Snapshot and Restore:** Adds `Snapshot()` and `Restore(state FeatureGateState)` methods to `MutableVersionedFeatureGate`. This enables capturing and restoring the complete internal state of a feature gate instance.

#### Which issue(s) this PR is related to:
part of #134009

#### Special notes for your reviewer:
* This PR includes both the new **freeze-on-first-read** mechanism and the **Snapshot/Restore** methods on the `MutableVersionedFeatureGate`.
* The original `NewFeatureGate` constructor remains unaffected, meaning existing callers who do not need this behavior continue to work as before (the frozen mode is opt-in).

```release-note
NONE
```

