### PR TITLE
ad-controller: async node status update

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -161,8 +161,12 @@ func NewAttachDetachController(
 			&adc.volumePluginMgr,
 			recorder,
 			blkutil))
-	adc.nodeStatusUpdater = statusupdater.NewNodeStatusUpdater(
-		kubeClient, nodeInformer.Lister(), adc.actualStateOfWorld)
+	var err error
+	adc.nodeStatusUpdater, err = statusupdater.NewNodeStatusUpdater(logger,
+		kubeClient, nodeInformer, adc.actualStateOfWorld)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize node status updater: %w", err)
+	}
 
 	// Default these to values in options
 	adc.reconciler = reconciler.NewReconciler(
@@ -367,6 +371,9 @@ func (adc *attachDetachController) Run(ctx context.Context) {
 	)
 
 	wg.Go(func() {
+		adc.nodeStatusUpdater.Run(ctx, 1)
+	})
+	wg.Go(func() {
 		adc.reconciler.Run(ctx)
 	})
 	wg.Go(func() {
@@ -551,19 +558,7 @@ func (adc *attachDetachController) podDelete(logger klog.Logger, obj interface{}
 }
 
 func (adc *attachDetachController) nodeAdd(logger klog.Logger, obj interface{}) {
-	node, ok := obj.(*v1.Node)
-	// TODO: investigate if nodeName is empty then if we can return
-	// kubernetes/kubernetes/issues/37777
-	if node == nil || !ok {
-		return
-	}
-	nodeName := types.NodeName(node.Name)
 	adc.nodeUpdate(logger, nil, obj)
-	// kubernetes/kubernetes/issues/37586
-	// This is to workaround the case when a node add causes to wipe out
-	// the attached volumes field. This function ensures that we sync with
-	// the actual status.
-	adc.actualStateOfWorld.SetNodeStatusUpdateNeeded(logger, nodeName)
 }
 
 func (adc *attachDetachController) nodeUpdate(logger klog.Logger, oldObj, newObj interface{}) {

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -407,7 +407,6 @@ func (adc *attachDetachController) populateActualStateOfWorld(logger klog.Logger
 				continue
 			}
 		}
-		adc.actualStateOfWorld.SetVolumesMountedByNode(logger, node.Status.VolumesInUse, nodeName)
 		adc.addNodeToDswp(node, types.NodeName(node.Name))
 	}
 	err = adc.processVolumeAttachments(logger)
@@ -569,7 +568,6 @@ func (adc *attachDetachController) nodeUpdate(logger klog.Logger, oldObj, newObj
 
 	nodeName := types.NodeName(node.Name)
 	adc.addNodeToDswp(node, nodeName)
-	adc.processVolumesInUse(logger, nodeName, node.Status.VolumesInUse)
 }
 
 func (adc *attachDetachController) nodeDelete(logger klog.Logger, obj interface{}) {
@@ -583,8 +581,6 @@ func (adc *attachDetachController) nodeDelete(logger klog.Logger, obj interface{
 		// This might happen during drain, but we still want it to appear in our logs
 		logger.Info("Error removing node from desired-state-of-world", "node", klog.KObj(node), "err", err)
 	}
-
-	adc.processVolumesInUse(logger, nodeName, node.Status.VolumesInUse)
 }
 
 func (adc *attachDetachController) enqueuePVC(obj interface{}) {
@@ -665,16 +661,6 @@ func (adc *attachDetachController) syncPVCByKey(logger klog.Logger, key string) 
 			adc.desiredStateOfWorld, &adc.volumePluginMgr, adc.pvcLister, adc.pvLister, adc.csiMigratedPluginManager, adc.intreeToCSITranslator)
 	}
 	return nil
-}
-
-// processVolumesInUse processes the list of volumes marked as "in-use"
-// according to the specified Node's Status.VolumesInUse and updates the
-// corresponding volume in the actual state of the world to indicate that it is
-// mounted.
-func (adc *attachDetachController) processVolumesInUse(
-	logger klog.Logger, nodeName types.NodeName, volumesInUse []v1.UniqueVolumeName) {
-	logger.V(4).Info("processVolumesInUse for node", "node", klog.KRef("", string(nodeName)))
-	adc.actualStateOfWorld.SetVolumesMountedByNode(logger, volumesInUse, nodeName)
 }
 
 // Process Volume-Attachment objects.

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -178,7 +178,6 @@ func NewAttachDetachController(
 		adc.desiredStateOfWorld,
 		adc.actualStateOfWorld,
 		adc.attacherDetacher,
-		adc.nodeStatusUpdater,
 		adc.nodeLister,
 		recorder)
 

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -435,6 +435,9 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 	}
 
 	wg.Go(func() {
+		adc.nodeStatusUpdater.Run(tCtx, 1)
+	})
+	wg.Go(func() {
 		adc.reconciler.Run(tCtx)
 	})
 	wg.Go(func() {

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	kcache "k8s.io/client-go/tools/cache"
@@ -121,21 +120,11 @@ func Test_AttachDetachControllerStateOfWorldPopulators_Positive(t *testing.T) {
 
 	for _, node := range nodes {
 		nodeName := types.NodeName(node.Name)
-		inUseVolumes := sets.New(node.Status.VolumesInUse...)
-		allAttachedVolumes := map[v1.UniqueVolumeName]cache.AttachedVolume{}
-		for _, v := range adc.actualStateOfWorld.GetAttachedVolumesForNode(nodeName) {
-			allAttachedVolumes[v.VolumeName] = v
-		}
 
 		for _, attachedVolume := range node.Status.VolumesAttached {
 			attachedState := adc.actualStateOfWorld.GetAttachState(attachedVolume.Name, nodeName)
 			if attachedState != cache.AttachStateAttached {
 				t.Fatalf("Run failed with error. Node %s, volume %s not found", nodeName, attachedVolume.Name)
-			}
-			inUse := inUseVolumes.Has(attachedVolume.Name)
-			mounted := allAttachedVolumes[attachedVolume.Name].MountedByNode
-			if mounted != inUse {
-				t.Fatalf("Node %s, volume %s MountedByNode %v unexpected", nodeName, attachedVolume.Name, mounted)
 			}
 		}
 	}

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -22,8 +22,9 @@ reference them.
 package cache
 
 import (
-	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -36,6 +37,23 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 )
+
+type NodeStatusReport int
+
+const (
+	// NodeStatusReportRemoved indicates that the volume is not present in node status.volumesAttached.
+	NodeStatusReportRemoved NodeStatusReport = iota
+	// NodeStatusReportForceRemoving indicates that the volume is requested to be removed from the node status.volumesAttached
+	// even if it is in use.
+	NodeStatusReportForceRemoving
+	// NodeStatusReportAdding indicates that the volume is requested to be added to the node status.volumesAttached.
+	NodeStatusReportAdding
+)
+
+type VolumeToReport struct {
+	Volume v1.AttachedVolume
+	Report NodeStatusReport
+}
 
 // ActualStateOfWorld defines a set of thread-safe operations supported on
 // the attach/detach controller's actual state of the world cache.
@@ -70,12 +88,25 @@ type ActualStateOfWorld interface {
 	// Otherwise, the volume is not mounted by the given node.
 	SetVolumesMountedByNode(logger klog.Logger, volumeNames []v1.UniqueVolumeName, nodeName types.NodeName)
 
-	// SetNodeStatusUpdateNeeded sets statusUpdateNeeded for the specified
-	// node to true indicating the AttachedVolume field in the Node's Status
-	// object needs to be updated by the node updater again.
+	// SetNodeUpdateHook sets a hook to be called when the node status update
+	// is needed. The hook should update the node asynchronously and call
+	// [ConfirmNodeStatusRemoved] when the update is finished.
+	SetNodeUpdateHook(hook func(types.NodeName))
+
+	// Marks desire to detach the specified volume (remove the volume from the node's
+	// volumesToReportAsAttached list)
+	// Returns true if the update has been propagated to the node object.
+	RemoveVolumeFromReportAsAttached(volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool
+
+	// Unmarks the desire to detach for the specified volume (add the volume back to
+	// the node's volumesToReportAsAttached list)
+	AddVolumeToReportAsAttached(logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName)
+
+	// ConfirmNodeStatusRemoved indicates removedVolumes have been removed from the
+	// AttachedVolume field in the Node's Status in API server.
 	// If the specified node does not exist in the nodesToUpdateStatusFor list,
 	// log the error and return
-	SetNodeStatusUpdateNeeded(logger klog.Logger, nodeName types.NodeName)
+	ConfirmNodeStatusRemoved(logger klog.Logger, nodeName types.NodeName, removedVolumes []v1.UniqueVolumeName)
 
 	// ResetDetachRequestTime resets the detachRequestTime to 0 which indicates there is no detach
 	// request any more for the volume
@@ -124,19 +155,10 @@ type ActualStateOfWorld interface {
 	// This function is used by reconciler for multi-attach check.
 	GetNodesForAttachedVolume(volumeName v1.UniqueVolumeName) []types.NodeName
 
-	// GetVolumesToReportAttached returns a map containing the set of nodes for
-	// which the VolumesAttached Status field in the Node API object should be
-	// updated. The key in this map is the name of the node to update and the
-	// value is list of volumes that should be reported as attached (note that
-	// this may differ from the actual list of attached volumes for the node
-	// since volumes should be removed from this list as soon a detach operation
-	// is considered, before the detach operation is triggered).
-	GetVolumesToReportAttached(logger klog.Logger) map[types.NodeName][]v1.AttachedVolume
-
 	// GetVolumesToReportAttachedForNode returns the list of volumes that should be reported as
-	// attached for the given node. It reports a boolean indicating if there is an update for that
-	// node and the corresponding attachedVolumes list.
-	GetVolumesToReportAttachedForNode(logger klog.Logger, name types.NodeName) (bool, []v1.AttachedVolume)
+	// attached for the given node. And a list of volumes that should be removed from this node.
+	// Caller should call [ConfirmNodeStatusRemoved] after the volumes are removed from API server.
+	GetVolumesToReportAttachedForNode(logger klog.Logger, name types.NodeName) []VolumeToReport
 
 	// GetNodesToUpdateStatusFor returns the map of nodeNames to nodeToUpdateStatusFor
 	GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor
@@ -191,6 +213,7 @@ func NewActualStateOfWorld(volumePluginMgr *volume.VolumePluginMgr) ActualStateO
 		nodesToUpdateStatusFor: make(map[types.NodeName]nodeToUpdateStatusFor),
 		inUseVolumes:           make(map[types.NodeName]sets.Set[v1.UniqueVolumeName]),
 		volumePluginMgr:        volumePluginMgr,
+		nodeUpdateHook:         func(types.NodeName) {},
 	}
 }
 
@@ -206,6 +229,9 @@ type actualStateOfWorld struct {
 	// of the node and the value is an object containing more information about
 	// the node (including the list of volumes to report attached).
 	nodesToUpdateStatusFor map[types.NodeName]nodeToUpdateStatusFor
+	// invoked when nodesToUpdateStatusFor is updated. The change should be
+	// updated to Node object asynchronously.
+	nodeUpdateHook func(nodeName types.NodeName)
 
 	// inUseVolumes is a map containing the set of volumes that are reported as
 	// in use by the kubelet.
@@ -257,22 +283,12 @@ type nodeAttachedTo struct {
 // volume attached. It keeps track of the volumes that should be reported as
 // attached in the Node's Status API object.
 type nodeToUpdateStatusFor struct {
-	// nodeName contains the name of this node.
-	nodeName types.NodeName
-
-	// statusUpdateNeeded indicates that the value of the VolumesAttached field
-	// in the Node's Status API object should be updated. This should be set to
-	// true whenever a volume is added or deleted from
-	// volumesToReportAsAttached. It should be reset whenever the status is
-	// updated.
-	statusUpdateNeeded bool
-
 	// volumesToReportAsAttached is the list of volumes that should be reported
 	// as attached in the Node's status (note that this may differ from the
 	// actual list of attached volumes since volumes should be removed from this
 	// list as soon a detach operation is considered, before the detach
 	// operation is triggered).
-	volumesToReportAsAttached map[v1.UniqueVolumeName]v1.UniqueVolumeName
+	volumesToReportAsAttached map[v1.UniqueVolumeName]NodeStatusReport
 }
 
 func (asw *actualStateOfWorld) MarkVolumeAsUncertain(
@@ -296,7 +312,7 @@ func (asw *actualStateOfWorld) MarkVolumeAsDetached(
 }
 
 func (asw *actualStateOfWorld) RemoveVolumeFromReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) error {
+	volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
 	asw.Lock()
 	defer asw.Unlock()
 	return asw.removeVolumeFromReportAsAttached(volumeName, nodeName)
@@ -466,23 +482,20 @@ func (asw *actualStateOfWorld) getNodeAndVolume(
 // Remove the volumeName from the node's volumesToReportAsAttached list
 // This is an internal function and caller should acquire and release the lock
 func (asw *actualStateOfWorld) removeVolumeFromReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) error {
+	volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
 
-	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[nodeName]
-	if nodeToUpdateExists {
-		_, nodeToUpdateVolumeExists :=
-			nodeToUpdate.volumesToReportAsAttached[volumeName]
-		if nodeToUpdateVolumeExists {
-			nodeToUpdate.statusUpdateNeeded = true
-			delete(nodeToUpdate.volumesToReportAsAttached, volumeName)
-			asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
-			return nil
-		}
+	nodeToUpdate := asw.nodesToUpdateStatusFor[nodeName]
+	report := nodeToUpdate.volumesToReportAsAttached[volumeName]
+	if report == NodeStatusReportRemoved {
+		return true
 	}
-	return fmt.Errorf("volume %q does not exist in volumesToReportAsAttached list or node %q does not exist in nodesToUpdateStatusFor list",
-		volumeName,
-		nodeName)
-
+	expect := NodeStatusReportForceRemoving
+	if report != expect {
+		nodeToUpdate.volumesToReportAsAttached[volumeName] = expect
+		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
+		asw.nodeUpdateHook(nodeName)
+	}
+	return false
 }
 
 // Add the volumeName to the node's volumesToReportAsAttached list
@@ -498,47 +511,46 @@ func (asw *actualStateOfWorld) addVolumeToReportAsAttached(
 	if !nodeToUpdateExists {
 		// Create object if it doesn't exist
 		nodeToUpdate = nodeToUpdateStatusFor{
-			nodeName:                  nodeName,
-			statusUpdateNeeded:        true,
-			volumesToReportAsAttached: make(map[v1.UniqueVolumeName]v1.UniqueVolumeName),
+			volumesToReportAsAttached: make(map[v1.UniqueVolumeName]NodeStatusReport),
 		}
 		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
 		logger.V(4).Info("Add new node to nodesToUpdateStatusFor", "node", klog.KRef("", string(nodeName)))
 	}
-	_, nodeToUpdateVolumeExists :=
-		nodeToUpdate.volumesToReportAsAttached[volumeName]
-	if !nodeToUpdateVolumeExists {
-		nodeToUpdate.statusUpdateNeeded = true
-		nodeToUpdate.volumesToReportAsAttached[volumeName] = volumeName
+	report := nodeToUpdate.volumesToReportAsAttached[volumeName]
+	if report != NodeStatusReportAdding {
+		nodeToUpdate.volumesToReportAsAttached[volumeName] = NodeStatusReportAdding
 		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
-		logger.V(4).Info("Report volume as attached to node", "node", klog.KRef("", string(nodeName)), "volumeName", volumeName)
+		logger.V(4).Info("Report volume as attached to node",
+			"node", klog.KRef("", string(nodeName)), "volumeName", volumeName)
+		asw.nodeUpdateHook(nodeName)
 	}
 }
 
-// Update the flag statusUpdateNeeded to indicate whether node status is already updated or
-// needs to be updated again by the node status updater.
-// If the specified node does not exist in the nodesToUpdateStatusFor list, log the error and return
-// This is an internal function and caller should acquire and release the lock
-func (asw *actualStateOfWorld) updateNodeStatusUpdateNeeded(nodeName types.NodeName, needed bool) error {
+func (asw *actualStateOfWorld) SetNodeUpdateHook(hook func(types.NodeName)) {
+	asw.Lock()
+	defer asw.Unlock()
+	asw.nodeUpdateHook = hook
+}
+
+func (asw *actualStateOfWorld) ConfirmNodeStatusRemoved(logger klog.Logger, nodeName types.NodeName, removedVolumes []v1.UniqueVolumeName) {
+	asw.Lock()
+	defer asw.Unlock()
+
 	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[nodeName]
 	if !nodeToUpdateExists {
 		// should not happen
-		errMsg := fmt.Sprintf("Failed to set statusUpdateNeeded to needed %t, because nodeName=%q does not exist",
-			needed, nodeName)
-		return errors.New(errMsg)
+		logger.V(2).Info("Failed to ConfirmNodeStatusRemoved because node does not exist", "node", nodeName)
+		return
 	}
 
-	nodeToUpdate.statusUpdateNeeded = needed
-	asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
-
-	return nil
-}
-
-func (asw *actualStateOfWorld) SetNodeStatusUpdateNeeded(logger klog.Logger, nodeName types.NodeName) {
-	asw.Lock()
-	defer asw.Unlock()
-	if err := asw.updateNodeStatusUpdateNeeded(nodeName, true); err != nil {
-		logger.Info("Failed to update statusUpdateNeeded field in actual state of world", "err", err)
+	for _, volumeName := range removedVolumes {
+		// The volume may have been re-added by the reconciler while our node status update was in flight
+		switch nodeToUpdate.volumesToReportAsAttached[volumeName] {
+		case NodeStatusReportRemoving, NodeStatusReportForceRemoving:
+			delete(nodeToUpdate.volumesToReportAsAttached, volumeName)
+			logger.V(4).Info("Confirmed volume removal from node status",
+				"node", klog.KRef("", string(nodeName)), "volumeName", volumeName)
+		}
 	}
 }
 
@@ -663,66 +675,35 @@ func (asw *actualStateOfWorld) GetNodesForAttachedVolume(volumeName v1.UniqueVol
 	return nodes
 }
 
-func (asw *actualStateOfWorld) GetVolumesToReportAttached(logger klog.Logger) map[types.NodeName][]v1.AttachedVolume {
-	asw.Lock()
-	defer asw.Unlock()
-
-	volumesToReportAttached := make(map[types.NodeName][]v1.AttachedVolume)
-	for nodeName, nodeToUpdateObj := range asw.nodesToUpdateStatusFor {
-		if nodeToUpdateObj.statusUpdateNeeded {
-			volumesToReportAttached[nodeToUpdateObj.nodeName] = asw.getAttachedVolumeFromUpdateObject(nodeToUpdateObj.volumesToReportAsAttached)
-		}
-		// When GetVolumesToReportAttached is called by node status updater, the current status
-		// of this node will be updated, so set the flag statusUpdateNeeded to false indicating
-		// the current status is already updated.
-		if err := asw.updateNodeStatusUpdateNeeded(nodeName, false); err != nil {
-			logger.Error(err, "Failed to update statusUpdateNeeded field when getting volumes")
-		}
-	}
-
-	return volumesToReportAttached
-}
-
-func (asw *actualStateOfWorld) GetVolumesToReportAttachedForNode(logger klog.Logger, nodeName types.NodeName) (bool, []v1.AttachedVolume) {
+func (asw *actualStateOfWorld) GetVolumesToReportAttachedForNode(logger klog.Logger, nodeName types.NodeName) []VolumeToReport {
 	asw.Lock()
 	defer asw.Unlock()
 
 	nodeToUpdateObj, ok := asw.nodesToUpdateStatusFor[nodeName]
 	if !ok {
-		return false, nil
-	}
-	if !nodeToUpdateObj.statusUpdateNeeded {
-		return false, nil
+		return nil
 	}
 
-	volumesToReportAttached := asw.getAttachedVolumeFromUpdateObject(nodeToUpdateObj.volumesToReportAsAttached)
-	// When GetVolumesToReportAttached is called by node status updater, the current status
-	// of this node will be updated, so set the flag statusUpdateNeeded to false indicating
-	// the current status is already updated.
-	if err := asw.updateNodeStatusUpdateNeeded(nodeName, false); err != nil {
-		logger.Error(err, "Failed to update statusUpdateNeeded field when getting volumes")
+	volumesToReportAsAttached := nodeToUpdateObj.volumesToReportAsAttached
+	volumes := make([]VolumeToReport, 0, len(volumesToReportAsAttached))
+	for name, report := range volumesToReportAsAttached {
+		volumes = append(volumes, VolumeToReport{
+			Volume: v1.AttachedVolume{
+				Name:       name,
+				DevicePath: asw.attachedVolumes[name].devicePath,
+			},
+			Report: report,
+		})
 	}
-
-	return true, volumesToReportAttached
+	// Sort to ensure consistent order and avoid unnecessary updates
+	slices.SortFunc(volumes, func(a, b VolumeToReport) int {
+		return strings.Compare(string(a.Volume.Name), string(b.Volume.Name))
+	})
+	return volumes
 }
 
 func (asw *actualStateOfWorld) GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor {
 	return asw.nodesToUpdateStatusFor
-}
-
-func (asw *actualStateOfWorld) getAttachedVolumeFromUpdateObject(volumesToReportAsAttached map[v1.UniqueVolumeName]v1.UniqueVolumeName) []v1.AttachedVolume {
-	var attachedVolumes = make(
-		[]v1.AttachedVolume,
-		0,
-		len(volumesToReportAsAttached) /* len */)
-	for _, volume := range volumesToReportAsAttached {
-		attachedVolumes = append(attachedVolumes,
-			v1.AttachedVolume{
-				Name:       volume,
-				DevicePath: asw.attachedVolumes[volume].devicePath,
-			})
-	}
-	return attachedVolumes
 }
 
 func (asw *actualStateOfWorld) getAttachedVolume(

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -96,7 +96,7 @@ type ActualStateOfWorld interface {
 	// Marks desire to detach the specified volume (remove the volume from the node's
 	// volumesToReportAsAttached list)
 	// Returns true if the update has been propagated to the node object.
-	RemoveVolumeFromReportAsAttached(volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool
+	RemoveVolumeFromReportAsAttached(logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool
 
 	// Unmarks the desire to detach for the specified volume (add the volume back to
 	// the node's volumesToReportAsAttached list)
@@ -312,10 +312,10 @@ func (asw *actualStateOfWorld) MarkVolumeAsDetached(
 }
 
 func (asw *actualStateOfWorld) RemoveVolumeFromReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
+	logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
 	asw.Lock()
 	defer asw.Unlock()
-	return asw.removeVolumeFromReportAsAttached(volumeName, nodeName)
+	return asw.removeVolumeFromReportAsAttached(logger, volumeName, nodeName)
 }
 
 func (asw *actualStateOfWorld) AddVolumeToReportAsAttached(
@@ -482,17 +482,20 @@ func (asw *actualStateOfWorld) getNodeAndVolume(
 // Remove the volumeName from the node's volumesToReportAsAttached list
 // This is an internal function and caller should acquire and release the lock
 func (asw *actualStateOfWorld) removeVolumeFromReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
+	logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
 
 	nodeToUpdate := asw.nodesToUpdateStatusFor[nodeName]
 	report := nodeToUpdate.volumesToReportAsAttached[volumeName]
 	if report == NodeStatusReportRemoved {
+		logger.V(4).Info("Volume already removed from node status", "node", klog.KRef("", string(nodeName)), "volumeName", volumeName)
 		return true
 	}
 	expect := NodeStatusReportForceRemoving
 	if report != expect {
 		nodeToUpdate.volumesToReportAsAttached[volumeName] = expect
 		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
+		logger.V(4).Info("Report volume as not attached to node",
+			"node", klog.KRef("", string(nodeName)), "volumeName", volumeName)
 		asw.nodeUpdateHook(nodeName)
 	}
 	return false
@@ -574,7 +577,7 @@ func (asw *actualStateOfWorld) DeleteVolumeNode(
 	}
 
 	// Remove volume from volumes to report as attached
-	asw.removeVolumeFromReportAsAttached(volumeName, nodeName)
+	asw.removeVolumeFromReportAsAttached(klog.TODO(), volumeName, nodeName)
 }
 
 func (asw *actualStateOfWorld) GetAttachState(

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -31,7 +31,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -81,14 +80,6 @@ type ActualStateOfWorld interface {
 	// If no node with the name nodeName exists in list of attached nodes for
 	// the specified volume, the node is added.
 	AddVolumeNode(logger klog.Logger, uniqueName v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string, attached bool) (v1.UniqueVolumeName, error)
-
-	// SetVolumesMountedByNode sets all the volumes mounted by the given node.
-	// These volumes should include attached volumes, not-yet-attached volumes,
-	// and may also include non-attachable volumes.
-	// When present in the volumeNames parameter, the volume
-	// is mounted by the given node, indicating it may not be safe to detach.
-	// Otherwise, the volume is not mounted by the given node.
-	SetVolumesMountedByNode(logger klog.Logger, volumeNames []v1.UniqueVolumeName, nodeName types.NodeName)
 
 	// SetNodeUpdateHook sets a hook to be called when the node status update
 	// is needed. The hook should update the node asynchronously and call
@@ -171,11 +162,6 @@ type ActualStateOfWorld interface {
 type AttachedVolume struct {
 	operationexecutor.AttachedVolume
 
-	// MountedByNode indicates that this volume has been mounted by the node and
-	// is unsafe to detach.
-	// The value is set and unset by SetVolumesMountedByNode(...).
-	MountedByNode bool
-
 	// DetachRequestedTime is used to capture the desire to detach this volume.
 	// When the volume is newly created this value is set to time zero.
 	// It is set to current time, when SetDetachRequestTime(...) is called, if it
@@ -214,7 +200,6 @@ func NewActualStateOfWorld(volumePluginMgr *volume.VolumePluginMgr) ActualStateO
 	return &actualStateOfWorld{
 		attachedVolumes:        make(map[v1.UniqueVolumeName]attachedVolume),
 		nodesToUpdateStatusFor: make(map[types.NodeName]nodeToUpdateStatusFor),
-		inUseVolumes:           make(map[types.NodeName]sets.Set[v1.UniqueVolumeName]),
 		volumePluginMgr:        volumePluginMgr,
 		nodeUpdateHook:         func(types.NodeName) {},
 	}
@@ -235,10 +220,6 @@ type actualStateOfWorld struct {
 	// invoked when nodesToUpdateStatusFor is updated. The change should be
 	// updated to Node object asynchronously.
 	nodeUpdateHook func(nodeName types.NodeName)
-
-	// inUseVolumes is a map containing the set of volumes that are reported as
-	// in use by the kubelet.
-	inUseVolumes map[types.NodeName]sets.Set[v1.UniqueVolumeName]
 
 	// volumePluginMgr is the volume plugin manager used to create volume
 	// plugin objects.
@@ -387,12 +368,6 @@ func (asw *actualStateOfWorld) AddVolumeNode(
 			attachedConfirmed:   isAttached,
 			detachRequestedTime: time.Time{},
 		}
-		// Assume mounted, until proven otherwise
-		if asw.inUseVolumes[nodeName] == nil {
-			asw.inUseVolumes[nodeName] = sets.New(volumeName)
-		} else {
-			asw.inUseVolumes[nodeName].Insert(volumeName)
-		}
 	} else {
 		node.attachedConfirmed = isAttached
 		logger.V(5).Info("Volume is already added to attachedVolume list to the node",
@@ -408,17 +383,6 @@ func (asw *actualStateOfWorld) AddVolumeNode(
 		asw.addVolumeToReportAsAttached(logger, volumeName, nodeName)
 	}
 	return volumeName, nil
-}
-
-func (asw *actualStateOfWorld) SetVolumesMountedByNode(
-	logger klog.Logger, volumeNames []v1.UniqueVolumeName, nodeName types.NodeName) {
-	asw.Lock()
-	defer asw.Unlock()
-
-	asw.inUseVolumes[nodeName] = sets.New(volumeNames...)
-	logger.V(5).Info("SetVolumesMountedByNode volume to the node",
-		"node", klog.KRef("", string(nodeName)),
-		"volumeNames", volumeNames)
 }
 
 func (asw *actualStateOfWorld) ResetDetachRequestTime(
@@ -726,6 +690,5 @@ func (asw *actualStateOfWorld) getAttachedVolume(
 			DevicePath:         attachedVolume.devicePath,
 			PluginIsAttachable: true,
 		},
-		MountedByNode:       asw.inUseVolumes[nodeAttachedTo.nodeName].Has(attachedVolume.volumeName),
 		DetachRequestedTime: nodeAttachedTo.detachRequestedTime}
 }

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -43,6 +43,8 @@ type NodeStatusReport int
 const (
 	// NodeStatusReportRemoved indicates that the volume is not present in node status.volumesAttached.
 	NodeStatusReportRemoved NodeStatusReport = iota
+	// NodeStatusReportRemoving indicates that the volume is requested to be removed from the node status.volumesAttached.
+	NodeStatusReportRemoving
 	// NodeStatusReportForceRemoving indicates that the volume is requested to be removed from the node status.volumesAttached
 	// even if it is in use.
 	NodeStatusReportForceRemoving
@@ -95,8 +97,9 @@ type ActualStateOfWorld interface {
 
 	// Marks desire to detach the specified volume (remove the volume from the node's
 	// volumesToReportAsAttached list)
+	// verifySafeToDetach indicates whether to verify if the volume is in use before removal.
 	// Returns true if the update has been propagated to the node object.
-	RemoveVolumeFromReportAsAttached(logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool
+	RemoveVolumeFromReportAsAttached(logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName, verifySafeToDetach bool) bool
 
 	// Unmarks the desire to detach for the specified volume (add the volume back to
 	// the node's volumesToReportAsAttached list)
@@ -312,10 +315,10 @@ func (asw *actualStateOfWorld) MarkVolumeAsDetached(
 }
 
 func (asw *actualStateOfWorld) RemoveVolumeFromReportAsAttached(
-	logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
+	logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName, verifySafeToDetach bool) bool {
 	asw.Lock()
 	defer asw.Unlock()
-	return asw.removeVolumeFromReportAsAttached(logger, volumeName, nodeName)
+	return asw.removeVolumeFromReportAsAttached(logger, volumeName, nodeName, verifySafeToDetach)
 }
 
 func (asw *actualStateOfWorld) AddVolumeToReportAsAttached(
@@ -482,7 +485,7 @@ func (asw *actualStateOfWorld) getNodeAndVolume(
 // Remove the volumeName from the node's volumesToReportAsAttached list
 // This is an internal function and caller should acquire and release the lock
 func (asw *actualStateOfWorld) removeVolumeFromReportAsAttached(
-	logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
+	logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName, verifySafeToDetach bool) bool {
 
 	nodeToUpdate := asw.nodesToUpdateStatusFor[nodeName]
 	report := nodeToUpdate.volumesToReportAsAttached[volumeName]
@@ -491,6 +494,9 @@ func (asw *actualStateOfWorld) removeVolumeFromReportAsAttached(
 		return true
 	}
 	expect := NodeStatusReportForceRemoving
+	if verifySafeToDetach {
+		expect = NodeStatusReportRemoving
+	}
 	if report != expect {
 		nodeToUpdate.volumesToReportAsAttached[volumeName] = expect
 		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
@@ -577,7 +583,7 @@ func (asw *actualStateOfWorld) DeleteVolumeNode(
 	}
 
 	// Remove volume from volumes to report as attached
-	asw.removeVolumeFromReportAsAttached(klog.TODO(), volumeName, nodeName)
+	asw.removeVolumeFromReportAsAttached(klog.TODO(), volumeName, nodeName, false)
 }
 
 func (asw *actualStateOfWorld) GetAttachState(

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -61,7 +61,7 @@ func Test_AddVolumeNode_Positive_NewVolumeNewNode(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Calls AddVolumeNode() once with attached set to false.
@@ -96,7 +96,7 @@ func Test_AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached(t *testing.T)
 	if len(allVolumes) != 1 {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(allVolumes))
 	}
-	verifyAttachedVolume(t, allVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, allVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 
 	reportAsAttachedVolumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	if len(reportAsAttachedVolumes) > 0 {
@@ -107,7 +107,7 @@ func Test_AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached(t *testing.T)
 	if len(volumesForNode) != 1 {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(volumesForNode))
 	}
-	verifyAttachedVolume(t, volumesForNode, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, volumesForNode, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 
 	attachedVolumesMap := asw.GetAttachedVolumesPerNode()
 	_, exists := attachedVolumesMap[nodeName]
@@ -145,7 +145,7 @@ func Test_AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached(t *testing.T)
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 
 	nodes = asw.GetNodesForAttachedVolume(volumeName)
 	if len(nodes) != 1 {
@@ -215,14 +215,14 @@ func Test_AddVolumeNode_Positive_NewVolumeTwoNodesWithFalseAttached(t *testing.T
 	if len(attachedVolumes) != 2 {
 		t.Fatalf("len(attachedVolumes) Expected: <2> Actual: <%v>", len(attachedVolumes))
 	}
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), node1Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), node2Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), node1Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), node2Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 
 	volumesForNode := asw.GetAttachedVolumesForNode(node2Name)
 	if len(volumesForNode) != 1 {
 		t.Fatalf("len(attachedVolumes) Expected: <2> Actual: <%v>", len(volumesForNode))
 	}
-	verifyAttachedVolume(t, volumesForNode, generatedVolumeName, string(volumeName), node2Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, volumesForNode, generatedVolumeName, string(volumeName), node2Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 
 	attachedVolumesMap := asw.GetAttachedVolumesPerNode()
 	attachedVolumesPerNode, exists := attachedVolumesMap[node2Name]
@@ -288,8 +288,8 @@ func Test_AddVolumeNode_Positive_ExistingVolumeNewNode(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <2> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node1Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node2Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node1Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node2Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Calls AddVolumeNode() twice. Uses the same volume and node both times.
@@ -333,7 +333,7 @@ func Test_AddVolumeNode_Positive_ExistingVolumeExistingNode(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with one volume/node entry.
@@ -440,7 +440,7 @@ func Test_DeleteVolumeNode_Positive_TwoNodesOneDeleted(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node2Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node2Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with one volume/node entry.
@@ -473,7 +473,7 @@ func Test_VolumeNodeExists_Positive_VolumeExistsNodeExists(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with one volume1/node1 entry.
@@ -507,7 +507,7 @@ func Test_VolumeNodeExists_Positive_VolumeExistsNodeDoesntExist(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), node1Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), node1Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Calls GetAttachState() on empty data struct.
@@ -574,7 +574,7 @@ func Test_GetAttachedVolumes_Positive_OneVolumeOneNode(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with two volume/node entries (different node and volume).
@@ -609,8 +609,8 @@ func Test_GetAttachedVolumes_Positive_TwoVolumeTwoNodes(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <2> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volume1Name), node1Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName2, string(volume2Name), node2Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volume1Name), node1Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName2, string(volume2Name), node2Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with two volume/node entries (same volume different node).
@@ -658,176 +658,8 @@ func Test_GetAttachedVolumes_Positive_OneVolumeTwoNodes(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <2> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node1Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node2Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-}
-
-// Populates data struct with one volume/node entry.
-// Verifies mountedByNode is true and DetachRequestedTime is zero.
-func Test_SetVolumesMountedByNode_Positive_Set(t *testing.T) {
-	// Arrange
-	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
-	asw := NewActualStateOfWorld(volumePluginMgr)
-	volumeName := v1.UniqueVolumeName("volume-name")
-	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
-	nodeName := types.NodeName("node-name")
-	devicePath := "fake/device/path"
-	logger, _ := ktesting.NewTestContext(t)
-	generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
-
-	// Act: do not mark -- test default value
-
-	// Assert
-	attachedVolumes := asw.GetAttachedVolumes()
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-}
-
-// Populates data struct with one volume/node entry.
-// Calls SetVolumesMountedByNode twice, first setting mounted to true then false.
-// Verifies mountedByNode is false.
-func Test_SetVolumesMountedByNode_Positive_UnsetWithInitialSet(t *testing.T) {
-	// Arrange
-	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
-	asw := NewActualStateOfWorld(volumePluginMgr)
-	volumeName := v1.UniqueVolumeName("volume-name")
-	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
-	nodeName := types.NodeName("node-name")
-	devicePath := "fake/device/path"
-	logger, _ := ktesting.NewTestContext(t)
-	generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
-
-	// Act
-	asw.SetVolumesMountedByNode(logger, []v1.UniqueVolumeName{generatedVolumeName}, nodeName)
-	asw.SetVolumesMountedByNode(logger, nil, nodeName)
-
-	attachedVolumes := asw.GetAttachedVolumes()
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-}
-
-// Populates data struct with one volume/node entry.
-// Calls SetVolumesMountedByNode once, setting mounted to false.
-// Verifies mountedByNode is false because value is overwritten
-func Test_SetVolumesMountedByNode_Positive_UnsetWithoutInitialSet(t *testing.T) {
-	// Arrange
-	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
-	asw := NewActualStateOfWorld(volumePluginMgr)
-	volumeName := v1.UniqueVolumeName("volume-name")
-	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
-	nodeName := types.NodeName("node-name")
-	devicePath := "fake/device/path"
-	logger, _ := ktesting.NewTestContext(t)
-	generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
-
-	attachedVolumes := asw.GetAttachedVolumes()
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-
-	// Act
-	asw.SetVolumesMountedByNode(logger, nil, nodeName)
-
-	// Assert
-	attachedVolumes = asw.GetAttachedVolumes()
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-}
-
-// Populates data struct with one volume/node entry.
-// Calls SetVolumesMountedByNode twice, first setting mounted to true then false.
-// Calls AddVolumeNode to readd the same volume/node.
-// Verifies mountedByNode is false and detachRequestedTime is zero.
-func Test_SetVolumesMountedByNode_Positive_UnsetWithInitialSetAddVolumeNodeNotReset(t *testing.T) {
-	// Arrange
-	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
-	asw := NewActualStateOfWorld(volumePluginMgr)
-	volumeName := v1.UniqueVolumeName("volume-name")
-	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
-	nodeName := types.NodeName("node-name")
-	devicePath := "fake/device/path"
-	logger, _ := ktesting.NewTestContext(t)
-	generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
-
-	// Act
-	asw.SetVolumesMountedByNode(logger, []v1.UniqueVolumeName{generatedVolumeName}, nodeName)
-	asw.SetVolumesMountedByNode(logger, nil, nodeName)
-	generatedVolumeName, addErr = asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-
-	// Assert
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
-
-	attachedVolumes := asw.GetAttachedVolumes()
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-}
-
-// Populates data struct with one volume/node entry.
-// Calls RemoveVolumeFromReportAsAttached() once on volume/node entry.
-// Calls SetVolumesMountedByNode() twice, first setting mounted to true then false.
-// Verifies mountedByNode is false and detachRequestedTime is NOT zero.
-func Test_SetVolumesMountedByNode_Positive_UnsetWithInitialSetVerifyDetachRequestedTimePerserved(t *testing.T) {
-	// Arrange
-	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
-	asw := NewActualStateOfWorld(volumePluginMgr)
-	volumeName := v1.UniqueVolumeName("volume-name")
-	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
-	nodeName := types.NodeName("node-name")
-	devicePath := "fake/device/path"
-	logger, _ := ktesting.NewTestContext(t)
-	generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
-	_, err := asw.SetDetachRequestTime(logger, generatedVolumeName, nodeName)
-	if err != nil {
-		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
-	}
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
-	expectedDetachRequestedTime := asw.GetAttachedVolumes()[0].DetachRequestedTime
-
-	// Act
-	asw.SetVolumesMountedByNode(logger, []v1.UniqueVolumeName{generatedVolumeName}, nodeName)
-	asw.SetVolumesMountedByNode(logger, nil, nodeName)
-
-	// Assert
-	attachedVolumes := asw.GetAttachedVolumes()
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectedMountedByNode */, true /* expectNonZeroDetachRequestedTime */)
-	if !expectedDetachRequestedTime.Equal(attachedVolumes[0].DetachRequestedTime) {
-		t.Fatalf("DetachRequestedTime changed. Expected: <%v> Actual: <%v>", expectedDetachRequestedTime, attachedVolumes[0].DetachRequestedTime)
-	}
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node1Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node2Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with one volume/node entry.
@@ -854,7 +686,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_Set(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with one volume/node entry.
@@ -887,7 +719,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_Marked(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, true /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with one volume/node entry.
@@ -923,42 +755,7 @@ func Test_MarkDesireToDetach_Positive_MarkedAddVolumeNodeReset(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
-}
-
-// Populates data struct with one volume/node entry.
-// Calls SetVolumesMountedByNode() twice, first setting mounted to true then false.
-// Calls RemoveVolumeFromReportAsAttached() once on volume/node entry.
-// Verifies mountedByNode is false and detachRequestedTime is NOT zero.
-func Test_RemoveVolumeFromReportAsAttached_Positive_UnsetWithInitialSetVolumesMountedByNodePreserved(t *testing.T) {
-	// Arrange
-	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
-	asw := NewActualStateOfWorld(volumePluginMgr)
-	volumeName := v1.UniqueVolumeName("volume-name")
-	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
-	nodeName := types.NodeName("node-name")
-	devicePath := "fake/device/path"
-	logger, _ := ktesting.NewTestContext(t)
-	generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
-	}
-	asw.SetVolumesMountedByNode(logger, []v1.UniqueVolumeName{generatedVolumeName}, nodeName)
-	asw.SetVolumesMountedByNode(logger, nil, nodeName)
-	// Act
-	_, err := asw.SetDetachRequestTime(logger, generatedVolumeName, nodeName)
-	if err != nil {
-		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
-	}
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
-
-	// Assert
-	attachedVolumes := asw.GetAttachedVolumes()
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectedMountedByNode */, true /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Populates data struct with one volume/node entry.
@@ -1181,7 +978,7 @@ func Test_GetAttachedVolumesForNode_Positive_OneVolumeOneNode(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 func Test_GetAttachedVolumesForNode_Positive_TwoVolumeTwoNodes(t *testing.T) {
@@ -1213,7 +1010,7 @@ func Test_GetAttachedVolumesForNode_Positive_TwoVolumeTwoNodes(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName2, string(volume2Name), node2Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName2, string(volume2Name), node2Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 func Test_GetAttachedVolumesForNode_Positive_OneVolumeTwoNodes(t *testing.T) {
@@ -1258,7 +1055,7 @@ func Test_GetAttachedVolumesForNode_Positive_OneVolumeTwoNodes(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node1Name, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), node1Name, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 func Test_OneVolumeTwoNodes_TwoDevicePaths(t *testing.T) {
@@ -1304,7 +1101,7 @@ func Test_OneVolumeTwoNodes_TwoDevicePaths(t *testing.T) {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
 
-	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName2, string(volumeName), node2Name, devicePath2, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName2, string(volumeName), node2Name, devicePath2, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Test_ConfirmNodeStatusRemovedError expects the map nodesToUpdateStatusFor
@@ -1409,7 +1206,7 @@ func Test_MarkVolumeAsAttached(t *testing.T) {
 	if len(attachedVolumes) != 1 {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
-	verifyAttachedVolume(t, attachedVolumes, volumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, volumeName, string(volumeName), nodeName, devicePath, false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Mark a volume as attachment as uncertain.
@@ -1445,7 +1242,7 @@ func Test_MarkVolumeAsUncertain(t *testing.T) {
 	if len(attachedVolumes) != 1 {
 		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
 	}
-	verifyAttachedVolume(t, attachedVolumes, volumeName, string(volumeName), nodeName, "", true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
+	verifyAttachedVolume(t, attachedVolumes, volumeName, string(volumeName), nodeName, "", false /* expectNonZeroDetachRequestedTime */)
 }
 
 // Calls AddVolumeNode() once with attached set to true.
@@ -1510,25 +1307,22 @@ func verifyAttachedVolume(
 	expectedVolumeSpecName string,
 	expectedNodeName types.NodeName,
 	expectedDevicePath string,
-	expectedMountedByNode,
 	expectNonZeroDetachRequestedTime bool) {
 	for _, attachedVolume := range attachedVolumes {
 		if attachedVolume.VolumeName == expectedVolumeName &&
 			attachedVolume.VolumeSpec.Name() == expectedVolumeSpecName &&
 			attachedVolume.NodeName == expectedNodeName &&
 			attachedVolume.DevicePath == expectedDevicePath &&
-			attachedVolume.MountedByNode == expectedMountedByNode &&
 			attachedVolume.DetachRequestedTime.IsZero() == !expectNonZeroDetachRequestedTime {
 			return
 		}
 	}
 
 	t.Fatalf(
-		"attachedVolumes (%v) should contain the volume/node combo %q/%q with DevicePath=%q MountedByNode=%v and NonZeroDetachRequestedTime=%v. It does not.",
+		"attachedVolumes (%v) should contain the volume/node combo %q/%q with DevicePath=%q and NonZeroDetachRequestedTime=%v. It does not.",
 		attachedVolumes,
 		expectedVolumeName,
 		expectedNodeName,
 		expectedDevicePath,
-		expectedMountedByNode,
 		expectNonZeroDetachRequestedTime)
 }

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -811,7 +811,7 @@ func Test_SetVolumesMountedByNode_Positive_UnsetWithInitialSetVerifyDetachReques
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
 	expectedDetachRequestedTime := asw.GetAttachedVolumes()[0].DetachRequestedTime
 
 	// Act
@@ -879,7 +879,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_Marked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -913,7 +913,7 @@ func Test_MarkDesireToDetach_Positive_MarkedAddVolumeNodeReset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
 	// Reset detach request time to 0
 	asw.ResetDetachRequestTime(logger, generatedVolumeName, nodeName)
 
@@ -950,7 +950,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_UnsetWithInitialSetVolumesMo
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -983,7 +983,7 @@ func Test_RemoveVolumeFromReportAsAttached(t *testing.T) {
 	vol1 := addVol("vol1")
 	vol2 := addVol("vol2")
 
-	removed := asw.RemoveVolumeFromReportAsAttached(vol1, nodeName)
+	removed := asw.RemoveVolumeFromReportAsAttached(logger, vol1, nodeName)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
 	}
@@ -1000,7 +1000,7 @@ func Test_RemoveVolumeFromReportAsAttached(t *testing.T) {
 	}
 
 	// remove vol2 after get `volumes`
-	removed = asw.RemoveVolumeFromReportAsAttached(vol2, nodeName)
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol2, nodeName)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
 	}
@@ -1014,12 +1014,12 @@ func Test_RemoveVolumeFromReportAsAttached(t *testing.T) {
 
 	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{vol1})
 	// Should success after async node update
-	removed = asw.RemoveVolumeFromReportAsAttached(vol1, nodeName)
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol1, nodeName)
 	if !removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached failed. ConfirmNodeStatusRemoved not effective")
 	}
 	// vol2 should still fail, because we only confirmed vol1
-	removed = asw.RemoveVolumeFromReportAsAttached(vol2, nodeName)
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol2, nodeName)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
 	}
@@ -1053,7 +1053,7 @@ func Test_RemoveVolumeFromReportAsAttached_AddVolumeToReportAsAttached_Positive(
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
 	}
 
-	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
 
 	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	reportAsAttachedVolumes := addingVolumes(volumes)
@@ -1088,7 +1088,7 @@ func Test_RemoveVolumeFromReportAsAttached_Delete_AddVolumeNode(t *testing.T) {
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
 	}
 
-	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
 
 	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	reportAsAttachedVolumes := addingVolumes(volumes)
@@ -1480,7 +1480,7 @@ func Test_GetVolumesToReportAttachedForNode_Positive(t *testing.T) {
 		t.Fatalf("volumes Actual: <%v>", volumes)
 	}
 
-	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
 
 	volumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	if !slices.Equal(volumes, []VolumeToReport{

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cache
 
 import (
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -96,9 +98,8 @@ func Test_AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached(t *testing.T)
 	}
 	verifyAttachedVolume(t, allVolumes, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
 
-	reportAsAttachedVolumesMap := asw.GetVolumesToReportAttached(logger)
-	_, exists := reportAsAttachedVolumesMap[nodeName]
-	if exists {
+	reportAsAttachedVolumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	if len(reportAsAttachedVolumes) > 0 {
 		t.Fatalf("AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached failed. Actual: <node %q exist> Expect: <node does not exist in the reportedAsAttached map", nodeName)
 	}
 
@@ -109,7 +110,7 @@ func Test_AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached(t *testing.T)
 	verifyAttachedVolume(t, volumesForNode, generatedVolumeName, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
 
 	attachedVolumesMap := asw.GetAttachedVolumesPerNode()
-	_, exists = attachedVolumesMap[nodeName]
+	_, exists := attachedVolumesMap[nodeName]
 	if exists {
 		t.Fatalf("AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached failed. Actual: <node %q exist> Expect: <node does not exist in the reportedAsAttached map", nodeName)
 	}
@@ -234,8 +235,7 @@ func Test_AddVolumeNode_Positive_NewVolumeTwoNodesWithFalseAttached(t *testing.T
 		t.Fatalf("AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached failed. Expect one node returned.")
 	}
 
-	reportAsAttachedVolumesMap := asw.GetVolumesToReportAttached(logger)
-	reportedVolumes, exists := reportAsAttachedVolumesMap[node2Name]
+	reportedVolumes := asw.GetVolumesToReportAttachedForNode(logger, node2Name)
 	if !exists || len(reportedVolumes) != 1 {
 		t.Fatalf("AddVolumeNode_Positive_NewVolumeNewNodeWithFalseAttached failed. Actual: <node %q exist> Expect: <node does not exist in the reportedAsAttached map", node2Name)
 	}
@@ -811,10 +811,7 @@ func Test_SetVolumesMountedByNode_Positive_UnsetWithInitialSetVerifyDetachReques
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	err = asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
-	if err != nil {
-		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", err)
-	}
+	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
 	expectedDetachRequestedTime := asw.GetAttachedVolumes()[0].DetachRequestedTime
 
 	// Act
@@ -882,10 +879,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_Marked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	markDesireToDetachErr := asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
-	if markDesireToDetachErr != nil {
-		t.Fatalf("MarkDesireToDetach failed. Expected: <no error> Actual: <%v>", markDesireToDetachErr)
-	}
+	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -919,14 +913,9 @@ func Test_MarkDesireToDetach_Positive_MarkedAddVolumeNodeReset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	markDesireToDetachErr := asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
 	// Reset detach request time to 0
 	asw.ResetDetachRequestTime(logger, generatedVolumeName, nodeName)
-
-	// Assert
-	if markDesireToDetachErr != nil {
-		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", markDesireToDetachErr)
-	}
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -961,10 +950,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_UnsetWithInitialSetVolumesMo
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	removeVolumeDetachErr := asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
-	if removeVolumeDetachErr != nil {
-		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", removeVolumeDetachErr)
-	}
+	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -982,30 +968,71 @@ func Test_RemoveVolumeFromReportAsAttached(t *testing.T) {
 	// Arrange
 	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
 	asw := NewActualStateOfWorld(volumePluginMgr)
-	volumeName := v1.UniqueVolumeName("volume-name")
-	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
+	updated := false
+	asw.SetNodeUpdateHook(func(types.NodeName) { updated = true })
 	nodeName := types.NodeName("node-name")
-	devicePath := "fake/device/path"
 	logger, _ := ktesting.NewTestContext(t)
-	generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, devicePath, true)
-	if addErr != nil {
-		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
+	addVol := func(volumeName v1.UniqueVolumeName) v1.UniqueVolumeName {
+		volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
+		generatedVolumeName, addErr := asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, "", true)
+		if addErr != nil {
+			t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
+		}
+		return generatedVolumeName
+	}
+	vol1 := addVol("vol1")
+	vol2 := addVol("vol2")
+
+	removed := asw.RemoveVolumeFromReportAsAttached(vol1, nodeName)
+	if removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
+	}
+	if !updated {
+		t.Fatalf("update hook is not called")
 	}
 
-	removeVolumeDetachErr := asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
-	if removeVolumeDetachErr != nil {
-		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", removeVolumeDetachErr)
+	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	if !slices.Equal(volumes, []VolumeToReport{
+		{v1.AttachedVolume{Name: vol1}, NodeStatusReportForceRemoving},
+		{v1.AttachedVolume{Name: vol2}, NodeStatusReportAdding},
+	}) {
+		t.Fatalf("reportAsAttachedVolumes Actual: %v", volumes)
 	}
 
-	reportAsAttachedVolumesMap := asw.GetVolumesToReportAttached(logger)
-	volumes, exists := reportAsAttachedVolumesMap[nodeName]
-	if !exists {
-		t.Fatalf("MarkDesireToDetach_UnmarkDesireToDetach failed. Expected: <node %q exist> Actual: <node does not exist in the reportedAsAttached map", nodeName)
+	// remove vol2 after get `volumes`
+	removed = asw.RemoveVolumeFromReportAsAttached(vol2, nodeName)
+	if removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
 	}
-	if len(volumes) > 0 {
-		t.Fatalf("len(reportAsAttachedVolumes) Expected: <0> Actual: <%v>", len(volumes))
+	volumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	if !slices.Equal(volumes, []VolumeToReport{
+		{v1.AttachedVolume{Name: vol1}, NodeStatusReportForceRemoving},
+		{v1.AttachedVolume{Name: vol2}, NodeStatusReportForceRemoving},
+	}) {
+		t.Fatalf("reportAsAttachedVolumes Actual: %v", volumes)
 	}
 
+	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{vol1})
+	// Should success after async node update
+	removed = asw.RemoveVolumeFromReportAsAttached(vol1, nodeName)
+	if !removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached failed. ConfirmNodeStatusRemoved not effective")
+	}
+	// vol2 should still fail, because we only confirmed vol1
+	removed = asw.RemoveVolumeFromReportAsAttached(vol2, nodeName)
+	if removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
+	}
+}
+
+func addingVolumes(volumes []VolumeToReport) []v1.UniqueVolumeName {
+	var result []v1.UniqueVolumeName
+	for _, v := range volumes {
+		if v.Report == NodeStatusReportAdding {
+			result = append(result, v.Volume.Name)
+		}
+	}
+	return result
 }
 
 // Populates data struct with one volume/node entry.
@@ -1026,28 +1053,19 @@ func Test_RemoveVolumeFromReportAsAttached_AddVolumeToReportAsAttached_Positive(
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
 	}
 
-	removeVolumeDetachErr := asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
-	if removeVolumeDetachErr != nil {
-		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", removeVolumeDetachErr)
-	}
+	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
 
-	reportAsAttachedVolumesMap := asw.GetVolumesToReportAttached(logger)
-	volumes, exists := reportAsAttachedVolumesMap[nodeName]
-	if !exists {
-		t.Fatalf("Test_RemoveVolumeFromReportAsAttached_AddVolumeToReportAsAttached_Positive failed. Expected: <node %q exist> Actual: <node does not exist in the reportedAsAttached map", nodeName)
-	}
-	if len(volumes) > 0 {
-		t.Fatalf("len(reportAsAttachedVolumes) Expected: <0> Actual: <%v>", len(volumes))
+	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	reportAsAttachedVolumes := addingVolumes(volumes)
+	if len(reportAsAttachedVolumes) > 0 {
+		t.Fatalf("len(reportAsAttachedVolumes) Expected: <0> Actual: <%v>", len(reportAsAttachedVolumes))
 	}
 
 	asw.AddVolumeToReportAsAttached(logger, generatedVolumeName, nodeName)
-	reportAsAttachedVolumesMap = asw.GetVolumesToReportAttached(logger)
-	volumes, exists = reportAsAttachedVolumesMap[nodeName]
-	if !exists {
-		t.Fatalf("Test_RemoveVolumeFromReportAsAttached_AddVolumeToReportAsAttached_Positive failed. Expected: <node %q exist> Actual: <node does not exist in the reportedAsAttached map", nodeName)
-	}
-	if len(volumes) != 1 {
-		t.Fatalf("len(reportAsAttachedVolumes) Expected: <1> Actual: <%v>", len(volumes))
+	volumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	reportAsAttachedVolumes = addingVolumes(volumes)
+	if len(reportAsAttachedVolumes) != 1 {
+		t.Fatalf("len(reportAsAttachedVolumes) Expected: <1> Actual: <%v>", len(reportAsAttachedVolumes))
 	}
 }
 
@@ -1070,31 +1088,22 @@ func Test_RemoveVolumeFromReportAsAttached_Delete_AddVolumeNode(t *testing.T) {
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
 	}
 
-	removeVolumeDetachErr := asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
-	if removeVolumeDetachErr != nil {
-		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", removeVolumeDetachErr)
-	}
+	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
 
-	reportAsAttachedVolumesMap := asw.GetVolumesToReportAttached(logger)
-	volumes, exists := reportAsAttachedVolumesMap[nodeName]
-	if !exists {
-		t.Fatalf("Test_RemoveVolumeFromReportAsAttached_Delete_AddVolumeNode failed. Expected: <node %q exists> Actual: <node does not exist in the reportedAsAttached map", nodeName)
-	}
-	if len(volumes) > 0 {
-		t.Fatalf("len(reportAsAttachedVolumes) Expected: <0> Actual: <%v>", len(volumes))
+	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	reportAsAttachedVolumes := addingVolumes(volumes)
+	if len(reportAsAttachedVolumes) > 0 {
+		t.Fatalf("len(reportAsAttachedVolumes) Expected: <0> Actual: <%v>", len(reportAsAttachedVolumes))
 	}
 
 	asw.DeleteVolumeNode(generatedVolumeName, nodeName)
 
 	asw.AddVolumeNode(logger, volumeName, volumeSpec, nodeName, "" /*device path*/, true)
 
-	reportAsAttachedVolumesMap = asw.GetVolumesToReportAttached(logger)
-	volumes, exists = reportAsAttachedVolumesMap[nodeName]
-	if !exists {
-		t.Fatalf("Test_RemoveVolumeFromReportAsAttached_Delete_AddVolumeNode failed. Expected: <node %q exists> Actual: <node does not exist in the reportedAsAttached map", nodeName)
-	}
-	if len(volumes) != 1 {
-		t.Fatalf("len(reportAsAttachedVolumes) Expected: <1> Actual: <%v>", len(volumes))
+	volumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	reportAsAttachedVolumes = addingVolumes(volumes)
+	if len(reportAsAttachedVolumes) != 1 {
+		t.Fatalf("len(reportAsAttachedVolumes) Expected: <1> Actual: <%v>", len(reportAsAttachedVolumes))
 	}
 }
 
@@ -1298,10 +1307,10 @@ func Test_OneVolumeTwoNodes_TwoDevicePaths(t *testing.T) {
 	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName2, string(volumeName), node2Name, devicePath2, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
 }
 
-// Test_SetNodeStatusUpdateNeededError expects the map nodesToUpdateStatusFor
-// to be empty if the SetNodeStatusUpdateNeeded is called on a node that
+// Test_ConfirmNodeStatusRemovedError expects the map nodesToUpdateStatusFor
+// to be empty if the ConfirmNodeStatusRemoved is called on a node that
 // does not exist in the actual state of the world
-func Test_SetNodeStatusUpdateNeededError(t *testing.T) {
+func Test_ConfirmNodeStatusRemovedError(t *testing.T) {
 	// Arrange
 	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
 	asw := NewActualStateOfWorld(volumePluginMgr)
@@ -1309,7 +1318,7 @@ func Test_SetNodeStatusUpdateNeededError(t *testing.T) {
 
 	// Act
 	logger, _ := ktesting.NewTestContext(t)
-	asw.SetNodeStatusUpdateNeeded(logger, nodeName)
+	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{"any-volume"})
 
 	// Assert
 	nodesToUpdateStatusFor := asw.GetNodesToUpdateStatusFor()
@@ -1318,9 +1327,9 @@ func Test_SetNodeStatusUpdateNeededError(t *testing.T) {
 	}
 }
 
-// Test_updateNodeStatusUpdateNeeded expects statusUpdateNeeded to be properly updated if
-// updateNodeStatusUpdateNeeded is called on a node that exists in the actual state of the world
-func Test_updateNodeStatusUpdateNeeded(t *testing.T) {
+// Test_ConfirmNodeStatusRemoved expects volumesToReportAsAttached to be properly updated if
+// ConfirmNodeStatusRemoved is called on a node that exists in the actual state of the world
+func Test_ConfirmNodeStatusRemoved(t *testing.T) {
 	// Arrange
 	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
 	asw := &actualStateOfWorld{
@@ -1330,43 +1339,37 @@ func Test_updateNodeStatusUpdateNeeded(t *testing.T) {
 	}
 	nodeName := types.NodeName("node-1")
 	nodeToUpdate := nodeToUpdateStatusFor{
-		nodeName:                  nodeName,
-		statusUpdateNeeded:        true,
-		volumesToReportAsAttached: make(map[v1.UniqueVolumeName]v1.UniqueVolumeName),
+		volumesToReportAsAttached: map[v1.UniqueVolumeName]NodeStatusReport{
+			"volume-1": NodeStatusReportForceRemoving,
+			"volume-2": NodeStatusReportForceRemoving,
+			"volume-3": NodeStatusReportAdding,
+		},
 	}
 	asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
 
-	// Act
-	err := asw.updateNodeStatusUpdateNeeded(nodeName, false)
+	logger, _ := ktesting.NewTestContext(t)
+	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{"volume-1"})
 
-	// Assert
-	if err != nil {
-		t.Fatalf("updateNodeStatusUpdateNeeded should not return error, but got: %v", err)
+	volumes := asw.GetNodesToUpdateStatusFor()[nodeName].volumesToReportAsAttached
+	if !maps.Equal(volumes, map[v1.UniqueVolumeName]NodeStatusReport{"volume-2": NodeStatusReportForceRemoving, "volume-3": NodeStatusReportAdding}) {
+		t.Fatalf("expect volumes-2 and volumes-3 to be reported as attached, got %v", volumes)
 	}
-	nodesToUpdateStatusFor := asw.GetNodesToUpdateStatusFor()
-	if nodesToUpdateStatusFor[nodeName].statusUpdateNeeded {
-		t.Fatalf("nodesToUpdateStatusFor should be updated to: false, but got: true")
+
+	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{"volume-1", "volume-2"})
+
+	volumes = asw.GetNodesToUpdateStatusFor()[nodeName].volumesToReportAsAttached
+	if !maps.Equal(volumes, map[v1.UniqueVolumeName]NodeStatusReport{"volume-3": NodeStatusReportAdding}) {
+		t.Fatalf("expect volumes-3 to be reported as attached, got %v", volumes)
 	}
-}
 
-// Test_updateNodeStatusUpdateNeededError expects statusUpdateNeeded to report error if
-// updateNodeStatusUpdateNeeded is called on a node that does not exist in the actual state of the world
-func Test_updateNodeStatusUpdateNeededError(t *testing.T) {
-	// Arrange
-	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
-	asw := &actualStateOfWorld{
-		attachedVolumes:        make(map[v1.UniqueVolumeName]attachedVolume),
-		nodesToUpdateStatusFor: make(map[types.NodeName]nodeToUpdateStatusFor),
-		volumePluginMgr:        volumePluginMgr,
-	}
-	nodeName := types.NodeName("node-1")
+	// A volume that has been re-added (NodeStatusReportAdding) since the node
+	// status update was issued must not be dropped, even if it is named in
+	// removedVolumes. Otherwise the re-attach is lost.
+	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{"volume-3"})
 
-	// Act
-	err := asw.updateNodeStatusUpdateNeeded(nodeName, false)
-
-	// Assert
-	if err == nil {
-		t.Fatalf("updateNodeStatusUpdateNeeded should return error, but got nothing")
+	volumes = asw.GetNodesToUpdateStatusFor()[nodeName].volumesToReportAsAttached
+	if !maps.Equal(volumes, map[v1.UniqueVolumeName]NodeStatusReport{"volume-3": NodeStatusReportAdding}) {
+		t.Fatalf("expect re-added volume-3 to be preserved, got %v", volumes)
 	}
 }
 
@@ -1470,30 +1473,20 @@ func Test_GetVolumesToReportAttachedForNode_Positive(t *testing.T) {
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	needsUpdate, attachedVolumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
-	if !needsUpdate {
-		t.Fatalf("GetVolumesToReportAttachedForNode_Positive_NewVolumeNewNodeWithTrueAttached failed. Actual: <node %q does not need an update> Expect: <node exists in the reportedAsAttached map and needs an update", nodeName)
-	}
-	if len(attachedVolumes) != 1 {
-		t.Fatalf("len(attachedVolumes) Expected: <1> Actual: <%v>", len(attachedVolumes))
-	}
-
-	needsUpdate, _ = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
-	if needsUpdate {
-		t.Fatalf("GetVolumesToReportAttachedForNode_Positive_NewVolumeNewNodeWithTrueAttached failed. Actual: <node %q needs an update> Expect: <node exists in the reportedAsAttached map and does not need an update", nodeName)
+	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	if !slices.Equal(volumes, []VolumeToReport{
+		{v1.AttachedVolume{Name: volumeName, DevicePath: devicePath}, NodeStatusReportAdding},
+	}) {
+		t.Fatalf("volumes Actual: <%v>", volumes)
 	}
 
-	removeVolumeDetachErr := asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
-	if removeVolumeDetachErr != nil {
-		t.Fatalf("RemoveVolumeFromReportAsAttached failed. Expected: <no error> Actual: <%v>", removeVolumeDetachErr)
-	}
+	asw.RemoveVolumeFromReportAsAttached(generatedVolumeName, nodeName)
 
-	needsUpdate, attachedVolumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
-	if !needsUpdate {
-		t.Fatalf("GetVolumesToReportAttachedForNode_Positive_NewVolumeNewNodeWithTrueAttached failed. Actual: <node %q does not need an update> Expect: <node exists in the reportedAsAttached map and needs an update", nodeName)
-	}
-	if len(attachedVolumes) != 0 {
-		t.Fatalf("len(attachedVolumes) Expected: <0> Actual: <%v>", len(attachedVolumes))
+	volumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	if !slices.Equal(volumes, []VolumeToReport{
+		{v1.AttachedVolume{Name: volumeName, DevicePath: devicePath}, NodeStatusReportForceRemoving},
+	}) {
+		t.Fatalf("volumes Actual: <%v>", volumes)
 	}
 }
 
@@ -1504,9 +1497,9 @@ func Test_GetVolumesToReportAttachedForNode_UnknownNode(t *testing.T) {
 	asw := NewActualStateOfWorld(volumePluginMgr)
 	nodeName := types.NodeName("node-name")
 	logger, _ := ktesting.NewTestContext(t)
-	needsUpdate, _ := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
-	if needsUpdate {
-		t.Fatalf("GetVolumesToReportAttachedForNode_UnknownNode failed. Actual: <node %q needs an update> Expect: <node does not exist in the reportedAsAttached map and does not need an update", nodeName)
+	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+	if volumes != nil {
+		t.Fatalf("GetVolumesToReportAttachedForNode_UnknownNode failed. Actual: <%d volumes> Expect: <nil>", len(volumes))
 	}
 }
 

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -811,7 +811,7 @@ func Test_SetVolumesMountedByNode_Positive_UnsetWithInitialSetVerifyDetachReques
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
 	expectedDetachRequestedTime := asw.GetAttachedVolumes()[0].DetachRequestedTime
 
 	// Act
@@ -879,7 +879,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_Marked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -913,7 +913,7 @@ func Test_MarkDesireToDetach_Positive_MarkedAddVolumeNodeReset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
 	// Reset detach request time to 0
 	asw.ResetDetachRequestTime(logger, generatedVolumeName, nodeName)
 
@@ -950,7 +950,7 @@ func Test_RemoveVolumeFromReportAsAttached_Positive_UnsetWithInitialSetVolumesMo
 	if err != nil {
 		t.Fatalf("SetDetachRequestTime failed. Expected: <no error> Actual: <%v>", err)
 	}
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
 
 	// Assert
 	attachedVolumes := asw.GetAttachedVolumes()
@@ -983,7 +983,7 @@ func Test_RemoveVolumeFromReportAsAttached(t *testing.T) {
 	vol1 := addVol("vol1")
 	vol2 := addVol("vol2")
 
-	removed := asw.RemoveVolumeFromReportAsAttached(logger, vol1, nodeName)
+	removed := asw.RemoveVolumeFromReportAsAttached(logger, vol1, nodeName, false)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
 	}
@@ -1000,26 +1000,26 @@ func Test_RemoveVolumeFromReportAsAttached(t *testing.T) {
 	}
 
 	// remove vol2 after get `volumes`
-	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol2, nodeName)
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol2, nodeName, true)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
 	}
 	volumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	if !slices.Equal(volumes, []VolumeToReport{
 		{v1.AttachedVolume{Name: vol1}, NodeStatusReportForceRemoving},
-		{v1.AttachedVolume{Name: vol2}, NodeStatusReportForceRemoving},
+		{v1.AttachedVolume{Name: vol2}, NodeStatusReportRemoving},
 	}) {
 		t.Fatalf("reportAsAttachedVolumes Actual: %v", volumes)
 	}
 
 	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{vol1})
 	// Should success after async node update
-	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol1, nodeName)
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol1, nodeName, false)
 	if !removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached failed. ConfirmNodeStatusRemoved not effective")
 	}
 	// vol2 should still fail, because we only confirmed vol1
-	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol2, nodeName)
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, vol2, nodeName, false)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached succeeded. Should wait for ConfirmNodeStatusRemoved")
 	}
@@ -1053,7 +1053,7 @@ func Test_RemoveVolumeFromReportAsAttached_AddVolumeToReportAsAttached_Positive(
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
 	}
 
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
 
 	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	reportAsAttachedVolumes := addingVolumes(volumes)
@@ -1088,7 +1088,7 @@ func Test_RemoveVolumeFromReportAsAttached_Delete_AddVolumeNode(t *testing.T) {
 		t.Fatalf("AddVolumeNode failed. Expected: <no error> Actual: <%v>", addErr)
 	}
 
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
 
 	volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	reportAsAttachedVolumes := addingVolumes(volumes)
@@ -1341,7 +1341,7 @@ func Test_ConfirmNodeStatusRemoved(t *testing.T) {
 	nodeToUpdate := nodeToUpdateStatusFor{
 		volumesToReportAsAttached: map[v1.UniqueVolumeName]NodeStatusReport{
 			"volume-1": NodeStatusReportForceRemoving,
-			"volume-2": NodeStatusReportForceRemoving,
+			"volume-2": NodeStatusReportRemoving,
 			"volume-3": NodeStatusReportAdding,
 		},
 	}
@@ -1351,7 +1351,7 @@ func Test_ConfirmNodeStatusRemoved(t *testing.T) {
 	asw.ConfirmNodeStatusRemoved(logger, nodeName, []v1.UniqueVolumeName{"volume-1"})
 
 	volumes := asw.GetNodesToUpdateStatusFor()[nodeName].volumesToReportAsAttached
-	if !maps.Equal(volumes, map[v1.UniqueVolumeName]NodeStatusReport{"volume-2": NodeStatusReportForceRemoving, "volume-3": NodeStatusReportAdding}) {
+	if !maps.Equal(volumes, map[v1.UniqueVolumeName]NodeStatusReport{"volume-2": NodeStatusReportRemoving, "volume-3": NodeStatusReportAdding}) {
 		t.Fatalf("expect volumes-2 and volumes-3 to be reported as attached, got %v", volumes)
 	}
 
@@ -1480,7 +1480,7 @@ func Test_GetVolumesToReportAttachedForNode_Positive(t *testing.T) {
 		t.Fatalf("volumes Actual: <%v>", volumes)
 	}
 
-	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName)
+	asw.RemoveVolumeFromReportAsAttached(logger, generatedVolumeName, nodeName, false)
 
 	volumes = asw.GetVolumesToReportAttachedForNode(logger, nodeName)
 	if !slices.Equal(volumes, []VolumeToReport{

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/metrics"
-	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/statusupdater"
 	kevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
@@ -73,7 +72,6 @@ func NewReconciler(
 	desiredStateOfWorld cache.DesiredStateOfWorld,
 	actualStateOfWorld cache.ActualStateOfWorld,
 	attacherDetacher operationexecutor.OperationExecutor,
-	nodeStatusUpdater statusupdater.NodeStatusUpdater,
 	nodeLister corelisters.NodeLister,
 	recorder record.EventRecorder) Reconciler {
 	return &reconciler{
@@ -85,7 +83,6 @@ func NewReconciler(
 		desiredStateOfWorld:         desiredStateOfWorld,
 		actualStateOfWorld:          actualStateOfWorld,
 		attacherDetacher:            attacherDetacher,
-		nodeStatusUpdater:           nodeStatusUpdater,
 		nodeLister:                  nodeLister,
 		timeOfLastSync:              time.Now(),
 		recorder:                    recorder,
@@ -99,7 +96,6 @@ type reconciler struct {
 	desiredStateOfWorld         cache.DesiredStateOfWorld
 	actualStateOfWorld          cache.ActualStateOfWorld
 	attacherDetacher            operationexecutor.OperationExecutor
-	nodeStatusUpdater           statusupdater.NodeStatusUpdater
 	nodeLister                  corelisters.NodeLister
 	timeOfLastSync              time.Time
 	disableReconciliationSync   bool

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -240,7 +240,7 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 
 			// Before triggering volume detach, mark volume as detached and update the node status
 			// Wait until the update is propagated to Node object.
-			removed := rc.actualStateOfWorld.RemoveVolumeFromReportAsAttached(attachedVolume.VolumeName, attachedVolume.NodeName)
+			removed := rc.actualStateOfWorld.RemoveVolumeFromReportAsAttached(logger, attachedVolume.VolumeName, attachedVolume.NodeName)
 			if !removed {
 				logger.V(5).Info("waiting RemoveVolumeFromReportAsAttached",
 					"node", klog.KRef("", string(attachedVolume.NodeName)),

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -206,23 +206,22 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 				logger.Error(err, "Cannot trigger detach because it fails to set detach request time with error")
 				continue
 			}
-			// Check whether the umount drain timer expired
-			maxWaitForUnmountDurationExpired := elapsedTime > rc.maxWaitForUnmountDuration
-
-			isHealthy, err := rc.nodeIsHealthy(attachedVolume.NodeName)
-			if err != nil {
-				logger.V(5).Info("Failed to get health of node",
-					"node", klog.KRef("", string(attachedVolume.NodeName)),
-					"err", err)
-			}
 
 			// Force detach volumes from unhealthy nodes after maxWaitForUnmountDuration if force detach is enabled
 			// Ensure that the timeout condition checks this correctly so that the correct metric is updated below
-			forceDetachTimeoutExpired := maxWaitForUnmountDurationExpired && !rc.disableForceDetachOnTimeout
-			if maxWaitForUnmountDurationExpired && rc.disableForceDetachOnTimeout {
-				logger.V(5).Info("Drain timeout expired for volume but disableForceDetachOnTimeout was set", "node", klog.KRef("", string(attachedVolume.NodeName)), "volumeName", attachedVolume.VolumeName)
+			forceDetach := false
+			if !rc.disableForceDetachOnTimeout {
+				isHealthy, err := rc.nodeIsHealthy(attachedVolume.NodeName)
+				if err != nil {
+					logger.V(5).Info("Failed to get health of node",
+						"node", klog.KRef("", string(attachedVolume.NodeName)),
+						"err", err)
+				}
+				// Check whether the umount drain timer expired
+				if !isHealthy && elapsedTime > rc.maxWaitForUnmountDuration {
+					forceDetach = true
+				}
 			}
-			forceDetach := !isHealthy && forceDetachTimeoutExpired
 
 			hasOutOfServiceTaint, err := rc.hasOutOfServiceTaint(attachedVolume.NodeName)
 			if err != nil {
@@ -249,19 +248,19 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 			}
 
 			// Trigger detach volume which requires verifying safe to detach step
-			// If forceDetachTimeoutExpired is true, skip verifySafeToDetach check
+			// If forceDetach is true, skip verifySafeToDetach check
 			// If the node has node.kubernetes.io/out-of-service taint with NoExecute effect, skip verifySafeToDetach check
 			logger.V(5).Info("Starting attacherDetacher.DetachVolume", "node", klog.KRef("", string(attachedVolume.NodeName)), "volumeName", attachedVolume.VolumeName)
 			if hasOutOfServiceTaint {
 				logger.V(4).Info("node has out-of-service taint", "node", klog.KRef("", string(attachedVolume.NodeName)))
 			}
-			verifySafeToDetach := !forceDetachTimeoutExpired && !hasOutOfServiceTaint
+			verifySafeToDetach := !forceDetach && !hasOutOfServiceTaint
 			err = rc.attacherDetacher.DetachVolume(logger, attachedVolume.AttachedVolume, verifySafeToDetach, rc.actualStateOfWorld)
 			if err == nil {
 				if verifySafeToDetach { // normal detach
 					logger.Info("attacherDetacher.DetachVolume started", "node", klog.KRef("", string(attachedVolume.NodeName)), "volumeName", attachedVolume.VolumeName)
 				} else { // force detach
-					if forceDetachTimeoutExpired {
+					if forceDetach {
 						metrics.RecordForcedDetachMetric(metrics.ForceDetachReasonTimeout)
 						logger.Info("attacherDetacher.DetachVolume started: this volume is not safe to detach, but maxWaitForUnmountDuration expired, force detaching",
 							"duration", rc.maxWaitForUnmountDuration,

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -237,9 +237,10 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 				continue
 			}
 
+			verifySafeToDetach := !forceDetach && !hasOutOfServiceTaint
 			// Before triggering volume detach, mark volume as detached and update the node status
 			// Wait until the update is propagated to Node object.
-			removed := rc.actualStateOfWorld.RemoveVolumeFromReportAsAttached(logger, attachedVolume.VolumeName, attachedVolume.NodeName)
+			removed := rc.actualStateOfWorld.RemoveVolumeFromReportAsAttached(logger, attachedVolume.VolumeName, attachedVolume.NodeName, verifySafeToDetach)
 			if !removed {
 				logger.V(5).Info("waiting RemoveVolumeFromReportAsAttached",
 					"node", klog.KRef("", string(attachedVolume.NodeName)),
@@ -254,7 +255,6 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 			if hasOutOfServiceTaint {
 				logger.V(4).Info("node has out-of-service taint", "node", klog.KRef("", string(attachedVolume.NodeName)))
 			}
-			verifySafeToDetach := !forceDetach && !hasOutOfServiceTaint
 			err = rc.attacherDetacher.DetachVolume(logger, attachedVolume.AttachedVolume, verifySafeToDetach, rc.actualStateOfWorld)
 			if err == nil {
 				if verifySafeToDetach { // normal detach

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -232,11 +232,6 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 
 			// Check whether volume is still mounted. Skip detach if it is still mounted unless we have
 			// decided to force detach or the node has `node.kubernetes.io/out-of-service` taint.
-			if attachedVolume.MountedByNode && !forceDetach && !hasOutOfServiceTaint {
-				logger.V(5).Info("Cannot detach volume because it is still mounted", "node", klog.KRef("", string(attachedVolume.NodeName)), "volumeName", attachedVolume.VolumeName)
-				continue
-			}
-
 			verifySafeToDetach := !forceDetach && !hasOutOfServiceTaint
 			// Before triggering volume detach, mark volume as detached and update the node status
 			// Wait until the update is propagated to Node object.

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -224,8 +224,6 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithUnmountedVolume(t *te
 			generatedVolumeName,
 			nodeName)
 	}
-	asw.SetVolumesMountedByNode(logger, []v1.UniqueVolumeName{generatedVolumeName}, nodeName)
-	asw.SetVolumesMountedByNode(logger, nil, nodeName)
 
 	// Assert
 	waitForNewDetacherCallCount(t, 1 /* expectedCallCount */, fakePlugin)
@@ -281,6 +279,16 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithMountedVolume(t *test
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
 	nodeName := k8stypes.NodeName("node-name")
+	node1 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: string(nodeName)},
+		Status: v1.NodeStatus{
+			VolumesInUse: []v1.UniqueVolumeName{"fake-plugin/" + volumeName},
+		},
+	}
+	addErr := informerFactory.Core().V1().Nodes().Informer().GetStore().Add(node1)
+	if addErr != nil {
+		t.Fatalf("Add node failed. Expected: <no error> Actual: <%v>", addErr)
+	}
 	dsw.AddNode(nodeName)
 
 	volumeExists := dsw.VolumeExists(volumeName, nodeName)
@@ -398,8 +406,6 @@ func Test_Run_Negative_OneDesiredVolumeAttachThenDetachWithUnmountedVolumeUpdate
 			generatedVolumeName,
 			nodeName)
 	}
-	asw.SetVolumesMountedByNode(logger, []v1.UniqueVolumeName{generatedVolumeName}, nodeName)
-	asw.SetVolumesMountedByNode(logger, nil, nodeName)
 
 	// Assert
 	verifyNewDetacherCallCount(t, true /* expectZeroNewDetacherCallCount */, fakePlugin)
@@ -654,10 +660,6 @@ func Test_Run_OneVolumeAttachAndDetachUncertainNodesWithReadWriteOnce(t *testing
 	verifyVolumeAttachedToNode(t, generatedVolumeName, nodeName1, cache.AttachStateAttached, asw)
 	verifyVolumeReportedAsAttachedToNode(t, logger, generatedVolumeName, nodeName1, true, asw, volumeAttachedCheckTimeout)
 
-	// When volume is added to the node, it is set to mounted by default. Then the status will be updated by checking node status VolumeInUse.
-	// Without this, the delete operation will be delayed due to mounted status
-	asw.SetVolumesMountedByNode(logger, nil, nodeName1)
-
 	dsw.DeletePod(types.UniquePodName(podName1), generatedVolumeName, nodeName1)
 
 	waitForVolumeRemovedFromNode(t, generatedVolumeName, nodeName1, asw)
@@ -868,10 +870,6 @@ func Test_Run_OneVolumeAttachAndDetachTimeoutNodesWithReadWriteOnce(t *testing.T
 	waitForVolumeAddedToNode(t, generatedVolumeName, nodeName1, asw)
 	verifyVolumeAttachedToNode(t, generatedVolumeName, nodeName1, cache.AttachStateUncertain, asw)
 	verifyVolumeReportedAsAttachedToNode(t, logger, generatedVolumeName, nodeName1, false, asw, volumeAttachedCheckTimeout)
-
-	// When volume is added to the node, it is set to mounted by default. Then the status will be updated by checking node status VolumeInUse.
-	// Without this, the delete operation will be delayed due to mounted status
-	asw.SetVolumesMountedByNode(logger, nil, nodeName1)
 
 	dsw.DeletePod(types.UniquePodName(podName1), generatedVolumeName, nodeName1)
 
@@ -1111,6 +1109,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNode(t *testing.T) {
 					Status: v1.ConditionTrue,
 				},
 			},
+			VolumesInUse: []v1.UniqueVolumeName{"fake-plugin/" + volumeName1},
 		},
 	}
 	informerFactory.Core().V1().Nodes().Informer().GetStore().Add(node1)
@@ -1228,6 +1227,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled(t *
 					Status: v1.ConditionTrue,
 				},
 			},
+			VolumesInUse: []v1.UniqueVolumeName{"fake-plugin/" + volumeName1},
 		},
 	}
 	addErr := informerFactory.Core().V1().Nodes().Informer().GetStore().Add(node1)
@@ -1260,7 +1260,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled(t *
 	waitForDetachCallCount(t, 0 /* expectedDetachCallCount */, fakePlugin)
 
 	// Act
-	// Delete the pod and the volume will be detached even after the maxWaitForUnmountDuration expires as volume is
+	// Delete the pod and the volume will not be detached even after the maxWaitForUnmountDuration expires as volume is
 	// not unmounted and the node is healthy.
 	dsw.DeletePod(types.UniquePodName(podName1), generatedVolumeName, nodeName1)
 	time.Sleep(maxWaitForUnmountDuration * 5)
@@ -1845,6 +1845,7 @@ func verifyNewDetacherCallCount(
 	expectZeroNewDetacherCallCount bool,
 	fakePlugin *volumetesting.FakeVolumePlugin) {
 
+	t.Helper()
 	if expectZeroNewDetacherCallCount &&
 		fakePlugin.GetNewDetacherCallCount() != 0 {
 		t.Fatalf("Wrong NewDetacherCallCount. Expected: <0> Actual: <%v>",

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -86,14 +86,14 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu, err := statusupdater.NewNodeStatusUpdater(
+	_, err := statusupdater.NewNodeStatusUpdater(
 		logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	if err != nil {
 		t.Fatalf("Failed to create NodeStatusUpdater: %v", err)
 	}
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 
 	// Act
 	go reconciler.Run(ctx)
@@ -127,10 +127,10 @@ func Test_Run_Positive_OneDesiredVolumeAttach(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -182,10 +182,10 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithUnmountedVolume(t *te
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -274,9 +274,9 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithMountedVolume(t *test
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -356,10 +356,10 @@ func Test_Run_Negative_OneDesiredVolumeAttachThenDetachWithUnmountedVolumeUpdate
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	asw.SetNodeUpdateHook(func(k8stypes.NodeName) {}) // Simulate node status update failure
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -435,10 +435,10 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteMany(t *testing.
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -532,9 +532,9 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -626,9 +626,9 @@ func Test_Run_OneVolumeAttachAndDetachUncertainNodesWithReadWriteOnce(t *testing
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -689,9 +689,9 @@ func Test_Run_UpdateNodeStatusFailBeforeOneVolumeDetachNodeWithReadWriteOnce(t *
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	rc := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	reconciliationLoopFunc := rc.(*reconciler).reconciliationLoopFunc(ctx)
 	podName1 := "pod-uid1"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -762,9 +762,9 @@ func Test_Run_OneVolumeDetachFailNodeWithReadWriteOnce(t *testing.T) {
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	podName3 := "pod-uid3"
@@ -842,9 +842,9 @@ func Test_Run_OneVolumeAttachAndDetachTimeoutNodesWithReadWriteOnce(t *testing.T
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -928,11 +928,11 @@ func Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -1015,11 +1015,11 @@ func Test_Run_OneVolumeDetachOnNoOutOfServiceTaintedNode(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -1093,11 +1093,11 @@ func Test_Run_OneVolumeDetachOnUnhealthyNode(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -1210,11 +1210,11 @@ func Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled(t *
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, true, dsw, asw, ad,
-		nsu, nodeLister, fakeRecorder)
+		nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
 	volumeSpec1 := controllervolumetesting.GetTestVolumeSpec(string(volumeName1), volumeName1)
@@ -1374,9 +1374,9 @@ func Test_ReportWaitingOnDetach(t *testing.T) {
 			fakeHandler))
 		informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 		nodeLister := informerFactory.Core().V1().Nodes().Lister()
-		nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+		newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 		rc := NewReconciler(
-			reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+			reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nodeLister, fakeRecorder)
 
 		nodes := []k8stypes.NodeName{}
 		for _, n := range test.nodes {

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -28,6 +28,8 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics/legacyregistry"
 	metricstestutil "k8s.io/component-base/metrics/testutil"
@@ -54,6 +56,15 @@ const (
 
 var registerMetrics sync.Once
 
+func newNodeUpdater(t *testing.T, logger klog.Logger, fakeKubeClient kubernetes.Interface, nodeInformer coreinformers.NodeInformer, asw cache.ActualStateOfWorld) statusupdater.NodeStatusUpdater {
+	nsu, err := statusupdater.NewNodeStatusUpdater(logger, fakeKubeClient, nodeInformer, asw)
+	if err != nil {
+		t.Fatalf("Failed to create NodeStatusUpdater: %v", err)
+	}
+	go nsu.Run(t.Context(), 1)
+	return nsu
+}
+
 // Calls Run()
 // Verifies there are no calls to attach or detach.
 func Test_Run_Positive_DoNothing(t *testing.T) {
@@ -75,8 +86,11 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := statusupdater.NewNodeStatusUpdater(
-		fakeKubeClient, informerFactory.Core().V1().Nodes().Lister(), asw)
+	nsu, err := statusupdater.NewNodeStatusUpdater(
+		logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	if err != nil {
+		t.Fatalf("Failed to create NodeStatusUpdater: %v", err)
+	}
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
@@ -113,7 +127,7 @@ func Test_Run_Positive_OneDesiredVolumeAttach(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
@@ -168,7 +182,7 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithUnmountedVolume(t *te
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
@@ -260,7 +274,7 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithMountedVolume(t *test
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName := "pod-uid"
@@ -342,7 +356,8 @@ func Test_Run_Negative_OneDesiredVolumeAttachThenDetachWithUnmountedVolumeUpdate
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := statusupdater.NewFakeNodeStatusUpdater(true /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
+	asw.SetNodeUpdateHook(func(k8stypes.NodeName) {}) // Simulate node status update failure
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName := "pod-uid"
@@ -419,8 +434,8 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteMany(t *testing.
 		volumePluginMgr,
 		fakeRecorder,
 		fakeHandler))
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
@@ -517,7 +532,7 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
@@ -611,7 +626,7 @@ func Test_Run_OneVolumeAttachAndDetachUncertainNodesWithReadWriteOnce(t *testing
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
@@ -674,7 +689,7 @@ func Test_Run_UpdateNodeStatusFailBeforeOneVolumeDetachNodeWithReadWriteOnce(t *
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	rc := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	reconciliationLoopFunc := rc.(*reconciler).reconciliationLoopFunc(ctx)
@@ -703,18 +718,27 @@ func Test_Run_UpdateNodeStatusFailBeforeOneVolumeDetachNodeWithReadWriteOnce(t *
 	dsw.DeletePod(types.UniquePodName(podName1), generatedVolumeName, nodeName1)
 
 	// Mock NodeStatusUpdate fail
-	rc.(*reconciler).nodeStatusUpdater = statusupdater.NewFakeNodeStatusUpdater(true /* returnError */)
+	asw.SetNodeUpdateHook(func(k8stypes.NodeName) {})
 	reconciliationLoopFunc(ctx)
 	// The first detach will be triggered after at least 50ms (maxWaitForUnmountDuration in test).
 	time.Sleep(100 * time.Millisecond)
+	reconciliationLoopFunc(ctx) // trigger async node status update
+	time.Sleep(100 * time.Millisecond)
 	reconciliationLoopFunc(ctx)
-	// Right before detach operation is performed, the volume will be first removed from being reported
-	// as attached on node status (RemoveVolumeFromReportAsAttached). After UpdateNodeStatus operation which is expected to fail,
-	// controller then added the volume back as attached.
-	// verifyVolumeReportedAsAttachedToNode will check volume is in the list of volume attached that needs to be updated
-	// in node status. By calling this function (GetVolumesToReportAttached), node status should be updated, and the volume
-	// will not need to be updated until new changes are applied (detach is triggered again)
+	time.Sleep(100 * time.Millisecond) // wait for possible detach
+	// Right before detach operation is performed, the volume will be removed from being reported
+	// as attached on node status (RemoveVolumeFromReportAsAttached).
+	// The failed update should be retried by NodeStatusUpdater.
 	verifyVolumeAttachedToNode(t, generatedVolumeName, nodeName1, cache.AttachStateAttached, asw)
+	verifyVolumeReportedAsAttachedToNode(t, logger, generatedVolumeName, nodeName1, false, asw, volumeAttachedCheckTimeout)
+
+	// re-create the pod, everything should goes back
+	podName2 := "pod-uid2"
+	generatedVolumeName, podAddErr = dsw.AddPod(types.UniquePodName(podName2), controllervolumetesting.NewPod(podName2, podName2), volumeSpec, nodeName1)
+	if podAddErr != nil {
+		t.Fatalf("AddPod failed. Expected: <no error> Actual: <%v>", podAddErr)
+	}
+	reconciliationLoopFunc(ctx)
 	verifyVolumeReportedAsAttachedToNode(t, logger, generatedVolumeName, nodeName1, true, asw, volumeAttachedCheckTimeout)
 
 }
@@ -738,7 +762,7 @@ func Test_Run_OneVolumeDetachFailNodeWithReadWriteOnce(t *testing.T) {
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
@@ -783,7 +807,6 @@ func Test_Run_OneVolumeDetachFailNodeWithReadWriteOnce(t *testing.T) {
 	time.Sleep(1000 * time.Millisecond)
 	verifyVolumeAttachedToNode(t, generatedVolumeName, nodeName1, cache.AttachStateAttached, asw)
 	verifyVolumeReportedAsAttachedToNode(t, logger, generatedVolumeName, nodeName1, true, asw, volumeAttachedCheckTimeout)
-	// verifyVolumeNoStatusUpdateNeeded(t, logger, generatedVolumeName, nodeName1, asw)
 
 	// Add a third pod which tries to attach the volume to a different node.
 	// At this point, volume is still attached to first node. There are no status update for both nodes.
@@ -792,8 +815,7 @@ func Test_Run_OneVolumeDetachFailNodeWithReadWriteOnce(t *testing.T) {
 		t.Fatalf("AddPod failed. Expected: <no error> Actual: <%v>", podAddErr)
 	}
 	verifyVolumeAttachedToNode(t, generatedVolumeName, nodeName1, cache.AttachStateAttached, asw)
-	verifyVolumeNoStatusUpdateNeeded(t, logger, generatedVolumeName, nodeName1, asw)
-	verifyVolumeNoStatusUpdateNeeded(t, logger, generatedVolumeName, nodeName2, asw)
+	verifyVolumeReportedAsAttachedToNode(t, logger, generatedVolumeName, nodeName1, true, asw, volumeAttachedCheckTimeout)
 }
 
 // Creates a volume with accessMode ReadWriteOnce
@@ -820,7 +842,7 @@ func Test_Run_OneVolumeAttachAndDetachTimeoutNodesWithReadWriteOnce(t *testing.T
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
@@ -906,7 +928,7 @@ func Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
@@ -993,7 +1015,7 @@ func Test_Run_OneVolumeDetachOnNoOutOfServiceTaintedNode(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
@@ -1071,7 +1093,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNode(t *testing.T) {
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad,
@@ -1188,7 +1210,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNodeWithForceDetachOnUnmountDisabled(t *
 		fakeRecorder,
 		fakeHandler))
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, true, dsw, asw, ad,
@@ -1352,7 +1374,7 @@ func Test_ReportWaitingOnDetach(t *testing.T) {
 			fakeHandler))
 		informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 		nodeLister := informerFactory.Core().V1().Nodes().Lister()
-		nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+		nsu := newNodeUpdater(t, logger, fakeKubeClient, informerFactory.Core().V1().Nodes(), asw)
 		rc := NewReconciler(
 			reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 
@@ -1794,9 +1816,9 @@ func verifyVolumeReportedAsAttachedToNode(
 	var result bool
 	var lastErr error
 	err := wait.PollUntilContextTimeout(context.TODO(), 50*time.Millisecond, timeout, false, func(context.Context) (done bool, err error) {
-		volumes := asw.GetVolumesToReportAttached(logger)
-		for _, volume := range volumes[nodeName] {
-			if volume.Name == volumeName {
+		volumes := asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+		for _, volume := range volumes {
+			if volume.Volume.Name == volumeName && volume.Report == cache.NodeStatusReportAdding {
 				result = true
 			}
 		}
@@ -1816,24 +1838,6 @@ func verifyVolumeReportedAsAttachedToNode(
 		t.Fatalf("last error: %q, wait timeout: %q", lastErr, err.Error())
 	}
 
-}
-
-func verifyVolumeNoStatusUpdateNeeded(
-	t *testing.T,
-	logger klog.Logger,
-	volumeName v1.UniqueVolumeName,
-	nodeName k8stypes.NodeName,
-	asw cache.ActualStateOfWorld,
-) {
-	volumes := asw.GetVolumesToReportAttached(logger)
-	for _, volume := range volumes[nodeName] {
-		if volume.Name == volumeName {
-			t.Fatalf("Check volume <%v> is reported as need to update status on node <%v>, expected false",
-				volumeName,
-				nodeName)
-		}
-	}
-	t.Logf("Volume <%v> is not reported as need to update status on node <%v>", volumeName, nodeName)
 }
 
 func verifyNewDetacherCallCount(

--- a/pkg/controller/volume/attachdetach/statusupdater/fake_node_status_updater.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/fake_node_status_updater.go
@@ -17,34 +17,36 @@ limitations under the License.
 package statusupdater
 
 import (
-	"fmt"
-	"k8s.io/klog/v2"
+	"context"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
 )
 
-func NewFakeNodeStatusUpdater(returnError bool) NodeStatusUpdater {
-	return &fakeNodeStatusUpdater{
-		returnError: returnError,
+// Passing nil to simulate update failure
+func NewFakeNodeStatusUpdater(asw cache.ActualStateOfWorld) NodeStatusUpdater {
+	u := &fakeNodeStatusUpdater{
+		asw: asw,
 	}
+	if asw != nil {
+		asw.SetNodeUpdateHook(u.QueueUpdate)
+	}
+	return u
 }
 
 type fakeNodeStatusUpdater struct {
-	returnError bool
+	asw cache.ActualStateOfWorld
 }
 
-func (fnsu *fakeNodeStatusUpdater) UpdateNodeStatuses(logger klog.Logger) error {
-	if fnsu.returnError {
-		return fmt.Errorf("fake error on update node status")
-	}
-
-	return nil
+func (fnsu *fakeNodeStatusUpdater) QueueUpdate(nodeName types.NodeName) {
+	go func() {
+		logger := klog.Background()
+		volumes := fnsu.asw.GetVolumesToReportAttachedForNode(logger, nodeName)
+		fnsu.asw.ConfirmNodeStatusRemoved(logger, nodeName, removingVolumes(volumes))
+	}()
 }
 
-func (fnsu *fakeNodeStatusUpdater) UpdateNodeStatusForNode(logger klog.Logger, nodeName types.NodeName) error {
-	if fnsu.returnError {
-		return fmt.Errorf("fake error on update node status")
-	}
-
-	return nil
+func (fnsu *fakeNodeStatusUpdater) Run(ctx context.Context, workers int) {
+	<-ctx.Done()
 }

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -143,14 +144,19 @@ type nodeStatusPatch struct {
 	VolumesAttached []v1.AttachedVolume `json:"volumesAttached"` // intentional not omitempty
 }
 
+type objectMetaPatch struct {
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+}
+
 type nodePatch struct {
-	Status nodeStatusPatch `json:"status"`
+	ObjectMeta objectMetaPatch `json:"metadata,omitzero"`
+	Status     nodeStatusPatch `json:"status"`
 }
 
 func removingVolumes(volumes []cache.VolumeToReport) []v1.UniqueVolumeName {
 	removed := make([]v1.UniqueVolumeName, 0)
 	for _, vol := range volumes {
-		if vol.Report == cache.NodeStatusReportForceRemoving {
+		if vol.Report == cache.NodeStatusReportRemoving || vol.Report == cache.NodeStatusReportForceRemoving {
 			removed = append(removed, vol.Volume.Name)
 		}
 	}
@@ -179,21 +185,40 @@ func (nsu *nodeStatusUpdater) processNodeVolumes(ctx context.Context, nodeName t
 
 	var attachedVolumes []v1.AttachedVolume
 	var removedVolumes []v1.UniqueVolumeName
+	var resourceVersion string // only set if we remove some volumes, to ensure kubelet doesn't add inUse volumes back after we check.
+	var inUseVolumes sets.Set[v1.UniqueVolumeName]
 	for _, vol := range volumesToReport {
 		switch vol.Report {
 		case cache.NodeStatusReportAdding:
 			attachedVolumes = append(attachedVolumes, vol.Volume)
+		case cache.NodeStatusReportRemoving:
+			if inUseVolumes == nil {
+				inUseVolumes = sets.New(nodeObj.Status.VolumesInUse...)
+			}
+			if !inUseVolumes.Has(vol.Volume.Name) {
+				resourceVersion = nodeObj.ResourceVersion
+				removedVolumes = append(removedVolumes, vol.Volume.Name)
+			} else {
+				logger.V(4).Info("Volume is still in use on node; will not remove from status",
+					"node", klog.KObj(nodeObj), "volumeName", vol.Volume.Name)
+				attachedVolumes = append(attachedVolumes, vol.Volume)
+			}
 		case cache.NodeStatusReportForceRemoving:
 			removedVolumes = append(removedVolumes, vol.Volume.Name)
 		}
 	}
+	// Both sides are sorted (we only ever write this list sorted), so slices.Equal is exact.
+	// An external reorder just triggers one corrective patch, then stays quiet.
 	if len(removedVolumes) == 0 && slices.Equal(attachedVolumes, nodeObj.Status.VolumesAttached) {
 		return nil // No update required
 		// we always do a patch if removedVolumes is non-empty
-		// in case the nodeObj from the lister is stale
+		// in case the nodeObj from the lister is stale and we mis-report a volume as removed
 	}
 
 	nodePatch := nodePatch{
+		ObjectMeta: objectMetaPatch{
+			ResourceVersion: resourceVersion,
+		},
 		Status: nodeStatusPatch{
 			VolumesAttached: attachedVolumes,
 		},
@@ -210,6 +235,11 @@ func (nsu *nodeStatusUpdater) processNodeVolumes(ctx context.Context, nodeName t
 		// Should queue again when the node is created to populate attached volumes.
 		logger.V(2).Info(
 			"Could not update node status, node does not exist - skipping", "node", klog.KObj(nodeObj))
+		return nil
+	} else if errors.IsConflict(err) {
+		// etcd holds a newer version than the one we read from the informer cache.
+		// Its watch event is already on its way to our informer.
+		logger.V(2).Info("Conflict updating node status; waiting for next event", "node", klog.KObj(nodeObj), "err", err)
 		return nil
 	} else if err != nil {
 		logger.V(2).Info("Could not update node status; re-marking for update", "node", klog.KObj(nodeObj), "err", err)

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
@@ -19,13 +19,21 @@ limitations under the License.
 package statusupdater
 
 import (
-	"fmt"
-	"k8s.io/api/core/v1"
+	"context"
+	"encoding/json"
+	"slices"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	nodeutil "k8s.io/component-helpers/node/util"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
 )
@@ -33,99 +41,182 @@ import (
 // NodeStatusUpdater defines a set of operations for updating the
 // VolumesAttached field in the Node Status.
 type NodeStatusUpdater interface {
-	// Gets a list of node statuses that should be updated from the actual state
-	// of the world and updates them.
-	UpdateNodeStatuses(logger klog.Logger) error
-	// Update any pending status change for the given node
-	UpdateNodeStatusForNode(logger klog.Logger, nodeName types.NodeName) error
+	// Run starts asynchronous updates queued by [QueueUpdate].
+	Run(ctx context.Context, workers int)
+	// Queue updating any pending status change for the given node
+	QueueUpdate(nodeName types.NodeName)
 }
 
 // NewNodeStatusUpdater returns a new instance of NodeStatusUpdater.
 func NewNodeStatusUpdater(
+	logger klog.Logger,
 	kubeClient clientset.Interface,
-	nodeLister corelisters.NodeLister,
-	actualStateOfWorld cache.ActualStateOfWorld) NodeStatusUpdater {
-	return &nodeStatusUpdater{
+	nodeInformer coreinformers.NodeInformer,
+	actualStateOfWorld cache.ActualStateOfWorld) (NodeStatusUpdater, error) {
+	u := &nodeStatusUpdater{
 		actualStateOfWorld: actualStateOfWorld,
-		nodeLister:         nodeLister,
+		nodeLister:         nodeInformer.Lister(),
 		kubeClient:         kubeClient,
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[types.NodeName](),
+			workqueue.TypedRateLimitingQueueConfig[types.NodeName]{Name: "node-attachedVolumes"},
+		),
 	}
+	actualStateOfWorld.SetNodeUpdateHook(u.QueueUpdate)
+	_, err := nodeInformer.Informer().AddEventHandlerWithOptions(toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			u.queueNode(logger, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			// in case others modified volumesAttached or our last sync see a stale state
+			u.queueNode(logger, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			// all volumes should be detached
+			tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown)
+			if ok {
+				obj = tombstone.Obj
+			}
+			u.queueNode(logger, obj)
+		},
+	}, toolscache.HandlerOptions{Logger: &logger})
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
 }
 
 type nodeStatusUpdater struct {
 	kubeClient         clientset.Interface
 	nodeLister         corelisters.NodeLister
 	actualStateOfWorld cache.ActualStateOfWorld
+	queue              workqueue.TypedRateLimitingInterface[types.NodeName]
 }
 
-func (nsu *nodeStatusUpdater) UpdateNodeStatuses(logger klog.Logger) error {
-	var nodeIssues int
-	// TODO: investigate right behavior if nodeName is empty
-	// kubernetes/kubernetes/issues/37777
-	nodesToUpdate := nsu.actualStateOfWorld.GetVolumesToReportAttached(logger)
-	for nodeName, attachedVolumes := range nodesToUpdate {
-		err := nsu.processNodeVolumes(logger, nodeName, attachedVolumes)
-		if err != nil {
-			nodeIssues += 1
+func (nsu *nodeStatusUpdater) Run(ctx context.Context, worker int) {
+	defer nsu.queue.ShutDown()
+	for range worker {
+		go wait.UntilWithContext(ctx, nsu.worker, time.Second)
+	}
+	<-ctx.Done()
+}
+
+// kubernetes/kubernetes/issues/37586
+// When a node add/update causes to wipe out the attached volumes field.
+// This function ensures that we sync with the actual status.
+func (nsu *nodeStatusUpdater) queueNode(logger klog.Logger, obj any) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		utilruntime.HandleErrorWithLogger(logger, nil, "object is not a node", "obj", obj)
+		return
+	}
+	nsu.QueueUpdate(types.NodeName(node.Name))
+}
+
+func (nsu *nodeStatusUpdater) QueueUpdate(nodeName types.NodeName) {
+	nsu.queue.Add(nodeName)
+}
+
+func (nsu *nodeStatusUpdater) worker(ctx context.Context) {
+	for nsu.syncNode(ctx) {
+	}
+	klog.FromContext(ctx).Info("NodeStatusUpdater worker shutting down")
+}
+
+func (nsu *nodeStatusUpdater) syncNode(ctx context.Context) bool {
+	nodeName, quit := nsu.queue.Get()
+	if quit {
+		return false
+	}
+	defer nsu.queue.Done(nodeName)
+
+	err := nsu.processNodeVolumes(ctx, nodeName)
+	if err != nil {
+		nsu.queue.AddRateLimited(nodeName)
+	} else {
+		nsu.queue.Forget(nodeName)
+	}
+	return true
+}
+
+type nodeStatusPatch struct {
+	VolumesAttached []v1.AttachedVolume `json:"volumesAttached"` // intentional not omitempty
+}
+
+type nodePatch struct {
+	Status nodeStatusPatch `json:"status"`
+}
+
+func removingVolumes(volumes []cache.VolumeToReport) []v1.UniqueVolumeName {
+	removed := make([]v1.UniqueVolumeName, 0)
+	for _, vol := range volumes {
+		if vol.Report == cache.NodeStatusReportForceRemoving {
+			removed = append(removed, vol.Volume.Name)
 		}
 	}
-	if nodeIssues > 0 {
-		return fmt.Errorf("unable to update %d nodes", nodeIssues)
-	}
-	return nil
+	return removed
 }
 
-func (nsu *nodeStatusUpdater) UpdateNodeStatusForNode(logger klog.Logger, nodeName types.NodeName) error {
-	needsUpdate, attachedVolumes := nsu.actualStateOfWorld.GetVolumesToReportAttachedForNode(logger, nodeName)
-	if !needsUpdate {
-		return nil
+func (nsu *nodeStatusUpdater) processNodeVolumes(ctx context.Context, nodeName types.NodeName) error {
+	logger := klog.FromContext(ctx)
+	volumesToReport := nsu.actualStateOfWorld.GetVolumesToReportAttachedForNode(logger, nodeName)
+	if volumesToReport == nil {
+		return nil // We know nothing about this node
 	}
-	return nsu.processNodeVolumes(logger, nodeName, attachedVolumes)
-}
 
-func (nsu *nodeStatusUpdater) processNodeVolumes(logger klog.Logger, nodeName types.NodeName, attachedVolumes []v1.AttachedVolume) error {
 	nodeObj, err := nsu.nodeLister.Get(string(nodeName))
 	if errors.IsNotFound(err) {
-		// If node does not exist, its status cannot be updated.
-		// Do nothing so that there is no retry until node is created.
+		// If node does not exist, all detaching volumes are already removed.
+		nsu.actualStateOfWorld.ConfirmNodeStatusRemoved(logger, nodeName, removingVolumes(volumesToReport))
+		// Should queue again when the node is created to populate attached volumes.
 		logger.V(2).Info(
 			"Could not update node status. Failed to find node in NodeInformer cache", "node", klog.KRef("", string(nodeName)), "err", err)
 		return nil
 	} else if err != nil {
-		// For all other errors, log error and reset flag statusUpdateNeeded
-		// back to true to indicate this node status needs to be updated again.
 		logger.V(2).Info("Error retrieving nodes from node lister", "err", err)
-		nsu.actualStateOfWorld.SetNodeStatusUpdateNeeded(logger, nodeName)
 		return err
 	}
 
-	err = nsu.updateNodeStatus(logger, nodeName, nodeObj, attachedVolumes)
+	var attachedVolumes []v1.AttachedVolume
+	var removedVolumes []v1.UniqueVolumeName
+	for _, vol := range volumesToReport {
+		switch vol.Report {
+		case cache.NodeStatusReportAdding:
+			attachedVolumes = append(attachedVolumes, vol.Volume)
+		case cache.NodeStatusReportForceRemoving:
+			removedVolumes = append(removedVolumes, vol.Volume.Name)
+		}
+	}
+	if len(removedVolumes) == 0 && slices.Equal(attachedVolumes, nodeObj.Status.VolumesAttached) {
+		return nil // No update required
+		// we always do a patch if removedVolumes is non-empty
+		// in case the nodeObj from the lister is stale
+	}
+
+	nodePatch := nodePatch{
+		Status: nodeStatusPatch{
+			VolumesAttached: attachedVolumes,
+		},
+	}
+	patchData, err := json.Marshal(&nodePatch)
+	if err != nil {
+		logger.Error(err, "Failed to marshal node patch", "node", klog.KObj(nodeObj))
+		return err
+	}
+	_, err = nsu.kubeClient.CoreV1().Nodes().PatchStatus(ctx, nodeObj.Name, patchData)
 	if errors.IsNotFound(err) {
-		// If node does not exist, its status cannot be updated.
-		// Do nothing so that there is no retry until node is created.
+		// If node does not exist, all detaching volumes are already removed.
+		nsu.actualStateOfWorld.ConfirmNodeStatusRemoved(logger, nodeName, removingVolumes(volumesToReport))
+		// Should queue again when the node is created to populate attached volumes.
 		logger.V(2).Info(
 			"Could not update node status, node does not exist - skipping", "node", klog.KObj(nodeObj))
 		return nil
 	} else if err != nil {
-		// If update node status fails, reset flag statusUpdateNeeded back to true
-		// to indicate this node status needs to be updated again
-		nsu.actualStateOfWorld.SetNodeStatusUpdateNeeded(logger, nodeName)
-
 		logger.V(2).Info("Could not update node status; re-marking for update", "node", klog.KObj(nodeObj), "err", err)
-
 		return err
 	}
-	return nil
-}
-
-func (nsu *nodeStatusUpdater) updateNodeStatus(logger klog.Logger, nodeName types.NodeName, nodeObj *v1.Node, attachedVolumes []v1.AttachedVolume) error {
-	node := nodeObj.DeepCopy()
-	node.Status.VolumesAttached = attachedVolumes
-	_, patchBytes, err := nodeutil.PatchNodeStatus(nsu.kubeClient.CoreV1(), nodeName, nodeObj, node)
-	if err != nil {
-		return err
+	if len(removedVolumes) > 0 {
+		nsu.actualStateOfWorld.ConfirmNodeStatusRemoved(logger, nodeName, removedVolumes)
 	}
-
-	logger.V(4).Info("Updating status for node succeeded", "node", klog.KObj(node), "patchBytes", patchBytes, "attachedVolumes", attachedVolumes)
 	return nil
 }

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
@@ -18,8 +18,9 @@ package statusupdater
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,30 +34,24 @@ import (
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
 	controllervolumetesting "k8s.io/kubernetes/pkg/controller/volume/attachdetach/testing"
 	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
-	"testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 // setupNodeStatusUpdate creates all the needed objects for testing.
 // the initial environment has 2 nodes with no volumes attached
 // and adds one volume to attach to each node to the actual state of the world
-func setupNodeStatusUpdate(logger klog.Logger, t *testing.T) (cache.ActualStateOfWorld, *fake.Clientset, NodeStatusUpdater) {
+func setupNodeStatusUpdate(logger klog.Logger, t *testing.T) (cache.ActualStateOfWorld, *fake.Clientset, *nodeStatusUpdater) {
 	testNode1 := corev1.Node{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Node",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "testnode-1",
+			Name:            "testnode-1",
+			ResourceVersion: "1",
 		},
 		Status: corev1.NodeStatus{},
 	}
 	testNode2 := corev1.Node{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Node",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "testnode-2",
+			Name:            "testnode-2",
+			ResourceVersion: "1",
 		},
 		Status: corev1.NodeStatus{},
 	}
@@ -65,16 +60,20 @@ func setupNodeStatusUpdate(logger klog.Logger, t *testing.T) (cache.ActualStateO
 	fakeKubeClient := fake.NewSimpleClientset(&testNode1, &testNode2)
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeInformer := informerFactory.Core().V1().Nodes()
-	nsu := NewNodeStatusUpdater(fakeKubeClient, nodeInformer.Lister(), asw)
+	nsui, err := NewNodeStatusUpdater(logger, fakeKubeClient, nodeInformer, asw)
+	if err != nil {
+		t.Fatalf("Failed to create NodeStatusUpdater: %v", err)
+	}
+	nsu := nsui.(*nodeStatusUpdater)
+	t.Cleanup(func() {
+		nsu.queue.ShutDown()
+	})
 
-	err := nodeInformer.Informer().GetStore().Add(&testNode1)
-	if err != nil {
-		t.Fatalf(".Informer().GetStore().Add failed. Expected: <no error> Actual: <%v>", err)
-	}
-	err = nodeInformer.Informer().GetStore().Add(&testNode2)
-	if err != nil {
-		t.Fatalf(".Informer().GetStore().Add failed. Expected: <no error> Actual: <%v>", err)
-	}
+	informerFactory.Start(t.Context().Done())
+	informerFactory.WaitForCacheSync(t.Context().Done())
+	t.Cleanup(func() {
+		informerFactory.Shutdown()
+	})
 
 	volumeName1 := corev1.UniqueVolumeName("volume-name-1")
 	volumeName2 := corev1.UniqueVolumeName("volume-name-2")
@@ -97,52 +96,48 @@ func setupNodeStatusUpdate(logger klog.Logger, t *testing.T) (cache.ActualStateO
 	return asw, fakeKubeClient, nsu
 }
 
-// TestNodeStatusUpdater_UpdateNodeStatuses_TwoNodesUpdate calls setup
-// calls UpdateNodeStatuses()
-// check that asw.GetVolumesToReportAttached reports nothing left to attach
-// checks that each node status.volumesAttached is of length 1 and contains the correct volume
-func TestNodeStatusUpdater_UpdateNodeStatuses_TwoNodesUpdate(t *testing.T) {
-	ctx := context.Background()
-	logger := klog.FromContext(ctx)
-	asw, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
-
-	err := nsu.UpdateNodeStatuses(logger)
-	if err != nil {
-		t.Fatalf("UpdateNodeStatuses failed. Expected: <no error> Actual: <%v>", err)
-	}
-
-	needToReport := asw.GetVolumesToReportAttached(logger)
-	if len(needToReport) != 0 {
-		t.Fatalf("len(asw.GetVolumesToReportAttached()) Expected: <0> Actual: <%v>", len(needToReport))
-	}
-
-	node, err := fakeKubeClient.CoreV1().Nodes().Get(ctx, "testnode-1", metav1.GetOptions{})
+func assertVolumeAttached(t *testing.T, ctx context.Context, client *fake.Clientset, nodeName string, volumeName corev1.UniqueVolumeName) {
+	t.Helper()
+	node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
 	}
 	if len(node.Status.VolumesAttached) != 1 {
 		t.Fatalf("len(node.Status.VolumesAttached) Expected: <1> Actual: <%v>", len(node.Status.VolumesAttached))
 	}
-	if node.Status.VolumesAttached[0].Name != "volume-name-1" {
-		t.Fatalf("volumeName Expected: <volume-name-1> Actual: <%s>", node.Status.VolumesAttached[0].Name)
-	}
-
-	node, err = fakeKubeClient.CoreV1().Nodes().Get(ctx, "testnode-2", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
-	}
-	if len(node.Status.VolumesAttached) != 1 {
-		t.Fatalf("len(node.Status.VolumesAttached) Expected: <1> Actual: <%v>", len(node.Status.VolumesAttached))
-	}
-	if node.Status.VolumesAttached[0].Name != "volume-name-2" {
-		t.Fatalf("volumeName Expected: <volume-name-2> Actual: <%s>", node.Status.VolumesAttached[0].Name)
+	if node.Status.VolumesAttached[0].Name != volumeName {
+		t.Fatalf("volumeName Expected: <%s> Actual: <%s>", volumeName, node.Status.VolumesAttached[0].Name)
 	}
 }
 
-func TestNodeStatusUpdater_UpdateNodeStatuses_FailureInFirstUpdate(t *testing.T) {
-	ctx := context.Background()
-	logger := klog.FromContext(ctx)
-	asw, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
+func assertNoVolumeAttached(t *testing.T, ctx context.Context, client *fake.Clientset, nodeName string) {
+	t.Helper()
+	node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
+	}
+	if len(node.Status.VolumesAttached) != 0 {
+		t.Fatalf("len(node.Status.VolumesAttached) Expected: <0> Actual: <%v>", len(node.Status.VolumesAttached))
+	}
+}
+
+// TestNodeStatusUpdater_syncNode_TwoNodesUpdate calls setup
+// calls nsu.syncNode() twice to process both nodes
+// checks that each node status.volumesAttached is of length 1 and contains the correct volume
+func TestNodeStatusUpdater_syncNode_TwoNodesUpdate(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	_, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
+
+	nsu.syncNode(ctx)
+	nsu.syncNode(ctx)
+
+	assertVolumeAttached(t, ctx, fakeKubeClient, "testnode-1", "volume-name-1")
+	assertVolumeAttached(t, ctx, fakeKubeClient, "testnode-2", "volume-name-2")
+}
+
+func TestNodeStatusUpdater_syncNode_FailureInFirstUpdate(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	_, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
 
 	var failedNode string
 	failedOnce := false
@@ -157,17 +152,12 @@ func TestNodeStatusUpdater_UpdateNodeStatuses_FailureInFirstUpdate(t *testing.T)
 		return false, nil, nil
 	})
 
-	err := nsu.UpdateNodeStatuses(logger)
-	if errors.Is(err, failureErr) {
-		t.Fatalf("UpdateNodeStatuses failed. Expected: <test generated error> Actual: <%v>", err)
-	}
+	nsu.syncNode(ctx)
+	nsu.syncNode(ctx)
 
-	needToReport := asw.GetVolumesToReportAttached(logger)
-	if len(needToReport) != 1 {
-		t.Fatalf("len(asw.GetVolumesToReportAttached()) Expected: <1> Actual: <%v>", len(needToReport))
-	}
-	if _, ok := needToReport[types.NodeName(failedNode)]; !ok {
-		t.Fatalf("GetVolumesToReportAttached() did not report correct node Expected: <%s> Actual: <%v>", failedNode, needToReport)
+	needToReport := nsu.queue.NumRequeues(types.NodeName(failedNode))
+	if needToReport != 1 {
+		t.Fatalf("nsu.queue.NumRequeues() Expected: <1> Actual: <%v>", needToReport)
 	}
 
 	nodes, err := fakeKubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
@@ -192,36 +182,105 @@ func TestNodeStatusUpdater_UpdateNodeStatuses_FailureInFirstUpdate(t *testing.T)
 	}
 }
 
-// TestNodeStatusUpdater_UpdateNodeStatusForNode calls setup
-// calls UpdateNodeStatusesForNode on testnode-1
-// check that asw.GetVolumesToReportAttached reports testnode-2 needs to be reported
+// TestNodeStatusUpdater_processNodeVolumes calls setup
+// calls processNodeVolumes on testnode-1
 // checks that testnode-1 status.volumesAttached is of length 1 and contains the correct volume
-func TestNodeStatusUpdater_UpdateNodeStatusForNode(t *testing.T) {
-	ctx := context.Background()
-	logger := klog.FromContext(ctx)
+func TestNodeStatusUpdater_processNodeVolumes(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	_, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
+
+	err := nsu.processNodeVolumes(ctx, "testnode-1")
+	if err != nil {
+		t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	assertVolumeAttached(t, ctx, fakeKubeClient, "testnode-1", "volume-name-1")
+}
+
+func TestNodeStatusUpdater_UpdateNonExistingNode(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	_, _, nsu := setupNodeStatusUpdate(logger, t)
+
+	err := nsu.processNodeVolumes(ctx, "testnode-999")
+	if err != nil {
+		t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
 	asw, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
 
-	err := nsu.UpdateNodeStatusForNode(logger, "testnode-1")
+	// do attach
+	err := nsu.processNodeVolumes(ctx, "testnode-1")
 	if err != nil {
-		t.Fatalf("UpdateNodeStatuses failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	needToReport := asw.GetVolumesToReportAttached(logger)
-	if len(needToReport) != 1 {
-		t.Fatalf("len(asw.GetVolumesToReportAttached()) Expected: <1> Actual: <%v>", len(needToReport))
-	}
-	if _, ok := needToReport["testnode-2"]; !ok {
-		t.Fatalf("GetVolumesToReportAttached() did not report correct node Expected: <testnode-2> Actual: <%v>", needToReport)
+	// ask for removal
+	removed := asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	if removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
 	}
 
-	node, err := fakeKubeClient.CoreV1().Nodes().Get(ctx, "testnode-1", metav1.GetOptions{})
+	// do removal
+	err = nsu.processNodeVolumes(ctx, "testnode-1")
 	if err != nil {
-		t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
+		t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
 	}
-	if len(node.Status.VolumesAttached) != 1 {
-		t.Fatalf("len(node.Status.VolumesAttached) Expected: <1> Actual: <%v>", len(node.Status.VolumesAttached))
+
+	// should be removed now
+	removed = asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	if !removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached returned false, expected true")
 	}
-	if node.Status.VolumesAttached[0].Name != "volume-name-1" {
-		t.Fatalf("volumeName Expected: <volume-name-1> Actual: <%s>", node.Status.VolumesAttached[0].Name)
+
+	assertNoVolumeAttached(t, ctx, fakeKubeClient, "testnode-1")
+
+}
+
+func TestNodeNotFound(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	asw, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
+
+	// do attach
+	err := nsu.processNodeVolumes(ctx, "testnode-1")
+	if err != nil {
+		t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
 	}
+
+	err = fakeKubeClient.CoreV1().Nodes().Delete(ctx, "testnode-1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Nodes().Delete failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	// ask for removal
+	removed := asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	if removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
+	}
+
+	// do removal
+	err = nsu.processNodeVolumes(ctx, "testnode-1")
+	if err != nil {
+		t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	// should be removed now even if the node is gone
+	removed = asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	if !removed {
+		t.Fatalf("RemoveVolumeFromReportAsAttached returned false, expected true")
+	}
+}
+
+func TestRun(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+	_, _, nsu := setupNodeStatusUpdate(logger, t)
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		tCtx.Cancel("test")
+	}()
+	nsu.Run(tCtx, 2)
 }

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
@@ -218,7 +218,7 @@ func TestRemove(t *testing.T) {
 	}
 
 	// ask for removal
-	removed := asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	removed := asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
 	}
@@ -230,7 +230,7 @@ func TestRemove(t *testing.T) {
 	}
 
 	// should be removed now
-	removed = asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
 	if !removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned false, expected true")
 	}
@@ -255,7 +255,7 @@ func TestNodeNotFound(t *testing.T) {
 	}
 
 	// ask for removal
-	removed := asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	removed := asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
 	}
@@ -267,7 +267,7 @@ func TestNodeNotFound(t *testing.T) {
 	}
 
 	// should be removed now even if the node is gone
-	removed = asw.RemoveVolumeFromReportAsAttached("volume-name-1", "testnode-1")
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
 	if !removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned false, expected true")
 	}

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -218,7 +219,7 @@ func TestRemove(t *testing.T) {
 	}
 
 	// ask for removal
-	removed := asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
+	removed := asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1", true)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
 	}
@@ -230,7 +231,7 @@ func TestRemove(t *testing.T) {
 	}
 
 	// should be removed now
-	removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1", true)
 	if !removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned false, expected true")
 	}
@@ -255,7 +256,7 @@ func TestNodeNotFound(t *testing.T) {
 	}
 
 	// ask for removal
-	removed := asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
+	removed := asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1", true)
 	if removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
 	}
@@ -267,10 +268,68 @@ func TestNodeNotFound(t *testing.T) {
 	}
 
 	// should be removed now even if the node is gone
-	removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1")
+	removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1", true)
 	if !removed {
 		t.Fatalf("RemoveVolumeFromReportAsAttached returned false, expected true")
 	}
+}
+
+func TestNotRemoveInUseVolumes(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	synctest.Test(t, func(t *testing.T) {
+		asw, fakeKubeClient, nsu := setupNodeStatusUpdate(logger, t)
+		// do attach
+		err := nsu.processNodeVolumes(ctx, "testnode-1")
+		if err != nil {
+			t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
+		}
+
+		// mark volume as in-use
+		node, err := fakeKubeClient.CoreV1().Nodes().Get(ctx, "testnode-1", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Nodes().Get failed. Expected: <no error> Actual: <%v>", err)
+		}
+		node.Status.VolumesInUse = []corev1.UniqueVolumeName{"volume-name-1"}
+		_, err = fakeKubeClient.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("Nodes().UpdateStatus failed. Expected: <no error> Actual: <%v>", err)
+		}
+		synctest.Wait() // wait for informer sync
+
+		// ask for removal
+		removed := asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1", true)
+		if removed {
+			t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
+		}
+
+		// do removal, will not remove in-use volume
+		err = nsu.processNodeVolumes(ctx, "testnode-1")
+		if err != nil {
+			t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
+		}
+
+		assertVolumeAttached(t, ctx, fakeKubeClient, "testnode-1", "volume-name-1")
+
+		// should still not removed, try force removal now
+		removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1", false)
+		if removed {
+			t.Fatalf("RemoveVolumeFromReportAsAttached returned true, expected false")
+		}
+
+		err = nsu.processNodeVolumes(ctx, "testnode-1")
+		if err != nil {
+			t.Fatalf("processNodeVolumes failed. Expected: <no error> Actual: <%v>", err)
+		}
+
+		// should be removed now
+		removed = asw.RemoveVolumeFromReportAsAttached(logger, "volume-name-1", "testnode-1", false)
+		if !removed {
+			t.Fatalf("RemoveVolumeFromReportAsAttached returned false, expected true")
+		}
+
+		assertNoVolumeAttached(t, ctx, fakeKubeClient, "testnode-1")
+	})
 }
 
 func TestRun(t *testing.T) {

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -533,15 +533,6 @@ func (asw *actualStateOfWorld) MarkVolumeAsMounted(markVolumeOpts operationexecu
 	return asw.AddPodToVolume(markVolumeOpts)
 }
 
-func (asw *actualStateOfWorld) AddVolumeToReportAsAttached(logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
-	// no operation for kubelet side
-}
-
-func (asw *actualStateOfWorld) RemoveVolumeFromReportAsAttached(volumeName v1.UniqueVolumeName, nodeName types.NodeName) error {
-	// no operation for kubelet side
-	return nil
-}
-
 func (asw *actualStateOfWorld) MarkVolumeAsUnmounted(
 	podName volumetypes.UniquePodName, volumeName v1.UniqueVolumeName) error {
 	return asw.DeletePodFromVolume(podName, volumeName)

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -267,14 +267,6 @@ type ActualStateOfWorldAttacherUpdater interface {
 	// Marks the specified volume as detached from the specified node
 	MarkVolumeAsDetached(volumeName v1.UniqueVolumeName, nodeName types.NodeName)
 
-	// Marks desire to detach the specified volume (remove the volume from the node's
-	// volumesToReportAsAttached list)
-	RemoveVolumeFromReportAsAttached(volumeName v1.UniqueVolumeName, nodeName types.NodeName) error
-
-	// Unmarks the desire to detach for the specified volume (add the volume back to
-	// the node's volumesToReportAsAttached list)
-	AddVolumeToReportAsAttached(logger klog.Logger, volumeName v1.UniqueVolumeName, nodeName types.NodeName)
-
 	// InitializeClaimSize sets pvc claim size by reading pvc.Status.Capacity
 	InitializeClaimSize(logger klog.Logger, volumeName v1.UniqueVolumeName, claimSize resource.Quantity)
 

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -173,13 +173,13 @@ func TestPodTerminationWithNodeOOSDetach(t *testing.T) {
 	ns := framework.CreateNamespaceOrDie(testClient, namespaceName, t)
 	defer framework.DeleteNamespaceOrDie(testClient, ns, t)
 
-	_, err := testClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+	_, err := testClient.CoreV1().Nodes().Create(tCtx, node, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	pod := fakePodWithVol(namespaceName)
-	if _, err := testClient.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().Pods(pod.Namespace).Create(tCtx, pod, metav1.CreateOptions{}); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -198,13 +198,13 @@ func TestPodTerminationWithNodeOOSDetach(t *testing.T) {
 	// Patch the node to mark the volume in use as attach-detach controller verifies if safe to detach the volume
 	// based on that.
 	node.Status.VolumesInUse = append(node.Status.VolumesInUse, "kubernetes.io/mock-provisioner/fake-mount")
-	node, err = testClient.CoreV1().Nodes().UpdateStatus(context.TODO(), node, metav1.UpdateOptions{})
+	node, err = testClient.CoreV1().Nodes().UpdateStatus(tCtx, node, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in patch volumeInUse status to nodes: %s", err)
 	}
 	// Delete the pod with grace period time so that it is stuck in terminating state
 	gracePeriod := int64(300)
-	err = testClient.CoreV1().Pods(namespaceName).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{
+	err = testClient.CoreV1().Pods(namespaceName).Delete(tCtx, pod.Name, metav1.DeleteOptions{
 		GracePeriodSeconds: &gracePeriod,
 	})
 	if err != nil {
@@ -220,7 +220,7 @@ func TestPodTerminationWithNodeOOSDetach(t *testing.T) {
 		Effect: v1.TaintEffectNoExecute,
 	}
 	node.Spec.Taints = append(node.Spec.Taints, taint)
-	if _, err := testClient.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Update(tCtx, node, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("error in patch oos taint to node: %v", err)
 	}
 	waitForNodeToBeTainted(tCtx, t, testClient, v1.TaintNodeOutOfService, nodeName)
@@ -338,13 +338,13 @@ func TestPodUpdateWithADC(t *testing.T) {
 	podStopCh := make(chan struct{})
 	defer close(podStopCh)
 
-	if _, err := testClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(tCtx, node, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.CoreV1().Pods(ns.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(tCtx, pod, metav1.CreateOptions{}); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -377,7 +377,7 @@ func TestPodUpdateWithADC(t *testing.T) {
 
 	pod.Status.Phase = v1.PodSucceeded
 
-	if _, err := testClient.CoreV1().Pods(ns.Name).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).UpdateStatus(tCtx, pod, metav1.UpdateOptions{}); err != nil {
 		t.Errorf("Failed to update pod : %v", err)
 	}
 
@@ -608,7 +608,7 @@ func TestPVCBoundWithADC(t *testing.T) {
 			},
 		},
 	}
-	if _, err := testClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(tCtx, node, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
@@ -616,10 +616,10 @@ func TestPVCBoundWithADC(t *testing.T) {
 	pvcs := []*v1.PersistentVolumeClaim{}
 	for i := range 3 {
 		pod, pvc := fakePodWithPVC(fmt.Sprintf("fakepod-pvcnotbound-%d", i), fmt.Sprintf("fakepvc-%d", i), namespaceName)
-		if _, err := testClient.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+		if _, err := testClient.CoreV1().Pods(pod.Namespace).Create(tCtx, pod, metav1.CreateOptions{}); err != nil {
 			t.Errorf("Failed to create pod : %v", err)
 		}
-		if _, err := testClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
+		if _, err := testClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(tCtx, pvc, metav1.CreateOptions{}); err != nil {
 			t.Errorf("Failed to create pvc : %v", err)
 		}
 		pvcs = append(pvcs, pvc)
@@ -627,7 +627,7 @@ func TestPVCBoundWithADC(t *testing.T) {
 	// pod with no pvc
 	podNew := fakePodWithVol(namespaceName)
 	podNew.SetName("fakepod")
-	if _, err := testClient.CoreV1().Pods(podNew.Namespace).Create(context.TODO(), podNew, metav1.CreateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().Pods(podNew.Namespace).Create(tCtx, podNew, metav1.CreateOptions{}); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -644,13 +644,13 @@ func TestPVCBoundWithADC(t *testing.T) {
 	time.Sleep(10 * time.Second)
 	waitForPodFuncInDSWP(t, ctrl.GetDesiredStateOfWorld(), 60*time.Second, "expected 1 pod in dsw", 1)
 	for _, pvc := range pvcs {
-		createPVForPVC(t, testClient, pvc)
+		createPVForPVC(tCtx, t, testClient, pvc)
 	}
 	waitForPodFuncInDSWP(t, ctrl.GetDesiredStateOfWorld(), 60*time.Second, "expected 4 pods in dsw after PVCs are bound", 4)
 }
 
 // Create PV for PVC, pv controller will bind them together.
-func createPVForPVC(t *testing.T, testClient *clientset.Clientset, pvc *v1.PersistentVolumeClaim) {
+func createPVForPVC(ctx context.Context, t *testing.T, testClient *clientset.Clientset, pvc *v1.PersistentVolumeClaim) {
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("fakepv-%s", pvc.Name),
@@ -667,15 +667,15 @@ func createPVForPVC(t *testing.T, testClient *clientset.Clientset, pvc *v1.Persi
 			StorageClassName: *pvc.Spec.StorageClassName,
 		},
 	}
-	if _, err := testClient.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
+	if _, err := testClient.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{}); err != nil {
 		t.Errorf("Failed to create pv : %v", err)
 	}
 }
 
 // Wait for DeletionTimestamp added to pod
 func waitForPodDeletionTimestampToSet(tCtx context.Context, t *testing.T, testingClient *clientset.Clientset, podName, podNamespace string) {
-	if err := wait.PollUntilContextCancel(tCtx, 100*time.Millisecond, false, func(context.Context) (bool, error) {
-		pod, err := testingClient.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err := wait.PollUntilContextCancel(tCtx, 100*time.Millisecond, false, func(ctx context.Context) (bool, error) {
+		pod, err := testingClient.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -690,8 +690,8 @@ func waitForPodDeletionTimestampToSet(tCtx context.Context, t *testing.T, testin
 
 // Wait for VolumeAttach added to node
 func waitForVolumeToBeAttached(ctx context.Context, t *testing.T, testingClient *clientset.Clientset, podName, nodeName string) {
-	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 120*time.Second, false, func(context.Context) (bool, error) {
-		node, err := testingClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 120*time.Second, false, func(ctx context.Context) (bool, error) {
+		node, err := testingClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if len(node.Status.VolumesAttached) >= 1 {
 			return true, nil
 		}
@@ -706,8 +706,8 @@ func waitForVolumeToBeAttached(ctx context.Context, t *testing.T, testingClient 
 
 // Wait for taint added to node
 func waitForNodeToBeTainted(ctx context.Context, t *testing.T, testingClient *clientset.Clientset, taintKey, nodeName string) {
-	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 60*time.Second, false, func(context.Context) (bool, error) {
-		node, err := testingClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+		node, err := testingClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Today the attach/detach controller updates every node's `status.volumesAttached` **synchronously, inside the reconciler's main loop**. Each detach blocks on a `Node.Status` PATCH round-trip before the loop can proceed, so node-status updates are effectively serialized. We measured this at ~50 attach/detach cycles per second maximum throughput.

This PR decouples node-status updates from the reconciler by moving them into a dedicated `nodeStatusUpdater` backed by a workqueue:

- The reconciler no longer PATCHes node status inline. Instead, each volume in `volumesToReportAsAttached` carries a report state (`NodeStatusReportAdding` / `NodeStatusReportForceRemoving` / `NodeStatusReportRemoved`). `nodeStatusUpdater` consumes these asynchronously, performs the API update, and calls `ConfirmNodeStatusRemoved` to drop the entry once the node object reflects the change.
- The old `statusUpdateNeeded` bookkeeping field is replaced by a callback that the updater registers into `ActualStateOfWorld`, fired whenever an update is needed.
- Detach still happens **only after** the node status is confirmed updated — the reconciler skips volumes whose node-status update is still pending and retries on a later cycle. The ordering guarantee (`volumesAttached` removed before detach is initiated) is preserved; only the mechanism becomes asynchronous.

Two throughput wins, both effective even with a single worker:

1. **Off the critical path** — the reconciler no longer stalls on node-status PATCH latency.
2. **Batching** — multiple volumes attached/detached on the same node within a short window collapse into a single node-status update instead of one PATCH per volume.

Cross-node concurrency is possible too — the workqueue already supports multiple workers updating different nodes in parallel — but this PR ships **a single worker** to stay conservative. A configurable worker count is left as a follow-up (it touches controller-manager options / API, so it is better reviewed separately).

This bottleneck was one of several found in a large-scale stress test that continuously creates, attaches, detaches, and deletes many volumes. After addressing this together with a few other bottlenecks (#134290, #133622, and some hard-coded worker-count limits), end-to-end throughput rose from ~50 to ~85 cycles/second, where each cycle is one create + attach + detach + delete. At that point the cluster was limited by the storage backend rather than Kubernetes. Since end-to-end throughput is gated by the slowest stage, sustaining 85 cycles/second implies the ad-controller now sustains at least that rate — though this PR alone may not reach it if the bottleneck has moved elsewhere.

#### Consolidating the in-use check

When removing a volume from `volumesAttached`, `nodeStatusUpdater` now sends the node's `resourceVersion` as a precondition in the PATCH. If kubelet concurrently adds the volume to `volumesInUse` after we read the node but before our write lands, the PATCH fails with a conflict and we do not detach.

The existing code is already correct here: before detaching, `operationExecutor` does one more live GET of the node and re-checks `volumesInUse` (`verifyVolumeIsSafeToDetach`). The `resourceVersion` precondition provides the same guarantee at the point of the status update itself, using the node object we already have in hand. This means we can eventually drop that extra live GET before detach — left as future work, not part of this PR — and it lets this single mechanism take over the equivalent in-use checks in the reconciler and operationExecutor.

Note on the consistency model: this deliberately changes node-status update from "immediately consistent" to "eventually consistent". The only guarantee the controller relies on is that `volumesAttached` is removed before detach is initiated — no timing relationship with `volumesInUse` is assumed. If the queue backs up, attach/detach is delayed but never incorrect, and this is no worse than the current serialized behavior.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Before — node status is PATCHed inline in the reconciler loop, so the loop stalls on every update:

```mermaid
sequenceDiagram
    participant R as Reconciler main loop
    participant API as kube-apiserver
    activate R
    loop each node
        R->>+API: PATCH node status.volumesAttached
        API-->>-R: ok
        R->>R: detach volume
    end
    deactivate R
```

After — the reconciler marks the desired report state and moves on; a workqueue-backed worker performs the PATCH asynchronously and confirms back before detach proceeds:

```mermaid
sequenceDiagram
    participant R as Reconciler main loop
    participant ASW as ActualStateOfWorld
    participant Q as workqueue
    participant W as nodeStatusUpdater
    participant API as kube-apiserver

    activate R
    R->>+ASW: mark report state
    ASW-->>Q: enqueue node
    ASW-->>-R: pending
    R->>R: keep reconciling, don't block
    deactivate R

    Q->>+W: dequeue node
    W->>+API: PATCH status<br>(batched, RV precondition)
    API-->>-W: ok
    W->>-ASW: ConfirmNodeStatusRemoved

    Note over R: several cycles later
    activate R
    R->>+ASW: mark report state
    ASW-->>-R: done
    R->>R: detach volume(s) for this node
    deactivate R
```

Here is how ad-controller currently behaves:
<img width="2998" height="460" alt="image" src="https://github.com/user-attachments/assets/e6e04640-990d-4f1c-9fd5-0efe661465f8" />

It is alternating 3 stage in the main loop:
1. update Node status for previously attached volumes sequentially.
2. update Node status for volumes to be detached sequentially while asynchronously detach volumes.
3. asynchronously attach volumes volumes

It takes about 46s for one cycle in the main loop. While updating node status takes 45s.

To explain more about this graph, it is generated by transforming APIServer audit logs and importing into https://ui.perfetto.dev/. Each block corresponds to a request to APIServer. To zoom in:
<img width="2964" height="522" alt="image" src="https://github.com/user-attachments/assets/01a47dc3-7f87-412e-aefa-99581bbe005a" />
<img width="2996" height="944" alt="image" src="https://github.com/user-attachments/assets/f211054c-58b9-4477-be15-e419d9c33e6a" />

Stage 1 is faster because multiple volumes attached to the same node can be batched to one PATCH request. And some of the updates are already batched to the PATCH request in the previous stage 2.

Reviewable commit-by-commit; each commit builds and passes tests independently:

1. `replace context.TODO()` — test cleanup, preparatory.
2. `test: avoid overwriting node.status.volumesAttached` — test fix, preparatory.
3. `ad-controller: async node status update` — the core change (workqueue, report-state enum, callback, reconciler skips pending volumes).
4. `no need to hold status updater in reconciler` — drop the now-unused `nsu` dependency from the reconciler.
5. `add a log to removeVolumeFromReportAsAttached` — observability; also threads a logger through the affected asw call sites.
6. `refactor forceDetach to be clearer` — readability, no behavior change.
7. `reject removing in-use volume` — the `resourceVersion`-guarded in-use rejection described above.
8. `remove in-use volume tracking in asw` — in-use tracking now lives in the status updater, so remove the redundant copy from ActualStateOfWorld.

#### Does this PR introduce a user-facing change?

```release-note
The attach/detach controller now updates node `status.volumesAttached` asynchronously, improving volume attach/detach throughput on large clusters.
```
