### PR TITLE
fix nested map segmentation fault

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
@@ -249,7 +249,7 @@ var _ LookupPatchMeta = PatchMetaFromOpenAPI{}
 
 func (s PatchMetaFromOpenAPI) LookupPatchMetadataForStruct(key string) (LookupPatchMeta, PatchMeta, error) {
 	if s.Schema == nil {
-		return nil, PatchMeta{}, nil
+		return &PatchMetaFromOpenAPI{}, PatchMeta{}, nil
 	}
 	kindItem := NewKindItem(key, s.Schema.GetPath())
 	s.Schema.Accept(kindItem)

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -25,7 +25,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/dump"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -98,19 +97,19 @@ type StrategicMergePatchRawTestCaseData struct {
 }
 
 type MergeItem struct {
-	Name                  string                `json:"name,omitempty"`
-	Value                 string                `json:"value,omitempty"`
-	Other                 string                `json:"other,omitempty"`
-	MergingList           []MergeItem           `json:"mergingList,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
-	NonMergingList        []MergeItem           `json:"nonMergingList,omitempty"`
-	MergingIntList        []int                 `json:"mergingIntList,omitempty" patchStrategy:"merge"`
-	NonMergingIntList     []int                 `json:"nonMergingIntList,omitempty"`
-	MergeItemPtr          *MergeItem            `json:"mergeItemPtr,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
-	SimpleMap             map[string]string     `json:"simpleMap,omitempty"`
-	ReplacingItem         runtime.RawExtension  `json:"replacingItem,omitempty" patchStrategy:"replace"`
-	JsonItem              *apiextensionsv1.JSON `json:"jsonItem,omitempty"`
-	RetainKeysMap         RetainKeysMergeItem   `json:"retainKeysMap,omitempty" patchStrategy:"retainKeys"`
-	RetainKeysMergingList []MergeItem           `json:"retainKeysMergingList,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+	Name                  string               `json:"name,omitempty"`
+	Value                 string               `json:"value,omitempty"`
+	Other                 string               `json:"other,omitempty"`
+	MergingList           []MergeItem          `json:"mergingList,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	NonMergingList        []MergeItem          `json:"nonMergingList,omitempty"`
+	MergingIntList        []int                `json:"mergingIntList,omitempty" patchStrategy:"merge"`
+	NonMergingIntList     []int                `json:"nonMergingIntList,omitempty"`
+	MergeItemPtr          *MergeItem           `json:"mergeItemPtr,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	SimpleMap             map[string]string    `json:"simpleMap,omitempty"`
+	ReplacingItem         runtime.RawExtension `json:"replacingItem,omitempty" patchStrategy:"replace"`
+	JSONItem              struct{ Raw []byte } `json:"jsonItem,omitempty"`
+	RetainKeysMap         RetainKeysMergeItem  `json:"retainKeysMap,omitempty" patchStrategy:"retainKeys"`
+	RetainKeysMergingList []MergeItem          `json:"retainKeysMergingList,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 }
 
 type RetainKeysMergeItem struct {

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item-v3.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item-v3.json
@@ -96,6 +96,14 @@
             },
             "x-kubernetes-patch-merge-key": "name",
             "x-kubernetes-patch-strategy": "merge,retainKeys"
+          },
+          "jsonItem": {
+            "description": "Values are the chart values.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+              }
+            ]
           }
         },
         "x-kubernetes-group-version-kind": [
@@ -161,6 +169,9 @@
             "version": "some-version"
           }
         ]
+      },
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON": {
+        "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
       },
       "io.k8s.apimachinery.pkg.runtime.RawExtension": {
         "description": "RawExtension is used to hold extensions in external versions.",

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item-v3.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item-v3.json
@@ -98,12 +98,7 @@
             "x-kubernetes-patch-strategy": "merge,retainKeys"
           },
           "jsonItem": {
-            "description": "Values are the chart values.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
-              }
-            ]
+            "description": "Values are the chart values."
           }
         },
         "x-kubernetes-group-version-kind": [
@@ -169,9 +164,6 @@
             "version": "some-version"
           }
         ]
