### PR TITLE
TEST: disable hostNetwork and hostUsers for the CP static pods

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -93,6 +93,8 @@ const (
 
 	// EtcdListenClientPort defines the port etcd listen on for client traffic
 	EtcdListenClientPort = 2379
+	// EtcdListenPeerPort defined the port etcd uses for peer-to-peer communication
+	EtcdListenPeerPort = 2380
 	// EtcdMetricsPort is the port at which to obtain etcd metrics and health status
 	EtcdMetricsPort = 2381
 
@@ -102,9 +104,6 @@ const (
 	EtcdPeerCertName = "etcd/peer.crt"
 	// EtcdPeerKeyName defines etcd's peer key name
 	EtcdPeerKeyName = "etcd/peer.key"
-
-	// EtcdListenPeerPort defines the port etcd listen on for peer traffic
-	EtcdListenPeerPort = 2380
 
 	// EtcdHealthcheckClientCertAndKeyBaseName defines etcd's healthcheck client certificate and key base name
 	EtcdHealthcheckClientCertAndKeyBaseName = "etcd/healthcheck-client"

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -95,7 +95,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-      hostNetwork: true
       serviceAccountName: kube-proxy
       volumes:
       - name: kube-proxy

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -86,6 +86,7 @@ func TestGetStaticPodSpecs(t *testing.T) {
 				{
 					Name:          kubeadmconstants.ProbePort,
 					ContainerPort: kubeadmconstants.KubeAPIServerPort,
+					HostPort:      kubeadmconstants.KubeAPIServerPort,
 					Protocol:      v1.ProtocolTCP,
 				},
 			},
@@ -101,6 +102,7 @@ func TestGetStaticPodSpecs(t *testing.T) {
 				{
 					Name:          kubeadmconstants.ProbePort,
 					ContainerPort: kubeadmconstants.KubeControllerManagerPort,
+					HostPort:      kubeadmconstants.KubeControllerManagerPort,
 					Protocol:      v1.ProtocolTCP,
 				},
 			},
@@ -117,6 +119,7 @@ func TestGetStaticPodSpecs(t *testing.T) {
 				{
 					Name:          kubeadmconstants.ProbePort,
 					ContainerPort: kubeadmconstants.KubeSchedulerPort,
+					HostPort:      kubeadmconstants.KubeSchedulerPort,
 					Protocol:      v1.ProtocolTCP,
 				},
 			},
@@ -308,7 +311,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--requestheader-allowed-names=front-proxy-client",
 				"--authorization-mode=Node,RBAC",
 				"--advertise-address=1.2.3.4",
-				fmt.Sprintf("--etcd-servers=https://127.0.0.1:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--etcd-servers=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
 				"--etcd-cafile=" + filepath.Join(testCertsDir, "etcd/ca.crt"),
 				"--etcd-certfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.crt"),
 				"--etcd-keyfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.key"),
@@ -346,7 +349,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--requestheader-allowed-names=front-proxy-client",
 				"--authorization-mode=Node,RBAC",
 				"--advertise-address=2001:db8::1",
-				fmt.Sprintf("--etcd-servers=https://[::1]:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--etcd-servers=https://[2001:db8::1]:%d", kubeadmconstants.EtcdListenClientPort),
 				"--etcd-cafile=" + filepath.Join(testCertsDir, "etcd/ca.crt"),
 				"--etcd-certfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.crt"),
 				"--etcd-keyfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.key"),
@@ -480,7 +483,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--requestheader-allowed-names=front-proxy-client",
 				"--authorization-mode=Node,RBAC",
 				"--advertise-address=9.9.9.9",
-				fmt.Sprintf("--etcd-servers=https://127.0.0.1:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--etcd-servers=https://9.9.9.9:%d", kubeadmconstants.EtcdListenClientPort),
 				"--etcd-cafile=" + filepath.Join(testCertsDir, "etcd/ca.crt"),
 				"--etcd-certfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.crt"),
 				"--etcd-keyfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.key"),
