### PR TITLE
DRA E2E node: fix cleanup of tests using separate registrar

### DIFF
--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -1056,7 +1056,7 @@ func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName,
 	allOpts = append(allOpts, opts...)
 
 	registrar, err := testdriver.StartPlugin(
-		ctx,
+		context.WithoutCancel(ctx), // It gets stopped during test cleanup or when requested earlier.
 		cdiDir,
 		driverName,
 		clientSet,
@@ -1065,6 +1065,7 @@ func newRegistrar(ctx context.Context, clientSet kubernetes.Interface, nodeName,
 		allOpts...,
 	)
 	framework.ExpectNoError(err, "start only Kubelet plugin registrar")
+	ginkgo.DeferCleanup(registrar.Stop)
 	return registrar
 }
 
@@ -1158,6 +1159,10 @@ func draServiceCleanup(ctx context.Context, clientSet kubernetes.Interface, driv
 	// shutdown.
 	ginkgo.By("Deleting pods and waiting for ResourceClaims to be released...")
 	framework.ExpectNoError(clientSet.CoreV1().Pods(testNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{}))
+
+	// Failing here is a bit more obvious than in the metric check below.
+	// The metrics get checked, too, because we want to be certain that those go down.
+	gomega.Eventually(ctx, framework.ListObjects(clientSet.CoreV1().Pods(testNamespace).List, metav1.ListOptions{})).Should(gomega.HaveField("Items", gomega.BeEmpty()), "All pods should be deleted, shut down and removed.")
 
 	// We allow for a delay because it takes a while till the kubelet fully deals with pod deletion.
 	// Typically there is no dra_resource_claims_in_use entry for the driver (covered by gstruct.IgnoreMissing).


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

8fed05c5b78ddc232819820c616d10f51d92b030 fixed the cleanup of tests which start registrar and service in a single call. But tests which first started the registrar and then the service separately still had the problem:

- registrar is started with test context
- pods remain running at end of test
- registrar stops because of test context cancellation
- pods remain pending despite deletion because the driver gets unregistered (timing dependent, so this may have flaked)

The fix is to also clean up the registrar after the test, in reverse startup order.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/134125 (keeping it open for verification after merge)

#### Special notes for your reviewer:

This replaces https://github.com/kubernetes/kubernetes/pull/134165/files#r2363529556.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 