### PR TITLE
Fix time shift handling in kubelet pod cache

### DIFF
--- a/pkg/kubelet/container/cache.go
+++ b/pkg/kubelet/container/cache.go
@@ -22,7 +22,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/clock"
 )
 
 // Cache stores the PodStatus for the pods. It represents *all* the visible
@@ -47,6 +49,26 @@ type Cache interface {
 	GetNewerThan(types.UID, time.Time) (*PodStatus, error)
 	Delete(types.UID)
 	UpdateTime(time.Time)
+}
+
+// CacheConfig holds configuration options for the cache
+type CacheConfig struct {
+	// TimeShiftThreshold is the threshold for detecting time shifts.
+	// When the current time is significantly earlier than expected (more than
+	// this threshold), the cache treats existing data as "newer" to avoid
+	// blocking indefinitely and prevent container name reservation conflicts.
+	// Default: 30 seconds
+	TimeShiftThreshold time.Duration
+	// Clock provides time functionality for the cache. If nil, uses time.Now()
+	Clock clock.Clock
+}
+
+// DefaultCacheConfig returns the default cache configuration
+func DefaultCacheConfig() *CacheConfig {
+	return &CacheConfig{
+		TimeShiftThreshold: 30 * time.Second,
+		Clock:              clock.RealClock{},
+	}
 }
 
 type data struct {
@@ -76,11 +98,25 @@ type cache struct {
 	timestamp *time.Time
 	// Map that stores the subscriber records.
 	subscribers map[types.UID][]*subRecord
+	// Configuration for the cache
+	config *CacheConfig
 }
 
-// NewCache creates a pod cache.
+// NewCache creates a pod cache with default configuration.
 func NewCache() Cache {
-	return &cache{pods: map[types.UID]*data{}, subscribers: map[types.UID][]*subRecord{}}
+	return NewCacheWithConfig(DefaultCacheConfig())
+}
+
+// NewCacheWithConfig creates a pod cache with the provided configuration.
+func NewCacheWithConfig(config *CacheConfig) Cache {
+	if config == nil {
+		config = DefaultCacheConfig()
+	}
+	return &cache{
+		pods:        map[types.UID]*data{},
+		subscribers: map[types.UID][]*subRecord{},
+		config:      config,
+	}
 }
 
 // Get returns the PodStatus for the pod; callers are expected not to
@@ -158,14 +194,23 @@ func (c *cache) get(id types.UID) *data {
 func (c *cache) getIfNewerThan(id types.UID, minTime time.Time) *data {
 	d, ok := c.pods[id]
 	globalTimestampIsNewer := (c.timestamp != nil && c.timestamp.After(minTime))
-
+	
 	// Handle time shift scenarios: if the current time is significantly earlier than minTime,
 	// it indicates a clock step backwards. In such cases, we should treat cached data as "newer"
 	// to avoid blocking indefinitely and prevent container name reservation conflicts.
-	currentTime := time.Now()
-	timeShiftThreshold := 30 * time.Second // Allow for reasonable clock adjustments
-	timeShiftDetected := currentTime.Before(minTime.Add(-timeShiftThreshold))
-
+	currentTime := c.config.Clock.Now()
+	timeShiftDetected := currentTime.Before(minTime.Add(-c.config.TimeShiftThreshold))
+	
+	if timeShiftDetected {
+		// Log time shift detection for monitoring and debugging
+		klog.V(2).InfoS("Time shift detected in pod cache",
+			"podUID", id,
+			"currentTime", currentTime,
+			"minTime", minTime,
+			"timeDifference", minTime.Sub(currentTime),
+			"threshold", c.config.TimeShiftThreshold)
+	}
+	
 	if !ok && (globalTimestampIsNewer || timeShiftDetected) {
 		// Status is not cached, but either:
 		//   * the global timestamp is newer than minTime, or
@@ -193,15 +238,24 @@ func (c *cache) notify(id types.UID, timestamp time.Time) {
 		return
 	}
 	newList := []*subRecord{}
-	currentTime := time.Now()
-	timeShiftThreshold := 30 * time.Second // Allow for reasonable clock adjustments
-
+	currentTime := c.config.Clock.Now()
+	
 	for i, r := range list {
 		// Handle time shift scenarios: if the current time is significantly earlier than the
 		// subscriber's time, it indicates a clock step backwards. In such cases, we should
 		// notify the subscriber to avoid blocking indefinitely.
-		timeShiftDetected := currentTime.Before(r.time.Add(-timeShiftThreshold))
-
+		timeShiftDetected := currentTime.Before(r.time.Add(-c.config.TimeShiftThreshold))
+		
+		if timeShiftDetected {
+			// Log time shift detection in notification for monitoring
+			klog.V(3).InfoS("Time shift detected in pod cache notification",
+				"podUID", id,
+				"currentTime", currentTime,
+				"subscriberTime", r.time,
+				"timeDifference", r.time.Sub(currentTime),
+				"threshold", c.config.TimeShiftThreshold)
+		}
+		
 		if timestamp.Before(r.time) && !timeShiftDetected {
 			// Doesn't meet the time requirement and no time shift detected; keep the record.
 			newList = append(newList, list[i])

--- a/pkg/kubelet/container/cache_test.go
+++ b/pkg/kubelet/container/cache_test.go
@@ -24,10 +24,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
 func newTestCache() *cache {
 	c := NewCache()
+	return c.(*cache)
+}
+
+func newTestCacheWithClock(testClock clock.Clock) *cache {
+	config := DefaultCacheConfig()
+	config.Clock = testClock
+	c := NewCacheWithConfig(config)
 	return c.(*cache)
 }
 
@@ -210,16 +219,19 @@ func TestRegisterNotification(t *testing.T) {
 }
 
 func TestTimeShiftHandling(t *testing.T) {
-	cache := newTestCache()
+	// Create a test clock to simulate time shifts
+	testClock := clocktesting.NewFakeClock(time.Now())
+	cache := newTestCacheWithClock(testClock)
 	podID, status := getTestPodIDAndStatus(1)
 	
 	// Set up initial cache state
-	baseTime := time.Now()
+	baseTime := testClock.Now()
 	cache.Set(podID, status, nil, baseTime)
 	cache.UpdateTime(baseTime)
 	
 	// Simulate time shift: clock goes backwards by 40 seconds
 	// This simulates the scenario described in issue #134153
+	testClock.Step(-40 * time.Second)
 	timeShiftedTime := baseTime.Add(-40 * time.Second)
 	
 	// Test getIfNewerThan with time shift
@@ -235,11 +247,13 @@ func TestTimeShiftHandling(t *testing.T) {
 }
 
 func TestTimeShiftThreshold(t *testing.T) {
-	cache := newTestCache()
+	// Create a test clock to simulate time shifts
+	testClock := clocktesting.NewFakeClock(time.Now())
+	cache := newTestCacheWithClock(testClock)
 	podID, status := getTestPodIDAndStatus(1)
 	
 	// Set up initial cache state
-	baseTime := time.Now()
+	baseTime := testClock.Now()
 	cache.Set(podID, status, nil, baseTime)
 	cache.UpdateTime(baseTime)
 	
@@ -249,8 +263,82 @@ func TestTimeShiftThreshold(t *testing.T) {
 	d := cache.getIfNewerThan(podID, normalTime)
 	assert.Nil(t, d, "should return nil for normal time progression")
 	
-	// Test with time shift scenario: simulate clock going backwards
-	// We need to simulate the scenario where the current time is much earlier than minTime
-	// This is tricky to test directly, so we'll test the overall behavior
-	// by ensuring our time shift detection doesn't interfere with normal operation
+	// Test with small time shift (should not trigger time shift detection)
+	// The key insight: we need to simulate the scenario where the current time
+	// (testClock.Now()) is much earlier than the minTime parameter
+	// This happens when the clock goes backwards after minTime was set
+	testClock.Step(-10 * time.Second) // Clock goes back 10 seconds
+	// But we're asking for data newer than a time that's 10 seconds in the future
+	// relative to the current clock time
+	futureTime := testClock.Now().Add(10 * time.Second)
+	d = cache.getIfNewerThan(podID, futureTime)
+	assert.Nil(t, d, "should return nil for small time difference")
+	
+	// Test with large time shift (should trigger time shift detection)
+	// Clock goes back 40 seconds total, and we ask for data newer than
+	// a time that's 40 seconds in the future relative to current clock
+	testClock.Step(-30 * time.Second) // Total: -40 seconds from original
+	futureTime = testClock.Now().Add(40 * time.Second)
+	d = cache.getIfNewerThan(podID, futureTime)
+	assert.NotNil(t, d, "should return cached data for large time difference (time shift)")
+}
+
+func TestTimeShiftEdgeCases(t *testing.T) {
+	// Create a test clock to simulate time shifts
+	testClock := clocktesting.NewFakeClock(time.Now())
+	cache := newTestCacheWithClock(testClock)
+	podID, status := getTestPodIDAndStatus(1)
+	
+	// Set up initial cache state
+	baseTime := testClock.Now()
+	cache.Set(podID, status, nil, baseTime)
+	cache.UpdateTime(baseTime)
+	
+	// Test exactly at the threshold boundary (30 seconds)
+	// Clock goes back 30 seconds, and we ask for data newer than
+	// a time that's 30 seconds in the future relative to current clock
+	testClock.Step(-30 * time.Second)
+	exactThresholdTime := testClock.Now().Add(30 * time.Second)
+	d := cache.getIfNewerThan(podID, exactThresholdTime)
+	assert.Nil(t, d, "should return nil for exactly threshold time difference")
+	
+	// Test just over the threshold (30.1 seconds)
+	// Clock goes back an additional 100ms, and we ask for data newer than
+	// a time that's 30.1 seconds in the future relative to current clock
+	testClock.Step(-100 * time.Millisecond) // Total: -30.1 seconds
+	overThresholdTime := testClock.Now().Add(30*time.Second + 100*time.Millisecond)
+	d = cache.getIfNewerThan(podID, overThresholdTime)
+	assert.NotNil(t, d, "should return cached data for time difference just over threshold")
+}
+
+func TestConfigurableThreshold(t *testing.T) {
+	// Create a test clock
+	testClock := clocktesting.NewFakeClock(time.Now())
+	
+	// Create cache with custom threshold
+	config := DefaultCacheConfig()
+	config.Clock = testClock
+	config.TimeShiftThreshold = 10 * time.Second // Custom threshold
+	cache := NewCacheWithConfig(config).(*cache)
+	
+	podID, status := getTestPodIDAndStatus(1)
+	baseTime := testClock.Now()
+	cache.Set(podID, status, nil, baseTime)
+	cache.UpdateTime(baseTime)
+	
+	// Test with time shift just under custom threshold (should not trigger)
+	// Clock goes back 5 seconds, and we ask for data newer than
+	// a time that's 5 seconds in the future relative to current clock
+	testClock.Step(-5 * time.Second)
+	underThresholdTime := testClock.Now().Add(5 * time.Second)
+	d := cache.getIfNewerThan(podID, underThresholdTime)
+	assert.Nil(t, d, "should return nil for time difference under custom threshold")
+	
+	// Test with time shift just over custom threshold (should trigger)
+	// Clock goes back an additional 6 seconds (total: -11 seconds), and we ask for data newer than
+	// a time that's 11 seconds in the future relative to current clock
+	testClock.Step(-6 * time.Second) // Total: -11 seconds
+	overThresholdTime := testClock.Now().Add(11 * time.Second)
+	d = cache.getIfNewerThan(podID, overThresholdTime)
+	assert.NotNil(t, d, "should return cached data for time difference over custom threshold")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This commit fixes issue https://github.com/kubernetes/kubernetes/issues/134153 where time shifts (clock going backwards) could cause kubelet to get stuck waiting for pod status updates and
subsequently create containers with duplicate names.

The fix adds time shift detection logic to the pod cache's getIfNewerThan
and notify methods. When a time shift is detected (current time is
significantly earlier than expected), the cache treats existing data as
'newer' to avoid blocking indefinitely and prevent container name
reservation conflicts.

#### Which issue(s) this PR is related to:
Issue #134153

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