@@ -527,7 +530,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--requestheader-allowed-names=front-proxy-client",
 				"--authorization-mode=ABAC",
 				"--advertise-address=1.2.3.4",
-				fmt.Sprintf("--etcd-servers=https://127.0.0.1:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--etcd-servers=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
 				"--etcd-cafile=" + filepath.Join(testCertsDir, "etcd/ca.crt"),
 				"--etcd-certfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.crt"),
 				"--etcd-keyfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.key"),
@@ -576,7 +579,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--requestheader-allowed-names=front-proxy-client",
 				"--authorization-mode=Node,RBAC,Webhook",
 				"--advertise-address=1.2.3.4",
-				fmt.Sprintf("--etcd-servers=https://127.0.0.1:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--etcd-servers=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
 				"--etcd-cafile=" + filepath.Join(testCertsDir, "etcd/ca.crt"),
 				"--etcd-certfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.crt"),
 				"--etcd-keyfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.key"),
@@ -621,7 +624,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--requestheader-allowed-names=front-proxy-client",
 				"--authorization-config=/path/to/authorization/config/file",
 				"--advertise-address=1.2.3.4",
-				fmt.Sprintf("--etcd-servers=https://127.0.0.1:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--etcd-servers=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
 				"--etcd-cafile=" + filepath.Join(testCertsDir, "etcd/ca.crt"),
 				"--etcd-certfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.crt"),
 				"--etcd-keyfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.key"),
@@ -673,7 +676,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--authorization-config=/path/to/authorization/config/file",
 				"--authorization-mode=Node,RBAC,Webhook",
 				"--advertise-address=1.2.3.4",
-				fmt.Sprintf("--etcd-servers=https://127.0.0.1:%d", kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--etcd-servers=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
 				"--etcd-cafile=" + filepath.Join(testCertsDir, "etcd/ca.crt"),
 				"--etcd-certfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.crt"),
 				"--etcd-keyfile=" + filepath.Join(testCertsDir, "apiserver-etcd-client.key"),
