### PR TITLE
KEP-3721: Promote EnvFiles feature gate to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1232,6 +1232,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 	EnvFiles: {
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 	EventedPLEG: {
 		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -932,12 +932,6 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 					return result, fmt.Errorf("failed to get host path for volume %q: %w", volume, err)
 				}
 
-				// Validate key length, must not exceed 128 characters.
-				// TODO: @HirazawaUi This limit will be relaxed after the EnvFiles feature gate beta stage.
-				if len(key) > 128 {
-					return result, fmt.Errorf("environment variable key %q exceeds maximum length of 128 characters", key)
-				}
-
 				// Construct the full path to the environment variable file
 				// by combining hostPath with the specified path in FileKeyRef
 				envFilePath, err := securejoin.SecureJoin(hostPath, f.Path)
@@ -949,12 +943,6 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 				if err != nil {
 					klog.ErrorS(err, "Failed to parse env file", "pod", klog.KObj(pod))
 					return result, fmt.Errorf("couldn't parse env file")
-				}
-
-				// Validate value size, must not exceed 32KB.
-				// TODO: @HirazawaUi This limit will be relaxed after the EnvFiles feature gate beta stage.
-				if len(runtimeVal) > 32*1024 {
-					return result, fmt.Errorf("environment variable value for key %q exceeds maximum size of 32KB", key)
 				}
 
 				// If the key was not found, and it's not optional, return an error

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -7020,7 +7020,7 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 				{Name: "DATABASE", Value: "mydb"},
 			},
 			setupFiles: func() []string {
-				content := "DATABASE=mydb\nAPI_KEY=secret123\n"
+				content := "DATABASE='mydb'\nAPI_KEY='secret123'\n"
 				return []string{createEnvFile("database.env", content)}
 			},
 		},
@@ -7049,7 +7049,7 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 				{Name: "API_KEY", Value: "secret123"},
 			},
 			setupFiles: func() []string {
-				content := "# This is a comment\n\nDATABASE=mydb\nAPI_KEY=secret123\n\n# Another comment\n"
+				content := "# This is a comment\n\nDATABASE='mydb'\nAPI_KEY='secret123'\n\n# Another comment\n"
 				return []string{createEnvFile("config.env", content)}
 			},
 		},
@@ -7077,8 +7077,10 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 			expectedEnvs: []kubecontainer.EnvVar{
 				{Name: "DEBUG_MODE", Value: "true"},
 			},
+			expectedError: true,
+			errorContains: "couldn't parse env file",
 			setupFiles: func() []string {
-				content := "DEBUG_MODE = true\nLOG_LEVEL = info\n"
+				content := "DEBUG_MODE = 'true'\nLOG_LEVEL = 'info'\n"
 				return []string{createEnvFile("debug.env", content)}
 			},
 		},
@@ -7106,7 +7108,7 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 			expectedError: true,
 			errorContains: "environment variable key \"MISSING_KEY\" not found in file",
 			setupFiles: func() []string {
-				content := "EXISTING_KEY=value\n"
+				content := "EXISTING_KEY='value'\n"
 				return []string{createEnvFile("config.env", content)}
 			},
 		},
@@ -7134,7 +7136,7 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 			},
 			expectedEnvs: nil,
 			setupFiles: func() []string {
-				content := "EXISTING_KEY=value\n"
+				content := "EXISTING_KEY='value'\n"
 				return []string{createEnvFile("config.env", content)}
 			},
 		},
