### PR TITLE
Updates to DRA Partitionable Devices feature

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15400,13 +15400,13 @@
       "type": "object"
     },
     "io.k8s.api.resource.v1.CounterSet": {
-      "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+      "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
       "properties": {
         "counters": {
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.api.resource.v1.Counter"
           },
-          "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+          "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
           "type": "object"
         },
         "name": {
@@ -15466,7 +15466,7 @@
           "type": "object"
         },
         "consumesCounters": {
-          "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+          "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceCounterConsumption"
           },
@@ -15770,7 +15770,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.api.resource.v1.Counter"
           },
-          "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+          "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
           "type": "object"
         }
       },
@@ -16397,7 +16397,7 @@
           "type": "boolean"
         },
         "devices": {
-          "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+          "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1.Device"
           },
@@ -16425,7 +16425,7 @@
           "description": "Pool describes the pool that this ResourceSlice belongs to."
         },
         "sharedCounters": {
-          "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+          "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1.CounterSet"
           },
@@ -16700,7 +16700,7 @@
           "type": "object"
         },
         "consumesCounters": {
-          "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+          "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceCounterConsumption"
           },
@@ -16809,7 +16809,7 @@
       "type": "object"
     },
     "io.k8s.api.resource.v1beta1.CounterSet": {
-      "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+      "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
       "properties": {
         "counters": {
           "additionalProperties": {
@@ -17117,7 +17117,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.Counter"
           },
-          "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+          "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
           "type": "object"
         }
       },
@@ -17731,7 +17731,7 @@
           "type": "boolean"
         },
         "devices": {
-          "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+          "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.Device"
           },
@@ -17759,7 +17759,7 @@
           "description": "Pool describes the pool that this ResourceSlice belongs to."
         },
         "sharedCounters": {
-          "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of SharedCounters is 32.",
+          "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.CounterSet"
           },
@@ -17920,13 +17920,13 @@
       "type": "object"
     },
     "io.k8s.api.resource.v1beta2.CounterSet": {
-      "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+      "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
       "properties": {
         "counters": {
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.Counter"
           },
-          "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+          "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
           "type": "object"
         },
         "name": {
@@ -17986,7 +17986,7 @@
           "type": "object"
         },
         "consumesCounters": {
-          "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+          "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceCounterConsumption"
           },
@@ -18290,7 +18290,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.Counter"
           },
-          "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+          "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
           "type": "object"
         }
       },
@@ -18917,7 +18917,7 @@
           "type": "boolean"
         },
         "devices": {
-          "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+          "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.Device"
           },
@@ -18945,7 +18945,7 @@
           "description": "Pool describes the pool that this ResourceSlice belongs to."
         },
         "sharedCounters": {
-          "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+          "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.CounterSet"
           },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -287,7 +287,7 @@
         "type": "object"
       },
       "io.k8s.api.resource.v1.CounterSet": {
-        "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+        "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
         "properties": {
           "counters": {
             "additionalProperties": {
@@ -298,7 +298,7 @@
               ],
               "default": {}
             },
-            "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+            "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
             "type": "object"
           },
           "name": {
@@ -371,7 +371,7 @@
             "type": "object"
           },
           "consumesCounters": {
-            "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+            "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
             "items": {
               "allOf": [
                 {
@@ -775,7 +775,7 @@
               ],
               "default": {}
             },
-            "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+            "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
             "type": "object"
           }
         },
@@ -1571,7 +1571,7 @@
             "type": "boolean"
           },
           "devices": {
-            "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+            "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
             "items": {
               "allOf": [
                 {
@@ -1614,7 +1614,7 @@
             "description": "Pool describes the pool that this ResourceSlice belongs to."
           },
           "sharedCounters": {
-            "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+            "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
             "items": {
               "allOf": [
                 {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -237,7 +237,7 @@
             "type": "object"
           },
           "consumesCounters": {
-            "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+            "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
             "items": {
               "allOf": [
                 {
@@ -385,7 +385,7 @@
         "type": "object"
       },
       "io.k8s.api.resource.v1beta1.CounterSet": {
-        "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+        "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
         "properties": {
           "counters": {
             "additionalProperties": {
@@ -789,7 +789,7 @@
               ],
               "default": {}
             },
-            "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+            "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
             "type": "object"
           }
         },
@@ -1568,7 +1568,7 @@
             "type": "boolean"
           },
           "devices": {
-            "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+            "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
             "items": {
               "allOf": [
                 {
@@ -1611,7 +1611,7 @@
             "description": "Pool describes the pool that this ResourceSlice belongs to."
           },
           "sharedCounters": {
-            "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of SharedCounters is 32.",
+            "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
             "items": {
               "allOf": [
                 {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -287,7 +287,7 @@
         "type": "object"
       },
       "io.k8s.api.resource.v1beta2.CounterSet": {
-        "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+        "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
         "properties": {
           "counters": {
             "additionalProperties": {
@@ -298,7 +298,7 @@
               ],
               "default": {}
             },
-            "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+            "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
             "type": "object"
           },
           "name": {
@@ -371,7 +371,7 @@
             "type": "object"
           },
           "consumesCounters": {
-            "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+            "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
             "items": {
               "allOf": [
                 {
@@ -775,7 +775,7 @@
               ],
               "default": {}
             },
-            "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+            "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
             "type": "object"
           }
         },
@@ -1571,7 +1571,7 @@
             "type": "boolean"
           },
           "devices": {
-            "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+            "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
             "items": {
               "allOf": [
                 {
@@ -1614,7 +1614,7 @@
             "description": "Pool describes the pool that this ResourceSlice belongs to."
           },
           "sharedCounters": {
-            "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+            "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
             "items": {
               "allOf": [
                 {

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -249,14 +249,10 @@ type ResourcePool struct {
 
 const ResourceSliceMaxSharedCapacity = 128
 const ResourceSliceMaxDevices = 128
-const ResourceSliceMaxDevicesWithTaints = 64
+const ResourceSliceMaxDevicesWithTaintsOrConsumesCounters = 64
 const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
-
-// Defines the max number of shared counters that can be specified
-// in a ResourceSlice. The number is summed up across all sets.
-const ResourceSliceMaxSharedCounters = 32
 
 // Defines the maximum number of counter sets (through the
 // SharedCounters field) that can be defined in a ResourceSlice.
@@ -274,11 +270,6 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // Defines the maximum number of counters that can be defined
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
-
-// Defines the maximum number of counters that can be defined
-// in device counter consumptions across all devices in a
-// ResourceSlice.
-const ResourceSliceMaxConsumedCountersPerResourceSlice = 2048
 
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
@@ -556,14 +547,6 @@ type CapacityRequestPolicyRange struct {
 
 // Limit for the sum of the number of entries in both attributes and capacity.
 const ResourceSliceMaxAttributesAndCapacitiesPerDevice = 32
-
-// Limit for the total number of counters in each device.
-const ResourceSliceMaxCountersPerDevice = 32
-
-// Limit for the total number of counters defined in devices in
-// a ResourceSlice. We want to allow up to 64 devices to specify
-// up to 16 counters, so the limit for the ResourceSlice will be 1024.
-const ResourceSliceMaxDeviceCountersPerSlice = 1024 // 64 * 16
 
 // QualifiedName is the name of a device attribute or capacity.
 //

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -193,6 +193,33 @@ func Validate_AllocationResult(ctx context.Context, op operation.Operation, fldP
 	return errs
 }
 
+// Validate_CounterSet validates an instance of CounterSet according
+// to declarative validation rules in the API schema.
+func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.CounterSet) (errs field.ErrorList) {
+	// field resourcev1.CounterSet.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *resourcev1.CounterSet) *string { return &oldObj.Name }), oldObj != nil)...)
+
+	// field resourcev1.CounterSet.Counters has no validation
+	return errs
+}
+
 // Validate_Device validates an instance of Device according
 // to declarative validation rules in the API schema.
 func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.Device) (errs field.ErrorList) {
@@ -213,7 +240,37 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 		}), oldObj != nil)...)
 
 	// field resourcev1.Device.Capacity has no validation
-	// field resourcev1.Device.ConsumesCounters has no validation
+
+	// field resourcev1.Device.ConsumesCounters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceCounterConsumption, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceCounterConsumption, b resourcev1.DeviceCounterConsumption) bool {
+				return a.CounterSet == b.CounterSet
+			})...)
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.DeviceCounterConsumption, b resourcev1.DeviceCounterConsumption) bool {
+				return a.CounterSet == b.CounterSet
+			}, validate.SemanticDeepEqual, Validate_DeviceCounterConsumption)...)
+			return
+		}(fldPath.Child("consumesCounters"), obj.ConsumesCounters, safe.Field(oldObj, func(oldObj *resourcev1.Device) []resourcev1.DeviceCounterConsumption { return oldObj.ConsumesCounters }), oldObj != nil)...)
+
 	// field resourcev1.Device.NodeName has no validation
 	// field resourcev1.Device.NodeSelector has no validation
 	// field resourcev1.Device.AllNodes has no validation
@@ -869,6 +926,33 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 		}(fldPath.Child("matchAttribute"), obj.MatchAttribute, safe.Field(oldObj, func(oldObj *resourcev1.DeviceConstraint) *resourcev1.FullyQualifiedName { return oldObj.MatchAttribute }), oldObj != nil)...)
 
 	// field resourcev1.DeviceConstraint.DistinctAttribute has no validation
+	return errs
+}
+
+// Validate_DeviceCounterConsumption validates an instance of DeviceCounterConsumption according
+// to declarative validation rules in the API schema.
+func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceCounterConsumption) (errs field.ErrorList) {
+	// field resourcev1.DeviceCounterConsumption.CounterSet
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("counterSet"), &obj.CounterSet, safe.Field(oldObj, func(oldObj *resourcev1.DeviceCounterConsumption) *string { return &oldObj.CounterSet }), oldObj != nil)...)
+
+	// field resourcev1.DeviceCounterConsumption.Counters has no validation
 	return errs
 }
 
@@ -1707,6 +1791,32 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1.ResourceSliceSpec) []resourcev1.Device { return oldObj.Devices }), oldObj != nil)...)
 
 	// field resourcev1.ResourceSliceSpec.PerDeviceNodeSelection has no validation
-	// field resourcev1.ResourceSliceSpec.SharedCounters has no validation
+
+	// field resourcev1.ResourceSliceSpec.SharedCounters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.CounterSet, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name })...)
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_CounterSet)...)
+			return
+		}(fldPath.Child("sharedCounters"), obj.SharedCounters, safe.Field(oldObj, func(oldObj *resourcev1.ResourceSliceSpec) []resourcev1.CounterSet { return oldObj.SharedCounters }), oldObj != nil)...)
+
 	return errs
 }

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -213,7 +213,39 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 		}), oldObj != nil)...)
 
 	// field resourcev1beta1.BasicDevice.Capacity has no validation
-	// field resourcev1beta1.BasicDevice.ConsumesCounters has no validation
+
+	// field resourcev1beta1.BasicDevice.ConsumesCounters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceCounterConsumption, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceCounterConsumption, b resourcev1beta1.DeviceCounterConsumption) bool {
+				return a.CounterSet == b.CounterSet
+			})...)
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.DeviceCounterConsumption, b resourcev1beta1.DeviceCounterConsumption) bool {
+				return a.CounterSet == b.CounterSet
+			}, validate.SemanticDeepEqual, Validate_DeviceCounterConsumption)...)
+			return
+		}(fldPath.Child("consumesCounters"), obj.ConsumesCounters, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []resourcev1beta1.DeviceCounterConsumption {
+			return oldObj.ConsumesCounters
+		}), oldObj != nil)...)
+
 	// field resourcev1beta1.BasicDevice.NodeName has no validation
 	// field resourcev1beta1.BasicDevice.NodeSelector has no validation
 	// field resourcev1beta1.BasicDevice.AllNodes has no validation
@@ -277,6 +309,33 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 		}(fldPath.Child("bindingFailureConditions"), obj.BindingFailureConditions, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []string { return oldObj.BindingFailureConditions }), oldObj != nil)...)
 
 	// field resourcev1beta1.BasicDevice.AllowMultipleAllocations has no validation
+	return errs
+}
+
+// Validate_CounterSet validates an instance of CounterSet according
+// to declarative validation rules in the API schema.
+func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.CounterSet) (errs field.ErrorList) {
+	// field resourcev1beta1.CounterSet.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *resourcev1beta1.CounterSet) *string { return &oldObj.Name }), oldObj != nil)...)
+
+	// field resourcev1beta1.CounterSet.Counters has no validation
 	return errs
 }
 
@@ -899,6 +958,33 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 		}), oldObj != nil)...)
 
 	// field resourcev1beta1.DeviceConstraint.DistinctAttribute has no validation
+	return errs
+}
+
+// Validate_DeviceCounterConsumption validates an instance of DeviceCounterConsumption according
+// to declarative validation rules in the API schema.
+func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceCounterConsumption) (errs field.ErrorList) {
+	// field resourcev1beta1.DeviceCounterConsumption.CounterSet
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("counterSet"), &obj.CounterSet, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceCounterConsumption) *string { return &oldObj.CounterSet }), oldObj != nil)...)
+
+	// field resourcev1beta1.DeviceCounterConsumption.Counters has no validation
 	return errs
 }
 
@@ -1741,6 +1827,34 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceSliceSpec) []resourcev1beta1.Device { return oldObj.Devices }), oldObj != nil)...)
 
 	// field resourcev1beta1.ResourceSliceSpec.PerDeviceNodeSelection has no validation
-	// field resourcev1beta1.ResourceSliceSpec.SharedCounters has no validation
+
+	// field resourcev1beta1.ResourceSliceSpec.SharedCounters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.CounterSet, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name })...)
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_CounterSet)...)
+			return
+		}(fldPath.Child("sharedCounters"), obj.SharedCounters, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceSliceSpec) []resourcev1beta1.CounterSet {
+			return oldObj.SharedCounters
+		}), oldObj != nil)...)
+
 	return errs
 }

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -195,6 +195,33 @@ func Validate_AllocationResult(ctx context.Context, op operation.Operation, fldP
 	return errs
 }
 
+// Validate_CounterSet validates an instance of CounterSet according
+// to declarative validation rules in the API schema.
+func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.CounterSet) (errs field.ErrorList) {
+	// field resourcev1beta2.CounterSet.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *resourcev1beta2.CounterSet) *string { return &oldObj.Name }), oldObj != nil)...)
+
+	// field resourcev1beta2.CounterSet.Counters has no validation
+	return errs
+}
+
 // Validate_Device validates an instance of Device according
 // to declarative validation rules in the API schema.
 func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.Device) (errs field.ErrorList) {
@@ -215,7 +242,39 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 		}), oldObj != nil)...)
 
 	// field resourcev1beta2.Device.Capacity has no validation
-	// field resourcev1beta2.Device.ConsumesCounters has no validation
+
+	// field resourcev1beta2.Device.ConsumesCounters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceCounterConsumption, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceCounterConsumption, b resourcev1beta2.DeviceCounterConsumption) bool {
+				return a.CounterSet == b.CounterSet
+			})...)
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.DeviceCounterConsumption, b resourcev1beta2.DeviceCounterConsumption) bool {
+				return a.CounterSet == b.CounterSet
+			}, validate.SemanticDeepEqual, Validate_DeviceCounterConsumption)...)
+			return
+		}(fldPath.Child("consumesCounters"), obj.ConsumesCounters, safe.Field(oldObj, func(oldObj *resourcev1beta2.Device) []resourcev1beta2.DeviceCounterConsumption {
+			return oldObj.ConsumesCounters
+		}), oldObj != nil)...)
+
 	// field resourcev1beta2.Device.NodeName has no validation
 	// field resourcev1beta2.Device.NodeSelector has no validation
 	// field resourcev1beta2.Device.AllNodes has no validation
@@ -881,6 +940,33 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 		}), oldObj != nil)...)
 
 	// field resourcev1beta2.DeviceConstraint.DistinctAttribute has no validation
+	return errs
+}
+
+// Validate_DeviceCounterConsumption validates an instance of DeviceCounterConsumption according
+// to declarative validation rules in the API schema.
+func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceCounterConsumption) (errs field.ErrorList) {
+	// field resourcev1beta2.DeviceCounterConsumption.CounterSet
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.ShortName(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("counterSet"), &obj.CounterSet, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceCounterConsumption) *string { return &oldObj.CounterSet }), oldObj != nil)...)
+
+	// field resourcev1beta2.DeviceCounterConsumption.Counters has no validation
 	return errs
 }
 
@@ -1743,6 +1829,34 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceSliceSpec) []resourcev1beta2.Device { return oldObj.Devices }), oldObj != nil)...)
 
 	// field resourcev1beta2.ResourceSliceSpec.PerDeviceNodeSelection has no validation
-	// field resourcev1beta2.ResourceSliceSpec.SharedCounters has no validation
+
+	// field resourcev1beta2.ResourceSliceSpec.SharedCounters
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.CounterSet, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name })...)
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_CounterSet)...)
+			return
+		}(fldPath.Child("sharedCounters"), obj.SharedCounters, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceSliceSpec) []resourcev1beta2.CounterSet {
+			return oldObj.SharedCounters
+		}), oldObj != nil)...)
+
 	return errs
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -48360,7 +48360,7 @@ func schema_k8sio_api_resource_v1_CounterSet(ref common.ReferenceCallback) commo
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+				Description: "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -48373,7 +48373,7 @@ func schema_k8sio_api_resource_v1_CounterSet(ref common.ReferenceCallback) commo
 					},
 					"counters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+							Description: "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -48447,7 +48447,7 @@ func schema_k8sio_api_resource_v1_Device(ref common.ReferenceCallback) common.Op
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+							Description: "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -49108,7 +49108,7 @@ func schema_k8sio_api_resource_v1_DeviceCounterConsumption(ref common.ReferenceC
 					},
 					"counters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+							Description: "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -50236,7 +50236,7 @@ func schema_k8sio_api_resource_v1_ResourceSliceSpec(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+							Description: "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -50262,7 +50262,7 @@ func schema_k8sio_api_resource_v1_ResourceSliceSpec(ref common.ReferenceCallback
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+							Description: "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -50735,7 +50735,7 @@ func schema_k8sio_api_resource_v1beta1_BasicDevice(ref common.ReferenceCallback)
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+							Description: "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -51004,7 +51004,7 @@ func schema_k8sio_api_resource_v1beta1_CounterSet(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+				Description: "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -51616,7 +51616,7 @@ func schema_k8sio_api_resource_v1beta1_DeviceCounterConsumption(ref common.Refer
 					},
 					"counters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+							Description: "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -52722,7 +52722,7 @@ func schema_k8sio_api_resource_v1beta1_ResourceSliceSpec(ref common.ReferenceCal
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+							Description: "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -52748,7 +52748,7 @@ func schema_k8sio_api_resource_v1beta1_ResourceSliceSpec(ref common.ReferenceCal
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of SharedCounters is 32.",
+							Description: "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -53040,7 +53040,7 @@ func schema_k8sio_api_resource_v1beta2_CounterSet(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+				Description: "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -53053,7 +53053,7 @@ func schema_k8sio_api_resource_v1beta2_CounterSet(ref common.ReferenceCallback) 
 					},
 					"counters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+							Description: "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -53127,7 +53127,7 @@ func schema_k8sio_api_resource_v1beta2_Device(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+							Description: "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -53788,7 +53788,7 @@ func schema_k8sio_api_resource_v1beta2_DeviceCounterConsumption(ref common.Refer
 					},
 					"counters": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+							Description: "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -54916,7 +54916,7 @@ func schema_k8sio_api_resource_v1beta2_ResourceSliceSpec(ref common.ReferenceCal
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+							Description: "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -54942,7 +54942,7 @@ func schema_k8sio_api_resource_v1beta2_ResourceSliceSpec(ref common.ReferenceCal
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+							Description: "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -48,43 +48,43 @@ func TestDeclarativeValidate(t *testing.T) {
 				expectedErrs field.ErrorList
 			}{
 				"valid": {
-					input: mkResourceSlice(),
+					input: mkResourceSliceWithDevices(),
 				},
 				// spec.devices[%d].bindingConditions
 				"valid: one binding condition": {
-					input: mkResourceSlice(tweakBindingConditions(1)),
+					input: mkResourceSliceWithDevices(tweakBindingConditions(1)),
 				},
 				"valid: at limit binding conditions": {
-					input: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize)),
+					input: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize)),
 				},
 				"invalid: too many binding conditions": {
-					input: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
+					input: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
 						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems"),
 					},
 				},
 				// spec.devices[%d].bindingFailureConditions
 				"valid: one binding failure conditions": {
-					input: mkResourceSlice(tweakBindingFailureConditions(1)),
+					input: mkResourceSliceWithDevices(tweakBindingFailureConditions(1)),
 				},
 				"valid: at limit binding failure conditions": {
-					input: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize)),
+					input: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize)),
 				},
 				"invalid: too many binding failure conditions": {
-					input: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
+					input: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
 						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems"),
 					},
 				},
 				// spec.Devices[%d].Taints[%d].Effect
 				"valid: taint NoSchedule": {
-					input: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoSchedule))),
+					input: mkResourceSliceWithDevices(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoSchedule))),
 				},
 				"valid: taint NoExecute": {
-					input: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoExecute))),
+					input: mkResourceSliceWithDevices(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoExecute))),
 				},
 				"invalid: taint Invalid": {
-					input: mkResourceSlice(tweakDeviceTaintEffect("Invalid")),
+					input: mkResourceSliceWithDevices(tweakDeviceTaintEffect("Invalid")),
 					expectedErrs: field.ErrorList{
 						field.NotSupported(
 							field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"),
@@ -92,34 +92,106 @@ func TestDeclarativeValidate(t *testing.T) {
 					},
 				},
 				"invalid: taint empty": {
-					input: mkResourceSlice(tweakDeviceTaintEffect("")),
+					input: mkResourceSliceWithDevices(tweakDeviceTaintEffect("")),
 					expectedErrs: field.ErrorList{
 						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), ""),
 					},
 				},
 				// spec.Devices[%].attribute
 				"valid: device attribute int": {
-					input: mkResourceSlice(tweakDeviceAttribute("test.io/int", resource.DeviceAttribute{IntValue: ptr.To[int64](123)})),
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/int", resource.DeviceAttribute{IntValue: ptr.To[int64](123)})),
 				},
 				"valid: device attribute bool": {
-					input: mkResourceSlice(tweakDeviceAttribute("test.io/bool", resource.DeviceAttribute{BoolValue: ptr.To(true)})),
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/bool", resource.DeviceAttribute{BoolValue: ptr.To(true)})),
 				},
 				"valid: device attribute string": {
-					input: mkResourceSlice(tweakDeviceAttribute("test.io/string", resource.DeviceAttribute{StringValue: ptr.To("value")})),
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/string", resource.DeviceAttribute{StringValue: ptr.To("value")})),
 				},
 				"valid: device attribute version": {
-					input: mkResourceSlice(tweakDeviceAttribute("test.io/version", resource.DeviceAttribute{VersionValue: ptr.To("1.2.3")})),
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/version", resource.DeviceAttribute{VersionValue: ptr.To("1.2.3")})),
 				},
 				"invalid: device attribute with multiple values": {
-					input: mkResourceSlice(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", ""),
 					},
 				},
 				"invalid: device attribute no value": {
-					input: mkResourceSlice(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{})),
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{})),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", ""),
+					},
+				},
+				// spec.sharedCounters
+				"valid: at limit shared counters": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets)),
+				},
+				"invalid: too many shared counters": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems"),
+					},
+				},
+				// spec.devices.consumesCounters
+				"valid: at limit device consumes counters": {
+					input: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice)),
+				},
+				"invalid: too many device consumes counters": {
+					input: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems"),
+					},
+				},
+				// spec.sharedCounters.name
+				"valid: counter set name": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("valid-key")),
+				},
+				"invalid: counter set name": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("InvalidKey")),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+					},
+				},
+				"invalid: counter set name not set": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("")),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), ""),
+					},
+				},
+				// spec.devices.consumesCounters.counterSet
+				"valid: device consumes counters counter set name": {
+					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("valid-key")),
+				},
+				"invalid: device consumes counters counter set name": {
+					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("InvalidKey")),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+					},
+				},
+				"invalid: device consumes counters counter set name not set": {
+					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("")),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), ""),
+					},
+				},
+				// spec.sharedCounters
+				"valid: distinct names for shared counters": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("valid-key-1", "valid-key-2")),
+				},
+				"invalid: duplicate names for shared counters": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCountersName("duplicate-key", "duplicate-key")),
+					expectedErrs: field.ErrorList{
+						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key"),
+					},
+				},
+				// spec.devices.consumesCounters
+				"valid: distinct names for counter set in device counter consumption": {
+					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("valid-key-1", "valid-key-2")),
+				},
+				"invalid: duplicate names for counter set in device counter consumption": {
+					input: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("duplicate-key", "duplicate-key")),
+					expectedErrs: field.ErrorList{
+						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key"),
 					},
 				},
 				// TODO: Add more test cases
