### PR TITLE
Fix passing runtime.Object to HaveValidResourceVersion check

### DIFF
--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -166,7 +166,7 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 			framework.ExpectNoError(err, "failed to lookup ControllerRevision: %v", err)
 			gomega.Expect(initialRevision).NotTo(gomega.BeNil(), "failed to lookup ControllerRevision: %v", initialRevision)
 		}
-		gomega.Expect(rev).To(apimachineryutils.HaveValidResourceVersion())
+		gomega.Expect(&rev).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By(fmt.Sprintf("Patching ControllerRevision %q", initialRevision.Name))
 		payload := "{\"metadata\":{\"labels\":{\"" + initialRevision.Name + "\":\"patched\"}}}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fixes test failure introduced in https://github.com/kubernetes/kubernetes/pull/134330/files#diff-7a4b9ed47f93f9c6a67fd91925a32ff1d2c92d9e8d757d4caa395d6fb84191db

https://testgrid.k8s.io/sig-release-master-blocking#Conformance%20-%20GCE%20-%20master&exclude-non-failed-tests=

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig apps api-machinery
/cc @michaelasp 