### PR TITLE
gogo protobuf interface cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/jsonreference v0.20.2
 	github.com/godbus/dbus/v5 v5.1.0
-	github.com/gogo/protobuf v1.3.2
 	github.com/google/cadvisor v0.53.0
 	github.com/google/cel-go v0.26.0
 	github.com/google/gnostic-models v0.7.0
@@ -156,6 +155,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect

--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -151,10 +151,8 @@
         "k8s.io/apiextensions-apiserver",
         "k8s.io/apimachinery",
         "k8s.io/apiserver",
-        "k8s.io/client-go",
         "k8s.io/code-generator",
         "k8s.io/kube-aggregator",
-        "k8s.io/kubernetes",
         "k8s.io/metrics"
       ],
       "github.com/golang/groupcache": [

--- a/pkg/api/testing/serialization_proto_test.go
+++ b/pkg/api/testing/serialization_proto_test.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
@@ -225,7 +224,7 @@ func BenchmarkDecodeCodecToInternalProtobuf(b *testing.B) {
 	b.StopTimer()
 }
 
-// BenchmarkDecodeJSON provides a baseline for regular JSON decode performance
+// BenchmarkDecodeIntoProtobuf provides a baseline for regular protobuf decode performance
 func BenchmarkDecodeIntoProtobuf(b *testing.B) {
 	items := benchmarkItems(b)
 	width := len(items)
@@ -237,14 +236,16 @@ func BenchmarkDecodeIntoProtobuf(b *testing.B) {
 		}
 		encoded[i] = data
 		validate := &v1.Pod{}
-		if err := proto.Unmarshal(data, validate); err != nil {
+		validate.Reset() // decode normally resets internally
+		if err := validate.Unmarshal(data); err != nil {
 			b.Fatalf("Failed to unmarshal %d: %v\n%#v", i, err, items[i])
 		}
 	}
 
 	for i := 0; i < b.N; i++ {
-		obj := v1.Pod{}
-		if err := proto.Unmarshal(encoded[i%width], &obj); err != nil {
+		obj := &v1.Pod{}
+		obj.Reset() // decode normally resets internally
+		if err := obj.Unmarshal(encoded[i%width]); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
@@ -20,11 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
-
-	"github.com/gogo/protobuf/proto"
 )
-
-var _ proto.Sizer = &Quantity{}
 
 func (m *Quantity) Marshal() (data []byte, err error) {
 	size := m.Size()

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections.go
@@ -21,8 +21,6 @@ import (
 	"io"
 	"math/bits"
 
-	"github.com/gogo/protobuf/proto"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -98,6 +96,10 @@ type streamingListData struct {
 	items      []runtime.Object
 }
 
+type sizer interface {
+	Size() int
+}
+
 // listSize return size of ListMeta and items to be later used for preallocations.
 // listMetaSize and itemSizes do not include header bytes (field identifier, size).
 func listSize(listMeta metav1.ListMeta, items []runtime.Object) (totalSize, listMetaSize int, itemSizes []int, err error) {
@@ -107,7 +109,7 @@ func listSize(listMeta metav1.ListMeta, items []runtime.Object) (totalSize, list
 	// Items
 	itemSizes = make([]int, len(items))
 	for i, item := range items {
-		sizer, ok := item.(proto.Sizer)
+		sizer, ok := item.(sizer)
 		if !ok {
 			return totalSize, listMetaSize, nil, errItemsSizer
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections_test.go
@@ -23,7 +23,6 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/randfill"
 
@@ -313,7 +312,6 @@ type countingSizer struct {
 	count int
 }
 
-var _ proto.Sizer = (*countingSizer)(nil)
 var _ runtime.ProtobufMarshaller = (*countingSizer)(nil)
 
 func (s *countingSizer) MarshalTo(data []byte) (int, error) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -23,8 +23,6 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/gogo/protobuf/proto"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -148,11 +146,13 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		types, _, err := s.typer.ObjectKinds(into)
 		switch {
 		case runtime.IsNotRegisteredError(err):
-			pb, ok := into.(proto.Message)
+			unmarshaler, ok := into.(unmarshaler)
 			if !ok {
 				return nil, &actual, errNotMarshalable{reflect.TypeOf(into)}
 			}
-			if err := proto.Unmarshal(unk.Raw, pb); err != nil {
+			// top-level unmarshal resets before delegating unmarshaling to the object
+			unmarshaler.Reset()
+			if err := unmarshaler.Unmarshal(unk.Raw); err != nil {
 				return nil, &actual, err
 			}
 			return into, &actual, nil
@@ -251,7 +251,7 @@ func (s *Serializer) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.
 		_, err = w.Write(data[:prefixSize+uint64(i)])
 		return err
 
-	case proto.Marshaler:
+	case unbufferedMarshaller:
 		// this path performs extra allocations
 		data, err := t.Marshal()
 		if err != nil {
@@ -306,14 +306,27 @@ func copyKindDefaults(dst, src *schema.GroupVersionKind) {
 // bufferedMarshaller describes a more efficient marshalling interface that can avoid allocating multiple
 // byte buffers by pre-calculating the size of the final buffer needed.
 type bufferedMarshaller interface {
-	proto.Sizer
 	runtime.ProtobufMarshaller
 }
 
 // Like bufferedMarshaller, but is able to marshal backwards, which is more efficient since it doesn't call Size() as frequently.
 type bufferedReverseMarshaller interface {
-	proto.Sizer
 	runtime.ProtobufReverseMarshaller
+}
+
+type unbufferedMarshaller interface {
+	Marshal() ([]byte, error)
+}
+
+// unmarshaler is the subset of gogo Message and Unmarshaler used by unmarshal
+type unmarshaler interface {
+	// Marker method, currently defined on all protoc-generated messages
+	ProtoMessage()
+	// Reset() is called on the top-level message before unmarshaling,
+	// and clears all existing data from the message instance.
+	Reset()
+	// Unmarshal decodes from the start of the data into the message.
+	Unmarshal([]byte) error
 }
 
 // estimateUnknownSize returns the expected bytes consumed by a given runtime.Unknown
@@ -381,11 +394,13 @@ func (s *RawSerializer) Decode(originalData []byte, gvk *schema.GroupVersionKind
 	types, _, err := s.typer.ObjectKinds(into)
 	switch {
 	case runtime.IsNotRegisteredError(err):
-		pb, ok := into.(proto.Message)
+		unmarshaler, ok := into.(unmarshaler)
 		if !ok {
 			return nil, actual, errNotMarshalable{reflect.TypeOf(into)}
 		}
-		if err := proto.Unmarshal(data, pb); err != nil {
+		// top-level unmarshal resets before delegating unmarshaling to the object
+		unmarshaler.Reset()
+		if err := unmarshaler.Unmarshal(data); err != nil {
 			return nil, actual, err
 		}
 		return into, actual, nil
@@ -419,11 +434,13 @@ func unmarshalToObject(typer runtime.ObjectTyper, creater runtime.ObjectCreater,
 		return nil, actual, err
 	}
 
-	pb, ok := obj.(proto.Message)
+	unmarshaler, ok := obj.(unmarshaler)
 	if !ok {
 		return nil, actual, errNotMarshalable{reflect.TypeOf(obj)}
 	}
-	if err := proto.Unmarshal(data, pb); err != nil {
+	// top-level unmarshal resets before delegating unmarshaling to the object
+	unmarshaler.Reset()
+	if err := unmarshaler.Unmarshal(data); err != nil {
 		return nil, actual, err
 	}
 	if actual != nil {
@@ -519,7 +536,7 @@ func doEncode(obj any, w io.Writer, precomputedObjSize *int, memAlloc runtime.Me
 		}
 		return w.Write(data[:n])
 
-	case proto.Marshaler:
+	case unbufferedMarshaller:
 		// this path performs extra allocations
 		data, err := t.Marshal()
 		if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto.go
@@ -21,11 +21,21 @@ import (
 	"io"
 )
 
+// ProtobufReverseMarshaller can precompute size, and marshals to the start of the provided data buffer.
 type ProtobufMarshaller interface {
+	// Size returns the number of bytes a call to MarshalTo would consume.
+	Size() int
+	// MarshalTo marshals to the start of the data buffer, which must be at least as big as Size(),
+	// and returns the number of bytes written, which must be identical to the return value of Size().
 	MarshalTo(data []byte) (int, error)
 }
 
+// ProtobufReverseMarshaller can precompute size, and marshals to the end of the provided data buffer.
 type ProtobufReverseMarshaller interface {
+	// Size returns the number of bytes a call to MarshalToSizedBuffer would consume.
+	Size() int
+	// MarshalToSizedBuffer marshals to the end of the data buffer, which must be at least as big as Size(),
+	// and returns the number of bytes written, which must be identical to the return value of Size().
 	MarshalToSizedBuffer(data []byte) (int, error)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto_test.go
@@ -101,6 +101,10 @@ func TestNestedMarshalToWriter(t *testing.T) {
 
 type copyMarshaler []byte
 
+func (c copyMarshaler) Size() int {
+	return len(c)
+}
+
 func (c copyMarshaler) MarshalTo(dest []byte) (int, error) {
 	n := copy(dest, []byte(c))
 	return n, nil

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -25,13 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	openapi_v3 "github.com/google/gnostic-models/openapiv3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	golangproto "google.golang.org/protobuf/proto"
+
 	apidiscovery "k8s.io/api/apidiscovery/v2"
 	apidiscoveryv2beta1 "k8s.io/api/apidiscovery/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -533,7 +533,7 @@ func openapiSchemaFakeServer(t *testing.T) (*httptest.Server, error) {
 			return
 		}
 
-		output, err := proto.Marshal(returnedOpenAPI())
+		output, err := golangproto.Marshal(returnedOpenAPI())
 		if err != nil {
 			errMsg := fmt.Sprintf("Unexpected marshal error: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -8,7 +8,6 @@ godebug default=go1.25
 
 require (
 	github.com/go-logr/logr v1.4.3
-	github.com/gogo/protobuf v1.3.2
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -43,6 +42,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
 	github.com/josharian/intern v1.0.0 // indirect


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

Starts cleaning up and isolating references to gogo protobuf packages.

This redefines the narrow subset of methods we rely on in local interfaces, and removes all references to gogo packages outside generated code.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/96564

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig api-machinery