### PR TITLE
fix: Update NodeLocalDNS manifest to optimize startup and fix DNS failures

### DIFF
--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -143,7 +143,7 @@ spec:
           requests:
             cpu: 25m
             memory: 5Mi
-        args: [ "-localip", "__PILLAR__LOCAL__DNS__,__PILLAR__DNS__SERVER__", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
+        args: [ "-localip", "__PILLAR__LOCAL__DNS__,__PILLAR__DNS__SERVER__", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream", "-pidfile", "/tmp/node-cache.pid" ]
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
Fix NodeLocalDNS startup delay and prevent DNS failures in specific environments
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind feature
/sig network

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds the `pidfile` option to NodeLocalDNS startup parameters to address two issues:

**Issue 1: Startup Delay (All Environments)**

Current NodeLocalDNS startup process:
1. NodeLocalDNS starts and creates dummy interface
2. Assigns kube-dns service IP to dummy interface
3. Waits ~60 seconds as the ticker that monitors the RAW table runs at 60-second intervals
(During this period, DNAT for kube-dns remains active as it was before NodeLocalDNS deployment)
5. NOTRACK rules are added to iptables RAW table
(From this point onwards, DNAT for kube-dns is disabled)


This means NodeLocalDNS cannot be used until about one minute after setup, as we must wait for the first execution of the [ticker](https://github.com/kubernetes/dns/blob/master/cmd/node-cache/app/cache_app.go#L259). During this period, DNS queries go to upstream DNS servers during critical scaling operations.


**Issue 2: Complete DNS Resolution Failure (EKS/VPC-CNI and Similar Environments)**

In Amazon EKS (VPC-CNI) environments, Pods configured with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet` experience **complete DNS resolution failure** during the 60-second waiting period (step 3 above).

**Root Cause**: When the kube-dns service IP is assigned to a dummy interface (step 2), a routing table entry is automatically configured in the local table. Subsequently, until a NOTRACK entry is added to the RAW table, DNS requests are sent with the kube-dns service IP as the source address and the CoreDNS IP as the destination.
However, EKS does not perform SNAT processing on packets with the kube-dns service IP as the source, and the virtual network considers these packets as having an unmanaged IP address and drops them.
As a result, hostNetwork Pods (dnsPolicy: ClusterFirstWithHostNet) attempting DNS resolution experience a 60-second timeout.
When DNAT is disabled by the NOTRACK rule being registered in the RAW table, communication switches to local communication using the kube-dns service IP as both source and destination IP, and connectivity is restored.

**Solution:** By using the pidfile option, RAW table rules are registered as early as possible during the first startup, resolving these issues. Although the DNS resolution failure is EKS-specific, this option has no significant downsides in other environments and will help in future scenarios with similar network behavior. I have been using the pidfile option in production environments to enable immediate NodeLocalDNS availability, and no issues have been observed to date. I believe this option can be safely enabled by default.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
- This change uses an existing node-cache option, no code changes to node-cache itself

#### Does this PR introduce a user-facing change?
```release-note
NONE