### PR TITLE
Fix ValidatingAdmissionPolicy param resolution race condition

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
 	webhookgeneric "k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -174,6 +175,8 @@ func (d *policyDispatcher[P, B, E]) Dispatch(ctx context.Context, a admission.At
 				hook.ParamScope,
 				bindingAccessor.GetParamRef(),
 				a.GetNamespace(),
+				hook.DynamicClient,
+				hook.RESTMapper,
 			)
 			if err != nil {
 				// There was an error collecting params for this binding.
@@ -264,12 +267,17 @@ func (d *policyDispatcher[P, B, E]) Dispatch(ctx context.Context, a admission.At
 // Returns params to use to evaluate a policy-binding with given param
 // configuration. If the policy-binding has no param configuration, it
 // returns a single-element list with a nil param.
+//
+// The dynamicClient and restMapper parameters enable direct API fallback when
+// the informer cache hasn't received the watch event for a newly created param yet.
 func CollectParams(
 	paramKind *v1.ParamKind,
 	paramInformer informers.GenericInformer,
 	paramScope meta.RESTScope,
 	paramRef *v1.ParamRef,
 	namespace string,
+	dynamicClient dynamic.Interface,
+	restMapper meta.RESTMapper,
 ) ([]runtime.Object, error) {
 	// If definition has paramKind, paramRef is required in binding.
 	// If definition has no paramKind, paramRef set in binding will be ignored.
@@ -331,7 +339,20 @@ func CollectParams(
 			return nil, fmt.Errorf("paramRef.name and paramRef.selector are mutually exclusive")
 		}
 
-		switch param, err := paramStore.Get(paramRef.Name); {
+		// First attempt: try to get the param from the informer cache (fast path)
+		param, err := paramStore.Get(paramRef.Name)
+
+		// If cache returns NotFound and we have a client, try direct API call as fallback.
+		// This handles the race condition where resources (ConfigMap, Policy, Binding, and Param)
+		// are created in quick succession. The informer cache may have completed its initial
+		// sync (checked by WaitForCacheSync above), but newly created params might not have
+		// propagated to the cache yet. The direct API call ensures we get the correct answer
+		// without timing-dependent retry logic.
+		if apierrors.IsNotFound(err) && dynamicClient != nil && restMapper != nil && paramKind != nil {
+			param, err = getParamDirectly(dynamicClient, restMapper, paramKind, paramRef, namespace, paramScope)
+		}
+
+		switch {
 		case err == nil:
 			params = []runtime.Object{param}
 		case apierrors.IsNotFound(err):
@@ -379,6 +400,59 @@ func CollectParams(
 	}
 
 	return params, nil
+}
+
+// getParamDirectly performs a direct API call to retrieve a param when the informer
+// cache doesn't have it yet. This handles the race condition where a param resource
+// is created but the watch event hasn't propagated to the informer cache.
+func getParamDirectly(
+	dynamicClient dynamic.Interface,
+	restMapper meta.RESTMapper,
+	paramKind *v1.ParamKind,
+	paramRef *v1.ParamRef,
+	namespace string,
+	paramScope meta.RESTScope,
+) (runtime.Object, error) {
+	// Convert GVK to GVR using the RESTMapper
+	gv, err := schema.ParseGroupVersion(paramKind.APIVersion)
+	if err != nil {
+		return nil, fmt.Errorf("invalid paramKind APIVersion %q: %w", paramKind.APIVersion, err)
+	}
+	gvk := gv.WithKind(paramKind.Kind)
+
+	mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		// An unknown paramKind (CRD not registered or deleted) is reported as
+		// NotFound so the caller routes it through ParameterNotFoundAction
+		// instead of failing the admission request as an internal error.
+		if meta.IsNoMatchError(err) {
+			return nil, apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, paramRef.Name)
+		}
+		return nil, fmt.Errorf("failed to find REST mapping for %v: %w", gvk, err)
+	}
+
+	// Determine the namespace for the Get request
+	var targetNamespace string
+	if paramScope.Name() == meta.RESTScopeNameNamespace {
+		if len(paramRef.Namespace) > 0 {
+			targetNamespace = paramRef.Namespace
+		} else {
+			targetNamespace = namespace
+		}
+	}
+
+	// Perform the direct API call with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	var resourceClient dynamic.ResourceInterface
+	if targetNamespace != "" {
+		resourceClient = dynamicClient.Resource(mapping.Resource).Namespace(targetNamespace)
+	} else {
+		resourceClient = dynamicClient.Resource(mapping.Resource)
+	}
+
+	return resourceClient.Get(ctx, paramRef.Name, metav1.GetOptions{})
 }
 
 var _ webhookgeneric.VersionedAttributeAccessor = &versionedAttributeAccessor{}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -99,6 +99,11 @@ type PolicyHook[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	ParamInformer informers.GenericInformer
 	ParamScope    meta.RESTScope
 
+	// DynamicClient is used for direct API calls to handle cache misses
+	DynamicClient dynamic.Interface
+	// RESTMapper is used to resolve GVK to GVR for direct API calls
+	RESTMapper meta.RESTMapper
+
 	Evaluator          E
 	ConfigurationError error
 }
@@ -352,6 +357,8 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 			Evaluator:          s.compilePolicyLocked(policySpec),
 			ParamInformer:      paramInformer,
 			ParamScope:         paramScope,
+			DynamicClient:      s.dynamicClient,
+			RESTMapper:         s.restMapper,
 			ConfigurationError: configurationError,
 		})
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -23,8 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/generic"
@@ -203,6 +206,7 @@ type FakeBinding struct {
 	metav1.ObjectMeta
 
 	PolicyName string
+	ParamRef   *v1.ParamRef
 }
 
 var _ generic.BindingAccessor = &FakeBinding{}
