### PR TITLE
Deprecate obsolete slice utility functions

### DIFF
--- a/cmd/cloud-controller-manager/.import-restrictions
+++ b/cmd/cloud-controller-manager/.import-restrictions
@@ -41,6 +41,5 @@ rules:
       - k8s.io/kubernetes/pkg/util/taints
       - k8s.io/kubernetes/pkg/proxy/util
       - k8s.io/kubernetes/pkg/proxy/util/testing
-      - k8s.io/kubernetes/pkg/util/slice
       - k8s.io/kubernetes/pkg/util/sysctl
       - k8s.io/kubernetes/test/utils/ktesting

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -19,6 +19,7 @@ package persistentvolume
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -411,7 +412,7 @@ func modifyDeletionFinalizers(logger klog.Logger, cmpm CSIMigratedPluginManager,
 	provisioner := volume.Annotations[storagehelpers.AnnDynamicallyProvisioned]
 	if cmpm.IsMigrationEnabledForPlugin(provisioner) {
 		// Remove in-tree delete finalizer on the PV as migration is enabled.
-		if slice.ContainsString(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer, nil) {
+		if slices.Contains(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer) {
 			outFinalizers = slice.RemoveString(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer, nil)
 			modified = true
 		}
@@ -424,18 +425,18 @@ func modifyDeletionFinalizers(logger klog.Logger, cmpm CSIMigratedPluginManager,
 	}
 	reclaimPolicy := volume.Spec.PersistentVolumeReclaimPolicy
 	// Add back the in-tree PV deletion protection finalizer if does not already exists
-	if reclaimPolicy == v1.PersistentVolumeReclaimDelete && !slice.ContainsString(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer, nil) {
+	if reclaimPolicy == v1.PersistentVolumeReclaimDelete && !slices.Contains(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer) {
 		logger.V(4).Info("Adding in-tree pv deletion protection finalizer on volume", "volumeName", volume.Name)
 		outFinalizers = append(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer)
 		modified = true
-	} else if (reclaimPolicy == v1.PersistentVolumeReclaimRetain || reclaimPolicy == v1.PersistentVolumeReclaimRecycle) && slice.ContainsString(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer, nil) {
+	} else if (reclaimPolicy == v1.PersistentVolumeReclaimRetain || reclaimPolicy == v1.PersistentVolumeReclaimRecycle) && slices.Contains(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer) {
 		// Remove the in-tree PV deletion protection finalizer if the reclaim policy is 'Retain' or 'Recycle'
 		logger.V(4).Info("Removing in-tree pv deletion protection finalizer on volume", "volumeName", volume.Name)
 		outFinalizers = slice.RemoveString(outFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer, nil)
 		modified = true
 	}
 	// Remove the external PV deletion protection finalizer
-	if slice.ContainsString(outFinalizers, storagehelpers.PVDeletionProtectionFinalizer, nil) {
+	if slices.Contains(outFinalizers, storagehelpers.PVDeletionProtectionFinalizer) {
 		logger.V(4).Info("Removing external pv deletion protection finalizer on volume", "volumeName", volume.Name)
 		outFinalizers = slice.RemoveString(outFinalizers, storagehelpers.PVDeletionProtectionFinalizer, nil)
 		modified = true

--- a/pkg/controller/volume/protectionutil/utils.go
+++ b/pkg/controller/volume/protectionutil/utils.go
@@ -17,18 +17,17 @@ limitations under the License.
 package protectionutil
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/util/slice"
 )
 
 // IsDeletionCandidate checks if object is candidate to be deleted
 func IsDeletionCandidate(obj metav1.Object, finalizer string) bool {
-	return obj.GetDeletionTimestamp() != nil && slice.ContainsString(obj.GetFinalizers(),
-		finalizer, nil)
+	return obj.GetDeletionTimestamp() != nil && slices.Contains(obj.GetFinalizers(), finalizer)
 }
 
 // NeedToAddFinalizer checks if need to add finalizer to object
 func NeedToAddFinalizer(obj metav1.Object, finalizer string) bool {
-	return obj.GetDeletionTimestamp() == nil && !slice.ContainsString(obj.GetFinalizers(),
-		finalizer, nil)
+	return obj.GetDeletionTimestamp() == nil && !slices.Contains(obj.GetFinalizers(), finalizer)
 }

--- a/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
-	"k8s.io/kubernetes/pkg/util/slice"
 	"k8s.io/utils/ptr"
 )
 
@@ -374,7 +373,7 @@ func createResourceRequestAndMappings(containerIndex int, container *v1.Containe
 	}
 	// resource requests in a container is a map, their names must
 	// be sorted to determine the resource's index order.
-	slice.SortStrings(keys)
+	slices.Sort(keys)
 	ridx := 0
 	for j := range keys {
 		if keys[j] == rName.String() {

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"sort"
 	"time"
 
@@ -44,7 +45,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
-	"k8s.io/kubernetes/pkg/util/slice"
 )
 
 const (
@@ -654,7 +654,7 @@ func (f *frameworkImpl) expandMultiPointPlugins(logger klog.Logger, profile *con
 		// - part 3: other plugins (excluded by part 1 & 2) in regular extension point.
 		newPlugins := reflect.New(reflect.TypeOf(e.slicePtr).Elem()).Elem()
 		// part 1
-		for _, name := range slice.CopyStrings(enabledSet.list) {
+		for _, name := range slices.Clone(enabledSet.list) {
 			if overridePlugins.has(name) {
 				newPlugins = reflect.Append(newPlugins, reflect.ValueOf(f.pluginsMap[name]))
 				enabledSet.delete(name)

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -18,37 +18,38 @@ limitations under the License.
 package slice
 
 import (
-	"sort"
+	"slices"
 )
 
 // CopyStrings copies the contents of the specified string slice
 // into a new slice.
+//
+// Deprecated: Use slices.Clone instead.
+//
+//go:fix inline
 func CopyStrings(s []string) []string {
-	if s == nil {
-		return nil
-	}
-	c := make([]string, len(s))
-	copy(c, s)
-	return c
+	return slices.Clone(s)
 }
 
 // SortStrings sorts the specified string slice in place. It returns the same
 // slice that was provided in order to facilitate method chaining.
+//
+// Deprecated: Use slices.Sort instead.
 func SortStrings(s []string) []string {
-	sort.Strings(s)
+	slices.Sort(s)
 	return s
 }
 
 // ContainsString checks if a given slice of strings contains the provided string.
 // If a modifier func is provided, it is called with the slice item before the comparation.
+//
+// Deprecated: Use slices.ContainsFunc or slices.Contains instead.
 func ContainsString(slice []string, s string, modifier func(s string) string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-		if modifier != nil && modifier(item) == s {
-			return true
-		}
+	if slices.Contains(slice, s) {
+		return true
+	}
+	if modifier != nil {
+		return slices.ContainsFunc(slice, func(item string) bool { return modifier(item) == s })
 	}
 	return false
 }

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"slices"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -30,7 +31,6 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/util/slice"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/utils/ptr"
 )
@@ -386,7 +386,9 @@ func TestMountOptionFromSpec(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		mountOptions := MountOptionFromSpec(scenario.volume, scenario.systemOptions...)
-		if !reflect.DeepEqual(slice.SortStrings(mountOptions), slice.SortStrings(scenario.expectedMountList)) {
+		slices.Sort(mountOptions)
+		slices.Sort(scenario.expectedMountList)
+		if !reflect.DeepEqual(mountOptions, scenario.expectedMountList) {
 			t.Errorf("for %s expected mount options : %v got %v", name, scenario.expectedMountList, mountOptions)
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -81,7 +81,6 @@ import (
 	"k8s.io/kubectl/pkg/util/qos"
 	"k8s.io/kubectl/pkg/util/rbac"
 	resourcehelper "k8s.io/kubectl/pkg/util/resource"
-	"k8s.io/kubectl/pkg/util/slice"
 	storageutil "k8s.io/kubectl/pkg/util/storage"
 )
 
@@ -312,7 +311,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 		switch typedValue := value.(type) {
 		case map[string]interface{}:
 			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
-			if slice.Contains[string](skip, skipExpr, nil) {
+			if slices.Contains(skip, skipExpr) {
 				continue
 			}
 			w.Write(level, "%s:\n", smartLabelFor(field))
@@ -320,7 +319,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 
 		case []interface{}:
 			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
-			if slice.Contains[string](skip, skipExpr, nil) {
+			if slices.Contains(skip, skipExpr) {
 				continue
 			}
 			w.Write(level, "%s:\n", smartLabelFor(field))
@@ -335,7 +334,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 
 		default:
 			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
-			if slice.Contains[string](skip, skipExpr, nil) {
+			if slices.Contains(skip, skipExpr) {
 				continue
 			}
 			w.Write(level, "%s:\t%v\n", smartLabelFor(field), typedValue)
@@ -383,7 +382,7 @@ func smartLabelFor(field string) string {
 			continue
 		}
 
-		if slice.Contains(commonAcronyms, strings.ToUpper(part), nil) {
+		if slices.Contains(commonAcronyms, strings.ToUpper(part)) {
 			part = strings.ToUpper(part)
 		} else if strings.ToLower(part) == part {
 			part = cases.Title(language.English).String(part)

--- a/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/slice/slice.go
@@ -18,36 +18,35 @@ package slice
 
 import "slices"
 
-// SortInts64 sorts []int64 in increasing order
+// SortInts64 sorts []int64 in increasing order.
+//
+// Deprecated: Use slices.Sort instead.
+//
+//go:fix inline
 func SortInts64(a []int64) { slices.Sort(a) }
 
 // Contains checks if a given slice of type T contains the provided item.
 // If a modifier func is provided, it is called with the slice item before the comparation.
+//
+// Deprecated: Use slices.Contains or slices.ContainsFunc instead.
 func Contains[T comparable](slice []T, s T, modifier func(s T) T) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-		if modifier != nil && modifier(item) == s {
-			return true
-		}
+	if slices.Contains(slice, s) {
+		return true
+	}
+	if modifier != nil {
+		return slices.ContainsFunc(slice, func(item T) bool { return modifier(item) == s })
 	}
 	return false
 }
 
 // ContainsString checks if a given slice of strings contains the provided string.
 // If a modifier func is provided, it is called with the slice item before the comparation.
-// Deprecated: Use Contains[T] instead
+//
+// Deprecated: Use slices.Contains or slices.ContainsFunc instead.
+//
+//go:fix inline
 func ContainsString(slice []string, s string, modifier func(s string) string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-		if modifier != nil && modifier(item) == s {
-			return true
-		}
-	}
-	return false
+	return Contains(slice, s, modifier)
 }
 
 // ToSet returns a single slice containing the unique values from one or more slices. The order of the items in the

--- a/test/e2e/apps/ttl_after_finished.go
+++ b/test/e2e/apps/ttl_after_finished.go
@@ -19,6 +19,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -26,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/pkg/util/slice"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ejob "k8s.io/kubernetes/test/e2e/framework/job"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -57,7 +57,7 @@ func cleanupJob(ctx context.Context, f *framework.Framework, job *batchv1.Job) {
 
 	framework.Logf("Remove the Job's dummy finalizer; the Job should be deleted cascadingly")
 	removeFinalizerFunc := func(j *batchv1.Job) {
-		j.ObjectMeta.Finalizers = slice.RemoveString(j.ObjectMeta.Finalizers, dummyFinalizer, nil)
+		j.ObjectMeta.Finalizers = slices.DeleteFunc(j.ObjectMeta.Finalizers, func(actual string) bool { return actual == dummyFinalizer })
 	}
 	_, err := updateJobWithRetries(ctx, c, ns, job.Name, removeFinalizerFunc)
 	framework.ExpectNoError(err)

--- a/test/integration/apiserver/oidc/oidc_test.go
+++ b/test/integration/apiserver/oidc/oidc_test.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -63,7 +64,6 @@ import (
 	kubeapiserverapptesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/kubeapiserver/options"
-	"k8s.io/kubernetes/pkg/util/slice"
 	"k8s.io/kubernetes/test/integration/framework"
 	utilsoidc "k8s.io/kubernetes/test/utils/oidc"
 	"k8s.io/kubernetes/test/utils/oidc/handlers"
@@ -1859,7 +1859,7 @@ jwt:
 	adminClient := kubernetes.NewForConfigOrDie(apiServer.ClientConfig)
 	gotMetricStrings := getMetrics(t, ctx, adminClient, "apiserver_authentication_jwt_authenticator_jwks_")
 
-	wantMetricStrings = slice.SortStrings(wantMetricStrings)
+	slices.Sort(wantMetricStrings)
 
 	if diff := cmp.Diff(wantMetricStrings, gotMetricStrings); diff != "" {
 		t.Errorf("unexpected metrics diff (-want +got): %s", diff)
@@ -1980,7 +1980,7 @@ jwt:
 	}
 	gotMetricStrings := getMetrics(t, ctx, adminClient, "apiserver_authentication_jwt_authenticator_jwks_")
 
-	wantMetricStrings = slice.SortStrings(wantMetricStrings)
+	slices.Sort(wantMetricStrings)
 	if diff := cmp.Diff(wantMetricStrings, gotMetricStrings); diff != "" {
 		t.Errorf("unexpected metrics before reload diff (-want +got): %s", diff)
 	}
@@ -2034,7 +2034,7 @@ jwt:
 		fmt.Sprintf(`apiserver_authentication_jwt_authenticator_jwks_fetch_last_key_set_info{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",hash="%s",jwt_issuer_hash="%s"} 1`, keySetHash1, jwtIssuerHash1),
 		fmt.Sprintf(`apiserver_authentication_jwt_authenticator_jwks_fetch_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",jwt_issuer_hash="%s",result="success"} FP`, jwtIssuerHash1),
 	}
-	wantMetricStringsAfterReload = slice.SortStrings(wantMetricStringsAfterReload)
+	slices.Sort(wantMetricStringsAfterReload)
 
 	err = wait.PollUntilContextTimeout(ctx, time.Second, 120*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		gotMetricStrings := getMetrics(t, ctx, adminClient, "apiserver_authentication_jwt_authenticator_jwks_")
@@ -2096,7 +2096,9 @@ func getMetrics(t *testing.T, ctx context.Context, adminClient *kubernetes.Clien
 		}
 	}
 
-	return slice.SortStrings(gotMetricStrings)
+	slices.Sort(gotMetricStrings)
+
+	return gotMetricStrings
 }
 
 func rsaGenerateKey(t *testing.T) (*rsa.PrivateKey, *rsa.PublicKey) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This deprecates obsolete slice utility functions in the project, and replaces their uses with standard library function calls (with a new helper for `slices.DeleteFunc`). This helps reduce the amount of project-specific code we need to maintain.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
