### PR TITLE
kubectl delete: Add --concurrency flag

### DIFF
--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v2 v2.4.3
+	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.40.0
 	golang.org/x/text v0.33.0
 	gopkg.in/evanphx/json-patch.v4 v4.13.0
@@ -83,7 +84,6 @@ require (
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -49,6 +49,7 @@ type DeleteFlags struct {
 	Output            *string
 	Raw               *string
 	Interactive       *bool
+	Concurrency       *int
 }
 
 func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams genericiooptions.IOStreams) (*DeleteOptions, error) {
@@ -110,6 +111,9 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 	if f.Interactive != nil {
 		options.Interactive = *f.Interactive
 	}
+	if f.Concurrency != nil {
+		options.Concurrency = *f.Concurrency
+	}
 
 	return options, nil
 }
@@ -163,6 +167,9 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	if f.Interactive != nil {
 		cmd.Flags().BoolVarP(f.Interactive, "interactive", "i", *f.Interactive, "If true, delete resource only when user confirms.")
 	}
+	if f.Concurrency != nil {
+		cmd.Flags().IntVar(f.Concurrency, "concurrency", *f.Concurrency, "Number of workers to use for concurrent deletion.")
+	}
 }
 
 // NewDeleteCommandFlags provides default flags and values for use with the "delete" command
@@ -183,6 +190,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 	wait := true
 	raw := ""
 	interactive := false
+	concurrency := 1
 
 	filenames := []string{}
 	recursive := false
@@ -207,6 +215,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 		Output:         &output,
 		Raw:            &raw,
 		Interactive:    &interactive,
+		Concurrency:    &concurrency,
 	}
 }
 
@@ -218,6 +227,7 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 	force := false
 	timeout := time.Duration(0)
 	wait := false
+	concurrency := 1
 
 	filenames := []string{}
 	kustomize := ""
@@ -230,9 +240,10 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 		GracePeriod:       &gracePeriod,
 
 		// add non-defaults
-		Force:   &force,
-		Timeout: &timeout,
-		Wait:    &wait,
+		Force:       &force,
+		Timeout:     &timeout,
+		Wait:        &wait,
+		Concurrency: &concurrency,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This flag can be used to set the number of workers to use for sending delete requests to Kubernetes. By default this is set to 1 to be compatible with the current behaviour.

This change makes the deletion logic always use a queue and a worker pool, even with concurrency 1. This introduces a slight overhead, but it should not be a big deal as we spent the most time on API calls anyway.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/125407

#### Special notes for your reviewer:

The original issue mentioned just enabling concurrency. I found it more helpful to be able to set the number of workers.

It may make sense to not use the queue and the pool on concurrency 1, but I didn't want to duplicate code.

Also it's really hard to test this in unit tests, because the fake client is not tread-safe and I didn't find a way how to hack this to make it  thread-safe. So any time you run a unit test with concurrency > 1, you get a data race error in the test. I added an e2e test, though, that doesn't really test that anything is running concurrently, but that the command works as expected and deletes the resources.

I also tested this manually.

#### Does this PR introduce a user-facing change?

```release-note
Added `--concurrency` option for `kubectl delete` that allows using multiple workers to send API requests concurrently.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A