### PR TITLE
Lock all mutable fields when printing gc node

### DIFF
--- a/pkg/controller/garbagecollector/graph.go
+++ b/pkg/controller/garbagecollector/graph.go
@@ -206,10 +206,17 @@ func ownerReferenceMatchesCoordinates(a, b metav1.OwnerReference) bool {
 }
 
 // String renders node as a string using fmt. Acquires a read lock to ensure the
-// reflective dump of dependents doesn't race with any concurrent writes.
+// reflective dump of fields doesn't race with any concurrent writes.
 func (n *node) String() string {
+	n.beingDeletedLock.RLock()
+	defer n.beingDeletedLock.RUnlock()
+
+	n.virtualLock.RLock()
+	defer n.virtualLock.RUnlock()
+
 	n.dependentsLock.RLock()
 	defer n.dependentsLock.RUnlock()
+
 	return fmt.Sprintf("%#v", n)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes https://github.com/kubernetes/kubernetes/issues/134371

There are multiple mutable fields in the `node` type, we need to read lock all of them before printing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-controller-manager: Fixes a possible data race in the garbage collection controller
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig api-machinery
/cc @pohly 
