### PR TITLE
Support PreStop HTTPGet hooks on hostNetwork pods without Host field

### DIFF
--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -146,22 +146,11 @@ func (hr *handlerRunner) runSleepHandler(ctx context.Context, seconds int64) err
 
 func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, container *v1.Container, handler *v1.LifecycleHandler, eventRecorder record.EventRecorder) error {
 	logger := klog.FromContext(ctx)
-	host := handler.HTTPGet.Host
-	podIP := host
-	if len(host) == 0 {
-		status, err := hr.containerManager.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
-		if err != nil {
-			logger.Error(err, "Unable to get pod info, event handlers may be invalid.", "pod", klog.KObj(pod))
-			return err
-		}
-		if len(status.IPs) == 0 {
-			return fmt.Errorf("failed to find networking container: %v", status)
-		}
-		host = status.IPs[0]
-		podIP = host
+	host, err := hr.resolveHost(ctx, pod, handler.HTTPGet.Host)
+	if err != nil {
+		return err
 	}
-
-	req, err := httpprobe.NewRequestForHTTPGetAction(handler.HTTPGet, container, podIP, "lifecycle")
+	req, err := httpprobe.NewRequestForHTTPGetAction(handler.HTTPGet, container, host, "lifecycle")
 	if err != nil {
 		return err
 	}
@@ -188,6 +177,39 @@ func (hr *handlerRunner) runHTTPHandler(ctx context.Context, pod *v1.Pod, contai
 		discardHTTPRespBody(resp)
 	}
 	return err
+}
+
+// resolveHost determines the host and podIP for a probe or hook.
+func (hr *handlerRunner) resolveHost(ctx context.Context, pod *v1.Pod, hostOverride string) (string, error) {
+	if len(hostOverride) > 0 {
+		return hostOverride, nil
+	}
+	// For hostNetwork pods, the runtime does not provide a sandbox IP.
+	// Since the kubelet executes the hook from the host's network namespace,
+	// which is the same namespace as the pod's,
+	// we use address from the pod.Status.PodIPs/HostIPs instead.
+	if pod.Spec.HostNetwork {
+		if len(pod.Status.PodIPs) > 0 {
+			return pod.Status.PodIPs[0].IP, nil
+		}
+		if len(pod.Status.HostIPs) > 0 {
+			return pod.Status.HostIPs[0].IP, nil
+		}
+		return "", fmt.Errorf("pod %s/%s uses hostNetwork but has no PodIPs or HostIPs in status: %+v", pod.Namespace, pod.Name, pod.Status)
+	}
+	// For non-hostNetwork pods, fall back to the existing logic of querying
+	// the container runtime for the pod's assigned IP address.
+	podStatus, err := hr.containerManager.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
+	if err != nil {
+		klog.FromContext(ctx).Error(err, "Unable to get pod info, event handlers may be invalid", "pod", klog.KObj(pod))
+		return "", err
+	}
+
+	if len(podStatus.IPs) == 0 {
+		return "", fmt.Errorf("failed to find network status or pod IP for pod: %v", klog.KObj(pod))
+	}
+
+	return podStatus.IPs[0], nil
 }
 
 func discardHTTPRespBody(resp *http.Response) {

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -347,10 +347,11 @@ func TestRunHTTPHandler(t *testing.T) {
 	}
 
 	tests := []struct {
-		Name     string
-		PodIP    string
-		HTTPGet  *v1.HTTPGetAction
-		Expected expected
+		Name          string
+		PodIP         string
+		HTTPGet       *v1.HTTPGetAction
+		PrePodSetFunc func(pod *v1.Pod)
+		Expected      expected
 	}{
 		{
 			Name:  "missing pod IP",
@@ -564,6 +565,96 @@ func TestRunHTTPHandler(t *testing.T) {
 					"Host":       {"from.header"},
 				},
 			},
+		}, {
+			Name:  "hostNetwork(no Host field use HostIPs): headers",
+			PodIP: "233.252.0.1",
+			PrePodSetFunc: func(pod *v1.Pod) {
+				pod.Spec.HostNetwork = true
+				pod.Status = v1.PodStatus{
+					HostIPs: []v1.HostIP{{IP: "233.252.0.1"}}, // only HostIPs
+				}
+			},
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   "foo",
+				Port:   intstr.FromString("80"),
+				Host:   "", // no Host field
+				Scheme: "http",
+				HTTPHeaders: []v1.HTTPHeader{
+					{
+						Name:  "Foo",
+						Value: "bar",
+					},
+				},
+			},
+			Expected: expected{
+				OldURL:    "http://233.252.0.1:80/foo",
+				OldHeader: http.Header{},
+				NewURL:    "http://233.252.0.1:80/foo",
+				NewHeader: http.Header{
+					"Accept":     {"*/*"},
+					"Foo":        {"bar"},
+					"User-Agent": {"kube-lifecycle/."},
+				},
+			},
+		}, {
+			Name:  "hostNetwork(no Host field use PodIPs): headers",
+			PodIP: "233.252.0.10",
+			PrePodSetFunc: func(pod *v1.Pod) {
+				pod.Spec.HostNetwork = true
+				pod.Status = v1.PodStatus{
+					PodIPs: []v1.PodIP{{IP: "233.252.0.10"}}, // only PodIPs
+				}
+			},
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   "foo",
+				Port:   intstr.FromString("80"),
+				Host:   "", // no Host field
+				Scheme: "http",
+				HTTPHeaders: []v1.HTTPHeader{
+					{
+						Name:  "Foo",
+						Value: "bar",
+					},
+				},
+			},
+			Expected: expected{
+				OldURL:    "http://233.252.0.10:80/foo",
+				OldHeader: http.Header{},
+				NewURL:    "http://233.252.0.10:80/foo",
+				NewHeader: http.Header{
+					"Accept":     {"*/*"},
+					"Foo":        {"bar"},
+					"User-Agent": {"kube-lifecycle/."},
+				},
+			},
+		}, {
+			Name:  "hostNetwork(set Host field use Host): host header",
+			PodIP: "233.252.0.1",
+			PrePodSetFunc: func(pod *v1.Pod) {
+				pod.Spec.HostNetwork = true
+			},
+			HTTPGet: &v1.HTTPGetAction{
+				Host:   "example.test", // set Host field
+				Path:   "foo",
+				Port:   intstr.FromString("80"),
+				Scheme: "http",
+				HTTPHeaders: []v1.HTTPHeader{
+					{
+						Name:  "Host",
+						Value: "from.header",
+					},
+				},
+			},
+			Expected: expected{
+				OldURL:    "http://example.test:80/foo",
+				OldHeader: http.Header{},
+				NewURL:    "http://example.test:80/foo",
+				NewHeader: http.Header{
+					"Accept":     {"*/*"},
+					"User-Agent": {"kube-lifecycle/."},
+					"Host":       {"from.header"},
+				},
+			},
 		},
 	}
 
@@ -595,7 +686,9 @@ func TestRunHTTPHandler(t *testing.T) {
 
 			container.Lifecycle.PostStart.HTTPGet = tt.HTTPGet
 			pod.Spec.Containers = []v1.Container{container}
-
+			if tt.PrePodSetFunc != nil {
+				tt.PrePodSetFunc(&pod)
+			}
 			verify := func(t *testing.T, expectedHeader http.Header, expectedURL string) {
 				fakeHTTPDoer := fakeHTTP{}
 				handlerRunner := NewHandlerRunner(&fakeHTTPDoer, &fakeContainerCommandRunner{}, fakePodStatusProvider, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig network

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Support PreStop HTTPGet hooks on hostNetwork pods without Host field
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #134285
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #134285
#### Special notes for your reviewer:

For hostNetwork pods, the runtime does not provide a sandbox IP.
Since the kubelet executes the hook from the host's network namespace,
which is the same namespace as the pod's,
we use address from the pod.Status.PodIPs/HostIPs instead.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support PreStop HTTPGet hooks on hostNetwork pods without host field
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
PTAL @aojea 