### PR TITLE
Add given namespace in dryrun=client output of HPA

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -362,6 +362,10 @@ func (o *AutoscaleOptions) createHorizontalPodAutoscalerV2(refName string, mappi
 		scaler.Spec.MinReplicas = &o.Min
 	}
 
+	if o.enforceNamespace {
+		scaler.ObjectMeta.Namespace = o.namespace
+	}
+
 	metrics := []autoscalingv2.MetricSpec{}
 
 	// add CPU metric if any of the CPU targets are specified
@@ -468,6 +472,10 @@ func (o *AutoscaleOptions) createHorizontalPodAutoscalerV1(refName string, mappi
 	if o.CPUPercent >= 0 {
 		c := int32(o.CPUPercent)
 		scaler.Spec.TargetCPUUtilizationPercentage = &c
+	}
+
+	if o.enforceNamespace {
+		scaler.ObjectMeta.Namespace = o.namespace
 	}
 
 	return &scaler

--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -811,6 +811,10 @@ run_rs_tests() {
     kube::test::if_has_string "${output_message}" 'kubectl-autoscale'
     # Clean up
     kubectl delete hpa frontend "${kube_flags[@]:?}"
+    # autoscale with --dry-run=client should include namespace in output
+    autoscale_namespace=$(kubectl get rs frontend "${kube_flags[@]:?}" -o jsonpath='{.metadata.namespace}')
+    output_message=$(kubectl autoscale rs frontend "${kube_flags[@]:?}" --max=3 -n "$autoscale_namespace" --dry-run=client -o yaml 2>&1)
+    kube::test::if_has_string "${output_message}" 'namespace:'
     # autoscale without specifying --max should fail
     ! kubectl autoscale rs frontend "${kube_flags[@]:?}" || exit 1
     # Clean up


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Namespace is a mandatory field for `kubectl autoscale` command . Namespace is determined as like all the other kubectl commands and it is inserted just before the HPA creation request is sent to API server (whether actual creation or dry-run=server execution) ([ref](https://github.com/kubernetes/kubernetes/blob/0e014fc8dd5312a5a0344005257946692061ac49/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go#L324)) 

That means in cases where `dry-run=client` is used, namespace hasn't been inserted yet. As a result printed output is an invalid HPA object. 

In order to fix this issue, we would explicitly pass namespace in [HPA object ](https://github.com/kubernetes/kubernetes/blob/0e014fc8dd5312a5a0344005257946692061ac49/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go#L348-L350) (assuming that this particular namespace will be used anyway). However, since that might cause unforeseen behavioral changes, I decided to insert namespace only for `dry-run=client`.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubectl/issues/1785

#### Does this PR introduce a user-facing change?
```release-note
Namespace is added to the output of dry-run=client of HPA object
```