### PR TITLE
fix: update ResourceClaim field Effect to be marked +required (was +optional)

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15932,6 +15932,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "effect"
+      ],
       "type": "object"
     },
     "io.k8s.api.resource.v1.ExactDeviceRequest": {
@@ -17324,6 +17327,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "effect"
+      ],
       "type": "object"
     },
     "io.k8s.api.resource.v1beta1.NetworkDeviceData": {
@@ -18464,6 +18470,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "effect"
+      ],
       "type": "object"
     },
     "io.k8s.api.resource.v1beta2.ExactDeviceRequest": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -1033,6 +1033,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "effect"
+        ],
         "type": "object"
       },
       "io.k8s.api.resource.v1.ExactDeviceRequest": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -1091,6 +1091,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "effect"
+        ],
         "type": "object"
       },
       "io.k8s.api.resource.v1beta1.NetworkDeviceData": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -1033,6 +1033,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "effect"
+        ],
         "type": "object"
       },
       "io.k8s.api.resource.v1beta2.ExactDeviceRequest": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -49407,6 +49407,7 @@ func schema_k8sio_api_resource_v1_DeviceToleration(ref common.ReferenceCallback)
 						},
 					},
 				},
+				Required: []string{"effect"},
 			},
 		},
 	}
@@ -51961,6 +51962,7 @@ func schema_k8sio_api_resource_v1beta1_DeviceToleration(ref common.ReferenceCall
 						},
 					},
 				},
+				Required: []string{"effect"},
 			},
 		},
 	}
@@ -54063,6 +54065,7 @@ func schema_k8sio_api_resource_v1beta2_DeviceToleration(ref common.ReferenceCall
 						},
 					},
 				},
+				Required: []string{"effect"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -1088,7 +1088,7 @@ message DeviceToleration {
   // Effect indicates the taint effect to match. Empty means match all taint effects.
   // When specified, allowed values are NoSchedule and NoExecute.
   //
-  // +optional
+  // +required
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1318,7 +1318,7 @@ type DeviceToleration struct {
 	// Effect indicates the taint effect to match. Empty means match all taint effects.
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
-	// +optional
+	// +required
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1210,7 +1210,7 @@ message DeviceToleration {
   // Effect indicates the taint effect to match. Empty means match all taint effects.
   // When specified, allowed values are NoSchedule and NoExecute.
   //
-  // +optional
+  // +required
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1326,7 +1326,7 @@ type DeviceToleration struct {
 	// Effect indicates the taint effect to match. Empty means match all taint effects.
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
-	// +optional
+	// +required
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1088,7 +1088,7 @@ message DeviceToleration {
   // Effect indicates the taint effect to match. Empty means match all taint effects.
   // When specified, allowed values are NoSchedule and NoExecute.
   //
-  // +optional
+  // +required
   optional string effect = 4;
 
   // TolerationSeconds represents the period of time the toleration (which must be

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1318,7 +1318,7 @@ type DeviceToleration struct {
 	// Effect indicates the taint effect to match. Empty means match all taint effects.
 	// When specified, allowed values are NoSchedule and NoExecute.
 	//
-	// +optional
+	// +required
 	Effect DeviceTaintEffect `json:"effect,omitempty" protobuf:"bytes,4,opt,name=effect,casttype=DeviceTaintEffect"`
 
 	// TolerationSeconds represents the period of time the toleration (which must be


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR updated the ResourceClaim.Effect field to have the correct Open API tag - +required (was +optional)

#### Which issue(s) this PR is related to:
fixes #134282 

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updated the ResourceClaim.Effect field to have the correct Open API tag - +required (was +optional)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
