### PR TITLE
doc: misspelling in csi_fsgroup_policy.go

### DIFF
--- a/test/e2e/storage/csimock/csi_fsgroup_policy.go
+++ b/test/e2e/storage/csimock/csi_fsgroup_policy.go
@@ -113,7 +113,7 @@ var _ = utils.SIGDescribe("CSI Mock volume fsgroup policies", func() {
 				newFSGroupPolicy: storagev1.NoneFSGroupPolicy,
 			},
 			{
-				name:             "should update fsGroup if update from detault to File",
+				name:             "should update fsGroup if update from default to File",
 				oldFSGroupPolicy: storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy,
 				newFSGroupPolicy: storagev1.FileFSGroupPolicy,
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Fixes spelling

#### Which issue(s) this PR is related to:
n/a

#### Special notes for your reviewer:
spelling was off, and wanted to clarify

#### Does this PR introduce a user-facing change?
n/a

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
n/a