@@ -151,65 +223,151 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 				expectedErrs field.ErrorList
 			}{
 				"valid no changes": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(),
 				},
 				// spec.devices[%d].bindingConditions
 				"valid update: at limit binding conditions": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize)),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize)),
 				},
 				"invalid update:update with too many binding conditions": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
 						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems"),
 					},
 				},
 				// spec.devices[%d].bindingFailureConditions
 				"valid update: at limit binding failure conditions": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize)),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize)),
 				},
 				"update with too many binding failure conditions": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
 					expectedErrs: field.ErrorList{
 						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems"),
 					},
 				},
 				// spec.devices.taints.effect
 				"valid update: NoSchedule taint effect": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoSchedule))),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoSchedule))),
 				},
 				"valid update: NoExecute taint effect": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoExecute))),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoExecute))),
 				},
 				"invalid update: unsupported taint effect": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakDeviceTaintEffect("InvalidEffect")),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect("InvalidEffect")),
 					expectedErrs: field.ErrorList{
 						field.NotSupported(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "InvalidEffect", []string{string(resource.DeviceTaintEffectNoSchedule), string(resource.DeviceTaintEffectNoExecute)}),
 					},
 				},
 				"invalid update: empty taint effect": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakDeviceTaintEffect("")),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceTaintEffect("")),
 					expectedErrs: field.ErrorList{
 						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), ""),
 					},
 				},
 				"valid update: device attribute": {
-					old:    mkResourceSlice(tweakDeviceAttribute("test.io/int", resource.DeviceAttribute{IntValue: ptr.To[int64](123)})),
-					update: mkResourceSlice(tweakDeviceAttribute("test.io/int", resource.DeviceAttribute{BoolValue: ptr.To(true)})),
+					old:    mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/int", resource.DeviceAttribute{IntValue: ptr.To[int64](123)})),
+					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/int", resource.DeviceAttribute{BoolValue: ptr.To(true)})),
 				},
 				"invalid update: device attribute with multiple values": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "may have only one of the following fields set: bool, int, string, version"),
+					},
+				},
+				// spec.sharedCounters
+				"valid update: at limit shared counters": {
+					old:    mkResourceSliceWithSharedCounters(),
+					update: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets)),
+				},
+				"invalid update: too many shared counters": {
+					old:    mkResourceSliceWithSharedCounters(),
+					update: mkResourceSliceWithSharedCounters(tweakSharedCounters(resource.ResourceSliceMaxCounterSets + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec").Child("sharedCounters"), resource.ResourceSliceMaxCounterSets+1, resource.ResourceSliceMaxCounterSets).WithOrigin("maxItems"),
+					},
+				},
+				// spec.devices.consumesCounters
+				"valid update: at limit device consumes counters": {
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice)),
+				},
+				"invalid update: too many device consumes counters": {
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceConsumesCounters(resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("consumesCounters"), resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice+1, resource.ResourceSliceMaxDeviceCounterConsumptionsPerDevice).WithOrigin("maxItems"),
+					},
+				},
+				// spec.sharedCounters.name
+				"valid update: counter set name": {
+					old:    mkResourceSliceWithSharedCounters(),
+					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("valid-key")),
+				},
+				"invalid update: counter set name": {
+					old:    mkResourceSliceWithSharedCounters(),
+					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("InvalidKey")),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+					},
+				},
+				"invalid update: counter set name not set": {
+					old:    mkResourceSliceWithSharedCounters(),
+					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("")),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), ""),
+					},
+				},
+				// spec.devices.consumesCounters.counterSet
+				"valid update: device consumes counters counter set name": {
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("valid-key")),
+				},
+				"invalid update: device consumes counters counter set name": {
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("InvalidKey")),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
+					},
+				},
+				"invalidupdate: device consumes counters counter set name not set": {
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("")),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), ""),
+					},
+				},
+				// spec.sharedCounters
+				"valid update: distinct names for shared counters": {
+					old:    mkResourceSliceWithSharedCounters(),
+					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("valid-key-1", "valid-key-2")),
+				},
+				"invalid update: duplicate names for shared counters": {
+					old:    mkResourceSliceWithSharedCounters(),
+					update: mkResourceSliceWithSharedCounters(tweakSharedCountersName("duplicate-key", "duplicate-key")),
+					expectedErrs: field.ErrorList{
+						field.Duplicate(field.NewPath("spec").Child("sharedCounters").Index(1), "duplicate-key"),
+					},
+				},
+				// spec.devices.consumesCounters
+				"valid update: distinct names for counter set in device counter consumption": {
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("valid-key-1", "valid-key-2")),
+				},
+				"invalid update: duplicate names for counter set in device counter consumption": {
+					old:    mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceConsumesCountersCounterSetName("duplicate-key", "duplicate-key")),
+					expectedErrs: field.ErrorList{
+						field.Duplicate(field.NewPath("spec").Child("devices").Index(0).Child("consumesCounters").Index(1), "duplicate-key"),
 					},
 				},
 			}
@@ -224,7 +382,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 	}
 }
 
-func mkResourceSlice(mutators ...func(*resource.ResourceSlice)) resource.ResourceSlice {
+func mkResourceSliceWithDevices(mutators ...func(*resource.ResourceSlice)) resource.ResourceSlice {
 	rs := resource.ResourceSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-slice",
@@ -245,6 +403,34 @@ func mkResourceSlice(mutators ...func(*resource.ResourceSlice)) resource.Resourc
 							Value:  "value1",
 							Effect: resource.DeviceTaintEffectNoSchedule,
 						},
+					},
+				},
+			},
+		},
+	}
+	for _, mutate := range mutators {
+		mutate(&rs)
+	}
+	return rs
+}
+
+func mkResourceSliceWithSharedCounters(mutators ...func(*resource.ResourceSlice)) resource.ResourceSlice {
+	rs := resource.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-slice",
+		},
+		Spec: resource.ResourceSliceSpec{
+			Driver:   "test.driver.io",
+			NodeName: ptr.To("test-node"),
+			Pool: resource.ResourcePool{
+				Name:               "test-pool",
+				ResourceSliceCount: 5,
+			},
+			SharedCounters: []resource.CounterSet{
+				{
+					Name: "shared-counter-set",
+					Counters: map[string]resource.Counter{
+						"valid-key": {},
 					},
 				},
 			},
@@ -292,5 +478,65 @@ func tweakDeviceAttribute(name resource.QualifiedName, value resource.DeviceAttr
 			rs.Spec.Devices[0].Attributes = make(map[resource.QualifiedName]resource.DeviceAttribute)
 		}
 		rs.Spec.Devices[0].Attributes[name] = value
+	}
+}
+
+func tweakSharedCountersName(names ...string) func(*resource.ResourceSlice) {
+	return func(rs *resource.ResourceSlice) {
+		var sharedCounters []resource.CounterSet
+		for _, name := range names {
+			sharedCounters = append(sharedCounters, resource.CounterSet{
+				Name: name,
+				Counters: map[string]resource.Counter{
+					"valid-key": {},
+				},
+			})
+		}
+		rs.Spec.SharedCounters = sharedCounters
+	}
+}
+
+func tweakSharedCounters(count int) func(*resource.ResourceSlice) {
+	return func(rs *resource.ResourceSlice) {
+		var counterSets []resource.CounterSet
+		for i := 0; i < count; i++ {
+			counterSets = append(counterSets, resource.CounterSet{
+				Name: fmt.Sprintf("shared-counter-set-%d", i),
+				Counters: map[string]resource.Counter{
+					"valid-key": {},
+				},
+			})
+		}
+		rs.Spec.SharedCounters = counterSets
+	}
+}
+
+func tweakDeviceConsumesCounters(count int) func(*resource.ResourceSlice) {
+	return func(rs *resource.ResourceSlice) {
+		var consumesCounters []resource.DeviceCounterConsumption
+		for i := 0; i < count; i++ {
+			consumesCounters = append(consumesCounters, resource.DeviceCounterConsumption{
+				CounterSet: fmt.Sprintf("shared-counter-set-%d", i),
+				Counters: map[string]resource.Counter{
+					"valid-key": {},
+				},
+			})
+		}
+		rs.Spec.Devices[0].ConsumesCounters = consumesCounters
+	}
+}
+
+func tweakDeviceConsumesCountersCounterSetName(counterSets ...string) func(*resource.ResourceSlice) {
+	return func(rs *resource.ResourceSlice) {
+		var consumesCounters []resource.DeviceCounterConsumption
+		for _, counterSet := range counterSets {
+			consumesCounters = append(consumesCounters, resource.DeviceCounterConsumption{
+				CounterSet: counterSet,
+				Counters: map[string]resource.Counter{
+					"valid-key": {},
+				},
+			})
+		}
+		rs.Spec.Devices[0].ConsumesCounters = consumesCounters
 	}
 }

--- a/pkg/registry/resource/resourceslice/strategy_test.go
+++ b/pkg/registry/resource/resourceslice/strategy_test.go
@@ -66,7 +66,7 @@ var sliceWithBindingConditions = func() *resource.ResourceSlice {
 	return slice
 }()
 
-var sliceWithPartitionableDevices = &resource.ResourceSlice{
+var sliceWithPartitionableDevicesPerDeviceNodeSelection = &resource.ResourceSlice{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "valid-resource-slice",
 	},
@@ -81,15 +81,29 @@ var sliceWithPartitionableDevices = &resource.ResourceSlice{
 			ResourceSliceCount: 1,
 			Generation:         1,
 		},
-		SharedCounters: []resource.CounterSet{
+		Devices: []resource.Device{
 			{
-				Name: "pool-1",
-				Counters: map[string]resource.Counter{
-					"memory": {
-						Value: k8sresource.MustParse("40Gi"),
-					},
-				},
+				Name: "device",
+				NodeName: func() *string {
+					r := "valid-node-name"
+					return &r
+				}(),
 			},
+		},
+	},
+}
+
+var sliceWithPartitionableDevicesConsumesCounters = &resource.ResourceSlice{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "valid-resource-slice",
+	},
+	Spec: resource.ResourceSliceSpec{
+		NodeName: ptr.To("valid-node-name"),
+		Driver:   "testdriver.example.com",
+		Pool: resource.ResourcePool{
+			Name:               "valid-pool-name",
+			ResourceSliceCount: 1,
+			Generation:         1,
 		},
 		Devices: []resource.Device{
 			{
@@ -104,10 +118,6 @@ var sliceWithPartitionableDevices = &resource.ResourceSlice{
 						},
 					},
 				},
-				NodeName: func() *string {
-					r := "valid-node-name"
-					return &r
-				}(),
 				Attributes: map[resource.QualifiedName]resource.DeviceAttribute{
 					resource.QualifiedName("version"): {
 						StringValue: func() *string {
@@ -118,6 +128,31 @@ var sliceWithPartitionableDevices = &resource.ResourceSlice{
 				},
 				Capacity: map[resource.QualifiedName]resource.DeviceCapacity{
 					resource.QualifiedName("memory"): {
+						Value: k8sresource.MustParse("40Gi"),
+					},
+				},
+			},
+		},
+	},
+}
+
+var sliceWithPartitionableDevicesSharedCounters = &resource.ResourceSlice{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "valid-resource-slice",
+	},
+	Spec: resource.ResourceSliceSpec{
+		NodeName: ptr.To("valid-node-name"),
+		Driver:   "testdriver.example.com",
+		Pool: resource.ResourcePool{
+			Name:               "valid-pool-name",
+			ResourceSliceCount: 1,
+			Generation:         1,
+		},
+		SharedCounters: []resource.CounterSet{
+			{
+				Name: "pool-1",
+				Counters: map[string]resource.Counter{
+					"memory": {
 						Value: k8sresource.MustParse("40Gi"),
 					},
 				},
@@ -207,26 +242,15 @@ func TestResourceSliceStrategyCreate(t *testing.T) {
 				return obj
 			}(),
 		},
-		"drop-fields-partitionable-devices": {
+		"drop-fields-partitionable-devices-with-consumes-counters": {
 			obj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
-				obj.Spec.PerDeviceNodeSelection = func() *bool {
-					r := false
-					return &r
-				}()
-				obj.Spec.NodeName = ptr.To("valid-node-name")
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
 				return obj
 			}(),
 			partitionableDevices: false,
 			expectObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
 				obj.ObjectMeta.Generation = 1
-				obj.Spec.SharedCounters = nil
-				obj.Spec.PerDeviceNodeSelection = nil
-				obj.Spec.NodeName = ptr.To("valid-node-name")
-				obj.Spec.Devices[0].NodeName = nil
-				obj.Spec.Devices[0].NodeSelector = nil
-				obj.Spec.Devices[0].AllNodes = nil
 				obj.Spec.Devices[0].ConsumesCounters = nil
 				return obj
 			}(),
@@ -235,15 +259,46 @@ func TestResourceSliceStrategyCreate(t *testing.T) {
 		// have a node selector after the perDeviceNodeSelection field got
 		// dropped.
 		"drop-fields-partitionable-devices-with-per-device-node-selection": {
-			obj:                     sliceWithPartitionableDevices,
+			obj:                     sliceWithPartitionableDevicesPerDeviceNodeSelection,
 			partitionableDevices:    false,
 			expectedValidationError: true,
 		},
-		"keep-fields-partitionable-devices": {
-			obj:                  sliceWithPartitionableDevices,
+		"drop-fields-partitionable-devices-with-shared-counters": {
+			obj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				return obj
+			}(),
+			partitionableDevices: false,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				obj.ObjectMeta.Generation = 1
+				obj.Spec.SharedCounters = nil
+				return obj
+			}(),
+		},
+		"keep-fields-partitionable-devices-with-consumes-counters": {
+			obj:                  sliceWithPartitionableDevicesConsumesCounters,
 			partitionableDevices: true,
 			expectObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
+				obj.Generation = 1
+				return obj
+			}(),
+		},
+		"keep-fields-partitionable-devices-with-per-device-node-selection": {
+			obj:                  sliceWithPartitionableDevicesPerDeviceNodeSelection,
+			partitionableDevices: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesPerDeviceNodeSelection.DeepCopy()
+				obj.Generation = 1
+				return obj
+			}(),
+		},
+		"keep-fields-partitionable-devices-with-shared-counters": {
+			obj:                  sliceWithPartitionableDevicesSharedCounters,
+			partitionableDevices: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
 				obj.Generation = 1
 				return obj
 			}(),
@@ -420,86 +475,168 @@ func TestResourceSliceStrategyUpdate(t *testing.T) {
 				return obj
 			}(),
 		},
-		"drop-fields-partitionable-devices": {
+		"drop-fields-partitionable-devices-with-consumes-counters": {
 			oldObj: slice,
 			newObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
 				obj.ResourceVersion = "4"
-				obj.Spec.PerDeviceNodeSelection = func() *bool {
-					r := false
-					return &r
-				}()
-				obj.Spec.NodeName = ptr.To("valid-node-name")
 				return obj
 			}(),
 			partitionableDevices: false,
 			expectObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
 				obj.ResourceVersion = "4"
 				obj.Generation = 1
-				obj.Spec.SharedCounters = nil
-				obj.Spec.PerDeviceNodeSelection = nil
-				obj.Spec.NodeName = ptr.To("valid-node-name")
 				obj.Spec.Devices[0].ConsumesCounters = nil
-				obj.Spec.Devices[0].NodeName = nil
 				return obj
 			}(),
 		},
 		"drop-fields-partitionable-devices-with-per-device-node-selection": {
 			oldObj: slice,
 			newObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
+				obj := sliceWithPartitionableDevicesPerDeviceNodeSelection.DeepCopy()
 				obj.ResourceVersion = "4"
 				return obj
 			}(),
 			partitionableDevices:  false,
 			expectValidationError: true,
 		},
