### PR TITLE
Automated cherry pick of #134400: Disable SchedulerAsyncAPICalls feature gate due to a known regression in v1.34

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1679,7 +1679,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 
 	SchedulerAsyncAPICalls: {
-		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Beta},
 	},
 
 	SchedulerAsyncPreemption: {

--- a/pkg/scheduler/backend/api_dispatcher/api_dispatcher_test.go
+++ b/pkg/scheduler/backend/api_dispatcher/api_dispatcher_test.go
@@ -22,19 +22,21 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
-func init() {
+func registerAndResetMetrics(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerAsyncAPICalls, true)
 	metrics.Register()
-}
 
-func resetMetrics() {
 	metrics.AsyncAPICallsTotal.Reset()
 	metrics.AsyncAPICallDuration.Reset()
 	metrics.AsyncAPIPendingCalls.Reset()
@@ -100,7 +102,7 @@ func (mac *mockAPICall) IsNoOp() bool {
 
 func TestAPIDispatcherLifecycle(t *testing.T) {
 	// Reset all async API metrics
-	resetMetrics()
+	registerAndResetMetrics(t)
 
 	logger, _ := ktesting.NewTestContext(t)
 

--- a/pkg/scheduler/backend/api_dispatcher/call_queue_test.go
+++ b/pkg/scheduler/backend/api_dispatcher/call_queue_test.go
@@ -106,7 +106,7 @@ func TestCallQueueAdd(t *testing.T) {
 	uid2 := types.UID("uid2")
 
 	t.Run("First call is added without collision", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call := &queuedAPICall{
@@ -124,7 +124,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("No-op call is skipped", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh := make(chan error, 1)
@@ -149,7 +149,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("Two calls for different objects don't collide", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call1 := &queuedAPICall{
@@ -176,7 +176,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("New call overwrites less relevant call", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh := make(chan error, 1)
@@ -206,7 +206,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("New call is skipped if less relevant", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh := make(chan error, 1)
@@ -237,7 +237,7 @@ func TestCallQueueAdd(t *testing.T) {
 	})
 
 	t.Run("New call merges with old call and skips if no-op", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		onFinishCh1 := make(chan error, 1)
@@ -308,7 +308,7 @@ func TestCallQueuePop(t *testing.T) {
 	uid2 := types.UID("uid2")
 
 	t.Run("Calls are popped from the queue in FIFO order", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call1 := &queuedAPICall{
@@ -395,7 +395,7 @@ func TestCallQueueFinalize(t *testing.T) {
 	uid := types.UID("uid")
 
 	t.Run("Call details are cleared if there is no waiting call", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call := &queuedAPICall{
@@ -420,7 +420,7 @@ func TestCallQueueFinalize(t *testing.T) {
 	})
 
 	t.Run("UID is re-queued if a new call arrived while one was in-flight", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		call1 := &queuedAPICall{
@@ -462,7 +462,7 @@ func TestCallQueueSyncObject(t *testing.T) {
 	uid2 := types.UID("uid2")
 
 	t.Run("Object is synced with pending call details", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		obj := &metav1.ObjectMeta{
@@ -497,7 +497,7 @@ func TestCallQueueSyncObject(t *testing.T) {
 	})
 
 	t.Run("Pending call is canceled if sync results in no-op", func(t *testing.T) {
-		resetMetrics()
+		registerAndResetMetrics(t)
 
 		cq := newCallQueue(mockRelevances)
 		obj := &metav1.ObjectMeta{UID: uid1}

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1417,7 +1417,7 @@
     version: "1.29"
 - name: SchedulerAsyncAPICalls
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.34"


### PR DESCRIPTION
Cherry pick of #134400 on release-1.34.

#134400: Disable SchedulerAsyncAPICalls feature gate due to a known regression in v1.34

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
The SchedulerAsyncAPICalls feature gate has been disabled to mitigate a bug where its interaction with asynchronous preemption in could degrade kube-scheduler performance, particularly under high kube-apiserver load.
```