### PR TITLE
Disable SchedulerAsyncAPICalls feature gate due to a known regression in v1.34

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1606,7 +1606,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 
 	SchedulerAsyncAPICalls: {
-		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Beta},
 	},
 
 	SchedulerAsyncPreemption: {

--- a/pkg/scheduler/backend/api_dispatcher/api_dispatcher_test.go
+++ b/pkg/scheduler/backend/api_dispatcher/api_dispatcher_test.go
@@ -22,19 +22,21 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
-func init() {
+func registerAndResetMetrics(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncAPICalls, true)
 	metrics.Register()
-}
 
-func resetMetrics() {
 	metrics.AsyncAPICallsTotal.Reset()
 	metrics.AsyncAPICallDuration.Reset()
 	metrics.AsyncAPIPendingCalls.Reset()
@@ -100,7 +102,7 @@ func (mac *mockAPICall) IsNoOp() bool {
 
 func TestAPIDispatcherLifecycle(t *testing.T) {
 	// Reset all async API metrics
-	resetMetrics()
+	registerAndResetMetrics(t)
 
 	logger, _ := ktesting.NewTestContext(t)
 

--- a/pkg/scheduler/backend/api_dispatcher/call_queue_test.go
+++ b/pkg/scheduler/backend/api_dispatcher/call_queue_test.go
@@ -106,7 +106,7 @@ func TestCallQueueAdd(t *testing.T) {
 	uid2 := types.UID("uid2")
 
 	t.Run("First call is added without collision", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call := &queuedAPICall{
@@ -124,7 +124,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("No-op call is skipped", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh := make(chan error, 1)
@@ -149,7 +149,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("Two calls for different objects don't collide", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call1 := &queuedAPICall{
@@ -176,7 +176,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("New call overwrites less relevant call", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh := make(chan error, 1)
@@ -206,7 +206,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("New call is skipped if less relevant", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh := make(chan error, 1)
@@ -237,7 +237,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("New call merges with old call and skips if no-op", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh1 := make(chan error, 1)
@@ -308,7 +308,7 @@ func TestCallQueuePop(t *testing.T) {
 	uid2 := types.UID("uid2")
 
 	t.Run("Calls are popped from the queue in FIFO order", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call1 := &queuedAPICall{
@@ -395,7 +395,7 @@ func TestCallQueueFinalize(t *testing.T) {
 	uid := types.UID("uid")
 
 	t.Run("Call details are cleared if there is no waiting call", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call := &queuedAPICall{
@@ -420,7 +420,7 @@ func TestCallQueueFinalize(t *testing.T) {
 	})
 
 	t.Run("UID is re-queued if a new call arrived while one was in-flight", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call1 := &queuedAPICall{
@@ -462,7 +462,7 @@ func TestCallQueueSyncObject(t *testing.T) {
 	uid2 := types.UID("uid2")
 
 	t.Run("Object is synced with pending call details", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		obj := &metav1.ObjectMeta{
@@ -497,7 +497,7 @@ func TestCallQueueSyncObject(t *testing.T) {
 	})
 
 	t.Run("Pending call is canceled if sync results in no-op", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		obj := &metav1.ObjectMeta{UID: uid1}

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1385,7 +1385,7 @@
     version: "1.29"
 - name: SchedulerAsyncAPICalls
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.34"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind regression

#### What this PR does / why we need it:

The SchedulerAsyncAPICalls feature, introduced in v1.34, stregthened existing bugs in the SchedulerAsyncPreemption feature (enabled by default in v1.33), making them more noticeable when the kube-apiserver response is slow. Two such bugs were discovered: #134217 and #134249. These issues were less severe in v1.33 because Pod status PATCH API calls acted as an implicit synchronization point between scheduling loops and asynchronous preemption attempts; when the API calls were throttled, scheduling cycles were blocked.

A related pull request introduced in v1.34 was reverted (#134245), but subsequent integration tests revealed another issue in async preemption, which was then resolved by #134294.

A test trying to simulate the regressed behavior (https://github.com/kubernetes/kubernetes/commit/3be081483ef0e93ff5181456046aafebf107eda4) showed that even after the two fixes above (#134245 and #134294), the issue is still reproducible. The options to immediately mitigate this regression are:

- Disabling SchedulerAsyncPreemption: This mitigates the regression, as the issue originates from this feature. However, this option was rejected because the feature provides a significant performance improvement and was already enabled in v1.33, so the users might expect it to be present.
- Disabling SchedulerPopFromBackoffQ: This mostly mitigates the regression, but the scheduler remains partially affected, and we are not certain if it would cover all possible scenarios.
- Disabling SchedulerAsyncAPICalls: This restores parity with v1.33 and allows us to ship the final fixes for issues [#134217](https://github.com/kubernetes/kubernetes/issues/134217) and [#134249](https://github.com/kubernetes/kubernetes/issues/134249) in v1.35, at which point the feature can be re-enabled.

This PR disables the SchedulerAsyncAPICalls feature gate and updates the tests that fail as a result.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Related to #134217 and #134249

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The SchedulerAsyncAPICalls feature gate has been disabled to mitigate a bug where its interaction with asynchronous preemption in could degrade kube-scheduler performance, particularly under high kube-apiserver load.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
