### PR TITLE
Feat: Adds warnings when ResourceSlice driver names contain uppercase characters

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15228,7 +15228,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "networkData": {
@@ -15792,7 +15792,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "pool": {
@@ -16006,7 +16006,7 @@
       "description": "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
       "properties": {
         "driver": {
-          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "parameters": {
@@ -16357,7 +16357,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "driver": {
-          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
           "type": "string"
         },
         "nodeName": {
@@ -16577,7 +16577,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "networkData": {
@@ -17184,7 +17184,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "pool": {
@@ -17352,7 +17352,7 @@
       "description": "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
       "properties": {
         "driver": {
-          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "parameters": {
@@ -17703,7 +17703,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "driver": {
-          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
           "type": "string"
         },
         "nodeName": {
@@ -17760,7 +17760,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "networkData": {
@@ -18324,7 +18324,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "pool": {
@@ -18538,7 +18538,7 @@
       "description": "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
       "properties": {
         "driver": {
-          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "parameters": {
@@ -18889,7 +18889,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "driver": {
-          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
           "type": "string"
         },
         "nodeName": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -120,7 +120,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "networkData": {
@@ -859,7 +859,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "pool": {
@@ -1124,7 +1124,7 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "parameters": {
@@ -1585,7 +1585,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+            "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
             "type": "string"
           },
           "nodeName": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -120,7 +120,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "networkData": {
@@ -917,7 +917,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "pool": {
@@ -1121,7 +1121,7 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "parameters": {
@@ -1582,7 +1582,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+            "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
             "type": "string"
           },
           "nodeName": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -120,7 +120,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "networkData": {
@@ -859,7 +859,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "pool": {
@@ -1124,7 +1124,7 @@
         "properties": {
           "driver": {
             "default": "",
-            "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+            "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
             "type": "string"
           },
           "parameters": {
@@ -1585,7 +1585,7 @@
           },
           "driver": {
             "default": "",
-            "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+            "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
             "type": "string"
           },
           "nodeName": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -47989,7 +47989,7 @@ func schema_k8sio_api_resource_v1_AllocatedDeviceStatus(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -49086,7 +49086,7 @@ func schema_k8sio_api_resource_v1_DeviceRequestAllocationResult(ref common.Refer
 					},
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -49557,7 +49557,7 @@ func schema_k8sio_api_resource_v1_OpaqueDeviceConfiguration(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -50084,7 +50084,7 @@ func schema_k8sio_api_resource_v1_ResourceSliceSpec(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+							Description: "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -50455,7 +50455,7 @@ func schema_k8sio_api_resource_v1beta1_AllocatedDeviceStatus(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -51640,7 +51640,7 @@ func schema_k8sio_api_resource_v1beta1_DeviceRequestAllocationResult(ref common.
 					},
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -52022,7 +52022,7 @@ func schema_k8sio_api_resource_v1beta1_OpaqueDeviceConfiguration(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -52549,7 +52549,7 @@ func schema_k8sio_api_resource_v1beta1_ResourceSliceSpec(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+							Description: "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -52645,7 +52645,7 @@ func schema_k8sio_api_resource_v1beta2_AllocatedDeviceStatus(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53742,7 +53742,7 @@ func schema_k8sio_api_resource_v1beta2_DeviceRequestAllocationResult(ref common.
 					},
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -54213,7 +54213,7 @@ func schema_k8sio_api_resource_v1beta2_OpaqueDeviceConfiguration(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+							Description: "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -54740,7 +54740,7 @@ func schema_k8sio_api_resource_v1beta2_ResourceSliceSpec(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"driver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+							Description: "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/registry/resource/resourceslice/strategy.go
+++ b/pkg/registry/resource/resourceslice/strategy.go
@@ -19,6 +19,7 @@ package resourceslice
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/fields"
@@ -60,8 +61,17 @@ func (resourceSliceStrategy) Validate(ctx context.Context, obj runtime.Object) f
 	return validation.ValidateResourceSlice(slice)
 }
 
+// WarningsOnCreate returns warnings for the creation of the given object.
 func (resourceSliceStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
-	return nil
+	newResourceSlice := obj.(*resource.ResourceSlice)
+	var warnings []string
+
+	if newResourceSlice.Spec.Driver != strings.ToLower(newResourceSlice.Spec.Driver) {
+		warnings = append(warnings,
+			fmt.Sprintf("spec.driver: driver names should be lowercase; %q contains uppercase characters", newResourceSlice.Spec.Driver))
+	}
+
+	return warnings
 }
 
 func (resourceSliceStrategy) Canonicalize(obj runtime.Object) {
@@ -87,8 +97,17 @@ func (resourceSliceStrategy) ValidateUpdate(ctx context.Context, obj, old runtim
 	return validation.ValidateResourceSliceUpdate(obj.(*resource.ResourceSlice), old.(*resource.ResourceSlice))
 }
 
+// WarningsOnUpdate returns warnings for the given update.
 func (resourceSliceStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+	newResourceSlice := obj.(*resource.ResourceSlice)
+	var warnings []string
+
+	if newResourceSlice.Spec.Driver != strings.ToLower(newResourceSlice.Spec.Driver) {
+		warnings = append(warnings,
+			fmt.Sprintf("spec.driver: driver names should be lowercase; %q contains uppercase characters", newResourceSlice.Spec.Driver))
+	}
+
+	return warnings
 }
 
 func (resourceSliceStrategy) AllowUnconditionalUpdate() bool {

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -41,7 +41,7 @@ message AllocatedDeviceStatus {
   // needed on a node.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 1;
@@ -814,7 +814,7 @@ message DeviceRequestAllocationResult {
   // needed on a node.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 2;
@@ -1253,7 +1253,7 @@ message OpaqueDeviceConfiguration {
   // to decide whether it needs to validate them.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 1;
@@ -1514,7 +1514,8 @@ message ResourceSliceSpec {
   // objects with a certain driver name.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver. This field is immutable.
+  // vendor of the driver. It should use only lower case characters.
+  // This field is immutable.
   //
   // +required
   optional string driver = 1;

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -101,7 +101,8 @@ type ResourceSliceSpec struct {
 	// objects with a certain driver name.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver. This field is immutable.
+	// vendor of the driver. It should use only lower case characters.
+	// This field is immutable.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
@@ -1268,7 +1269,7 @@ type OpaqueDeviceConfiguration struct {
 	// to decide whether it needs to validate them.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
@@ -1494,7 +1495,7 @@ type DeviceRequestAllocationResult struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
@@ -1797,7 +1798,7 @@ type AllocatedDeviceStatus struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,rep,name=driver"`

--- a/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AllocatedDeviceStatus = map[string]string{
 	"":            "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.\n\nThe combination of Driver, Pool, Device, and ShareID must match the corresponding key in Status.Allocation.Devices.",
-	"driver":      "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":      "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"pool":        "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
 	"device":      "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
 	"shareID":     "ShareID uniquely identifies an individual allocation share of the device.",
@@ -277,7 +277,7 @@ func (DeviceRequest) SwaggerDoc() map[string]string {
 var map_DeviceRequestAllocationResult = map[string]string{
 	"":                         "DeviceRequestAllocationResult contains the allocation result for one request.",
 	"request":                  "Request is the name of the request in the claim which caused this device to be allocated. If it references a subrequest in the firstAvailable list on a DeviceRequest, this field must include both the name of the main request and the subrequest using the format <main request>/<subrequest>.\n\nMultiple devices may have been allocated per request.",
-	"driver":                   "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":                   "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"pool":                     "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
 	"device":                   "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
 	"adminAccess":              "AdminAccess indicates that this device was allocated for administrative access. See the corresponding request field for a definition of mode.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
@@ -369,7 +369,7 @@ func (NetworkDeviceData) SwaggerDoc() map[string]string {
 
 var map_OpaqueDeviceConfiguration = map[string]string{
 	"":           "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
-	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"parameters": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki.",
 }
 
@@ -493,7 +493,7 @@ func (ResourceSliceList) SwaggerDoc() map[string]string {
 
 var map_ResourceSliceSpec = map[string]string{
 	"":                       "ResourceSliceSpec contains the information published by the driver in one ResourceSlice.",
-	"driver":                 "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+	"driver":                 "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
 	"pool":                   "Pool describes the pool that this ResourceSlice belongs to.",
 	"nodeName":               "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
 	"nodeSelector":           "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -41,7 +41,7 @@ message AllocatedDeviceStatus {
   // needed on a node.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 1;
@@ -935,7 +935,7 @@ message DeviceRequestAllocationResult {
   // needed on a node.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 2;
@@ -1267,7 +1267,7 @@ message OpaqueDeviceConfiguration {
   // to decide whether it needs to validate them.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 1;
@@ -1528,7 +1528,8 @@ message ResourceSliceSpec {
   // objects with a certain driver name.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver. This field is immutable.
+  // vendor of the driver. It should use only lower case characters.
+  // This field is immutable.
   //
   // +required
   optional string driver = 1;

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -101,7 +101,8 @@ type ResourceSliceSpec struct {
 	// objects with a certain driver name.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver. This field is immutable.
+	// vendor of the driver. It should use only lower case characters.
+	// This field is immutable.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
@@ -1276,7 +1277,7 @@ type OpaqueDeviceConfiguration struct {
 	// to decide whether it needs to validate them.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
@@ -1502,7 +1503,7 @@ type DeviceRequestAllocationResult struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
@@ -1805,7 +1806,7 @@ type AllocatedDeviceStatus struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,rep,name=driver"`

--- a/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1beta1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AllocatedDeviceStatus = map[string]string{
 	"":            "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.\n\nThe combination of Driver, Pool, Device, and ShareID must match the corresponding key in Status.Allocation.Devices.",
-	"driver":      "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":      "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"pool":        "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
 	"device":      "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
 	"shareID":     "ShareID uniquely identifies an individual allocation share of the device.",
@@ -292,7 +292,7 @@ func (DeviceRequest) SwaggerDoc() map[string]string {
 var map_DeviceRequestAllocationResult = map[string]string{
 	"":                         "DeviceRequestAllocationResult contains the allocation result for one request.",
 	"request":                  "Request is the name of the request in the claim which caused this device to be allocated. If it references a subrequest in the firstAvailable list on a DeviceRequest, this field must include both the name of the main request and the subrequest using the format <main request>/<subrequest>.\n\nMultiple devices may have been allocated per request.",
-	"driver":                   "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":                   "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"pool":                     "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
 	"device":                   "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
 	"adminAccess":              "AdminAccess indicates that this device was allocated for administrative access. See the corresponding request field for a definition of mode.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
@@ -369,7 +369,7 @@ func (NetworkDeviceData) SwaggerDoc() map[string]string {
 
 var map_OpaqueDeviceConfiguration = map[string]string{
 	"":           "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
-	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"parameters": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki.",
 }
 
@@ -493,7 +493,7 @@ func (ResourceSliceList) SwaggerDoc() map[string]string {
 
 var map_ResourceSliceSpec = map[string]string{
 	"":                       "ResourceSliceSpec contains the information published by the driver in one ResourceSlice.",
-	"driver":                 "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+	"driver":                 "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
 	"pool":                   "Pool describes the pool that this ResourceSlice belongs to.",
 	"nodeName":               "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
 	"nodeSelector":           "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -41,7 +41,7 @@ message AllocatedDeviceStatus {
   // needed on a node.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 1;
@@ -814,7 +814,7 @@ message DeviceRequestAllocationResult {
   // needed on a node.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 2;
@@ -1253,7 +1253,7 @@ message OpaqueDeviceConfiguration {
   // to decide whether it needs to validate them.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver.
+  // vendor of the driver. It should use only lower case characters.
   //
   // +required
   optional string driver = 1;
@@ -1514,7 +1514,8 @@ message ResourceSliceSpec {
   // objects with a certain driver name.
   //
   // Must be a DNS subdomain and should end with a DNS domain owned by the
-  // vendor of the driver. This field is immutable.
+  // vendor of the driver. It should use only lower case characters.
+  // This field is immutable.
   //
   // +required
   optional string driver = 1;

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -101,7 +101,8 @@ type ResourceSliceSpec struct {
 	// objects with a certain driver name.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver. This field is immutable.
+	// vendor of the driver. It should use only lower case characters.
+	// This field is immutable.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
@@ -1268,7 +1269,7 @@ type OpaqueDeviceConfiguration struct {
 	// to decide whether it needs to validate them.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,name=driver"`
@@ -1494,7 +1495,7 @@ type DeviceRequestAllocationResult struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,2,name=driver"`
@@ -1797,7 +1798,7 @@ type AllocatedDeviceStatus struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	//
 	// +required
 	Driver string `json:"driver" protobuf:"bytes,1,rep,name=driver"`

--- a/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1beta2
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AllocatedDeviceStatus = map[string]string{
 	"":            "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.\n\nThe combination of Driver, Pool, Device, and ShareID must match the corresponding key in Status.Allocation.Devices.",
-	"driver":      "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":      "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"pool":        "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
 	"device":      "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
 	"shareID":     "ShareID uniquely identifies an individual allocation share of the device.",
@@ -277,7 +277,7 @@ func (DeviceRequest) SwaggerDoc() map[string]string {
 var map_DeviceRequestAllocationResult = map[string]string{
 	"":                         "DeviceRequestAllocationResult contains the allocation result for one request.",
 	"request":                  "Request is the name of the request in the claim which caused this device to be allocated. If it references a subrequest in the firstAvailable list on a DeviceRequest, this field must include both the name of the main request and the subrequest using the format <main request>/<subrequest>.\n\nMultiple devices may have been allocated per request.",
-	"driver":                   "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":                   "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"pool":                     "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
 	"device":                   "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
 	"adminAccess":              "AdminAccess indicates that this device was allocated for administrative access. See the corresponding request field for a definition of mode.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
@@ -369,7 +369,7 @@ func (NetworkDeviceData) SwaggerDoc() map[string]string {
 
 var map_OpaqueDeviceConfiguration = map[string]string{
 	"":           "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
-	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+	"driver":     "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
 	"parameters": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki.",
 }
 
@@ -493,7 +493,7 @@ func (ResourceSliceList) SwaggerDoc() map[string]string {
 
 var map_ResourceSliceSpec = map[string]string{
 	"":                       "ResourceSliceSpec contains the information published by the driver in one ResourceSlice.",
-	"driver":                 "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+	"driver":                 "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
 	"pool":                   "Pool describes the pool that this ResourceSlice belongs to.",
 	"nodeName":               "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
 	"nodeSelector":           "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/content/dns.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/content/dns.go
@@ -67,9 +67,16 @@ func IsDNS1123Subdomain(value string) []string {
 
 // IsDNS1123SubdomainCaseless tests for a string that conforms to the definition of a
 // subdomain in DNS (RFC 1123).
-// Deprecated: Use IsDNS1123Subdomain for strict, lowercase validation.
-// Case-insensitive names are not recommended as they can lead to ambiguity
-// (e.g., 'Foo', 'FOO', and 'foo' would be allowed names for foo).
+//
+// Deprecated: API validation should never be caseless. Caseless validation is a vector
+// for bugs and failed uniqueness assumptions. For example, names like "foo.com" and
+// "FOO.COM" are both accepted as valid, but they are typically not treated as equal by
+// consumers (e.g. CSI and DRA driver names). This fails the "least surprise" principle and
+// can cause inconsistent behaviors.
+//
+// Note: This allows uppercase names but is not caseless — uppercase and lowercase are
+// treated as different values. Use IsDNS1123Subdomain for strict, lowercase validation
+// instead.
 func IsDNS1123SubdomainCaseless(value string) []string {
 	return isDNS1123Subdomain(value, true)
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/allocateddevicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/allocateddevicestatus.go
@@ -37,7 +37,7 @@ type AllocatedDeviceStatusApplyConfiguration struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// This name together with the driver name and the device name field
 	// identify which device was allocated (`<driver name>/<pool name>/<device name>`).

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/devicerequestallocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/devicerequestallocationresult.go
@@ -42,7 +42,7 @@ type DeviceRequestAllocationResultApplyConfiguration struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// This name together with the driver name and the device name field
 	// identify which device was allocated (`<driver name>/<pool name>/<device name>`).

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/opaquedeviceconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/opaquedeviceconfiguration.go
@@ -35,7 +35,7 @@ type OpaqueDeviceConfigurationApplyConfiguration struct {
 	// to decide whether it needs to validate them.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// Parameters can contain arbitrary data. It is the responsibility of
 	// the driver developer to handle validation and versioning. Typically this

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceslicespec.go
@@ -32,7 +32,8 @@ type ResourceSliceSpecApplyConfiguration struct {
 	// objects with a certain driver name.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver. This field is immutable.
+	// vendor of the driver. It should use only lower case characters.
+	// This field is immutable.
 	Driver *string `json:"driver,omitempty"`
 	// Pool describes the pool that this ResourceSlice belongs to.
 	Pool *ResourcePoolApplyConfiguration `json:"pool,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/allocateddevicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/allocateddevicestatus.go
@@ -37,7 +37,7 @@ type AllocatedDeviceStatusApplyConfiguration struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// This name together with the driver name and the device name field
 	// identify which device was allocated (`<driver name>/<pool name>/<device name>`).

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicerequestallocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicerequestallocationresult.go
@@ -42,7 +42,7 @@ type DeviceRequestAllocationResultApplyConfiguration struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// This name together with the driver name and the device name field
 	// identify which device was allocated (`<driver name>/<pool name>/<device name>`).

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/opaquedeviceconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/opaquedeviceconfiguration.go
@@ -35,7 +35,7 @@ type OpaqueDeviceConfigurationApplyConfiguration struct {
 	// to decide whether it needs to validate them.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// Parameters can contain arbitrary data. It is the responsibility of
 	// the driver developer to handle validation and versioning. Typically this

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslicespec.go
@@ -32,7 +32,8 @@ type ResourceSliceSpecApplyConfiguration struct {
 	// objects with a certain driver name.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver. This field is immutable.
+	// vendor of the driver. It should use only lower case characters.
+	// This field is immutable.
 	Driver *string `json:"driver,omitempty"`
 	// Pool describes the pool that this ResourceSlice belongs to.
 	Pool *ResourcePoolApplyConfiguration `json:"pool,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/allocateddevicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/allocateddevicestatus.go
@@ -37,7 +37,7 @@ type AllocatedDeviceStatusApplyConfiguration struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// This name together with the driver name and the device name field
 	// identify which device was allocated (`<driver name>/<pool name>/<device name>`).

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicerequestallocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicerequestallocationresult.go
@@ -42,7 +42,7 @@ type DeviceRequestAllocationResultApplyConfiguration struct {
 	// needed on a node.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// This name together with the driver name and the device name field
 	// identify which device was allocated (`<driver name>/<pool name>/<device name>`).

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/opaquedeviceconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/opaquedeviceconfiguration.go
@@ -35,7 +35,7 @@ type OpaqueDeviceConfigurationApplyConfiguration struct {
 	// to decide whether it needs to validate them.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver.
+	// vendor of the driver. It should use only lower case characters.
 	Driver *string `json:"driver,omitempty"`
 	// Parameters can contain arbitrary data. It is the responsibility of
 	// the driver developer to handle validation and versioning. Typically this

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceslicespec.go
@@ -32,7 +32,8 @@ type ResourceSliceSpecApplyConfiguration struct {
 	// objects with a certain driver name.
 	//
 	// Must be a DNS subdomain and should end with a DNS domain owned by the
-	// vendor of the driver. This field is immutable.
+	// vendor of the driver. It should use only lower case characters.
+	// This field is immutable.
 	Driver *string `json:"driver,omitempty"`
 	// Pool describes the pool that this ResourceSlice belongs to.
 	Pool *ResourcePoolApplyConfiguration `json:"pool,omitempty"`

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -205,7 +205,8 @@ type Device struct {
 type Option func(o *options) error
 
 // DriverName defines the driver name for the dynamic resource allocation driver.
-// Must be set.
+// Must be set. Must be a DNS subdomain and should end with a DNS domain
+// owned by the vendor of the driver. It should use only lower case characters.
 func DriverName(driverName string) Option {
 	return func(o *options) error {
 		o.driverName = driverName

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -194,6 +194,8 @@ func StartController(ctx context.Context, options Options) (*Controller, error) 
 // Options contains various optional settings for [StartController].
 type Options struct {
 	// DriverName is the required name of the DRA driver.
+	// Must be a DNS subdomain and should end with a DNS domain
+	// owned by the vendor of the driver. It should use only lower case characters.
 	DriverName string
 
 	// KubeClient is used to read Node objects (if necessary) and to access


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Adds warnings when ResourceSlice driver names contain uppercase characters. 
- Clarifies that driver names must use only lowercase characters.
- Updates tests to check for these warnings.
- Updates generated code / OpenAPI spec to reflect this validation.
- This addresses feedback from #134094 and follow-up comments in the discussion.

#### Which issue(s) this PR is related to:
#134094
#134131

```release-note
NONE
```
-->
