### PR TITLE
[InPlacePodVerticalScaling] pod resize tests should verify allocated resources

### DIFF
--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -203,6 +203,10 @@ func verifyPodContainersStatusResources(gotCtrStatuses []v1.ContainerStatus, wan
 			continue
 		}
 
+		if err := framework.Gomega().Expect(gotCtrStatus.AllocatedResources).To(gomega.BeComparableTo(wantCtr.Resources.Requests)); err != nil {
+			errs = append(errs, fmt.Errorf("container[%s] status allocatedResources mismatch: %w", wantCtr.Name, err))
+		}
+
 		if err := framework.Gomega().Expect(*gotCtrStatus.Resources).To(gomega.BeComparableTo(wantCtr.Resources)); err != nil {
 			errs = append(errs, fmt.Errorf("container[%s] status resources mismatch: %w", wantCtr.Name, err))
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area test

#### What this PR does / why we need it:

This PR adds a check to the in-place pod resize tests for the `allocatedResources` field in the container status (which currently does not have coverage). All of our e2e tests wait for the currently allocated resize to complete before checking the status, so `allocatedResources` should always be equal to `resources`. 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/priority important-soon