### PR TITLE
test/e2e_node: mark MirrorPod update tests as [NodeConformance]

### DIFF
--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -300,7 +300,7 @@ var _ = SIGDescribe("MirrorPod (Pod Generation)", func() {
 			}, 2*time.Minute, time.Second*4).Should(gomega.Succeed())
 		})
 
-		f.It("mirror pod: update activeDeadlineSeconds", func(ctx context.Context) {
+		f.It("mirror pod: update activeDeadlineSeconds", f.WithNodeConformance(), func(ctx context.Context) {
 			ginkgo.By("get mirror pod uid")
 			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, mirrorPodName, metav1.GetOptions{})
 			framework.ExpectNoError(err)
@@ -323,7 +323,7 @@ var _ = SIGDescribe("MirrorPod (Pod Generation)", func() {
 			gomega.Expect(pod.Status.ObservedGeneration).To(gomega.BeEquivalentTo(int64(0)))
 		})
 
-		f.It("mirror pod: update container image", func(ctx context.Context) {
+		f.It("mirror pod: update container image", f.WithNodeConformance(), func(ctx context.Context) {
 			ginkgo.By("get mirror pod uid")
 			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, mirrorPodName, metav1.GetOptions{})
 			framework.ExpectNoError(err)
@@ -346,7 +346,7 @@ var _ = SIGDescribe("MirrorPod (Pod Generation)", func() {
 			gomega.Expect(pod.Status.ObservedGeneration).To(gomega.BeEquivalentTo(int64(0)))
 		})
 
-		f.It("mirror pod: update initContainer image", func(ctx context.Context) {
+		f.It("mirror pod: update initContainer image", f.WithNodeConformance(), func(ctx context.Context) {
 			ginkgo.By("get mirror pod uid")
 			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, mirrorPodName, metav1.GetOptions{})
 			framework.ExpectNoError(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup  
/sig node  
/area conformance  
/priority backlog  

#### What this PR does:

This PR marks three MirrorPod update tests as `[NodeConformance]` by wrapping them in `f.WithNodeConformance()`.  

Targeted tests:  
- mirror pod: update activeDeadlineSeconds  
- mirror pod: update container image  
- mirror pod: update initContainer image  

Why:  
- These validate kubelet static pod → mirror pod update paths.  
- This is a kubelet requirement (NodeConformance), but not a GA API guarantee.  
- No changes to `conformance.yaml` required.  

#### Which issue(s) this PR is related to:

- Follow-up to kubernetes/kubernetes#134062 (ConfigMap update NodeConformance).  
- Umbrella: kubernetes/test-infra#33827  

#### Special notes:

- Screenshot below: shows that one ConfigMap test already became **stale** (after #134062), while the three MirrorPod update tests remain in the **unlabelled lane** — which this PR addresses.  
<img width="1091" height="842" alt="image" src="https://github.com/user-attachments/assets/0fcbf820-7d8b-4aac-9596-97c95cb409a7" />  

- No flakes found in the past 2 weeks:  
  - [update activeDeadlineSeconds](https://storage.googleapis.com/k8s-triage/index.html?date=2025-09-19&pr=1&test=update%20activeDeadlineSeconds)  
  - [update container image](https://storage.googleapis.com/k8s-triage/index.html?date=2025-09-19&pr=1&test=update%20container%20image)  
  - [update initContainer image](https://storage.googleapis.com/k8s-triage/index.html?date=2025-09-19&pr=1&test=update%20initContainer%20image)  

- Git blame checked — no indication these tests were intentionally excluded.  

#### Does this PR introduce a user-facing change?

```release-note
NONE
```