### PR TITLE
update publishing rules for 1.33/1.34 to set go1.24.7

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -19,13 +19,13 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.34
       dirs:
@@ -60,7 +60,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -184,7 +184,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -193,7 +193,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -242,7 +242,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -255,7 +255,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -309,7 +309,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -322,7 +322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -364,7 +364,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -373,7 +373,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -435,7 +435,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -452,7 +452,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -534,7 +534,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -555,7 +555,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -655,7 +655,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -681,7 +681,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -768,7 +768,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -788,7 +788,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -878,7 +878,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -901,7 +901,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -970,7 +970,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -985,7 +985,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1041,7 +1041,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1054,7 +1054,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1114,7 +1114,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1190,7 +1190,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1205,7 +1205,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1240,13 +1240,13 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.34
       dirs:
@@ -1305,7 +1305,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1322,7 +1322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1404,7 +1404,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1425,7 +1425,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1505,7 +1505,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1524,7 +1524,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1614,7 +1614,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1637,7 +1637,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1737,7 +1737,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1762,7 +1762,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1822,7 +1822,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1833,7 +1833,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1879,7 +1879,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1890,7 +1890,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1921,13 +1921,13 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.34
       dirs:
@@ -2004,7 +2004,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2027,7 +2027,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2109,7 +2109,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2128,7 +2128,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2224,7 +2224,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -2249,7 +2249,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -2355,7 +2355,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -2417,7 +2417,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2432,7 +2432,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2460,13 +2460,13 @@ rules:
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.33
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.34
-    go: 1.24.6
+    go: 1.24.7
     source:
       branch: release-1.34
       dirs:


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- update publishing rules for 1.33/1.34 to set go1.24.7



/assign @saschagrunert @dims @Verolop 
cc @kubernetes/release-managers 

#### Which issue(s) this PR is related to:

xref: https://github.com/kubernetes/release/issues/4129

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
