### PR TITLE
DRA extended resource quota

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -597,7 +597,7 @@ func newResourceQuotaController(ctx context.Context, controllerContext Controlle
 
 	discoveryFunc := resourceQuotaControllerDiscoveryClient.ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(controllerContext.InformerFactory.ForResource)
-	quotaConfiguration := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
+	quotaConfiguration := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource, controllerContext.InformerFactory)
 
 	resourceQuotaControllerOptions := &resourcequotacontroller.ControllerOptions{
 		QuotaClient:               resourceQuotaControllerClient.CoreV1(),

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -111,7 +111,7 @@ type quotaController struct {
 
 func setupQuotaController(t *testing.T, kubeClient kubernetes.Interface, lister quota.ListerForResourceFunc, discoveryFunc NamespacedResourcesFunc) quotaController {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
-	quotaConfiguration := install.NewQuotaConfigurationForControllers(lister)
+	quotaConfiguration := install.NewQuotaConfigurationForControllers(lister, informerFactory)
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
 	resourceQuotaControllerOptions := &ControllerOptions{

--- a/pkg/controlplane/apiserver/admission/config.go
+++ b/pkg/controlplane/apiserver/admission/config.go
@@ -43,7 +43,7 @@ func (c *Config) New(proxyTransport *http.Transport, egressSelector *egressselec
 	webhookPluginInitializer := webhookinit.NewPluginInitializer(webhookAuthResolverWrapper, serviceResolver)
 
 	kubePluginInitializer := NewPluginInitializer(
-		quotainstall.NewQuotaConfigurationForAdmission(),
+		quotainstall.NewQuotaConfigurationForAdmission(c.ExternalInformers),
 		exclusion.Excluded(),
 	)
 

--- a/pkg/quota/v1/evaluator/core/pods_test.go
+++ b/pkg/quota/v1/evaluator/core/pods_test.go
@@ -276,6 +276,23 @@ func TestPodEvaluatorUsage(t *testing.T) {
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
 			},
 		},
+		"init container implicit extended resources": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					InitContainers: []api.Container{{
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{api.ResourceName("deviceclass.resource.kubernetes.io/dongle"): resource.MustParse("3")},
+							Limits:   api.ResourceList{api.ResourceName("deviceclass.resource.kubernetes.io/dongle"): resource.MustParse("3")},
+						},
+					}},
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceName("requests.deviceclass.resource.kubernetes.io/dongle"): resource.MustParse("3"),
+				corev1.ResourcePods: resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+		},
 		"container CPU": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
@@ -363,6 +380,23 @@ func TestPodEvaluatorUsage(t *testing.T) {
 			},
 			usage: corev1.ResourceList{
 				corev1.ResourceName("requests.example.com/dongle"): resource.MustParse("3"),
+				corev1.ResourcePods: resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+		},
+		"container implicit extended resources": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{{
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{api.ResourceName("deviceclass.resource.kubernetes.io/dongle"): resource.MustParse("3")},
+							Limits:   api.ResourceList{api.ResourceName("deviceclass.resource.kubernetes.io/dongle"): resource.MustParse("3")},
+						},
+					}},
+				},
+			},
+			usage: corev1.ResourceList{
+				corev1.ResourceName("requests.deviceclass.resource.kubernetes.io/dongle"): resource.MustParse("3"),
 				corev1.ResourcePods: resource.MustParse("1"),
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
 			},

--- a/pkg/quota/v1/evaluator/core/registry.go
+++ b/pkg/quota/v1/evaluator/core/registry.go
@@ -17,11 +17,17 @@ limitations under the License.
 package core
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/clock"
 )
@@ -35,7 +41,7 @@ var legacyObjectCountAliases = map[schema.GroupVersionResource]corev1.ResourceNa
 }
 
 // NewEvaluators returns the list of static evaluators that manage more than counts
