### PR TITLE
Fix storage version test flake

### DIFF
--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -26,6 +26,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -328,7 +329,7 @@ func Test_StorageVersionDeletedOnLeaseDeletion(t *testing.T) {
 		},
 	}
 
-	clientset := fake.NewSimpleClientset(lease1, storageVersion)
+	clientset := fake.NewClientset(lease1, storageVersion)
 	_, ctx := ktesting.NewTestContext(t)
 	setupController(ctx, clientset)
 
@@ -337,12 +338,12 @@ func Test_StorageVersionDeletedOnLeaseDeletion(t *testing.T) {
 		t.Fatalf("error deleting lease object: %v", err)
 	}
 
-	// add a delay to ensure controller had a chance to reconcile
-	time.Sleep(2 * time.Second)
-
-	// expect deleted
-	_, err := clientset.InternalV1alpha1().StorageVersions().Get(context.Background(), "k8s.test.resources", metav1.GetOptions{})
-	if !apierrors.IsNotFound(err) {
-		t.Fatalf("expected IsNotFound error, got: %v", err)
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		// expect deleted
+		_, err := clientset.InternalV1alpha1().StorageVersions().Get(context.Background(), "k8s.test.resources", metav1.GetOptions{})
+		return apierrors.IsNotFound(err), nil
+	})
+	if err != nil {
+		t.Fatalf("expected IsNotFound error, but got error: %v", err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR tries to fix the test flake
Test tries to validate that object is deleted if there are no kube-apiserver Leases, 
currently in the test, it creates a leases, creates objects, deletes lease and after 2 second sleep expects the object to be deleted, But in few cases that's not happening.

I don't see any recent changes to any relevant files.
So instead of 2 second sleep, Added changes to poll for object over 5 seconds.

#### Which issue(s) this PR is related to:
Fixes #134430

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
