### PR TITLE
Support PreStop HTTPGet hooks on hostNetwork pods without host field

### DIFF
--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -347,10 +347,11 @@ func TestRunHTTPHandler(t *testing.T) {
 	}
 
 	tests := []struct {
-		Name     string
-		PodIP    string
-		HTTPGet  *v1.HTTPGetAction
-		Expected expected
+		Name          string
+		PodIP         string
+		HTTPGet       *v1.HTTPGetAction
+		PrePodSetFunc func(pod *v1.Pod)
+		Expected      expected
 	}{
 		{
 			Name:  "missing pod IP",
@@ -564,6 +565,69 @@ func TestRunHTTPHandler(t *testing.T) {
 					"Host":       {"from.header"},
 				},
 			},
+		}, {
+			Name:  "hostNetwork(no Host field): headers",
+			PodIP: "233.252.0.1",
+			PrePodSetFunc: func(pod *v1.Pod) {
+				pod.Spec.HostNetwork = true
+				pod.Status = v1.PodStatus{
+					HostIPs: []v1.HostIP{{IP: "233.252.0.1"}}, // only HostIPs
+				}
+			},
+			HTTPGet: &v1.HTTPGetAction{
+				Path: "foo",
+				Port: intstr.FromString("80"),
+				// no Host field
+				Host:   "",
+				Scheme: "http",
+				HTTPHeaders: []v1.HTTPHeader{
+					{
+						Name:  "Foo",
+						Value: "bar",
+					},
+				},
+			},
+			Expected: expected{
+				OldURL:    "http://233.252.0.1:80/foo",
+				OldHeader: http.Header{},
+				NewURL:    "http://233.252.0.1:80/foo",
+				NewHeader: http.Header{
+					"Accept":     {"*/*"},
+					"Foo":        {"bar"},
+					"User-Agent": {"kube-lifecycle/."},
+				},
+			},
+		}, {
+			Name:  "hostNetwork(set Host field): host header",
+			PodIP: "233.252.0.1",
+			PrePodSetFunc: func(pod *v1.Pod) {
+				pod.Spec.HostNetwork = true
+				pod.Status = v1.PodStatus{
+					PodIPs: []v1.PodIP{{IP: "233.252.0.1"}}, // only PodIPs
+				}
+			},
+			HTTPGet: &v1.HTTPGetAction{
+				Host:   "example.test", // set Host field
+				Path:   "foo",
+				Port:   intstr.FromString("80"),
+				Scheme: "http",
+				HTTPHeaders: []v1.HTTPHeader{
+					{
+						Name:  "Host",
+						Value: "from.header",
+					},
+				},
+			},
+			Expected: expected{
+				OldURL:    "http://example.test:80/foo",
+				OldHeader: http.Header{},
+				NewURL:    "http://example.test:80/foo",
+				NewHeader: http.Header{
+					"Accept":     {"*/*"},
+					"User-Agent": {"kube-lifecycle/."},
+					"Host":       {"from.header"},
+				},
+			},
 		},
 	}
 
@@ -595,7 +659,9 @@ func TestRunHTTPHandler(t *testing.T) {
 
 			container.Lifecycle.PostStart.HTTPGet = tt.HTTPGet
 			pod.Spec.Containers = []v1.Container{container}
-
+			if tt.PrePodSetFunc != nil {
+				tt.PrePodSetFunc(&pod)
+			}
 			verify := func(t *testing.T, expectedHeader http.Header, expectedURL string) {
 				fakeHTTPDoer := fakeHTTP{}
 				handlerRunner := NewHandlerRunner(&fakeHTTPDoer, &fakeContainerCommandRunner{}, fakePodStatusProvider, nil)

--- a/test/e2e/common/node/lifecycle_hook.go
+++ b/test/e2e/common/node/lifecycle_hook.go
@@ -256,6 +256,63 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 			testPodWithHook(ctx, podWithHook)
 		})
 	})
+	ginkgo.Context("when using hostNetwork without explicit host in HTTPGet", func() {
+		/*
+			Release : v1.34
+			Testname: Pod Lifecycle, prestop http hook with hostNetwork and no host field (self request)
+			Description: When a pre-stop handler is specified in the container lifecycle using a 'HttpGet' action,
+			and the Pod uses hostNetwork but the HTTPGet Host field is not set, then the handler MUST be invoked
+			by sending an HTTP request to the Pod itself before the container is terminated.
+			A pod with hostNetwork is created with agnhost 'netexec' server running,
+			with a pre-stop hook that hits /echo?msg=prestop. The container logs MUST show the
+			request was received when the pod is deleted.
+		*/
+		framework.ConformanceIt("should execute prestop http hook to itself with no host field", f.WithNodeConformance(), func(ctx context.Context) {
+			const (
+				podName       = "hostnetwork-pod-with-prestop-http-nohost"
+				containerName = "agnhost-container"
+			)
+			var (
+				port      int32 = 8080
+				httpPorts       = []v1.ContainerPort{
+					{
+						ContainerPort: port,
+						Protocol:      v1.ProtocolTCP,
+					},
+				}
+			)
+			c := e2epod.NewAgnhostContainer(containerName, nil, httpPorts, "netexec")
+			c.Lifecycle = &v1.Lifecycle{
+				PreStop: &v1.LifecycleHandler{
+					HTTPGet: &v1.HTTPGetAction{
+						Path: "/echo?msg=prestop",
+						Port: intstr.FromInt32(port),
+						// Host isn't set -> should resolve to Pod IP
+					},
+				},
+			}
+			podHandleHookRequest := e2epod.NewAgnhostPodFromContainers("", podName, nil, c)
+			podHandleHookRequest.Spec.HostNetwork = true
+
+			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+			framework.ExpectNoError(err)
+			targetNode := node.Name
+			nodeSelection := e2epod.NodeSelection{}
+			e2epod.SetAffinity(&nodeSelection, targetNode)
+			e2epod.SetNodeSelection(&podHandleHookRequest.Spec, nodeSelection)
+
+			e2epod.NewPodClient(f).CreateSync(ctx, podHandleHookRequest)
+
+			ginkgo.By("delete the hostnetwork pod with lifecycle hook")
+			e2epod.NewPodClient(f).DeleteSync(ctx, podName, metav1.DeleteOptions{}, time.Minute)
+
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return podClient.MatchContainerOutput(ctx, podName, containerName,
+					`GET /echo\?msg=prestop`)
+			}, preStopWaitTimeout, podCheckInterval).Should(gomega.BeNil())
+		})
+	})
+
 })
 
 var _ = SIGDescribe(feature.SidecarContainers, framework.WithFeatureGate(features.SidecarContainers), "Restartable Init Container Lifecycle Hook", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
https://github.com/kubernetes/kubernetes/pull/134306#top3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig node
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 Support PreStop HTTPGet hooks on hostNetwork pods without host field

#### Which issue(s) this PR is related to:
Fixes #134285
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
For hostNetwork pods, the container runtime status (e.g., status.IPs) may not contain IP addresses
because networking is shared with the host. Therefore, we use PodIPs from the pod's status instead.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support PreStop HTTPGet hooks on hostNetwork pods without host field
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
