### PR TITLE
Automated cherry pick of #132328: clean: use correct pod template

### DIFF
--- a/test/integration/scheduler_perf/affinity/performance-config.yaml
+++ b/test/integration/scheduler_perf/affinity/performance-config.yaml
@@ -211,7 +211,7 @@
       measurePods: 5000
 
 - name: SchedulingPreferredPodAntiAffinity
-  defaultPodTemplatePath: ../templates/pod-with-preferred-pod-affinity.yaml
+  defaultPodTemplatePath: ../templates/pod-with-preferred-pod-anti-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes


### PR DESCRIPTION
Cherry pick of #132328 on release-1.33.

#132328: clean: use correct pod template

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
The test is intended to verify pod scheduling with an anti-affinity scenario, but it uses the wrong pod template. 
This affects functional correctness.
```