### PR TITLE
Replace reflector.Run with reflector.RunWithContext in kubelet

### DIFF
--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -33,7 +33,8 @@ import (
 const WaitForAPIServerSyncPeriod = 1 * time.Second
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
-func NewSourceApiserver(logger klog.Logger, c clientset.Interface, nodeName types.NodeName, nodeHasSynced func() bool, updates chan<- sourceUpdate) {
+func NewSourceApiserver(ctx context.Context, c clientset.Interface, nodeName types.NodeName, nodeHasSynced func() bool, updates chan<- sourceUpdate) {
+	logger := klog.FromContext(ctx)
 	lw := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector("spec.nodeName", string(nodeName)))
 
 	// The Reflector responsible for watching pods at the apiserver should be run only after
@@ -49,12 +50,13 @@ func NewSourceApiserver(logger klog.Logger, c clientset.Interface, nodeName type
 			logger.V(4).Info("node sync has not completed yet")
 		}
 		logger.Info("Watching apiserver")
-		newSourceApiserverFromLW(lw, updates)
+		newSourceApiserverFromLW(ctx, lw, updates)
 	}()
 }
 
 // newSourceApiserverFromLW holds creates a config source that watches and pulls from the apiserver.
-func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- sourceUpdate) {
+
+func newSourceApiserverFromLW(ctx context.Context, lw cache.ListerWatcher, updates chan<- sourceUpdate) {
 	send := func(objs []interface{}) {
 		var pods []*v1.Pod
 		for _, o := range objs {
@@ -63,5 +65,5 @@ func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- sourceUpdat
 		updates <- sourceUpdate{Pods: pods}
 	}
 	r := cache.NewReflector(lw, &v1.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc), 0)
-	go r.Run(wait.NeverStop)
+	go r.RunWithContext(ctx)
 }

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 type fakePodLW struct {
@@ -52,6 +53,8 @@ func (lw fakePodLW) IsWatchListSemanticsUnSupported() bool { return true }
 var _ cache.ListerWatcher = fakePodLW{}
 
 func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	pod1v1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "p"},
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/one"}}}}
@@ -71,7 +74,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 
 	ch := make(chan sourceUpdate)
 
-	newSourceApiserverFromLW(lw, ch)
+	newSourceApiserverFromLW(tCtx, lw, ch)
 
 	update, ok := <-ch
 	if !ok {
@@ -133,6 +136,8 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 }
 
 func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	pod1 := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "one"},
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/one"}}}}
@@ -149,7 +154,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 
 	ch := make(chan sourceUpdate)
 
