### PR TITLE
Update comments around an old bug workaround

### DIFF
--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -304,13 +304,9 @@ func (s *ProxyServer) setupConntrack(ctx context.Context, ct Conntracker) error 
 			if err != errReadOnlySysFS {
 				return err
 			}
-			// errReadOnlySysFS is caused by a known docker issue (https://github.com/docker/docker/issues/24000),
-			// the only remediation we know is to restart the docker daemon.
-			// Here we'll send an node event with specific reason and message, the
-			// administrator should decide whether and how to handle this issue,
-			// whether to drain the node and restart docker.  Occurs in other container runtimes
-			// as well.
-			// TODO(random-liu): Remove this when the docker bug is fixed.
+			// errReadOnlySysFS means we ran into a known container runtim bug
+			// (https://issues.k8s.io/134108). For historical reasons we ignore
+			// this problem and just alert the admin that it occurred.
 			const message = "CRI error: /sys is read-only: " +
 				"cannot modify conntrack limits, problems may arise later (If running Docker, see docker issue #24000)"
 			s.Recorder.Eventf(s.NodeRef, nil, v1.EventTypeWarning, err.Error(), "StartKubeProxy", message)


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates some comments in the code to refer to a k8s issue rather than a docker issue, with more clarity about when the workaround can be removed.

I didn't bother updating the Event text because nobody has complained about it so far (meaning maybe nobody ever actually hits this bug any more?) and anyway, the original docker bug describes the workaround ("restart docker") while the new k8s bug doesn't...

#### Which issue(s) this PR is related to:
#134108

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/area kube-proxy
