### PR TITLE
deflake e2e: ensure pod with sidecars restarts in correct order after node reboot

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -5916,7 +5916,7 @@ var _ = SIGDescribe(feature.SidecarContainers, framework.WithSerial(), "Containe
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	ginkgo.When("A node running restartable init containers reboots", func() {
-		ginkgo.It("should restart the containers in right order with the proper phase after the node reboot", func(ctx context.Context) {
+		ginkgo.It("should restart the containers in right order after the node reboot", func(ctx context.Context) {
 			init1 := "init-1"
 			restartableInit2 := "restartable-init-2"
 			init3 := "init-3"
@@ -6016,9 +6016,9 @@ var _ = SIGDescribe(feature.SidecarContainers, framework.WithSerial(), "Containe
 			})
 			framework.ExpectNoError(err)
 
-			ginkgo.By("Waiting for the pod to run after re-initialization")
-			err = e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
-			framework.ExpectNoError(err)
+			ginkgo.By("Waiting for regular container to start running")
+			err = e2epod.WaitForContainerRunning(ctx, f.ClientSet, pod.Namespace, pod.Name, regular1, f.Timeouts.PodStart)
+			framework.ExpectNoError(err, "regular container %q should be running", regular1)
 
 			ginkgo.By("Parsing results")
 			pod, err = client.Get(ctx, pod.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

Deflake `[sig-node] [Feature:SidecarContainers] [Serial] when A node running restartable init containers reboots should restart the containers in right order with the proper phase after the node reboot` test.

The Pod phase transitioned to Running as soon as the `init-1` container completed. Because of that, the container logs were parsed before `restartable-init-2` had a chance to run, so the logs of both `restartable-init-2` and `init-3` were not captured, causing the test to fail. For more information, see https://github.com/kubernetes/kubernetes/issues/132930#issuecomment-3311419471.

While preparing this PR, I noticed that the test name says it ensures with the proper pod phase. However, as described in https://github.com/kubernetes/kubernetes/issues/132930#issuecomment-3311419471, the issue remains if a node running a Pod with multiple initContainers (including a restartable init container) is rebooted, the Pod phase transitions to Running immediately after the first init container completes. In other words, the Pod phase is not transitioning properly.

Since fixing this problem will require more time to work out the right approach without breaking the current behavior, how about we temporarily remove the phrase `with the proper phase` from the test name, create a separate issue to track the fix, and then restore the original test once the issue has been addressed? If that sounds reasonable, I’ll open the issue.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #132930

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