-		"keep-fields-partitionable-devices": {
+		"drop-fields-partitionable-devices-with-shared-counters": {
 			oldObj: slice,
 			newObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
-				obj.ResourceVersion = "4"
-				obj.Spec.NodeName = ptr.To("valid-node-name")
-				obj.Spec.PerDeviceNodeSelection = nil
-				obj.Spec.Devices[0].NodeName = nil
-				return obj
-			}(),
-			partitionableDevices: true,
-			expectObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
-				obj.ResourceVersion = "4"
-				obj.Generation = 1
-				obj.Spec.NodeName = ptr.To("valid-node-name")
-				obj.Spec.PerDeviceNodeSelection = nil
-				obj.Spec.Devices[0].NodeName = nil
-				return obj
-			}(),
-		},
-		"keep-existing-fields-partitionable-devices": {
-			oldObj: sliceWithPartitionableDevices,
-			newObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
-				obj.ResourceVersion = "4"
-				return obj
-			}(),
-			partitionableDevices: true,
-			expectObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
-				obj.ResourceVersion = "4"
-				return obj
-			}(),
-		},
-		"keep-existing-fields-partitionable-devices-disabled-feature": {
-			oldObj: sliceWithPartitionableDevices,
-			newObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
 				obj.ResourceVersion = "4"
 				return obj
 			}(),
 			partitionableDevices: false,
 			expectObj: func() *resource.ResourceSlice {
-				obj := sliceWithPartitionableDevices.DeepCopy()
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				obj.Generation = 1
+				obj.Spec.SharedCounters = nil
+				return obj
+			}(),
+		},
+		"keep-fields-partitionable-devices-with-consumes-counters": {
+			oldObj: slice,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				obj.Generation = 1
+				return obj
+			}(),
+		},
+		"keep-fields-partitionable-devices-with-per-device-node-selection": {
+			oldObj: slice,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesPerDeviceNodeSelection.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices:  true,
+			expectValidationError: true, // Spec.NodeName is immutable.
+		},
+		"keep-fields-partitionable-devices-with-shared-counters": {
+			oldObj: slice,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				obj.Generation = 1
+				return obj
+			}(),
+		},
+		"keep-existing-fields-partitionable-devices-with-consumes-counters": {
+			oldObj: sliceWithPartitionableDevicesConsumesCounters,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+		},
+		"keep-existing-fields-partitionable-devices-with-per-device-node-selection": {
+			oldObj: sliceWithPartitionableDevicesPerDeviceNodeSelection,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesPerDeviceNodeSelection.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesPerDeviceNodeSelection.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+		},
+		"keep-existing-fields-partitionable-devices-with-shared-counters": {
+			oldObj: sliceWithPartitionableDevicesSharedCounters,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+		},
+		"keep-existing-fields-partitionable-devices-consumes-counters-disabled-feature": {
+			oldObj: sliceWithPartitionableDevicesConsumesCounters,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: false,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesConsumesCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+		},
+		"keep-existing-fields-partitionable-devices-per-device-node-selection-disabled-feature": {
+			oldObj: sliceWithPartitionableDevicesPerDeviceNodeSelection,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesPerDeviceNodeSelection.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: false,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesPerDeviceNodeSelection.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+		},
+		"keep-existing-fields-partitionable-devices-shared-counters-disabled-feature": {
+			oldObj: sliceWithPartitionableDevicesSharedCounters,
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			partitionableDevices: false,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithPartitionableDevicesSharedCounters.DeepCopy()
 				obj.ResourceVersion = "4"
 				return obj
 			}(),

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -888,6 +888,10 @@ func (pl *DynamicResources) Filter(ctx context.Context, cs fwk.CycleState, pod *
 		switch {
 		case errors.Is(err, context.DeadlineExceeded):
 			return statusUnschedulable(logger, "timed out trying to allocate devices", "pod", klog.KObj(pod), "node", klog.KObj(node), "resourceclaims", klog.KObjSlice(claimsToAllocate))
+		case errors.Is(err, structured.ErrFailedAllocationOnNode):
+			// Not a fatal error, allocation on other nodes may proceed.
+			// The error is only surfaced if allocation fails on all nodes.
+			return statusUnschedulable(logger, err.Error(), "pod", klog.KObj(pod), "node", klog.KObj(node))
 		case ctx.Err() != nil:
 			return statusUnschedulable(logger, fmt.Sprintf("asked by caller to stop allocating devices: %v", context.Cause(ctx)), "pod", klog.KObj(pod), "node", klog.KObj(node), "resourceclaims", klog.KObjSlice(claimsToAllocate))
 		case err != nil:

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -296,7 +296,7 @@ message Counter {
 
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -307,12 +307,14 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
+  // +k8s:required
+  // +k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
   // The name of each counter must be unique in that set and must be a DNS label.
   //
-  // The maximum number of counters in all sets is 32.
+  // The maximum number of counters is 32.
   //
   // +required
   map<string, Counter> counters = 2;
@@ -349,14 +351,17 @@ message Device {
   //
   // There can only be a single entry per counterSet.
   //
-  // The total number of device counter consumption entries
-  // must be <= 32. In addition, the total number in the
-  // entire ResourceSlice must be <= 1024 (for example,
-  // 64 devices with 16 counters each).
+  // The maximum number of device counter consumptions per
+  // device is 2.
   //
   // +optional
+  // +k8s:optional
   // +listType=atomic
+  // +k8s:listType=atomic
+  // +k8s:unique=map
+  // +k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
+  // +k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 4;
 
   // NodeName identifies the node where the device is available.
@@ -784,14 +789,13 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
+  // +k8s:required
+  // +k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
   //
-  // The maximum number counters in a device is 32.
-  // In addition, the maximum number of all counters
-  // in all devices is 1024 (for example, 64 devices with
-  // 16 counters each).
+  // The maximum number of counters is 32.
   //
   // +required
   map<string, Counter> counters = 2;
@@ -1658,11 +1662,14 @@ message ResourceSliceSpec {
 
   // Devices lists some or all of the devices in this pool.
   //
-  // Must not have more than 128 entries. If any device uses taints the limit is 64.
+  // Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+  //
+  // Only one of Devices and SharedCounters can be set in a ResourceSlice.
   //
   // +optional
   // +listType=atomic
   // +k8s:optional
+  // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
   // PerDeviceNodeSelection defines whether the access from nodes to
@@ -1680,13 +1687,21 @@ message ResourceSliceSpec {
   // SharedCounters defines a list of counter sets, each of which
   // has a name and a list of counters available.
   //
-  // The names of the SharedCounters must be unique in the ResourceSlice.
+  // The names of the counter sets must be unique in the ResourcePool.
   //
-  // The maximum number of counters in all sets is 32.
+  // Only one of Devices and SharedCounters can be set in a ResourceSlice.
+  //
+  // The maximum number of counter sets is 8.
   //
   // +optional
+  // +k8s:optional
   // +listType=atomic
+  // +k8s:listType=atomic
+  // +k8s:unique=map
+  // +k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
+  // +zeroOrOneOf=ResourceSliceType
+  // +k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -149,12 +149,15 @@ type ResourceSliceSpec struct {
 
 	// Devices lists some or all of the devices in this pool.
 	//
-	// Must not have more than 128 entries. If any device uses taints the limit is 64.
+	// Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+	//
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
 	//
 	// +optional
 	// +listType=atomic
 	// +k8s:optional
-	Devices []Device `json:"devices" protobuf:"bytes,6,name=devices"`
+	// +zeroOrOneOf=ResourceSliceType
+	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
 	// PerDeviceNodeSelection defines whether the access from nodes to
 	// resources in the pool is set on the ResourceSlice level or on each
@@ -171,19 +174,27 @@ type ResourceSliceSpec struct {
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
 	//
-	// The names of the SharedCounters must be unique in the ResourceSlice.
+	// The names of the counter sets must be unique in the ResourcePool.
 	//
-	// The maximum number of counters in all sets is 32.
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
+	//
+	// The maximum number of counter sets is 8.
 	//
 	// +optional
+	// +k8s:optional
 	// +listType=atomic
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
+	// +zeroOrOneOf=ResourceSliceType
+	// +k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -194,12 +205,14 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
+	// +k8s:required
+	// +k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
 	// The name of each counter must be unique in that set and must be a DNS label.
 	//
-	// The maximum number of counters in all sets is 32.
+	// The maximum number of counters is 32.
 	//
 	// +required
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
@@ -257,6 +270,28 @@ const BindingFailureConditionsMaxSize = 4
 // in a ResourceSlice. The number is summed up across all sets.
 const ResourceSliceMaxSharedCounters = 32
 
+// Defines the maximum number of counter sets (through the
+// SharedCounters field) that can be defined in a ResourceSlice.
+const ResourceSliceMaxCounterSets = 8
+
+// Defines the maximum number of counters that can be defined
+// in a counter set.
+const ResourceSliceMaxCountersPerCounterSet = 32
+
+// Defines the maximum number of device counter consumptions
+// (through the ConsumesCounters field) that can be defined per
+// device.
+const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
+
+// Defines the maximum number of counters that can be defined
+// per device counter consumption.
+const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
+
+// Defines the maximum number of counters that can be defined
+// in device counter consumptions across all devices in a
+// ResourceSlice.
+const ResourceSliceMaxConsumedCountersPerResourceSlice = 2048
+
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
 type Device struct {
@@ -288,14 +323,17 @@ type Device struct {
 	//
 	// There can only be a single entry per counterSet.
 	//
-	// The total number of device counter consumption entries
-	// must be <= 32. In addition, the total number in the
-	// entire ResourceSlice must be <= 1024 (for example,
-	// 64 devices with 16 counters each).
+	// The maximum number of device counter consumptions per
+	// device is 2.
 	//
 	// +optional
+	// +k8s:optional
 	// +listType=atomic
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
+	// +k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,4,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -410,14 +448,13 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
+	// +k8s:required
+	// +k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
 	//
-	// The maximum number counters in a device is 32.
-	// In addition, the maximum number of all counters
-	// in all devices is 1024 (for example, 64 devices with
-	// 16 counters each).
+	// The maximum number of counters is 32.
 	//
 	// +required
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -261,14 +261,10 @@ type ResourcePool struct {
 
 const ResourceSliceMaxSharedCapacity = 128
 const ResourceSliceMaxDevices = 128
-const ResourceSliceMaxDevicesWithTaints = 64
+const ResourceSliceMaxDevicesWithTaintsOrConsumesCounters = 64
 const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
-
-// Defines the max number of shared counters that can be specified
-// in a ResourceSlice. The number is summed up across all sets.
-const ResourceSliceMaxSharedCounters = 32
 
 // Defines the maximum number of counter sets (through the
 // SharedCounters field) that can be defined in a ResourceSlice.
@@ -286,11 +282,6 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // Defines the maximum number of counters that can be defined
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
-
-// Defines the maximum number of counters that can be defined
-// in device counter consumptions across all devices in a
-// ResourceSlice.
-const ResourceSliceMaxConsumedCountersPerResourceSlice = 2048
 
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
@@ -576,14 +567,6 @@ type CapacityRequestPolicyRange struct {
 
 // Limit for the sum of the number of entries in both attributes and capacity.
 const ResourceSliceMaxAttributesAndCapacitiesPerDevice = 32
-
-// Limit for the total number of counters in each device.
-const ResourceSliceMaxCountersPerDevice = 32
-
-// Limit for the total number of counters defined in devices in
-// a ResourceSlice. We want to allow up to 64 devices to specify
-// up to 16 counters, so the limit for the ResourceSlice will be 1024.
-const ResourceSliceMaxDeviceCountersPerSlice = 1024 // 64 * 16
 
 // QualifiedName is the name of a device attribute or capacity.
 //

--- a/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
@@ -103,9 +103,9 @@ func (Counter) SwaggerDoc() map[string]string {
 }
 
 var map_CounterSet = map[string]string{
-	"":         "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+	"":         "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
 	"name":     "Name defines the name of the counter set. It must be a DNS label.",
-	"counters": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+	"counters": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
 }
 
 func (CounterSet) SwaggerDoc() map[string]string {
@@ -117,7 +117,7 @@ var map_Device = map[string]string{
 	"name":                     "Name is unique identifier among all devices managed by the driver in the pool. It must be a DNS label.",
 	"attributes":               "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
 	"capacity":                 "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
-	"consumesCounters":         "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+	"consumesCounters":         "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
 	"nodeName":                 "NodeName identifies the node where the device is available.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
 	"nodeSelector":             "NodeSelector defines the nodes where the device is available.\n\nMust use exactly one term.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
 	"allNodes":                 "AllNodes indicates that all nodes have access to the device.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
@@ -256,7 +256,7 @@ func (DeviceConstraint) SwaggerDoc() map[string]string {
 var map_DeviceCounterConsumption = map[string]string{
 	"":           "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
 	"counterSet": "CounterSet is the name of the set from which the counters defined will be consumed.",
-	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
 }
 
 func (DeviceCounterConsumption) SwaggerDoc() map[string]string {
@@ -498,9 +498,9 @@ var map_ResourceSliceSpec = map[string]string{
 	"nodeName":               "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
 	"nodeSelector":           "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
 	"allNodes":               "AllNodes indicates that all nodes have access to the resources in the pool.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
-	"devices":                "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+	"devices":                "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
 	"perDeviceNodeSelection": "PerDeviceNodeSelection defines whether the access from nodes to resources in the pool is set on the ResourceSlice level or on each device. If it is set to true, every device defined the ResourceSlice must specify this individually.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
-	"sharedCounters":         "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+	"sharedCounters":         "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
 }
 
 func (ResourceSliceSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -142,14 +142,17 @@ message BasicDevice {
   //
   // There can only be a single entry per counterSet.
   //
-  // The total number of device counter consumption entries
-  // must be <= 32. In addition, the total number in the
-  // entire ResourceSlice must be <= 1024 (for example,
-  // 64 devices with 16 counters each).
+  // The maximum number of device counter consumptions per
+  // device is 2.
   //
   // +optional
+  // +k8s:optional
   // +listType=atomic
+  // +k8s:listType=atomic
+  // +k8s:unique=map
+  // +k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
+  // +k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 3;
 
   // NodeName identifies the node where the device is available.
@@ -434,7 +437,7 @@ message Counter {
 
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -445,6 +448,8 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
+  // +k8s:required
+  // +k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
@@ -792,14 +797,13 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
+  // +k8s:required
+  // +k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
   //
-  // The maximum number counters in a device is 32.
-  // In addition, the maximum number of all counters
-  // in all devices is 1024 (for example, 64 devices with
-  // 16 counters each).
+  // The maximum number of counters is 32.
   //
   // +required
   map<string, Counter> counters = 2;
@@ -1672,11 +1676,14 @@ message ResourceSliceSpec {
 
   // Devices lists some or all of the devices in this pool.
   //
-  // Must not have more than 128 entries. If any device uses taints the limit is 64.
+  // Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+  //
+  // Only one of Devices and SharedCounters can be set in a ResourceSlice.
   //
   // +optional
   // +listType=atomic
   // +k8s:optional
+  // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
   // PerDeviceNodeSelection defines whether the access from nodes to
@@ -1694,13 +1701,21 @@ message ResourceSliceSpec {
   // SharedCounters defines a list of counter sets, each of which
   // has a name and a list of counters available.
   //
-  // The names of the SharedCounters must be unique in the ResourceSlice.
+  // The names of the counter sets must be unique in the ResourcePool.
   //
-  // The maximum number of SharedCounters is 32.
+  // Only one of Devices and SharedCounters can be set in a ResourceSlice.
+  //
+  // The maximum number of counter sets is 8.
   //
   // +optional
+  // +k8s:optional
   // +listType=atomic
+  // +k8s:listType=atomic
+  // +k8s:unique=map
+  // +k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
+  // +zeroOrOneOf=ResourceSliceType
+  // +k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -269,14 +269,10 @@ type ResourcePool struct {
 
 const ResourceSliceMaxSharedCapacity = 128
 const ResourceSliceMaxDevices = 128
-const ResourceSliceMaxDevicesWithTaints = 64
+const ResourceSliceMaxDevicesWithTaintsOrConsumesCounters = 64
 const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
-
-// Defines the max number of shared counters that can be specified
-// in a ResourceSlice. The number is summed up across all sets.
-const ResourceSliceMaxSharedCounters = 32
 
 // Defines the maximum number of counter sets (through the
 // SharedCounters field) that can be defined in a ResourceSlice.
@@ -294,11 +290,6 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // Defines the maximum number of counters that can be defined
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
-
-// Defines the maximum number of counters that can be defined
-// in device counter consumptions across all devices in a
-// ResourceSlice.
-const ResourceSliceMaxConsumedCountersPerResourceSlice = 2048
 
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
@@ -584,14 +575,6 @@ type CapacityRequestPolicyRange struct {
 
 // Limit for the sum of the number of entries in both attributes and capacity.
 const ResourceSliceMaxAttributesAndCapacitiesPerDevice = 32
-
-// Limit for the total number of counters in each device.
-const ResourceSliceMaxCountersPerDevice = 32
-
-// Limit for the total number of counters defined in devices in
-// a ResourceSlice. We want to allow up to 64 devices to specify
-// up to 16 counters, so the limit for the ResourceSlice will be 1024.
-const ResourceSliceMaxDeviceCountersPerSlice = 1024 // 64 * 16
 
 // QualifiedName is the name of a device attribute or capacity.
 //

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -149,12 +149,15 @@ type ResourceSliceSpec struct {
 
 	// Devices lists some or all of the devices in this pool.
 	//
-	// Must not have more than 128 entries. If any device uses taints the limit is 64.
+	// Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+	//
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
 	//
 	// +optional
 	// +listType=atomic
 	// +k8s:optional
-	Devices []Device `json:"devices" protobuf:"bytes,6,name=devices"`
+	// +zeroOrOneOf=ResourceSliceType
+	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
 	// PerDeviceNodeSelection defines whether the access from nodes to
 	// resources in the pool is set on the ResourceSlice level or on each
@@ -171,19 +174,27 @@ type ResourceSliceSpec struct {
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
 	//
-	// The names of the SharedCounters must be unique in the ResourceSlice.
+	// The names of the counter sets must be unique in the ResourcePool.
 	//
-	// The maximum number of SharedCounters is 32.
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
+	//
+	// The maximum number of counter sets is 8.
 	//
 	// +optional
+	// +k8s:optional
 	// +listType=atomic
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
+	// +zeroOrOneOf=ResourceSliceType
+	// +k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -194,6 +205,8 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
+	// +k8s:required
+	// +k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
@@ -261,6 +274,32 @@ const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a 
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
 
+// Defines the max number of shared counters that can be specified
+// in a ResourceSlice. The number is summed up across all sets.
+const ResourceSliceMaxSharedCounters = 32
+
+// Defines the maximum number of counter sets (through the
+// SharedCounters field) that can be defined in a ResourceSlice.
+const ResourceSliceMaxCounterSets = 8
+
+// Defines the maximum number of counters that can be defined
+// in a counter set.
+const ResourceSliceMaxCountersPerCounterSet = 32
+
+// Defines the maximum number of device counter consumptions
+// (through the ConsumesCounters field) that can be defined per
+// device.
+const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
+
+// Defines the maximum number of counters that can be defined
+// per device counter consumption.
+const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
+
+// Defines the maximum number of counters that can be defined
+// in device counter consumptions across all devices in a
+// ResourceSlice.
+const ResourceSliceMaxConsumedCountersPerResourceSlice = 2048
+
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
 type Device struct {
@@ -301,14 +340,17 @@ type BasicDevice struct {
 	//
 	// There can only be a single entry per counterSet.
 	//
-	// The total number of device counter consumption entries
-	// must be <= 32. In addition, the total number in the
-	// entire ResourceSlice must be <= 1024 (for example,
-	// 64 devices with 16 counters each).
+	// The maximum number of device counter consumptions per
+	// device is 2.
 	//
 	// +optional
+	// +k8s:optional
 	// +listType=atomic
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
+	// +k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,3,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -422,14 +464,13 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
+	// +k8s:required
+	// +k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
 	//
-	// The maximum number counters in a device is 32.
-	// In addition, the maximum number of all counters
-	// in all devices is 1024 (for example, 64 devices with
-	// 16 counters each).
+	// The maximum number of counters is 32.
 	//
 	// +required
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`

--- a/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
@@ -57,7 +57,7 @@ var map_BasicDevice = map[string]string{
 	"":                         "BasicDevice defines one device instance.",
 	"attributes":               "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
 	"capacity":                 "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
-	"consumesCounters":         "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+	"consumesCounters":         "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
 	"nodeName":                 "NodeName identifies the node where the device is available.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
 	"nodeSelector":             "NodeSelector defines the nodes where the device is available.\n\nMust use exactly one term.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
 	"allNodes":                 "AllNodes indicates that all nodes have access to the device.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
@@ -122,7 +122,7 @@ func (Counter) SwaggerDoc() map[string]string {
 }
 
 var map_CounterSet = map[string]string{
-	"":         "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+	"":         "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
 	"name":     "Name defines the name of the counter set. It must be a DNS label.",
 	"counters": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
 }
@@ -265,7 +265,7 @@ func (DeviceConstraint) SwaggerDoc() map[string]string {
 var map_DeviceCounterConsumption = map[string]string{
 	"":           "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
 	"counterSet": "CounterSet is the name of the set from which the counters defined will be consumed.",
-	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
 }
 
 func (DeviceCounterConsumption) SwaggerDoc() map[string]string {
@@ -498,9 +498,9 @@ var map_ResourceSliceSpec = map[string]string{
 	"nodeName":               "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
 	"nodeSelector":           "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
 	"allNodes":               "AllNodes indicates that all nodes have access to the resources in the pool.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
-	"devices":                "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+	"devices":                "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
 	"perDeviceNodeSelection": "PerDeviceNodeSelection defines whether the access from nodes to resources in the pool is set on the ResourceSlice level or on each device. If it is set to true, every device defined the ResourceSlice must specify this individually.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
-	"sharedCounters":         "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of SharedCounters is 32.",
+	"sharedCounters":         "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
 }
 
 func (ResourceSliceSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -296,7 +296,7 @@ message Counter {
 
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -307,12 +307,14 @@ message CounterSet {
   // It must be a DNS label.
   //
   // +required
+  // +k8s:required
+  // +k8s:format=k8s-short-name
   optional string name = 1;
 
   // Counters defines the set of counters for this CounterSet
   // The name of each counter must be unique in that set and must be a DNS label.
   //
-  // The maximum number of counters in all sets is 32.
+  // The maximum number of counters is 32.
   //
   // +required
   map<string, Counter> counters = 2;
@@ -349,14 +351,17 @@ message Device {
   //
   // There can only be a single entry per counterSet.
   //
-  // The total number of device counter consumption entries
-  // must be <= 32. In addition, the total number in the
-  // entire ResourceSlice must be <= 1024 (for example,
-  // 64 devices with 16 counters each).
+  // The maximum number of device counter consumptions per
+  // device is 2.
   //
   // +optional
+  // +k8s:optional
   // +listType=atomic
+  // +k8s:listType=atomic
+  // +k8s:unique=map
+  // +k8s:listMapKey=counterSet
   // +featureGate=DRAPartitionableDevices
+  // +k8s:maxItems=2
   repeated DeviceCounterConsumption consumesCounters = 4;
 
   // NodeName identifies the node where the device is available.
@@ -784,14 +789,13 @@ message DeviceCounterConsumption {
   // counters defined will be consumed.
   //
   // +required
+  // +k8s:required
+  // +k8s:format=k8s-short-name
   optional string counterSet = 1;
 
   // Counters defines the counters that will be consumed by the device.
   //
-  // The maximum number counters in a device is 32.
-  // In addition, the maximum number of all counters
-  // in all devices is 1024 (for example, 64 devices with
-  // 16 counters each).
+  // The maximum number of counters is 32.
   //
   // +required
   map<string, Counter> counters = 2;
@@ -1658,11 +1662,14 @@ message ResourceSliceSpec {
 
   // Devices lists some or all of the devices in this pool.
   //
-  // Must not have more than 128 entries. If any device uses taints the limit is 64.
+  // Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+  //
+  // Only one of Devices and SharedCounters can be set in a ResourceSlice.
   //
   // +optional
   // +listType=atomic
   // +k8s:optional
+  // +zeroOrOneOf=ResourceSliceType
   repeated Device devices = 6;
 
   // PerDeviceNodeSelection defines whether the access from nodes to
@@ -1680,13 +1687,21 @@ message ResourceSliceSpec {
   // SharedCounters defines a list of counter sets, each of which
   // has a name and a list of counters available.
   //
-  // The names of the SharedCounters must be unique in the ResourceSlice.
+  // The names of the counter sets must be unique in the ResourcePool.
   //
-  // The maximum number of counters in all sets is 32.
+  // Only one of Devices and SharedCounters can be set in a ResourceSlice.
+  //
+  // The maximum number of counter sets is 8.
   //
   // +optional
+  // +k8s:optional
   // +listType=atomic
+  // +k8s:listType=atomic
+  // +k8s:unique=map
+  // +k8s:listMapKey=name
   // +featureGate=DRAPartitionableDevices
+  // +zeroOrOneOf=ResourceSliceType
+  // +k8s:maxItems=8
   repeated CounterSet sharedCounters = 8;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -149,12 +149,15 @@ type ResourceSliceSpec struct {
 
 	// Devices lists some or all of the devices in this pool.
 	//
-	// Must not have more than 128 entries. If any device uses taints the limit is 64.
+	// Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+	//
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
 	//
 	// +optional
 	// +listType=atomic
 	// +k8s:optional
-	Devices []Device `json:"devices" protobuf:"bytes,6,name=devices"`
+	// +zeroOrOneOf=ResourceSliceType
+	Devices []Device `json:"devices,omitempty" protobuf:"bytes,6,name=devices"`
 
 	// PerDeviceNodeSelection defines whether the access from nodes to
 	// resources in the pool is set on the ResourceSlice level or on each
@@ -171,19 +174,27 @@ type ResourceSliceSpec struct {
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
 	//
-	// The names of the SharedCounters must be unique in the ResourceSlice.
+	// The names of the counter sets must be unique in the ResourcePool.
 	//
-	// The maximum number of counters in all sets is 32.
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
+	//
+	// The maximum number of counter sets is 8.
 	//
 	// +optional
+	// +k8s:optional
 	// +listType=atomic
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=name
 	// +featureGate=DRAPartitionableDevices
+	// +zeroOrOneOf=ResourceSliceType
+	// +k8s:maxItems=8
 	SharedCounters []CounterSet `json:"sharedCounters,omitempty" protobuf:"bytes,8,name=sharedCounters"`
 }
 
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -194,12 +205,14 @@ type CounterSet struct {
 	// It must be a DNS label.
 	//
 	// +required
+	// +k8s:required
+	// +k8s:format=k8s-short-name
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// Counters defines the set of counters for this CounterSet
 	// The name of each counter must be unique in that set and must be a DNS label.
 	//
-	// The maximum number of counters in all sets is 32.
+	// The maximum number of counters is 32.
 	//
 	// +required
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
@@ -257,6 +270,28 @@ const BindingFailureConditionsMaxSize = 4
 // in a ResourceSlice. The number is summed up across all sets.
 const ResourceSliceMaxSharedCounters = 32
 
+// Defines the maximum number of counter sets (through the
+// SharedCounters field) that can be defined in a ResourceSlice.
+const ResourceSliceMaxCounterSets = 8
+
+// Defines the maximum number of counters that can be defined
+// in a counter set.
+const ResourceSliceMaxCountersPerCounterSet = 32
+
+// Defines the maximum number of device counter consumptions
+// (through the ConsumesCounters field) that can be defined per
+// device.
+const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
+
+// Defines the maximum number of counters that can be defined
+// per device counter consumption.
+const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
+
+// Defines the maximum number of counters that can be defined
+// in device counter consumptions across all devices in a
+// ResourceSlice.
+const ResourceSliceMaxConsumedCountersPerResourceSlice = 2048
+
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
 type Device struct {
@@ -288,14 +323,17 @@ type Device struct {
 	//
 	// There can only be a single entry per counterSet.
 	//
-	// The total number of device counter consumption entries
-	// must be <= 32. In addition, the total number in the
-	// entire ResourceSlice must be <= 1024 (for example,
-	// 64 devices with 16 counters each).
+	// The maximum number of device counter consumptions per
+	// device is 2.
 	//
 	// +optional
+	// +k8s:optional
 	// +listType=atomic
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=counterSet
 	// +featureGate=DRAPartitionableDevices
+	// +k8s:maxItems=2
 	ConsumesCounters []DeviceCounterConsumption `json:"consumesCounters,omitempty" protobuf:"bytes,4,rep,name=consumesCounters"`
 
 	// NodeName identifies the node where the device is available.
@@ -410,14 +448,13 @@ type DeviceCounterConsumption struct {
 	// counters defined will be consumed.
 	//
 	// +required
+	// +k8s:required
+	// +k8s:format=k8s-short-name
 	CounterSet string `json:"counterSet" protobuf:"bytes,1,opt,name=counterSet"`
 
 	// Counters defines the counters that will be consumed by the device.
 	//
-	// The maximum number counters in a device is 32.
-	// In addition, the maximum number of all counters
-	// in all devices is 1024 (for example, 64 devices with
-	// 16 counters each).
+	// The maximum number of counters is 32.
 	//
 	// +required
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -261,14 +261,10 @@ type ResourcePool struct {
 
 const ResourceSliceMaxSharedCapacity = 128
 const ResourceSliceMaxDevices = 128
-const ResourceSliceMaxDevicesWithTaints = 64
+const ResourceSliceMaxDevicesWithTaintsOrConsumesCounters = 64
 const PoolNameMaxLength = validation.DNS1123SubdomainMaxLength // Same as for a single node name.
 const BindingConditionsMaxSize = 4
 const BindingFailureConditionsMaxSize = 4
-
-// Defines the max number of shared counters that can be specified
-// in a ResourceSlice. The number is summed up across all sets.
-const ResourceSliceMaxSharedCounters = 32
 
 // Defines the maximum number of counter sets (through the
 // SharedCounters field) that can be defined in a ResourceSlice.
@@ -286,11 +282,6 @@ const ResourceSliceMaxDeviceCounterConsumptionsPerDevice = 2
 // Defines the maximum number of counters that can be defined
 // per device counter consumption.
 const ResourceSliceMaxCountersPerDeviceCounterConsumption = 32
-
-// Defines the maximum number of counters that can be defined
-// in device counter consumptions across all devices in a
-// ResourceSlice.
-const ResourceSliceMaxConsumedCountersPerResourceSlice = 2048
 
 // Device represents one individual hardware instance that can be selected based
 // on its attributes. Besides the name, exactly one field must be set.
@@ -576,14 +567,6 @@ type CapacityRequestPolicyRange struct {
 
 // Limit for the sum of the number of entries in both attributes and capacity.
 const ResourceSliceMaxAttributesAndCapacitiesPerDevice = 32
-
-// Limit for the total number of counters in each device.
-const ResourceSliceMaxCountersPerDevice = 32
-
-// Limit for the total number of counters defined in devices in
-// a ResourceSlice. We want to allow up to 64 devices to specify
-// up to 16 counters, so the limit for the ResourceSlice will be 1024.
-const ResourceSliceMaxDeviceCountersPerSlice = 1024 // 64 * 16
 
 // QualifiedName is the name of a device attribute or capacity.
 //

--- a/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
@@ -103,9 +103,9 @@ func (Counter) SwaggerDoc() map[string]string {
 }
 
 var map_CounterSet = map[string]string{
-	"":         "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+	"":         "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
 	"name":     "Name defines the name of the counter set. It must be a DNS label.",
-	"counters": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+	"counters": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
 }
 
 func (CounterSet) SwaggerDoc() map[string]string {
@@ -117,7 +117,7 @@ var map_Device = map[string]string{
 	"name":                     "Name is unique identifier among all devices managed by the driver in the pool. It must be a DNS label.",
 	"attributes":               "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
 	"capacity":                 "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
-	"consumesCounters":         "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+	"consumesCounters":         "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
 	"nodeName":                 "NodeName identifies the node where the device is available.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
 	"nodeSelector":             "NodeSelector defines the nodes where the device is available.\n\nMust use exactly one term.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
 	"allNodes":                 "AllNodes indicates that all nodes have access to the device.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
@@ -256,7 +256,7 @@ func (DeviceConstraint) SwaggerDoc() map[string]string {
 var map_DeviceCounterConsumption = map[string]string{
 	"":           "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
 	"counterSet": "CounterSet is the name of the set from which the counters defined will be consumed.",
-	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+	"counters":   "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
 }
 
 func (DeviceCounterConsumption) SwaggerDoc() map[string]string {
@@ -498,9 +498,9 @@ var map_ResourceSliceSpec = map[string]string{
 	"nodeName":               "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
 	"nodeSelector":           "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
 	"allNodes":               "AllNodes indicates that all nodes have access to the resources in the pool.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
-	"devices":                "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints the limit is 64.",
+	"devices":                "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
 	"perDeviceNodeSelection": "PerDeviceNodeSelection defines whether the access from nodes to resources in the pool is set on the ResourceSlice level or on each device. If it is set to true, every device defined the ResourceSlice must specify this individually.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
-	"sharedCounters":         "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+	"sharedCounters":         "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
 }
 
 func (ResourceSliceSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/counterset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/counterset.go
@@ -23,7 +23,7 @@ package v1
 //
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -36,7 +36,7 @@ type CounterSetApplyConfiguration struct {
 	// Counters defines the set of counters for this CounterSet
 	// The name of each counter must be unique in that set and must be a DNS label.
 	//
-	// The maximum number of counters in all sets is 32.
+	// The maximum number of counters is 32.
 	Counters map[string]CounterApplyConfiguration `json:"counters,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/device.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/device.go
@@ -48,10 +48,8 @@ type DeviceApplyConfiguration struct {
 	//
 	// There can only be a single entry per counterSet.
 	//
-	// The total number of device counter consumption entries
-	// must be <= 32. In addition, the total number in the
-	// entire ResourceSlice must be <= 1024 (for example,
-	// 64 devices with 16 counters each).
+	// The maximum number of device counter consumptions per
+	// device is 2.
 	ConsumesCounters []DeviceCounterConsumptionApplyConfiguration `json:"consumesCounters,omitempty"`
 	// NodeName identifies the node where the device is available.
 	//

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/devicecounterconsumption.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/devicecounterconsumption.go
@@ -29,10 +29,7 @@ type DeviceCounterConsumptionApplyConfiguration struct {
 	CounterSet *string `json:"counterSet,omitempty"`
 	// Counters defines the counters that will be consumed by the device.
 	//
-	// The maximum number counters in a device is 32.
-	// In addition, the maximum number of all counters
-	// in all devices is 1024 (for example, 64 devices with
-	// 16 counters each).
+	// The maximum number of counters is 32.
 	Counters map[string]CounterApplyConfiguration `json:"counters,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourceslicespec.go
@@ -62,7 +62,9 @@ type ResourceSliceSpecApplyConfiguration struct {
 	AllNodes *bool `json:"allNodes,omitempty"`
 	// Devices lists some or all of the devices in this pool.
 	//
-	// Must not have more than 128 entries. If any device uses taints the limit is 64.
+	// Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+	//
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
 	Devices []DeviceApplyConfiguration `json:"devices,omitempty"`
 	// PerDeviceNodeSelection defines whether the access from nodes to
 	// resources in the pool is set on the ResourceSlice level or on each
@@ -74,9 +76,11 @@ type ResourceSliceSpecApplyConfiguration struct {
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
 	//
-	// The names of the SharedCounters must be unique in the ResourceSlice.
+	// The names of the counter sets must be unique in the ResourcePool.
 	//
-	// The maximum number of counters in all sets is 32.
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
+	//
+	// The maximum number of counter sets is 8.
 	SharedCounters []CounterSetApplyConfiguration `json:"sharedCounters,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/basicdevice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/basicdevice.go
@@ -44,10 +44,8 @@ type BasicDeviceApplyConfiguration struct {
 	//
 	// There can only be a single entry per counterSet.
 	//
-	// The total number of device counter consumption entries
-	// must be <= 32. In addition, the total number in the
-	// entire ResourceSlice must be <= 1024 (for example,
-	// 64 devices with 16 counters each).
+	// The maximum number of device counter consumptions per
+	// device is 2.
 	ConsumesCounters []DeviceCounterConsumptionApplyConfiguration `json:"consumesCounters,omitempty"`
 	// NodeName identifies the node where the device is available.
 	//

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/counterset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/counterset.go
@@ -23,7 +23,7 @@ package v1beta1
 //
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicecounterconsumption.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/devicecounterconsumption.go
@@ -29,10 +29,7 @@ type DeviceCounterConsumptionApplyConfiguration struct {
 	CounterSet *string `json:"counterSet,omitempty"`
 	// Counters defines the counters that will be consumed by the device.
 	//
-	// The maximum number counters in a device is 32.
-	// In addition, the maximum number of all counters
-	// in all devices is 1024 (for example, 64 devices with
-	// 16 counters each).
+	// The maximum number of counters is 32.
 	Counters map[string]CounterApplyConfiguration `json:"counters,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourceslicespec.go
@@ -62,7 +62,9 @@ type ResourceSliceSpecApplyConfiguration struct {
 	AllNodes *bool `json:"allNodes,omitempty"`
 	// Devices lists some or all of the devices in this pool.
 	//
-	// Must not have more than 128 entries. If any device uses taints the limit is 64.
+	// Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+	//
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
 	Devices []DeviceApplyConfiguration `json:"devices,omitempty"`
 	// PerDeviceNodeSelection defines whether the access from nodes to
 	// resources in the pool is set on the ResourceSlice level or on each
@@ -74,9 +76,11 @@ type ResourceSliceSpecApplyConfiguration struct {
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
 	//
-	// The names of the SharedCounters must be unique in the ResourceSlice.
+	// The names of the counter sets must be unique in the ResourcePool.
 	//
-	// The maximum number of SharedCounters is 32.
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
+	//
+	// The maximum number of counter sets is 8.
 	SharedCounters []CounterSetApplyConfiguration `json:"sharedCounters,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/counterset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/counterset.go
@@ -23,7 +23,7 @@ package v1beta2
 //
 // CounterSet defines a named set of counters
 // that are available to be used by devices defined in the
-// ResourceSlice.
+// ResourcePool.
 //
 // The counters are not allocatable by themselves, but
 // can be referenced by devices. When a device is allocated,
@@ -36,7 +36,7 @@ type CounterSetApplyConfiguration struct {
 	// Counters defines the set of counters for this CounterSet
 	// The name of each counter must be unique in that set and must be a DNS label.
 	//
-	// The maximum number of counters in all sets is 32.
+	// The maximum number of counters is 32.
 	Counters map[string]CounterApplyConfiguration `json:"counters,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/device.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/device.go
@@ -48,10 +48,8 @@ type DeviceApplyConfiguration struct {
 	//
 	// There can only be a single entry per counterSet.
 	//
-	// The total number of device counter consumption entries
-	// must be <= 32. In addition, the total number in the
-	// entire ResourceSlice must be <= 1024 (for example,
-	// 64 devices with 16 counters each).
+	// The maximum number of device counter consumptions per
+	// device is 2.
 	ConsumesCounters []DeviceCounterConsumptionApplyConfiguration `json:"consumesCounters,omitempty"`
 	// NodeName identifies the node where the device is available.
 	//

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicecounterconsumption.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/devicecounterconsumption.go
@@ -29,10 +29,7 @@ type DeviceCounterConsumptionApplyConfiguration struct {
 	CounterSet *string `json:"counterSet,omitempty"`
 	// Counters defines the counters that will be consumed by the device.
 	//
-	// The maximum number counters in a device is 32.
-	// In addition, the maximum number of all counters
-	// in all devices is 1024 (for example, 64 devices with
-	// 16 counters each).
+	// The maximum number of counters is 32.
 	Counters map[string]CounterApplyConfiguration `json:"counters,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceslicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourceslicespec.go
@@ -62,7 +62,9 @@ type ResourceSliceSpecApplyConfiguration struct {
 	AllNodes *bool `json:"allNodes,omitempty"`
 	// Devices lists some or all of the devices in this pool.
 	//
-	// Must not have more than 128 entries. If any device uses taints the limit is 64.
+	// Must not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.
+	//
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
 	Devices []DeviceApplyConfiguration `json:"devices,omitempty"`
 	// PerDeviceNodeSelection defines whether the access from nodes to
 	// resources in the pool is set on the ResourceSlice level or on each
@@ -74,9 +76,11 @@ type ResourceSliceSpecApplyConfiguration struct {
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
 	//
-	// The names of the SharedCounters must be unique in the ResourceSlice.
+	// The names of the counter sets must be unique in the ResourcePool.
 	//
-	// The maximum number of counters in all sets is 32.
+	// Only one of Devices and SharedCounters can be set in a ResourceSlice.
+	//
+	// The maximum number of counter sets is 8.
 	SharedCounters []CounterSetApplyConfiguration `json:"sharedCounters,omitempty"`
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/api/uniquestring.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/api/uniquestring.go
@@ -41,6 +41,12 @@ func (us UniqueString) MarshalJSON() ([]byte, error) {
 	return json.Marshal(us.String())
 }
 
+// MarshalText allows UniqueString to be used as the key in maps
+// without causing problems for logging.
+func (us UniqueString) MarshalText() ([]byte, error) {
+	return []byte(us.String()), nil
+}
+
 // MakeUniqueString constructs a new unique string.
 func MakeUniqueString(str string) UniqueString {
 	return UniqueString(unique.Make(str))

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/validation.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/validation.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceslice
+
+import (
+	"fmt"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// validateDriverResources identifies problems that cannot be caught by
+// the server-side validation and that would prevent using the published
+// ResourceSlices, like incorrect cross-references. We do validation here
+// so any issues can be discovered as early as possible. This is also
+// checked in the allocator before allocating any devices.
+func validateDriverResources(resources *DriverResources) error {
+	for poolName, pool := range resources.Pools {
+		if err := validatePool(poolName, pool); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validatePool checks that there aren't any pool-wide issues that
+// can't be caught in the API-server per-ResourceSlice validation.
+//
+// This logic is very similar to what we do in the allocator when we
+// gather the pools. We might want to see if there is a good way to
+// put this logic in one place.
+func validatePool(name string, pool Pool) error {
+	counterSets := make(map[string]resourceapi.CounterSet)
+	for _, slice := range pool.Slices {
+		for _, counterSet := range slice.SharedCounters {
+			if _, found := counterSets[counterSet.Name]; found {
+				return fmt.Errorf("found duplicate counter set %q in pool %q", counterSet.Name, name)
+			}
+			counterSets[counterSet.Name] = counterSet
+		}
+	}
+
+	devices := sets.New[string]()
+	for _, slice := range pool.Slices {
+		for _, device := range slice.Devices {
+			if _, found := devices[device.Name]; found {
+				return fmt.Errorf("found duplicate device %q in pool %q", device.Name, name)
+			}
+			devices.Insert(device.Name)
+
+			for _, dcc := range device.ConsumesCounters {
+				counterSet, found := counterSets[dcc.CounterSet]
+				if !found {
+					return fmt.Errorf("counter set %q referenced by device %q not found", dcc.CounterSet, device.Name)
+				}
+				for counterName := range dcc.Counters {
+					if _, found := counterSet.Counters[counterName]; !found {
+						return fmt.Errorf("counter %q referenced by device %q not found in counter set %q", counterName, device.Name, counterSet.Name)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -34,6 +34,20 @@ import (
 	"k8s.io/dynamic-resource-allocation/structured/schedulerapi"
 )
 
+// ErrFailedAllocationOnNode is the base error for errors returned by Allocate
+// which, in contrast to other errors, only affect the one node and not
+// the entire scheduling attempt.
+//
+// The scheduler is expected to check for this with
+//
+//	errors.Is(err, structured.ErrFailedAllocation)
+//
+// and then use the error string as explanation for
+// the unscheduable status.
+//
+// It has no text of its own and can be used with fmt.Errorf("%wsome other error", ErrFailedAllocationOnNode).
+var ErrFailedAllocationOnNode = internal.ErrFailedAllocationOnNode
+
 // To keep the code in different packages simple, type aliases are used everywhere.
 // Functions are wrappers instead of variables to enable compiler optimization.
 // The Allocator interface is defined twice intentionally: that way, the docs

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -88,6 +88,8 @@ const (
 	claim1      = "claim-1"
 	slice1      = "slice-1"
 	slice2      = "slice-2"
+	slice3      = "slice-3"
+	slice4      = "slice-4"
 	device0     = "device-0"
 	device1     = "device-1"
 	device2     = "device-2"
@@ -554,27 +556,34 @@ const (
 )
 
 // generate a ResourceSlice object with the given name, node,
-// driver and pool names, generation and a list of devices.
+// driver and pool names and generation.
 // The nodeSelection parameter may be a string with the value
 // nodeSelectionAll for all nodes, the value nodeSelectionPerDevice
 // for per device node selection, or any other value to set the
 // node name. Providing a node selectors sets the NodeSelector field.
-func slice(name string, nodeSelection any, pool, driver string, devices ...wrapDevice) wrapResourceSlice {
+func slice(name string, nodeSelection, pool any, driver string) *resourceapi.ResourceSlice {
+	var resourcePool resourceapi.ResourcePool
+	switch poolSelection := pool.(type) {
+	case resourceapi.ResourcePool:
+		resourcePool = poolSelection
+	case string:
+		resourcePool = resourceapi.ResourcePool{
+			Name:               poolSelection,
+			ResourceSliceCount: 1,
+			Generation:         1,
+		}
+	default:
+		panic(fmt.Sprintf("unexpected pool type %T: %+v", poolSelection, poolSelection))
+	}
+
 	slice := &resourceapi.ResourceSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: resourceapi.ResourceSliceSpec{
 			Driver: driver,
-			Pool: resourceapi.ResourcePool{
-				Name:               pool,
-				ResourceSliceCount: 1,
-				Generation:         1,
-			},
+			Pool:   resourcePool,
 		},
-	}
-	for _, device := range devices {
-		slice.Spec.Devices = append(slice.Spec.Devices, resourceapi.Device(device.Device))
 	}
 	switch nodeSelection := nodeSelection.(type) {
 	case *v1.NodeSelector:
@@ -594,21 +603,45 @@ func slice(name string, nodeSelection any, pool, driver string, devices ...wrapD
 		panic(fmt.Sprintf("unexpected nodeSelection type %T: %+v", nodeSelection, nodeSelection))
 	}
 
-	return wrapResourceSlice{ResourceSlice: slice}
+	return slice
 }
 
-type wrapResourceSlice struct {
+func sliceWithDevices(name string, nodeSelection, pool any, driver string, devices ...wrapDevice) wrapResourceSliceWithDevices {
+	slice := slice(name, nodeSelection, pool, driver)
+	for _, device := range devices {
+		slice.Spec.Devices = append(slice.Spec.Devices, resourceapi.Device(device.Device))
+	}
+	return wrapResourceSliceWithDevices{ResourceSlice: slice}
+}
+
+type wrapResourceSliceWithDevices struct {
 	*resourceapi.ResourceSlice
 }
 
-func (in wrapResourceSlice) obj() *resourceapi.ResourceSlice {
+func (in wrapResourceSliceWithDevices) obj() *resourceapi.ResourceSlice {
 	return in.ResourceSlice
 }
 
-func (in wrapResourceSlice) withCounterSet(counterSets ...resourceapi.CounterSet) wrapResourceSlice {
-	inResourceSlice := in.DeepCopy()
-	inResourceSlice.Spec.SharedCounters = append(inResourceSlice.Spec.SharedCounters, counterSets...)
-	return wrapResourceSlice{ResourceSlice: inResourceSlice}
+func sliceWithCounterSets(name string, nodeSelection, pool any, driver string, counterSets ...resourceapi.CounterSet) wrapResourceSliceWithCounterSets {
+	slice := slice(name, nodeSelection, pool, driver)
+	slice.Spec.SharedCounters = counterSets
+	return wrapResourceSliceWithCounterSets{ResourceSlice: slice}
+}
+
+type wrapResourceSliceWithCounterSets struct {
+	*resourceapi.ResourceSlice
+}
+
+func (in wrapResourceSliceWithCounterSets) obj() *resourceapi.ResourceSlice {
+	return in.ResourceSlice
+}
+
+func resourcePool(name string, count int64) resourceapi.ResourcePool {
+	return resourceapi.ResourcePool{
+		Name:               name,
+		ResourceSliceCount: count,
+		Generation:         1,
+	}
 }
 
 func deviceAllocationResult(request, driver, pool, device string, adminAccess bool, tolerations ...resourceapi.DeviceToleration) resourceapi.DeviceRequestAllocationResult {
@@ -792,23 +825,36 @@ type wrapper[T any] interface {
 	obj() T
 }
 
+// convert a list of wrapper objects to a slice
+func unwrapResourceSlices(objs ...resourceSliceWrapper) []*resourceapi.ResourceSlice {
+	out := make([]*resourceapi.ResourceSlice, len(objs))
+	for i, obj := range objs {
+		out[i] = obj.obj()
+	}
+	return out
+}
+
+type resourceSliceWrapper interface {
+	obj() *resourceapi.ResourceSlice
+}
+
 // generate a ResourceSlice object with the given parameters and no devices
-func sliceWithNoDevices(name string, nodeSelection any, pool, driver string) wrapResourceSlice {
-	return slice(name, nodeSelection, pool, driver)
+func sliceWithNoDevices(name string, nodeSelection, pool any, driver string) wrapResourceSliceWithDevices {
+	return sliceWithDevices(name, nodeSelection, pool, driver)
 }
 
 // generate a ResourceSlice object with the given parameters and one device "device-1"
-func sliceWithOneDevice(name string, nodeSelection any, pool, driver string) wrapResourceSlice {
-	return slice(name, nodeSelection, pool, driver, device(device1, nil, nil))
+func sliceWithOneDevice(name string, nodeSelection, pool any, driver string) wrapResourceSliceWithDevices {
+	return sliceWithDevices(name, nodeSelection, pool, driver, device(device1, nil, nil))
 }
 
 // generate a ResourceSclie object with the given parameters and the specified number of devices.
-func sliceWithMultipleDevices(name string, nodeSelection any, pool, driver string, count int) wrapResourceSlice {
+func sliceWithMultipleDevices(name string, nodeSelection, pool any, driver string, count int) wrapResourceSliceWithDevices {
 	var devices []wrapDevice
 	for i := 0; i < count; i++ {
 		devices = append(devices, device(fmt.Sprintf("device-%d", i), nil, nil))
 	}
-	return slice(name, nodeSelection, pool, driver, devices...)
+	return sliceWithDevices(name, nodeSelection, pool, driver, devices...)
 }
 
 func counterSet(name string, counters map[string]resource.Quantity) resourceapi.CounterSet {
@@ -923,7 +969,7 @@ func TestAllocator(t *testing.T,
 		"simple": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: []any{allocationResult(
@@ -934,7 +980,7 @@ func TestAllocator(t *testing.T,
 		"other-node": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverB),
 				sliceWithOneDevice(slice2, node2, pool2, driverA),
 			),
@@ -959,7 +1005,7 @@ func TestAllocator(t *testing.T,
 					}}),
 			)),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, map[resourceapi.QualifiedName]resource.Quantity{
 					"memory": resource.MustParse("1Gi"),
 				}, nil),
@@ -992,7 +1038,7 @@ func TestAllocator(t *testing.T,
 			// Reversing the order in which the devices are listed causes the "large" device to
 			// be allocated for the "small" request, leaving the "large" request unsatisfied.
 			// The initial decision needs to be undone before a solution is found.
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device2, map[resourceapi.QualifiedName]resource.Quantity{
 					"memory": resource.MustParse("2Gi"),
 				}, nil),
@@ -1029,7 +1075,7 @@ func TestAllocator(t *testing.T,
 			// Reversing the order in which the devices are listed causes the "large" device to
 			// be allocated for the "small" request, leaving the "large" request unsatisfied.
 			// The initial decision needs to be undone before a solution is found.
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device2, map[resourceapi.QualifiedName]resource.Quantity{
 					"memory": resource.MustParse("2Gi"),
 				}, nil),
@@ -1054,7 +1100,7 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverA),
 				sliceWithOneDevice(slice2, node1, pool2, driverA),
 			),
@@ -1069,10 +1115,14 @@ func TestAllocator(t *testing.T,
 		"obsolete-slice": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
-				sliceWithOneDevice("slice-1-obsolete", node1, pool1, driverA),
-				func() wrapResourceSlice {
-					slice := sliceWithOneDevice(slice1, node1, pool1, driverA)
+			slices: unwrapResourceSlices(
+				sliceWithDevices("slice-1-obsolete", node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				func() wrapResourceSliceWithDevices {
+					slice := sliceWithDevices("slice-1-obsolete", node1, resourcePool(pool1, 2), driverA,
+						device(device2, nil, nil),
+					)
 					// This makes the other slice obsolete.
 					slice.Spec.Pool.Generation++
 					return slice
@@ -1080,10 +1130,7 @@ func TestAllocator(t *testing.T,
 			),
 			node: node(node1, region1),
 
-			expectResults: []any{allocationResult(
-				localNodeSelector(node1),
-				deviceAllocationResult(req0, driverA, pool1, device1, false),
-			)},
+			expectResults: []any{},
 		},
 		"duplicate-slice": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
@@ -1105,7 +1152,7 @@ func TestAllocator(t *testing.T,
 			}(),
 			node: node(node1, region1),
 
-			expectError: gomega.MatchError(gomega.ContainSubstring(fmt.Sprintf("pool %s is invalid: duplicate device name %s", pool1, device1))),
+			expectError: gomega.MatchError(gomega.ContainSubstring("invalid resource pools were encountered")),
 		},
 		"no-slices": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
@@ -1118,7 +1165,7 @@ func TestAllocator(t *testing.T,
 		"not-enough-suitable-devices": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA), claimWithRequest(claim0, req1, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 
 			node: node(node1, region1),
 
@@ -1127,7 +1174,7 @@ func TestAllocator(t *testing.T,
 		"no-classes": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          nil,
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: nil,
@@ -1136,7 +1183,7 @@ func TestAllocator(t *testing.T,
 		"unknown-class": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, "unknown-class")),
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: nil,
@@ -1145,7 +1192,7 @@ func TestAllocator(t *testing.T,
 		"empty-class": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, "")),
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: nil,
@@ -1154,7 +1201,7 @@ func TestAllocator(t *testing.T,
 		"no-claims-to-allocate": {
 			claimsToAllocate: nil,
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: nil,
@@ -1168,7 +1215,7 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: []any{allocationResult(
@@ -1185,7 +1232,7 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverA),
 				sliceWithOneDevice(slice1, node1, pool2, driverA),
 			),
@@ -1207,8 +1254,8 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				func() wrapResourceSlice {
+			slices: unwrapResourceSlices(
+				func() wrapResourceSliceWithDevices {
 					slice := sliceWithOneDevice(slice1, node1, pool1, driverA)
 					// This makes the pool incomplete, one other slice is missing.
 					slice.Spec.Pool.ResourceSliceCount++
@@ -1242,7 +1289,7 @@ func TestAllocator(t *testing.T,
 				class(classA, driverA),
 				class(classB, driverB),
 			),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverA),
 				sliceWithOneDevice(slice1, node1, pool1, driverB),
 			),
@@ -1281,7 +1328,7 @@ func TestAllocator(t *testing.T,
 				class(classA, driverA),
 				class(classB, driverB),
 			),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverA),
 				sliceWithOneDevice(slice1, node1, pool1, driverB),
 			),
@@ -1320,8 +1367,8 @@ func TestAllocator(t *testing.T,
 				class(classA, driverA),
 				class(classB, driverB),
 			),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil),
 					device(device2, nil, nil),
 				),
@@ -1363,8 +1410,8 @@ func TestAllocator(t *testing.T,
 				class(classA, driverA),
 				class(classB, driverB),
 			),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil),
 					device(device2, nil, nil),
 				),
@@ -1406,7 +1453,7 @@ func TestAllocator(t *testing.T,
 			classes: objects(
 				class(classA, driverA),
 			),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverA),
 			),
 			node: node(node1, region1),
@@ -1433,7 +1480,7 @@ func TestAllocator(t *testing.T,
 			classes: objects(
 				class(classA, driverA),
 			),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverA),
 			),
 			node: node(node1, region1),
@@ -1447,7 +1494,7 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes:       objects(class(classA, driverA)),
-			slices:        unwrap(sliceWithNoDevices(slice1, node1, pool1, driverA)),
+			slices:        unwrapResourceSlices(sliceWithNoDevices(slice1, node1, pool1, driverA)),
 			node:          node(node1, region1),
 			expectResults: nil,
 		},
@@ -1476,8 +1523,8 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device1),
 			},
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
 			),
 			node:          node(node1, region1),
 			expectResults: nil,
@@ -1496,8 +1543,8 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device1),
 			},
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
 			),
 			node: node(node1, region1),
 			expectResults: []any{allocationResult(
@@ -1520,8 +1567,8 @@ func TestAllocator(t *testing.T,
 				return []wrapResourceClaim{c}
 			}(),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
 			),
 			node:          node(node1, region1),
 			expectResults: nil,
@@ -1541,8 +1588,8 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device1),
 			},
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
 			),
 			node: node(node1, region1),
 			expectResults: []any{allocationResult(
@@ -1564,8 +1611,8 @@ func TestAllocator(t *testing.T,
 				return []wrapResourceClaim{c1, c2}
 			}(),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
 			),
 			node: node(node1, region1),
 			expectResults: []any{
@@ -1589,8 +1636,8 @@ func TestAllocator(t *testing.T,
 				return []wrapResourceClaim{claimWithRequest(claim0, req0, classA), admin}
 			}(),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
 			),
 			node: node(node1, region1),
 			expectResults: []any{
@@ -1622,7 +1669,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithNoDevices(slice1, node1, pool1, driverA),
 				sliceWithOneDevice(slice2, node1, pool2, driverB),
 			),
@@ -1650,7 +1697,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice2, node1, pool2, driverB),
 			),
 			node: node(node1, region1),
@@ -1680,8 +1727,8 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device1),
 			},
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA, device(device1, nil, nil), device(device2, nil, nil)),
 				sliceWithOneDevice(slice2, node1, pool2, driverB),
 			),
 			node: node(node1, region1),
@@ -1693,7 +1740,7 @@ func TestAllocator(t *testing.T,
 		"network-attached-device": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, nodeLabelSelector(regionKey, region1), pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, nodeLabelSelector(regionKey, region1), pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: []any{allocationResult(
@@ -1704,7 +1751,7 @@ func TestAllocator(t *testing.T,
 		"unsuccessful-allocation-network-attached-device": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, nodeLabelSelector(regionKey, region1), pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, nodeLabelSelector(regionKey, region1), pool1, driverA)),
 			// Wrong region, no devices available.
 			node: node(node2, region2),
 
@@ -1713,7 +1760,7 @@ func TestAllocator(t *testing.T,
 		"many-network-attached-devices": {
 			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 4))),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, nodeLabelSelector(regionKey, region1), pool1, driverA),
 				sliceWithOneDevice(slice1, nodeSelectionAll, pool2, driverA),
 				sliceWithOneDevice(slice1, nodeLabelSelector(planetKey, planetValueEarth), pool3, driverA),
@@ -1743,7 +1790,7 @@ func TestAllocator(t *testing.T,
 		"local-and-network-attached-devices": {
 			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 2))),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, nodeLabelSelector(regionKey, region1), pool1, driverA),
 				sliceWithOneDevice(slice1, node1, pool2, driverA),
 			),
@@ -1759,8 +1806,8 @@ func TestAllocator(t *testing.T,
 		"several-different-drivers": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA), claimWithRequest(claim0, req0, classB)),
 			classes:          objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil),
 					device(device2, nil, nil),
 				),
@@ -1780,7 +1827,7 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device2),
 			},
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: nil,
@@ -1795,7 +1842,7 @@ func TestAllocator(t *testing.T,
 				return []wrapResourceClaim{c}
 			}(),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: nil,
@@ -1815,7 +1862,7 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device2),
 			},
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: []any{
@@ -1836,7 +1883,7 @@ func TestAllocator(t *testing.T,
 			),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 					"driverVersion":   {VersionValue: ptr.To("1.0.0")},
 					"numa":            {IntValue: ptr.To(int64(1))},
@@ -1863,7 +1910,7 @@ func TestAllocator(t *testing.T,
 				MatchAttribute: &nonExistentAttribute,
 			})),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: nil,
@@ -1875,7 +1922,7 @@ func TestAllocator(t *testing.T,
 				request(req0, classA, 2)),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 					"numa": {IntValue: ptr.To(int64(1))},
 				}),
@@ -1900,7 +1947,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 					"numa": {IntValue: ptr.To(int64(1))},
 				}),
@@ -1919,7 +1966,7 @@ func TestAllocator(t *testing.T,
 				request(req0, classA, 2)),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 					"stringAttribute": {StringValue: ptr.To("stringAttributeValue")},
 				}),
@@ -1938,7 +1985,7 @@ func TestAllocator(t *testing.T,
 				request(req0, classA, 2)),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 					"boolAttribute": {BoolValue: ptr.To(true)},
 				}),
@@ -1957,7 +2004,7 @@ func TestAllocator(t *testing.T,
 				request(req0, classA, 2)),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 					"driverVersion": {VersionValue: ptr.To("1.0.0")},
 				}),
@@ -1982,7 +2029,7 @@ func TestAllocator(t *testing.T,
 				request(req1, classA, 1),
 			)),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 					"driverVersion": {VersionValue: ptr.To("1.0.0")},
 				}),
@@ -2014,7 +2061,7 @@ func TestAllocator(t *testing.T,
 				request(req1, classA, 1),
 			)),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				// This device does not satisfy the second
 				// match attribute, so the allocator must
 				// backtrack.
@@ -2042,7 +2089,7 @@ func TestAllocator(t *testing.T,
 		"with-class-device-config": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(classWithConfig(classA, driverA, "classAttribute")),
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: []any{
@@ -2097,7 +2144,7 @@ func TestAllocator(t *testing.T,
 		"claim-with-device-config": {
 			claimsToAllocate: objects(claimWithDeviceConfig(claim0, req0, classA, driverA, "deviceAttribute")),
 			classes:          objects(class(classA, driverA)),
-			slices:           unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:           unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:             node(node1, region1),
 
 			expectResults: []any{
@@ -2121,7 +2168,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("CEL expression empty (unsupported selector type?)")),
@@ -2135,7 +2182,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("unsupported count mode future-mode")),
@@ -2151,7 +2198,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("empty constraint (unsupported constraint type?)")),
@@ -2167,7 +2214,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("undeclared reference")),
@@ -2181,7 +2228,7 @@ func TestAllocator(t *testing.T,
 					return c
 				}(),
 			),
-			slices: unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices: unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:   node(node1, region1),
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("undeclared reference")),
@@ -2198,7 +2245,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("undeclared reference")),
@@ -2221,7 +2268,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize+1)),
+			slices:  unwrapResourceSlices(sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize+1)),
 			node:    node(node1, region1),
 
 			expectError: gomega.MatchError(gomega.ContainSubstring("exceeds the claim limit")),
@@ -2243,7 +2290,7 @@ func TestAllocator(t *testing.T,
 						subRequest(subReq1, classA, 1),
 					))),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: []any{allocationResult(
@@ -2262,7 +2309,7 @@ func TestAllocator(t *testing.T,
 						subRequest(subReq1, classA, 2),
 					))),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithOneDevice(slice1, node1, pool1, driverA),
 				sliceWithOneDevice(slice2, node1, pool2, driverB),
 			),
