### PR TITLE
feat(resource): Add validation for DeviceClass selectors and configs

### DIFF
--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -39,6 +39,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type DeviceClass
+	scheme.AddValidationFunc((*resourcev1.DeviceClass)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_DeviceClass(ctx, op, nil /* fldPath */, obj.(*resourcev1.DeviceClass), safe.Cast[*resourcev1.DeviceClass](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type DeviceClassList
+	scheme.AddValidationFunc((*resourcev1.DeviceClassList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_DeviceClassList(ctx, op, nil /* fldPath */, obj.(*resourcev1.DeviceClassList), safe.Cast[*resourcev1.DeviceClassList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type ResourceClaim
 	scheme.AddValidationFunc((*resourcev1.ResourceClaim)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -163,6 +179,74 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			return
 		}(fldPath.Child("config"), obj.Config, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClaim) []resourcev1.DeviceClaimConfiguration { return oldObj.Config }))...)
 
+	return errs
+}
+
+// Validate_DeviceClass validates an instance of DeviceClass according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClass(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceClass) (errs field.ErrorList) {
+	// field resourcev1.DeviceClass.TypeMeta has no validation
+	// field resourcev1.DeviceClass.ObjectMeta has no validation
+
+	// field resourcev1.DeviceClass.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1.DeviceClassSpec) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceClassSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClass) *resourcev1.DeviceClassSpec { return &oldObj.Spec }))...)
+
+	return errs
+}
+
+// Validate_DeviceClassList validates an instance of DeviceClassList according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClassList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceClassList) (errs field.ErrorList) {
+	// field resourcev1.DeviceClassList.TypeMeta has no validation
+	// field resourcev1.DeviceClassList.ListMeta has no validation
+
+	// field resourcev1.DeviceClassList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceClass) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceClass)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClassList) []resourcev1.DeviceClass { return oldObj.Items }))...)
+
+	return errs
+}
+
+// Validate_DeviceClassSpec validates an instance of DeviceClassSpec according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceClassSpec) (errs field.ErrorList) {
+	// field resourcev1.DeviceClassSpec.Selectors
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceSelector) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("selectors"), obj.Selectors, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClassSpec) []resourcev1.DeviceSelector { return oldObj.Selectors }))...)
+
+	// field resourcev1.DeviceClassSpec.Config has no validation
+	// field resourcev1.DeviceClassSpec.ExtendedResourceName has no validation
 	return errs
 }
 

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -245,7 +245,24 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			return
 		}(fldPath.Child("selectors"), obj.Selectors, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClassSpec) []resourcev1.DeviceSelector { return oldObj.Selectors }))...)
 
-	// field resourcev1.DeviceClassSpec.Config has no validation
+	// field resourcev1.DeviceClassSpec.Config
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceClassConfiguration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("config"), obj.Config, safe.Field(oldObj, func(oldObj *resourcev1.DeviceClassSpec) []resourcev1.DeviceClassConfiguration { return oldObj.Config }))...)
+
 	// field resourcev1.DeviceClassSpec.ExtendedResourceName has no validation
 	return errs
 }

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -39,6 +39,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type DeviceClass
+	scheme.AddValidationFunc((*resourcev1beta1.DeviceClass)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_DeviceClass(ctx, op, nil /* fldPath */, obj.(*resourcev1beta1.DeviceClass), safe.Cast[*resourcev1beta1.DeviceClass](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type DeviceClassList
+	scheme.AddValidationFunc((*resourcev1beta1.DeviceClassList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_DeviceClassList(ctx, op, nil /* fldPath */, obj.(*resourcev1beta1.DeviceClassList), safe.Cast[*resourcev1beta1.DeviceClassList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type ResourceClaim
 	scheme.AddValidationFunc((*resourcev1beta1.ResourceClaim)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -169,6 +185,76 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			return oldObj.Config
 		}))...)
 
+	return errs
+}
+
+// Validate_DeviceClass validates an instance of DeviceClass according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClass(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceClass) (errs field.ErrorList) {
+	// field resourcev1beta1.DeviceClass.TypeMeta has no validation
+	// field resourcev1beta1.DeviceClass.ObjectMeta has no validation
+
+	// field resourcev1beta1.DeviceClass.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceClassSpec) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceClassSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceClass) *resourcev1beta1.DeviceClassSpec { return &oldObj.Spec }))...)
+
+	return errs
+}
+
+// Validate_DeviceClassList validates an instance of DeviceClassList according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClassList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceClassList) (errs field.ErrorList) {
+	// field resourcev1beta1.DeviceClassList.TypeMeta has no validation
+	// field resourcev1beta1.DeviceClassList.ListMeta has no validation
+
+	// field resourcev1beta1.DeviceClassList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceClass) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceClass)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceClassList) []resourcev1beta1.DeviceClass { return oldObj.Items }))...)
+
+	return errs
+}
+
+// Validate_DeviceClassSpec validates an instance of DeviceClassSpec according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceClassSpec) (errs field.ErrorList) {
+	// field resourcev1beta1.DeviceClassSpec.Selectors
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceSelector) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("selectors"), obj.Selectors, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceClassSpec) []resourcev1beta1.DeviceSelector {
+			return oldObj.Selectors
+		}))...)
+
+	// field resourcev1beta1.DeviceClassSpec.Config has no validation
+	// field resourcev1beta1.DeviceClassSpec.ExtendedResourceName has no validation
 	return errs
 }
 

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -253,7 +253,26 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			return oldObj.Selectors
 		}))...)
 
