### PR TITLE
fixed the CRD statusResetFields init issue

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -1054,6 +1054,9 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	// resetField write all version information
 	for _, v := range crd.Spec.Versions {
 		clusterScoped := crd.Spec.Scope == apiextensionsv1.ClusterScoped
+		if requestScopes[v.Name] == nil {
+			continue
+		}
 		statusScope := *requestScopes[v.Name]
 		statusScope.Subresource = "status"
 		statusScope.Namer = handlers.ContextBasedNaming{
@@ -1069,6 +1072,9 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		if subresources != nil && subresources.Status != nil {
 			var statusResetFields = make(map[fieldpath.APIVersion]*fieldpath.Set)
 			for _, value := range crd.Spec.Versions {
+				if storages[value.Name].Status == nil {
+					continue
+				}
 				resetField := storages[value.Name].Status.GetResetFields()
 				for apiVersion, set := range resetField {
 					statusResetFields[apiVersion] = set

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -1054,7 +1054,8 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	// resetField write all version information
 	for _, v := range crd.Spec.Versions {
 		clusterScoped := crd.Spec.Scope == apiextensionsv1.ClusterScoped
-		if requestScopes[v.Name] == nil {
+		// Do not construct storage if version is neither served nor stored
+		if !v.Storage && !v.Served {
 			continue
 		}
 		statusScope := *requestScopes[v.Name]

--- a/test/integration/apiserver/apply/apply_crd_beta_test.go
+++ b/test/integration/apiserver/apply/apply_crd_beta_test.go
@@ -227,3 +227,82 @@ func nearlyRemovedBetaMultipleVersionNoxuCRD(scope apiextensionsv1beta1.Resource
 		},
 	}
 }
+
+func nearlyRemovedBetaMultipleVersionNoxuCRDWithStatus(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
+	return &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "myresources.example.com"},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "example.com",
+			Version: "v1beta1",
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:     "myresources",
+				Singular:   "myresource",
+				Kind:       "MyResource",
+				ShortNames: []string{"mr"},
+				ListKind:   "MyResourceList",
+			},
+			Scope: scope,
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: false,
+					Schema: &apiextensionsv1beta1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"a": {Type: "string"},
+										"b": {Type: "string"},
+									},
+								},
+								"status": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"a": {Type: "string"},
+									},
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+						Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+					},
+				},
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1beta1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"a": {Type: "string"},
+										"b": {Type: "string"},
+									},
+								},
+								"status": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+										"a": {Type: "string"},
+									},
+								},
+							},
+						},
+					},
+					Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+						Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+					},
+				},
+			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
+		},
+	}
+}

--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -409,6 +409,9 @@ spec:
 	}
 	t.Logf("result: %s", string(result))
 	newManagedFields, err := getManagedFields(result)
+	if err != nil {
+		t.Fatalf("failed to get managed fields: %v", err)
+	}
 	// newManagedFields should include oldManagedFields
 	var applyManagerFound, subresourceManagerFound bool
 	for i, field := range newManagedFields {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When initializing the managedfields.NewDefaultCRDFieldManager method, the injected resetFields variable is not fully initialized for CRD resources with multiple versions. As a result, performing a status put request with spec!=nil through a non-storage version's status update API endpoint can overwrite the field manager ownership of spec.


#### Which issue(s) this PR is related to:
Fixes #133704 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