-      },
-      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON": {
-        "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
       },
       "io.k8s.apimachinery.pkg.runtime.RawExtension": {
         "description": "RawExtension is used to hold extensions in external versions.",

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item.json
@@ -86,6 +86,10 @@
           },
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge,retainKeys"
+        },
+        "jsonItem": {
+          "description": "JSON field",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON",
         }
       },
       "x-kubernetes-group-version-kind": [
@@ -152,6 +156,9 @@
           "version": "some-version"
         }
       ]
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON": {
+      "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
     },
     "io.k8s.apimachinery.pkg.runtime.RawExtension": {
       "description": "RawExtension is used to hold extensions in external versions.",

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item.json
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testdata/swagger-merge-item.json
@@ -89,7 +89,6 @@
         },
         "jsonItem": {
           "description": "JSON field",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON",
         }
       },
       "x-kubernetes-group-version-kind": [
@@ -156,9 +155,6 @@
           "version": "some-version"
         }
       ]
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON": {
-      "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
     },
     "io.k8s.apimachinery.pkg.runtime.RawExtension": {
       "description": "RawExtension is used to hold extensions in external versions.",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes an issue with client-side patches in nested maps.  Example logs:

```
k apply -f provider-aws.yaml
warning: error calculating patch from openapi v3 spec: unable to find api field "image"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x10349c604]

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff({0x14001e0b670, 0xa}, 0x14001690690, 0x1400167de60, 0x140016accf0, {0x0?, 0x0?}, {0x80?, 0x5?, 0x10?, ...})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:263 +0x44
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0x14001690660, 0x1400167de30, {0x0, 0x0}, {0x20?, 0xed?, 0xb4?, 0xc?})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x3a0
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff({0x14001e0b660, 0xe}, 0x14001690660, 0x1400167de30, 0x140016acc90, {0x1045778e0?, 0x140014645f0?}, {0x0?, 0x0?, 0x0?, ...})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:286 +0x1c8
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0x14001690630, 0x1400167de00, {0x1045778e0, 0x140014645f0}, {0x0?, 0x0?, 0x0?, 0x0?})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x3a0
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff({0x14001e0b64b, 0x3}, 0x14001690630, 0x1400167de00, 0x140016acba0, {0x1045778e0?, 0x14001464580?}, {0x0?, 0x0?, 0x0?, ...})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:286 +0x1c8
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0x14001690060, 0x1400167d9b0, {0x1045778e0, 0x14001464580}, {0x10?, 0xed?, 0xa3?, 0xc?})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x3a0
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff({0x14001e0b4e0, 0x6}, 0x14001690060, 0x1400167d9b0, 0x140016acb40, {0x1045778e0?, 0x14001464530?}, {0x0?, 0x0?, 0x0?, ...})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:286 +0x1c8
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0x14001690000, 0x1400167d860, {0x1045778e0, 0x14001464530}, {0x0?, 0x0?, 0x0?, 0x0?})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x3a0
k8s.io/apimachinery/pkg/util/strategicpatch.handleMapDiff({0x14001e0b6a4, 0x4}, 0x14001690000, 0x1400167d860, 0x140016acb10, {0x1045778e0?, 0x1400127dc20?}, {0x94?, 0x7b?, 0x89?, ...})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:286 +0x1c8
k8s.io/apimachinery/pkg/util/strategicpatch.diffMaps(0x1400167df50, 0x1400167d830, {0x1045778e0, 0x1400127dc20}, {0x88?, 0x40?, 0x5a?, 0x3?})
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:212 +0x3a0
k8s.io/apimachinery/pkg/util/strategicpatch.CreateThreeWayMergePatch({0x14000ef7000, 0x2e6c, 0x3000}, {0x14000e2c000, 0x5e59, 0x6000}, {0x14000f0c000, 0x66ef, 0x6a80}, {0x1045778e0, ...}, ...)
        k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:2135 +0x228
k8s.io/kubectl/pkg/cmd/apply.(*Patcher).buildStrategicMergeFromOpenAPI(0x14000069960, {0x10456f340?, 0x14000dd7b40?}, {0x14000ef7000, 0x2e6c, 0x3000}, {0x14000e2c000, 0x5e59, 0x6000}, {0x14000f0c000, ...})
        k8s.io/kubectl/pkg/cmd/apply/patcher.go:320 +0x108
k8s.io/kubectl/pkg/cmd/apply.(*Patcher).patchSimple(0x14000069960, {0x10456e290, 0x14000512100}, {0x14000e2c000, 0x5e59, 0x6000}, {0x0, 0x0}, {0x14000900e10, 0xc}, ...)
        k8s.io/kubectl/pkg/cmd/apply/patcher.go:166 +0x6a8
k8s.io/kubectl/pkg/cmd/apply.(*Patcher).Patch(0x14000069960, {0x10456e290, 0x14000512100}, {0x14000e2c000, 0x5e59, 0x6000}, {0x14000051db8, 0x11}, {0x0, 0x0}, ...)
        k8s.io/kubectl/pkg/cmd/apply/patcher.go:362 +0x70
k8s.io/kubectl/pkg/cmd/apply.(*ApplyOptions).applyOneObject(0x140006b21a0, 0x140006ada00)
        k8s.io/kubectl/pkg/cmd/apply/apply.go:741 +0x608
k8s.io/kubectl/pkg/cmd/apply.(*ApplyOptions).Run(0x140006b21a0)
        k8s.io/kubectl/pkg/cmd/apply/apply.go:534 +0x250
k8s.io/kubectl/pkg/cmd/apply.NewCmdApply.func1(0x14000688908?, {0x1400046bda0?, 0x0?, 0x2?})
        k8s.io/kubectl/pkg/cmd/apply/apply.go:211 +0x8c
github.com/spf13/cobra.(*Command).execute(0x14000688908, {0x1400046bd80, 0x2, 0x2})
        github.com/spf13/cobra@v1.8.1/command.go:989 +0x81c
github.com/spf13/cobra.(*Command).ExecuteC(0x140001d1508)
        github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.8.1/command.go:1041
k8s.io/component-base/cli.run(0x140001d1508)
        k8s.io/component-base/cli/run.go:143 +0x20c
k8s.io/component-base/cli.RunNoErrOutput(...)
        k8s.io/component-base/cli/run.go:82
main.main()
```

The actual resource that I tried to update was https://github.com/gardener/gardener/blob/master/pkg/apis/core/v1beta1/types_controllerdeployment.go#L62 and trying to remove an item from a nested map in the JSON object. 

In sort description, nested unknown fields in the `PatchMetaFromOpenAPI` eventually will try to use a subschema of nil value in https://github.com/kon-angelo/kubernetes/blob/a0149e33d661dd2ef4e33c4ad81d28c29614cb46/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go#L92 and that will crash later at https://github.com/kon-angelo/kubernetes/blob/a0149e33d661dd2ef4e33c4ad81d28c29614cb46/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go#L263

In the other implementations of the `LookupPatchMeta` interface we either return an error or an empty struct (like this fix does).

In addition, it adapts the method called in one test as it was incorrectly trying to create a schema out of the schema struct, rather than the actual json object received.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The change is much smaller than the accompanying test 🤷 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
NONE

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Prevent a segfault occurring when updating deeply nested JSON fields 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
