### PR TITLE
kubeadm: ensure waiting for apiserver uses a local client

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -569,24 +569,23 @@ func (d *initData) Client() (clientset.Interface, error) {
 	return d.client, nil
 }
 
-// ClientWithoutBootstrap returns a dry-run client or a regular client from admin.conf.
-// Unlike Client(), it does not call EnsureAdminClusterRoleBinding() or sets d.client.
-// This means the client only has anonymous permissions and does not persist in initData.
-func (d *initData) ClientWithoutBootstrap() (clientset.Interface, error) {
-	var (
-		client clientset.Interface
-		err    error
-	)
-	if d.dryRun {
-		client, err = getDryRunClient(d)
-		if err != nil {
-			return nil, err
-		}
-	} else { // Use a real client
-		client, err = kubeconfigutil.ClientSetFromFile(d.KubeConfigPath())
-		if err != nil {
-			return nil, err
-		}
+// WaitControlPlaneClient returns a basic client used for the purpose of waiting
+// for control plane components to report 'ok' on their respective health check endpoints.
+// It uses the admin.conf as the base, but modifies it to point at the local API server instead
+// of the control plane endpoint.
+func (d *initData) WaitControlPlaneClient() (clientset.Interface, error) {
+	config, err := clientcmd.LoadFromFile(d.KubeConfigPath())
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range config.Clusters {
+		v.Server = fmt.Sprintf("https://%s:%d",
+			d.Cfg().LocalAPIEndpoint.AdvertiseAddress,
+			d.Cfg().LocalAPIEndpoint.BindPort)
+	}
+	client, err := kubeconfigutil.ToClientSet(config)
+	if err != nil {
+		return nil, err
 	}
 	return client, nil
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -47,7 +47,7 @@ type InitData interface {
 	ExternalCA() bool
 	OutputWriter() io.Writer
 	Client() (clientset.Interface, error)
-	ClientWithoutBootstrap() (clientset.Interface, error)
+	WaitControlPlaneClient() (clientset.Interface, error)
 	Tokens() []string
 	PatchesDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -50,6 +50,6 @@ func (t *testInitData) KubeletDir() string                                   { r
 func (t *testInitData) ExternalCA() bool                                     { return false }
 func (t *testInitData) OutputWriter() io.Writer                              { return nil }
 func (t *testInitData) Client() (clientset.Interface, error)                 { return nil, nil }
-func (t *testInitData) ClientWithoutBootstrap() (clientset.Interface, error) { return nil, nil }
+func (t *testInitData) WaitControlPlaneClient() (clientset.Interface, error) { return nil, nil }
 func (t *testInitData) Tokens() []string                                     { return nil }
 func (t *testInitData) PatchesDir() string                                   { return "" }

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -58,8 +58,7 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		}
 	}
 
-	// Both Wait* calls below use a /healthz endpoint, thus a client without permissions works fine
-	client, err := data.ClientWithoutBootstrap()
+	client, err := data.WaitControlPlaneClient()
 	if err != nil {
 		return errors.Wrap(err, "cannot obtain client without bootstrap")
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -35,6 +35,7 @@ type JoinData interface {
 	TLSBootstrapCfg() (*clientcmdapi.Config, error)
 	InitCfg() (*kubeadmapi.InitConfiguration, error)
 	Client() (clientset.Interface, error)
+	WaitControlPlaneClient() (clientset.Interface, error)
 	IgnorePreflightErrors() sets.Set[string]
 	OutputWriter() io.Writer
 	PatchesDir() string

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -32,16 +32,17 @@ type testJoinData struct{}
 // testJoinData must satisfy JoinData.
 var _ JoinData = &testJoinData{}
 
-func (j *testJoinData) CertificateKey() string                          { return "" }
-func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration              { return nil }
-func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)  { return nil, nil }
-func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error) { return nil, nil }
-func (j *testJoinData) Client() (clientset.Interface, error)            { return nil, nil }
-func (j *testJoinData) IgnorePreflightErrors() sets.Set[string]         { return nil }
-func (j *testJoinData) OutputWriter() io.Writer                         { return nil }
-func (j *testJoinData) PatchesDir() string                              { return "" }
-func (j *testJoinData) DryRun() bool                                    { return false }
-func (j *testJoinData) KubeConfigDir() string                           { return "" }
-func (j *testJoinData) KubeletDir() string                              { return "" }
-func (j *testJoinData) ManifestDir() string                             { return "" }
-func (j *testJoinData) CertificateWriteDir() string                     { return "" }
+func (j *testJoinData) CertificateKey() string                               { return "" }
+func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration                   { return nil }
+func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)       { return nil, nil }
+func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error)      { return nil, nil }
+func (j *testJoinData) Client() (clientset.Interface, error)                 { return nil, nil }
+func (j *testJoinData) WaitControlPlaneClient() (clientset.Interface, error) { return nil, nil }
+func (j *testJoinData) IgnorePreflightErrors() sets.Set[string]              { return nil }
+func (j *testJoinData) OutputWriter() io.Writer                              { return nil }
+func (j *testJoinData) PatchesDir() string                                   { return "" }
+func (j *testJoinData) DryRun() bool                                         { return false }
+func (j *testJoinData) KubeConfigDir() string                                { return "" }
+func (j *testJoinData) KubeletDir() string                                   { return "" }
+func (j *testJoinData) ManifestDir() string                                  { return "" }
+func (j *testJoinData) CertificateWriteDir() string                          { return "" }

--- a/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
@@ -50,7 +50,7 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		return nil
 	}
 
-	client, err := data.Client()
+	client, err := data.WaitControlPlaneClient()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When waiting for the kube-apiserver to report 'ok' in the 'init' and 'join' phase 'wait-control-plane', a client constructed from the 'admin.conf' is used. In the case of the kube-apiserver, the discovery client is used so that anonymous-auth works. But if 'admin.conf' is used as is, it would point to the CPE and not the LAE.

Implement a new method WaitControlPlaneClient() for both init.go and join.go that patches the 'Server' field in the loaded v1.Config to point to the LAE, before constructing a client set and using it in the kube-apiserver waiter.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

fixes https://github.com/kubernetes/kubeadm/issues/3242

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: ensured waiting for apiserver uses a local client that doesn't reach to the control plane endpoint and instead reaches directly to the local API server endpoint.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
