### PR TITLE
Mark the assumed pods that are being removed as pending deletion

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -91,7 +91,9 @@ type podState struct {
 	// Used to block cache from expiring assumedPod if binding still runs
 	bindingFinished bool
 	// pendingDeletion says whether the pod is pending deletion
-	// and will be removed from the cache soon.
+	// and is expected to be removed from the cache when both are met:
+	// 1) the notification about pod removal comes from the api-server
+	// 2) the scheduler finishes processing (scheduling/binding) the in-memory pod.
 	pendingDeletion bool
 }
 

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -118,6 +118,13 @@ type Cache interface {
 	// BindPod handles the pod binding by adding a bind API call to the dispatcher.
 	// This method should be used only if the SchedulerAsyncAPICalls feature gate is enabled.
 	BindPod(binding *v1.Binding) (<-chan error, error)
+
+	// MarkPendingDeletion marks the pod as pending deletion.
+	// This allows to skip the processing for a pod that will be removed from the scheduler soon.
+	MarkPendingDeletion(pod *v1.Pod) error
+
+	// PendingDeletion returns whether the pod is pending deletion.
+	PendingDeletion(pod *v1.Pod) (bool, error)
 }
 
 // Dump is a dump of the cache state.

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -207,7 +207,7 @@ func (sched *Scheduler) updatePodInSchedulingQueue(oldObj, newObj interface{}) {
 	if isAssumed {
 		if newPod.DeletionTimestamp != nil && oldPod.DeletionTimestamp == nil {
 			// If the DeletionTimestamp was added, it means that the pod deletion process has started.
-			// If it happend to the assumed pod, it should be handled appropriately,
+			// If it happened to the assumed pod, it should be handled appropriately,
 			// because we can't update it in any structure.
 			sched.handleAssumedPodDeletion(newPod)
 		}

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -439,6 +439,7 @@ func TestPostFilter(t *testing.T) {
 					apiDispatcher.Run(logger)
 					defer apiDispatcher.Close()
 				}
+				cache := internalcache.New(ctx, 100*time.Millisecond, apiDispatcher)
 
 				f, err := tf.NewFramework(ctx, registeredPlugins, "",
 					frameworkruntime.WithClientSet(cs),
@@ -450,12 +451,12 @@ func TestPostFilter(t *testing.T) {
 					frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(tt.pods, tt.nodes)),
 					frameworkruntime.WithLogger(logger),
 					frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+					frameworkruntime.WithPendingDeletionChecker(cache),
 				)
 				if err != nil {
 					t.Fatal(err)
 				}
 				if asyncAPICallsEnabled {
-					cache := internalcache.New(ctx, 100*time.Millisecond, apiDispatcher)
 					f.SetAPICacher(apicache.New(nil, cache))
 				}
 
@@ -2219,6 +2220,7 @@ func TestPreempt(t *testing.T) {
 						frameworkruntime.WithWaitingPods(waitingPods),
 						frameworkruntime.WithLogger(logger),
 						frameworkruntime.WithPodActivator(&fakePodActivator{}),
+						frameworkruntime.WithPendingDeletionChecker(cache),
 					)
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -197,6 +197,10 @@ func NewEvaluator(pluginName string, fh fwk.Handle, i Interface, enableAsyncPree
 				return err
 			}
 			logger.V(2).Info("Preemptor Pod preempted victim Pod", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
+
+			if err := ev.Handler.MarkPendingDeletion(victim); err != nil {
+				logger.Error(err, "Failed to mark victim pod as pending deletion", "victim", klog.KObj(victim), "preemptor", klog.KObj(preemptor))
+			}
 		}
 
 		ev.Handler.EventRecorder().Eventf(victim, preemptor, v1.EventTypeNormal, "Preempted", "Preempting", "Preempted by pod %v on node %v", preemptor.UID, c.Name())

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -751,6 +751,7 @@ func TestPrepareCandidate(t *testing.T) {
 						apiDispatcher.Run(logger)
 						defer apiDispatcher.Close()
 					}
+					cache := internalcache.New(ctx, 100*time.Millisecond, apiDispatcher)
 
 					fwk, err := tf.NewFramework(
 						ctx,
@@ -764,6 +765,7 @@ func TestPrepareCandidate(t *testing.T) {
 						frameworkruntime.WithPodNominator(nominator),
 						frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, "test-scheduler")),
 						frameworkruntime.WithPodActivator(fakeActivator),
+						frameworkruntime.WithPendingDeletionChecker(cache),
 					)
 					if err != nil {
 						t.Fatal(err)
@@ -772,7 +774,6 @@ func TestPrepareCandidate(t *testing.T) {
 					informerFactory.WaitForCacheSync(ctx.Done())
 					fakePreemptionScorePostFilterPlugin := &FakePreemptionScorePostFilterPlugin{}
 					if asyncAPICallsEnabled {
-						cache := internalcache.New(ctx, 100*time.Millisecond, apiDispatcher)
 						fwk.SetAPICacher(apicache.New(nil, cache))
 					}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -348,6 +348,8 @@ func New(ctx context.Context,
 		apiDispatcher = apidispatcher.New(client, int(options.parallelism), apicalls.Relevances)
 	}
 
+	schedulerCache := internalcache.New(ctx, durationToExpireAssumedPod, apiDispatcher)
+
 	profiles, err := profile.NewMap(ctx, options.profiles, registry, recorderFactory,
 		frameworkruntime.WithComponentConfigVersion(options.componentConfigVersion),
 		frameworkruntime.WithClientSet(client),
@@ -361,6 +363,7 @@ func New(ctx context.Context,
 		frameworkruntime.WithMetricsRecorder(metricsRecorder),
 		frameworkruntime.WithWaitingPods(waitingPods),
 		frameworkruntime.WithAPIDispatcher(apiDispatcher),
+		frameworkruntime.WithPendingDeletionChecker(schedulerCache),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("initializing profiles: %v", err)
@@ -404,8 +407,6 @@ func New(ctx context.Context,
 		internalqueue.WithMetricsRecorder(metricsRecorder),
 		internalqueue.WithAPIDispatcher(apiDispatcher),
 	)
-
-	schedulerCache := internalcache.New(ctx, durationToExpireAssumedPod, apiDispatcher)
 
 	var apiCache fwk.APICacher
 	if apiDispatcher != nil {

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -754,6 +754,9 @@ type PluginsRunner interface {
 
 // PendingDeletionChecker allows to check if the deletion is already pending for a pod.
 type PendingDeletionChecker interface {
+	// MarkPendingDeletion marks the pod as pending deletion.
+	// This allows to skip the processing for a pod that will be removed from the scheduler soon.
+	MarkPendingDeletion(pod *v1.Pod) error
 	// PendingDeletion returns whether the pod is pending deletion.
 	PendingDeletion(pod *v1.Pod) (bool, error)
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -632,6 +632,8 @@ type Handle interface {
 	PluginsRunner
 	// PodActivator abstracts operations in the scheduling queue.
 	PodActivator
+	// PendingDeletionChecker abstracts operation to check if the deletion is already pending for a pod.
+	PendingDeletionChecker
 	// SnapshotSharedLister returns listers from the latest NodeInfo Snapshot. The snapshot
 	// is taken at the beginning of a scheduling cycle and remains unchanged until
 	// a pod finishes "Permit" point.
@@ -748,4 +750,10 @@ type PluginsRunner interface {
 	// PreFilter plugins. It returns directly if any of the plugins return any
 	// status other than Success.
 	RunPreFilterExtensionRemovePod(ctx context.Context, state CycleState, podToSchedule *v1.Pod, podInfoToRemove PodInfo, nodeInfo NodeInfo) *Status
+}
+
+// PendingDeletionChecker allows to check if the deletion is already pending for a pod.
+type PendingDeletionChecker interface {
+	// PendingDeletion returns whether the pod is pending deletion.
+	PendingDeletion(pod *v1.Pod) (bool, error)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When pod is in the binding phase it occupies the space on the node (is assumed). When the higher priority pods tried to preempt such pod, it deleted it from the cluster, but it remained in the scheduler's cache without any indicator. Since the binding phase can take some time (PreBind, Bind), the pod occupies the space for a long time. The higher priority pod, when retried, would try to preempt the pod again, making unnecessary API calls to the kube-apiserver.

In some scenarios, this behavior can seriously affect the scheduling performance, by continuously sending the preemption API calls for the already deleted pod.

This PR adds a new field to scheduler's cache that indicates that the pod is pending deletion. It is set when the pod delete event (or update setting the `deletionTimestamp`) for assumed pod is registered by the scheduler. Moreover, preemption algorithm sets that right after deleting the pod to shorten the window.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Related to #134217

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where Pod/Delete API calls were sent continuously for an already deleted pod, leading to a poor kube-scheduler performance.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
