### PR TITLE
Dedicated package for scheduler interaction with DRA structured types

### DIFF
--- a/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
@@ -24,7 +24,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/dynamic-resource-allocation/structured/schedulerapi"
 	fwk "k8s.io/kube-scheduler/framework"
 )
 
@@ -96,11 +96,11 @@ func (r *resourceClaimTrackerContract) Get(_, _ string) (*resourceapi.ResourceCl
 	return nil, nil
 }
 
-func (r *resourceClaimTrackerContract) ListAllAllocatedDevices() (sets.Set[structured.DeviceID], error) {
+func (r *resourceClaimTrackerContract) ListAllAllocatedDevices() (sets.Set[schedulerapi.DeviceID], error) {
 	return nil, nil
 }
 
-func (r *resourceClaimTrackerContract) GatherAllocatedState() (*structured.AllocatedState, error) {
+func (r *resourceClaimTrackerContract) GatherAllocatedState() (*schedulerapi.AllocatedState, error) {
 	return nil, nil
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/dynamic-resource-allocation/structured/internal/experimental"
 	"k8s.io/dynamic-resource-allocation/structured/internal/incubating"
 	"k8s.io/dynamic-resource-allocation/structured/internal/stable"
+	"k8s.io/dynamic-resource-allocation/structured/schedulerapi"
 )
 
 // To keep the code in different packages simple, type aliases are used everywhere.
@@ -40,30 +41,32 @@ import (
 
 type DeviceClassLister = internal.DeviceClassLister
 type Features = internal.Features
-type DeviceID = internal.DeviceID
+
+// Type aliases to schedulerapi package for types that are part of the
+// scheduler and autoscaler contract. This ensures that changes to these
+// types require autoscaler approval.
+type DeviceID = schedulerapi.DeviceID
+type AllocatedState = schedulerapi.AllocatedState
+type SharedDeviceID = schedulerapi.SharedDeviceID
+type DeviceConsumedCapacity = schedulerapi.DeviceConsumedCapacity
+type ConsumedCapacityCollection = schedulerapi.ConsumedCapacityCollection
+type ConsumedCapacity = schedulerapi.ConsumedCapacity
 
 func MakeDeviceID(driver, pool, device string) DeviceID {
-	return internal.MakeDeviceID(driver, pool, device)
+	return schedulerapi.MakeDeviceID(driver, pool, device)
 }
 
-// types_experimental
-type AllocatedState = internal.AllocatedState
-type SharedDeviceID = internal.SharedDeviceID
-type DeviceConsumedCapacity = internal.DeviceConsumedCapacity
-type ConsumedCapacityCollection = internal.ConsumedCapacityCollection
-type ConsumedCapacity = internal.ConsumedCapacity
-
 func MakeSharedDeviceID(deviceID DeviceID, shareID *types.UID) SharedDeviceID {
-	return internal.MakeSharedDeviceID(deviceID, shareID)
+	return schedulerapi.MakeSharedDeviceID(deviceID, shareID)
 }
 
 func NewConsumedCapacityCollection() ConsumedCapacityCollection {
-	return internal.NewConsumedCapacityCollection()
+	return schedulerapi.NewConsumedCapacityCollection()
 }
 
 func NewDeviceConsumedCapacity(deviceID DeviceID,
 	consumedCapacity map[resourceapi.QualifiedName]resource.Quantity) DeviceConsumedCapacity {
-	return internal.NewDeviceConsumedCapacity(deviceID, consumedCapacity)
+	return schedulerapi.NewDeviceConsumedCapacity(deviceID, consumedCapacity)
 }
 
 // Allocator calculates how to allocate a set of unallocated claims which use

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatedstate.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatedstate.go
@@ -23,182 +23,44 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	draapi "k8s.io/dynamic-resource-allocation/api"
+	"k8s.io/dynamic-resource-allocation/structured/schedulerapi"
 )
 
-type DeviceID struct {
-	Driver, Pool, Device draapi.UniqueString
-}
+// Type aliases pointing to the schedulerapi package where the actual
+// definitions are maintained. This ensures that any changes to these types
+// require autoscaler approval.
+type DeviceID = schedulerapi.DeviceID
+type SharedDeviceID = schedulerapi.SharedDeviceID
+type AllocatedState = schedulerapi.AllocatedState
+type ConsumedCapacity = schedulerapi.ConsumedCapacity
+type ConsumedCapacityCollection = schedulerapi.ConsumedCapacityCollection
+type DeviceConsumedCapacity = schedulerapi.DeviceConsumedCapacity
 
-func (d DeviceID) String() string {
-	return d.Driver.String() + "/" + d.Pool.String() + "/" + d.Device.String()
-}
-
+// Wrapper functions that delegate to the schedulerapi package
 func MakeDeviceID(driver, pool, device string) DeviceID {
-	return DeviceID{
-		Driver: draapi.MakeUniqueString(driver),
-		Pool:   draapi.MakeUniqueString(pool),
-		Device: draapi.MakeUniqueString(device),
-	}
+	return schedulerapi.MakeDeviceID(driver, pool, device)
 }
 
-type SharedDeviceID struct {
-	Driver, Pool, Device, ShareID draapi.UniqueString
-}
-
-// MakeSharedDeviceID creates a SharedDeviceID by extending MakeDeviceID with shareID.
 func MakeSharedDeviceID(deviceID DeviceID, shareID *types.UID) SharedDeviceID {
-	// This function avoids disruptive changes to MakeDeviceID
-	// while enabling ShareID as part of the device key.
-	var shareIDStr string
-	if shareID != nil {
-		shareIDStr = string(*shareID)
-	}
-	return SharedDeviceID{
-		Driver:  deviceID.Driver,
-		Pool:    deviceID.Pool,
-		Device:  deviceID.Device,
-		ShareID: draapi.MakeUniqueString(shareIDStr),
-	}
+	return schedulerapi.MakeSharedDeviceID(deviceID, shareID)
 }
 
-func (d SharedDeviceID) String() string {
-	deviceIDStr := d.Driver.String() + "/" + d.Pool.String() + "/" + d.Device.String()
-	if d.ShareID.String() != "" {
-		deviceIDStr += "/" + d.ShareID.String()
-	}
-	return deviceIDStr
+func NewConsumedCapacity() ConsumedCapacity {
+	return schedulerapi.NewConsumedCapacity()
 }
 
+func NewConsumedCapacityCollection() ConsumedCapacityCollection {
+	return schedulerapi.NewConsumedCapacityCollection()
+}
+
+func NewDeviceConsumedCapacity(deviceID DeviceID, consumedCapacity map[resourceapi.QualifiedName]resource.Quantity) DeviceConsumedCapacity {
+	return schedulerapi.NewDeviceConsumedCapacity(deviceID, consumedCapacity)
+}
+
+// GenerateShareID is a helper function that generates a new share ID.
+// This remains in the internal package as it's a utility function.
 func GenerateShareID() *types.UID {
 	newUID := uuid.NewUUID()
 	return &newUID
-}
-
-// AllocatedState packs information of allocated devices which is gathered from allocated resource claims.
-type AllocatedState struct {
-	AllocatedDevices         sets.Set[DeviceID]
-	AllocatedSharedDeviceIDs sets.Set[SharedDeviceID]
-	AggregatedCapacity       ConsumedCapacityCollection
-}
-
-// ConsumedCapacity defines consumable capacity values
-type ConsumedCapacity map[resourceapi.QualifiedName]*resource.Quantity
-
-// ConsumedCapacityCollection collects consumable capacity values of each device
-type ConsumedCapacityCollection map[DeviceID]ConsumedCapacity
-
-// NewConsumedCapacity initiates a new map of consumable capacity values
-func NewConsumedCapacity() ConsumedCapacity {
-	return make(ConsumedCapacity)
-}
-
-// NewConsumedCapacity initiates a new map of device's consumable capacity values
-func NewConsumedCapacityCollection() ConsumedCapacityCollection {
-	return make(ConsumedCapacityCollection)
-}
-
-// Clone makes a copy of consumed capacity values
-func (s ConsumedCapacity) Clone() ConsumedCapacity {
-	clone := make(ConsumedCapacity)
-	for name, quantity := range s {
-		q := quantity.DeepCopy()
-		clone[name] = &q
-	}
-	return clone
-}
-
-// Add adds quantity to corresponding consumable capacity,
-// and creates a new entry if no capacity created yet.
-func (s ConsumedCapacity) Add(addedCapacity ConsumedCapacity) {
-	for name, quantity := range addedCapacity {
-		val := quantity.DeepCopy()
-		if _, found := s[name]; found {
-			s[name].Add(val)
-		} else {
-			s[name] = &val
-		}
-	}
-}
-
-// Sub subtracts quantity,
-// and ignore if no capacity entry found.
-func (s ConsumedCapacity) Sub(subtractedCapacity ConsumedCapacity) {
-	for name, quantity := range subtractedCapacity {
-		if _, found := s[name]; found {
-			s[name].Sub(*quantity)
-		}
-	}
-}
-
-// Empty return true if all quantity is zero.
-func (s ConsumedCapacity) Empty() bool {
-	for _, quantity := range s {
-		if !quantity.IsZero() {
-			return false
-		}
-	}
-	return true
-}
-
-// Clone makes a copy of ConsumedCapacity of each capacity.
-func (c ConsumedCapacityCollection) Clone() ConsumedCapacityCollection {
-	clone := NewConsumedCapacityCollection()
-	for deviceID, share := range c {
-		clone[deviceID] = share.Clone()
-	}
-	return clone
-}
-
-// Insert adds a new allocated capacity to the collection.
-func (c ConsumedCapacityCollection) Insert(cap DeviceConsumedCapacity) {
-	consumedCapacity := cap.ConsumedCapacity
-	if _, found := c[cap.DeviceID]; found {
-		c[cap.DeviceID].Add(consumedCapacity)
-	} else {
-		c[cap.DeviceID] = consumedCapacity.Clone()
-	}
-}
-
-// Remove removes an allocated capacity from the collection.
-func (c ConsumedCapacityCollection) Remove(cap DeviceConsumedCapacity) {
-	if _, found := c[cap.DeviceID]; found {
-		c[cap.DeviceID].Sub(cap.ConsumedCapacity)
-		if c[cap.DeviceID].Empty() {
-			delete(c, cap.DeviceID)
-		}
-	}
-}
-
-// DeviceConsumedCapacity contains consumed capacity result within device allocation.
-type DeviceConsumedCapacity struct {
-	DeviceID
-	ConsumedCapacity
-}
-
-// NewDeviceConsumedCapacity creates DeviceConsumedCapacity instance from device ID and its consumed capacity.
-func NewDeviceConsumedCapacity(deviceID DeviceID, consumedCapacity map[resourceapi.QualifiedName]resource.Quantity) DeviceConsumedCapacity {
-	allocatedCapacity := NewConsumedCapacity()
-	for name, quantity := range consumedCapacity {
-		allocatedCapacity[name] = &quantity
-	}
-	return DeviceConsumedCapacity{
-		DeviceID:         deviceID,
-		ConsumedCapacity: allocatedCapacity,
-	}
-}
-
-// Clone makes a copy of DeviceConsumedCapacity.
-func (a DeviceConsumedCapacity) Clone() DeviceConsumedCapacity {
-	return DeviceConsumedCapacity{
-		DeviceID:         a.DeviceID,
-		ConsumedCapacity: a.ConsumedCapacity.Clone(),
-	}
-}
-
-// String returns formatted device ID.
-func (a DeviceConsumedCapacity) String() string {
-	return a.DeviceID.String()
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/OWNERS
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS file documentation: https://git.k8s.io/community/contributors/guide/owners.md
+# Disable inheritance as code changes under this package should be known to sig-autoscaling team.
+options:
+  no_parent_owners: true
+approvers:
+  - sig-autoscaling-maintainers

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/types.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/schedulerapi/types.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulerapi
+
+import (
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	draapi "k8s.io/dynamic-resource-allocation/api"
+)
+
+// DeviceID represents a unique identifier for a device in the DRA system.
+// This type is used in the scheduler and autoscaler contract.
+type DeviceID struct {
+	Driver, Pool, Device draapi.UniqueString
+}
+
+func (d DeviceID) String() string {
+	return d.Driver.String() + "/" + d.Pool.String() + "/" + d.Device.String()
+}
+
+// MakeDeviceID creates a new DeviceID from driver, pool, and device names.
+// This function is used in the scheduler and autoscaler contract.
+func MakeDeviceID(driver, pool, device string) DeviceID {
+	return DeviceID{
+		Driver: draapi.MakeUniqueString(driver),
+		Pool:   draapi.MakeUniqueString(pool),
+		Device: draapi.MakeUniqueString(device),
+	}
+}
+
+// SharedDeviceID represents a shared device allocation.
+// This type is used in consumable capacity features and the scheduler.
+type SharedDeviceID struct {
+	Driver, Pool, Device, ShareID draapi.UniqueString
+}
+
+func (d SharedDeviceID) String() string {
+	deviceIDStr := d.Driver.String() + "/" + d.Pool.String() + "/" + d.Device.String()
+	if d.ShareID.String() != "" {
+		deviceIDStr += "/" + d.ShareID.String()
+	}
+	return deviceIDStr
+}
+
+// MakeSharedDeviceID creates a new SharedDeviceID from a DeviceID and share ID.
+// This function is used in consumable capacity features and the scheduler.
+func MakeSharedDeviceID(deviceID DeviceID, shareID *types.UID) SharedDeviceID {
+	// This function avoids disruptive changes to MakeDeviceID
+	// while enabling ShareID as part of the device key.
+	var shareIDStr string
+	if shareID != nil {
+		shareIDStr = string(*shareID)
+	}
+	return SharedDeviceID{
+		Driver:  deviceID.Driver,
+		Pool:    deviceID.Pool,
+		Device:  deviceID.Device,
+		ShareID: draapi.MakeUniqueString(shareIDStr),
+	}
+}
+
+// AllocatedState represents the current state of allocated resources.
+// This type is used in the scheduler and autoscaler contract.
+// AllocatedState packs information of allocated devices which is gathered from allocated resource claims.
+type AllocatedState struct {
+	AllocatedDevices         sets.Set[DeviceID]
+	AllocatedSharedDeviceIDs sets.Set[SharedDeviceID]
+	AggregatedCapacity       ConsumedCapacityCollection
+}
+
+// ConsumedCapacity represents the consumed capacity of a specific resource.
+// This type is used in consumable capacity features and the scheduler.
+// ConsumedCapacity defines consumable capacity values
+type ConsumedCapacity map[resourceapi.QualifiedName]*resource.Quantity
+
+// NewConsumedCapacity creates a new ConsumedCapacity.
+// This function is used in consumable capacity features and the scheduler.
+// NewConsumedCapacity initiates a new map of consumable capacity values
+func NewConsumedCapacity() ConsumedCapacity {
+	return make(ConsumedCapacity)
+}
+
+// Clone makes a copy of consumed capacity values
+func (s ConsumedCapacity) Clone() ConsumedCapacity {
+	clone := make(ConsumedCapacity)
+	for name, quantity := range s {
+		q := quantity.DeepCopy()
+		clone[name] = &q
+	}
+	return clone
+}
+
+// Add adds quantity to corresponding consumable capacity,
+// and creates a new entry if no capacity created yet.
+func (s ConsumedCapacity) Add(addedCapacity ConsumedCapacity) {
+	for name, quantity := range addedCapacity {
+		val := quantity.DeepCopy()
+		if _, found := s[name]; found {
+			s[name].Add(val)
+		} else {
+			s[name] = &val
+		}
+	}
+}
+
+// Sub subtracts quantity,
+// and ignore if no capacity entry found.
+func (s ConsumedCapacity) Sub(subtractedCapacity ConsumedCapacity) {
+	for name, quantity := range subtractedCapacity {
+		if _, found := s[name]; found {
+			s[name].Sub(*quantity)
+		}
+	}
+}
+
+// Empty return true if all quantity is zero.
+func (s ConsumedCapacity) Empty() bool {
+	for _, quantity := range s {
+		if !quantity.IsZero() {
+			return false
+		}
+	}
+	return true
+}
+
+// ConsumedCapacityCollection represents a collection of consumed capacities.
+// This type is used in consumable capacity features and the scheduler.
+// ConsumedCapacityCollection collects consumable capacity values of each device
+type ConsumedCapacityCollection map[DeviceID]ConsumedCapacity
+
+// NewConsumedCapacityCollection creates a new ConsumedCapacityCollection.
+// This function is used in consumable capacity features and the scheduler.
+// NewConsumedCapacityCollection initiates a new map of device's consumable capacity values
+func NewConsumedCapacityCollection() ConsumedCapacityCollection {
+	return make(ConsumedCapacityCollection)
+}
+
+// Clone makes a copy of ConsumedCapacity of each capacity.
+func (c ConsumedCapacityCollection) Clone() ConsumedCapacityCollection {
+	clone := NewConsumedCapacityCollection()
+	for deviceID, share := range c {
+		clone[deviceID] = share.Clone()
+	}
+	return clone
+}
+
+// Insert adds a new allocated capacity to the collection.
+func (c ConsumedCapacityCollection) Insert(cap DeviceConsumedCapacity) {
+	consumedCapacity := cap.ConsumedCapacity
+	if _, found := c[cap.DeviceID]; found {
+		c[cap.DeviceID].Add(consumedCapacity)
+	} else {
+		c[cap.DeviceID] = consumedCapacity.Clone()
+	}
+}
+
+// Remove removes an allocated capacity from the collection.
+func (c ConsumedCapacityCollection) Remove(cap DeviceConsumedCapacity) {
+	if _, found := c[cap.DeviceID]; found {
+		c[cap.DeviceID].Sub(cap.ConsumedCapacity)
+		if c[cap.DeviceID].Empty() {
+			delete(c, cap.DeviceID)
+		}
+	}
+}
+
+// DeviceConsumedCapacity represents the consumed capacity of a device.
+// This type is used in consumable capacity features and the scheduler.
+// DeviceConsumedCapacity contains consumed capacity result within device allocation.
+type DeviceConsumedCapacity struct {
+	DeviceID
+	ConsumedCapacity
+}
+
+// NewDeviceConsumedCapacity creates a new DeviceConsumedCapacity.
+// This function is used in consumable capacity features and the scheduler.
+// NewDeviceConsumedCapacity creates DeviceConsumedCapacity instance from device ID and its consumed capacity.
+func NewDeviceConsumedCapacity(deviceID DeviceID, consumedCapacity map[resourceapi.QualifiedName]resource.Quantity) DeviceConsumedCapacity {
+	allocatedCapacity := NewConsumedCapacity()
+	for name, quantity := range consumedCapacity {
+		allocatedCapacity[name] = &quantity
+	}
+	return DeviceConsumedCapacity{
+		DeviceID:         deviceID,
+		ConsumedCapacity: allocatedCapacity,
+	}
+}
+
+// Clone makes a copy of DeviceConsumedCapacity.
+func (a DeviceConsumedCapacity) Clone() DeviceConsumedCapacity {
+	return DeviceConsumedCapacity{
+		DeviceID:         a.DeviceID,
+		ConsumedCapacity: a.ConsumedCapacity.Clone(),
+	}
+}
+
+// String returns formatted device ID.
+func (a DeviceConsumedCapacity) String() string {
+	return a.DeviceID.String()
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR extends `pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go` with a lister that uses a data structure defined in the `k8s.io/dynamic-resource-allocation/structured` package.

Currently, changes to that struct do not fall under SIG Autoscaling review unless explicitly requested. This makes it harder to catch issues during code review.

**Why this is needed:**  
To ensure that changes affecting the autoscaler are visible to SIG Autoscaling reviewers and do not slip through unnoticed.

#### Which issue(s) this PR is related to:
Fixes  #133162

#### Special notes for your reviewer:

One potential solution applied here is moving the relevant types into a new package:  
`k8s.io/dynamic-resource-allocation/structured/schedulerapi`  as @pohly  mentioned in the issue.

An OWNERS file is set up there similar to the one under `autoscaler_contract`, so that the right reviewers are automatically added.

/wg device-management  
/sig autoscaling  

#### Does this PR introduce a user-facing change?
```release-note
NONE
