### PR TITLE
kubectl config set-context: Add -n flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_context.go
@@ -79,7 +79,7 @@ func NewCmdConfigSetContext(restClientGetter genericclioptions.RESTClientGetter,
 	cmd.Flags().BoolVar(&options.currContext, "current", options.currContext, "Modify the current context")
 	cmd.Flags().Var(&options.cluster, clientcmd.FlagClusterName, clientcmd.FlagClusterName+" for the context entry in kubeconfig")
 	cmd.Flags().Var(&options.authInfo, clientcmd.FlagAuthInfoName, clientcmd.FlagAuthInfoName+" for the context entry in kubeconfig")
-	cmd.Flags().Var(&options.namespace, clientcmd.FlagNamespace, clientcmd.FlagNamespace+" for the context entry in kubeconfig")
+	cmd.Flags().VarP(&options.namespace, clientcmd.FlagNamespace, "n", clientcmd.FlagNamespace+" for the context entry in kubeconfig")
 	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc(
 		"namespace",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/test/cmd/delete.sh
+++ b/test/cmd/delete.sh
@@ -38,7 +38,7 @@ run_kubectl_delete_allnamespaces_tests() {
   kubectl delete configmap --dry-run=server -l deletetest=true --all-namespaces
   kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
   kube::test::get_object_assert 'configmap -l deletetest' "{{range.items}}{{${id_field:?}}}:{{end}}" 'one:'
-  kubectl config set-context "${CONTEXT}" --namespace="${ns_two}"
+  kubectl config set-context "${CONTEXT}" -n "${ns_two}"
   kube::test::get_object_assert 'configmap -l deletetest' "{{range.items}}{{${id_field:?}}}:{{end}}" 'two:'
 
   kubectl delete configmap -l deletetest=true --all-namespaces
@@ -46,7 +46,7 @@ run_kubectl_delete_allnamespaces_tests() {
   # no configmaps should be in either of those namespaces with label deletetest
   kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
   kube::test::get_object_assert 'configmap -l deletetest' "{{range.items}}{{${id_field:?}}}:{{end}}" ''
-  kubectl config set-context "${CONTEXT}" --namespace="${ns_two}"
+  kubectl config set-context "${CONTEXT}" -n "${ns_two}"
   kube::test::get_object_assert 'configmap -l deletetest' "{{range.items}}{{${id_field:?}}}:{{end}}" ''
 
   set +o nounset


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add `-n` flag as a shorthand for `--namespace` as with other commands.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1789

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Added kubectl config set-context -n flag as a shorthand for --namespace
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A