-	// field resourcev1beta1.DeviceClassSpec.Config has no validation
+	// field resourcev1beta1.DeviceClassSpec.Config
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceClassConfiguration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("config"), obj.Config, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceClassSpec) []resourcev1beta1.DeviceClassConfiguration {
+			return oldObj.Config
+		}))...)
+
 	// field resourcev1beta1.DeviceClassSpec.ExtendedResourceName has no validation
 	return errs
 }

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -39,6 +39,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type DeviceClass
+	scheme.AddValidationFunc((*resourcev1beta2.DeviceClass)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_DeviceClass(ctx, op, nil /* fldPath */, obj.(*resourcev1beta2.DeviceClass), safe.Cast[*resourcev1beta2.DeviceClass](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type DeviceClassList
+	scheme.AddValidationFunc((*resourcev1beta2.DeviceClassList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_DeviceClassList(ctx, op, nil /* fldPath */, obj.(*resourcev1beta2.DeviceClassList), safe.Cast[*resourcev1beta2.DeviceClassList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type ResourceClaim
 	scheme.AddValidationFunc((*resourcev1beta2.ResourceClaim)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -169,6 +185,76 @@ func Validate_DeviceClaim(ctx context.Context, op operation.Operation, fldPath *
 			return oldObj.Config
 		}))...)
 
+	return errs
+}
+
+// Validate_DeviceClass validates an instance of DeviceClass according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClass(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceClass) (errs field.ErrorList) {
+	// field resourcev1beta2.DeviceClass.TypeMeta has no validation
+	// field resourcev1beta2.DeviceClass.ObjectMeta has no validation
+
+	// field resourcev1beta2.DeviceClass.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceClassSpec) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceClassSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceClass) *resourcev1beta2.DeviceClassSpec { return &oldObj.Spec }))...)
+
+	return errs
+}
+
+// Validate_DeviceClassList validates an instance of DeviceClassList according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClassList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceClassList) (errs field.ErrorList) {
+	// field resourcev1beta2.DeviceClassList.TypeMeta has no validation
+	// field resourcev1beta2.DeviceClassList.ListMeta has no validation
+
+	// field resourcev1beta2.DeviceClassList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceClass) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceClass)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceClassList) []resourcev1beta2.DeviceClass { return oldObj.Items }))...)
+
+	return errs
+}
+
+// Validate_DeviceClassSpec validates an instance of DeviceClassSpec according
+// to declarative validation rules in the API schema.
+func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceClassSpec) (errs field.ErrorList) {
+	// field resourcev1beta2.DeviceClassSpec.Selectors
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceSelector) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("selectors"), obj.Selectors, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceClassSpec) []resourcev1beta2.DeviceSelector {
+			return oldObj.Selectors
+		}))...)
+
+	// field resourcev1beta2.DeviceClassSpec.Config has no validation
+	// field resourcev1beta2.DeviceClassSpec.ExtendedResourceName has no validation
 	return errs
 }
 

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -253,7 +253,26 @@ func Validate_DeviceClassSpec(ctx context.Context, op operation.Operation, fldPa
 			return oldObj.Selectors
 		}))...)
 
