### PR TITLE
cluster/addons: update container images to latest versions

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -29,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: registry.k8s.io/networking/ip-masq-agent:v2.9.3
+        image: registry.k8s.io/networking/ip-masq-agent:v2.9.4
         args:
           - --masq-chain=IP-MASQ
           - --nomasq-all-reserved-ranges

--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -29,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: registry.k8s.io/networking/ip-masq-agent:v2.9.4
+        image: registry.k8s.io/networking/ip-masq-agent:v2.12.0
         args:
           - --masq-chain=IP-MASQ
           - --nomasq-all-reserved-ranges

--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.8.0
+        image: registry.k8s.io/networking/kube-network-policies:v0.9.2
         command:
         - /bin/netpol
         - --v=4

--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.7.0
+        image: registry.k8s.io/networking/kube-network-policies:v0.8.0
         command:
         - /bin/netpol
         - --v=4

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,23 +23,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.7.2
+  name: metrics-server-v0.8.0
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.7.2
+    version: v0.8.0
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.7.2
+      version: v0.8.0
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.7.2
+        version: v0.8.0
     spec:
       securityContext:
         seccompProfile:
@@ -50,7 +50,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: metrics-server
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.2
+        image: registry.k8s.io/metrics-server/metrics-server:v0.8.0
         command:
         - /metrics-server
         - --metric-resolution=15s
@@ -81,7 +81,7 @@ spec:
         - mountPath: /tmp
           name: tmp-dir
       - name: metrics-server-nanny
-        image: registry.k8s.io/autoscaling/addon-resizer:1.8.14
+        image: registry.k8s.io/autoscaling/addon-resizer:1.8.20
         resources:
           limits:
             cpu: 100m
@@ -109,7 +109,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.7.2
+          - --deployment=metrics-server-v0.8.0
           - --container=metrics-server
           - --poll-period=30000
           - --estimator=exponential


### PR DESCRIPTION
Update several addon container images to their latest stable versions:
- metrics-server: v0.7.2 → v0.8.0
- addon-resizer: 1.8.14 → 1.8.20
- ip-masq-agent: v2.9.3 → v2.9.4
- kube-network-policies: v0.7.0 → v0.8.0

These updates provide bug fixes, security improvements, and enhanced functionality


/kind cleanup

```release-note
NONE
```

