### PR TITLE
KEP-4540: StrictCPUReservationOption moved to GA

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_options.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options.go
@@ -43,12 +43,12 @@ var (
 		DistributeCPUsAcrossCoresOption,
 	)
 	betaOptions = sets.New[string](
-		StrictCPUReservationOption,
 		DistributeCPUsAcrossNUMAOption,
 		PreferAlignByUnCoreCacheOption,
 	)
 	stableOptions = sets.New[string](
 		FullPCPUsOnlyOption,
+		StrictCPUReservationOption,
 	)
 )
 

--- a/pkg/kubelet/cm/cpumanager/policy_options_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options_test.go
@@ -107,18 +107,6 @@ func TestPolicyOptionsAvailable(t *testing.T) {
 			expectedAvailable: false,
 		},
 		{
-			option:            StrictCPUReservationOption,
-			featureGate:       pkgfeatures.CPUManagerPolicyBetaOptions,
-			featureGateEnable: false,
-			expectedAvailable: false,
-		},
-		{
-			option:            StrictCPUReservationOption,
-			featureGate:       pkgfeatures.CPUManagerPolicyBetaOptions,
-			featureGateEnable: true,
-			expectedAvailable: true,
-		},
-		{
 			option:            PreferAlignByUnCoreCacheOption,
 			featureGate:       pkgfeatures.CPUManagerPolicyBetaOptions,
 			featureGateEnable: false,
@@ -146,6 +134,7 @@ func TestPolicyOptionsAvailable(t *testing.T) {
 func TestPolicyOptionsAlwaysAvailableOnceGA(t *testing.T) {
 	options := []string{
 		FullPCPUsOnlyOption,
+		StrictCPUReservationOption,
 	}
 	for _, option := range options {
 		t.Run(option, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Changes to graduate the CPU Manager static policy option `strict-cpu-reservation` to GA

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/4540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
CPU Manager static policy option `strict-cpu-reservation` moved to the GA version
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4540
```