-	// field resourcev1beta2.DeviceClassSpec.Config has no validation
+	// field resourcev1beta2.DeviceClassSpec.Config
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceClassConfiguration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("config"), obj.Config, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceClassSpec) []resourcev1beta2.DeviceClassConfiguration {
+			return oldObj.Config
+		}))...)
+
 	// field resourcev1beta2.DeviceClassSpec.ExtendedResourceName has no validation
 	return errs
 }

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1129,7 +1129,7 @@ func validateSlice[T any](slice []T, maxSize int, validateItem func(T, *field.Pa
 		// just shows the number of entries.
 		err := field.TooMany(fldPath, len(slice), maxSize).WithOrigin("maxItems")
 		if slices.Contains(opts, sizeCovered) {
-			err = err.MarkCoveredByDeclarative().WithOrigin("maxItems")
+			err = err.MarkCoveredByDeclarative()
 		}
 		allErrs = append(allErrs, err)
 	}

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -546,6 +546,7 @@ func validateDeviceClassSpec(spec, oldSpec *resource.DeviceClassSpec, fldPath *f
 		},
 		fldPath.Child("selectors"), sizeCovered)...)
 	// Same logic as above for configs.
+	stored = false
 	if oldSpec != nil {
 		stored = apiequality.Semantic.DeepEqual(spec.Config, oldSpec.Config)
 	}
@@ -553,7 +554,7 @@ func validateDeviceClassSpec(spec, oldSpec *resource.DeviceClassSpec, fldPath *f
 		func(config resource.DeviceClassConfiguration, fldPath *field.Path) field.ErrorList {
 			return validateDeviceClassConfiguration(config, fldPath, stored)
 		},
-		fldPath.Child("config"))...)
+		fldPath.Child("config"), sizeCovered)...)
 	if spec.ExtendedResourceName != nil && !v1helper.IsExtendedResourceName(corev1.ResourceName(*spec.ExtendedResourceName)) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("extendedResourceName"), *spec.ExtendedResourceName,
 			"must be a valid extended resource name"))

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -544,7 +544,7 @@ func validateDeviceClassSpec(spec, oldSpec *resource.DeviceClassSpec, fldPath *f
 		func(selector resource.DeviceSelector, fldPath *field.Path) field.ErrorList {
 			return validateSelector(selector, fldPath, stored)
 		},
-		fldPath.Child("selectors"))...)
+		fldPath.Child("selectors"), sizeCovered)...)
 	// Same logic as above for configs.
 	if oldSpec != nil {
 		stored = apiequality.Semantic.DeepEqual(spec.Config, oldSpec.Config)
@@ -1128,7 +1128,7 @@ func validateSlice[T any](slice []T, maxSize int, validateItem func(T, *field.Pa
 		// just shows the number of entries.
 		err := field.TooMany(fldPath, len(slice), maxSize).WithOrigin("maxItems")
 		if slices.Contains(opts, sizeCovered) {
-			err = err.MarkCoveredByDeclarative()
+			err = err.MarkCoveredByDeclarative().WithOrigin("maxItems")
 		}
 		allErrs = append(allErrs, err)
 	}

--- a/pkg/apis/resource/validation/validation_deviceclass_test.go
+++ b/pkg/apis/resource/validation/validation_deviceclass_test.go
@@ -219,7 +219,7 @@ func TestValidateClass(t *testing.T) {
 		},
 		"too-many-selectors": {
 			wantFailures: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "selectors"), resource.DeviceSelectorsMaxSize+1, resource.DeviceSelectorsMaxSize),
+				field.TooMany(field.NewPath("spec", "selectors"), resource.DeviceSelectorsMaxSize+1, resource.DeviceSelectorsMaxSize).WithOrigin("maxItems").MarkCoveredByDeclarative(),
 			},
 			class: func() *resource.DeviceClass {
 				class := testClass(goodName)

--- a/pkg/apis/resource/validation/validation_deviceclass_test.go
+++ b/pkg/apis/resource/validation/validation_deviceclass_test.go
@@ -313,7 +313,7 @@ func TestValidateClass(t *testing.T) {
 		},
 		"too-many-configs": {
 			wantFailures: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "config"), resource.DeviceConfigMaxSize+1, resource.DeviceConfigMaxSize),
