### PR TITLE
Remove warning on pod creation with non RFC 1123 compliant name if hostname is set

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -121,7 +121,7 @@ func (podStrategy) Validate(ctx context.Context, obj runtime.Object) field.Error
 func (podStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	newPod := obj.(*api.Pod)
 	var warnings []string
-	if msgs := utilvalidation.IsDNS1123Label(newPod.Name); len(msgs) != 0 {
+	if msgs := utilvalidation.IsDNS1123Label(newPod.Name); len(msgs) != 0 && newPod.Spec.Hostname == "" {
 		warnings = append(warnings, fmt.Sprintf("metadata.name: this is used in the Pod's hostname, which can result in surprising behavior; a DNS label is recommended: %v", msgs))
 	}
 	warnings = append(warnings, podutil.GetWarningsForPod(ctx, newPod, nil)...)

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -4253,3 +4253,62 @@ func TestWarningsOnUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestWarningsOnCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *api.Pod
+		warnings []string
+	}{
+		{
+			name: "valid pod name",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-pod",
+				},
+			},
+			warnings: nil,
+		},
+		{
+			name: "invalid pod name with no hostname",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "invald-pod.1",
+				},
+			},
+			warnings: []string{
+				"this is used in the Pod's hostname",
+			},
+		},
+		{
+			name: "invalid pod name with hostname",
+			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-pod.1",
+				},
+				Spec: api.PodSpec{
+					Hostname: "valid-pod",
+				},
+			},
+			warnings: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			warnings := Strategy.WarningsOnCreate(context.Background(), test.pod)
+			ok := len(warnings) == len(test.warnings)
+			if ok {
+				for i := range warnings {
+					if !strings.Contains(warnings[i], test.warnings[i]) {
+						ok = false
+						break
+					}
+				}
+			}
+			if !ok {
+				t.Errorf("Expected warnings for %v, got %v", test.warnings, warnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
A small change to cover the case where a pod is created with a none RFC 1123 compliant name but has the host name set.
To reproduce:
```bash
$ kubectl run nginx.1 \
  --image=nginx:latest \
  --overrides='{
    "spec": {
      "hostname": "nginx-1",
      "containers": [
        {
          "name": "nginx-1",
          "image": "nginx:latest"
        }
      ]
    }
  }'
Warning: metadata.name: this is used in the Pod's hostname, which can result in surprising behavior; a DNS label is recommended: [must not contain dots]
pod/nginx.1 created
$ kubectl exec nginx.1 -- hostname
nginx-1
```
In this example the warning is not correct, since the pod will have a different host name which is compliant with the RFC. 

/kind feature

#### What this PR does / why we need it:
The PR changes the behaviour so that the warning is only displayed when the host name is not set.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
This warning also appears when creating several other resources like Jobs or CronJobs. If the PR is found to be valid, I could change those messages as well.

#### Does this PR introduce a user-facing change?
```release-note
Remove incorrect warning when creating pods with non RFC 1123 compliant name and hostname set
```