### PR TITLE
Add resource version comparison function in client-go along with conformance

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion.go
@@ -40,6 +40,8 @@ func (i InvalidResourceVersion) Error() string {
 // The function will return an error if the resource version is not a properly
 // formatted positive integer, but has no restriction on length. A properly
 // formatted integer will not contain leading zeros or non integer characters.
+// Zero is also considered an invalid value as it is used as a special value in
+// list/watch events and will never be a live resource version.
 func CompareResourceVersion(a, b string) (int, error) {
 	if !isWellFormed(a) {
 		return 0, InvalidResourceVersion{rv: a}

--- a/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceversion
+
+import (
+	"fmt"
+	"strings"
+)
+
+type InvalidResourceVersion struct {
+	rv string
+}
+
+func (i InvalidResourceVersion) Error() string {
+	return fmt.Sprintf("resource version is not well formed: %s", i.rv)
+}
+
+// CompareResourceVersion runs a comparison between two ResourceVersions. This
+// only has semantic meaning when the comparison is done on two objects of the
+// same resource. The return values are:
+//
+//	-1: If RV a < RV b
+//	 0: If RV a == RV b
+//	+1: If RV a > RV b
+//
+// The function will return an error if the resource version is not a properly
+// formatted positive integer, but has no restriction on length. A properly
+// formatted integer will not contain leading zeros or non integer characters.
+func CompareResourceVersion(a, b string) (int, error) {
+	if !isWellFormed(a) {
+		return 0, InvalidResourceVersion{rv: a}
+	}
+	if !isWellFormed(b) {
+		return 0, InvalidResourceVersion{rv: b}
+	}
+	// both are well-formed integer strings with no leading zeros
+	aLen := len(a)
+	bLen := len(b)
+	switch {
+	case aLen < bLen:
+		// shorter is less
+		return -1, nil
+	case aLen > bLen:
+		// longer is greater
+		return 1, nil
+	default:
+		// equal-length compares lexically
+		return strings.Compare(a, b), nil
+	}
+}
+
+func isWellFormed(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if s[0] == '0' {
+		return false
+	}
+	for i := range s {
+		if !isDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceversion
+
+import (
+	"testing"
+)
+
+func TestCompareResourceVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		a        string
+		b        string
+		expected int
+		err      bool
+	}{
+		{
+			name:     "a less than b",
+			a:        "100",
+			b:        "200",
+			expected: -1,
+		},
+		{
+			name:     "a greater than b",
+			a:        "200",
+			b:        "100",
+			expected: 1,
+		},
+		{
+			name:     "a equal to b",
+			a:        "100",
+			b:        "100",
+			expected: 0,
+		},
+		{
+			name:     "a shorter than b",
+			a:        "99",
+			b:        "100",
+			expected: -1,
+		},
+		{
+			name:     "a longer than b",
+			a:        "100",
+			b:        "99",
+			expected: 1,
+		},
+		{
+			name:     "a with leading zero",
+			a:        "0100",
+			b:        "100",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name:     "b with leading zero",
+			a:        "100",
+			b:        "0100",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name:     "a empty",
+			a:        "",
+			b:        "100",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name:     "b empty",
+			a:        "100",
+			b:        "",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name: "a non-digit",
+			a:    "100a",
+			b:    "100",
+			err:  true,
+		},
+		{
+			name: "b non-digit",
+			a:    "100",
+			b:    "100a",
+			err:  true,
+		},
+		{
+			name:     "large int a less than b",
+			a:        "99999999999999999999999999999999999999999999999999",
+			b:        "100000000000000000000000000000000000000000000000000",
+			expected: -1,
+		},
+		{
+			name:     "large int a greater than b",
+			a:        "100000000000000000000000000000000000000000000000000",
+			b:        "99999999999999999999999999999999999999999999999999",
+			expected: 1,
+		},
+		{
+			name:     "large int a equal to b",
+			a:        "12345678901234567890123456789012345678901234567890",
+			b:        "12345678901234567890123456789012345678901234567890",
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := CompareResourceVersion(tc.a, tc.b)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error, but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.expected {
+				t.Errorf("expected %d, got %d", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/resourceversion/resourceversion_test.go
@@ -35,10 +35,34 @@ func TestCompareResourceVersion(t *testing.T) {
 			expected: -1,
 		},
 		{
+			name: "a is zero, invalid",
+			a:    "0",
+			b:    "1",
+			err:  true,
+		},
+		{
+			name: "both zero",
+			a:    "0",
+			b:    "0",
+			err:  true,
+		},
+		{
 			name:     "a greater than b",
 			a:        "200",
 			b:        "100",
 			expected: 1,
+		},
+		{
+			name: "b is 0, invalid",
+			a:    "1",
+			b:    "0",
+			err:  true,
+		},
+		{
+			name:     "a equal to b small",
+			a:        "1",
+			b:        "1",
+			expected: 0,
 		},
 		{
 			name:     "a equal to b",

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -45,6 +45,7 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eauth "k8s.io/kubernetes/test/e2e/framework/auth"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
@@ -527,6 +528,7 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 
 	var jr *apiregistrationv1.APIService
 	err = json.Unmarshal([]byte(statusContent), &jr)
+	gomega.Expect(jr).To(apimachineryutils.HaveValidResourceVersion())
 	framework.ExpectNoError(err, "Failed to process statusContent: %v | err: %v ", string(statusContent), err)
 	gomega.Expect(jr.Status.Conditions[0].Message).To(gomega.Equal("all checks passed"), "The Message returned was %v", jr.Status.Conditions[0].Message)
 

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -45,6 +45,7 @@ import (
 	k8sclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	"k8s.io/kubernetes/test/utils/crd"
@@ -449,6 +450,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		if err != nil {
 			framework.Failf("%v", err)
 		}
+		gomega.Expect(crd.Crd).To(apimachineryutils.HaveValidResourceVersion())
 		// just double check. setupCRD() checked this for us already
 		if err := waitForDefinition(f.ClientSet, definitionName(crd, "v6alpha1"), schemaFoo); err != nil {
 			framework.Failf("%v", err)

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apiserver/pkg/cel/environment"
@@ -39,6 +40,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8sclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -461,10 +463,12 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("%v", err)
 		}
 		crd.Crd.Spec.Versions[1].Served = false
+		oldRV := crd.Crd.ResourceVersion
 		crd.Crd, err = crd.APIExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd.Crd, metav1.UpdateOptions{})
 		if err != nil {
 			framework.Failf("%v", err)
 		}
+		gomega.Expect(resourceversion.CompareResourceVersion(oldRV, crd.Crd.ResourceVersion)).To(gomega.BeNumerically("==", -1), "updated object should have a larger resource version")
 
 		ginkgo.By("check the unserved version gets removed")
 		if err := waitForDefinitionCleanup(f.ClientSet, definitionName(crd, "v6alpha1")); err != nil {

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
@@ -306,7 +307,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			},
 		}}, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "creating CR")
-
+		gomega.Expect(u1).To(apimachineryutils.HaveValidResourceVersion())
 		// Setting default for a to "A" and waiting for the CR to get defaulted on read
 		crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Patch(ctx, crd.Name, types.JSONPatchType, []byte(`[
 			{"op":"add","path":"/spec/versions/0/schema/openAPIV3Schema/properties/a/default", "value": "A"}

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/rest"
 	clientsideflowcontrol "k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
@@ -385,6 +386,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		fsRead, err := client.Get(ctx, fsCreated.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(fsRead.UID).To(gomega.Equal(fsCreated.UID))
+		gomega.Expect(fsRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
@@ -612,6 +614,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		plRead, err := client.Get(ctx, plCreated.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(plRead.UID).To(gomega.Equal(plCreated.UID))
+		gomega.Expect(plRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/util/apihelpers"
@@ -401,6 +402,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		framework.ExpectNoError(err)
 		gomega.Expect(fsPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(fsPatched.Spec.MatchingPrecedence).To(gomega.Equal(int32(9999)), "patched object should have the applied spec")
+		gomega.Expect(resourceversion.CompareResourceVersion(fsCreated.ResourceVersion, fsPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		var fsUpdated *flowcontrol.FlowSchema
@@ -627,6 +629,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		framework.ExpectNoError(err)
 		gomega.Expect(plPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(plPatched.Spec.Limited.NominalConcurrencyShares).To(gomega.Equal(ptr.To(int32(4))), "patched object should have the applied spec")
+		gomega.Expect(resourceversion.CompareResourceVersion(plCreated.ResourceVersion, plPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		var plUpdated *flowcontrol.PriorityLevelConfiguration

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -278,6 +279,7 @@ var _ = SIGDescribe("Namespaces", framework.WithSerial(), func() {
 		ns, err := f.CreateNamespace(ctx, namespaceName, nil)
 		framework.ExpectNoError(err, "failed creating Namespace")
 		namespaceName = ns.ObjectMeta.Name
+		gomega.Expect(ns).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("patching the Namespace")
 		nspatch, err := json.Marshal(map[string]interface{}{

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	quota "k8s.io/apiserver/pkg/quota/v1"
@@ -1044,6 +1045,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		framework.ExpectNoError(err, "failed to patch ResourceQuota %s in namespace %s", rqName, ns)
 		gomega.Expect(patchedResourceQuota.Labels[rqName]).To(gomega.Equal("patched"), "Failed to find the label for this ResourceQuota. Current labels: %v", patchedResourceQuota.Labels)
 		gomega.Expect(*patchedResourceQuota.Spec.Hard.Memory()).To(gomega.Equal(resource.MustParse("750Mi")), "Hard memory value for ResourceQuota %q is %s not 750Mi.", patchedResourceQuota.ObjectMeta.Name, patchedResourceQuota.Spec.Hard.Memory().String())
+		gomega.Expect(resourceversion.CompareResourceVersion(rq.Items[0].ResourceVersion, patchedResourceQuota.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("Deleting a Collection of ResourceQuotas")
 		err = client.CoreV1().ResourceQuotas(ns).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/quota/v1/evaluator/core"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -1033,6 +1034,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		framework.ExpectNoError(err)
 		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceCPU]).To(gomega.Equal(resource.MustParse("1")))
 		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("500Mi")))
+		gomega.Expect(resourceQuotaResult).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("Listing all ResourceQuotas with LabelSelector")
 		rq, err := client.CoreV1().ResourceQuotas("").List(ctx, metav1.ListOptions{LabelSelector: labelSelector})

--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -42,6 +42,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/openapi3"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
@@ -520,6 +521,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		vapRead, err := client.Get(ctx, vapCreated.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(vapRead.UID).To(gomega.Equal(vapCreated.UID))
+		gomega.Expect(vapRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
@@ -766,6 +768,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		vapbRead, err := client.Get(ctx, vapbCreated.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(vapbRead.UID).To(gomega.Equal(vapbCreated.UID))
+		gomega.Expect(vapbRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})

--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	applyadmissionregistrationv1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
@@ -535,6 +536,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		framework.ExpectNoError(err)
 		gomega.Expect(vapPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(vapPatched.Spec.FailurePolicy).To(gomega.HaveValue(gomega.Equal(admissionregistrationv1.Ignore)), "patched object should have the applied spec")
+		gomega.Expect(resourceversion.CompareResourceVersion(vapRead.ResourceVersion, vapPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		var vapUpdated *admissionregistrationv1.ValidatingAdmissionPolicy
@@ -780,6 +782,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		framework.ExpectNoError(err)
 		gomega.Expect(vapbPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(vapbPatched.Spec.ValidationActions).To(gomega.Equal([]admissionregistrationv1.ValidationAction{admissionregistrationv1.Warn}), "patched object should have the applied spec")
+		gomega.Expect(resourceversion.CompareResourceVersion(vapbRead.ResourceVersion, vapbPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		var vapbUpdated *admissionregistrationv1.ValidatingAdmissionPolicyBinding

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2eendpointslice "k8s.io/kubernetes/test/e2e/framework/endpointslice"
@@ -413,6 +414,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			},
 		})
 		framework.ExpectNoError(err, "Creating validating webhook configuration")
+		gomega.Expect(hook).To(apimachineryutils.HaveValidResourceVersion())
 		defer func() {
 			err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, hook.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "Deleting validating webhook configuration")
@@ -507,6 +509,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			},
 		})
 		framework.ExpectNoError(err, "Creating mutating webhook configuration")
+		gomega.Expect(hook).To(apimachineryutils.HaveValidResourceVersion())
 		defer func() {
 			err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, hook.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "Deleting mutating webhook configuration")

--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -170,6 +171,7 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 		patchedControllerRevision, err := csAppsV1.ControllerRevisions(ns).Patch(ctx, initialRevision.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch ControllerRevision %s in namespace %s", initialRevision.Name, ns)
 		gomega.Expect(patchedControllerRevision.Labels).To(gomega.HaveKeyWithValue(initialRevision.Name, "patched"), "Did not find 'patched' label for this ControllerRevision. Current labels: %v", patchedControllerRevision.Labels)
+		gomega.Expect(resourceversion.CompareResourceVersion(rev.ResourceVersion, patchedControllerRevision.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 		framework.Logf("%s has been patched", patchedControllerRevision.Name)
 
 		ginkgo.By("Create a new ControllerRevision")

--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -38,6 +38,7 @@ import (
 	extensionsinternal "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/controller"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edaemonset "k8s.io/kubernetes/test/e2e/framework/daemonset"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
@@ -165,6 +166,7 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 			framework.ExpectNoError(err, "failed to lookup ControllerRevision: %v", err)
 			gomega.Expect(initialRevision).NotTo(gomega.BeNil(), "failed to lookup ControllerRevision: %v", initialRevision)
 		}
+		gomega.Expect(rev).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By(fmt.Sprintf("Patching ControllerRevision %q", initialRevision.Name))
 		payload := "{\"metadata\":{\"labels\":{\"" + initialRevision.Name + "\":\"patched\"}}}"

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
@@ -413,6 +414,7 @@ var _ = SIGDescribe("CronJob", func() {
 			[]byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(patchedCronJob.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
+		gomega.Expect(resourceversion.CompareResourceVersion(createdCronJob.ResourceVersion, patchedCronJob.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		var cjToUpdate, updatedCronJob *batchv1.CronJob

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	batchinternal "k8s.io/kubernetes/pkg/apis/batch"
 	jobutil "k8s.io/kubernetes/pkg/controller/job/util"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ejob "k8s.io/kubernetes/test/e2e/framework/job"
 	e2eresource "k8s.io/kubernetes/test/e2e/framework/resource"
@@ -381,6 +382,7 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("creating")
 		createdCronJob, err := cjClient.Create(ctx, cjTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
+		gomega.Expect(createdCronJob).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("getting")
 		gottenCronJob, err := cjClient.Get(ctx, createdCronJob.Name, metav1.GetOptions{})

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -53,6 +53,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	extensionsinternal "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/controller/daemon"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edaemonset "k8s.io/kubernetes/test/e2e/framework/daemonset"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -391,6 +392,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
+		gomega.Expect(ds).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	appsinternal "k8s.io/kubernetes/pkg/apis/apps"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -216,6 +217,7 @@ var _ = SIGDescribe("Deployment", func() {
 
 		createdDeployment, err := f.ClientSet.AppsV1().Deployments(testNamespaceName).Create(ctx, testDeployment, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create Deployment %v in namespace %v", testDeploymentName, testNamespaceName)
+		gomega.Expect(createdDeployment).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("waiting for Deployment to be created")
 		ctxUntil, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -131,6 +132,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 			return newBytes, nil
 		})
 		gomega.Expect(patchedPDB.Spec.MinAvailable.String()).To(gomega.Equal("3%"))
+		gomega.Expect(resourceversion.CompareResourceVersion(updatedPDB.ResourceVersion, patchedPDB.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		deletePDBOrDie(ctx, cs, ns, defaultName)
 	})

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -46,6 +46,7 @@ import (
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -120,6 +121,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 			return pdb
 		}, cs.PolicyV1().PodDisruptionBudgets(ns).Update)
 		gomega.Expect(updatedPDB.Spec.MinAvailable.String()).To(gomega.Equal("2%"))
+		gomega.Expect(updatedPDB).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("patching the pdb")
 		patchedPDB := patchPDBOrDie(ctx, cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	batchinternal "k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/features"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ejob "k8s.io/kubernetes/test/e2e/framework/job"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -1183,6 +1184,7 @@ done`}
 		job.Spec.Suspend = ptr.To(true)
 		job, err = e2ejob.CreateJob(ctx, f.ClientSet, ns, job)
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", ns)
+		gomega.Expect(job).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("Patching the Job")
 		payload := "{\"metadata\":{\"labels\":{\"" + jobName + "\":\"patched\"}}}"

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -1187,6 +1188,7 @@ done`}
 		payload := "{\"metadata\":{\"labels\":{\"" + jobName + "\":\"patched\"}}}"
 		patchedJob, err := f.ClientSet.BatchV1().Jobs(ns).Patch(ctx, jobName, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch Job %s in namespace %s", jobName, ns)
+		gomega.Expect(resourceversion.CompareResourceVersion(job.ResourceVersion, patchedJob.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("Watching for Job to be patched")
 		c := watchEventConfig{

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -40,6 +40,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/pkg/controller/replication"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -155,6 +156,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 			// Create a ReplicationController
 			testRcCreated, err := f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).Create(ctx, &rcTest, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Failed to create ReplicationController")
+			gomega.Expect(testRcCreated).To(apimachineryutils.HaveValidResourceVersion())
 
 			ginkgo.By("waiting for RC to be added")
 			eventFound := false

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/controller/replicaset"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2ereplicaset "k8s.io/kubernetes/test/e2e/framework/replicaset"
@@ -495,6 +496,7 @@ func testRSLifeCycle(ctx context.Context, f *framework.Framework) {
 	rs := newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil)
 	createdRS, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
+	gomega.Expect(createdRS).To(apimachineryutils.HaveValidResourceVersion())
 
 	// Verify that the required pods have come up.
 	err = e2epod.VerifyPodsRunning(ctx, c, ns, podName, labels.SelectorFromSet(map[string]string{"name": podName}), false, replicas)

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
@@ -492,7 +493,7 @@ func testRSLifeCycle(ctx context.Context, f *framework.Framework) {
 	framework.ExpectNoError(err, "failed to list rsList")
 	// Create a ReplicaSet
 	rs := newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil)
-	_, err = c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
+	createdRS, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	// Verify that the required pods have come up.
@@ -527,8 +528,9 @@ func testRSLifeCycle(ctx context.Context, f *framework.Framework) {
 		},
 	})
 	framework.ExpectNoError(err, "failed to Marshal ReplicaSet JSON patch")
-	_, err = f.ClientSet.AppsV1().ReplicaSets(ns).Patch(ctx, rsName, types.StrategicMergePatchType, []byte(rsPatch), metav1.PatchOptions{})
+	patchedRS, err := f.ClientSet.AppsV1().ReplicaSets(ns).Patch(ctx, rsName, types.StrategicMergePatchType, []byte(rsPatch), metav1.PatchOptions{})
 	framework.ExpectNoError(err, "failed to patch ReplicaSet")
+	gomega.Expect(resourceversion.CompareResourceVersion(createdRS.ResourceVersion, patchedRS.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 	ctxUntil, cancel := context.WithTimeout(ctx, f.Timeouts.PodStart)
 	defer cancel()

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -51,6 +51,7 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
@@ -1059,6 +1060,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			setHTTPProbe(ss)
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
+			gomega.Expect(ss).To(apimachineryutils.HaveValidResourceVersion())
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			waitForStatus(ctx, c, ss)
 

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/certificate/csr"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -307,6 +308,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err)
 		gomega.Expect(gottenCSR.UID).To(gomega.Equal(createdCSR.UID))
 		gomega.Expect(gottenCSR.Spec.ExpirationSeconds).To(gomega.Equal(csr.DurationToExpirationSeconds(time.Hour)))
+		gomega.Expect(gottenCSR).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		csrs, err := csrClient.List(ctx, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -33,6 +33,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
@@ -321,6 +322,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		patchedCSR, err := csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(patchedCSR.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
+		gomega.Expect(resourceversion.CompareResourceVersion(gottenCSR.ResourceVersion, patchedCSR.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		csrToUpdate := patchedCSR.DeepCopy()

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -39,6 +39,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -690,6 +691,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		}
 		createdServiceAccount, err := f.ClientSet.CoreV1().ServiceAccounts(testNamespaceName).Create(ctx, &testServiceAccount, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create a ServiceAccount")
+		gomega.Expect(createdServiceAccount).To(apimachineryutils.HaveValidResourceVersion())
 
 		getServiceAccount, err := f.ClientSet.CoreV1().ServiceAccounts(testNamespaceName).Get(ctx, testServiceAccountName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to fetch the created ServiceAccount")

--- a/test/e2e/common/apimachinery/resourceversion_matchers.go
+++ b/test/e2e/common/apimachinery/resourceversion_matchers.go
@@ -57,6 +57,10 @@ func (m *HaveValidResourceVersionMatcher) Match(actual interface{}) (success boo
 		m.failureReason = fmt.Sprintf("resource version requires %d bits (more than 128)", val.BitLen())
 		return false, nil
 	}
+	if val.Cmp(big.NewInt(0)) == 0 {
+		m.failureReason = "the resource version is zero which is not valid"
+		return false, nil
+	}
 
 	return true, nil
 }

--- a/test/e2e/common/apimachinery/resourceversion_matchers.go
+++ b/test/e2e/common/apimachinery/resourceversion_matchers.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apimachinery
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HaveValidResourceVersion returns a Gomega matcher that checks if a kubernetes
+// objects resource version is a valid 128-bit unsigned integer.
+func HaveValidResourceVersion() types.GomegaMatcher {
+	return &HaveValidResourceVersionMatcher{}
+}
+
+type HaveValidResourceVersionMatcher struct {
+	failureReason string
+}
+
+// Match is a gomega matcher that checks whether or not the provided interface
+// is a metav1.Object with a uint128 resource version string.
+func (m *HaveValidResourceVersionMatcher) Match(actual interface{}) (success bool, err error) {
+	// First, ensure the input is an object.
+	o, ok := actual.(metav1.Object)
+	if !ok {
+		return false, fmt.Errorf("HaveValidResourceVersionMatcher matcher expects an api object, but got %T", actual)
+	}
+
+	val, ok := new(big.Int).SetString(o.GetResourceVersion(), 10)
+
+	if !ok {
+		m.failureReason = "the resource version is not a valid integer"
+		return false, nil
+	}
+	if val.Sign() < 0 {
+		m.failureReason = "the resource version is a negative number"
+		return false, nil
+	}
+	if val.BitLen() > 128 {
+		m.failureReason = fmt.Sprintf("resource version requires %d bits (more than 128)", val.BitLen())
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// FailureMessage is used when the assertion is `Expect(...).To(...)`
+func (m *HaveValidResourceVersionMatcher) FailureMessage(actual interface{}) (message string) {
+	o, ok := actual.(metav1.Object)
+	if !ok {
+		return fmt.Sprintf("HaveValidResourceVersion matcher expects an api object, but got %T", actual)
+	}
+	return fmt.Sprintf("Expected resource version to be a valid uint128, but got %q: %s", o.GetResourceVersion(), m.failureReason)
+}
+
+// NegatedFailureMessage is used when the assertion is `Expect(...).ToNot(...)`
+func (m *HaveValidResourceVersionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	o, ok := actual.(metav1.Object)
+	if !ok {
+		return fmt.Sprintf("HaveValidResourceVersion matcher expects an api object, but got %T", actual)
+	}
+	return fmt.Sprintf("Expected resource version not to be a valid uint128, but got %q", o.GetResourceVersion())
+}

--- a/test/e2e/common/apimachinery/resourceversion_matchers_test.go
+++ b/test/e2e/common/apimachinery/resourceversion_matchers_test.go
@@ -38,7 +38,8 @@ func TestHaveValidResourceVersionMatch(t *testing.T) {
 		{
 			name:            "zero resource version",
 			resourceVersion: "0",
-			expectedMatch:   true,
+			expectedMatch:   false,
+			expectedFailure: "Expected resource version to be a valid uint128, but got \"0\": the resource version is zero which is not valid",
 		},
 		{
 			name:            "negative resource version",

--- a/test/e2e/common/apimachinery/resourceversion_matchers_test.go
+++ b/test/e2e/common/apimachinery/resourceversion_matchers_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apimachinery
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHaveValidResourceVersionMatch(t *testing.T) {
+	tests := []struct {
+		name            string
+		resourceVersion string
+		expectedMatch   bool
+		expectedFailure string
+	}{
+		{
+			name:            "valid resource version",
+			resourceVersion: "123456789012345678901234567890123456789", // 128-bit unsigned int
+			expectedMatch:   true,
+		},
+		{
+			name:            "zero resource version",
+			resourceVersion: "0",
+			expectedMatch:   true,
+		},
+		{
+			name:            "negative resource version",
+			resourceVersion: "-1",
+			expectedMatch:   false,
+			expectedFailure: "Expected resource version to be a valid uint128, but got \"-1\": the resource version is a negative number",
+		},
+		{
+			name:            "non-numeric resource version",
+			resourceVersion: "abc",
+			expectedMatch:   false,
+			expectedFailure: "Expected resource version to be a valid uint128, but got \"abc\": the resource version is not a valid integer",
+		},
+		{
+			name:            "empty resource version",
+			resourceVersion: "",
+			expectedMatch:   false,
+			expectedFailure: "Expected resource version to be a valid uint128, but got \"\": the resource version is not a valid integer",
+		},
+		{
+			name:            "resource version too large (129 bits)",
+			resourceVersion: "340282366920938463463374607431768211456", // 2^128
+			expectedMatch:   false,
+			expectedFailure: "Expected resource version to be a valid uint128, but got \"340282366920938463463374607431768211456\": resource version requires 129 bits (more than 128)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: tt.resourceVersion,
+				},
+			}
+
+			matcher := HaveValidResourceVersion()
+			match, err := matcher.Match(obj)
+
+			if match != tt.expectedMatch {
+				t.Errorf("Expected match to be %v, but got %v", tt.expectedMatch, match)
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !match && matcher.FailureMessage(obj) != tt.expectedFailure {
+				t.Errorf("Expected failure message to be %q, but got %q", tt.expectedFailure, matcher.FailureMessage(obj))
+			}
+		})
+	}
+}

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -197,6 +198,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 		framework.ExpectNoError(err, "failed to get ConfigMap")
 		gomega.Expect(configMap.Data["valueName"]).To(gomega.Equal(testConfigMap.Data["valueName"]))
 		gomega.Expect(configMap.Labels["test-configmap-static"]).To(gomega.Equal(testConfigMap.Labels["test-configmap-static"]))
+		gomega.Expect(configMap).To(apimachineryutils.HaveValidResourceVersion())
 
 		configMapPatchPayload, err := json.Marshal(v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/node/configmap.go
+++ b/test/e2e/common/node/configmap.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -210,8 +211,9 @@ var _ = SIGDescribe("ConfigMap", func() {
 		framework.ExpectNoError(err, "failed to marshal patch data")
 
 		ginkgo.By("patching the ConfigMap")
-		_, err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Patch(ctx, testConfigMapName, types.StrategicMergePatchType, []byte(configMapPatchPayload), metav1.PatchOptions{})
+		patchedConfigMap, err := f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Patch(ctx, testConfigMapName, types.StrategicMergePatchType, []byte(configMapPatchPayload), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch ConfigMap")
+		gomega.Expect(resourceversion.CompareResourceVersion(configMap.ResourceVersion, patchedConfigMap.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("listing all ConfigMaps in all namespaces with a label selector")
 		configMapList, err := f.ClientSet.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{

--- a/test/e2e/common/node/lease.go
+++ b/test/e2e/common/node/lease.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
@@ -90,6 +91,7 @@ var _ = SIGDescribe("Lease", func() {
 
 		createdLease, err := leaseClient.Create(ctx, lease, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "creating Lease failed")
+		gomega.Expect(createdLease).To(apimachineryutils.HaveValidResourceVersion())
 
 		readLease, err := leaseClient.Get(ctx, name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "couldn't read Lease")

--- a/test/e2e/common/node/lease.go
+++ b/test/e2e/common/node/lease.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -132,6 +133,7 @@ var _ = SIGDescribe("Lease", func() {
 		if !apiequality.Semantic.DeepEqual(patchedLease.Spec, readLease.Spec) {
 			framework.Failf("Leases don't match. Diff (- for expected, + for actual):\n%s", cmp.Diff(patchedLease.Spec, readLease.Spec))
 		}
+		gomega.Expect(resourceversion.CompareResourceVersion(createdLease.ResourceVersion, readLease.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		name2 := "lease2"
 		lease2 := &coordinationv1.Lease{

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
@@ -1002,6 +1003,7 @@ var _ = SIGDescribe("Pods", func() {
 		framework.ExpectNoError(err, "failed to fetch Pod %s in namespace %s", testPodName, testNamespaceName)
 		gomega.Expect(pod.ObjectMeta.Labels).To(gomega.HaveKeyWithValue("test-pod", "patched"), "failed to patch Pod - missing label")
 		gomega.Expect(pod.Spec.Containers[0].Image).To(gomega.Equal(testPodImage2), "failed to patch Pod - wrong image")
+		gomega.Expect(resourceversion.CompareResourceVersion(p.ResourceVersion, pod.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("replacing the Pod's status Ready condition to False")
 		var podStatusUpdate *v1.Pod

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/kubectl/pkg/util/podutils"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -961,6 +962,7 @@ var _ = SIGDescribe("Pods", func() {
 		p, err := f.ClientSet.CoreV1().Pods(testNamespaceName).Get(ctx, testPodName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get Pod %v in namespace %v", testPodName, testNamespaceName)
 		gomega.Expect(p.Status.Phase).To(gomega.Equal(v1.PodRunning), "failed to see Pod %v in namespace %v running", p.ObjectMeta.Name, testNamespaceName)
+		gomega.Expect(p).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("patching the Pod with a new Label and updated data")
 		prePatchResourceVersion := p.ResourceVersion

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -85,6 +86,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 		podTemplateRead, err := f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Get(ctx, podTemplateName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get created PodTemplate")
 		gomega.Expect(podTemplateRead.ObjectMeta.Name).To(gomega.Equal(podTemplateName))
+		gomega.Expect(podTemplateRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		// patch template
 		podTemplatePatch, err := json.Marshal(map[string]interface{}{

--- a/test/e2e/common/node/runtimeclass.go
+++ b/test/e2e/common/node/runtimeclass.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/pkg/kubelet/events"
@@ -297,6 +298,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		patchedRC, err := rcClient.Patch(ctx, createdRC.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(patchedRC.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
+		gomega.Expect(resourceversion.CompareResourceVersion(gottenRC.ResourceVersion, patchedRC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		csrToUpdate := patchedRC.DeepCopy()

--- a/test/e2e/common/node/runtimeclass.go
+++ b/test/e2e/common/node/runtimeclass.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	runtimeclasstest "k8s.io/kubernetes/pkg/kubelet/runtimeclass/testing"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
@@ -288,6 +289,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		gottenRC, err := rcClient.Get(ctx, rc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(gottenRC.UID).To(gomega.Equal(createdRC.UID))
+		gomega.Expect(gottenRC).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		rcs, err := rcClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})

--- a/test/e2e/common/node/secrets.go
+++ b/test/e2e/common/node/secrets.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -172,6 +173,7 @@ var _ = SIGDescribe("Secrets", func() {
 			Type: "Opaque",
 		}, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create secret")
+		gomega.Expect(createdSecret).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing secrets in all namespaces to ensure that there are more than zero")
 		// list all secrets in all namespaces to ensure endpoint coverage

--- a/test/e2e/common/node/secrets.go
+++ b/test/e2e/common/node/secrets.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -158,7 +159,7 @@ var _ = SIGDescribe("Secrets", func() {
 		secretTestName := "test-secret-" + string(uuid.NewUUID())
 
 		// create a secret in the test namespace
-		_, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, &v1.Secret{
+		createdSecret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: secretTestName,
 				Labels: map[string]string{
@@ -208,6 +209,7 @@ var _ = SIGDescribe("Secrets", func() {
 
 		secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(ctx, secretCreatedName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get secret")
+		gomega.Expect(resourceversion.CompareResourceVersion(createdSecret.ResourceVersion, secret.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		secretDecodedstring, err := base64.StdEncoding.DecodeString(string(secret.Data["key"]))
 		framework.ExpectNoError(err, "failed to decode secret from Base64")

--- a/test/e2e/instrumentation/events.go
+++ b/test/e2e/instrumentation/events.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	typedeventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/instrumentation/common"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -102,6 +103,7 @@ var _ = common.SIGDescribe("Events API", func() {
 		ginkgo.By("creating a test event")
 		createdEvent, err := client.Create(ctx, newTestEvent(f.Namespace.Name, eventName, "testevent-constant"), metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create test event")
+		gomega.Expect(createdEvent).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing events in all namespaces")
 		foundCreatedEvent := eventExistsInList(ctx, clientAllNamespaces, f.Namespace.Name, eventName)

--- a/test/e2e/instrumentation/events.go
+++ b/test/e2e/instrumentation/events.go
@@ -25,6 +25,7 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	typedeventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
@@ -99,7 +100,7 @@ var _ = common.SIGDescribe("Events API", func() {
 		eventName := "event-test"
 
 		ginkgo.By("creating a test event")
-		_, err := client.Create(ctx, newTestEvent(f.Namespace.Name, eventName, "testevent-constant"), metav1.CreateOptions{})
+		createdEvent, err := client.Create(ctx, newTestEvent(f.Namespace.Name, eventName, "testevent-constant"), metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create test event")
 
 		ginkgo.By("listing events in all namespaces")
@@ -152,6 +153,7 @@ var _ = common.SIGDescribe("Events API", func() {
 		ginkgo.By("getting the test event")
 		event, err := client.Get(ctx, eventName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to get test event")
+		gomega.Expect(resourceversion.CompareResourceVersion(createdEvent.ResourceVersion, event.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 		// clear ResourceVersion and ManagedFields which are set by control-plane
 		event.ObjectMeta.ResourceVersion = ""
 		testEvent.ObjectMeta.ResourceVersion = ""

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/network/common"
@@ -438,6 +439,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		queriedEPS, err := epsClient.Get(ctx, createdEPS.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(queriedEPS.UID).To(gomega.Equal(createdEPS.UID))
+		gomega.Expect(queriedEPS).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		epsList, err := epsClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -464,6 +465,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		patchedEPS, err := epsClient.Patch(ctx, createdEPS.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(patchedEPS.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
+		gomega.Expect(resourceversion.CompareResourceVersion(createdEPS.ResourceVersion, patchedEPS.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		var epsToUpdate, updatedEPS *discoveryv1.EndpointSlice

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -177,6 +178,7 @@ var _ = common.SIGDescribe("Ingress API", func() {
 		gottenIngress, err := ingClient.Get(ctx, createdIngress.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(gottenIngress.UID).To(gomega.Equal(createdIngress.UID))
+		gomega.Expect(gottenIngress).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		ings, err := ingClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
@@ -202,6 +203,7 @@ var _ = common.SIGDescribe("Ingress API", func() {
 		ginkgo.By("patching")
 		patchedIngress, err := ingClient.Patch(ctx, createdIngress.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
+		gomega.Expect(resourceversion.CompareResourceVersion(createdIngress.ResourceVersion, patchedIngress.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 		gomega.Expect(patchedIngress.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 
 		ginkgo.By("updating")

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
@@ -353,6 +354,7 @@ var _ = common.SIGDescribe("IngressClass API", func() {
 		patchedIC, err := icClient.Patch(ctx, ingressClass1.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(patchedIC.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
+		gomega.Expect(resourceversion.CompareResourceVersion(ingressClass1.ResourceVersion, patchedIC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		icToUpdate := patchedIC.DeepCopy()

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/network/common"
@@ -339,6 +340,7 @@ var _ = common.SIGDescribe("IngressClass API", func() {
 		framework.ExpectNoError(err)
 		gomega.Expect(gottenIC.UID).To(gomega.Equal(ingressClass1.UID))
 		gomega.Expect(gottenIC.UID).To(gomega.Equal(ingressClass1.UID))
+		gomega.Expect(gottenIC).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		ics, err := icClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=generic"})

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2eendpointslice "k8s.io/kubernetes/test/e2e/framework/endpointslice"
@@ -3284,6 +3285,7 @@ var _ = common.SIGDescribe("Services", func() {
 		ginkgo.By("creating an Endpoint")
 		createdEP, err := f.ClientSet.CoreV1().Endpoints(testNamespaceName).Create(ctx, &testEndpoints, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create Endpoint")
+		gomega.Expect(createdEP).To(apimachineryutils.HaveValidResourceVersion())
 		ginkgo.By("waiting for available Endpoint")
 		ctxUntil, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
@@ -3820,6 +3822,7 @@ var _ = common.SIGDescribe("Services", func() {
 		if err != nil {
 			framework.Failf("failed to get Service %q: %v", serviceName, err)
 		}
+		gomega.Expect(service).To(apimachineryutils.HaveValidResourceVersion())
 		service.Spec.Ports = []v1.ServicePort{svcTCPport}
 		updatedSVC, err := cs.CoreV1().Services(ns).Update(ctx, service, metav1.UpdateOptions{})
 		if err != nil {

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3821,10 +3821,11 @@ var _ = common.SIGDescribe("Services", func() {
 			framework.Failf("failed to get Service %q: %v", serviceName, err)
 		}
 		service.Spec.Ports = []v1.ServicePort{svcTCPport}
-		_, err = cs.CoreV1().Services(ns).Update(ctx, service, metav1.UpdateOptions{})
+		updatedSVC, err := cs.CoreV1().Services(ns).Update(ctx, service, metav1.UpdateOptions{})
 		if err != nil {
 			framework.Failf("failed to get Service %q: %v", serviceName, err)
 		}
+		gomega.Expect(resourceversion.CompareResourceVersion(service.ResourceVersion, updatedSVC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "updated object should have a larger resource version")
 
 		ginkgo.By("Checking if the Service forwards traffic to TCP only")
 		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolTCP, execPod, 30*time.Second)

--- a/test/e2e/network/service_cidrs.go
+++ b/test/e2e/network/service_cidrs.go
@@ -32,6 +32,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/controlplane/controller/defaultservicecidr"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -248,6 +249,7 @@ var _ = common.SIGDescribe("ServiceCIDR and IPAddress API", func() {
 		if err != nil {
 			framework.Failf("unexpected error getting IPAddress: %v", err)
 		}
+		gomega.Expect(createdIP).To(apimachineryutils.HaveValidResourceVersion())
 		_, err = f.ClientSet.NetworkingV1().IPAddresses().Create(ctx, ipv6, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("unexpected error getting IPAddress: %v", err)

--- a/test/e2e/node/node_lifecycle.go
+++ b/test/e2e/node/node_lifecycle.go
@@ -29,6 +29,7 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -81,6 +82,7 @@ var _ = SIGDescribe("Node Lifecycle", func() {
 		createdNode, err := nodeClient.Create(ctx, &fakeNode, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create node %q", fakeNode.Name)
 		gomega.Expect(createdNode.Name).To(gomega.Equal(fakeNode.Name), "Checking that the node has been created")
+		gomega.Expect(createdNode).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By(fmt.Sprintf("Getting %q", fakeNode.Name))
 		retrievedNode, err := nodeClient.Get(ctx, fakeNode.Name, metav1.GetOptions{})

--- a/test/e2e/node/node_lifecycle.go
+++ b/test/e2e/node/node_lifecycle.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -92,6 +93,7 @@ var _ = SIGDescribe("Node Lifecycle", func() {
 		framework.ExpectNoError(err, "Failed to patch %q", fakeNode.Name)
 		gomega.Expect(patchedNode.Labels).To(gomega.HaveKeyWithValue(fakeNode.Name, "patched"), "Checking that patched label has been applied")
 		patchedSelector := labels.Set{fakeNode.Name: "patched"}.AsSelector().String()
+		gomega.Expect(resourceversion.CompareResourceVersion(createdNode.ResourceVersion, patchedNode.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By(fmt.Sprintf("Listing nodes with LabelSelector %q", patchedSelector))
 		nodes, err := nodeClient.List(ctx, metav1.ListOptions{LabelSelector: patchedSelector})

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -334,6 +335,7 @@ var _ = SIGDescribe("LimitRange", func() {
 			framework.Failf("LimitRange does not have the correct min limitRange. Currently is %#v ", patchedLimitRange.Spec.Limits[0].Min)
 		}
 		framework.Logf("LimitRange %q has been patched", lrName)
+		gomega.Expect(resourceversion.CompareResourceVersion(limitRange.ResourceVersion, patchedLimitRange.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By(fmt.Sprintf("Delete LimitRange %q by Collection with labelSelector: %q", lrName, patchedLabelSelector))
 		err = lrClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: patchedLabelSelector})

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/klog/v2"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -294,6 +295,7 @@ var _ = SIGDescribe("LimitRange", func() {
 		ginkgo.By(fmt.Sprintf("Creating LimitRange %q in namespace %q", lrName, f.Namespace.Name))
 		limitRange, err := lrClient.Create(ctx, limitRange, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Failed to create limitRange %q", lrName)
+		gomega.Expect(limitRange).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("Creating another limitRange in another namespace")
 		lrNamespace, err := f.CreateNamespace(ctx, lrName, nil)

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -976,6 +977,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 				framework.ExpectNoError(err)
 				gomega.Expect(livePC.Value).To(gomega.Equal(pc.Value))
 				gomega.Expect(livePC.Description).To(gomega.Equal(newDesc))
+				gomega.Expect(livePC).To(apimachineryutils.HaveValidResourceVersion())
 				gomega.Expect(resourceversion.CompareResourceVersion(pc.ResourceVersion, livePC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "changed object should have a larger resource version")
 			}
 		})

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -975,6 +976,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 				framework.ExpectNoError(err)
 				gomega.Expect(livePC.Value).To(gomega.Equal(pc.Value))
 				gomega.Expect(livePC.Description).To(gomega.Equal(newDesc))
+				gomega.Expect(resourceversion.CompareResourceVersion(pc.ResourceVersion, livePC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "changed object should have a larger resource version")
 			}
 		})
 	})

--- a/test/e2e/storage/csi_inline.go
+++ b/test/e2e/storage/csi_inline.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -194,8 +195,10 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		ginkgo.By("Creating two CSIDrivers")
 		createdDriver1, err := client.Create(ctx, driver1, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Failed to create first CSIDriver")
+		gomega.Expect(createdDriver1).To(apimachineryutils.HaveValidResourceVersion())
 		createdDriver2, err := client.Create(ctx, driver2, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Failed to create second CSIDriver")
+		gomega.Expect(createdDriver2).To(apimachineryutils.HaveValidResourceVersion())
 		_, err = client.Create(ctx, driver1, metav1.CreateOptions{})
 		if !apierrors.IsAlreadyExists(err) {
 			framework.Failf("expected 409, got %#v", err)

--- a/test/e2e/storage/csi_inline.go
+++ b/test/e2e/storage/csi_inline.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -214,6 +215,7 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		patchedCSIDriver, err := client.Patch(ctx, createdDriver2.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch CSIDriver %q", createdDriver2.Name)
 		gomega.Expect(patchedCSIDriver.Labels[createdDriver2.Name]).To(gomega.ContainSubstring("patched"), "Checking that patched label has been applied")
+		gomega.Expect(resourceversion.CompareResourceVersion(createdDriver2.ResourceVersion, patchedCSIDriver.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By(fmt.Sprintf("Updating the CSIDriver %q", createdDriver2.Name))
 		var updatedCSIDriver *storagev1.CSIDriver

--- a/test/e2e/storage/csi_node.go
+++ b/test/e2e/storage/csi_node.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -75,6 +76,7 @@ var _ = utils.SIGDescribe("CSINodes", func() {
 			patchedCSINode, err := csiNodeClient.Patch(ctx, csiNode.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 			framework.ExpectNoError(err, "Failed to patch csiNode %q", csiNode.Name)
 			gomega.Expect(patchedCSINode.Labels).To(gomega.HaveKeyWithValue(csiNode.Name, "patched"), "Checking that patched label has been applied")
+			gomega.Expect(resourceversion.CompareResourceVersion(csiNode.ResourceVersion, patchedCSINode.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 			patchedSelector := labels.Set{csiNode.Name: "patched"}.AsSelector().String()
 			ginkgo.By(fmt.Sprintf("Listing csiNodes with LabelSelector %q", patchedSelector))

--- a/test/e2e/storage/csi_node.go
+++ b/test/e2e/storage/csi_node.go
@@ -28,6 +28,7 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 
@@ -65,6 +66,7 @@ var _ = utils.SIGDescribe("CSINodes", func() {
 			ginkgo.By(fmt.Sprintf("Creating initial csiNode %q", initialCSINode.Name))
 			csiNode, err := csiNodeClient.Create(ctx, &initialCSINode, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create csiNode %q", initialCSINode.Name)
+			gomega.Expect(csiNode).To(apimachineryutils.HaveValidResourceVersion())
 
 			ginkgo.By(fmt.Sprintf("Getting initial csiNode %q", initialCSINode.Name))
 			retrievedCSINode, err := csiNodeClient.Get(ctx, initialCSINode.Name, metav1.GetOptions{})

--- a/test/e2e/storage/csistoragecapacity.go
+++ b/test/e2e/storage/csistoragecapacity.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -155,6 +156,7 @@ var _ = utils.SIGDescribe("CSIStorageCapacity", func() {
 		gottenCSC, err := cscClient.Get(ctx, csc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(gottenCSC.UID).To(gomega.Equal(createdCSC.UID))
+		gomega.Expect(gottenCSC).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing in namespace")
 		cscs, err := cscClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})

--- a/test/e2e/storage/csistoragecapacity.go
+++ b/test/e2e/storage/csistoragecapacity.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -169,6 +170,7 @@ var _ = utils.SIGDescribe("CSIStorageCapacity", func() {
 		patchedCSC, err := cscClient.Patch(ctx, createdCSC.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
 		framework.ExpectNoError(err)
 		gomega.Expect(patchedCSC.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
+		gomega.Expect(resourceversion.CompareResourceVersion(createdCSC.ResourceVersion, patchedCSC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		ginkgo.By("updating")
 		csrToUpdate := patchedCSC.DeepCopy()

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -506,12 +507,14 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			patchedPV, err := pvClient.Patch(ctx, initialPV.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 			framework.ExpectNoError(err, "Failed to patch PV %q", initialPV.Name)
 			gomega.Expect(patchedPV.Labels).To(gomega.HaveKeyWithValue(patchedPV.Name, "patched"), "Checking that patched label has been applied")
+			gomega.Expect(resourceversion.CompareResourceVersion(initialPV.ResourceVersion, patchedPV.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 			ginkgo.By(fmt.Sprintf("Patching the PVC %q", initialPVC.Name))
 			payload = "{\"metadata\":{\"labels\":{\"" + initialPVC.Name + "\":\"patched\"}}}"
 			patchedPVC, err := pvcClient.Patch(ctx, initialPVC.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 			framework.ExpectNoError(err, "Failed to patch PVC %q", initialPVC.Name)
 			gomega.Expect(patchedPVC.Labels).To(gomega.HaveKeyWithValue(patchedPVC.Name, "patched"), "Checking that patched label has been applied")
+			gomega.Expect(resourceversion.CompareResourceVersion(initialPVC.ResourceVersion, patchedPVC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 			ginkgo.By(fmt.Sprintf("Getting PV %q", patchedPV.Name))
 			retrievedPV, err := pvClient.Get(ctx, patchedPV.Name, metav1.GetOptions{})

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -495,12 +496,14 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			framework.ExpectNoError(err, "Failed to list PVs with the labelSelector: %q", volLabel.AsSelector().String())
 			gomega.Expect(pvList.Items).To(gomega.HaveLen(1))
 			initialPV := pvList.Items[0]
+			gomega.Expect(&initialPV).To(apimachineryutils.HaveValidResourceVersion())
 
 			ginkgo.By(fmt.Sprintf("Listing PVCs in namespace %q", ns))
 			pvcList, err := pvcClient.List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err, "Failed to list PVCs with the labelSelector: %q", volLabel.AsSelector().String())
 			gomega.Expect(pvcList.Items).To(gomega.HaveLen(1))
 			initialPVC := pvcList.Items[0]
+			gomega.Expect(&initialPVC).To(apimachineryutils.HaveValidResourceVersion())
 
 			ginkgo.By(fmt.Sprintf("Patching the PV %q", initialPV.Name))
 			payload := "{\"metadata\":{\"labels\":{\"" + initialPV.Name + "\":\"patched\"}}}"

--- a/test/e2e/storage/storageclass.go
+++ b/test/e2e/storage/storageclass.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -78,6 +79,7 @@ var _ = utils.SIGDescribe("StorageClasses", func() {
 			patchedStorageClass, err := scClient.Patch(ctx, retrievedStorageClass.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
 			framework.ExpectNoError(err, "failed to patch StorageClass %q", retrievedStorageClass.Name)
 			gomega.Expect(patchedStorageClass.Labels).To(gomega.HaveKeyWithValue(patchedStorageClass.Name, "patched"), "checking that patched label has been applied")
+			gomega.Expect(resourceversion.CompareResourceVersion(retrievedStorageClass.ResourceVersion, patchedStorageClass.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 			ginkgo.By(fmt.Sprintf("Delete StorageClass %q", patchedStorageClass.Name))
 			err = scClient.Delete(ctx, patchedStorageClass.Name, metav1.DeleteOptions{})

--- a/test/e2e/storage/storageclass.go
+++ b/test/e2e/storage/storageclass.go
@@ -27,6 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -69,6 +70,7 @@ var _ = utils.SIGDescribe("StorageClasses", func() {
 			ginkgo.By("Creating a StorageClass")
 			createdStorageClass, err := scClient.Create(ctx, initialSC, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create the requested StorageClass")
+			gomega.Expect(createdStorageClass).To(apimachineryutils.HaveValidResourceVersion())
 
 			ginkgo.By(fmt.Sprintf("Get StorageClass %q", createdStorageClass.Name))
 			retrievedStorageClass, err := scClient.Get(ctx, createdStorageClass.Name, metav1.GetOptions{})

--- a/test/e2e/storage/volume_attachment.go
+++ b/test/e2e/storage/volume_attachment.go
@@ -31,6 +31,7 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
+	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 
@@ -66,6 +67,7 @@ var _ = utils.SIGDescribe("VolumeAttachment", func() {
 			retrievedVA, err := vaClient.Get(ctx, firstVA, metav1.GetOptions{})
 			framework.ExpectNoError(err, "failed to get VolumeAttachment %q", firstVA)
 			gomega.Expect(retrievedVA.Name).To(gomega.Equal(firstVA), "Checking that retrieved VolumeAttachment has the correct name")
+			gomega.Expect(retrievedVA).To(apimachineryutils.HaveValidResourceVersion())
 
 			ginkgo.By(fmt.Sprintf("Patch VolumeAttachment %q on node %q", firstVA, vaNodeName))
 			payload := "{\"metadata\":{\"labels\":{\"" + retrievedVA.Name + "\":\"patched\"}}}"

--- a/test/e2e/storage/volume_attachment.go
+++ b/test/e2e/storage/volume_attachment.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -71,6 +72,7 @@ var _ = utils.SIGDescribe("VolumeAttachment", func() {
 			patchedVA, err := vaClient.Patch(ctx, retrievedVA.Name, types.MergePatchType, []byte(payload), metav1.PatchOptions{})
 			framework.ExpectNoError(err, "failed to patch PV %q", firstVA)
 			gomega.Expect(patchedVA.Labels).To(gomega.HaveKeyWithValue(patchedVA.Name, "patched"), "Checking that patched label has been applied")
+			gomega.Expect(resourceversion.CompareResourceVersion(retrievedVA.ResourceVersion, patchedVA.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 			patchedSelector := labels.Set{patchedVA.Name: "patched"}.AsSelector().String()
 			ginkgo.By(fmt.Sprintf("List VolumeAttachments with %q label", patchedSelector))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a helper function to client go to compare resource versions along with conformance tests ensuring that Resource Version comparability is respected in a conformant cluster

Adds conformance tests for GA types:
- [x] APIService
- [x] CertificateSigningRequest - test/e2e/auth/certificates.go
- [x] ConfigMap - test/e2e/common/node/configmap.go
- [x] ControllerRevision
- [x] CronJob - test/e2e/apps/cronjob.go
- [x] CSIDriver - test/e2e/storage/csi_inline.go
- [x] CSINode - test/e2e/storage/csi_node.go
- [x] CSIStorageCapacity - test/e2e/storage/csistoragecapacity.go
- [x] CustomResourceDefinition - test/e2e/apimachinery/crd_publish_openapi.go in `removes definition from spec when one version gets changed to not be served`
- [x] DaemonSet - test/e2e/apps/daemon_set.go
- [x] Deployment - test/e2e/apps/deployment.go
- [x] Endpoints - test/e2e/network/service.go
- [x] EndpointSlice - test/e2e/network/endpointslice.go
- [x] Event - test/e2e/instrumentation/events.go
- [x] FlowSchema - test/e2e/apimachinery/flowcontrol.go
- [x] Ingress - test/e2e/network/ingress.go
- [x] IngressClass - test/e2e/network/ingressclass.go
- [x] IPAddress - test/e2e/network/service_cidrs.go
- [x] Job - test/e2e/apps/job.go
- [x] Lease - test/e2e/common/node/lease.go
- [x] LimitRange - test/e2e/scheduling/limit_range.go
- [x] MutatingWebhookConfiguration - test/e2e/apimachinery/webhook.go
- [x] Namespace - test/e2e/apimachinery/namespace.go
- [x] Node - test/e2e/node/node_lifecycle.go
- [x] PersistentVolume - test/e2e/storage/persistent_volumes.go
- [x] PersistentVolumeClaim - test/e2e/storage/persistent_volumes.go
- [x] Pod - test/e2e/common/node/pods.go
- [x] PodDisruptionBudget - test/e2e/apps/disruption.go
- [x] PodTemplate - test/e2e/common/node/podtemplates.go
- [x] PriorityClass - test/e2e/scheduling/preemption.go in `verify PriorityClass endpoints can be operated with different HTTP methods`
- [x] PriorityLevelConfiguration - test/e2e/apimachinery/flowcontrol.go
- [x] ReplicaSet - test/e2e/apps/replica_set.go
- [x] ReplicationController - test/e2e/apps/rc.go
- [x] ResourceQuota - test/e2e/apimachinery/resource_quota.go
- [x] RuntimeClass - test/e2e/common/node/runtimeclass.go
- [x] Secret - test/e2e/common/node/secrets.go
- [x] Service - test/e2e/network/service.go in `should serve endpoints on same port and different protocols`
- [x] ServiceAccount - test/e2e/auth/service_accounts.go
- [x] StatefulSet - test/e2e/apps/statefulset.go
- [x] StorageClass - test/e2e/storage/storageclass.go
- [x] ValidatingAdmissionPolicy - test/e2e/apimachinery/validatingadmissionpolicy.go
- [x] ValidatingAdmissionPolicyBinding - test/e2e/apimachinery/validatingadmissionpolicy.go
- [x] ValidatingWebhookConfiguration - test/e2e/apimachinery/webhook.go
- [x] VolumeAttachment - test/e2e/storage/volume_attachment.go
- [x] Example custom resource - test/e2e/apimachinery/custom_resource_definition.go in `custom resource defaulting for requests and from storage works`, can compare the resourceVersion from the first `crClient.Create` to the second `crClient.Create` call

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5504
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)


If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
k8s.io/apimachinery: Introduce a helper function to compare resourceVersion strings from two objects of the same resource
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:

- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/5505
```
