### PR TITLE
[InPlacePodVerticalScaling] refactor and increase coverage for pod resize tests

### DIFF
--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -203,6 +203,10 @@ func verifyPodContainersStatusResources(gotCtrStatuses []v1.ContainerStatus, wan
 			continue
 		}
 
+		if err := framework.Gomega().Expect(gotCtrStatus.AllocatedResources).To(gomega.BeComparableTo(wantCtr.Resources.Requests)); err != nil {
+			errs = append(errs, fmt.Errorf("container[%s] status allocatedResources mismatch: %w", wantCtr.Name, err))
+		}
+
 		if err := framework.Gomega().Expect(*gotCtrStatus.Resources).To(gomega.BeComparableTo(wantCtr.Resources)); err != nil {
 			errs = append(errs, fmt.Errorf("container[%s] status resources mismatch: %w", wantCtr.Name, err))
 		}
@@ -371,6 +375,9 @@ func UpdateExpectedContainerRestarts(ctx context.Context, pod *v1.Pod, expectedC
 	initialRestarts := make(map[string]int32)
 	newExpectedContainers := []ResizableContainerInfo{}
 	for _, ctr := range pod.Status.ContainerStatuses {
+		initialRestarts[ctr.Name] = ctr.RestartCount
+	}
+	for _, ctr := range pod.Status.InitContainerStatuses {
 		initialRestarts[ctr.Name] = ctr.RestartCount
 	}
 	for i, ctr := range expectedContainers {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area test

#### What this PR does / why we need it:

This PR is primarily a refactor of the pod resize e2e tests, largely for readability, but also increases coverage to cover a larger combination of things and more error cases. 

I was going through them to make sure we don’t have significant gaps in coverage prior to GA, but I found it a little hard to systematically determine what cases we are covering, hence the refactor. I updated them to use nested ginkgo.Tables rather than go native subtests. 

It is not practical to cover every possible combination of resize operations imaginable — the dimensions being qos, number of containers, number of init containers, operation (add, remove, increase, decrease), resource requirement (req or lim), and resource type (cpu or memory). This PR may have a slightly different subset of the possible combinations than the current tests have, but coverage of everything is still there and this PR definitely increases coverage. In fact, I think that some of the tests here are redundant and I’d be open to removing some of them for the sake of faster execution of the suite.

#### Special notes for your reviewer:

Some of the tests here (and some of the modifications I made to the test helpers) should be included in the v1.35 conformance suite, so this needs to merge early to allow for the 2 weeks of required soak time before we promote to conformance.

/sig node
/release-note-none
