### PR TITLE
[WIP] fix: deduplicate affinities when creating pods from deployments

### DIFF
--- a/pkg/util/affinities/affinities.go
+++ b/pkg/util/affinities/affinities.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package affinities
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// DedupAffinityFields de-duplicates sub-fields in an affinity and keeps any strict supersets.
+func DedupAffinityFields(affinity *api.Affinity) *api.Affinity {
+	if affinity == nil {
+		return nil
+	}
+	dedupNodeAffinity(affinity)
+	dedupPodAffinity(affinity)
+	dedupPodAntiAffinity(affinity)
+	return affinity
+}
+
+func dedupNodeAffinity(affinity *api.Affinity) {
+	if affinity.NodeAffinity == nil {
+		return
+	}
+
+	if affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = dedupNodeSelectorTerms(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)
+	}
+
+	if affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+		affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = dedupPreferredSchedulingTerms(affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+	}
+}
+
+func dedupPodAffinity(affinity *api.Affinity) {
+	if affinity.PodAffinity == nil {
+		return
+	}
+
+	affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = dedupPodAffinityTerms(affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = dedupWeightedPodAffinityTerms(affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+}
+
+func dedupPodAntiAffinity(affinity *api.Affinity) {
+	if affinity.PodAntiAffinity == nil {
+		return
+	}
+
+	affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = dedupPodAffinityTerms(affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = dedupWeightedPodAffinityTerms(affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+}
+
+func dedupNodeSelectorTerms(terms []api.NodeSelectorTerm) []api.NodeSelectorTerm {
+	if len(terms) <= 1 {
+		return terms
+	}
+
+	var deduped []api.NodeSelectorTerm
+	for i, term := range terms {
+		isSubset := false
+		for j, otherTerm := range terms {
+			if i == j {
+				continue
+			}
+			if isNodeSelectorTermSubset(term, otherTerm) {
+				if !isNodeSelectorTermSubset(otherTerm, term) { // strict subset
+					isSubset = true
+					break
+				} else { // equal
+					if i > j {
+						isSubset = true
+						break
+					}
+				}
+			}
+		}
+		if !isSubset {
+			deduped = append(deduped, term)
+		}
+	}
+	return deduped
+}
+
+func dedupPreferredSchedulingTerms(terms []api.PreferredSchedulingTerm) []api.PreferredSchedulingTerm {
+	if len(terms) <= 1 {
+		return terms
+	}
+
+	var deduped []api.PreferredSchedulingTerm
+	for i, term := range terms {
+		isSubset := false
+		for j, otherTerm := range terms {
+			if i == j {
+				continue
+			}
+			if term.Weight == otherTerm.Weight && isNodeSelectorTermSubset(term.Preference, otherTerm.Preference) {
+				if !isNodeSelectorTermSubset(otherTerm.Preference, term.Preference) { // strict subset
+					isSubset = true
+					break
+				} else { // equal
+					if i > j {
+						isSubset = true
+						break
+					}
+				}
+			}
+		}
+		if !isSubset {
+			deduped = append(deduped, term)
+		}
+	}
+	return deduped
+}
+
+func dedupPodAffinityTerms(terms []api.PodAffinityTerm) []api.PodAffinityTerm {
+	if len(terms) <= 1 {
+		return terms
+	}
+
+	var deduped []api.PodAffinityTerm
+	for i, term := range terms {
+		isSubset := false
+		for j, otherTerm := range terms {
+			if i == j {
+				continue
+			}
+			if isPodAffinityTermSubset(term, otherTerm) {
+				if !isPodAffinityTermSubset(otherTerm, term) { // strict subset
+					isSubset = true
+					break
+				} else { // equal
+					if i > j {
+						isSubset = true
+						break
+					}
+				}
+			}
+		}
+		if !isSubset {
+			deduped = append(deduped, term)
+		}
+	}
+	return deduped
+}
+
+func dedupWeightedPodAffinityTerms(terms []api.WeightedPodAffinityTerm) []api.WeightedPodAffinityTerm {
+	if len(terms) <= 1 {
+		return terms
+	}
+
+	var deduped []api.WeightedPodAffinityTerm
+	for i, term := range terms {
+		isSubset := false
+		for j, otherTerm := range terms {
+			if i == j {
+				continue
+			}
+			if term.Weight == otherTerm.Weight && isPodAffinityTermSubset(term.PodAffinityTerm, otherTerm.PodAffinityTerm) {
+				if !isPodAffinityTermSubset(otherTerm.PodAffinityTerm, term.PodAffinityTerm) { // strict subset
+					isSubset = true
+					break
+				} else { // equal
+					if i > j {
+						isSubset = true
+						break
+					}
+				}
+			}
+		}
+		if !isSubset {
+			deduped = append(deduped, term)
+		}
+	}
+	return deduped
+}
+
+func isNodeSelectorTermSubset(a, b api.NodeSelectorTerm) bool {
+	return isNodeSelectorRequirementSubset(a.MatchExpressions, b.MatchExpressions) && isNodeSelectorRequirementSubset(a.MatchFields, b.MatchFields)
+}
+
+func isPodAffinityTermSubset(a, b api.PodAffinityTerm) bool {
+	if a.TopologyKey != b.TopologyKey {
+		return false
+	}
+
+	if !isLabelSelectorSubset(a.LabelSelector, b.LabelSelector) {
+		return false
+	}
+
+	if !isStringSliceSubset(a.Namespaces, b.Namespaces) {
+		return false
+	}
+
+	return true
+}
+
+func isNodeSelectorRequirementSubset(a, b []api.NodeSelectorRequirement) bool {
+	for _, reqA := range a {
+		found := false
+		for _, reqB := range b {
+			if reqA.Key == reqB.Key && reqA.Operator == reqB.Operator && isStringSliceSubset(reqA.Values, reqB.Values) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func isLabelSelectorSubset(a, b *metav1.LabelSelector) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	for k, v := range a.MatchLabels {
+		if w, ok := b.MatchLabels[k]; !ok || v != w {
+			return false
+		}
+	}
+
+	return isLabelSelectorRequirementSubset(a.MatchExpressions, b.MatchExpressions)
+}
+
+func isLabelSelectorRequirementSubset(a, b []metav1.LabelSelectorRequirement) bool {
+	for _, reqA := range a {
+		found := false
+		for _, reqB := range b {
+			if reqA.Key == reqB.Key && reqA.Operator == reqB.Operator && isStringSliceSubset(reqA.Values, reqB.Values) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func isStringSliceSubset(a, b []string) bool {
+	for _, valA := range a {
+		found := false
+		for _, valB := range b {
+			if valA == valB {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/affinities/affinities_test.go
+++ b/pkg/util/affinities/affinities_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package affinities
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestDedupAffinityFields(t *testing.T) {
+	t.Run("NodeAffinity", func(t *testing.T) {
+		testNodeAffinity(t)
+	})
+	t.Run("PodAffinity", func(t *testing.T) {
+		testPodAffinity(t)
+	})
+	t.Run("PodAntiAffinity", func(t *testing.T) {
+		testPodAntiAffinity(t)
+	})
+}
+
+func testNodeAffinity(t *testing.T) {
+	term1 := api.NodeSelectorTerm{
+		MatchExpressions: []api.NodeSelectorRequirement{
+			{Key: "key1", Operator: api.NodeSelectorOpIn, Values: []string{"value1"}},
+		},
+	}
+	term2 := api.NodeSelectorTerm{
+		MatchExpressions: []api.NodeSelectorRequirement{
+			{Key: "key2", Operator: api.NodeSelectorOpIn, Values: []string{"value2"}},
+		},
+	}
+	term3 := api.NodeSelectorTerm{
+		MatchExpressions: []api.NodeSelectorRequirement{
+			{Key: "key1", Operator: api.NodeSelectorOpIn, Values: []string{"value1"}},
+			{Key: "key2", Operator: api.NodeSelectorOpIn, Values: []string{"value2"}},
+		},
+	}
+	term4 := api.NodeSelectorTerm{
+		MatchExpressions: []api.NodeSelectorRequirement{
+			{Key: "key2", Operator: api.NodeSelectorOpIn, Values: []string{"value2"}},
+			{Key: "key3", Operator: api.NodeSelectorOpIn, Values: []string{"value3"}},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		affinity *api.Affinity
+		expected *api.Affinity
+	}{
+		{
+			name: "RequiredDuringSchedulingIgnoredDuringExecution with duplicates",
+			affinity: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &api.NodeSelector{
+						NodeSelectorTerms: []api.NodeSelectorTerm{term1, term2, term1},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &api.NodeSelector{
+						NodeSelectorTerms: []api.NodeSelectorTerm{term1, term2},
+					},
+				},
+			},
+		},
+		{
+			name: "RequiredDuringSchedulingIgnoredDuringExecution with subset",
+			affinity: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &api.NodeSelector{
+						NodeSelectorTerms: []api.NodeSelectorTerm{term1, term3},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &api.NodeSelector{
+						NodeSelectorTerms: []api.NodeSelectorTerm{term3},
+					},
+				},
+			},
+		},
+		{
+			name: "PreferredDuringSchedulingIgnoredDuringExecution with duplicates",
+			affinity: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{
+						{Weight: 1, Preference: term1},
+						{Weight: 1, Preference: term2},
+						{Weight: 1, Preference: term1},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{
+						{Weight: 1, Preference: term1},
+						{Weight: 1, Preference: term2},
+					},
+				},
+			},
+		},
+		{
+			name: "PreferredDuringSchedulingIgnoredDuringExecution with subset",
+			affinity: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{
+						{Weight: 1, Preference: term1},
+						{Weight: 1, Preference: term3},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{
+						{Weight: 1, Preference: term3},
+					},
+				},
+			},
+		},
+		{
+			name: "PreferredDuringSchedulingIgnoredDuringExecution with intersection",
+			affinity: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{
+						{Weight: 1, Preference: term3},
+						{Weight: 1, Preference: term4},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				NodeAffinity: &api.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{
+						{Weight: 1, Preference: term3},
+						{Weight: 1, Preference: term4},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DedupAffinityFields(tt.affinity)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("DedupAffinityFields() returned diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func testPodAffinity(t *testing.T) {
+	term1 := api.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key1": "value1"}},
+		TopologyKey:   "node",
+	}
+	term2 := api.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key2": "value2"}},
+		TopologyKey:   "node",
+	}
+	term3 := api.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key1": "value1", "key2": "value2"}},
+		TopologyKey:   "node",
+	}
+
+	tests := []struct {
+		name     string
+		affinity *api.Affinity
+		expected *api.Affinity
+	}{
+		{
+			name: "RequiredDuringSchedulingIgnoredDuringExecution with duplicates",
+			affinity: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term1, term2, term1},
+				},
+			},
+			expected: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term1, term2},
+				},
+			},
+		},
+		{
+			name: "RequiredDuringSchedulingIgnoredDuringExecution with subset",
+			affinity: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term1, term3},
+				},
+			},
+			expected: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term3},
+				},
+			},
+		},
+		{
+			name: "PreferredDuringSchedulingIgnoredDuringExecution with duplicates",
+			affinity: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term1},
+						{Weight: 1, PodAffinityTerm: term2},
+						{Weight: 1, PodAffinityTerm: term1},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term1},
+						{Weight: 1, PodAffinityTerm: term2},
+					},
+				}},
+		},
+		{
+			name: "PreferredDuringSchedulingIgnoredDuringExecution with subset",
+			affinity: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term1},
+						{Weight: 1, PodAffinityTerm: term3},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term3},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DedupAffinityFields(tt.affinity)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("DedupAffinityFields() returned diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func testPodAntiAffinity(t *testing.T) {
+	term1 := api.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key1": "value1"}},
+		TopologyKey:   "node",
+	}
+	term2 := api.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key2": "value2"}},
+		TopologyKey:   "node",
+	}
+	term3 := api.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key1": "value1", "key2": "value2"}},
+		TopologyKey:   "node",
+	}
+
+	tests := []struct {
+		name     string
+		affinity *api.Affinity
+		expected *api.Affinity
+	}{
+		{
+			name: "RequiredDuringSchedulingIgnoredDuringExecution with duplicates",
+			affinity: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term1, term2, term1},
+				},
+			},
+			expected: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term1, term2},
+				},
+			},
+		},
+		{
+			name: "RequiredDuringSchedulingIgnoredDuringExecution with subset",
+			affinity: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term1, term3},
+				},
+			},
+			expected: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{term3},
+				},
+			},
+		},
+		{
+			name: "PreferredDuringSchedulingIgnoredDuringExecution with duplicates",
+			affinity: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term1},
+						{Weight: 1, PodAffinityTerm: term2},
+						{Weight: 1, PodAffinityTerm: term1},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term1},
+						{Weight: 1, PodAffinityTerm: term2},
+					},
+				},
+			},
+		},
+		{
+			name: "PreferredDuringSchedulingIgnoredDuringExecution with subset",
+			affinity: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term1},
+						{Weight: 1, PodAffinityTerm: term3},
+					},
+				},
+			},
+			expected: &api.Affinity{
+				PodAntiAffinity: &api.PodAntiAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{Weight: 1, PodAffinityTerm: term3},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DedupAffinityFields(tt.affinity)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("DedupAffinityFields() returned diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -35,6 +35,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	qoshelper "k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	"k8s.io/kubernetes/pkg/util/affinities"
 	"k8s.io/kubernetes/pkg/util/tolerations"
 	pluginapi "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction"
 )
@@ -110,6 +111,9 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 	if len(extraTolerations) > 0 {
 		pod.Spec.Tolerations = tolerations.MergeTolerations(pod.Spec.Tolerations, extraTolerations)
 	}
+	klog.Info("admission affinity: ", pod.Spec.Affinity)
+	pod.Spec.Affinity = affinities.DedupAffinityFields(pod.Spec.Affinity)
+	klog.Info("admission affinity updated: ", pod.Spec.Affinity)
 	return p.Validate(ctx, a, o)
 }
 

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -39,6 +39,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	node "k8s.io/kubernetes/pkg/apis/node"
 	apinodev1 "k8s.io/kubernetes/pkg/apis/node/v1"
+	"k8s.io/kubernetes/pkg/util/affinities"
 	"k8s.io/kubernetes/pkg/util/tolerations"
 )
 
@@ -212,6 +213,7 @@ func setScheduling(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.Ru
 
 	pod.Spec.NodeSelector = newNodeSelector
 	pod.Spec.Tolerations = newTolerations
+	pod.Spec.Affinity = affinities.DedupAffinityFields(pod.Spec.Affinity)
 
 	return nil
 }


### PR DESCRIPTION
[WIP] not ready for review

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Deduplicate equal affinities when creating pods from deployments, if one is a superset of another only the superset is kept. This behavior already exists for tolerations.

#### Which issue(s) this PR is related to:
Fixes #129833

#### Does this PR introduce a user-facing change?
```release-note
Affinities are deduplicated from pods when generated from deployments, similarly to tolerations. Manually created pods are unaffected.
```