+				field.TooMany(field.NewPath("spec", "config"), resource.DeviceConfigMaxSize+1, resource.DeviceConfigMaxSize).WithOrigin("maxItems").MarkCoveredByDeclarative(),
 			},
 			class: func() *resource.DeviceClass {
 				class := testClass(goodName)

--- a/pkg/registry/resource/deviceclass/declarative_validation_test.go
+++ b/pkg/registry/resource/deviceclass/declarative_validation_test.go
@@ -49,17 +49,25 @@ func TestDeclarativeValidate(t *testing.T) {
 				"valid": {
 					input: mkDeviceClass(),
 				},
+				// spec.selectors.
+				"valid: at limit selectors": {
+					input: mkDeviceClass(tweakSelectors(32)),
+				},
 				"too many selectors": {
 					input: mkDeviceClass(tweakSelectors(33)),
 					expectedErrs: field.ErrorList{
 						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems"),
 					},
 				},
+				// spec.config
 				"too many configs": {
 					input: mkDeviceClass(tweakConfig(33)),
 					expectedErrs: field.ErrorList{
 						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems"),
 					},
+				},
+				"valid: at limit configs": {
+					input: mkDeviceClass(tweakConfig(32)),
 				},
 				// TODO: Add more test cases
 			}
@@ -93,6 +101,10 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(),
 				},
+				"valid update: at limit selectors": {
+					old:    mkDeviceClass(),
+					update: mkDeviceClass(tweakSelectors(32)),
+				},
 				"update with too many selectors": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakSelectors(33)),
@@ -100,7 +112,10 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems"),
 					},
 				},
