### PR TITLE
remove cpuSharesToCPUWeight that is not used any longer

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -170,49 +170,6 @@ func TestParseSystemdToCgroupName(t *testing.T) {
 	}
 }
 
-func TestCpuSharesToCPUWeight(t *testing.T) {
-	testCases := []struct {
-		cpuShares         uint64
-		expectedCpuWeight uint64
-	}{
-		{
-			cpuShares:         2,
-			expectedCpuWeight: 1,
-		},
-		{
-			cpuShares:         3,
-			expectedCpuWeight: 1,
-		},
-		{
-			cpuShares:         4,
-			expectedCpuWeight: 1,
-		},
-		{
-			cpuShares:         28,
-			expectedCpuWeight: 1,
-		},
-		{
-			cpuShares:         29,
-			expectedCpuWeight: 2,
-		},
-		{
-			cpuShares:         245,
-			expectedCpuWeight: 10,
-		},
-		{
-			cpuShares:         262144,
-			expectedCpuWeight: 10000,
-		},
-	}
-
-	for _, testCase := range testCases {
-		if actual := cpuSharesToCPUWeight(testCase.cpuShares); actual != testCase.expectedCpuWeight {
-			t.Errorf("cpuShares: %v, expectedCpuWeight: %v, actualCpuWeight: %v",
-				testCase.cpuShares, testCase.expectedCpuWeight, actual)
-		}
-	}
-}
-
 func TestCpuWeightToCPUShares(t *testing.T) {
 	testCases := []struct {
 		cpuWeight         uint64

--- a/pkg/kubelet/cm/cgroup_v2_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_v2_manager_linux.go
@@ -168,12 +168,6 @@ func (c *cgroupV2impl) buildCgroupUnifiedPath(name CgroupName) string {
 	return path.Join(cmutil.CgroupRoot, cgroupFsAdaptedName)
 }
 
-// Convert cgroup v1 cpu.shares value to cgroup v2 cpu.weight
-// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
-func cpuSharesToCPUWeight(cpuShares uint64) uint64 {
-	return uint64((((cpuShares - 2) * 9999) / 262142) + 1)
-}
-
 // Convert cgroup v2 cpu.weight value to cgroup v1 cpu.shares
 // https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2254-cgroup-v2#phase-1-convert-from-cgroups-v1-settings-to-v2
 func cpuWeightToCPUShares(cpuWeight uint64) uint64 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

See https://github.com/google/cadvisor/issues/3737 The use of it was removed in https://github.com/kubernetes/kubernetes/pull/124216/

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
