### PR TITLE
refactor(apiextensions-apiserver): Make NamingConditionController context-aware

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -242,7 +242,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			}
 		}
 
-		go namingController.Run(hookContext.Done())
+		go namingController.RunWithContext(hookContext)
 		go establishingController.RunWithContext(hookContext)
 		go nonStructuralSchemaController.Run(5, hookContext.Done())
 		go apiApprovalController.Run(5, hookContext.Done())


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR refactors the `NamingConditionController` in `apiextensions-apiserver` to be context-aware for its lifecycle management.

The primary change is the conversion of the legacy `Run(stopCh <-chan struct{})` method to `RunWithContext(ctx context.Context)`. The context is propagated through the controller's worker loop to improve shutdown signal handling. The legacy `Run` method is maintained as a wrapper for compatibility.

Note: The `klog.TODO()` for contextual logging could not be addressed in this PR due to an architectural constraint where the controller must be instantiated before a `context.Context` is available.

**Which issue(s) this PR fixes**:
Contributes to #126379

**Special notes for your reviewer**:
```
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```