-func NewEvaluators(f quota.ListerForResourceFunc) []quota.Evaluator {
+func NewEvaluators(f quota.ListerForResourceFunc, i informers.SharedInformerFactory) []quota.Evaluator {
 	// these evaluators have special logic
 	result := []quota.Evaluator{
 		NewPodEvaluator(f, clock.RealClock{}),
@@ -43,7 +49,17 @@ func NewEvaluators(f quota.ListerForResourceFunc) []quota.Evaluator {
 		NewPersistentVolumeClaimEvaluator(f),
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
-		result = append(result, NewResourceClaimEvaluator(f))
+		var podLister corev1listers.PodLister
+		var deviceClassMapping *extendedresourcecache.ExtendedResourceCache
+		if utilfeature.DefaultFeatureGate.Enabled(features.DRAExtendedResource) {
+			podLister = i.Core().V1().Pods().Lister()
+			logger := klog.FromContext(context.Background())
+			deviceClassMapping = extendedresourcecache.NewExtendedResourceCache(logger)
+			if _, err := i.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceClassMapping); err != nil {
+				logger.Error(err, "failed to add device class informer event handler")
+			}
+		}
+		result = append(result, NewResourceClaimEvaluator(f, deviceClassMapping, podLister))
 	}
 
 	// these evaluators require an alias for backwards compatibility

--- a/pkg/quota/v1/evaluator/core/resource_claims_test.go
+++ b/pkg/quota/v1/evaluator/core/resource_claims_test.go
@@ -17,30 +17,54 @@ limitations under the License.
 package core
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
+	quota "k8s.io/apiserver/pkg/quota/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
+	"k8s.io/klog/v2/ktesting"
 	api "k8s.io/kubernetes/pkg/apis/resource"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
 )
 
-func testResourceClaim(name string, namespace string, spec api.ResourceClaimSpec) *api.ResourceClaim {
-	return &api.ResourceClaim{
+func testResourceClaim(name string, namespace string, isExtended bool, podName string, spec api.ResourceClaimSpec) *api.ResourceClaim {
+	claim := &api.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec:       spec,
 	}
+	if isExtended {
+		claim.Annotations = map[string]string{resourceapi.ExtendedResourceClaimAnnotation: "true"}
+		claim.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       podName,
+				UID:        "uid",
+				Controller: ptr.To(true),
+			},
+		}
+	}
+	return claim
 }
 
 func TestResourceClaimEvaluatorUsage(t *testing.T) {
 	classGpu := "gpu"
 	classTpu := "tpu"
-	validClaim := testResourceClaim("foo", "ns", api.ResourceClaimSpec{
+	validClaim := testResourceClaim("foo", "ns", false, "", api.ResourceClaimSpec{
 		Devices: api.DeviceClaim{
 			Requests: []api.DeviceRequest{
 				{
@@ -54,7 +78,7 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 			},
 		},
 	})
-	validClaimWithPrioritizedList := testResourceClaim("foo", "ns", api.ResourceClaimSpec{
+	validClaimWithPrioritizedList := testResourceClaim("foo", "ns", false, "", api.ResourceClaimSpec{
 		Devices: api.DeviceClaim{
 			Requests: []api.DeviceRequest{
 				{
@@ -71,18 +95,362 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 			},
 		},
 	})
+	explicitExtendedResourceClaim := testResourceClaim("foo", "ns", true, "pod-explicit", api.ResourceClaimSpec{
+		Devices: api.DeviceClaim{
+			Requests: []api.DeviceRequest{
+				{
+					Name: "container-0-request-0",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+			},
+		},
+	})
+	implicitExtendedResourceClaim := testResourceClaim("foo", "ns", true, "pod-implicit", api.ResourceClaimSpec{
+		Devices: api.DeviceClaim{
+			Requests: []api.DeviceRequest{
+				{
+					Name: "container-0-request-0",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+			},
+		},
+	})
+	hybridExtendedResourceClaim := testResourceClaim("foo", "ns", true, "pod-hybrid", api.ResourceClaimSpec{
+		Devices: api.DeviceClaim{
+			Requests: []api.DeviceRequest{
+				{
+					Name: "container-1-request-0",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+				{
+					Name: "container-1-request-1",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+			},
+		},
+	})
+	nilStatusExtendedResourceClaim := testResourceClaim("foo", "ns", true, "pod-nil-status", api.ResourceClaimSpec{
+		Devices: api.DeviceClaim{
+			Requests: []api.DeviceRequest{
+				{
+					Name: "request-0",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+				{
+					Name: "container-1-request-0",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+			},
+		},
+	})
+	initExtendedResourceClaim := testResourceClaim("foo", "ns", true, "pod-init", api.ResourceClaimSpec{
+		Devices: api.DeviceClaim{
+			Requests: []api.DeviceRequest{
+				{
+					Name: "container-2-request-0",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+				{
+					Name: "container-2-request-1",
+					Exactly: &api.ExactDeviceRequest{
+						DeviceClassName: classGpu,
+						AllocationMode:  api.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+			},
+		},
+	})
 
-	evaluator := NewResourceClaimEvaluator(nil)
+	podImplicit := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pod-implicit",
+			UID:       "uid",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceName("deviceclass.resource.kubernetes.io/" + classGpu): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ExtendedResourceClaimStatus: &corev1.PodExtendedResourceClaimStatus{
+				ResourceClaimName: "foo",
+			},
+		},
+	}
+	podExplicit := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pod-explicit",
+			UID:       "uid",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"example.com/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ExtendedResourceClaimStatus: &corev1.PodExtendedResourceClaimStatus{
+				ResourceClaimName: "foo",
+			},
+		},
+	}
+	podHybrid := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pod-hybrid",
+			UID:       "uid",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"example.com/gpu": resource.MustParse("1"),
+							corev1.ResourceName("deviceclass.resource.kubernetes.io/" + classGpu): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"example.com/gpu": resource.MustParse("1"),
+							corev1.ResourceName("deviceclass.resource.kubernetes.io/" + classGpu): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ExtendedResourceClaimStatus: &corev1.PodExtendedResourceClaimStatus{
+				ResourceClaimName: "foo",
+			},
+		},
+	}
+	podNilStatus := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pod-nil-status",
+			UID:       "uid",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"example.com/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceName("deviceclass.resource.kubernetes.io/" + classGpu): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{},
+	}
+	podInit := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pod-init",
+			UID:       "uid",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name: "init-container-1",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"example.com/gpu": resource.MustParse("1"),
+							corev1.ResourceName("deviceclass.resource.kubernetes.io/" + classGpu): resource.MustParse("1"),
+						},
+					},
+				},
+				{
+					Name: "init-container-2",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"example.com/gpu": resource.MustParse("1"),
+							corev1.ResourceName("deviceclass.resource.kubernetes.io/" + classGpu): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "container-1",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"example.com/gpu": resource.MustParse("1"),
+							corev1.ResourceName("deviceclass.resource.kubernetes.io/" + classGpu): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			ExtendedResourceClaimStatus: &corev1.PodExtendedResourceClaimStatus{
+				ResourceClaimName: "foo",
+			},
+		},
+	}
+
+	deviceClass1 := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: classGpu,
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: ptr.To("example.com/gpu"),
+		},
+	}
+
+	logger, ctx := ktesting.NewTestContext(t)
+	tCtx, tCancel := context.WithCancel(ctx)
+	client := fake.NewClientset(deviceClass1, podImplicit, podExplicit, podHybrid, podNilStatus, podInit)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	deviceclassmapping := extendedresourcecache.NewExtendedResourceCache(logger)
+	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceclassmapping); err != nil {
+		logger.Error(err, "failed to add device class informer event handler")
+	}
+	evaluatorWithDeviceMapping := NewResourceClaimEvaluator(nil, deviceclassmapping, informerFactory.Core().V1().Pods().Lister())
+
+	informerFactory.Start(tCtx.Done())
+	t.Cleanup(func() {
+		// Need to cancel before waiting for the shutdown.
+		tCancel()
+		// Now we can wait for all goroutines to stop.
+		informerFactory.Shutdown()
+	})
+	informerFactory.WaitForCacheSync(tCtx.Done())
+
+	// wait for informer sync
+	time.Sleep(1 * time.Second)
+
+	evaluator := NewResourceClaimEvaluator(nil, nil, nil)
 	testCases := map[string]struct {
-		claim  *api.ResourceClaim
-		usage  corev1.ResourceList
-		errMsg string
+		evaluator quota.Evaluator
+		claim     *api.ResourceClaim
+		usage     corev1.ResourceList
+		errMsg    string
 	}{
-		"simple": {
-			claim: validClaim,
+		"implicit-extended-resource-claim": {
+			evaluator: evaluatorWithDeviceMapping,
+			claim:     implicitExtendedResourceClaim,
 			usage: corev1.ResourceList{
 				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
 				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("1"),
+				"requests.example.com/gpu":                resource.MustParse("1"),
+			},
+		},
+		"explicit-extended-resource-claim": {
+			evaluator: evaluatorWithDeviceMapping,
+			claim:     explicitExtendedResourceClaim,
+			usage: corev1.ResourceList{
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("1"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
+			},
+		},
+		"hybrid-extended-resource-claim": {
+			evaluator: evaluatorWithDeviceMapping,
+			claim:     hybridExtendedResourceClaim,
+			usage: corev1.ResourceList{
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("2"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
+				"requests.example.com/gpu":                        resource.MustParse("1"),
+			},
+		},
+		"ni-status-extended-resource-claim": {
+			evaluator: evaluatorWithDeviceMapping,
+			claim:     nilStatusExtendedResourceClaim,
+			usage: corev1.ResourceList{
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("2"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
+				"requests.example.com/gpu":                        resource.MustParse("1"),
+			},
+		},
+		"init-extended-resource-claim": {
+			evaluator: evaluatorWithDeviceMapping,
+			claim:     initExtendedResourceClaim,
+			usage: corev1.ResourceList{
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("2"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
+				"requests.example.com/gpu":                        resource.MustParse("1"),
+			},
+		},
+		"simple": {
+			claim: validClaim,
+			usage: corev1.ResourceList{
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("1"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
 			},
 		},
 		"many-requests": {
@@ -94,8 +462,9 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 				return claim
 			}(),
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("5"),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("5"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("5"),
 			},
 		},
 		"count": {
@@ -105,8 +474,9 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 				return claim
 			}(),
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("5"),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("5"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("5"),
 			},
 		},
 		"all": {
@@ -116,8 +486,9 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 				return claim
 			}(),
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": *resource.NewQuantity(api.AllocationResultsMaxSize, resource.DecimalSI),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         *resource.NewQuantity(api.AllocationResultsMaxSize, resource.DecimalSI),
+				"requests.deviceclass.resource.kubernetes.io/gpu": *resource.NewQuantity(api.AllocationResultsMaxSize, resource.DecimalSI),
 			},
 		},
 		"unknown-count-mode": {
@@ -139,15 +510,17 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 				return claim
 			}(),
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("1"),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("1"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
 			},
 		},
 		"prioritized-list": {
 			claim: validClaimWithPrioritizedList,
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("1"),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("1"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
 			},
 		},
 		"prioritized-list-multiple-subrequests": {
@@ -163,8 +536,9 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 				return claim
 			}(),
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("2"),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("2"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("2"),
 			},
 		},
 		"prioritized-list-multiple-subrequests-allocation-mode-all": {
@@ -178,8 +552,9 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 				return claim
 			}(),
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("32"),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("32"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("32"),
 			},
 		},
 		"prioritized-list-multiple-subrequests-different-device-classes": {
@@ -193,15 +568,21 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 				return claim
 			}(),
 			usage: corev1.ResourceList{
-				"count/resourceclaims.resource.k8s.io":    resource.MustParse("1"),
-				"gpu.deviceclass.resource.k8s.io/devices": resource.MustParse("1"),
-				"tpu.deviceclass.resource.k8s.io/devices": resource.MustParse("32"),
+				"count/resourceclaims.resource.k8s.io":            resource.MustParse("1"),
+				"gpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("1"),
+				"requests.deviceclass.resource.kubernetes.io/gpu": resource.MustParse("1"),
+				"tpu.deviceclass.resource.k8s.io/devices":         resource.MustParse("32"),
+				"requests.deviceclass.resource.kubernetes.io/tpu": resource.MustParse("32"),
 			},
 		},
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			actual, err := evaluator.Usage(testCase.claim)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAExtendedResource, true)
+			if testCase.evaluator == nil {
+				testCase.evaluator = evaluator
+			}
+			actual, err := testCase.evaluator.Usage(testCase.claim)
 			if err != nil {
 				if testCase.errMsg == "" {
 					t.Fatalf("Unexpected error: %v", err)
@@ -222,7 +603,37 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 }
 
 func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
-	evaluator := NewResourceClaimEvaluator(nil)
+	deviceClass1 := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu",
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: ptr.To("example.com/gpu"),
+		},
+	}
+
+	logger, ctx := ktesting.NewTestContext(t)
+	tCtx, tCancel := context.WithCancel(ctx)
+	client := fake.NewClientset(deviceClass1)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	deviceclassmapping := extendedresourcecache.NewExtendedResourceCache(logger)
+	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceclassmapping); err != nil {
+		logger.Error(err, "failed to add device class informer event handler")
+	}
+	evaluator := NewResourceClaimEvaluator(nil, deviceclassmapping, informerFactory.Core().V1().Pods().Lister())
+
+	informerFactory.Start(tCtx.Done())
+	t.Cleanup(func() {
+		// Need to cancel before waiting for the shutdown.
+		tCancel()
+		// Now we can wait for all goroutines to stop.
+		informerFactory.Shutdown()
+	})
+	informerFactory.WaitForCacheSync(tCtx.Done())
+
+	// wait for informer sync
+	time.Sleep(1 * time.Second)
+
 	testCases := map[string]struct {
 		items []corev1.ResourceName
 		want  []corev1.ResourceName
@@ -231,11 +642,15 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 			items: []corev1.ResourceName{
 				"count/resourceclaims.resource.k8s.io",
 				"gpu.deviceclass.resource.k8s.io/devices",
+				"requests.example.com/gpu",
+				"requests.deviceclass.resource.kubernetes.io/gpu",
 			},
 
 			want: []corev1.ResourceName{
 				"count/resourceclaims.resource.k8s.io",
 				"gpu.deviceclass.resource.k8s.io/devices",
+				"requests.example.com/gpu",
+				"requests.deviceclass.resource.kubernetes.io/gpu",
 			},
 		},
 		"unsupported-resources": {
@@ -251,6 +666,7 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAExtendedResource, true)
 			actual := evaluator.MatchingResources(testCase.items)
 
 			if diff := cmp.Diff(testCase.want, actual); diff != "" {
@@ -261,7 +677,7 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 }
 
 func TestResourceClaimEvaluatorHandles(t *testing.T) {
-	evaluator := NewResourceClaimEvaluator(nil)
+	evaluator := NewResourceClaimEvaluator(nil, nil, nil)
 	testCases := []struct {
 		name  string
 		attrs admission.Attributes

--- a/pkg/quota/v1/install/registry.go
+++ b/pkg/quota/v1/install/registry.go
@@ -21,20 +21,21 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
+	"k8s.io/client-go/informers"
 	"k8s.io/kubernetes/pkg/apis/authentication"
 	"k8s.io/kubernetes/pkg/apis/authorization"
 	"k8s.io/kubernetes/pkg/quota/v1/evaluator/core"
 )
 
 // NewQuotaConfigurationForAdmission returns a quota configuration for admission control.
-func NewQuotaConfigurationForAdmission() quota.Configuration {
-	evaluators := core.NewEvaluators(nil)
+func NewQuotaConfigurationForAdmission(i informers.SharedInformerFactory) quota.Configuration {
+	evaluators := core.NewEvaluators(nil, i)
 	return generic.NewConfiguration(evaluators, DefaultIgnoredResources())
 }
 
 // NewQuotaConfigurationForControllers returns a quota configuration for controllers.
-func NewQuotaConfigurationForControllers(f quota.ListerForResourceFunc) quota.Configuration {
-	evaluators := core.NewEvaluators(f)
+func NewQuotaConfigurationForControllers(f quota.ListerForResourceFunc, i informers.SharedInformerFactory) quota.Configuration {
+	evaluators := core.NewEvaluators(f, i)
 	return generic.NewConfiguration(evaluators, DefaultIgnoredResources())
 }
 

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -110,7 +110,7 @@ func createHandlerWithConfig(kubeClient kubernetes.Interface, informerFactory in
 	if config == nil {
 		config = &resourcequotaapi.Configuration{}
 	}
-	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
+	quotaConfiguration := install.NewQuotaConfigurationForAdmission(nil)
 
 	handler, err := resourcequota.NewResourceQuota(config, 5)
 	if err != nil {

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7655,6 +7655,8 @@ const (
 	ResourceLimitsEphemeralStorage ResourceName = "limits.ephemeral-storage"
 	// resource.k8s.io devices requested with a certain DeviceClass, number
 	ResourceClaimsPerClass string = ".deviceclass.resource.k8s.io/devices"
+	// resource.k8s.io devices requested with a certain DeviceClass by implicit extended resource name, number
+	ResourceImplicitExtendedClaimsPerClass string = "requests.deviceclass.resource.kubernetes.io/"
 )
 
 // The following identify resource prefix for Kubernetes object types

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -323,3 +323,84 @@ func TestExtendedResourceCache(t *testing.T) {
 		t.Errorf("Expected 'deviceclass.resource.kubernetes.io/gpu-class-0' to be removed after deleting device class, got %s", cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class"))
 	}
 }
+
+func TestDeviceClassMapping(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	tCtx, tCancel := context.WithCancel(ctx)
+
+	client := fake.NewClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cache := NewExtendedResourceCache(logger)
+	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(cache); err != nil {
+		logger.Error(err, "failed to add device class informer event handler")
+	}
+	informerFactory.Start(tCtx.Done())
+	t.Cleanup(func() {
+		// Need to cancel before waiting for the shutdown.
+		tCancel()
+		// Now we can wait for all goroutines to stop.
+		informerFactory.Shutdown()
+	})
+	informerFactory.WaitForCacheSync(tCtx.Done())
+
+	deviceClass1 := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-class",
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: ptr.To("example.com/gpu"),
+		},
+	}
+
+	deviceClass2 := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tpu-class",
+		},
+	}
+
+	// Test adding device classes
+	_, err := client.ResourceV1().DeviceClasses().Create(tCtx, deviceClass1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create device class: %v", err)
+	}
+	_, err = client.ResourceV1().DeviceClasses().Create(tCtx, deviceClass2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create device class: %v", err)
+	}
+
+	time.Sleep(1 * time.Second)
+	name := cache.GetExtendedResource("gpu-class")
+	if name != "example.com/gpu" {
+		t.Errorf("Expected to find device class 'gpu-class', got %s", name)
+	}
+	name = cache.GetExtendedResource("tpu-class")
+	if name != "" {
+		t.Errorf("Expected device class 'tpu-class' not found")
+	}
+
+	// Test updating device classes
+	deviceClass1Modified := deviceClass1.DeepCopy()
+	deviceClass1Modified.Spec.ExtendedResourceName = ptr.To("my.com/gpu")
+	_, err = client.ResourceV1().DeviceClasses().Update(tCtx, deviceClass1Modified, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update device class: %v", err)
+	}
+
+	time.Sleep(1 * time.Second)
+	name = cache.GetExtendedResource("gpu-class")
+	if name != "my.com/gpu" {
+		t.Errorf("Expected to find device class 'gpu-class' with  'my.com/gpu' after modification, got %s", name)
+	}
+
+	// Test deleting device classes
+	err = client.ResourceV1().DeviceClasses().Delete(tCtx, deviceClass1.Name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete device class: %v", err)
+	}
+
+	time.Sleep(1 * time.Second)
+	name = cache.GetExtendedResource("gpu-class")
+	if name != "" {
+		t.Error("Expected 'gpu-class' not found after deletion")
+	}
+}

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -2146,11 +2146,85 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		b := drautils.NewBuilder(f, driver)
 		b.UseExtendedResourceName = true
 
+		ginkgo.It("must run a pod with extended resource with resource quota", func(ctx context.Context) {
+			hard := v1.ResourceList{
+				v1.ResourceName("count/resourceclaims.resource.k8s.io"):                                          resource.MustParse("10"),
+				v1.ResourceName(fmt.Sprintf("requests.%s", b.ExtendedResourceName(0))):                           resource.MustParse("10"),
+				v1.ResourceName(fmt.Sprintf("requests.%s", "deviceclass.resource.kubernetes.io/"+b.ClassName())): resource.MustParse("10"),
+				v1.ResourceName(fmt.Sprintf("%s.deviceclass.resource.k8s.io/devices", b.Class(0).Name)):          resource.MustParse("10"),
+			}
+
+			quota := &v1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-quota", Namespace: f.Namespace.Name},
+				Spec: v1.ResourceQuotaSpec{
+					Hard: hard,
+				},
+			}
+			b.Create(ctx, quota)
+
+			pod := b.Pod()
+			res := v1.ResourceList{}
+
+			// b.ExtendedResourceName(0) is added to the device class with name: b.ClassName()+"0"
+			res[v1.ResourceName(b.ExtendedResourceName(0))] = resource.MustParse("1")
+			// implicit extended resource name
+			res[v1.ResourceName("deviceclass.resource.kubernetes.io/"+b.ClassName())] = resource.MustParse("1")
+
+			pod.Spec.Containers[0].Resources.Requests = res
+			pod.Spec.Containers[0].Resources.Limits = res
+			pod.Spec.InitContainers = []v1.Container{pod.Spec.Containers[0], pod.Spec.Containers[0], pod.Spec.Containers[0]}
+			pod.Spec.InitContainers[0].Name += "-init"
+			// This must succeed for the pod to start.
+			pod.Spec.InitContainers[0].Command = []string{"sh", "-c", "env|grep request_0=true"}
+			pod.Spec.InitContainers[0].Resources.Requests = res
+			pod.Spec.InitContainers[0].Resources.Limits = res
+			pod.Spec.InitContainers[1].Name += "-sidecar"
+			// This must succeed for the pod to start.
+			pod.Spec.InitContainers[1].Command = []string{"sh", "-c", "env|grep container_1_request_0=true; sleep 1"}
+			pod.Spec.InitContainers[1].RestartPolicy = ptr.To(v1.ContainerRestartPolicyAlways)
+			pod.Spec.InitContainers[1].Resources.Requests = res
+			pod.Spec.InitContainers[1].Resources.Limits = res
+			pod.Spec.InitContainers[2].Name += "-init-1"
+			// This must succeed for the pod to start.
+			pod.Spec.InitContainers[2].Command = []string{"sh", "-c", "env|grep request_0=true"}
+			pod.Spec.InitContainers[2].Resources.Requests = res
+			pod.Spec.InitContainers[2].Resources.Limits = res
+
+			b.Create(ctx, pod)
+			err := e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)
+			framework.ExpectNoError(err, "start pod")
+			containerEnv := []string{
+				"container_3_request_0", "true",
+				"container_3_request_1", "true",
+			}
+			drautils.TestContainerEnv(ctx, f, pod, pod.Spec.Containers[0].Name, false, containerEnv...)
+
+			claim := b.ExternalClaim()
+			pod2 := b.PodExternal()
+			b.Create(ctx, claim, pod2)
+			b.TestPod(ctx, f, pod2)
+
+			usedResources := v1.ResourceList{}
+			usedResources[v1.ResourceName("count/resourceclaims.resource.k8s.io")] = resource.MustParse("2")
+			usedResources[v1.ResourceName(fmt.Sprintf("requests.%s", b.ExtendedResourceName(0)))] = resource.MustParse("9")
+			usedResources[v1.ResourceName(fmt.Sprintf("requests.%s", "deviceclass.resource.kubernetes.io/"+b.ClassName()))] = resource.MustParse("9")
+			usedResources[v1.ResourceName(fmt.Sprintf("%s.deviceclass.resource.k8s.io/devices", b.Class(0).Name))] = resource.MustParse("9")
+
+			gomega.Eventually(ctx, framework.GetObject(f.ClientSet.CoreV1().ResourceQuotas(quota.Namespace).Get, quota.Name, metav1.GetOptions{})).
+				Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Status": gomega.Equal(v1.ResourceQuotaStatus{
+						Hard: hard,
+						Used: usedResources,
+					})})))
+
+			framework.ExpectNoError(err)
+		})
+
 		ginkgo.It("must run a pod with both implicit and explicit extended resource with one container two resources", func(ctx context.Context) {
 			extendedResourceTest(ctx, b, f, []string{
 				// implicit extended resource name
 				"deviceclass.resource.kubernetes.io/" + b.ClassName(),
-				// b.ExtendedResourceName(0) is added to the deivce class with name: b.ClassName()+"0"
+				// b.ExtendedResourceName(0) is added to the device class with name: b.ClassName()+"0"
 				b.ExtendedResourceName(0),
 			}, []string{
 				"container_0_request_0", "true",

--- a/test/e2e/dra/utils/builder.go
+++ b/test/e2e/dra/utils/builder.go
@@ -353,6 +353,8 @@ func (b *Builder) Create(ctx context.Context, objs ...klog.KMetadata) []klog.KMe
 			})
 		case *v1.Pod:
 			createdObj, err = b.f.ClientSet.CoreV1().Pods(b.f.Namespace.Name).Create(ctx, obj, metav1.CreateOptions{})
+		case *v1.ResourceQuota:
+			createdObj, err = b.f.ClientSet.CoreV1().ResourceQuotas(b.f.Namespace.Name).Create(ctx, obj, metav1.CreateOptions{})
 		case *v1.ConfigMap:
 			createdObj, err = b.f.ClientSet.CoreV1().ConfigMaps(b.f.Namespace.Name).Create(ctx, obj, metav1.CreateOptions{})
 		case *resourceapi.ResourceClaim:

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -90,7 +90,7 @@ func TestQuota(t *testing.T) {
 
 	discoveryFunc := clientset.Discovery().ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(informers.ForResource)
-	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
+	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource, nil)
 	informersStarted := make(chan struct{})
 	resourceQuotaControllerOptions := &resourcequotacontroller.ControllerOptions{
 		QuotaClient:               clientset.CoreV1(),
@@ -319,7 +319,7 @@ plugins:
 
 	discoveryFunc := clientset.Discovery().ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(informers.ForResource)
-	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
+	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource, nil)
 	informersStarted := make(chan struct{})
 	resourceQuotaControllerOptions := &resourcequotacontroller.ControllerOptions{
 		QuotaClient:               clientset.CoreV1(),
@@ -445,7 +445,7 @@ plugins:
 
 	discoveryFunc := clientset.Discovery().ServerPreferredNamespacedResources
 	listerFuncForResource := generic.ListerFuncForResourceFunc(informers.ForResource)
-	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource)
+	qc := quotainstall.NewQuotaConfigurationForControllers(listerFuncForResource, nil)
 	informersStarted := make(chan struct{})
 	resourceQuotaControllerOptions := &resourcequotacontroller.ControllerOptions{
 		QuotaClient:               clientset.CoreV1(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
 
#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
adjusts DRA extended resource quota to include devices usages from regular resource claims

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/133671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ResourceQuota now counts device class requests within a ResourceClaim object as consuming two additional quotas when the DRAExtendedResource feature is enabled:
- `requests.deviceclass.resource.k8s.io/<deviceclass>` with a quantity equal to the worst case count of devices requested
- requests for device classes that map to an extended resource consume `requests.<extended resource name>`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
