### PR TITLE
Record proper orphaned pod cleanup error based on the system call

### DIFF
--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -145,7 +145,7 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(uid types.UID) []error {
 		for _, subpathVolumePath := range subpathVolumePaths {
 			// Remove both files and empty directories here, as the subpath may have been a bind-mount of a file or a directory.
 			if err := os.Remove(subpathVolumePath); err != nil {
-				orphanVolumeErrors = append(orphanVolumeErrors, fmt.Errorf("orphaned pod %q found, but failed to rmdir() subpath at path %v: %v", uid, subpathVolumePath, err))
+				orphanVolumeErrors = append(orphanVolumeErrors, fmt.Errorf("orphaned pod %q found, but failed to remove subpath at path %v: %w", uid, subpathVolumePath, err))
 			} else {
 				klog.InfoS("Cleaned up orphaned volume subpath from pod", "podUID", uid, "path", subpathVolumePath)
 			}
@@ -201,7 +201,7 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*v1.Pod, runningPods []*kubecon
 			continue
 		}
 
-		// Attempt to remove the pod volumes directory and its subdirs
+		// Attempt to remove the pod volumes directory and its subdirectories
 		podVolumeErrors := kl.removeOrphanedPodVolumeDirs(uid)
 		if len(podVolumeErrors) > 0 {
 			errorPods++
@@ -214,7 +214,7 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*v1.Pod, runningPods []*kubecon
 			continue
 		}
 
-		// Call RemoveAllOneFilesystem for remaining subdirs under the pod directory
+		// Call RemoveAllOneFilesystem for remaining subdirectories under the pod directory
 		podDir := kl.getPodDir(uid)
 		podSubdirs, err := os.ReadDir(podDir)
 		if err != nil {

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -453,7 +453,7 @@ func (c *csiMountMgr) TearDownAt(dir string) error {
 	// to the spec.
 	//
 	// Kubelet should only be responsible for removal of json data files it
-	// creates and parent directories.
+	// creates and their parent directories.
 	//
 	// However, some CSI plugins maybe buggy and don't adhere to the standard,
 	// so we still need to remove the target_path here if it's unmounted and


### PR DESCRIPTION
The code actually calls os.Remove(), not rmdir(). The error message
should accurately reflect the operation being performed.
os.Remove() can remove both files and directories, while rmdir()
only removes directories
    
Signed-off-by: Humble Devassy Chirammal <humble.devassy@gmail.com>

/kind cleanup

```release-note
NONE
```

