### PR TITLE
Introduce --as-user-extra persistent flag in kubectl

### DIFF
--- a/test/cmd/authorization.sh
+++ b/test/cmd/authorization.sh
@@ -74,11 +74,12 @@ run_impersonation_tests() {
     kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
 
     # --as-user-extra
-    kubectl create -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}" --as=user1 --as-uid=abc123 --as-user-extra key1="val1,val2" --as-user-extra key2=val3
+    kubectl create -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}" --as=user1 --as-uid=abc123 \
+    --as-user-extra key1="hello there" --as-user-extra key1="one,two" --as-user-extra key1="pandas are" --as-user-extra key1="the best" --as-user-extra key2=val3
     kubectl get csr/foo -oyaml
     kube::test::get_object_assert 'csr/foo' '{{.spec.username}}' 'user1'
     kube::test::get_object_assert 'csr/foo' '{{.spec.uid}}' 'abc123'
-    kube::test::get_object_assert 'csr/foo' '{{range .spec.extra.key1}}{{.}} {{end}}' 'val1 val2 '
+    kube::test::get_object_assert 'csr/foo' '{{range .spec.extra.key1}}{{.}} {{end}}' 'hello there one,two pandas are the best '
     kube::test::get_object_assert 'csr/foo' '{{range .spec.extra.key2}}{{.}} {{end}}' 'val3 '
     kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
 

--- a/test/cmd/authorization.sh
+++ b/test/cmd/authorization.sh
@@ -73,6 +73,15 @@ run_impersonation_tests() {
     kube::test::get_object_assert 'csr/foo' '{{.spec.uid}}' 'abc123'
     kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
 
+    # --as-user-extra
+    kubectl create -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}" --as=user1 --as-uid=abc123 --as-user-extra key1="val1,val2" --as-user-extra key2=val3
+    kubectl get csr/foo -oyaml
+    kube::test::get_object_assert 'csr/foo' '{{.spec.username}}' 'user1'
+    kube::test::get_object_assert 'csr/foo' '{{.spec.uid}}' 'abc123'
+    kube::test::get_object_assert 'csr/foo' '{{range .spec.extra.key1}}{{.}} {{end}}' 'val1 val2 '
+    kube::test::get_object_assert 'csr/foo' '{{range .spec.extra.key2}}{{.}} {{end}}' 'val3 '
+    kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
+
   fi
 
   set +o nounset


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

[API definitions](https://github.com/kubernetes/kubernetes/blob/33cd2e1ba08bf6b936c0c2c29bcabe502ce75851/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go#L133) support accepting `as-user-extras` during impersonation. Based on the references issue, kubeconfig also supports passing user extras. The only missing piece looks like kubectl lacks the persistent flag that wires user extra to this API definitions during impersonation. 

This PR achieves this.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/130389

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Introducing new flag --as-user-extra persistent flag in kubectl that can be used to pass extra arguments during the impersonation
```