### PR TITLE
[apiserver] [126379]: replace call to HandleCrash with call to HandleCrashWithContext in apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
@@ -174,7 +174,7 @@ func (c *RequestHeaderAuthRequestController) AllowedClientNames() []string {
 
 // Run starts RequestHeaderAuthRequestController controller and blocks until stopCh is closed.
 func (c *RequestHeaderAuthRequestController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.Infof("Starting %s", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1263,7 +1263,7 @@ func (e *Store) DeleteCollection(ctx context.Context, deleteValidation rest.Vali
 	for i := 0; i < workersNumber; i++ {
 		go func() {
 			// panics don't cross goroutine boundaries
-			defer utilruntime.HandleCrash(func(panicReason interface{}) {
+			defer utilruntime.HandleCrashWithContext(ctx, func(_ context.Context, panicReason interface{}) {
 				errs <- fmt.Errorf("DeleteCollection goroutine panicked: %v", panicReason)
 			})
 			defer wg.Done()
@@ -1288,7 +1288,7 @@ func (e *Store) DeleteCollection(ctx context.Context, deleteValidation rest.Vali
 	}
 	// In case of all workers exit, notify distributor.
 	go func() {
-		defer utilruntime.HandleCrash(func(panicReason interface{}) {
+		defer utilruntime.HandleCrashWithContext(ctx, func(_ context.Context, panicReason interface{}) {
 			errs <- fmt.Errorf("DeleteCollection workers closer panicked: %v", panicReason)
 		})
 		wg.Wait()

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
@@ -199,7 +199,7 @@ func (c *ConfigMapCAController) RunOnce(ctx context.Context) error {
 
 // Run starts the kube-apiserver and blocks until stopCh is closed.
 func (c *ConfigMapCAController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.InfoS("Starting controller", "name", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go
@@ -155,7 +155,7 @@ func (c *DynamicFileCAContent) RunOnce(ctx context.Context) error {
 
 // Run starts the controller and blocks until stopCh is closed.
 func (c *DynamicFileCAContent) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.InfoS("Starting controller", "name", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
@@ -129,7 +129,7 @@ func (c *DynamicCertKeyPairContent) RunOnce(ctx context.Context) error {
 
 // Run starts the controller and blocks until context is killed.
 func (c *DynamicCertKeyPairContent) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.InfoS("Starting controller", "name", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -530,7 +530,7 @@ func (s preparedGenericAPIServer) RunWithContext(ctx context.Context) error {
 	// If UDS profiling is enabled, start a local http server listening on that socket
 	if s.UnprotectedDebugSocket != nil {
 		go func() {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithContext(ctx)
 			klog.Error(s.UnprotectedDebugSocket.RunWithContext(ctx))
 		}()
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -196,7 +196,7 @@ func runPostStartHook(name string, entry postStartHookEntry, context PostStartHo
 	var err error
 	func() {
 		// don't let the hook *accidentally* panic and kill the server
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(context)
 		err = entry.hook(context)
 	}()
 	// if the hook intentionally wants to kill server, let it.

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -195,7 +195,6 @@ func (s *GenericAPIServer) isPostStartHookRegistered(name string) bool {
 func runPostStartHook(name string, entry postStartHookEntry, context PostStartHookContext) {
 	var err error
 	func() {
-		// don't let the hook *accidentally* panic and kill the server
 		defer utilruntime.HandleCrashWithContext(context)
 		err = entry.hook(context)
 	}()

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
@@ -92,7 +92,7 @@ func NewDynamicEncryptionConfiguration(
 
 // Run starts the controller and blocks until ctx is canceled.
 func (d *DynamicEncryptionConfigContent) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	klog.InfoS("Starting controller", "name", d.name)
 	defer klog.InfoS("Shutting down controller", "name", d.name)
@@ -101,7 +101,7 @@ func (d *DynamicEncryptionConfigContent) Run(ctx context.Context) {
 
 	wg.Add(1)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		defer wg.Done()
 		defer d.queue.ShutDown()
 		<-ctx.Done()
@@ -109,7 +109,7 @@ func (d *DynamicEncryptionConfigContent) Run(ctx context.Context) {
 
 	wg.Add(1)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		defer wg.Done()
 		d.runWorker(ctx)
 	}()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -434,7 +434,7 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
 }
 
 func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watchCacheInterval, resourceVersion uint64) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer close(c.result)
 	defer c.Stop()
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go
@@ -71,7 +71,7 @@ func (pr *ConditionalProgressRequester) Run(stopCh <-chan struct{}) {
 		ctx = metadata.NewOutgoingContext(ctx, pr.contextMetadata)
 	}
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		<-stopCh
 		pr.mux.Lock()
 		defer pr.mux.Unlock()

--- a/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
@@ -109,7 +109,7 @@ func (f *defaultFeatureSupportChecker) checkClient(ctx context.Context, c client
 		}
 		f.checkingEndpoint[ep] = struct{}{}
 		go func(ep string) {
-			defer runtime.HandleCrash()
+			defer runtime.HandleCrashWithContext(ctx)
 			err := delayFunc.Until(ctx, true, true, func(ctx context.Context) (done bool, err error) {
 				internalErr := f.clientSupportsRequestWatchProgress(ctx, c, ep)
 				return internalErr == nil, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service.go
@@ -86,7 +86,7 @@ func NewGRPCService(ctx context.Context, endpoint string, callTimeout time.Durat
 	s.kmsClient = kmsapi.NewKeyManagementServiceClient(s.connection)
 
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 
 		<-ctx.Done()
 		_ = s.connection.Close()

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service.go
@@ -83,7 +83,7 @@ func NewGRPCService(ctx context.Context, endpoint, providerName string, callTime
 	s.kmsClient = kmsapi.NewKeyManagementServiceClient(s.connection)
 
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 
 		<-ctx.Done()
 		_ = s.connection.Close()

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
@@ -42,7 +42,7 @@ const (
 )
 
 func (h *peerProxyHandler) RunPeerDiscoveryCacheSync(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer h.peerLeaseQueue.ShutDown()
 	defer func() {
 		err := h.apiserverIdentityInformer.Informer().RemoveEventHandler(h.leaseRegistration)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This pr replaces calls to `HandleCrash` with `HandleCrashWithContext` in `staging/src/k8s.io/apiserver` where ctx object is available for client code, which is required according to the issue mentioned below. 

#### Which issue(s) this PR is related to:
Contributes to #126379
<!--
Please link relevant issues to help wctxith tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
