### PR TITLE
Remove deprecated WaitForServiceEndpointsNum

### DIFF
--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -40,6 +40,7 @@ import (
 	scaleclient "k8s.io/client-go/scale"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
+	e2eendpointslice "k8s.io/kubernetes/test/e2e/framework/endpointslice"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
@@ -62,8 +63,6 @@ const (
 	targetPort                      = 8080
 	sidecarTargetPort               = 8081
 	timeoutRC                       = 120 * time.Second
-	startServiceTimeout             = time.Minute
-	startServiceInterval            = 5 * time.Second
 	invalidKind                     = "ERROR: invalid workload kind for resource consumer"
 	customMetricName                = "QPS"
 	serviceInitializationTimeout    = 2 * time.Minute
@@ -613,8 +612,8 @@ func runServiceAndSidecarForResourceConsumer(ctx context.Context, c clientset.In
 
 	framework.ExpectNoError(e2erc.RunRC(ctx, controllerRcConfig))
 	// Wait for endpoints to propagate for the controller service.
-	framework.ExpectNoError(framework.WaitForServiceEndpointsNum(
-		ctx, c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
+	framework.ExpectNoError(e2eendpointslice.WaitForEndpointCount(
+		ctx, c, ns, controllerName, 1))
 }
 
 func runServiceAndWorkloadForResourceConsumer(ctx context.Context, c clientset.Interface, resourceClient dynamic.ResourceInterface, apiExtensionClient crdclientset.Interface, ns, name string, kind schema.GroupVersionKind, replicas int, cpuLimitMillis, memLimitMb int64, podAnnotations, serviceAnnotations map[string]string, additionalContainers []v1.Container, podResources *v1.ResourceRequirements) {
@@ -699,8 +698,8 @@ func runServiceAndWorkloadForResourceConsumer(ctx context.Context, c clientset.I
 
 	framework.ExpectNoError(e2erc.RunRC(ctx, controllerRcConfig))
 	// Wait for endpoints to propagate for the controller service.
-	framework.ExpectNoError(framework.WaitForServiceEndpointsNum(
-		ctx, c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
+	framework.ExpectNoError(e2eendpointslice.WaitForEndpointCount(
+		ctx, c, ns, controllerName, 1))
 }
 
 func CreateHorizontalPodAutoscaler(ctx context.Context, rc *ResourceConsumer, targetRef autoscalingv2.CrossVersionObjectReference, namespace string, metrics []autoscalingv2.MetricSpec, resourceType v1.ResourceName, metricTargetType autoscalingv2.MetricTargetType, metricTargetValue, minReplicas, maxReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -36,7 +36,6 @@ import (
 	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -408,46 +407,6 @@ func CheckTestingNSDeletedExcept(ctx context.Context, c clientset.Interface, ski
 		}
 	}
 	return fmt.Errorf("Waiting for terminating namespaces to be deleted timed out")
-}
-
-// WaitForServiceEndpointsNum waits until there are EndpointSlices for serviceName
-// containing a total of expectNum endpoints. (If the service is dual-stack, expectNum
-// must count the endpoints of both IP families.)
-//
-// Deprecated: use e2eendpointslice.WaitForEndpointCount or other related functions.
-func WaitForServiceEndpointsNum(ctx context.Context, c clientset.Interface, namespace, serviceName string, expectNum int, interval, timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(ctx, interval, timeout, false, func(ctx context.Context) (bool, error) {
-		Logf("Waiting for amount of service:%s endpoints to be %d", serviceName, expectNum)
-		esList, err := c.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, serviceName)})
-		if err != nil {
-			Logf("Unexpected error trying to get EndpointSlices for %s : %v", serviceName, err)
-			return false, nil
-		}
-
-		if len(esList.Items) == 0 {
-			Logf("Waiting for at least 1 EndpointSlice to exist")
-			return false, nil
-		}
-
-		if countEndpointsSlicesNum(esList) != expectNum {
-			Logf("Unexpected number of Endpoints on Slices, got %d, expected %d", countEndpointsSlicesNum(esList), expectNum)
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
-func countEndpointsSlicesNum(epList *discoveryv1.EndpointSliceList) int {
-	// EndpointSlices can contain the same address on multiple Slices
-	addresses := sets.Set[string]{}
-	for _, epSlice := range epList.Items {
-		for _, ep := range epSlice.Endpoints {
-			if len(ep.Addresses) > 0 {
-				addresses.Insert(ep.Addresses[0])
-			}
-		}
-	}
-	return addresses.Len()
 }
 
 // restclientConfig returns a config holds the information needed to build connection to kubernetes clusters.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replacing the calls to `WaitForServiceEndpointsNum` with `WaitForEndpointCount`, since `WaitForServiceEndpointsNum` is deprecated, also remove `WaitForServiceEndpointsNum`, as it is no longer used anymore.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

WaitForServiceEndpointsNum was deprecated in https://github.com/kubernetes/kubernetes/pull/132991
This changes the sig-autoscaling use of it, and removes the function itself.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @danwinship 