@@ -2288,7 +2335,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverB,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverB,
 				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{}),
 				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{}),
 			)),
@@ -2325,12 +2372,12 @@ func TestAllocator(t *testing.T,
 				classWithConfig(classA, driverA, "foo"),
 				classWithConfig(classB, driverB, "bar"),
 			),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverB,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverB,
 					device(device1, nil, nil),
 					device(device2, nil, nil),
 				),
-				slice(slice2, node1, pool2, driverA,
+				sliceWithDevices(slice2, node1, pool2, driverA,
 					device(device3, nil, nil),
 				),
 			),
@@ -2377,7 +2424,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, map[resourceapi.QualifiedName]resource.Quantity{
 					"memory": resource.MustParse("2Gi"),
 				}, nil),
@@ -2428,8 +2475,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -2439,7 +2486,7 @@ func TestAllocator(t *testing.T,
 						},
 					),
 				),
-				slice(slice2, node1, pool2, driverA,
+				sliceWithDevices(slice2, node1, pool2, driverA,
 					device(device2,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("2Gi"),
@@ -2497,8 +2544,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -2508,7 +2555,7 @@ func TestAllocator(t *testing.T,
 						},
 					),
 				),
-				slice(slice2, node1, pool2, driverA,
+				sliceWithDevices(slice2, node1, pool2, driverA,
 					device(device2,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("2Gi"),
@@ -2545,8 +2592,8 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil),
 					device(device2, nil, nil),
 				),
@@ -2575,8 +2622,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil),
 					device(device2, nil, nil),
 				),
