### PR TITLE
Update hostpathplugin image version in DRA test driver manifest

### DIFF
--- a/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
+++ b/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: pause
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.7.3
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update image from v1.7.3 to v1.16.1 to avoid pulling multiple images in CI.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