@@ -7163,63 +7165,6 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 			errorContains: "couldn't parse env file",
 			setupFiles: func() []string {
 				return []string{} // No files created
-			},
-		},
-		{
-			name: "key length exceeds 128 characters",
-			container: &v1.Container{
-				Env: []v1.EnvVar{
-					{
-						Name: "LONG_KEY",
-						ValueFrom: &v1.EnvVarSource{
-							FileKeyRef: &v1.FileKeySelector{
-								VolumeName: "config-volume",
-								Path:       "config.env",
-								Key:        strings.Repeat("A", 129),
-							},
-						},
-					},
-				},
-			},
-			podVolumes: map[string]kubecontainer.VolumeInfo{
-				"config-volume": {
-					Mounter: &testVolumeMounter{path: tmpDir},
-				},
-			},
-			expectedError: true,
-			errorContains: "exceeds maximum length of 128 characters",
-			setupFiles: func() []string {
-				content := "EXISTING_KEY=value\n"
-				return []string{createEnvFile("config.env", content)}
-			},
-		},
-		{
-			name: "value size exceeds 32KB",
-			container: &v1.Container{
-				Env: []v1.EnvVar{
-					{
-						Name: "LARGE_VALUE",
-						ValueFrom: &v1.EnvVarSource{
-							FileKeyRef: &v1.FileKeySelector{
-								VolumeName: "config-volume",
-								Path:       "large.env",
-								Key:        "LARGE_VALUE",
-							},
-						},
-					},
-				},
-			},
-			podVolumes: map[string]kubecontainer.VolumeInfo{
-				"config-volume": {
-					Mounter: &testVolumeMounter{path: tmpDir},
-				},
-			},
-			expectedError: true,
-			errorContains: "environment variable value for key \"LARGE_VALUE\" exceeds maximum size of 32KB",
-			setupFiles: func() []string {
-				largeValue := strings.Repeat("A", 33*1024) // 33KB
-				content := fmt.Sprintf("LARGE_VALUE=%s\n", largeValue)
-				return []string{createEnvFile("large.env", content)}
 			},
 		},
 		{
@@ -7312,8 +7257,8 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 				{Name: "API_KEY", Value: "secret123"},
 			},
 			setupFiles: func() []string {
-				dbContent := "DATABASE=mydb\n"
-				apiContent := "API_KEY=secret123\n"
+				dbContent := "DATABASE='mydb'\n"
+				apiContent := "API_KEY='secret123'\n"
 				return []string{
 					createEnvFile("database.env", dbContent),
 					createEnvFile("api.env", apiContent),
@@ -7350,7 +7295,7 @@ func TestMakeEnvironmentVariablesWithFileKeyRef(t *testing.T) {
 				{Name: "FILE_VAR", Value: "file_value"},
 			},
 			setupFiles: func() []string {
-				content := "FILE_VAR=file_value\n"
+				content := "FILE_VAR='file_value'\n"
 				return []string{createEnvFile("config.env", content)}
 			},
 		},

--- a/pkg/kubelet/util/env/env_util_test.go
+++ b/pkg/kubelet/util/env/env_util_test.go
@@ -18,9 +18,41 @@ package env
 
 import (
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+// testShellBehavior tests how a POSIX shell would interpret the given environment file content
+// and returns the value that would be assigned to the given key
+// This test will not run on Windows.
+func testShellBehavior(t *testing.T, envContent, key string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "shell_test_*")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	if _, err := tmpFile.Write([]byte(envContent)); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+
+	// Use bash with POSIX mode to source the file and print the variable
+	// We use . instead of source for POSIX compliance
+	cmd := exec.Command("bash", "--posix", "-c",
+		"set -a && . \""+tmpFile.Name()+"\" && printf '%s' \"${"+key+"}\"")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
 
 func TestParseEnv(t *testing.T) {
 	tempDir := t.TempDir()
@@ -36,245 +68,498 @@ func TestParseEnv(t *testing.T) {
 	tests := []testCase{
 		{
 			name: "ignore leading whitespace",
-			envContent: `   KEY1=val1
-		KEY2=val2
-KEY3=val3
+			envContent: `   KEY1='val1'
+		KEY2='val2'
+KEY3='val3'
 `,
 			key:       "KEY2",
-			wantValue: "val2",
+			wantValue: `val2`,
 		},
 		{
 			name: "ignore blank and comment lines",
 			envContent: `# comment
 
-KEY1=foo
+KEY1='foo'
    # another comment
-	
-KEY2=bar
+
+KEY2='bar'
 `,
 			key:       "KEY2",
-			wantValue: "bar",
+			wantValue: `bar`,
 		},
 		{
-			name: "whitespace around = and trailing",
-			envContent: `KEY1 = val1   
-KEY2=   val2	
-KEY3=val3   	
-`,
-			key:       "KEY2",
-			wantValue: "val2",
-		},
-		{
-			name: "continuation line with \\",
-			envContent: `KEY1=foo \
-bar \
-baz
-KEY2=val2
-`,
-			key:       "KEY1",
-			wantValue: "foo bar baz",
-		},
-		{
-			name: "continuation with whitespace and comment",
-			envContent: `KEY1=foo \
-  bar
-# comment
-KEY2=val2
-`,
-			key:       "KEY1",
-			wantValue: "foo bar",
-		},
-		{
-			name: "invalid line triggers error with line number",
-			envContent: `KEY1=foo
-INVALID_LINE
-KEY2=bar
+			name: "whitespace around = and not allowed",
+			envContent: `KEY1 = 'val1'
+KEY2=   'val2'
+KEY3='val3'
 `,
 			key:         "KEY2",
 			wantErr:     true,
-			errContains: "at line 2",
-		},
-		{
-			name: "unfinished continuation triggers error",
-			envContent: `KEY1=foo \
-bar \
-`,
-			key:         "KEY1",
-			wantErr:     true,
-			errContains: "unfinished line continuation",
+			errContains: `whitespace before '=' is not allowed`,
 		},
 		{
 			name: "key not found returns empty",
-			envContent: `KEY1=foo
-KEY2=bar
+			envContent: `KEY1='foo'
+KEY2='bar'
 `,
 			key:       "KEY3",
-			wantValue: "",
+			wantValue: ``,
 		},
 		{
 			name: "value with embedded #",
-			envContent: `KEY1=foo#notcomment
-KEY2=bar
+			envContent: `KEY1='foo#notcomment'
+KEY2='bar'
 `,
 			key:       "KEY1",
-			wantValue: "foo#notcomment",
+			wantValue: `foo#notcomment`,
 		},
 		{
-			name: "key with trailing whitespace",
-			envContent: `KEY1 =foo
-KEY2=bar
+			name: "key with whitespace (should error)",
+			envContent: `KEY1 ='foo'
+KEY2='bar'
 `,
-			key:       "KEY1",
-			wantValue: "foo",
+			key:         "KEY1",
+			wantErr:     true,
+			errContains: "whitespace before '=' is not allowed",
 		},
 		{
 			name: "value with leading and trailing whitespace",
-			envContent: `KEY1=   foo bar   
-KEY2=bar
+			envContent: `KEY1='   foo bar   '
+KEY2='bar'
 `,
 			key:       "KEY1",
-			wantValue: "foo bar",
+			wantValue: `   foo bar   `,
 		},
 		{
 			name: "multiple comments and blank lines",
 			envContent: `# first comment
 
 # second comment
-KEY1=foo
+KEY1='foo'
 
 # third comment
-KEY2=bar
+KEY2='bar'
 `,
 			key:       "KEY2",
-			wantValue: "bar",
-		},
-		{
-			name: "continuation with blank line in between (should error)",
-			envContent: `KEY1=foo \
-
-bar
-`,
-			key:         "KEY1",
-			wantErr:     true,
-			errContains: "invalid environment variable format",
-		},
-		{
-			name: "continuation with comment in between (should error)",
-			envContent: `KEY1=foo \
-# comment
-bar
-`,
-			key:         "KEY1",
-			wantErr:     true,
-			errContains: "invalid environment variable format",
+			wantValue: `bar`,
 		},
 		{
 			name: "empty value",
-			envContent: `KEY1=foo
-KEY2=
-KEY3=bar
+			envContent: `KEY1='foo'
+KEY2=''
+KEY3='bar'
 `,
 			key:       "KEY2",
-			wantValue: "",
-		},
-		{
-			name: "value with only spaces",
-			envContent: `KEY1=foo
-KEY2=   
-KEY3=bar
-`,
-			key:       "KEY2",
-			wantValue: "",
+			wantValue: ``,
 		},
 		{
 			name: "key is empty (should error)",
-			envContent: `=foo
-KEY2=bar
+			envContent: `='foo'
+KEY2='bar'
 `,
 			key:         "KEY2",
-			wantValue:   "bar",
 			wantErr:     true,
 			errContains: "invalid environment variable format",
 		},
 		{
 			name: "multiple = in value",
-			envContent: `KEY1=foo=bar=baz
-KEY2=bar
+			envContent: `KEY1='foo=bar=baz'
+KEY2='bar'
 `,
 			key:       "KEY1",
-			wantValue: "foo=bar=baz",
-		},
-		{
-			name: "continuation with trailing spaces",
-			envContent: `KEY1=foo   \
-  bar   \
-  baz   
-KEY2=bar
-`,
-			key:       "KEY1",
-			wantValue: "foo bar baz",
+			wantValue: `foo=bar=baz`,
 		},
 		{
 			name: "comment after key value pair",
-			envContent: `KEY1=foo
-KEY2=bar # comment
+			envContent: `KEY1='foo'
+KEY2='bar' # comment
 `,
 			key:       "KEY2",
-			wantValue: "bar # comment",
-		},
-		{
-			name: "blank line in continuation triggers error with line number",
-			envContent: `KEY1=foo \
-
-bar=val`,
-			key:         "bar",
-			wantErr:     true,
-			errContains: "at line 2",
-		},
-		{
-			name: "comment in continuation triggers error with line number",
-			envContent: `KEY1=foo \
-# comment
-bar=val`,
-			key:         "bar",
-			wantErr:     true,
-			errContains: "at line 2",
+			wantValue: `bar`,
 		},
 		{
 			name: "missing key triggers error with line number",
-			envContent: `=foo
-KEY2=bar`,
+			envContent: `='foo'
+KEY2='bar'`,
 			key:         "KEY2",
 			wantErr:     true,
 			errContains: "at line 1",
 		},
 		{
 			name: "value contains $VAR, should not expand",
-			envContent: `KEY1=$VAR
-KEY2=bar`,
+			envContent: `KEY1='$VAR'
+KEY2='bar'`,
 			key:       "KEY1",
-			wantValue: "$VAR",
+			wantValue: `$VAR`,
 		},
 		{
 			name: "value contains ${VAR}, should not expand",
-			envContent: `KEY1=${VAR}
-KEY2=bar`,
+			envContent: `KEY1='${VAR}'
+KEY2='bar'`,
 			key:       "KEY1",
-			wantValue: "${VAR}",
+			wantValue: `${VAR}`,
 		},
 		{
 			name: "value contains $HOME, should not expand",
-			envContent: `KEY1=$HOME
-KEY2=bar`,
+			envContent: `KEY1='$HOME'
+KEY2='bar'`,
 			key:       "KEY1",
-			wantValue: "$HOME",
+			wantValue: `$HOME`,
 		},
 		{
 			name: "value contains mixed shell variable syntax, should not expand",
-			envContent: `KEY1=foo$BAR-${HOME}_$
-KEY2=bar`,
+			envContent: `KEY1='foo$BAR-${HOME}_$'
+KEY2='bar'`,
 			key:       "KEY1",
-			wantValue: "foo$BAR-${HOME}_$",
+			wantValue: `foo$BAR-${HOME}_$`,
+		},
+		{
+			name: "invalid line triggers error with line number",
+			envContent: `KEY1='foo'
+INVALID_LINE
+KEY2='bar'
+`,
+			key:         "KEY2",
+			wantErr:     true,
+			errContains: "at line 2",
+		},
+		{
+			name: "unquoted value triggers error",
+			envContent: `KEY1='foo'
+KEY2=bar
+KEY3='baz'
+`,
+			key:         "KEY2",
+			wantErr:     true,
+			errContains: "value must be enclosed in single quotes",
+		},
+		{
+			name: "double quoted value triggers error",
+			envContent: `KEY1='foo'
+KEY2="bar"
+KEY3='baz'
+`,
+			key:         "KEY2",
+			wantErr:     true,
+			errContains: "value must be enclosed in single quotes",
+		},
+		{
+			name:        "value with multiple adjacent quoted strings",
+			envContent:  `KEY1='foo''bar'`,
+			key:         "KEY1",
+			wantErr:     true,
+			errContains: `unexpected content after closing quote`,
+		},
+		{
+			name: "unclosed single quote triggers error",
+			envContent: `KEY1='foo'
+KEY2='bar
+KEY3='baz'
+`,
+			key:         "KEY2",
+			wantErr:     true,
+			errContains: "unexpected content after closing quote",
+		},
+		{
+			name: "content after closing quote triggers error",
+			envContent: `KEY1='foo'
+KEY2='bar'baz
+KEY3='baz'
+`,
+			key:         "KEY2",
+			wantErr:     true,
+			errContains: "unexpected content after closing quote",
+		},
+		{
+			name: "empty quotes preserve literal content",
+			envContent: `KEY1=''
+KEY2='   '
+KEY3='bar'
+`,
+			key:       "KEY1",
+			wantValue: ``,
+		},
+		{
+			name: "quotes preserve all literal content including spaces",
+			envContent: `KEY1='  foo  bar  '
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `  foo  bar  `,
+		},
+		{
+			name: "special characters in value",
+			envContent: `KEY1='!@#$%^&*()_+-=[]{}|;:,.<>?/'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `!@#$%^&*()_+-=[]{}|;:,.<>?/`,
+		},
+		{
+			name: "newlines and tabs in value",
+			envContent: `KEY1='line1\nline2\tline3'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `line1\nline2\tline3`,
+		},
+		{
+			name: "unicode characters in value",
+			envContent: `KEY1='中文 Español Français 🌍'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `中文 Español Français 🌍`,
+		},
+		{
+			name: "backslashes in value",
+			envContent: `KEY1='path\\to\\file'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `path\\to\\file`,
+		},
+		{
+			name: "single quotes within value quotes",
+			envContent: `KEY1='value with \'nested\' quotes'
+KEY2='bar'
+`,
+			key:         "KEY1",
+			wantErr:     true,
+			errContains: "unexpected content after closing quote",
+		},
+		{
+			name: "double quotes within value quotes",
+			envContent: `KEY1='value with "nested" quotes'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantErr:   false,
+			wantValue: `value with "nested" quotes`,
+		},
+		{
+			name: "empty single quotes",
+			envContent: `KEY1=''
+KEY2=''
+KEY3='bar'
+`,
+			key:       "KEY2",
+			wantValue: ``,
+		},
+		{
+			name: "only whitespace in quotes",
+			envContent: `KEY1='   '
+KEY2='\t\n'
+KEY3='bar'
+`,
+			key:       "KEY1",
+			wantValue: "   ",
+		},
+		{
+			name: "complex JSON-like value",
+			envContent: `KEY1='{"name": "test", "value": 123, "nested": {"key": "val"}}'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `{"name": "test", "value": 123, "nested": {"key": "val"}}`,
+		},
+		{
+			name: "URL with special characters",
+			envContent: `KEY1='https://example.com/path?query=value&another=param'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `https://example.com/path?query=value&another=param`,
+		},
+		{
+			name: "XML-like content",
+			envContent: `KEY1='<root><element attr="value">content</element></root>'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `<root><element attr="value">content</element></root>`,
+		},
+		{
+			name: "base64 encoded data",
+			envContent: `KEY1='SGVsbG8gV29ybGQh'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `SGVsbG8gV29ybGQh`,
+		},
+		{
+			name: "regex pattern",
+			envContent: `KEY1='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$'
+KEY2='bar'
+`,
+			key:       "KEY1",
+			wantValue: `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$`,
+		},
+		{
+			name: "multi-line value with spaces",
+			envContent: `KEY1='line one
+  line two with spaces
+    line three with more spaces'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `line one
+  line two with spaces
+    line three with more spaces`,
+		},
+		{
+			name: "multi-line value with special characters",
+			envContent: `KEY1='line1: !@#$%^&*()
+line2: []{}|;:,.<>?/
+line3: \\\\tabs\\nnewlines'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `line1: !@#$%^&*()
+line2: []{}|;:,.<>?/
+line3: \\\\tabs\\nnewlines`,
+		},
+		{
+			name: "multi-line value with mixed content",
+			envContent: `KEY1='First line
+Second line with $VAR and ${HOME}
+Third line with spaces    and    tabs\\t
+Fourth line with special chars: !@#$%^&*()_+'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `First line
+Second line with $VAR and ${HOME}
+Third line with spaces    and    tabs\\t
+Fourth line with special chars: !@#$%^&*()_+`,
+		},
+		{
+			name: "multi-line value with empty lines",
+			envContent: `KEY1='line1
+
+line3 after empty line
+
+line5 after another empty'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `line1
+
+line3 after empty line
+
+line5 after another empty`,
+		},
+		{
+			name: "multi-line value with trailing spaces",
+			envContent: `KEY1='line1
+line2 with trailing spaces
+line3   '
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `line1
+line2 with trailing spaces
+line3   `,
+		},
+		{
+			name: "multi-line value with unicode characters",
+			envContent: `KEY1='中文 第一行
+English second line
+Français troisième ligne 🌍
+Русский четвертая строка'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `中文 第一行
+English second line
+Français troisième ligne 🌍
+Русский четвертая строка`,
+		},
+		{
+			name: "multi-line value with code-like content",
+			envContent: `KEY1='func main() {
+    fmt.Println(\"Hello, World!\")
+    for i := 0; i < 10; i++ {
+        fmt.Printf(\"i=%d\\n\", i)
+    }
+}'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `func main() {
+    fmt.Println(\"Hello, World!\")
+    for i := 0; i < 10; i++ {
+        fmt.Printf(\"i=%d\\n\", i)
+    }
+}`,
+		},
+		{
+			name: "multi-line value with JSON content",
+			envContent: `KEY1='{
+  "name": "test",
+  "value": 123,
+  "nested": {
+    "key": "val",
+    "array": [1, 2, 3]
+  }
+}'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `{
+  "name": "test",
+  "value": 123,
+  "nested": {
+    "key": "val",
+    "array": [1, 2, 3]
+  }
+}`,
+		},
+		{
+			name: "multi-line value with YAML content",
+			envContent: `KEY1='name: test
+value: 123
+nested:
+  key: val
+  array:
+    - 1
+    - 2
+    - 3'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `name: test
+value: 123
+nested:
+  key: val
+  array:
+    - 1
+    - 2
+    - 3`,
+		},
+		{
+			name: "multi-line value with Cert",
+			envContent: `KEY1='-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQSSSSSSSSSSSSSBlwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAYEAyUgx65kBQf/Nl+EcOFkP8q7n7FDetNrH7WYAnpYnaWG8w4rA9ht9
+upttTNyRbCVpb32f5m8DFvVug0vAa/ksX8iSKzD53bWTuTQiN/i9Q/iG0eCNPR0KoW/gLV
+SS9pIWWVYNav6dBjknR85202+YryJkn8THAf8Kg5Lwl0dom41dZvN1DirbcqWOU1BKG2sl
+pFIq8BdXedRjwoNYngMvLBOb4CAfvQyKr1+ARQecqzPn4pTovYtIZRasIgrBOpSpHGZa70
+pTAVP5+KGXN5DigjQUWaje1AiEx5zk8J3T5AA0abSaNn0uE53tjgalTzcY9kxHdo2rgHJC
+huHhWsWslkcntkKp0V1Jc8oGv86Dp5mPhpfpMOK+vCe2TrS/saes9fNVxjorSpLl4xTU/V
+-----END OPENSSH PRIVATE KEY-----'
+KEY2='bar'
+`,
+			key: "KEY1",
+			wantValue: `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQSSSSSSSSSSSSSBlwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAYEAyUgx65kBQf/Nl+EcOFkP8q7n7FDetNrH7WYAnpYnaWG8w4rA9ht9
+upttTNyRbCVpb32f5m8DFvVug0vAa/ksX8iSKzD53bWTuTQiN/i9Q/iG0eCNPR0KoW/gLV
+SS9pIWWVYNav6dBjknR85202+YryJkn8THAf8Kg5Lwl0dom41dZvN1DirbcqWOU1BKG2sl
+pFIq8BdXedRjwoNYngMvLBOb4CAfvQyKr1+ARQecqzPn4pTovYtIZRasIgrBOpSpHGZa70
+pTAVP5+KGXN5DigjQUWaje1AiEx5zk8J3T5AA0abSaNn0uE53tjgalTzcY9kxHdo2rgHJC
+huHhWsWslkcntkKp0V1Jc8oGv86Dp5mPhpfpMOK+vCe2TrS/saes9fNVxjorSpLl4xTU/V
+-----END OPENSSH PRIVATE KEY-----`,
 		},
 	}
 
@@ -309,6 +594,18 @@ KEY2=bar`,
 			}
 			if gotValue != tt.wantValue {
 				t.Errorf("got %q, want %q", gotValue, tt.wantValue)
+			}
+
+			// Verify shell behavior matches our parser
+			if runtime.GOOS != "windows" {
+				shellValue, shellErr := testShellBehavior(t, tt.envContent, tt.key)
+				if shellErr != nil {
+					t.Errorf("shell failed to parse valid syntax: %v", shellErr)
+					return
+				}
+				if gotValue != shellValue {
+					t.Errorf("shell behavior mismatch: ParseEnv=%q, shell=%q", gotValue, shellValue)
+				}
 			}
 		})
 	}

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -563,6 +563,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.34"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.35"
 - name: EventedPLEG
   versionedSpecs:
   - default: false

--- a/test/e2e/common/node/file_key.go
+++ b/test/e2e/common/node/file_key.go
@@ -61,7 +61,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'CONFIG_1=value1' > /data/config.env && echo 'CONFIG_2=value2' >> /data/config.env"},
+						Command: []string{"sh", "-c", `echo CONFIG_1=\'value1\' > /data/config.env && echo CONFIG_2=\'value2\' >> /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -136,7 +136,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'CONFIG_1=value1' > /data/config.env && echo 'CONFIG_2=value2' >> /data/config.env && echo 'CONFIG_3=value3' >> /data/config.env"},
+						Command: []string{"sh", "-c", `echo CONFIG_1=\'value1\' > /data/config.env && echo CONFIG_2=\'value2\' >> /data/config.env && echo CONFIG_3=\'value3\' >> /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -239,7 +239,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'EXISTING_KEY=existing_value' > /data/config.env"},
+						Command: []string{"sh", "-c", `echo EXISTING_KEY=\'existing_value\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -313,7 +313,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'HOOK_CONFIG=hook_value' > /data/config.env"},
+						Command: []string{"sh", "-c", `echo HOOK_CONFIG=\'hook_value\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -394,7 +394,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'HOOK_CONFIG=hook_value' > /data/config.env"},
+						Command: []string{"sh", "-c", `echo HOOK_CONFIG=\'hook_value\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -475,7 +475,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'CONFIG_1=value1' > /data/config.env"},
+						Command: []string{"sh", "-c", `echo CONFIG_1=\'value1\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -545,7 +545,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'CONFIG_1=value1' > /data/config.env"},
+						Command: []string{"sh", "-c", `echo CONFIG_1=\'value1\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -607,7 +607,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'EXISTING_KEY=value' > /data/config.env"},
+						Command: []string{"sh", "-c", `echo EXISTING_KEY=\'value\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -679,7 +679,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:    "setup-envfile",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"sh", "-c", "echo 'EXISTING_KEY=value' > /data/config.env"},
+						Command: []string{"sh", "-c", `echo EXISTING_KEY=\'value\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "config",
@@ -749,7 +749,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:         "setup-envfile",
 						Image:        imageutils.GetE2EImage(imageutils.BusyBox),
-						Command:      []string{"sh", "-c", "echo 'CONFIG_1=value1' > /data/config.env"},
+						Command:      []string{"sh", "-c", `echo CONFIG_1=\'value1\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{{Name: "config", MountPath: "/data"}},
 					},
 					{
@@ -807,7 +807,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 					{
 						Name:         "setup-envfile",
 						Image:        imageutils.GetE2EImage(imageutils.BusyBox),
-						Command:      []string{"sh", "-c", "echo 'CONFIG_INIT=fail' > /data/config.env"},
+						Command:      []string{"sh", "-c", `echo CONFIG_INIT=\'fail\' > /data/config.env`},
 						VolumeMounts: []v1.VolumeMount{{Name: "config", MountPath: "/data"}},
 					},
 					{
@@ -856,7 +856,7 @@ var _ = SIGDescribe("FileKeyRef", framework.WithFeatureGate(features.EnvFiles), 
 				InitContainers: []v1.Container{{
 					Name:         "setup-envfile",
 					Image:        imageutils.GetE2EImage(imageutils.BusyBox),
-					Command:      []string{"sh", "-c", "echo 'CONFIG_EPH=ephemeral' > /data/config.env"},
+					Command:      []string{"sh", "-c", `echo CONFIG_EPH=\'ephemeral\' > /data/config.env`},
 					VolumeMounts: []v1.VolumeMount{{Name: "config", MountPath: "/data"}},
 				}},
 				Containers: []v1.Container{{

--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -24,26 +24,150 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubernetes/pkg/cluster/ports"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
+	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	testutils "k8s.io/kubernetes/test/utils"
 )
+
+var _ = SIGDescribe(feature.StandaloneMode, framework.WithFeatureGate(features.EnvFiles), func() {
+	f := framework.NewDefaultFramework("static-pod-envfiles")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	ginkgo.Context("when creating a static pod with EnvFiles", func() {
+		var ns, podPath, staticPodName string
+
+		ginkgo.It("the pod should be running and consume variables", func(ctx context.Context) {
+			ns = f.Namespace.Name
+			staticPodName = "static-pod-envfiles-" + string(uuid.NewUUID())
+			podPath = kubeletCfg.StaticPodPath
+
+			podSpec := &v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      staticPodName,
+					Namespace: ns,
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:    "setup-envfile",
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"sh", "-c", `echo CONFIG_1=\'value1\' > /data/config.env && echo CONFIG_2=\'value2\' >> /data/config.env`},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: "/data",
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:    "use-envfile",
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"sh", "-c", "env | grep -E '(CONFIG_1|CONFIG_2)' | sort"},
+							Env: []v1.EnvVar{
+								{
+									Name: "CONFIG_1",
+									ValueFrom: &v1.EnvVarSource{
+										FileKeyRef: &v1.FileKeySelector{
+											VolumeName: "config",
+											Path:       "config.env",
+											Key:        "CONFIG_1",
+										},
+									},
+								},
+								{
+									Name: "CONFIG_2",
+									ValueFrom: &v1.EnvVarSource{
+										FileKeyRef: &v1.FileKeySelector{
+											VolumeName: "config",
+											Path:       "config.env",
+											Key:        "CONFIG_2",
+										},
+									},
+								},
+							},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+					Volumes: []v1.Volume{
+						{
+							Name: "config",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			}
+
+			err := scheduleStaticPod(podPath, staticPodName, ns, podSpec)
+			framework.ExpectNoError(err)
+
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				pod, err := getPodFromStandaloneKubelet(ctx, ns, staticPodName)
+				if err != nil {
+					return fmt.Errorf("error getting pod(%v/%v) from standalone kubelet: %w", ns, staticPodName, err)
+				}
+				if pod.Status.Phase == v1.PodSucceeded {
+					return nil
+				}
+				if pod.Status.Phase == v1.PodFailed {
+					logs, err := getPodLogsFromStandaloneKubelet(ctx, ns, staticPodName, "use-envfile")
+					if err != nil {
+						framework.Logf("failed to get logs on pod failure: %v", err)
+					}
+					return fmt.Errorf("pod (%v/%v) failed, logs: %s", ns, staticPodName, logs)
+				}
+				return fmt.Errorf("pod (%v/%v) is not succeeded, phase: %s", ns, staticPodName, pod.Status.Phase)
+			}, f.Timeouts.PodStart, time.Second*5).Should(gomega.Succeed())
+
+			logs, err := getPodLogsFromStandaloneKubelet(ctx, ns, staticPodName, "use-envfile")
+			framework.ExpectNoError(err)
+
+			gomega.Expect(logs).To(gomega.ContainSubstring("CONFIG_1=value1"))
+			gomega.Expect(logs).To(gomega.ContainSubstring("CONFIG_2=value2"))
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			ginkgo.By(fmt.Sprintf("delete the static pod (%v/%v)", ns, staticPodName))
+			err := deleteStaticPod(podPath, staticPodName, ns)
+			framework.ExpectNoError(err)
+
+			ginkgo.By(fmt.Sprintf("wait for pod to disappear (%v/%v)", ns, staticPodName))
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				_, err := getPodFromStandaloneKubelet(ctx, ns, staticPodName)
+
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("pod (%v/%v) still exists", ns, staticPodName)
+			}).Should(gomega.Succeed())
+		})
+	})
+})
 
 var _ = SIGDescribe(feature.StandaloneMode, func() {
 	f := framework.NewDefaultFramework("static-pod")
@@ -313,6 +437,36 @@ func getPodFromStandaloneKubelet(ctx context.Context, podNamespace string, podNa
 	}
 
 	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, podName)
+}
+
+func getPodLogsFromStandaloneKubelet(ctx context.Context, podNamespace string, podName string, containerName string) (string, error) {
+	pod, err := getPodFromStandaloneKubelet(ctx, podNamespace, podName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod %s/%s: %w", podNamespace, podName, err)
+	}
+
+	logCRIDir := "/var/log/pods"
+	podLogDir := filepath.Join(logCRIDir, fmt.Sprintf("%s_%s_%s", pod.Namespace, pod.Name, pod.UID))
+	logFile := filepath.Join(podLogDir, containerName, "0.log")
+
+	var content []byte
+	err = wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		var errRead error
+		content, errRead = os.ReadFile(logFile)
+		if errRead != nil {
+			if os.IsNotExist(errRead) {
+				return false, nil
+			}
+			return false, errRead
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("could not read log file %s: %w", logFile, err)
+	}
+
+	return string(content), nil
 }
 
 // Decodes the http response from /configz and returns a kubeletconfig.KubeletConfiguration (internal type).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This PR updates the syntax for parsing environment variable files, incorporating the conclusions from the discussions in:

  * https://github.com/kubernetes/enhancements/pull/5530
  * https://github.com/kubernetes/kubernetes/issues/133606

Additionally, it expands test coverage with more unit tests and real-world examples to cover edge cases in the parsing logic.

It also introduces support for static pods and examines their behavior in standalone mode—a deliverable I committed to for the beta phase.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promoted the `EnvFiles` feature gate to beta and is enabled by default. Additionally, the syntax specification for environment variables has been restricted to a subset of POSIX shell syntax (all variable values must be wrapped in single quotes).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3721-support-for-env-files
```