@@ -2604,7 +2651,7 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: nil,
@@ -2637,8 +2684,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -2646,7 +2693,7 @@ func TestAllocator(t *testing.T,
 						map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
 					),
 				),
-				slice(slice2, node1, pool2, driverA,
+				sliceWithDevices(slice2, node1, pool2, driverA,
 					device(device2,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("4Gi"),
@@ -2689,8 +2736,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -2698,7 +2745,7 @@ func TestAllocator(t *testing.T,
 						map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
 					),
 				),
-				slice(slice2, node1, pool2, driverA,
+				sliceWithDevices(slice2, node1, pool2, driverA,
 					device(device2,
 						map[resourceapi.QualifiedName]resource.Quantity{
 							"memory": resource.MustParse("4Gi"),
@@ -2724,7 +2771,7 @@ func TestAllocator(t *testing.T,
 					subRequest(subReq1, classA, 1),
 				))),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices:  unwrap(sliceWithOneDevice(slice1, node1, pool1, driverA)),
+			slices:  unwrapResourceSlices(sliceWithOneDevice(slice1, node1, pool1, driverA)),
 			node:    node(node1, region1),
 
 			expectResults: []any{allocationResult(
@@ -2740,8 +2787,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim0, nil, request(req0, classA, 1)),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, nil, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -2749,7 +2796,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -2786,8 +2834,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -2809,7 +2857,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -2835,8 +2884,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -2858,7 +2907,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -2896,8 +2946,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -2934,7 +2984,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
@@ -2965,8 +3016,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3009,7 +3060,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"cpus":   resource.MustParse("8"),
@@ -3042,8 +3094,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3068,7 +3120,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"cpus":   resource.MustParse("8"),
@@ -3076,7 +3129,7 @@ func TestAllocator(t *testing.T,
 						},
 					),
 				),
-				slice(slice2, node1, pool2, driverA,
+				sliceWithDevices(slice3, node1, resourcePool(pool2, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3101,7 +3154,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice4, node1, resourcePool(pool2, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"cpus":   resource.MustParse("8"),
@@ -3130,8 +3184,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim0, nil, request(req0, classA, 2)),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, nil, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3153,7 +3207,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -3179,8 +3234,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3195,7 +3250,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, pool1, driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
@@ -3219,8 +3275,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3235,7 +3291,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, pool1, driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
@@ -3259,8 +3316,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3268,7 +3325,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, pool1, driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
@@ -3289,8 +3347,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, nil, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3299,7 +3357,8 @@ func TestAllocator(t *testing.T,
 						),
 					),
 					device(device2, nil, nil),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
@@ -3323,8 +3382,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, nodeSelectionPerDevice, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, nodeSelectionPerDevice, pool1, driverA,
 					device(device2, nil, nil).withNodeSelection(node1),
 				),
 			),
@@ -3353,8 +3412,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, nodeSelectionPerDevice, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, nodeSelectionPerDevice, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3369,7 +3428,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					).withNodeSelection(node2),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, nodeSelectionPerDevice, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
@@ -3392,8 +3452,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim0, nil, request(req0, classA, 1)),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, nodeSelectionPerDevice, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, nodeSelectionPerDevice, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3401,7 +3461,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					).withNodeSelection(nodeLabelSelector(regionKey, region1)),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, nodeSelectionPerDevice, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
@@ -3433,8 +3494,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(
-				slice(slice1, nodeSelectionPerDevice, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, nodeSelectionPerDevice, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -3456,14 +3517,15 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					).withNodeSelection(nodeSelectionAll),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, nodeSelectionPerDevice, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("18Gi"),
 						},
 					),
 				),
-				slice(slice2, node1, pool2, driverB,
+				sliceWithDevices(slice3, node1, resourcePool(pool2, 2), driverB,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet2,
 							map[string]resource.Quantity{
@@ -3485,7 +3547,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice4, node1, resourcePool(pool2, 2), driverB,
 					counterSet(counterSet2,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("12Gi"),
@@ -3516,7 +3579,7 @@ func TestAllocator(t *testing.T,
 			},
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 				device(device2, nil, nil).withTaints(taintNoExecute),
 			)),
@@ -3528,7 +3591,7 @@ func TestAllocator(t *testing.T,
 			},
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule, taintNoExecute),
 			)),
 			node: node(node1, region1),
@@ -3539,7 +3602,7 @@ func TestAllocator(t *testing.T,
 			},
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA).withTolerations(tolerationNoExecute)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 				device(device2, nil, nil).withTaints(taintNoExecute),
 			)),
@@ -3560,7 +3623,7 @@ func TestAllocator(t *testing.T,
 					subRequest(subReq1, classA, 1, tolerationNoExecute),
 				))),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 				device(device2, nil, nil).withTaints(taintNoExecute),
 			)),
@@ -3576,7 +3639,7 @@ func TestAllocator(t *testing.T,
 			},
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNone),
 			)),
 			node: node(node1, region1),
@@ -3591,7 +3654,7 @@ func TestAllocator(t *testing.T,
 			},
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA).withTolerations(tolerationNoSchedule, tolerationNoExecute)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule, taintNoExecute),
 			)),
 			node: node(node1, region1),
@@ -3606,7 +3669,7 @@ func TestAllocator(t *testing.T,
 			},
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule, taintNoExecute),
 			)),
 			node: node(node1, region1),
@@ -3627,7 +3690,7 @@ func TestAllocator(t *testing.T,
 						subRequest(subReq1, classA, 1),
 					))),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 			)),
 			node: node(node1, region1),
@@ -3644,7 +3707,7 @@ func TestAllocator(t *testing.T,
 						subRequest(subReq1, classA, 1),
 					))),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 			)),
 			node: node(node1, region1),
@@ -3669,7 +3732,7 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device2),
 			},
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 			)),
 			node: node(node1, region1),
@@ -3689,7 +3752,7 @@ func TestAllocator(t *testing.T,
 				MakeDeviceID(driverA, pool1, device2),
 			},
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 			)),
 			node: node(node1, region1),
@@ -3711,7 +3774,7 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 			)),
 			node: node(node1, region1),
@@ -3728,7 +3791,7 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withTaints(taintNoSchedule),
 			)),
 			node: node(node1, region1),
@@ -3751,7 +3814,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil),
 				device(device2, nil, nil),
 			)),
@@ -3771,7 +3834,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize)),
+			slices:  unwrapResourceSlices(sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize)),
 			node:    node(node1, region1),
 
 			expectResults: []any{allocationResult(
@@ -3794,8 +3857,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, nil,
 						map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 							"special": {
@@ -3850,7 +3913,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"cpu1": resource.MustParse("1"),
@@ -3890,7 +3954,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices:  unwrap(sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize*2)),
+			slices:  unwrapResourceSlices(sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize*2)),
 			node:    node(node1, region1),
 
 			expectResults: []any{allocationResult(
@@ -3916,7 +3980,7 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA), class(classB, driverB)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				sliceWithMultipleDevices(slice1, node1, pool1, driverA, resourceapi.AllocationResultsMaxSize-1),
 				sliceWithMultipleDevices(slice2, node1, pool2, driverB, 2),
 			),
@@ -3937,7 +4001,7 @@ func TestAllocator(t *testing.T,
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 1))),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}))),
 			node: node(node1, region1),
 
@@ -3961,7 +4025,7 @@ func TestAllocator(t *testing.T,
 					request(req0, classA, 2),
 					request(req1, classA, 1))),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}),
 				device(device2, nil, nil).withBindingConditions([]string{"IsPrepare2"}, []string{"BindingFailed2"}),
 				device(device3, nil, nil).withBindingConditions([]string{"IsPrepare3"}, []string{"BindingFailed3"}),
@@ -3989,7 +4053,7 @@ func TestAllocator(t *testing.T,
 					request(req0, classA, 1),
 					request(req1, classA, 1))),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil),
 				device(device2, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}),
 			)),
@@ -4013,7 +4077,7 @@ func TestAllocator(t *testing.T,
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil, request(req0, classA, 1))),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 				device(device1, nil, nil).withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}))),
 			node:          node(node1, region1),
 			expectResults: nil,
@@ -4024,7 +4088,7 @@ func TestAllocator(t *testing.T,
 			},
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(slice(slice1, nodeLabelSelector(planetKey, planetValueEarth), pool1, driverA,
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, nodeLabelSelector(planetKey, planetValueEarth), pool1, driverA,
 				device(device1, nil, nil).withBindsToNode(true))),
 			node: node(node1, region1),
 			expectResults: []any{allocationResult(
@@ -4041,8 +4105,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim0, nil, request(req0, classA, 1)),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
@@ -4050,7 +4114,8 @@ func TestAllocator(t *testing.T,
 							}),
 						).
 						withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
@@ -4079,8 +4144,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
@@ -4095,7 +4160,8 @@ func TestAllocator(t *testing.T,
 							}),
 						).
 						withBindingConditions([]string{"IsPrepare2"}, []string{"BindingFailed2"}),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
@@ -4125,8 +4191,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
@@ -4147,7 +4213,8 @@ func TestAllocator(t *testing.T,
 							}),
 						).
 						withBindingConditions([]string{"IsReady"}, []string{"BindingTimeout"}),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
@@ -4176,8 +4243,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim0, nil, request(req0, classA, 2)),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 4), driverA,
 					device(device1, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
@@ -4185,20 +4252,22 @@ func TestAllocator(t *testing.T,
 							}),
 						).
 						withBindingConditions([]string{"IsPrepare"}, []string{"BindingFailed"}),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 4), driverA,
 					counterSet(counterSet1, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
 				),
-				slice(slice2, node1, pool1, driverA,
+				sliceWithDevices(slice3, node1, resourcePool(pool1, 4), driverA,
 					device(device2, fromCounters, nil).
 						withDeviceCounterConsumption(
-							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							deviceCounterConsumption(counterSet2, map[string]resource.Quantity{
 								"memory": resource.MustParse("4Gi"),
 							}),
 						),
-				).withCounterSet(
-					counterSet(counterSet1, map[string]resource.Quantity{
+				),
+				sliceWithCounterSets(slice4, node1, resourcePool(pool1, 4), driverA,
+					counterSet(counterSet2, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
 				),
@@ -4226,8 +4295,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim0, nil, request(req0, classA, 2)),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
@@ -4246,7 +4315,8 @@ func TestAllocator(t *testing.T,
 								"memory": resource.MustParse("4Gi"),
 							}),
 						),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, pool1, driverA,
 					counterSet(counterSet1, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
@@ -4265,8 +4335,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim0, nil, request(req0, classA, 2)).withTolerations(tolerationNoScheduleKey1),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).
 						withDeviceCounterConsumption(
 							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
@@ -4285,7 +4355,8 @@ func TestAllocator(t *testing.T,
 								"memory": resource.MustParse("4Gi"),
 							}),
 						),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1, map[string]resource.Quantity{
 						"memory": resource.MustParse("8Gi"),
 					}),
