### PR TITLE
Added rest_client_rate_limiter_hit_count_total metric

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -689,6 +689,7 @@ func (r *Request) tryThrottleWithInfo(ctx context.Context, retryInfo string) err
 		}
 	}
 	metrics.RateLimiterLatency.Observe(ctx, r.verb, r.finalURLTemplate(), latency)
+	metrics.RateLimiterHitCount.Increment(ctx, r.verb, r.finalURLTemplate())
 
 	return err
 }

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -42,6 +42,11 @@ type LatencyMetric interface {
 	Observe(ctx context.Context, verb string, u url.URL, latency time.Duration)
 }
 
+// RateLimiterHitCountMetric observes client rate limiter hit count partitioned by verb and url.
+type RateLimiterHitCountMetric interface {
+	Increment(ctx context.Context, verb string, u url.URL)
+}
+
 type ResolverLatencyMetric interface {
 	Observe(ctx context.Context, host string, latency time.Duration)
 }
@@ -94,6 +99,8 @@ var (
 	ResponseSize SizeMetric = noopSize{}
 	// RateLimiterLatency is the client side rate limiter latency metric.
 	RateLimiterLatency LatencyMetric = noopLatency{}
+	// RateLimitHitCount is the client side rate limiter hit count metric.
+	RateLimiterHitCount RateLimiterHitCountMetric = noopRateLimiterHitCount{}
 	// RequestResult is the result metric that rest clients will update.
 	RequestResult ResultMetric = noopResult{}
 	// ExecPluginCalls is the number of calls made to an exec plugin, partitioned by
@@ -119,6 +126,7 @@ type RegisterOpts struct {
 	RequestSize           SizeMetric
 	ResponseSize          SizeMetric
 	RateLimiterLatency    LatencyMetric
+	RateLimiterHitCount   RateLimiterHitCountMetric
 	RequestResult         ResultMetric
 	ExecPluginCalls       CallsMetric
 	RequestRetry          RetryMetric
@@ -151,6 +159,9 @@ func Register(opts RegisterOpts) {
 		if opts.RateLimiterLatency != nil {
 			RateLimiterLatency = opts.RateLimiterLatency
 		}
+		if opts.RateLimiterHitCount != nil {
+			RateLimiterHitCount = opts.RateLimiterHitCount
+		}
 		if opts.RequestResult != nil {
 			RequestResult = opts.RequestResult
 		}
@@ -180,6 +191,10 @@ func (noopExpiry) Set(*time.Time) {}
 type noopLatency struct{}
 
 func (noopLatency) Observe(context.Context, string, url.URL, time.Duration) {}
+
+type noopRateLimiterHitCount struct{}
+
+func (noopRateLimiterHitCount) Increment(ctx context.Context, verb string, u url.URL) {}
 
 type noopResolverLatency struct{}
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -85,6 +85,15 @@ var (
 		[]string{"verb", "host"},
 	)
 
+	rateLimiterHitCount = k8smetrics.NewCounterVec(
+		&k8smetrics.CounterOpts{
+			Name:           "rest_client_rate_limiter_hit_count_total",
+			Help:           "Client side rate limiter hit count. Broken down by verb and host.",
+			StabilityLevel: k8smetrics.ALPHA,
+		},
+		[]string{"verb", "host"},
+	)
+
 	requestResult = k8smetrics.NewCounterVec(
 		&k8smetrics.CounterOpts{
 			Name:           "rest_client_requests_total",
@@ -190,6 +199,7 @@ func init() {
 	legacyregistry.MustRegister(requestSize)
 	legacyregistry.MustRegister(responseSize)
 	legacyregistry.MustRegister(rateLimiterLatency)
+	legacyregistry.MustRegister(rateLimiterHitCount)
 	legacyregistry.MustRegister(requestResult)
 	legacyregistry.MustRegister(requestRetry)
 	legacyregistry.RawMustRegister(execPluginCertTTL)
@@ -205,6 +215,7 @@ func init() {
 		RequestSize:           &sizeAdapter{m: requestSize},
 		ResponseSize:          &sizeAdapter{m: responseSize},
 		RateLimiterLatency:    &latencyAdapter{m: rateLimiterLatency},
+		RateLimiterHitCount:   &rateLimitHitCountAdapter{m: rateLimiterHitCount},
 		RequestResult:         &resultAdapter{requestResult},
 		RequestRetry:          &retryAdapter{requestRetry},
 		ExecPluginCalls:       &callsAdapter{m: execPluginCalls},
@@ -219,6 +230,14 @@ type latencyAdapter struct {
 
 func (l *latencyAdapter) Observe(ctx context.Context, verb string, u url.URL, latency time.Duration) {
 	l.m.WithContext(ctx).WithLabelValues(verb, u.Host).Observe(latency.Seconds())
+}
+
+type rateLimitHitCountAdapter struct {
+	m *k8smetrics.CounterVec
+}
+
+func (l *rateLimitHitCountAdapter) Increment(ctx context.Context, verb string, u url.URL) {
+	l.m.WithContext(ctx).WithLabelValues(verb, u.Host).Inc()
 }
 
 type resolverLatencyAdapter struct {

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
@@ -18,6 +18,7 @@ package restclient
 
 import (
 	"context"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -58,6 +59,19 @@ func TestClientGOMetrics(t *testing.T) {
 			            # HELP rest_client_request_retries_total [ALPHA] Number of request retries, partitioned by status code, verb, and host.
 			            # TYPE rest_client_request_retries_total counter
 			            rest_client_request_retries_total{code="500",host="www.bar.com",verb="GET"} 1
+				`,
+		},
+		{
+			description: "Number of rate limiter hits, partitioned by verb and host.",
+			name:        "rest_client_rate_limiter_hit_count_total",
+			metric:      rateLimiterHitCount,
+			update: func() {
+				metrics.RateLimiterHitCount.Increment(context.TODO(), "GET", url.URL{Host: "www.bar.com"})
+			},
+			want: `
+						# HELP rest_client_rate_limiter_hit_count_total [ALPHA] Client side rate limiter hit count. Broken down by verb and host.
+						# TYPE rest_client_rate_limiter_hit_count_total counter
+						rest_client_rate_limiter_hit_count_total{host="www.bar.com",verb="GET"} 1
 				`,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds a new metric, `rest_client_rate_limiter_hit_count_total` that counts the number of times the client-go client side rate limiter is hit. 

#### Which issue(s) this PR is related to:

#113072
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

For the implementation, I referred to how the `rest_client_rate_limiter_duration_seconds` metric is done and added the new counter metric based on this.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now check if the client side rate limiter is getting hit and by how much with the rest_client_rate_limiter_hit_count_total metric.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
nil
```
