### PR TITLE
Forget pod from scheduler's cache immediately when it's deleted

### DIFF
--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -1043,9 +1043,9 @@ func TestForgetPod(t *testing.T) {
 		if err := isForgottenFromCache(pod, cache); err != nil {
 			t.Errorf("pod %q: %v", pod.Name, err)
 		}
-		// trying to forget a pod already forgotten should return an error
-		if err := cache.ForgetPod(logger, pod); err == nil {
-			t.Error("expected error, no error found")
+		// trying to forget a pod already forgotten should return nil
+		if err := cache.ForgetPod(logger, pod); err != nil {
+			t.Error("expected no error, error found")
 		}
 	}
 }

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -41,6 +41,7 @@ import (
 	dyfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
 	"k8s.io/klog/v2"
@@ -52,13 +53,17 @@ import (
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodename"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/profile"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
 )
@@ -127,7 +132,7 @@ func TestEventHandlers_MoveToActiveOnNominatedNodeUpdate(t *testing.T) {
 		{
 			name: "Removal of a pod that had nominated node name should trigger rescheduling of lower priority pods",
 			updateFunc: func(s *Scheduler) {
-				s.deletePodFromSchedulingQueue(medNominatedPriorityPod)
+				s.deletePodFromSchedulingQueue(medNominatedPriorityPod, false)
 			},
 			wantInActiveOrBackoff: sets.New(lowPriorityPod.Name, medPriorityPod.Name),
 		},
@@ -222,24 +227,24 @@ func newDefaultQueueSort() fwk.LessFunc {
 	return sort.Less
 }
 
-func TestUpdatePodInCache(t *testing.T) {
+func TestUpdateAssignedPodInCache(t *testing.T) {
 	ttl := 10 * time.Second
 	nodeName := "node"
 
 	tests := []struct {
 		name   string
-		oldObj interface{}
-		newObj interface{}
+		oldPod *v1.Pod
+		newPod *v1.Pod
 	}{
 		{
 			name:   "pod updated with the same UID",
-			oldObj: withPodName(podWithPort("oldUID", nodeName, 80), "pod"),
-			newObj: withPodName(podWithPort("oldUID", nodeName, 8080), "pod"),
+			oldPod: withPodName(podWithPort("oldUID", nodeName, 80), "pod"),
+			newPod: withPodName(podWithPort("oldUID", nodeName, 8080), "pod"),
 		},
 		{
 			name:   "pod updated with different UIDs",
-			oldObj: withPodName(podWithPort("oldUID", nodeName, 80), "pod"),
-			newObj: withPodName(podWithPort("newUID", nodeName, 8080), "pod"),
+			oldPod: withPodName(podWithPort("oldUID", nodeName, 80), "pod"),
+			newPod: withPodName(podWithPort("newUID", nodeName, 8080), "pod"),
 		},
 	}
 	for _, tt := range tests {
@@ -252,20 +257,20 @@ func TestUpdatePodInCache(t *testing.T) {
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 			}
-			sched.addPodToCache(tt.oldObj)
-			sched.updatePodInCache(tt.oldObj, tt.newObj)
+			sched.addAssignedPodToCache(tt.oldPod)
+			sched.updateAssignedPodInCache(tt.oldPod, tt.newPod)
 
-			if tt.oldObj.(*v1.Pod).UID != tt.newObj.(*v1.Pod).UID {
-				if pod, err := sched.Cache.GetPod(tt.oldObj.(*v1.Pod)); err == nil {
+			if tt.oldPod.UID != tt.newPod.UID {
+				if pod, err := sched.Cache.GetPod(tt.oldPod); err == nil {
 					t.Errorf("Get pod UID %v from cache but it should not happen", pod.UID)
 				}
 			}
-			pod, err := sched.Cache.GetPod(tt.newObj.(*v1.Pod))
+			pod, err := sched.Cache.GetPod(tt.newPod)
 			if err != nil {
 				t.Errorf("Failed to get pod from scheduler: %v", err)
 			}
-			if pod.UID != tt.newObj.(*v1.Pod).UID {
-				t.Errorf("Want pod UID %v, got %v", tt.newObj.(*v1.Pod).UID, pod.UID)
+			if pod.UID != tt.newPod.UID {
+				t.Errorf("Want pod UID %v, got %v", tt.newPod.UID, pod.UID)
 			}
 		})
 	}
@@ -670,6 +675,306 @@ func TestAdmissionCheck(t *testing.T) {
 				if diff := cmp.Diff(tt.wantAdmissionResults[i], admissionResults); diff != "" {
 					t.Errorf("Unexpected admissionResults (-want, +got):\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestAddPod(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		expectInQueue bool
+		expectInCache bool
+	}{
+		{
+			name:          "add unscheduled pod",
+			pod:           st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj(),
+			expectInQueue: true,
+		},
+		{
+			name: "add unscheduled pod with other scheduler name",
+			pod:  st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj(),
+		},
+		{
+			name:          "add scheduled pod",
+			pod:           st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").Obj(),
+			expectInCache: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			sched := &Scheduler{
+				Cache:           internalcache.New(ctx, 0, nil),
+				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				logger:          logger,
+				Profiles: profile.Map{
+					"supported-scheduler": nil,
+				},
+			}
+
+			sched.addPod(tt.pod)
+
+			_, ok := sched.SchedulingQueue.GetPod(tt.pod.Name, tt.pod.Namespace)
+			if tt.expectInQueue && !ok {
+				t.Errorf("Expected pod to be in scheduling queue")
+			} else if !tt.expectInQueue && ok {
+				t.Errorf("Expected pod not to be in scheduling queue")
+			}
+			_, err := sched.Cache.GetPod(tt.pod)
+			if tt.expectInCache && err != nil {
+				t.Errorf("Expected pod to be in cache: %v", err)
+			} else if !tt.expectInCache && err == nil {
+				t.Errorf("Expected pod not to be in cache")
+			}
+		})
+	}
+}
+
+func TestUpdatePod(t *testing.T) {
+	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj()
+	updatedPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("supported-scheduler").Obj()
+
+	otherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj()
+	updatedOtherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("other-scheduler").Obj()
+
+	scheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("supported-scheduler").Obj()
+	updatedScheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").Node("node1").SchedulerName("supported-scheduler").Obj()
+
+	otherScheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("other-scheduler").Obj()
+	updatedOtherScheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").Node("node1").SchedulerName("other-scheduler").Obj()
+
+	scheduledPodOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node2").SchedulerName("supported-scheduler").Obj()
+
+	tests := []struct {
+		name          string
+		oldPod        *v1.Pod
+		assumedPod    *v1.Pod
+		newPod        *v1.Pod
+		expectInQueue *v1.Pod
+		expectInCache *v1.Pod
+	}{
+		{
+			name:          "update unscheduled pod",
+			oldPod:        pod,
+			newPod:        updatedPod,
+			expectInQueue: updatedPod,
+		},
+		{
+			name:   "update unscheduled pod with other scheduler name",
+			oldPod: otherPod,
+			newPod: updatedOtherPod,
+		},
+		{
+			name:          "update assumed pod",
+			oldPod:        pod,
+			assumedPod:    scheduledPod,
+			newPod:        updatedPod,
+			expectInCache: scheduledPod,
+		},
+		{
+			name:          "update scheduled pod",
+			oldPod:        scheduledPod,
+			newPod:        updatedScheduledPod,
+			expectInCache: updatedScheduledPod,
+		},
+		{
+			name:          "update scheduled pod with other scheduler name",
+			oldPod:        otherScheduledPod,
+			newPod:        updatedOtherScheduledPod,
+			expectInCache: updatedOtherScheduledPod,
+		},
+		{
+			name:          "bind unscheduled pod",
+			oldPod:        pod,
+			newPod:        scheduledPod,
+			expectInCache: scheduledPod,
+		},
+		{
+			name:          "bind unscheduled pod with other scheduler name",
+			oldPod:        pod,
+			newPod:        scheduledPod,
+			expectInCache: scheduledPod,
+		},
+		{
+			name:          "bind assumed pod",
+			oldPod:        pod,
+			assumedPod:    scheduledPod,
+			newPod:        scheduledPod,
+			expectInCache: scheduledPod,
+		},
+		{
+			name:          "bind assumed pod to a different node",
+			oldPod:        pod,
+			assumedPod:    scheduledPod,
+			newPod:        scheduledPodOtherNode,
+			expectInCache: scheduledPodOtherNode,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			registerPluginFuncs := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			waitingPods := frameworkruntime.NewWaitingPodsMap()
+			schedFramework, err := tf.NewFramework(
+				ctx,
+				registerPluginFuncs,
+				"supported-scheduler",
+				frameworkruntime.WithWaitingPods(waitingPods),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+			sched := &Scheduler{
+				Cache:           internalcache.New(ctx, 0, nil),
+				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				logger:          logger,
+				Profiles: profile.Map{
+					"supported-scheduler": schedFramework,
+				},
+			}
+
+			if tt.assumedPod != nil {
+				err := sched.Cache.AssumePod(logger, tt.assumedPod)
+				if err != nil {
+					t.Fatalf("Failed to assume pod: %v", err)
+				}
+			} else {
+				sched.addPod(tt.oldPod)
+			}
+
+			sched.updatePod(tt.oldPod, tt.newPod)
+
+			qPod, ok := sched.SchedulingQueue.GetPod(tt.newPod.Name, tt.newPod.Namespace)
+			if tt.expectInQueue != nil {
+				if !ok {
+					t.Errorf("Expected pod to be in scheduling queue")
+				} else if diff := cmp.Diff(tt.expectInQueue, qPod.Pod); diff != "" {
+					t.Errorf("Unexpected pod after update (-want,+got):\n%s", diff)
+				}
+			} else if ok {
+				t.Errorf("Expected pod not to be in scheduling queue")
+			}
+			pod, err := sched.Cache.GetPod(tt.newPod)
+			if tt.expectInCache != nil {
+				if err != nil {
+					t.Errorf("Expected pod to be in cache: %v", err)
+				} else if diff := cmp.Diff(tt.expectInCache, pod); diff != "" {
+					t.Errorf("Unexpected pod after update (-want,+got):\n%s", diff)
+				}
+			} else if err == nil {
+				t.Errorf("Expected pod not to be in cache")
+			}
+		})
+	}
+}
+
+func TestDeletePod(t *testing.T) {
+	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj()
+	otherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj()
+	scheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("supported-scheduler").Obj()
+	otherScheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("other-scheduler").Obj()
+
+	tests := []struct {
+		name            string
+		initialPod      *v1.Pod
+		assumed         bool
+		waitingOnPermit bool
+		podToDelete     any
+	}{
+		{
+			name:        "delete unscheduled pod",
+			initialPod:  pod,
+			podToDelete: pod,
+		},
+		{
+			name:        "delete unscheduled pod with other scheduler name",
+			initialPod:  otherPod,
+			podToDelete: otherPod,
+		},
+		{
+			name:        "delete unscheduled pod with unknown state",
+			initialPod:  pod,
+			podToDelete: cache.DeletedFinalStateUnknown{Obj: pod},
+		},
+		{
+			name:        "delete scheduled pod",
+			initialPod:  scheduledPod,
+			podToDelete: scheduledPod,
+		},
+		{
+			name:        "delete scheduled pod with other scheduler name",
+			initialPod:  otherScheduledPod,
+			podToDelete: otherScheduledPod,
+		},
+		{
+			name:        "delete scheduled pod with unknown state",
+			initialPod:  scheduledPod,
+			podToDelete: cache.DeletedFinalStateUnknown{Obj: scheduledPod},
+		},
+		{
+			name:        "delete scheduled pod with unknown older state",
+			initialPod:  scheduledPod,
+			podToDelete: cache.DeletedFinalStateUnknown{Obj: pod},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			registerPluginFuncs := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			waitingPods := frameworkruntime.NewWaitingPodsMap()
+			schedFramework, err := tf.NewFramework(
+				ctx,
+				registerPluginFuncs,
+				"supported-scheduler",
+				frameworkruntime.WithWaitingPods(waitingPods),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+			sched := &Scheduler{
+				Cache:           internalcache.New(ctx, 0, nil),
+				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				logger:          logger,
+				Profiles: profile.Map{
+					"supported-scheduler": schedFramework,
+				},
+			}
+
+			if tt.assumed {
+				err := sched.Cache.AssumePod(logger, tt.initialPod)
+				if err != nil {
+					t.Fatalf("Failed to assume pod: %v", err)
+				}
+			} else {
+				sched.addPod(tt.initialPod)
+			}
+
+			sched.deletePod(tt.podToDelete)
+
+			_, err = sched.Cache.GetPod(tt.initialPod)
+			if err == nil {
+				t.Errorf("Unexpected pod in cache after removal")
+			}
+			_, ok := sched.SchedulingQueue.GetPod(tt.initialPod.Name, tt.initialPod.Namespace)
+			if ok {
+				t.Errorf("Unexpected pod in scheduling queue after removal")
 			}
 		})
 	}

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -739,6 +739,8 @@ func TestUpdatePod(t *testing.T) {
 	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj()
 	updatedPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("supported-scheduler").Obj()
 
+	podWithDeletionTimestamp := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Terminating().ResourceVersion("2").SchedulerName("supported-scheduler").Obj()
+
 	otherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj()
 	updatedOtherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("other-scheduler").Obj()
 
@@ -813,6 +815,12 @@ func TestUpdatePod(t *testing.T) {
 			assumedPod:    scheduledPod,
 			newPod:        scheduledPodOtherNode,
 			expectInCache: scheduledPodOtherNode,
+		},
+		{
+			name:       "delete assumed pod with deletion timestamp",
+			oldPod:     pod,
+			assumedPod: scheduledPod,
+			newPod:     podWithDeletionTimestamp,
 		},
 	}
 	for _, tt := range tests {
@@ -906,6 +914,12 @@ func TestDeletePod(t *testing.T) {
 			name:        "delete unscheduled pod with unknown state",
 			initialPod:  pod,
 			podToDelete: cache.DeletedFinalStateUnknown{Obj: pod},
+		},
+		{
+			name:        "delete assumed pod",
+			initialPod:  scheduledPod,
+			assumed:     true,
+			podToDelete: pod,
 		},
 		{
 			name:        "delete scheduled pod",

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -2097,7 +2097,7 @@ func TestSchedulerBinding(t *testing.T) {
 	}
 }
 
-func TestUpdatePod(t *testing.T) {
+func TestUpdatePodStatus(t *testing.T) {
 	tests := []struct {
 		name                     string
 		currentPodConditions     []v1.PodCondition

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -417,6 +417,12 @@ func (p *PodWrapper) ZeroTerminationGracePeriod() *PodWrapper {
 	return p
 }
 
+// TerminationGracePeriodSeconds sets the TerminationGracePeriodSeconds of the inner pod.
+func (p *PodWrapper) TerminationGracePeriodSeconds(s int64) *PodWrapper {
+	p.Spec.TerminationGracePeriodSeconds = &s
+	return p
+}
+
 // Node sets `s` as the nodeName of the inner pod.
 func (p *PodWrapper) Node(s string) *PodWrapper {
 	p.Spec.NodeName = s

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -562,6 +562,12 @@ func (p *PodWrapper) SchedulingGates(gates []string) *PodWrapper {
 	return p
 }
 
+// ResourceVersion sets the inner pod's ResurceVersion.
+func (p *PodWrapper) ResourceVersion(version string) *PodWrapper {
+	p.ObjectMeta.ResourceVersion = version
+	return p
+}
+
 // PodAffinityKind represents different kinds of PodAffinity.
 type PodAffinityKind int
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When pod is in the binding phase it occupies the space on the node (is assumed). When the higher priority pod tried to preempt such pod, it deleted it from the cluster, but it remained in the scheduler's cache. Since the binding phase can take some time (PreBind, Bind), the pod occupies the space for a long time. The higher priority pod, when retried, would try to preempt the pod again, wasting scheduling cycles and API calls to the kube-apiserver.

In some scenarios, this behavior can seriously affect the scheduling performance, by continuously preempting the already deleted pod.

This PR forgets the pod from a cache when the pod delete event is registered by the scheduler. Such pod will eventually fail its binding cycle as previously, but the space won't be occupied anymore. Similar behavior is implemented for pods that are under graceful termination.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #134217

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that caused a deleted pod staying in the binding phase to occupy space on the node in the kube-scheduler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