@@ -4345,8 +4416,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity1: one}, nil).withAllowMultipleAllocations(),
 				),
 			),
@@ -4361,8 +4432,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(allDeviceRequest(req0, classA).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity1: one}, nil).withAllowMultipleAllocations(),
 				),
 			),
@@ -4378,8 +4449,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1)),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations(),
 				),
 			),
@@ -4404,8 +4475,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1)),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
@@ -4431,8 +4502,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1)),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}, nil).withAllowMultipleAllocations(),
 				),
 			),
@@ -4448,8 +4519,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}, nil).withAllowMultipleAllocations(),
 				),
 			),
@@ -4474,8 +4545,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim1, nil, request(req0, classA, 1)),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
 				),
 			),
@@ -4501,8 +4572,8 @@ func TestAllocator(t *testing.T,
 				claimWithRequests(claim1, nil, request(req0, classA, 1)),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyValidValues(zero, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil),
 				),
 			),
@@ -4527,8 +4598,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyValidValues(zero, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil),
 				),
 			),
@@ -4545,8 +4616,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
 				),
 			),
@@ -4572,8 +4643,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(resource.NewQuantity(3, resource.BinarySI))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
 				),
 			),
@@ -4594,8 +4665,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(resource.NewQuantity(2, resource.BinarySI))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyValidValues(one, map[resourceapi.QualifiedName]resource.Quantity{capacity0: four},
 						[]resource.Quantity{two}),
 				),
@@ -4616,8 +4687,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(resource.NewQuantity(2, resource.BinarySI))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyValidValues(one, map[resourceapi.QualifiedName]resource.Quantity{capacity0: three},
 						[]resource.Quantity{three}), // capacity value must be explicitly added
 				),
@@ -4639,8 +4710,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(two))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
 			),
@@ -4656,8 +4727,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(resource.NewQuantity(6, resource.BinarySI))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: *resource.NewQuantity(10, resource.BinarySI)}),
 				),
 			),
@@ -4678,8 +4749,8 @@ func TestAllocator(t *testing.T,
 				},
 			},
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
 				),
 			),
@@ -4705,8 +4776,8 @@ func TestAllocator(t *testing.T,
 				},
 			},
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 					device(device2, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
@@ -4733,8 +4804,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(two))),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device2, nil,
 						map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 							"stringAttribute": {StringValue: ptr.To("stringAttributeValue1")},
@@ -4769,8 +4840,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
 			),
@@ -4795,8 +4866,8 @@ func TestAllocator(t *testing.T,
 				},
 			},
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
 			),
@@ -4812,8 +4883,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(allDeviceRequest(req0, classA).withCapacityRequest(ptr.To(two))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}, nil).withAllowMultipleAllocations(),
 					device(device2, nil, nil).withAllowMultipleAllocations(),
 				),
@@ -4834,8 +4905,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(allDeviceRequest(req0, classA).withCapacityRequest(ptr.To(two))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}, nil).withAllowMultipleAllocations(),
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
@@ -4859,8 +4930,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}, nil).withAllowMultipleAllocations(),
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
@@ -4890,8 +4961,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}, nil).withAllowMultipleAllocations(),
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
@@ -4916,8 +4987,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
@@ -4940,8 +5011,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
@@ -4962,8 +5033,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, false)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil),
 				),
 			),
@@ -4985,8 +5056,8 @@ func TestAllocator(t *testing.T,
 				claim(claim1).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, false)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
 			),
@@ -5001,8 +5072,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, false)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
 			),
@@ -5021,8 +5092,8 @@ func TestAllocator(t *testing.T,
 				claim(claim0).withRequests(deviceRequest(req0, classA, 1).withCapacityRequest(ptr.To(one))),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
 			),
@@ -5043,8 +5114,8 @@ func TestAllocator(t *testing.T,
 				},
 			},
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
 				),
 			),
@@ -5076,8 +5147,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -5099,7 +5170,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					).withAllowMultipleAllocations(),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							"memory": resource.MustParse("8Gi"),
@@ -5147,8 +5219,8 @@ func TestAllocator(t *testing.T,
 			//   device1, device2, and device3 consume (2,4), (4,4), and (2,4) for (capacity0, capacity1) respectively.
 			//   i.e., only two options are valid those are [device1, device3] or [device2].
 			// Capacity.RequestPolicy of ConsumableCapacity forces the capacity1 consuming with range policy (min,step,max)=(2,2,4).
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, fromCounters, nil).withDeviceCounterConsumption(
 						deviceCounterConsumption(counterSet1,
 							map[string]resource.Quantity{
@@ -5185,7 +5257,8 @@ func TestAllocator(t *testing.T,
 							},
 						),
 					).withAllowMultipleAllocations().withCapacityRequestPolicyRange((map[resourceapi.QualifiedName]resource.Quantity{capacity1: four})),
-				).withCounterSet(
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
 					counterSet(counterSet1,
 						map[string]resource.Quantity{
 							capacity0: four,
@@ -5232,8 +5305,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 						"driverVersion": {VersionValue: ptr.To("1.0.0")},
 						"numa":          {IntValue: ptr.To(int64(0))},
@@ -5278,8 +5351,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil).withAllowMultipleAllocations(),
 				),
 			),
@@ -5299,8 +5372,8 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"boolAttribute": {}}).withAllowMultipleAllocations(),
 				),
 			),
@@ -5343,8 +5416,8 @@ func TestAllocator(t *testing.T,
 					),
 			),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 						"boolAttribute": {BoolValue: ptr.To(true)},
 					}).withAllowMultipleAllocations(),
@@ -5374,8 +5447,8 @@ func TestAllocator(t *testing.T,
 					deviceRequest(req1, classA, 1).withCapacityRequest(ptr.To(one)),
 				)),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil,
 						map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"stringAttribute": {StringValue: ptr.To("stringAttributeValue")}},
 					).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: two}),
@@ -5395,13 +5468,13 @@ func TestAllocator(t *testing.T,
 				),
 			),
 			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
-			slices: unwrap(
-				slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device1, nil,
 						map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"stringAttribute": {StringValue: ptr.To("stringAttributeValue1")}},
 					).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
 				),
-				slice(slice1, node1, pool1, driverA,
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
 					device(device2, nil,
 						map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"stringAttribute": {StringValue: ptr.To("stringAttributeValue2")}},
 					).withAllowMultipleAllocations().withCapacityRequestPolicyRange(map[resourceapi.QualifiedName]resource.Quantity{capacity0: four}),
@@ -5427,21 +5500,13 @@ func TestAllocator(t *testing.T,
 				},
 			})),
 			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				func() wrapResourceSlice {
-					s := slice(slice1, node1, pool1, driverA,
-						device(device1, nil, nil),
-					)
-					s.Spec.Pool.ResourceSliceCount = 2
-					return s
-				}(),
-				func() wrapResourceSlice {
-					s := slice(slice2, node2, pool1, driverA,
-						device(device2, nil, nil),
-					)
-					s.Spec.Pool.ResourceSliceCount = 2
-					return s
-				}(),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice2, node2, resourcePool(pool1, 2), driverA,
+					device(device2, nil, nil),
+				),
 			),
 			node: node(node1, region1),
 
@@ -5452,21 +5517,20 @@ func TestAllocator(t *testing.T,
 				),
 			},
 		},
-
 		"multi-host-resource-pool-with-stale-slice-for-current-node": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
-				func() wrapResourceSlice {
-					s := slice(slice1, node1, pool1, driverA,
+			slices: unwrapResourceSlices(
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node1, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
 					s.Spec.Pool.ResourceSliceCount = 2
 					return s
 				}(),
-				func() wrapResourceSlice {
-					s := slice(slice2, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice2, node2, pool1, driverA,
 						device(device2, nil, nil),
 					)
 					s.Spec.Pool.Generation = 2
@@ -5494,18 +5558,18 @@ func TestAllocator(t *testing.T,
 		"multi-host-resource-pool-complete-update-from-node-1-to-node-2": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				// Node 1, generation 1.
-				func() wrapResourceSlice {
-					s := slice(slice1, node1, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node1, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
 					s.Spec.Pool.ResourceSliceCount = 2
 					return s
 				}(),
-				func() wrapResourceSlice {
-					s := slice(slice1, node1, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node1, pool1, driverA,
 						device(device2, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
@@ -5513,16 +5577,16 @@ func TestAllocator(t *testing.T,
 					return s
 				}(),
 				// Node 2, generation 2.
-				func() wrapResourceSlice {
-					s := slice(slice2, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice2, node2, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 2
 					s.Spec.Pool.ResourceSliceCount = 2
 					return s
 				}(),
-				func() wrapResourceSlice {
-					s := slice(slice2, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice2, node2, pool1, driverA,
 						device(device2, nil, nil),
 					)
 					s.Spec.Pool.Generation = 2
@@ -5547,18 +5611,18 @@ func TestAllocator(t *testing.T,
 		"multi-host-resource-pool-complete-update-from-node-2-to-node-1": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				// Node 2, generation 1.
-				func() wrapResourceSlice {
-					s := slice(slice1, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node2, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
 					s.Spec.Pool.ResourceSliceCount = 2
 					return s
 				}(),
-				func() wrapResourceSlice {
-					s := slice(slice1, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node2, pool1, driverA,
 						device(device2, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
@@ -5566,16 +5630,16 @@ func TestAllocator(t *testing.T,
 					return s
 				}(),
 				// Node 1, generation 2.
-				func() wrapResourceSlice {
-					s := slice(slice2, node1, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice2, node1, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 2
 					s.Spec.Pool.ResourceSliceCount = 2
 					return s
 				}(),
-				func() wrapResourceSlice {
-					s := slice(slice2, node1, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice2, node1, pool1, driverA,
 						device(device2, nil, nil),
 					)
 					s.Spec.Pool.Generation = 2
@@ -5596,18 +5660,18 @@ func TestAllocator(t *testing.T,
 		"multi-host-resource-pool-incomplete-update-from-node-1-to-node-2": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				// Node 1, generation 1.
-				func() wrapResourceSlice {
-					s := slice(slice1, node1, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node1, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
 					s.Spec.Pool.ResourceSliceCount = 2
 					return s
 				}(),
-				func() wrapResourceSlice {
-					s := slice(slice1, node1, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node1, pool1, driverA,
 						device(device2, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
@@ -5615,8 +5679,8 @@ func TestAllocator(t *testing.T,
 					return s
 				}(),
 				// Node 2, generation 2.
-				func() wrapResourceSlice {
-					s := slice(slice2, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice2, node2, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 2
@@ -5641,18 +5705,18 @@ func TestAllocator(t *testing.T,
 		"multi-host-resource-pool-incomplete-update-from-node-2-to-node-1": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
-			slices: unwrap(
+			slices: unwrapResourceSlices(
 				// Node 2, generation 1.
-				func() wrapResourceSlice {
-					s := slice(slice1, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node2, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
 					s.Spec.Pool.ResourceSliceCount = 2
 					return s
 				}(),
-				func() wrapResourceSlice {
-					s := slice(slice1, node2, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node2, pool1, driverA,
 						device(device2, nil, nil),
 					)
 					s.Spec.Pool.Generation = 1
@@ -5660,8 +5724,8 @@ func TestAllocator(t *testing.T,
 					return s
 				}(),
 				// Node 1, generation 2.
-				func() wrapResourceSlice {
-					s := slice(slice2, node1, pool1, driverA,
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice2, node1, pool1, driverA,
 						device(device1, nil, nil),
 					)
 					s.Spec.Pool.Generation = 2
@@ -5670,13 +5734,285 @@ func TestAllocator(t *testing.T,
 				}(),
 			),
 			node: node(node1, region1),
-
-			expectResults: []any{
-				allocationResult(
-					localNodeSelector(node1),
-					deviceAllocationResult(req0, driverA, pool1, device1, false),
-				),
+			// This does not get allocated since slice2 is incomplete.
+		},
+		"partitionable-devices-same-counter-set-name-in-different-resource-slices": {
+			features: Features{
+				PartitionableDevices: true,
 			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					deviceRequest(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 4), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 4), driverA,
+					counterSet(counterSet1, nil),
+				),
+				sliceWithDevices(slice3, node1, resourcePool(pool1, 4), driverA,
+					device(device2, nil, nil),
+				),
+				sliceWithCounterSets(slice4, node1, resourcePool(pool1, 4), driverA,
+					counterSet(counterSet1, nil),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("invalid resource pools were encountered")),
+		},
+		"partitionable-devices-device-counter-consumption-references-unknown-counter-set": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					deviceRequest(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet2, nil),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1, nil),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("invalid resource pools were encountered")),
+		},
+		"partitionable-devices-device-counter-consumption-references-unknown-counter-in-counter-set": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					deviceRequest(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						}),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{
+						"other-memory": resource.MustParse("8Gi"),
+					}),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("invalid resource pools were encountered")),
+		},
+		"partitionable-devices-device-counter-consumption-references-counter-set-in-other-pool": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					deviceRequest(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, pool1, driverA,
+					device(device1, nil, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						}),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, pool2, driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{
+						"memory": resource.MustParse("8Gi"),
+					}),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("invalid resource pools were encountered")),
+		},
+		"partitionable-devices-devices-on-different-nodes-consume-same-counter-set": {
+			features: Features{
+				PartitionableDevices: true,
+				PrioritizedList:      true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					requestWithPrioritizedList(req0,
+						subRequest(subReq0, classA, 1, resourceapi.DeviceSelector{
+							CEL: &resourceapi.CELDeviceSelector{
+								Expression: fmt.Sprintf(`device.capacity["%s"].memory.compareTo(quantity("6Gi")) >= 0`, driverA),
+							},
+						}),
+						subRequest(subReq1, classA, 1, resourceapi.DeviceSelector{
+							CEL: &resourceapi.CELDeviceSelector{
+								Expression: fmt.Sprintf(`device.capacity["%s"].memory.compareTo(quantity("2Gi")) >= 0`, driverA),
+							},
+						}),
+					),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithCounterSets(slice1, node1, resourcePool(pool1, 3), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{
+						"memory": resource.MustParse("8Gi"),
+					}),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 3), driverA,
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("6Gi"),
+						}),
+					),
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("2Gi"),
+						}),
+					),
+				),
+				sliceWithDevices(slice3, node2, resourcePool(pool1, 3), driverA,
+					device(device3, nil, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("6Gi"),
+						}),
+					),
+				),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device3),
+			},
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0SubReq1, driverA, pool1, device2, false),
+			)},
+		},
+		"partitionable-devices-validation-error-on-non-targeting-slice": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil,
+					request(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithCounterSets(slice1, node1, resourcePool(pool1, 3), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{
+						"memory": resource.MustParse("8Gi"),
+					}),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 3), driverA,
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("6Gi"),
+						}),
+					),
+				),
+				sliceWithDevices(slice3, node2, resourcePool(pool1, 3), driverA,
+					device(device3, nil, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet2, map[string]resource.Quantity{
+							"memory": resource.MustParse("6Gi"),
+						}),
+					),
+				),
+			),
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("invalid resource pools were encountered")),
+		},
+		"different-resourceslices-in-pool-can-target-different-nodes": {
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil,
+					request(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node2, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device2, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		"invalid-pool-is-ok-if-devices-can-be-allocated-from-other": {
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil,
+					request(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice3, node1, resourcePool(pool2, 1), driverA,
+					device(device2, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool2, device2, false),
+			)},
+		},
+		"invalid-pool-is-error-if-no-other-device-can-be-allocated": {
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil,
+					request(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+				sliceWithDevices(slice3, node1, resourcePool(pool2, 1), driverA,
+					device(device2, nil, nil),
+				),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool2, device2),
+			},
+			node:        node(node1, region1),
+			expectError: gomega.MatchError(gomega.ContainSubstring("invalid resource pools were encountered")),
+		},
+		"no-allocation-from-incomplete-pools": {
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil,
+					request(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				),
+			),
+			node: node(node1, region1),
 		},
 	}
 
