### PR TITLE
Update CSI sidecar container images in test manifest

### DIFF
--- a/pkg/volume/util/fsquota/common/quota_common_linux_impl.go
+++ b/pkg/volume/util/fsquota/common/quota_common_linux_impl.go
@@ -71,9 +71,11 @@ var (
 type VolumeProvider struct {
 }
 
-var quotaCmds = []string{"/sbin/xfs_quota",
+var quotaCmds = []string{
+	"/sbin/xfs_quota",
 	"/usr/sbin/xfs_quota",
-	"/bin/xfs_quota"}
+	"/bin/xfs_quota",
+}
 
 var quotaParseRegexp = regexp.MustCompilePOSIX("^[^ \t]*[ \t]*([0-9]+)")
 

--- a/pkg/volume/util/nested_volumes.go
+++ b/pkg/volume/util/nested_volumes.go
@@ -50,7 +50,7 @@ func getNestedMountpoints(name, baseDir string, pod v1.Pod) ([]string, error) {
 				// Don't let a container trick us into creating directories outside of its rootfs
 				return fmt.Errorf("invalid container mount point %v", myMountPoint)
 			}
-			myMPSlash := myMountPoint + string(os.PathSeparator)
+			myMountPointWithSlash := myMountPoint + string(os.PathSeparator)
 			// The previously found nested mountpoints.
 			// NOTE: We can't simply rely on sort.Strings to have all the mountpoints sorted and
 			// grouped. For example, the following strings are sorted in this exact order:
@@ -64,7 +64,7 @@ func getNestedMountpoints(name, baseDir string, pod v1.Pod) ([]string, error) {
 			// For example, if this volume is mounted as /dir and other volumes are mounted
 			//              as /dir/nested and /dir/nested/other, only create /dir/nested.
 			for _, mp := range allMountPoints {
-				if !strings.HasPrefix(mp, myMPSlash) {
+				if !strings.HasPrefix(mp, myMountPointWithSlash) {
 					continue // skip -- not nested beneath myMountPoint
 				}
 
@@ -80,7 +80,7 @@ func getNestedMountpoints(name, baseDir string, pod v1.Pod) ([]string, error) {
 				}
 				// since this mount point is nested, remember it so that we can check that following ones aren't nested beneath this one
 				prevNestedMPs = append(prevNestedMPs, mp+string(os.PathSeparator))
-				retval = append(retval, mp[len(myMPSlash):])
+				retval = append(retval, mp[len(myMountPointWithSlash):])
 			}
 		}
 		return nil

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -302,7 +302,7 @@ type VolumeLogger interface {
 	GenerateError(prefixMsg string, err error) (simpleErr, detailedErr error)
 }
 
-// Generates an error string with the format ": <err>" if err exists
+// errSuffix generates an error string with the format ": <err>" if err exists
 func errSuffix(err error) string {
 	errStr := ""
 	if err != nil {
@@ -311,12 +311,12 @@ func errSuffix(err error) string {
 	return errStr
 }
 
-// Generate a detailed error msg for logs
+// generateVolumeMsgDetailed generates a detailed error msg for logs
 func generateVolumeMsgDetailed(prefixMsg, suffixMsg, volumeName, details string) (detailedMsg string) {
 	return fmt.Sprintf("%v for volume %q %v %v", prefixMsg, volumeName, details, suffixMsg)
 }
 
-// Generate a simplified error msg for events and a detailed error msg for logs
+// generateVolumeMsg generates a simplified error msg for events and a detailed error msg for logs
 func generateVolumeMsg(prefixMsg, suffixMsg, volumeName, details string) (simpleMsg, detailedMsg string) {
 	simpleMsg = fmt.Sprintf("%v for volume %q %v", prefixMsg, volumeName, suffixMsg)
 	return simpleMsg, generateVolumeMsgDetailed(prefixMsg, suffixMsg, volumeName, details)

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/csi-hostpath-plugin.yaml
@@ -276,7 +276,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -304,13 +304,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -324,7 +324,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -340,7 +340,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -276,7 +276,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -304,13 +304,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -324,7 +324,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -340,7 +340,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock


### PR DESCRIPTION

test: update CSI sidecar images to latest versions

Update CSI sidecar container images in test manifests:
- livenessprobe: v2.15.0 → v2.17.0
- csi-attacher: v4.8.0 → v4.10.0
- csi-provisioner: v5.1.0 → v5.3.0
- csi-resizer: v1.13.1 → v1.14.0



/kind cleanup
```release-note
NONE
```
