### PR TITLE
Remove redundant KubeletPSI feature label from sig-node e2e test

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -30,7 +30,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	kubeletstatsv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -368,11 +367,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 	})
 
-	framework.Context("when querying /stats/summary under pressure", feature.KubeletPSI, framework.WithSerial(), func() {
+	framework.Context("when querying /stats/summary under pressure", framework.WithSerial(), framework.WithFeatureGate(features.KubeletPSI), func() {
 		ginkgo.BeforeEach(func() {
-			if !utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
-				ginkgo.Skip("KubeletPSI feature gate is not enabled")
-			}
 			if !IsCgroup2UnifiedMode() {
 				ginkgo.Skip("Skipping since CgroupV2 not used")
 			}

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -367,7 +367,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 	})
 
-	framework.Context("when querying /stats/summary under pressure", framework.WithSerial(), framework.WithFeatureGate(features.KubeletPSI), func() {
+	framework.Context("when querying /stats/summary under pressure", framework.WithSerial(), framework.WithNodeConformance(), framework.WithFeatureGate(features.KubeletPSI), func() {
 		ginkgo.BeforeEach(func() {
 			if !IsCgroup2UnifiedMode() {
 				ginkgo.Skip("Skipping since CgroupV2 not used")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR removes a redundant feature label from the sig-node e2e test suite. 

The test in `summary_test.go` already checks the KubeletPSI feature gate directly using `utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI)`, making the `feature.KubeletPSI` label redundant.

This is part of the cleanup effort tracked in issue #134172 to remove unnecessary feature labels from sig-node e2e tests.

#### Which issue(s) this PR is related to:

Partial fix for #134172

#### Special notes for your reviewer:

This is part of the broader cleanup effort to review and clean up feature labels in sig-node e2e tests as outlined in issue #134172. The goal is to:

1. Remove feature labels that are just used for categorization
2. Replace feature labels with feature gates where appropriate  
3. Ensure feature labels that indicate special environments are well documented

This specific change removes a redundant feature label where the feature gate check already exists in the test code.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```