### PR TITLE
Add desired_replicas gauge metric to HPA controller

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -953,6 +953,9 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 
 	a.setStatus(hpa, currentReplicas, desiredReplicas, metricStatuses, rescale)
 
+	// Monitor the desired replicas
+	a.monitor.ObserveDesiredReplicas(hpa.Namespace, hpa.Name, desiredReplicas)
+
 	err = a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa)
 	if err != nil {
 		// we can overwrite retErr in this case because it's an internal error.

--- a/pkg/controller/podautoscaler/monitor/metrics.go
+++ b/pkg/controller/podautoscaler/monitor/metrics.go
@@ -68,6 +68,13 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+	desiredReplicasCount = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      hpaControllerSubsystem,
+			Name:           "desired_replicas",
+			Help:           "Current desired replica count for HPA objects.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"namespace", "hpa_name"})
 
 	metricsList = []metrics.Registerable{
 		reconciliationsTotal,
@@ -75,6 +82,7 @@ var (
 		metricComputationTotal,
 		metricComputationDuration,
 		numHorizontalPodAutoscalers,
+		desiredReplicasCount,
 	}
 )
 

--- a/pkg/controller/podautoscaler/monitor/monitor.go
+++ b/pkg/controller/podautoscaler/monitor/monitor.go
@@ -43,6 +43,7 @@ type Monitor interface {
 	ObserveMetricComputationResult(action ActionLabel, err ErrorLabel, duration time.Duration, metricType v2.MetricSourceType)
 	ObserveHPAAddition()
 	ObserveHPADeletion()
+	ObserveDesiredReplicas(namespace, hpaName string, desiredReplicas int32)
 }
 
 type monitor struct{}
@@ -71,4 +72,9 @@ func (r *monitor) ObserveHPAAddition() {
 // ObserveHPADeletion observes the deletion of an HPA object.
 func (r *monitor) ObserveHPADeletion() {
 	numHorizontalPodAutoscalers.Dec()
+}
+
+// ObserveDesiredReplicas records the desired replica count for an HPA object.
+func (r *monitor) ObserveDesiredReplicas(namespace, hpaName string, desiredReplicas int32) {
+	desiredReplicasCount.WithLabelValues(namespace, hpaName).Set(float64(desiredReplicas))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a new histogram metric `desired_replicas` to track the scaling history of HPA objects over time. This metric helps operators understand scaling patterns and behaviors of their HPA-managed workloads by providing visibility into the desired replica counts that HPA calculates, labeled by namespace and HPA name.

#### Which issue(s) this PR is related to:
Part of: #115639
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