-	newSourceApiserverFromLW(lw, ch)
+	newSourceApiserverFromLW(tCtx, lw, ch)
 
 	update, ok := <-ch
 	if !ok {
@@ -172,6 +177,8 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 }
 
 func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	// Setup fake api client.
 	fakeWatch := watch.NewFake()
 	lw := fakePodLW{
@@ -181,7 +188,7 @@ func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
 
 	ch := make(chan sourceUpdate)
 
-	newSourceApiserverFromLW(lw, ch)
+	newSourceApiserverFromLW(tCtx, lw, ch)
 
 	update, ok := <-ch
 	if !ok {

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -136,7 +136,7 @@ func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.G
 //   - whenever a pod is created or updated, we start individual watches for all
 //     referenced objects that aren't referenced from other registered pods
 //   - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
+func NewWatchingConfigMapManager(ctx context.Context, kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
 	listConfigMap := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
 	}
@@ -157,6 +157,6 @@ func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval 
 	}
 	gr := corev1.Resource("configmap")
 	return &configMapManager{
-		manager: manager.NewWatchBasedManager(listConfigMap, watchConfigMap, newConfigMap, isImmutable, listWatcherWithWatchListSemanticsWrapper, gr, resyncInterval, getConfigMapNames),
+		manager: manager.NewWatchBasedManager(ctx, listConfigMap, watchConfigMap, newConfigMap, isImmutable, listWatcherWithWatchListSemanticsWrapper, gr, resyncInterval, getConfigMapNames),
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -649,8 +649,8 @@ func NewMainKubelet(ctx context.Context,
 	if klet.kubeClient != nil {
 		switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 		case kubeletconfiginternal.WatchChangeDetectionStrategy:
-			secretManager = secret.NewWatchingSecretManager(klet.kubeClient, klet.resyncInterval)
-			configMapManager = configmap.NewWatchingConfigMapManager(klet.kubeClient, klet.resyncInterval)
+			secretManager = secret.NewWatchingSecretManager(ctx, klet.kubeClient, klet.resyncInterval)
+			configMapManager = configmap.NewWatchingConfigMapManager(ctx, klet.kubeClient, klet.resyncInterval)
 		case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 			secretManager = secret.NewCachingSecretManager(
 				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -390,7 +390,7 @@ func makePodSourceConfig(ctx context.Context, kubeCfg *kubeletconfiginternal.Kub
 
 	if kubeDeps.KubeClient != nil {
 		logger.Info("Adding apiserver pod source")
-		config.NewSourceApiserver(logger, kubeDeps.KubeClient, nodeName, nodeHasSynced, cfg.Channel(ctx, kubetypes.ApiserverSource))
+		config.NewSourceApiserver(ctx, kubeDeps.KubeClient, nodeName, nodeHasSynced, cfg.Channel(ctx, kubetypes.ApiserverSource))
 	}
 	return cfg, nil
 }

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -137,7 +137,7 @@ func NewCachingSecretManager(kubeClient clientset.Interface, getTTL manager.GetO
 //   - whenever a pod is created or updated, we start individual watches for all
 //     referenced objects that aren't referenced from other registered pods
 //   - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingSecretManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
+func NewWatchingSecretManager(ctx context.Context, kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
 	listSecret := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().Secrets(namespace).List(context.TODO(), opts)
 	}
@@ -158,6 +158,6 @@ func NewWatchingSecretManager(kubeClient clientset.Interface, resyncInterval tim
 	}
 	gr := corev1.Resource("secret")
 	return &secretManager{
-		manager: manager.NewWatchBasedManager(listSecret, watchSecret, newSecret, isImmutable, listWatcherWithWatchListSemanticsWrapper, gr, resyncInterval, getSecretNames),
+		manager: manager.NewWatchBasedManager(ctx, listSecret, watchSecret, newSecret, isImmutable, listWatcherWithWatchListSemanticsWrapper, gr, resyncInterval, getSecretNames),
 	}
 }

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -63,7 +63,8 @@ type objectCacheItem struct {
 	lastAccessTime time.Time
 	stopped        bool
 	immutable      bool
-	stopCh         chan struct{}
+	parentCtx      context.Context
+	cancel         context.CancelFunc
 }
 
 func (i *objectCacheItem) stop() bool {
@@ -77,7 +78,7 @@ func (i *objectCacheItem) stopThreadUnsafe() bool {
 		return false
 	}
 	i.stopped = true
-	close(i.stopCh)
+	i.cancel()
 	if !i.immutable {
 		i.store.unsetInitialized()
 	}
@@ -115,16 +116,21 @@ func (i *objectCacheItem) restartReflectorIfNeeded() {
 	if i.immutable || !i.stopped {
 		return
 	}
-	i.stopCh = make(chan struct{})
+
+	i.cancel()
+
+	ctx, cancel := context.WithCancel(i.parentCtx)
+	i.cancel = cancel
+
 	i.stopped = false
-	go i.startReflector()
+	go i.startReflector(ctx)
 }
 
-func (i *objectCacheItem) startReflector() {
+func (i *objectCacheItem) startReflector(ctx context.Context) {
 	i.waitGroup.Wait()
 	i.waitGroup.Add(1)
 	defer i.waitGroup.Done()
-	i.reflector.Run(i.stopCh)
+	i.reflector.RunWithContext(ctx)
 }
 
 // cacheStore is in order to rewrite Replace function to mark initialized flag
@@ -178,6 +184,7 @@ const minIdleTime = 1 * time.Minute
 
 // NewObjectCache returns a new watch-based instance of Store interface.
 func NewObjectCache(
+	ctx context.Context,
 	listObject listObjectFunc,
 	watchObject watchObjectFunc,
 	newObject newObjectFunc,
@@ -186,8 +193,7 @@ func NewObjectCache(
 	groupResource schema.GroupResource,
 	clock clock.Clock,
 	maxIdleTime time.Duration,
-	stopCh <-chan struct{}) Store {
-
+) Store {
 	if maxIdleTime < minIdleTime {
 		maxIdleTime = minIdleTime
 	}
@@ -204,8 +210,8 @@ func NewObjectCache(
 		items:                                    make(map[objectKey]*objectCacheItem),
 	}
 
-	go wait.Until(store.startRecycleIdleWatch, time.Minute, stopCh)
-	go store.shutdownWhenStopped(stopCh)
+	go wait.UntilWithContext(ctx, store.startRecycleIdleWatch, time.Minute)
+	go store.shutdownWhenStopped(ctx)
 	return store
 }
 
@@ -219,7 +225,7 @@ func (c *objectCache) newStore() *cacheStore {
 	return &cacheStore{store, sync.Mutex{}, false}
 }
 
-func (c *objectCache) newReflectorLocked(namespace, name string) *objectCacheItem {
+func (c *objectCache) newReflectorLocked(parentCtx context.Context, namespace, name string) *objectCacheItem {
 	fieldSelector := fields.Set{"metadata.name": name}.AsSelector().String()
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		options.FieldSelector = fieldSelector
@@ -241,17 +247,19 @@ func (c *objectCache) newReflectorLocked(namespace, name string) *objectCacheIte
 			MinWatchTimeout: 30 * time.Minute,
 		},
 	)
+	ctx, cancel := context.WithCancel(parentCtx)
 	item := &objectCacheItem{
 		refMap:    make(map[types.UID]int),
 		store:     store,
 		reflector: reflector,
 		hasSynced: func() (bool, error) { return store.hasSynced(), nil },
-		stopCh:    make(chan struct{}),
+		parentCtx: parentCtx,
+		cancel:    cancel,
 	}
 
 	// Don't start reflector if Kubelet is already shutting down.
 	if !c.stopped {
-		go item.startReflector()
+		go item.startReflector(ctx)
 	}
 	return item
 }
@@ -268,7 +276,9 @@ func (c *objectCache) AddReference(namespace, name string, referencedFrom types.
 	defer c.lock.Unlock()
 	item, exists := c.items[key]
 	if !exists {
-		item = c.newReflectorLocked(namespace, name)
+		// TODO: Pass a proper context from the caller.
+		// This requires adding a context parameter to the Store.AddReference interface.
+		item = c.newReflectorLocked(context.TODO(), namespace, name)
 		c.items[key] = item
 	}
 	item.refMap[referencedFrom]++
@@ -360,9 +370,7 @@ func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
 	return nil, fmt.Errorf("unexpected object type: %v", obj)
 }
 
-func (c *objectCache) startRecycleIdleWatch() {
-	// TODO: it needs to be replaced by a proper context in the future
-	ctx := context.TODO()
+func (c *objectCache) startRecycleIdleWatch(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -374,8 +382,8 @@ func (c *objectCache) startRecycleIdleWatch() {
 	}
 }
 
-func (c *objectCache) shutdownWhenStopped(stopCh <-chan struct{}) {
-	<-stopCh
+func (c *objectCache) shutdownWhenStopped(ctx context.Context) {
+	<-ctx.Done()
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -393,6 +401,7 @@ func (c *objectCache) shutdownWhenStopped(stopCh <-chan struct{}) {
 //     referenced objects that aren't referenced from other registered pods
 //   - every GetObject() returns a value from local cache propagated via watches
 func NewWatchBasedManager(
+	ctx context.Context,
 	listObject listObjectFunc,
 	watchObject watchObjectFunc,
 	newObject newObjectFunc,
@@ -400,8 +409,8 @@ func NewWatchBasedManager(
 	listWatcherWithWatchListSemanticsWrapper listWatcherWithWatchListSemanticsWrapperFunc,
 	groupResource schema.GroupResource,
 	resyncInterval time.Duration,
-	getReferencedObjects func(*v1.Pod) sets.Set[string]) Manager {
-
+	getReferencedObjects func(*v1.Pod) sets.Set[string],
+) Manager {
 	// If a configmap/secret is used as a volume, the volumeManager will visit the objectCacheItem every resyncInterval cycle,
 	// We just want to stop the objectCacheItem referenced by environment variables,
 	// So, maxIdleTime is set to an integer multiple of resyncInterval,
@@ -409,6 +418,6 @@ func NewWatchBasedManager(
 	maxIdleTime := resyncInterval * 5
 
 	// TODO propagate stopCh from the higher level.
-	objectStore := NewObjectCache(listObject, watchObject, newObject, isImmutable, listWatcherWithWatchListSemanticsWrapper, groupResource, clock.RealClock{}, maxIdleTime, wait.NeverStop)
+	objectStore := NewObjectCache(ctx, listObject, watchObject, newObject, isImmutable, listWatcherWithWatchListSemanticsWrapper, groupResource, clock.RealClock{}, maxIdleTime)
 	return NewCacheBasedManager(objectStore, getReferencedObjects)
 }

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -404,7 +404,7 @@ func TestMaxIdleTimeStopsTheReflector(t *testing.T) {
 	assert.True(t, reflectorRunning())
 
 	fakeClock.Step(90 * time.Second)
-	store.startRecycleIdleWatch()
+	store.startRecycleIdleWatch(tCtx)
 
 	// Reflector should already be stopped for maxIdleTime exceeded.
 	assert.False(t, reflectorRunning())
@@ -420,7 +420,7 @@ func TestMaxIdleTimeStopsTheReflector(t *testing.T) {
 	_, _ = store.Get("ns", "name")
 	fakeClock.Step(20 * time.Second)
 	_, _ = store.Get("ns", "name")
-	store.startRecycleIdleWatch()
+	store.startRecycleIdleWatch(tCtx)
 
 	// Reflector should be running when the get function is called periodically.
 	assert.True(t, reflectorRunning())
@@ -492,7 +492,7 @@ func TestReflectorNotStoppedOnSlowInitialization(t *testing.T) {
 	}
 
 	fakeClock.Step(90 * time.Second)
-	store.startRecycleIdleWatch()
+	store.startRecycleIdleWatch(tCtx)
 
 	// Reflector didn't yet initialize, so it shouldn't be stopped.
 	// However, Get should still be failing.
@@ -513,7 +513,7 @@ func TestReflectorNotStoppedOnSlowInitialization(t *testing.T) {
 	}
 
 	// recycling shouldn't stop the reflector because it was accessed within last minute.
-	store.startRecycleIdleWatch()
+	store.startRecycleIdleWatch(tCtx)
 	assert.True(t, reflectorRunning())
 
 	obj, _ := store.Get("ns", "name")
@@ -642,6 +642,8 @@ func TestRefMapHandlesReferencesCorrectly(t *testing.T) {
 }
 
 func TestUnSupportWatchListSemantics(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -652,7 +654,7 @@ func TestUnSupportWatchListSemantics(t *testing.T) {
 	defer cancel()
 	target := newSecretCache(context.TODO(), fakeClient, fakeClock, time.Minute)
 
-	ret := target.newReflectorLocked("ns", "obj")
+	ret := target.newReflectorLocked(tCtx, "ns", "obj")
 	defer ret.stop()
 
 	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (bool, error) {
@@ -663,6 +665,8 @@ func TestUnSupportWatchListSemantics(t *testing.T) {
 }
 
 func TestWatchListSemanticsSimple(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -719,7 +723,7 @@ func TestWatchListSemanticsSimple(t *testing.T) {
 	defer cancel()
 	target := newSecretCache(context.TODO(), client, fakeClock, time.Second)
 
-	ret := target.newReflectorLocked("ns", "obj")
+	ret := target.newReflectorLocked(tCtx, "ns", "obj")
 	defer ret.stop()
 
 	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -72,10 +72,7 @@ func TestWatchBasedManager(t *testing.T) {
 	}
 	fakeClock := testingclock.NewFakeClock(time.Now())
 
-	stopCh := make(chan struct{})
-	t.Cleanup(func() { close(stopCh) })
-
-	store := manager.NewObjectCache(listObj, watchObj, newObj, isImmutable, listWatcherWithWatchListSemanticsWrapper, schema.GroupResource{Group: "v1", Resource: "secrets"}, fakeClock, time.Minute, stopCh)
+	store := manager.NewObjectCache(ctx, listObj, watchObj, newObj, isImmutable, listWatcherWithWatchListSemanticsWrapper, schema.GroupResource{Group: "v1", Resource: "secrets"}, fakeClock, time.Minute)
 
 	// create 1000 secrets in parallel
 	t.Log(time.Now(), "creating 1000 secrets")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replace `reflector.Run` with `reflector.RunWithContext` for support contextual logging.

#### Which issue(s) this PR is related to:

Related https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:

When I replaced `i.reflector.Run(i.stopCh)` with `i.reflector.RunWithContext(i.ctx)`, I changed a lot of code. I hope I didn't make any mistakes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
