### PR TITLE
fix - preserve the original, accurate failure status of admission-rejected pods across restarts

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1884,7 +1884,36 @@ func (kl *Kubelet) generateAPIPodStatus(ctx context.Context, pod *v1.Pod, podSta
 	if !found {
 		oldPodStatus = pod.Status
 	}
-	s := kl.convertStatusToAPIStatus(ctx, pod, podStatus, oldPodStatus)
+	// A pod that is terminal, has no backing runtime containers, and has no container statuses in its
+	// last known state was likely rejected at admission time. In that case, we should not
+	// generate container statuses, as that would be misleading.
+	isEmptyRuntimeStatus := len(podStatus.ContainerStatuses) == 0 && len(podStatus.SandboxStatuses) == 0
+	wasRejectedAtAdmission := (pod.Status.Phase == v1.PodFailed) &&
+		len(pod.Status.ContainerStatuses) == 0 &&
+		len(pod.Status.InitContainerStatuses) == 0
+
+	var s *v1.PodStatus
+	if podIsTerminal && isEmptyRuntimeStatus && wasRejectedAtAdmission {
+		// Pod was rejected at admission, so we will not generate container statuses.
+		// We will copy the status from the pod object which is the source of truth,
+		// as the status manager may not have a cached entry after a restart.
+		s = pod.Status.DeepCopy()
+
+		// QOS Class is not persisted to the API server, so we must re-calculate it.
+		s.QOSClass = v1qos.GetPodQOS(pod)
+
+		// Ensure slices are non-nil to avoid hitting the nil-check paths
+		// in the condition generators.
+		if s.ContainerStatuses == nil {
+			s.ContainerStatuses = []v1.ContainerStatus{}
+		}
+		if s.InitContainerStatuses == nil {
+			s.InitContainerStatuses = []v1.ContainerStatus{}
+		}
+	} else {
+		// Updated to match master signature
+		s = kl.convertStatusToAPIStatus(ctx, pod, podStatus, oldPodStatus)
+	}
 	// calculate the next phase and preserve reason
 	allStatus := append(append([]v1.ContainerStatus{}, s.ContainerStatuses...), s.InitContainerStatuses...)
 	s.Phase = getPhase(logger, pod, allStatus, podIsTerminal, kubecontainer.HasAnyActiveRegularContainerStarted(&pod.Spec, podStatus))


### PR DESCRIPTION
### PR Title: `kubelet: Fix misleading status for admission-rejected pods across restarts`

<hr>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR addresses a bug where pods that are rejected by the Kubelet's own admission control (e.g., due to `OutOfCpu` or `TaintToleration` failures) have their status incorrectly changed after a Kubelet restart.

Currently, such pods are correctly marked with a `Failed` phase and a clear reason. However, upon Kubelet restart, the status is altered to include a `containerStatuses` array with each container marked as `Terminated` with the reason `ContainerStatusUnknown`. This is misleading because no containers were ever created or run, and it incorrectly suggests a container runtime issue rather than an admission failure.

This PR fixes the issue by enhancing the `generateAPIPodStatus` function. It now includes a specific check to identify this "admission-rejected" scenario (a terminal pod with no corresponding runtime state and no container statuses in its API object). When these conditions are met, the function preserves the pod's original `Failed` status from the API server and avoids generating any spurious container statuses.

This ensures that the pod's status remains accurate and reflects the initial admission failure reason across Kubelet restarts, providing clear and correct feedback to users and controllers.

#### Which issue(s) this PR is related to:

Fixes #133733

#### Special notes for your reviewer:

The core of the change is in `pkg/kubelet/kubelet_pods.go` within the `generateAPIPodStatus` function.

A new test case, `Test_generateAPIPodStatus/admission_rejected_pod_status_is_preserved_after_restart`, has been added to specifically validate this fix.

The key to the fix was not only to identify the admission-rejected state but also to ensure that `ContainerStatuses` and `InitContainerStatuses` are initialized as empty (but non-nil) slices. This prevents the downstream condition generation logic from misinterpreting the state and incorrectly applying the `UnknownContainerStatuses` reason.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where pods rejected by Kubelet admission control (e.g., for `OutOfCpu`) would incorrectly report a status of `ContainerStatusUnknown` for their containers after a Kubelet restart. These pods will now correctly retain their original `Failed` phase and admission failure reason without generating misleading container statuses.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```