### PR TITLE
Automated cherry pick of #133996: Disable too short scheduler_perf workloads

### DIFF
--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -139,8 +139,10 @@ The test cases labeled as `short` are executed in pull-kubernetes-integration jo
 | ci-kubernetes-integration-master | integration-test       |
 | pull-kubernetes-integration      | integration-test,short |
 | ci-benchmark-scheduler-perf      | performance            |
+| pull-kubernetes-scheduler-perf   | performance            |
 
 See the comment on [./misc/performance-config.yaml](./misc/performance-config.yaml) for the details.
+Workloads without any labels are good for local usage, because they run faster than performance ones.
 
 ## Scheduling throughput thresholds
 

--- a/test/integration/scheduler_perf/affinity/performance-config.yaml
+++ b/test/integration/scheduler_perf/affinity/performance-config.yaml
@@ -50,13 +50,11 @@
       initPods: 1
       measurePods: 4
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 100
       measurePods: 400
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 1000
@@ -117,7 +115,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -180,13 +177,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance]
     params:
       initNodes: 5000
       initPods: 5000
@@ -243,7 +238,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -305,13 +299,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 5000
@@ -387,13 +379,11 @@
       initPods: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 200
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance]
     params:
       initNodes: 5000
       initPods: 2000
@@ -460,7 +450,6 @@
       initNamespaces: 2
       measurePods: 6
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
@@ -537,7 +526,6 @@
       initNamespaces: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
@@ -617,7 +605,6 @@
       initNamespaces: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
@@ -694,14 +681,12 @@
       initNamespaces: 2
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
       initNamespaces: 10
       measurePods: 100
   - name: 5000Nodes
-    labels: [performance]
     params:
       initNodes: 5000
       initPodsPerNamespace: 50

--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -45,13 +45,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 1000
@@ -230,7 +228,6 @@
       initPods: 20
       measurePods: 5
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 2000
@@ -299,13 +296,11 @@
       initPods: 1
       measurePods: 10
   - name: 500Nodes/10Init/1kPods
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 10
       measurePods: 1000
   - name: 5kNodes/100Init/1kPods
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 100
@@ -377,12 +372,10 @@
       initNodes: 10
       measurePods: 100
   - name: 1000Nodes
-    labels: [performance, short]
     params:
       initNodes: 1000
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       measurePods: 2000
@@ -513,7 +506,6 @@
   - name: 1000Node_1000DeletingPods
     featureGates:
       SchedulerQueueingHints: false
-    labels: [performance, short]
     params:
       initNodes: 1000
       deletingPods: 1000
@@ -521,8 +513,23 @@
   - name: 1000Node_1000DeletingPods_QueueingHintsEnabled
     featureGates:
       SchedulerQueueingHints: true
-    labels: [performance, short]
     params:
       initNodes: 1000
       deletingPods: 1000
       measurePods: 1000
+  - name: 5000Node_5000DeletingPods
+    featureGates:
+      SchedulerQueueingHints: false
+    labels: [performance]
+    params:
+      initNodes: 5000
+      deletingPods: 5000
+      measurePods: 5000
+  - name: 5000Node_5000DeletingPods_QueueingHintsEnabled
+    featureGates:
+      SchedulerQueueingHints: true
+    labels: [performance]
+    params:
+      initNodes: 5000
+      deletingPods: 5000
+      measurePods: 5000

--- a/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
+++ b/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
@@ -50,7 +50,6 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 1000
@@ -113,7 +112,6 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 1000
@@ -182,7 +180,6 @@
       initPods: 10
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 1000
@@ -241,7 +238,6 @@
       normalNodes: 4
       measurePods: 4
   - name: 500Nodes
-    labels: [performance, short]
     params:
       taintNodes: 100
       normalNodes: 400

--- a/test/integration/scheduler_perf/volumes/performance-config.yaml
+++ b/test/integration/scheduler_perf/volumes/performance-config.yaml
@@ -45,13 +45,11 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
-    labels: [performance, short]
     params:
       initNodes: 5000
       initPods: 5000
@@ -106,7 +104,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -176,7 +173,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500
@@ -244,7 +240,6 @@
       initPods: 5
       measurePods: 10
   - name: 500Nodes
-    labels: [performance, short]
     params:
       initNodes: 500
       initPods: 500


### PR DESCRIPTION
Cherry pick of #133996 on release-1.33.

#133996: Disable too short scheduler_perf workloads

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Integration tests often timeout at k8s.io/kubernetes/test/integration/scheduler_perf/affinity.affinity
These changes were merged onto master but never back-ported. 
Cherry-picking them to avoid timeout in release branch.
```