### PR TITLE
Automated cherry pick of #134265: kubeadm: ensure waiting for apiserver uses a local client

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -19,9 +19,11 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -579,9 +581,12 @@ func (d *initData) WaitControlPlaneClient() (clientset.Interface, error) {
 		return nil, err
 	}
 	for _, v := range config.Clusters {
-		v.Server = fmt.Sprintf("https://%s:%d",
-			d.Cfg().LocalAPIEndpoint.AdvertiseAddress,
-			d.Cfg().LocalAPIEndpoint.BindPort)
+		v.Server = fmt.Sprintf("https://%s",
+			net.JoinHostPort(
+				d.Cfg().LocalAPIEndpoint.AdvertiseAddress,
+				strconv.Itoa(int(d.Cfg().LocalAPIEndpoint.BindPort)),
+			),
+		)
 	}
 	client, err := kubeconfigutil.ToClientSet(config)
 	if err != nil {

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -569,24 +569,23 @@ func (d *initData) Client() (clientset.Interface, error) {
 	return d.client, nil
 }
 
-// ClientWithoutBootstrap returns a dry-run client or a regular client from admin.conf.
-// Unlike Client(), it does not call EnsureAdminClusterRoleBinding() or sets d.client.
-// This means the client only has anonymous permissions and does not persist in initData.
-func (d *initData) ClientWithoutBootstrap() (clientset.Interface, error) {
-	var (
-		client clientset.Interface
-		err    error
-	)
-	if d.dryRun {
-		client, err = getDryRunClient(d)
-		if err != nil {
-			return nil, err
-		}
-	} else { // Use a real client
-		client, err = kubeconfigutil.ClientSetFromFile(d.KubeConfigPath())
-		if err != nil {
-			return nil, err
-		}
+// WaitControlPlaneClient returns a basic client used for the purpose of waiting
+// for control plane components to report 'ok' on their respective health check endpoints.
+// It uses the admin.conf as the base, but modifies it to point at the local API server instead
+// of the control plane endpoint.
+func (d *initData) WaitControlPlaneClient() (clientset.Interface, error) {
+	config, err := clientcmd.LoadFromFile(d.KubeConfigPath())
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range config.Clusters {
+		v.Server = fmt.Sprintf("https://%s:%d",
+			d.Cfg().LocalAPIEndpoint.AdvertiseAddress,
+			d.Cfg().LocalAPIEndpoint.BindPort)
+	}
+	client, err := kubeconfigutil.ToClientSet(config)
+	if err != nil {
+		return nil, err
 	}
 	return client, nil
 }

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -19,8 +19,10 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -636,9 +638,12 @@ func (j *joinData) WaitControlPlaneClient() (clientset.Interface, error) {
 		return nil, err
 	}
 	for _, v := range config.Clusters {
-		v.Server = fmt.Sprintf("https://%s:%d",
-			j.Cfg().ControlPlane.LocalAPIEndpoint.AdvertiseAddress,
-			j.Cfg().ControlPlane.LocalAPIEndpoint.BindPort)
+		v.Server = fmt.Sprintf("https://%s",
+			net.JoinHostPort(
+				j.Cfg().ControlPlane.LocalAPIEndpoint.AdvertiseAddress,
+				strconv.Itoa(int(j.Cfg().ControlPlane.LocalAPIEndpoint.BindPort)),
+			),
+		)
 	}
 	client, err := kubeconfigutil.ToClientSet(config)
 	if err != nil {

--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -47,7 +47,7 @@ type InitData interface {
 	ExternalCA() bool
 	OutputWriter() io.Writer
 	Client() (clientset.Interface, error)
-	ClientWithoutBootstrap() (clientset.Interface, error)
+	WaitControlPlaneClient() (clientset.Interface, error)
 	Tokens() []string
 	PatchesDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -50,6 +50,6 @@ func (t *testInitData) KubeletDir() string                                   { r
 func (t *testInitData) ExternalCA() bool                                     { return false }
 func (t *testInitData) OutputWriter() io.Writer                              { return nil }
 func (t *testInitData) Client() (clientset.Interface, error)                 { return nil, nil }
-func (t *testInitData) ClientWithoutBootstrap() (clientset.Interface, error) { return nil, nil }
+func (t *testInitData) WaitControlPlaneClient() (clientset.Interface, error) { return nil, nil }
 func (t *testInitData) Tokens() []string                                     { return nil }
 func (t *testInitData) PatchesDir() string                                   { return "" }

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -58,8 +58,7 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		}
 	}
 
-	// Both Wait* calls below use a /healthz endpoint, thus a client without permissions works fine
-	client, err := data.ClientWithoutBootstrap()
+	client, err := data.WaitControlPlaneClient()
 	if err != nil {
 		return errors.Wrap(err, "cannot obtain client without bootstrap")
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -38,6 +38,7 @@ type JoinData interface {
 	TLSBootstrapCfg() (*clientcmdapi.Config, error)
 	InitCfg() (*kubeadmapi.InitConfiguration, error)
 	Client() (clientset.Interface, error)
+	WaitControlPlaneClient() (clientset.Interface, error)
 	IgnorePreflightErrors() sets.Set[string]
 	OutputWriter() io.Writer
 	PatchesDir() string

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -32,16 +32,17 @@ type testJoinData struct{}
 // testJoinData must satisfy JoinData.
 var _ JoinData = &testJoinData{}
 
-func (j *testJoinData) CertificateKey() string                          { return "" }
-func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration              { return nil }
-func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)  { return nil, nil }
-func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error) { return nil, nil }
-func (j *testJoinData) Client() (clientset.Interface, error)            { return nil, nil }
-func (j *testJoinData) IgnorePreflightErrors() sets.Set[string]         { return nil }
-func (j *testJoinData) OutputWriter() io.Writer                         { return nil }
-func (j *testJoinData) PatchesDir() string                              { return "" }
-func (j *testJoinData) DryRun() bool                                    { return false }
-func (j *testJoinData) KubeConfigDir() string                           { return "" }
-func (j *testJoinData) KubeletDir() string                              { return "" }
-func (j *testJoinData) ManifestDir() string                             { return "" }
-func (j *testJoinData) CertificateWriteDir() string                     { return "" }
+func (j *testJoinData) CertificateKey() string                               { return "" }
+func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration                   { return nil }
+func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)       { return nil, nil }
+func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error)      { return nil, nil }
+func (j *testJoinData) Client() (clientset.Interface, error)                 { return nil, nil }
+func (j *testJoinData) WaitControlPlaneClient() (clientset.Interface, error) { return nil, nil }
+func (j *testJoinData) IgnorePreflightErrors() sets.Set[string]              { return nil }
+func (j *testJoinData) OutputWriter() io.Writer                              { return nil }
+func (j *testJoinData) PatchesDir() string                                   { return "" }
+func (j *testJoinData) DryRun() bool                                         { return false }
+func (j *testJoinData) KubeConfigDir() string                                { return "" }
+func (j *testJoinData) KubeletDir() string                                   { return "" }
+func (j *testJoinData) ManifestDir() string                                  { return "" }
+func (j *testJoinData) CertificateWriteDir() string                          { return "" }

--- a/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
@@ -50,7 +50,7 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		return nil
 	}
 
-	client, err := data.Client()
+	client, err := data.WaitControlPlaneClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -357,7 +358,8 @@ func (w *KubeWaiter) WaitForKubelet(healthzAddress string, healthzPort int32) er
 	var (
 		lastError       error
 		start           = time.Now()
-		healthzEndpoint = fmt.Sprintf("http://%s:%d/healthz", healthzAddress, healthzPort)
+		addrPort        = net.JoinHostPort(healthzAddress, strconv.Itoa(int(healthzPort)))
+		healthzEndpoint = fmt.Sprintf("http://%s/healthz", addrPort)
 	)
 
 	if healthzPort == 0 {

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -19,8 +19,10 @@ package dryrun
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -103,7 +105,11 @@ func (w *Waiter) WaitForPodsWithLabel(kvLabel string) error {
 
 // WaitForKubelet blocks until the kubelet /healthz endpoint returns 'ok'
 func (w *Waiter) WaitForKubelet(healthzAddress string, healthzPort int32) error {
-	fmt.Printf("[dryrun] Would make sure the kubelet returns 'ok' at http://%s:%d/healthz\n", healthzAddress, healthzPort)
+	var (
+		addrPort        = net.JoinHostPort(healthzAddress, strconv.Itoa(int(healthzPort)))
+		healthzEndpoint = fmt.Sprintf("http://%s/healthz", addrPort)
+	)
+	fmt.Printf("[dryrun] Would make sure the kubelet returns 'ok' at %s\n", healthzEndpoint)
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #134265 on release-1.34.

#134265: kubeadm: ensure waiting for apiserver uses a local client

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: ensured waiting for apiserver uses a local client that doesn't reach to the control plane endpoint and instead reaches directly to the local API server endpoint.
```

includes fixup https://github.com/kubernetes/kubernetes/pull/134274 as second commit