@@ -246,7 +250,7 @@ func (fb *FakeBinding) GetMatchResources() *v1.MatchResources {
 }
 
 func (fb *FakeBinding) GetParamRef() *v1.ParamRef {
-	return nil
+	return fb.ParamRef
 }
 
 func (fp *FakePolicy) DeepCopyObject() runtime.Object {
@@ -261,4 +265,220 @@ func (fb *FakeBinding) DeepCopyObject() runtime.Object {
 	newFB := &FakeBinding{}
 	*newFB = *fb
 	return newFB
+}
+
+// TestCollectParamsHandlesCacheMiss tests the race condition where a param
+// exists in the API server but hasn't propagated to the informer cache yet.
+// This can happen when Policy, Binding, and Param (e.g., ConfigMap) resources
+// are created in rapid succession. The test verifies that CollectParams falls
+// back to a direct API call when the cache returns NotFound.
+func TestCollectParamsHandlesCacheMiss(t *testing.T) {
+	testContext, testCancel, err := generic.NewPolicyTestContext(
+		t,
+		func(fp *FakePolicy) generic.PolicyAccessor { return fp },
+		func(fb *FakeBinding) generic.BindingAccessor { return fb },
+		func(fp *FakePolicy) generic.Evaluator { return nil },
+		makeTestDispatcher,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	defer testCancel()
+	require.NoError(t, testContext.Start())
+
+	// Create a ConfigMap directly in the dynamic client (simulating etcd)
+	// without going through the informer, to simulate the race condition
+	configMap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-param",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"maxReplicas": "3",
+			},
+		},
+	}
+
+	// Add ConfigMap directly to dynamic client's tracker (bypassing informer)
+	// This simulates the state where the object exists in etcd but the
+	// watch event hasn't reached the informer cache yet
+	ctx := context.Background()
+	_, err = testContext.DynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "configmaps",
+	}).Namespace("default").Create(ctx, configMap, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Now create policy and binding that reference this ConfigMap
+	policy := &FakePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+		ParamKind: &v1.ParamKind{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+	}
+
+	binding := &FakeBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-binding",
+		},
+		PolicyName: "test-policy",
+		ParamRef: &v1.ParamRef{
+			Name:      "test-param",
+			Namespace: "default",
+		},
+	}
+
+	// Create policy and binding through normal path (they'll be in informers)
+	require.NoError(t, testContext.UpdateAndWait(policy, binding))
+
+	// Get the param informer for ConfigMap
+	hooks := testContext.Source.Hooks()
+	require.Len(t, hooks, 1, "should have one policy hook")
+
+	hook := hooks[0]
+	require.NotNil(t, hook.ParamInformer, "param informer should be set")
+
+	// Call CollectParams - this should succeed via client fallback
+	// even though the ConfigMap isn't in the informer cache
+	params, err := generic.CollectParams(
+		policy.GetParamKind(),
+		hook.ParamInformer,
+		hook.ParamScope,
+		binding.GetParamRef(),
+		"default",
+		hook.DynamicClient,
+		hook.RESTMapper,
+	)
+
+	// With the client fallback fix: this should succeed
+	require.NoError(t, err, "CollectParams should succeed by falling back to direct client Get")
+	require.Len(t, params, 1, "should have retrieved the param")
+	require.NotNil(t, params[0], "param should not be nil")
+
+	// Without the client fallback fix: the above would fail with NotFound error
+	// because the informer cache doesn't have the ConfigMap yet
+}
+
+// TestCollectParamsHandlesMissingCRD verifies that when a paramKind references
+// a CR for a CRD that the RESTMapper does not know about, CollectParams treats
+// the param as missing and routes the binding through ParameterNotFoundAction
+// rather than returning an internal error.
+func TestCollectParamsHandlesMissingCRD(t *testing.T) {
+	testContext, testCancel, err := generic.NewPolicyTestContext(
+		t,
+		func(fp *FakePolicy) generic.PolicyAccessor { return fp },
+		func(fb *FakeBinding) generic.BindingAccessor { return fb },
+		func(fp *FakePolicy) generic.Evaluator { return nil },
+		makeTestDispatcher,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	defer testCancel()
+	require.NoError(t, testContext.Start())
+
+	// Bootstrap a hook with a known paramKind (ConfigMap) so we get a
+	// non-nil ParamInformer/RESTMapper/DynamicClient. The CollectParams
+	// calls below substitute a different paramKind that the RESTMapper
+	// cannot resolve, which is the scenario under test.
+	policy := &FakePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+		ParamKind: &v1.ParamKind{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+	}
+	binding := &FakeBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-binding"},
+		PolicyName: "test-policy",
+		ParamRef: &v1.ParamRef{
+			Name:      "ignored",
+			Namespace: "default",
+		},
+	}
+	require.NoError(t, testContext.UpdateAndWait(policy, binding))
+
+	hooks := testContext.Source.Hooks()
+	require.Len(t, hooks, 1, "should have one policy hook")
+	hook := hooks[0]
+	require.NotNil(t, hook.ParamInformer, "param informer should be set")
+	require.NotNil(t, hook.RESTMapper, "restMapper should be set")
+	require.NotNil(t, hook.DynamicClient, "dynamicClient should be set")
+
+	missingParamKind := &v1.ParamKind{
+		APIVersion: "missing.example.com/v1",
+		Kind:       "MissingCRD",
+	}
+
+	t.Run("no ParameterNotFoundAction returns no params and no error", func(t *testing.T) {
+		paramRef := &v1.ParamRef{
+			Name:      "some-param",
+			Namespace: "default",
+		}
+
+		params, err := generic.CollectParams(
+			missingParamKind,
+			hook.ParamInformer,
+			meta.RESTScopeNamespace,
+			paramRef,
+			"default",
+			hook.DynamicClient,
+			hook.RESTMapper,
+		)
+
+		require.NoError(t, err, "an unknown paramKind must not surface as an internal error")
+		require.Empty(t, params, "no params should be returned when the paramKind cannot be resolved")
+	})
+
+	t.Run("ParameterNotFoundAction=Deny returns deny error", func(t *testing.T) {
+		denyAction := v1.DenyAction
+		paramRef := &v1.ParamRef{
+			Name:                    "some-param",
+			Namespace:               "default",
+			ParameterNotFoundAction: &denyAction,
+		}
+
+		params, err := generic.CollectParams(
+			missingParamKind,
+			hook.ParamInformer,
+			meta.RESTScopeNamespace,
+			paramRef,
+			"default",
+			hook.DynamicClient,
+			hook.RESTMapper,
+		)
+
+		require.Error(t, err, "Deny action should produce an error when the param is missing")
+		require.Contains(t, err.Error(), "no params found")
+		require.Empty(t, params)
+	})
+
+	t.Run("ParameterNotFoundAction=Allow returns no params and no error", func(t *testing.T) {
+		allowAction := v1.AllowAction
+		paramRef := &v1.ParamRef{
+			Name:                    "some-param",
+			Namespace:               "default",
+			ParameterNotFoundAction: &allowAction,
+		}
+
+		params, err := generic.CollectParams(
+			missingParamKind,
+			hook.ParamInformer,
+			meta.RESTScopeNamespace,
+			paramRef,
+			"default",
+			hook.DynamicClient,
+			hook.RESTMapper,
+		)
+
+		require.NoError(t, err, "Allow action should not produce an error when the param is missing")
+		require.Empty(t, params)
+	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
@@ -57,10 +57,11 @@ type Logger interface {
 // PolicyTestContext is everything you need to unit test a policy plugin
 type PolicyTestContext[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	context.Context
-	Logger Logger
-	Plugin *Plugin[PolicyHook[P, B, E]]
-	Source Source[PolicyHook[P, B, E]]
-	Start  func() error
+	Logger        Logger
+	Plugin        *Plugin[PolicyHook[P, B, E]]
+	Source        Source[PolicyHook[P, B, E]]
+	Start         func() error
+	DynamicClient dynamic.Interface
 
 	scheme     *runtime.Scheme
 	restMapper *meta.DefaultRESTMapper
@@ -225,10 +226,11 @@ func NewPolicyTestContext[P, B runtime.Object, E Evaluator](
 	}
 
 	res := &PolicyTestContext[P, B, E]{
-		Logger:  logger,
-		Context: testContext,
-		Plugin:  plugin,
-		Source:  source,
+		Logger:        logger,
+		Context:       testContext,
+		Plugin:        plugin,
+		Source:        source,
+		DynamicClient: dynamicClient,
 
 		restMapper:              fakeRestMapper,
 		scheme:                  policySourceTestScheme,

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -159,6 +159,8 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 				hook.ParamScope,
 				binding.Spec.ParamRef,
 				a.GetNamespace(),
+				hook.DynamicClient,
+				hook.RESTMapper,
 			)
 
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It fixes a race condition in ValidatingAdmissionPolicy param resolution that causes false "no params found" errors when resources are created in batch

Problem:
When a ConfigMap, ValidatingAdmissionPolicy, and ValidatingAdmissionPolicyBinding are created in quick succession, the admission request may fail with:
```
  failed to configure binding: no params found for policy binding with `Deny` parameterNotFoundAction
```

This happens even though the ConfigMap exists, because:
  1. The ConfigMap informer was already synced (from earlier startup)
  2. `WaitForCacheSync()` returns immediately since the informer completed its initial LIST
  3. The watch event for the newly created ConfigMap hasn't propagated to the cache yet
  4. `paramStore.Get()` returns NotFound, causing the policy to deny the request

Solution:
Wire in `dynamicClient` and `restMapper` to enable direct API fallback when the informer cache returns NotFound:
  - **Fast path:** Try informer cache first (instant, no API server load)
  - **Fallback:** On NotFound error, make a single direct GET to the API server
  - **Self-correcting:** Once cache syncs, all future requests use the fast path

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/133827
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

  **Test coverage:**
  Added `TestCollectParamsHandlesCacheMiss` that:
  - Creates a ConfigMap directly in the API server (bypassing informer cache)
  - Verifies `CollectParams` successfully retrieves it via client fallback
  - Without this fix, the test would fail with NotFound error

  **Changes:**
  1. Added `DynamicClient` and `RESTMapper` fields to `PolicyHook` struct
  2. Modified `CollectParams` to accept these parameters
  3. Implemented `getParamDirectly` helper for direct API calls
  4. Updated call sites to pass the new parameters


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