@@ -726,7 +729,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -750,7 +752,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -774,7 +775,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -804,7 +804,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -834,7 +833,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -866,7 +864,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -900,7 +897,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -931,7 +927,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -967,7 +962,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 			},
 			expected: []string{
 				"kube-controller-manager",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 				"--root-ca-file=" + filepath.Join(testCertsDir, "ca.crt"),
@@ -1020,7 +1014,6 @@ func TestGetControllerManagerCommandExternalCA(t *testing.T) {
 			expectedArgFunc: func(tmpdir string) []string {
 				return []string{
 					"kube-controller-manager",
-					"--bind-address=127.0.0.1",
 					"--leader-elect=true",
 					"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 					"--root-ca-file=" + filepath.Join(tmpdir, "ca.crt"),
@@ -1049,7 +1042,6 @@ func TestGetControllerManagerCommandExternalCA(t *testing.T) {
 			expectedArgFunc: func(tmpdir string) []string {
 				return []string{
 					"kube-controller-manager",
-					"--bind-address=127.0.0.1",
 					"--leader-elect=true",
 					"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "controller-manager.conf"),
 					"--root-ca-file=" + filepath.Join(tmpdir, "ca.crt"),
@@ -1111,7 +1103,6 @@ func TestGetSchedulerCommand(t *testing.T) {
 			cfg:  &kubeadmapi.ClusterConfiguration{},
 			expected: []string{
 				"kube-scheduler",
-				"--bind-address=127.0.0.1",
 				"--leader-elect=true",
 				"--kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "scheduler.conf"),
 				"--authentication-kubeconfig=" + filepath.Join(kubeadmconstants.KubernetesDir, "scheduler.conf"),

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -111,9 +111,9 @@ spec:
     - --initial-advertise-peer-urls=https://:2380
     - --initial-cluster==https://:2380
     - --key-file=etcd/server.key
-    - --listen-client-urls=https://127.0.0.1:2379,https://:2379
+    - --listen-client-urls=https://0.0.0.0:2379
     - --listen-metrics-urls=http://127.0.0.1:2381
-    - --listen-peer-urls=https://:2380
+    - --listen-peer-urls=https://0.0.0.0:2380
     - --name=
     - --peer-cert-file=etcd/peer.crt
     - --peer-client-cert-auth=true
@@ -136,7 +136,14 @@ spec:
       timeoutSeconds: 15
     name: etcd
     ports:
+    - containerPort: 2379
+      hostPort: 2379
+      protocol: TCP
+    - containerPort: 2380
+      hostPort: 2380
+      protocol: TCP
     - containerPort: 2381
+      hostPort: 2381
       name: probe-port
       protocol: TCP
     readinessProbe:
@@ -167,7 +174,7 @@ spec:
       name: etcd-data
     - mountPath: /etcd
       name: etcd-certs
-  hostNetwork: true
+  hostUsers: false
   priority: 2000001000
   priorityClassName: system-node-critical
   securityContext:
@@ -303,10 +310,10 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--name=foo",
 				"--feature-gates=InitialCorruptCheck=true",
 				"--watch-progress-notify-interval=5s",
-				fmt.Sprintf("--listen-client-urls=https://127.0.0.1:%d,https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort, kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-client-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenClientPort),
 				fmt.Sprintf("--listen-metrics-urls=http://127.0.0.1:%d", kubeadmconstants.EtcdMetricsPort),
 				fmt.Sprintf("--advertise-client-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
-				fmt.Sprintf("--listen-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--listen-peer-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenPeerPort),
 				fmt.Sprintf("--initial-advertise-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),
@@ -334,10 +341,10 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--name=foo",
 				"--feature-gates=InitialCorruptCheck=true",
 				"--watch-progress-notify-interval=5s",
-				fmt.Sprintf("--listen-client-urls=https://127.0.0.1:%d,https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort, kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-client-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenClientPort),
 				fmt.Sprintf("--listen-metrics-urls=http://127.0.0.1:%d", kubeadmconstants.EtcdMetricsPort),
 				fmt.Sprintf("--advertise-client-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
-				fmt.Sprintf("--listen-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--listen-peer-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenPeerPort),
 				fmt.Sprintf("--initial-advertise-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),
@@ -369,7 +376,7 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--listen-client-urls=https://10.0.1.10:2379",
 				fmt.Sprintf("--listen-metrics-urls=http://127.0.0.1:%d", kubeadmconstants.EtcdMetricsPort),
 				"--advertise-client-urls=https://10.0.1.10:2379",
-				fmt.Sprintf("--listen-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--listen-peer-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenPeerPort),
 				fmt.Sprintf("--initial-advertise-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),
@@ -393,10 +400,10 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--name=foo",
 				"--feature-gates=InitialCorruptCheck=true",
 				"--watch-progress-notify-interval=5s",
-				fmt.Sprintf("--listen-client-urls=https://[::1]:%d,https://[2001:db8::3]:%d", kubeadmconstants.EtcdListenClientPort, kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-client-urls=https://[::]:%d", kubeadmconstants.EtcdListenClientPort),
 				fmt.Sprintf("--listen-metrics-urls=http://[::1]:%d", kubeadmconstants.EtcdMetricsPort),
 				fmt.Sprintf("--advertise-client-urls=https://[2001:db8::3]:%d", kubeadmconstants.EtcdListenClientPort),
-				fmt.Sprintf("--listen-peer-urls=https://[2001:db8::3]:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--listen-peer-urls=https://[::]:%d", kubeadmconstants.EtcdListenPeerPort),
 				fmt.Sprintf("--initial-advertise-peer-urls=https://[2001:db8::3]:%d", kubeadmconstants.EtcdListenPeerPort),
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),
@@ -421,10 +428,10 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--name=bar",
 				"--experimental-initial-corrupt-check=true",
 				"--experimental-watch-progress-notify-interval=5s",
-				fmt.Sprintf("--listen-client-urls=https://127.0.0.1:%d,https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort, kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-client-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenClientPort),
 				fmt.Sprintf("--listen-metrics-urls=http://127.0.0.1:%d", kubeadmconstants.EtcdMetricsPort),
 				fmt.Sprintf("--advertise-client-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
-				fmt.Sprintf("--listen-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--listen-peer-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenPeerPort),
 				fmt.Sprintf("--initial-advertise-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),
@@ -449,10 +456,10 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--name=bar",
 				"--experimental-initial-corrupt-check=true",
 				"--experimental-watch-progress-notify-interval=5s",
-				fmt.Sprintf("--listen-client-urls=https://127.0.0.1:%d,https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort, kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-client-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenClientPort),
 				fmt.Sprintf("--listen-metrics-urls=http://127.0.0.1:%d", kubeadmconstants.EtcdMetricsPort),
 				fmt.Sprintf("--advertise-client-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
-				fmt.Sprintf("--listen-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--listen-peer-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenPeerPort),
 				fmt.Sprintf("--initial-advertise-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),
@@ -477,10 +484,10 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--name=bar",
 				"--experimental-initial-corrupt-check=true",
 				"--experimental-watch-progress-notify-interval=5s",
-				fmt.Sprintf("--listen-client-urls=https://127.0.0.1:%d,https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort, kubeadmconstants.EtcdListenClientPort),
+				fmt.Sprintf("--listen-client-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenClientPort),
 				fmt.Sprintf("--listen-metrics-urls=http://127.0.0.1:%d", kubeadmconstants.EtcdMetricsPort),
 				fmt.Sprintf("--advertise-client-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenClientPort),
-				fmt.Sprintf("--listen-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
+				fmt.Sprintf("--listen-peer-urls=https://0.0.0.0:%d", kubeadmconstants.EtcdListenPeerPort),
 				fmt.Sprintf("--initial-advertise-peer-urls=https://1.2.3.4:%d", kubeadmconstants.EtcdListenPeerPort),
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + filepath.FromSlash(kubeadmconstants.EtcdServerCertName),

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -36,6 +36,7 @@ import (
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
@@ -279,12 +280,14 @@ func (w *KubeWaiter) WaitForControlPlaneComponents(podMap map[string]*v1.Pod, ap
 							Get().AbsPath(comp.endpoint).Do(ctx).StatusCode(&statusCode)
 						if err := result.Error(); err != nil {
 							lastError = errors.WithMessagef(err, "%s check failed at %s", comp.name, url)
+							klog.V(5).Info(lastError)
 							return false, nil
 						}
 					} else {
 						resp, err := client.Get(url)
 						if err != nil {
 							lastError = errors.WithMessagef(err, "%s check failed at %s", comp.name, url)
+							klog.V(5).Info(lastError)
 							return false, nil
 						}
 						defer func() {

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/dump"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -73,13 +74,13 @@ func ComponentPod(container v1.Container, volumes map[string]v1.Volume, annotati
 			Containers:        []v1.Container{container},
 			Priority:          &priority,
 			PriorityClassName: "system-node-critical",
-			HostNetwork:       true,
 			Volumes:           VolumeMapToSlice(volumes),
 			SecurityContext: &v1.PodSecurityContext{
 				SeccompProfile: &v1.SeccompProfile{
 					Type: v1.SeccompProfileTypeRuntimeDefault,
 				},
 			},
+			HostUsers: ptr.To(false),
 		},
 	}
 }

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -432,9 +433,9 @@ func TestComponentPod(t *testing.T) {
 							Name: "foo",
 						},
 					},
+					HostUsers:         ptr.To(false),
 					Priority:          &priority,
 					PriorityClassName: "system-node-critical",
-					HostNetwork:       true,
 					Volumes:           []v1.Volume{},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

tested locally and works for a single node cluster.

using:

```
containerd --version && echo "--" && runc --version
containerd github.com/containerd/containerd/v2 v2.1.4 75cb2b7193e4e490e9fbdc236c0e811ccaba3376
--
runc version 1.3.1
commit: v1.3.1-0-ge6457afc
spec: 1.2.1
go: go1.23.12
libseccomp: 2.5.6
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