-
+				"valid update: at limit configs": {
+					old:    mkDeviceClass(),
+					update: mkDeviceClass(tweakConfig(32)),
+				},
 				"update with too many configs": {
 					old:    mkDeviceClass(),
 					update: mkDeviceClass(tweakConfig(33)),
@@ -130,7 +145,7 @@ func mkDeviceClass(mutators ...func(*resource.DeviceClass)) resource.DeviceClass
 		},
 		Spec: resource.DeviceClassSpec{
 			Selectors: []resource.DeviceSelector{
-				resource.DeviceSelector{
+				{
 					CEL: &resource.CELDeviceSelector{
 						Expression: "device.driver == \"test.driver.io\"",
 					},
@@ -158,6 +173,8 @@ func mkDeviceClass(mutators ...func(*resource.DeviceClass)) resource.DeviceClass
 
 func tweakSelectors(count int) func(*resource.DeviceClass) {
 	return func(dc *resource.DeviceClass) {
+		dc.Spec.Selectors = []resource.DeviceSelector{}
+
 		for i := 0; i < count; i++ {
 			dc.Spec.Selectors = append(dc.Spec.Selectors, resource.DeviceSelector{
 				CEL: &resource.CELDeviceSelector{
@@ -170,6 +187,7 @@ func tweakSelectors(count int) func(*resource.DeviceClass) {
 
 func tweakConfig(count int) func(*resource.DeviceClass) {
 	return func(dc *resource.DeviceClass) {
+		dc.Spec.Config = []resource.DeviceClassConfiguration{}
 		for i := 0; i < count; i++ {
 			dc.Spec.Config = append(dc.Spec.Config, resource.DeviceClassConfiguration{
 				DeviceConfiguration: resource.DeviceConfiguration{

--- a/pkg/registry/resource/deviceclass/declarative_validation_test.go
+++ b/pkg/registry/resource/deviceclass/declarative_validation_test.go
@@ -55,6 +55,12 @@ func TestDeclarativeValidate(t *testing.T) {
 						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems"),
 					},
 				},
+				"too many configs": {
+					input: mkDeviceClass(tweakConfig(33)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems"),
+					},
+				},
 				// TODO: Add more test cases
 			}
 
@@ -92,6 +98,14 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					update: mkDeviceClass(tweakSelectors(33)),
 					expectedErrs: field.ErrorList{
 						field.TooMany(field.NewPath("spec", "selectors"), 33, 32).WithOrigin("maxItems"),
+					},
+				},
+
+				"update with too many configs": {
+					old:    mkDeviceClass(),
+					update: mkDeviceClass(tweakConfig(33)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "config"), 33, 32).WithOrigin("maxItems"),
 					},
 				},
 				// TODO: Add more test cases
@@ -148,6 +162,23 @@ func tweakSelectors(count int) func(*resource.DeviceClass) {
 			dc.Spec.Selectors = append(dc.Spec.Selectors, resource.DeviceSelector{
 				CEL: &resource.CELDeviceSelector{
 					Expression: fmt.Sprintf("device.driver == \"test.driver.io%d\"", i),
+				},
+			})
+		}
+	}
+}
+
+func tweakConfig(count int) func(*resource.DeviceClass) {
+	return func(dc *resource.DeviceClass) {
+		for i := 0; i < count; i++ {
+			dc.Spec.Config = append(dc.Spec.Config, resource.DeviceClassConfiguration{
+				DeviceConfiguration: resource.DeviceConfiguration{
+					Opaque: &resource.OpaqueDeviceConfiguration{
+						Driver: "test.driver.io",
+						Parameters: runtime.RawExtension{
+							Raw: []byte(fmt.Sprintf(`{"key":"value%d"}`, i)),
+						},
+					},
 				},
 			})
 		}

--- a/pkg/registry/resource/deviceclass/strategy.go
+++ b/pkg/registry/resource/deviceclass/strategy.go
@@ -84,8 +84,7 @@ func (deviceClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.
 	newClass := obj.(*resource.DeviceClass)
 	oldClass := old.(*resource.DeviceClass)
 
-	errorList := validation.ValidateDeviceClass(newClass)
-	errorList = append(errorList, validation.ValidateDeviceClassUpdate(newClass, oldClass)...)
+	errorList := validation.ValidateDeviceClassUpdate(newClass, oldClass)
 
 	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newClass, oldClass, errorList, operation.Update)
 }

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -654,6 +654,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
+  // +k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -642,6 +642,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
+  // +k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1672,6 +1672,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
+	// +k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1684,6 +1684,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
+	// +k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -650,6 +650,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
+  // +k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -662,6 +662,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
+  // +k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1692,6 +1692,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
+	// +k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1680,6 +1680,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
+	// +k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -654,6 +654,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
+  // +k8s:maxItems=32
   repeated DeviceClassConfiguration config = 2;
 
   // ExtendedResourceName is the extended resource name for the devices of this class.

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -642,6 +642,8 @@ message DeviceClassSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
+  // +k8s:maxItems=32
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1672,6 +1672,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
+	// +k8s:maxItems=32
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1684,6 +1684,8 @@ type DeviceClassSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
+	// +k8s:maxItems=32
 	Config []DeviceClassConfiguration `json:"config,omitempty" protobuf:"bytes,2,opt,name=config"`
 
 	// SuitableNodes is tombstoned since Kubernetes 1.32 where

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -83,10 +83,10 @@ func (mitv maxItemsTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:         mitv.TagName(),
 		Scopes:      mitv.ValidScopes().UnsortedList(),
-		Description: "Indicates that a list field has a limit on its size.",
+		Description: "Indicates that a list has a limit on its size.",
 		Payloads: []TagPayloadDoc{{
 			Description: "<non-negative integer>",
-			Docs:        "This field must be no more than X items long.",
+			Docs:        "This list must be no more than X items long.",
 		}},
 		PayloadsType:     codetags.ValueTypeInt,
 		PayloadsRequired: true,


### PR DESCRIPTION
This PR adds validation to the `DeviceClass` API to limit the number of items in selectors and configs.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces declarative validation to limit the number of selectors and configs in a `DeviceClass` to 32. 

The following changes are included:
- Added `+k8s:maxItems=32` marker to the `DeviceClassSpec` for both `selectors` and `configs`.
- Regenerated validation code in `pkg/apis/resource/v*/zz_generated.validations.go`.
- Added a generic `maxLength` declarative validation validator.
- Added tests in `pkg/registry/resource/deviceclass/declarative_validation_test.go` to cover the new validation.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```