### PR TITLE
Add Linux Foundation Health Score badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Kubernetes (K8s)
 
+[![LFX Health Score](https://insights.linuxfoundation.org/api/badge/health-score?project=k8s)](https://insights.linuxfoundation.org/project/k8s)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/569/badge)](https://bestpractices.coreinfrastructure.org/projects/569) [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes/kubernetes)](https://goreportcard.com/report/github.com/kubernetes/kubernetes) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kubernetes/kubernetes?sort=semver)
 
 <img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png" width="100">


### PR DESCRIPTION
Linux Foundation's Health Score helps users to understand a project's health.

Today, k8s is rated with "Excellent" (highest score). We recently added a feature for project groups to let everyone view insights per SIG.