@@ -5765,7 +6101,7 @@ func TestAllocator(t *testing.T,
 				claimsToAllocate := unwrap(claimWithRequests(claim0, nil,
 					request(req0, classA, 6),
 				))
-				slices := unwrap(slice(slice1, node1, pool1, driverA,
+				slices := unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
 					device(device1, nil, nil),
 					device(device2, nil, nil),
 					device(device3, nil, nil),

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -90,16 +90,16 @@ type Allocator struct {
 	classLister    DeviceClassLister
 	slices         []*resourceapi.ResourceSlice
 	celCache       *cel.Cache
-	// availableCounters contains the available counters for individual
-	// ResourceSlices. It acts as a cache that is updated the first time
-	// the available counters are needed for each ResourceSlice. The information
-	// about each slice is never updated once set the first time.
+	// availableCounters contains the available counters for each
+	// resource pool. It acts as a cache that is updated the first time
+	// the available counters are needed for each pool. The information
+	// about each pool is never updated once set the first time.
 	// This is computed bsed on information on the Allocator, so it will
 	// be correct even for multiple usages of the Allocator.
-	// The keys in the map are ResourceSlice names.
+	// The keys in the map are resource pool names.
 	// The allocator might be accessed by different goroutines, so
 	// access to this map must be synchronized.
-	availableCounters map[string]counterSets
+	availableCounters map[draapi.UniqueString]counterSets
 	mutex             sync.RWMutex
 	// numAllocateOneInvocations counts the number of times the allocateOne
 	// function is called for the allocator. This is a measurement of the
@@ -127,7 +127,7 @@ func NewAllocator(ctx context.Context,
 		classLister:       classLister,
 		slices:            slices,
 		celCache:          celCache,
-		availableCounters: make(map[string]counterSets),
+		availableCounters: make(map[draapi.UniqueString]counterSets),
 	}, nil
 }
 
@@ -140,7 +140,7 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 		claimsToAllocate:     claims,
 		deviceMatchesRequest: make(map[matchKey]bool),
 		constraints:          make([][]constraint, len(claims)),
-		consumedCounters:     make(map[string]counterSets),
+		consumedCounters:     make(map[draapi.UniqueString]counterSets),
 		requestData:          make(map[requestIndices]requestData),
 		result:               make([]internalAllocationResult, len(claims)),
 		allocatingCapacity:   NewConsumedCapacityCollection(),
@@ -337,6 +337,17 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 		return nil, err
 	}
 	if !done {
+		// If no devices could be allocated, but we found one or more
+		// invalid pools, return an error here. We didn't do it during
+		// allocation since there might be valid pools from which the
+		// claims could be satisfied.
+		for _, pool := range pools {
+			if pool.IsInvalid {
+				// Not a fatal error, allocation on other nodes may proceed.
+				// The error is only surfaced if allocation fails on all nodes.
+				return nil, fmt.Errorf("invalid resource pools were encountered%w", internal.ErrFailedAllocationOnNode)
+			}
+		}
 		return nil, nil
 	}
 
@@ -530,8 +541,7 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 			if pool.IsInvalid {
 				return requestData, fmt.Errorf("claim %s, request %s: asks for all devices, but resource pool %s is currently invalid", klog.KObj(claim), request.name(), pool.PoolID)
 			}
-
-			for _, slice := range pool.Slices {
+			for _, slice := range pool.DeviceSlicesTargetingNode {
 				for deviceIndex := range slice.Spec.Devices {
 					selectable, err := alloc.isSelectable(requestKey, requestData, slice, deviceIndex)
 					if err != nil {
@@ -594,8 +604,8 @@ type allocator struct {
 	constraints          [][]constraint // one list of constraints per claim
 	// consumedCounters keeps track of the counters consumed by all devices
 	// that are in the process of being allocated.
-	// The keys in the map are ResourceSlice names.
-	consumedCounters map[string]counterSets
+	// The keys in the map are resource pool names.
+	consumedCounters map[draapi.UniqueString]counterSets
 	requestData      map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
 	// allocatingDevices tracks which devices will be newly allocated for a
 	// particular attempt to find a solution. The map is indexed by device
@@ -669,6 +679,7 @@ type deviceWithID struct {
 	*draapi.Device
 	id    DeviceID
 	slice *draapi.ResourceSlice
+	pool  *Pool
 }
 
 type internalAllocationResult struct {
@@ -1011,13 +1022,13 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 
 	// We need to find suitable devices.
 	for _, pool := range alloc.pools {
-		// If the pool is not valid, then fail now. It's okay when pools of one driver
-		// are invalid if we allocate from some other pool, but it's not safe to
-		// allocated from an invalid pool.
-		if pool.IsInvalid {
-			return false, fmt.Errorf("pool %s is invalid: %s", pool.Pool, pool.InvalidReason)
+		// We don't allocate devices from invalid or incomplete pools, but
+		// don't error out here since there might be available devices in other
+		// pools.
+		if pool.IsIncomplete || pool.IsInvalid {
+			continue
 		}
-		for _, slice := range pool.Slices {
+		for _, slice := range pool.DeviceSlicesTargetingNode {
 			for deviceIndex := range slice.Spec.Devices {
 				deviceID := DeviceID{Driver: pool.Driver, Pool: pool.Pool, Device: slice.Spec.Devices[deviceIndex].Name}
 
@@ -1061,6 +1072,7 @@ func (alloc *allocator) allocateOne(r deviceIndices, allocateSubRequest bool) (b
 					id:     deviceID,
 					Device: &slice.Spec.Devices[deviceIndex],
 					slice:  slice,
+					pool:   pool,
 				}
 				allocated, deallocate, err := alloc.allocateDevice(r, device, false)
 				if err != nil {
@@ -1408,13 +1420,13 @@ func taintTolerated(taint resourceapi.DeviceTaint, request requestAccessor) bool
 // Gets called only if the partitionable devices feature is enabled and the device
 // consumes counters.
 func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error) {
-	slice := device.slice
-	sliceName := slice.Name
+	pool := device.pool
+	poolName := pool.PoolID.Pool
 
-	// Check first if the available counters for this slice have already been
+	// Check first if the available counters for this pool have already been
 	// calculated.
 	alloc.mutex.RLock()
-	availableCountersForSlice, found := alloc.availableCounters[sliceName]
+	availableCountersForPool, found := alloc.availableCounters[poolName]
 	alloc.mutex.RUnlock()
 	// If not, we need to do it now. But we store the result so it doesn't need
 	// to be calculated again.
@@ -1422,69 +1434,73 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	// might also do this work. But the input will be the same to all of them, so
 	// the result will also always be the same.
 	if !found {
-		availableCountersForSlice = make(counterSets, len(slice.Spec.SharedCounters))
-		for _, counterSet := range slice.Spec.SharedCounters {
+		availableCountersForPool = make(counterSets, len(pool.CounterSets))
+		for _, counterSet := range pool.CounterSets {
 			availableCountersForCounterSet := make(map[string]resourceapi.Counter, len(counterSet.Counters))
 			for name, c := range counterSet.Counters {
 				availableCountersForCounterSet[name] = c
 			}
-			availableCountersForSlice[counterSet.Name] = availableCountersForCounterSet
+			availableCountersForPool[counterSet.Name] = availableCountersForCounterSet
 		}
 
 		// Update the data structure to reflect counters already consumed by allocated devices. This
 		// only includes devices where the allocation process has completed, so this will never
 		// change during the allocation process.
-		for _, device := range slice.Spec.Devices {
-			deviceID := DeviceID{
-				Driver: slice.Spec.Driver,
-				Pool:   slice.Spec.Pool.Name,
-				Device: device.Name,
-			}
-			// Devices that aren't allocated doesn't consume any counters, so we don't
-			// need to consider them.
-			if !alloc.allocatedState.AllocatedDevices.Has(deviceID) {
-				continue
-			}
-			for _, deviceCounterConsumption := range device.ConsumesCounters {
-				availableCountersForCounterSet := availableCountersForSlice[deviceCounterConsumption.CounterSet]
-				for name, c := range deviceCounterConsumption.Counters {
-					existingCounter, ok := availableCountersForCounterSet[name]
-					if !ok {
-						// the API validation logic has been added to make sure the counters referred should exist in counter sets.
+		for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
+			for _, slice := range resourceSlices {
+				for _, device := range slice.Spec.Devices {
+					deviceID := DeviceID{
+						Driver: slice.Spec.Driver,
+						Pool:   slice.Spec.Pool.Name,
+						Device: device.Name,
+					}
+					// Devices that aren't allocated doesn't consume any counters, so we don't
+					// need to consider them.
+					if !alloc.allocatedState.AllocatedDevices.Has(deviceID) {
 						continue
 					}
-					// This can potentially result in negative available counters. That is fine,
-					// we just treat it as no counters available.
-					existingCounter.Value.Sub(c.Value)
-					availableCountersForCounterSet[name] = existingCounter
+					for _, deviceCounterConsumption := range device.ConsumesCounters {
+						availableCountersForCounterSet := availableCountersForPool[deviceCounterConsumption.CounterSet]
+						for name, c := range deviceCounterConsumption.Counters {
+							existingCounter, ok := availableCountersForCounterSet[name]
+							if !ok {
+								// the API validation logic has been added to make sure the counters referred should exist in counter sets.
+								continue
+							}
+							// This can potentially result in negative available counters. That is fine,
+							// we just treat it as no counters available.
+							existingCounter.Value.Sub(c.Value)
+							availableCountersForCounterSet[name] = existingCounter
+						}
+					}
+					// Note that we don't include devices in the alloc.allocatingDevices here since
+					// counters consumed by devices for the current claims are tracked in
+					// alloc.consumedCounters
 				}
 			}
-			// Note that we don't include devices in the alloc.allocatingDevices here since
-			// counters consumed by devices for the current claims are tracked in
-			// alloc.consumedCounters
 		}
 
 		// Set the available counters on the allocator so we don't have to
 		// compute this again.
 		alloc.mutex.Lock()
-		alloc.availableCounters[sliceName] = availableCountersForSlice
+		alloc.availableCounters[poolName] = availableCountersForPool
 		alloc.mutex.Unlock()
 	}
 
 	// Update the consumedCounters data structure with the counters consumed
 	// by the current device.
-	consumedCountersForSlice, found := alloc.consumedCounters[sliceName]
+	consumedCountersForPool, found := alloc.consumedCounters[poolName]
 	// If no devices in the allocating state have consumed any counters from the current
-	// slice, initialize the data structure.
+	// pool, initialize the data structure.
 	if !found {
-		consumedCountersForSlice = make(counterSets)
-		alloc.consumedCounters[sliceName] = consumedCountersForSlice
+		consumedCountersForPool = make(counterSets)
+		alloc.consumedCounters[poolName] = consumedCountersForPool
 	}
 	for _, deviceCounterConsumption := range device.ConsumesCounters {
-		consumedCountersForCounterSet, found := consumedCountersForSlice[deviceCounterConsumption.CounterSet]
+		consumedCountersForCounterSet, found := consumedCountersForPool[deviceCounterConsumption.CounterSet]
 		if !found {
 			consumedCountersForCounterSet = make(map[string]resourceapi.Counter)
-			consumedCountersForSlice[deviceCounterConsumption.CounterSet] = consumedCountersForCounterSet
+			consumedCountersForPool[deviceCounterConsumption.CounterSet] = consumedCountersForCounterSet
 		}
 		for name, c := range deviceCounterConsumption.Counters {
 			consumedCounters, found := consumedCountersForCounterSet[name]
@@ -1500,8 +1516,8 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	// Check that we didn't exceed the availability of any counters by allocating
 	// the current device. If we did, the current set of devices doesn't work, so we
 	// update the consumed counters to no longer reflect the current device.
-	for availableCounterSetName, availableCounters := range availableCountersForSlice {
-		consumedCounters := consumedCountersForSlice[availableCounterSetName]
+	for availableCounterSetName, availableCounters := range availableCountersForPool {
+		consumedCounters := consumedCountersForPool[availableCounterSetName]
 		for availableCounterName, availableCounter := range availableCounters {
 			consumedCounter := consumedCounters[availableCounterName]
 			if availableCounter.Value.Cmp(consumedCounter.Value) < 0 {
@@ -1539,13 +1555,12 @@ func (alloc *allocator) allocatingCapacityForAnyClaim(deviceID DeviceID) bool {
 // deallocateCountersForDevice subtracts the consumed counters of the provided
 // device from the consumedCounters data structure.
 func (alloc *allocator) deallocateCountersForDevice(device deviceWithID) {
-	slice := device.slice
-	sliceName := slice.Name
+	poolName := device.pool.PoolID.Pool
 
-	consumedCountersForSlice := alloc.consumedCounters[sliceName]
+	consumedCountersForPool := alloc.consumedCounters[poolName]
 	for _, deviceCounterConsumption := range device.ConsumesCounters {
 		counterSetName := deviceCounterConsumption.CounterSet
-		consumedCounterSet := consumedCountersForSlice[counterSetName]
+		consumedCounterSet := consumedCountersForPool[counterSetName]
 		for name, c := range deviceCounterConsumption.Counters {
 			consumedCounter := consumedCounterSet[name]
 			consumedCounter.Value.Sub(c.Value)

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -52,15 +52,21 @@ func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
-	pools := make(map[PoolID]*Pool)
+	pools := make(map[PoolID][]*draapi.ResourceSlice)
 	var slicesWithBindingConditions []*resourceapi.ResourceSlice
 
 	for _, slice := range slices {
-		if !features.PartitionableDevices && slice.Spec.PerDeviceNodeSelection != nil {
+		if !features.PartitionableDevices && (slice.Spec.PerDeviceNodeSelection != nil || len(slice.Spec.SharedCounters) > 0) {
 			continue
 		}
 
-		if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
+		// Always include slices with SharedCounters since they are needed to use a pool
+		// regardless of their node selector.
+		if len(slice.Spec.SharedCounters) > 0 {
+			if err := addSlice(pools, slice); err != nil {
+				return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
+			}
+		} else if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
 			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
@@ -118,33 +124,63 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	}
 
 	// Find incomplete pools and flatten into a single slice.
+	//
+	// When we get here, we only have slices relevant for the node.
+	// There is at least one.
+	// We may have skipped slices with a higher generation
+	// if they are not relevant for the node, so we have to be
+	// careful with the "is incomplete" check.
 	result := make([]*Pool, 0, len(pools))
 	var resultWithBindingConditions []*Pool
-	for poolID, pool := range pools {
-		// If we have all slices, we are done. If not, then we need to start looking for slices
+	for poolID, slicesForPool := range pools {
+		// If we have all slices, we are done.
+		isComplete := int64(len(slicesForPool)) == slicesForPool[0].Spec.Pool.ResourceSliceCount
+		if isComplete {
+			pool, err := buildPool(poolID, slicesForPool, features, nil)
+			if err != nil {
+				return nil, err
+			}
+			if poolHasBindingConditions(*pool) {
+				resultWithBindingConditions = append(resultWithBindingConditions, pool)
+				continue
+			}
+			result = append(result, pool)
+			continue
+		}
+		// If not, then we need to start looking for slices
 		// which were filtered out above because their node selection made them look irrelevant
 		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
 		// pools).
-		isComplete := int64(len(pool.Slices)) == pool.Slices[0].Spec.Pool.ResourceSliceCount
-		if !isComplete {
-			isObsolete, numSlices := checkSlicesInPool(slices, poolID, pool.Slices[0].Spec.Pool.Generation)
-			if isObsolete {
-				// A more thorough check determined that the DRA driver is in the process
-				// of replacing the current generation. The newer one didn't have any slice
-				// which devices for the node, or we would have noticed sooner.
-				//
-				// Let's ignore the old device information by ignoring the pool.
-				continue
-			}
-			// Use the more complete number of slices to check for "incomplete pool".
+		isObsolete, allSlicesForPool := checkSlicesInPool(slices, poolID, slicesForPool[0].Spec.Pool.Generation)
+		if isObsolete {
+			// A more thorough check determined that the DRA driver is in the process
+			// of replacing the current generation. The newer one didn't have any slice
+			// which devices for the node, or we would have noticed sooner.
 			//
-			// The slices that we return to the caller still don't represent the whole
-			// pool, but that's okay: we *want* to limit the result to relevant devices
-			// so the caller doesn't need to check node selectors unnecessarily.
-			isComplete = numSlices == pool.Slices[0].Spec.Pool.ResourceSliceCount
+			// Let's ignore the old device information by ignoring the pool.
+			continue
 		}
-		pool.IsIncomplete = !isComplete
-		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
+		// Use the more complete number of slices to check for "incomplete pool".
+		//
+		// The slices that we return to the caller still don't represent the whole
+		// pool, but that's okay: we *want* to limit the result to relevant devices
+		// so the caller doesn't need to check node selectors unnecessarily.
+		isComplete = int64(len(allSlicesForPool)) == slicesForPool[0].Spec.Pool.ResourceSliceCount
+		// If a pool is incomplete, we don't allow allocation so we don't need
+		// to do any validation. We need to keep track of the incomplete pools here
+		// to make sure allocationMode: All doesn't succeed without considering all
+		// devices.
+		if !isComplete {
+			result = append(result, &Pool{
+				PoolID:       poolID,
+				IsIncomplete: true,
+			})
+			continue
+		}
+		pool, err := buildPool(poolID, slicesForPool, features, allSlicesForPool)
+		if err != nil {
+			return nil, err
+		}
 		// if pool has binding conditions, add the pool to the end of the result
 		if poolHasBindingConditions(*pool) {
 			resultWithBindingConditions = append(resultWithBindingConditions, pool)
@@ -159,50 +195,183 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	return result, nil
 }
 
-func addSlice(pools map[PoolID]*Pool, s *resourceapi.ResourceSlice) error {
+func addSlice(pools map[PoolID][]*draapi.ResourceSlice, s *resourceapi.ResourceSlice) error {
 	var slice draapi.ResourceSlice
 	if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(s, &slice, nil); err != nil {
 		return fmt.Errorf("convert ResourceSlice: %w", err)
 	}
 
 	id := PoolID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name}
-	pool := pools[id]
-	if pool == nil {
+	slicesForPool := pools[id]
+	if slicesForPool == nil {
 		// New pool.
-		pool = &Pool{
-			PoolID: id,
-			Slices: []*draapi.ResourceSlice{&slice},
-		}
-		pools[id] = pool
+		pools[id] = []*draapi.ResourceSlice{&slice}
 		return nil
 	}
 
-	if slice.Spec.Pool.Generation < pool.Slices[0].Spec.Pool.Generation {
+	if slice.Spec.Pool.Generation < slicesForPool[0].Spec.Pool.Generation {
 		// Out-dated.
 		return nil
 	}
 
-	if slice.Spec.Pool.Generation > pool.Slices[0].Spec.Pool.Generation {
+	if slice.Spec.Pool.Generation > slicesForPool[0].Spec.Pool.Generation {
 		// Newer, replaces all old slices.
-		pool.Slices = nil
+		pools[id] = []*draapi.ResourceSlice{&slice}
+		return nil
 	}
 
 	// Add to pool.
-	pool.Slices = append(pool.Slices, &slice)
+	slicesForPool = append(slicesForPool, &slice)
+	pools[id] = slicesForPool
 	return nil
 }
 
-func poolIsInvalid(pool *Pool) (bool, string) {
-	devices := sets.New[draapi.UniqueString]()
-	for _, slice := range pool.Slices {
-		for _, device := range slice.Spec.Devices {
-			if devices.Has(device.Name) {
-				return true, fmt.Sprintf("duplicate device name %s", device.Name)
+func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, allSlicesForPool []*resourceapi.ResourceSlice) (*Pool, error) {
+	var deviceSlices []*draapi.ResourceSlice
+	var counterSetSlices []*draapi.ResourceSlice
+	if features.PartitionableDevices {
+		for _, slice := range slices {
+			if len(slice.Spec.SharedCounters) > 0 {
+				counterSetSlices = append(counterSetSlices, slice)
+			} else {
+				deviceSlices = append(deviceSlices, slice)
 			}
-			devices.Insert(device.Name)
+		}
+	} else {
+		deviceSlices = slices
+	}
+	if err := validateDeviceNames(deviceSlices); err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+	// If the partitionable devices feature is not enabled, we don't need to
+	// validate counter sets and consumed counters, so we are done.
+	if !features.PartitionableDevices {
+		return &Pool{
+			PoolID:                    id,
+			DeviceSlicesTargetingNode: deviceSlices,
+		}, nil
+	}
+
+	counterSets, err := getAndValidateCounterSets(counterSetSlices)
+	if err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+
+	if err := validateDeviceCounterConsumption(counterSets, slices); err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+	// If we have already seen all slices (both with counter sets and devices),
+	// we don't need to do any more validation.
+	if allSlicesForPool == nil || len(slices) == len(allSlicesForPool) {
+		return &Pool{
+			PoolID:                    id,
+			DeviceSlicesTargetingNode: deviceSlices,
+			CounterSets:               counterSets,
+		}, nil
+	}
+
+	// If we have slices that were discarded earlier because they didn't target the current node
+	// we need to check them now. They might include devices that consume counters in the pool and
+	// the allocator needs to know about them to correctly determine available counters.
+	//
+	// We only want to convert the slices we haven't already converted, so make it easy to
+	// look up the names of converted slices.
+	slicesTargetingNodeNames := sets.New[string]()
+	for _, slice := range slices {
+		slicesTargetingNodeNames.Insert(slice.Name)
+	}
+	var slicesNotTargetingNode []*draapi.ResourceSlice
+	for _, slice := range allSlicesForPool {
+		if slicesTargetingNodeNames.Has(slice.Name) {
+			continue
+		}
+		var convertedSlice draapi.ResourceSlice
+		if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(slice, &convertedSlice, nil); err != nil {
+			return nil, fmt.Errorf("convert ResourceSlice: %w", err)
+		}
+		slicesNotTargetingNode = append(slicesNotTargetingNode, &convertedSlice)
+	}
+	// We need to make sure the devices here are correctly consuming counters and counter
+	// sets. Otherwise the allocator might make incorrect decisions.
+	// We don't validate the device names here. It might be that we should do that, but
+	// this is consistent with existing behavior where we don't validate slices that
+	// we don't allocate from.
+	if err := validateDeviceCounterConsumption(counterSets, slicesNotTargetingNode); err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+	return &Pool{
+		PoolID:                       id,
+		DeviceSlicesTargetingNode:    deviceSlices,
+		DeviceSlicesNotTargetingNode: slicesNotTargetingNode,
+		CounterSets:                  counterSets,
+	}, nil
+}
+
+func getAndValidateCounterSets(slices []*draapi.ResourceSlice) (map[draapi.UniqueString]*draapi.CounterSet, error) {
+	counterSets := make(map[draapi.UniqueString]*draapi.CounterSet)
+	// We only capture the first error we encounter.
+	for _, slice := range slices {
+		for i := range slice.Spec.SharedCounters {
+			counterSet := slice.Spec.SharedCounters[i]
+			if _, found := counterSets[counterSet.Name]; found {
+				return nil, fmt.Errorf("duplicate counter set name %s", counterSet.Name)
+			}
+			counterSets[counterSet.Name] = &counterSet
 		}
 	}
-	return false, ""
+	return counterSets, nil
+}
+
+func validateDeviceNames(resourceSlices []*draapi.ResourceSlice) error {
+	deviceNames := sets.New[draapi.UniqueString]()
+	for _, slice := range resourceSlices {
+		for _, device := range slice.Spec.Devices {
+			// Make sure we don't have duplicate device names
+			if deviceNames.Has(device.Name) {
+				return fmt.Errorf("duplicate device name %s", device.Name)
+			}
+			deviceNames.Insert(device.Name)
+		}
+	}
+	return nil
+}
+
+func validateDeviceCounterConsumption(counterSets map[draapi.UniqueString]*draapi.CounterSet, resourceSlices []*draapi.ResourceSlice) error {
+	for _, slice := range resourceSlices {
+		for _, device := range slice.Spec.Devices {
+			// Make sure all consumed counters for the device references counter sets that exists and
+			// that they consume counters that exists within those counter sets.
+			for _, deviceCounterConsumption := range device.ConsumesCounters {
+				counterSet, found := counterSets[deviceCounterConsumption.CounterSet]
+				if !found {
+					return fmt.Errorf("counter set %s not found", deviceCounterConsumption.CounterSet)
+				}
+
+				for counterName := range deviceCounterConsumption.Counters {
+					if _, found := counterSet.Counters[counterName]; !found {
+						return fmt.Errorf("counter %s not found in counter set %s", counterName, counterSet.Name)
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func hasBindingConditions(slice *resourceapi.ResourceSlice) bool {
@@ -215,7 +384,7 @@ func hasBindingConditions(slice *resourceapi.ResourceSlice) bool {
 }
 
 func poolHasBindingConditions(pool Pool) bool {
-	for _, slice := range pool.Slices {
+	for _, slice := range pool.DeviceSlicesTargetingNode {
 		for _, device := range slice.Spec.Devices {
 			if device.BindingConditions != nil {
 				return true
@@ -230,13 +399,15 @@ func poolHasBindingConditions(pool Pool) bool {
 //
 // It returns:
 // - current generation is obsolete -> no further checking
-// - total number of slices with the generation
+// - all slices with the generation in the pool
 //
 // Future TODO: detect inconsistent ResourceSliceCount, also in poolIsInvalid.
-func checkSlicesInPool(slices []*resourceapi.ResourceSlice, poolID PoolID, generation int64) (isObsolete bool, numSlices int64) {
+func checkSlicesInPool(slices []*resourceapi.ResourceSlice, poolID PoolID, generation int64) (bool, []*resourceapi.ResourceSlice) {
 	// A cached index by pool ID would make this more efficient.
 	// It may be needed long-term to support features which always have to consider all slices.
-	for _, slice := range slices {
+	var allSlicesForPool []*resourceapi.ResourceSlice
+	for i := range slices {
+		slice := slices[i]
 		if slice.Spec.Driver != poolID.Driver.String() ||
 			slice.Spec.Pool.Name != poolID.Pool.String() {
 			// Different pool.
@@ -244,24 +415,26 @@ func checkSlicesInPool(slices []*resourceapi.ResourceSlice, poolID PoolID, gener
 		}
 		switch {
 		case slice.Spec.Pool.Generation == generation:
-			numSlices++
+			allSlicesForPool = append(allSlicesForPool, slice)
 		case slice.Spec.Pool.Generation > generation:
 			// The caller must have missed some other slice in the pool.
 			// Abort!
-			return true, 0
+			return true, nil
 		default:
 			// Older generation, ignore.
 		}
 	}
-	return false, numSlices
+	return false, allSlicesForPool
 }
 
 type Pool struct {
 	PoolID
-	IsIncomplete  bool
-	IsInvalid     bool
-	InvalidReason string
-	Slices        []*draapi.ResourceSlice
+	IsIncomplete                 bool
+	IsInvalid                    bool
+	InvalidReason                string
+	DeviceSlicesTargetingNode    []*draapi.ResourceSlice
+	DeviceSlicesNotTargetingNode []*draapi.ResourceSlice
+	CounterSets                  map[draapi.UniqueString]*draapi.CounterSet
 }
 
 type PoolID struct {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -52,14 +52,20 @@ func NodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
-	pools := make(map[PoolID]*Pool)
+	pools := make(map[PoolID][]*draapi.ResourceSlice)
 
 	for _, slice := range slices {
-		if !features.PartitionableDevices && slice.Spec.PerDeviceNodeSelection != nil {
+		if !features.PartitionableDevices && (slice.Spec.PerDeviceNodeSelection != nil || len(slice.Spec.SharedCounters) > 0) {
 			continue
 		}
 
-		if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
+		// Always include slices with SharedCounters since they are needed to use a pool
+		// regardless of their node selector.
+		if len(slice.Spec.SharedCounters) > 0 {
+			if err := addSlice(pools, slice); err != nil {
+				return nil, fmt.Errorf("failed to add node slice %s: %w", slice.Name, err)
+			}
+		} else if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
 			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
@@ -104,81 +110,234 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	// if they are not relevant for the node, so we have to be
 	// careful with the "is incomplete" check.
 	result := make([]*Pool, 0, len(pools))
-	for poolID, pool := range pools {
-		// If we have all slices, we are done. If not, then we need to start looking for slices
+	for poolID, slicesForPool := range pools {
+		// If we have all slices, we are done.
+		isComplete := int64(len(slicesForPool)) == slicesForPool[0].Spec.Pool.ResourceSliceCount
+		if isComplete {
+			pool, err := buildPool(poolID, slicesForPool, features, nil)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, pool)
+			continue
+		}
+		// If not, then we need to start looking for slices
 		// which were filtered out above because their node selection made them look irrelevant
 		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
 		// pools).
-		isComplete := int64(len(pool.Slices)) == pool.Slices[0].Spec.Pool.ResourceSliceCount
-		if !isComplete {
-			isObsolete, numSlices := checkSlicesInPool(slices, poolID, pool.Slices[0].Spec.Pool.Generation)
-			if isObsolete {
-				// A more thorough check determined that the DRA driver is in the process
-				// of replacing the current generation. The newer one didn't have any slice
-				// which devices for the node, or we would have noticed sooner.
-				//
-				// Let's ignore the old device information by ignoring the pool.
-				continue
-			}
-			// Use the more complete number of slices to check for "incomplete pool".
+		isObsolete, allSlicesForPool := checkSlicesInPool(slices, poolID, slicesForPool[0].Spec.Pool.Generation)
+		if isObsolete {
+			// A more thorough check determined that the DRA driver is in the process
+			// of replacing the current generation. The newer one didn't have any slice
+			// which devices for the node, or we would have noticed sooner.
 			//
-			// The slices that we return to the caller still don't represent the whole
-			// pool, but that's okay: we *want* to limit the result to relevant devices
-			// so the caller doesn't need to check node selectors unnecessarily.
-			isComplete = numSlices == pool.Slices[0].Spec.Pool.ResourceSliceCount
+			// Let's ignore the old device information by ignoring the pool.
+			continue
 		}
-		pool.IsIncomplete = !isComplete
-		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
+		// Use the more complete number of slices to check for "incomplete pool".
+		//
+		// The slices that we return to the caller still don't represent the whole
+		// pool, but that's okay: we *want* to limit the result to relevant devices
+		// so the caller doesn't need to check node selectors unnecessarily.
+		isComplete = int64(len(allSlicesForPool)) == slicesForPool[0].Spec.Pool.ResourceSliceCount
+		// If a pool is incomplete, we don't allow allocation so we don't need
+		// to do any validation. We need to keep track of the incomplete pools here
+		// to make sure allocationMode: All doesn't succeed without considering all
+		// devices.
+		if !isComplete {
+			result = append(result, &Pool{
+				PoolID:       poolID,
+				IsIncomplete: true,
+			})
+			continue
+		}
+		pool, err := buildPool(poolID, slicesForPool, features, allSlicesForPool)
+		if err != nil {
+			return nil, err
+		}
 		result = append(result, pool)
 	}
 
 	return result, nil
 }
 
-func addSlice(pools map[PoolID]*Pool, s *resourceapi.ResourceSlice) error {
+func addSlice(pools map[PoolID][]*draapi.ResourceSlice, s *resourceapi.ResourceSlice) error {
 	var slice draapi.ResourceSlice
 	if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(s, &slice, nil); err != nil {
 		return fmt.Errorf("convert ResourceSlice: %w", err)
 	}
 
 	id := PoolID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name}
-	pool := pools[id]
-	if pool == nil {
+	slicesForPool := pools[id]
+	if slicesForPool == nil {
 		// New pool.
-		pool = &Pool{
-			PoolID: id,
-			Slices: []*draapi.ResourceSlice{&slice},
-		}
-		pools[id] = pool
+		pools[id] = []*draapi.ResourceSlice{&slice}
 		return nil
 	}
 
-	if slice.Spec.Pool.Generation < pool.Slices[0].Spec.Pool.Generation {
+	if slice.Spec.Pool.Generation < slicesForPool[0].Spec.Pool.Generation {
 		// Out-dated.
 		return nil
 	}
 
-	if slice.Spec.Pool.Generation > pool.Slices[0].Spec.Pool.Generation {
+	if slice.Spec.Pool.Generation > slicesForPool[0].Spec.Pool.Generation {
 		// Newer, replaces all old slices.
-		pool.Slices = nil
+		pools[id] = []*draapi.ResourceSlice{&slice}
+		return nil
 	}
 
 	// Add to pool.
-	pool.Slices = append(pool.Slices, &slice)
+	slicesForPool = append(slicesForPool, &slice)
+	pools[id] = slicesForPool
 	return nil
 }
 
-func poolIsInvalid(pool *Pool) (bool, string) {
-	devices := sets.New[draapi.UniqueString]()
-	for _, slice := range pool.Slices {
-		for _, device := range slice.Spec.Devices {
-			if devices.Has(device.Name) {
-				return true, fmt.Sprintf("duplicate device name %s", device.Name)
+func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, allSlicesForPool []*resourceapi.ResourceSlice) (*Pool, error) {
+	var deviceSlices []*draapi.ResourceSlice
+	var counterSetSlices []*draapi.ResourceSlice
+	if features.PartitionableDevices {
+		for _, slice := range slices {
+			if len(slice.Spec.SharedCounters) > 0 {
+				counterSetSlices = append(counterSetSlices, slice)
+			} else {
+				deviceSlices = append(deviceSlices, slice)
 			}
-			devices.Insert(device.Name)
+		}
+	} else {
+		deviceSlices = slices
+	}
+	if err := validateDeviceNames(deviceSlices); err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+	// If the partitionable devices feature is not enabled, we don't need to
+	// validate counter sets and consumed counters, so we are done.
+	if !features.PartitionableDevices {
+		return &Pool{
+			PoolID:                    id,
+			DeviceSlicesTargetingNode: deviceSlices,
+		}, nil
+	}
+
+	counterSets, err := getAndValidateCounterSets(counterSetSlices)
+	if err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+
+	if err := validateDeviceCounterConsumption(counterSets, slices); err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+	// If we have already seen all slices (both with counter sets and devices),
+	// we don't need to do any more validation.
+	if allSlicesForPool == nil || len(slices) == len(allSlicesForPool) {
+		return &Pool{
+			PoolID:                    id,
+			DeviceSlicesTargetingNode: deviceSlices,
+			CounterSets:               counterSets,
+		}, nil
+	}
+
+	// If we have slices that were discarded earlier because they didn't target the current node
+	// we need to check them now. They might include devices that consume counters in the pool and
+	// the allocator needs to know about them to correctly determine available counters.
+	//
+	// We only want to convert the slices we haven't already converted, so make it easy to
+	// look up the names of converted slices.
+	slicesTargetingNodeNames := sets.New[string]()
+	for _, slice := range slices {
+		slicesTargetingNodeNames.Insert(slice.Name)
+	}
+	var slicesNotTargetingNode []*draapi.ResourceSlice
+	for _, slice := range allSlicesForPool {
+		if slicesTargetingNodeNames.Has(slice.Name) {
+			continue
+		}
+		var convertedSlice draapi.ResourceSlice
+		if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(slice, &convertedSlice, nil); err != nil {
+			return nil, fmt.Errorf("convert ResourceSlice: %w", err)
+		}
+		slicesNotTargetingNode = append(slicesNotTargetingNode, &convertedSlice)
+	}
+	// We need to make sure the devices here are correctly consuming counters and counter
+	// sets. Otherwise the allocator might make incorrect decisions.
+	// We don't validate the device names here. It might be that we should do that, but
+	// this is consistent with existing behavior where we don't validate slices that
+	// we don't allocate from.
+	if err := validateDeviceCounterConsumption(counterSets, slicesNotTargetingNode); err != nil {
+		return &Pool{
+			PoolID:        id,
+			IsInvalid:     true,
+			InvalidReason: err.Error(),
+		}, nil
+	}
+	return &Pool{
+		PoolID:                       id,
+		DeviceSlicesTargetingNode:    deviceSlices,
+		DeviceSlicesNotTargetingNode: slicesNotTargetingNode,
+		CounterSets:                  counterSets,
+	}, nil
+}
+
+func getAndValidateCounterSets(slices []*draapi.ResourceSlice) (map[draapi.UniqueString]*draapi.CounterSet, error) {
+	counterSets := make(map[draapi.UniqueString]*draapi.CounterSet)
+	// We only capture the first error we encounter.
+	for _, slice := range slices {
+		for i := range slice.Spec.SharedCounters {
+			counterSet := slice.Spec.SharedCounters[i]
+			if _, found := counterSets[counterSet.Name]; found {
+				return nil, fmt.Errorf("duplicate counter set name %s", counterSet.Name)
+			}
+			counterSets[counterSet.Name] = &counterSet
 		}
 	}
-	return false, ""
+	return counterSets, nil
+}
+
+func validateDeviceNames(resourceSlices []*draapi.ResourceSlice) error {
+	deviceNames := sets.New[draapi.UniqueString]()
+	for _, slice := range resourceSlices {
+		for _, device := range slice.Spec.Devices {
+			// Make sure we don't have duplicate device names
+			if deviceNames.Has(device.Name) {
+				return fmt.Errorf("duplicate device name %s", device.Name)
+			}
+			deviceNames.Insert(device.Name)
+		}
+	}
+	return nil
+}
+
+func validateDeviceCounterConsumption(counterSets map[draapi.UniqueString]*draapi.CounterSet, resourceSlices []*draapi.ResourceSlice) error {
+	for _, slice := range resourceSlices {
+		for _, device := range slice.Spec.Devices {
+			// Make sure all consumed counters for the device references counter sets that exists and
+			// that they consume counters that exists within those counter sets.
+			for _, deviceCounterConsumption := range device.ConsumesCounters {
+				counterSet, found := counterSets[deviceCounterConsumption.CounterSet]
+				if !found {
+					return fmt.Errorf("counter set %s not found", deviceCounterConsumption.CounterSet)
+				}
+
+				for counterName := range deviceCounterConsumption.Counters {
+					if _, found := counterSet.Counters[counterName]; !found {
+						return fmt.Errorf("counter %s not found in counter set %s", counterName, counterSet.Name)
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // checkSlicesInPool is an expensive check of all slices in the pool.
@@ -186,13 +345,15 @@ func poolIsInvalid(pool *Pool) (bool, string) {
 //
 // It returns:
 // - current generation is obsolete -> no further checking
-// - total number of slices with the generation
+// - all slices with the generation in the pool
 //
 // Future TODO: detect inconsistent ResourceSliceCount, also in poolIsInvalid.
-func checkSlicesInPool(slices []*resourceapi.ResourceSlice, poolID PoolID, generation int64) (isObsolete bool, numSlices int64) {
+func checkSlicesInPool(slices []*resourceapi.ResourceSlice, poolID PoolID, generation int64) (bool, []*resourceapi.ResourceSlice) {
 	// A cached index by pool ID would make this more efficient.
 	// It may be needed long-term to support features which always have to consider all slices.
-	for _, slice := range slices {
+	var allSlicesForPool []*resourceapi.ResourceSlice
+	for i := range slices {
+		slice := slices[i]
 		if slice.Spec.Driver != poolID.Driver.String() ||
 			slice.Spec.Pool.Name != poolID.Pool.String() {
 			// Different pool.
@@ -200,24 +361,26 @@ func checkSlicesInPool(slices []*resourceapi.ResourceSlice, poolID PoolID, gener
 		}
 		switch {
 		case slice.Spec.Pool.Generation == generation:
-			numSlices++
+			allSlicesForPool = append(allSlicesForPool, slice)
 		case slice.Spec.Pool.Generation > generation:
 			// The caller must have missed some other slice in the pool.
 			// Abort!
-			return true, 0
+			return true, nil
 		default:
 			// Older generation, ignore.
 		}
 	}
-	return false, numSlices
+	return false, allSlicesForPool
 }
 
 type Pool struct {
 	PoolID
-	IsIncomplete  bool
-	IsInvalid     bool
-	InvalidReason string
-	Slices        []*draapi.ResourceSlice
+	IsIncomplete                 bool
+	IsInvalid                    bool
+	InvalidReason                string
+	DeviceSlicesTargetingNode    []*draapi.ResourceSlice
+	DeviceSlicesNotTargetingNode []*draapi.ResourceSlice
+	CounterSets                  map[draapi.UniqueString]*draapi.CounterSet
 }
 
 type PoolID struct {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/types.go
@@ -18,11 +18,16 @@ package internal
 
 import (
 	"context"
+	"errors"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+// ErrFailedAllocationOnNode is an empty sentinel for errors.Is.
+// See allocator.go for details.
+var ErrFailedAllocationOnNode = errors.New("")
 
 type DeviceClassLister interface {
 	// List returns a list of all DeviceClasses.

--- a/test/e2e/dra/utils/builder.go
+++ b/test/e2e/dra/utils/builder.go
@@ -667,7 +667,9 @@ func ToDriverResources(counters []resourceapi.CounterSet, devices ...resourceapi
 						Slices: []resourceslice.Slice{
 							{
 								SharedCounters: counters,
-								Devices:        devices,
+							},
+							{
+								Devices: devices,
 							},
 						},
 					},

--- a/test/integration/dra/objects.go
+++ b/test/integration/dra/objects.go
@@ -32,14 +32,15 @@ import (
 // NewMaxResourceSlices creates slices that are as large as possible given the current validation constraints.
 func NewMaxResourceSlices() map[string]*resourceapi.ResourceSlice {
 	slices := map[string]*resourceapi.ResourceSlice{
-		"basic":       newBasicResourceSlice(resourceapi.ResourceSliceMaxDevices),
-		"with-taints": newTaintedResourceSlice(),
+		"basic":                             newBasicResourceSlice(resourceapi.ResourceSliceMaxDevices),
+		"with-taints-and-consumes-counters": newResourceSliceWithTaintsAndConsumesCounters(),
+		"with-shared-counters":              newSharedCountersResourceSlice(),
 	}
 	return slices
 }
 
-func newTaintedResourceSlice() *resourceapi.ResourceSlice {
-	slice := newBasicResourceSlice(resourceapi.ResourceSliceMaxDevicesWithTaints)
+func newResourceSliceWithTaintsAndConsumesCounters() *resourceapi.ResourceSlice {
+	slice := newBasicResourceSlice(resourceapi.ResourceSliceMaxDevicesWithTaintsOrConsumesCounters)
 	for i := range slice.Spec.Devices {
 		for j := 0; j < resourceapi.DeviceTaintsMaxLength; j++ {
 			slice.Spec.Devices[i].Taints = append(slice.Spec.Devices[i].Taints,
@@ -51,14 +52,78 @@ func newTaintedResourceSlice() *resourceapi.ResourceSlice {
 				},
 			)
 		}
+		slice.Spec.Devices[i].ConsumesCounters = func() []resourceapi.DeviceCounterConsumption {
+			var consumesCounters []resourceapi.DeviceCounterConsumption
+			for i := 0; i < resourceapi.ResourceSliceMaxDeviceCounterConsumptionsPerDevice; i++ {
+				consumesCounters = append(consumesCounters, resourceapi.DeviceCounterConsumption{
+					CounterSet: maxDNSLabel(i),
+					Counters: func() map[string]resourceapi.Counter {
+						counters := make(map[string]resourceapi.Counter)
+						for i := 0; i < resourceapi.ResourceSliceMaxCountersPerDeviceCounterConsumption; i++ {
+							counters[maxDNSLabel(i)] = resourceapi.Counter{
+								Value: resource.MustParse("80Gi"),
+							}
+						}
+						return counters
+					}(),
+				})
+			}
+			return consumesCounters
+		}()
 	}
 	return slice
 }
 
 func newBasicResourceSlice(numDevices int) *resourceapi.ResourceSlice {
-	slice := &resourceapi.ResourceSlice{
+	slice := commonResourceSlice()
+	slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+	var devices []resourceapi.Device
+	for i := 0; i < numDevices; i++ {
+		devices = append(devices, resourceapi.Device{
+			Name: maxDNSLabel(i),
+			// Use attributes rather than capacity since it is more expensive.
+			Attributes: func() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+				attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+				for i := 0; i < resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice; i++ {
+					attributes[maxResourceQualifiedName(i)] = resourceapi.DeviceAttribute{
+						StringValue: ptr.To(maxDNSLabel(i)),
+					}
+				}
+				return attributes
+			}(),
+			NodeName: ptr.To(maxSubDomain(0)),
+		})
+	}
+	slice.Spec.Devices = devices
+	return slice
+}
+
+func newSharedCountersResourceSlice() *resourceapi.ResourceSlice {
+	slice := commonResourceSlice()
+	slice.Spec.NodeName = ptr.To(maxSubDomain(0))
+	var counterSets []resourceapi.CounterSet
+	for i := 0; i < resourceapi.ResourceSliceMaxCounterSets; i++ {
+		counterSets = append(counterSets, resourceapi.CounterSet{
+			Name: maxDNSLabel(i),
+			Counters: func() map[string]resourceapi.Counter {
+				counters := make(map[string]resourceapi.Counter)
+				for i := 0; i < resourceapi.ResourceSliceMaxCountersPerCounterSet; i++ {
+					counters[maxDNSLabel(i)] = resourceapi.Counter{
+						Value: resource.MustParse("80Gi"),
+					}
+				}
+				return counters
+			}(),
+		})
+	}
+	slice.Spec.SharedCounters = counterSets
+	return slice
+}
+
+func commonResourceSlice() *resourceapi.ResourceSlice {
+	return &resourceapi.ResourceSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: maxSubDomain(0),
+			Name: maxSubDomain(1),
 			// Number of labels is not restricted.
 			Labels: maxKeyValueMap(10),
 			// Total size of annotations is limited to TotalAnnotationSizeLimitB = 256 KB.
@@ -73,63 +138,8 @@ func newBasicResourceSlice(numDevices int) *resourceapi.ResourceSlice {
 				Generation:         math.MaxInt64,
 				ResourceSliceCount: math.MaxInt64,
 			},
-			// use PerDeviceNodeSelection as it requires setting the node selection on
-			// every device and therefore will be the most expensive option in terms of
-			// object size.
-			PerDeviceNodeSelection: ptr.To(true),
-			// The validation caps the total number of counters across all CounterSets. So
-			// the most expensive option is to have a single counter per CounterSet.
-			SharedCounters: func() []resourceapi.CounterSet {
-				var counterSets []resourceapi.CounterSet
-				for i := 0; i < resourceapi.ResourceSliceMaxSharedCounters; i++ {
-					counterSets = append(counterSets, resourceapi.CounterSet{
-						Name: maxDNSLabel(i),
-						Counters: map[string]resourceapi.Counter{
-							maxDNSLabel(0): {
-								Value: resource.MustParse("80Gi"),
-							},
-						},
-					})
-				}
-				return counterSets
-			}(),
-			Devices: func() []resourceapi.Device {
-				var devices []resourceapi.Device
-				for i := 0; i < numDevices; i++ {
-					devices = append(devices, resourceapi.Device{
-						Name: maxDNSLabel(i),
-						// Use attributes rather than capacity since it is more expensive.
-						Attributes: func() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
-							attributes := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
-							for i := 0; i < resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice; i++ {
-								attributes[maxResourceQualifiedName(i)] = resourceapi.DeviceAttribute{
-									StringValue: ptr.To(maxDNSLabel(i)),
-								}
-							}
-							return attributes
-						}(),
-						ConsumesCounters: func() []resourceapi.DeviceCounterConsumption {
-							var consumesCounters []resourceapi.DeviceCounterConsumption
-							for i := 0; i < resourceapi.ResourceSliceMaxDeviceCountersPerSlice/resourceapi.ResourceSliceMaxDevices; i++ {
-								consumesCounters = append(consumesCounters, resourceapi.DeviceCounterConsumption{
-									CounterSet: maxDNSLabel(i),
-									Counters: map[string]resourceapi.Counter{
-										maxDNSLabel(0): {
-											Value: resource.MustParse("80Gi"),
-										},
-									},
-								})
-							}
-							return consumesCounters
-						}(),
-						NodeName: ptr.To(maxSubDomain(0)),
-					})
-				}
-				return devices
-			}(),
 		},
 	}
-	return slice
 }
 
 // maxKeyValueMap produces a map for labels or annotations.

--- a/test/integration/scheduler_perf/dra/partitionabledevices/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/partitionabledevices/performance-config.yaml
@@ -32,7 +32,10 @@
     nodeTemplatePath: ../templates/node-with-dra-test-driver.yaml
     countParam: $nodesWithDRA
   - opcode: createAny
-    templatePath: ../templates/resourceslice-partitionable.yaml
+    templatePath: ../templates/resourceslice-partitionable-countersets.yaml
+    countParam: $resourceSlices
+  - opcode: createAny
+    templatePath: ../templates/resourceslice-partitionable-devices.yaml
     countParam: $resourceSlices
   - opcode: createAny
     templatePath: ../templates/deviceclass.yaml
@@ -106,7 +109,10 @@
     nodeTemplatePath: ../templates/node-with-dra-test-driver.yaml
     countParam: $nodesWithDRA
   - opcode: createAny
-    templatePath: ../templates/resourceslice-partitionable-backtracking.yaml
+    templatePath: ../templates/resourceslice-partitionable-backtracking-countersets.yaml
+    countParam: $resourceSlices
+  - opcode: createAny
+    templatePath: ../templates/resourceslice-partitionable-backtracking-devices.yaml
     countParam: $resourceSlices
   - opcode: createAny
     templatePath: ../templates/deviceclass.yaml

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-backtracking-countersets.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-backtracking-countersets.yaml
@@ -1,0 +1,40 @@
+kind: ResourceSlice
+apiVersion: resource.k8s.io/v1
+metadata:
+  name: resourceslice-countersets-{{.Index}}
+spec:
+  pool:
+    name: resourceslice-{{.Index}}
+    generation: 1
+    resourceSliceCount: 2
+  driver: test-driver.cdi.k8s.io
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: node-with-dra
+        operator: In
+        values:
+        - "true"
+  sharedCounters:
+  - name: counter-set-for-cpu
+    counters:
+      cpu1:
+        value: "1"
+      cpu2:
+        value: "1"
+      cpu3:
+        value: "1"
+      cpu4:
+        value: "1"
+      cpu5:
+        value: "1"
+      cpu6:
+        value: "1"
+      cpu7:
+        value: "1"
+      cpu8:
+        value: "1"
+  - name: counter-set-for-mem
+    counters:
+      mem:
+        value: "70Gi"

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-backtracking-devices.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-backtracking-devices.yaml
@@ -1,12 +1,12 @@
 kind: ResourceSlice
 apiVersion: resource.k8s.io/v1
 metadata:
-  name: resourceslice-{{.Index}}
+  name: resourceslice-devices-{{.Index}}
 spec:
   pool:
     name: resourceslice-{{.Index}}
     generation: 1
-    resourceSliceCount: 1
+    resourceSliceCount: 2
   driver: test-driver.cdi.k8s.io
   nodeSelector:
     nodeSelectorTerms:
@@ -15,29 +15,6 @@ spec:
         operator: In
         values:
         - "true"
-  sharedCounters:
-  - name: counter-set-for-cpu
-    counters:
-      cpu1:
-        value: "1"
-      cpu2:
-        value: "1"
-      cpu3:
-        value: "1"
-      cpu4:
-        value: "1"
-      cpu5:
-        value: "1"
-      cpu6:
-        value: "1"
-      cpu7:
-        value: "1"
-      cpu8:
-        value: "1"
-  - name: counter-set-for-mem
-    counters:
-      mem:
-        value: "70Gi"
   devices:
   - name: device-1
     consumesCounters:

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-countersets.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-countersets.yaml
@@ -1,0 +1,28 @@
+kind: ResourceSlice
+apiVersion: resource.k8s.io/v1
+metadata:
+  name: resourceslice-countersets-{{.Index}}
+spec:
+  pool:
+    name: resourceslice-{{.Index}}
+    generation: 1
+    resourceSliceCount: 2
+  driver: test-driver.cdi.k8s.io
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: node-with-dra
+        operator: In
+        values:
+        - "true"
+  sharedCounters:
+  - name: counter-set
+    counters:
+      counter1:
+        value: "1"
+      counter2:
+        value: "1"
+      counter3:
+        value: "1"
+      counter4:
+        value: "1"

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-devices.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-partitionable-devices.yaml
@@ -1,12 +1,12 @@
 kind: ResourceSlice
 apiVersion: resource.k8s.io/v1
 metadata:
-  name: resourceslice-{{.Index}}
+  name: resourceslice-devices-{{.Index}}
 spec:
   pool:
     name: resourceslice-{{.Index}}
     generation: 1
-    resourceSliceCount: 1
+    resourceSliceCount: 2
   driver: test-driver.cdi.k8s.io
   nodeSelector:
     nodeSelectorTerms:
@@ -15,17 +15,6 @@ spec:
         operator: In
         values:
         - "true"
-  sharedCounters:
-  - name: counter-set
-    counters:
-      counter1:
-        value: "1"
-      counter2:
-        value: "1"
-      counter3:
-        value: "1"
-      counter4:
-        value: "1"
   devices:
   # 2 counter devices
   - name: device-2-counters-1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR updates the Partitionable Devices feature according to the changes described in https://github.com/kubernetes/enhancements/pull/5515

#### Which issue(s) this PR is related to:

Related-to: https://github.com/kubernetes/enhancements/issues/4815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updates to the Partitionable Devices feature which allows for referencing counter sets across different ResourceSlices within the same resource pool.

Devices from incomplete pools are no longer considered for allocation.

This contains backwards incompatible changes to the Partitionable Devices alpha feature, so any ResourceSlices that uses the feature should be removed prior to upgrading or downgrading between 1.34 and 1.35.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4815-dra-partitionable-devices
