### PR TITLE
Fix ResourceQuota test for CRDs with long names

### DIFF
--- a/test/utils/crd/crd_util.go
+++ b/test/utils/crd/crd_util.go
@@ -116,8 +116,8 @@ func CreateMultiVersionTestCRD(f *framework.Framework, group string, opts ...Opt
 // the opts, it will create a default version "v1" with an allow-all schema.
 func genRandomCRD(f *framework.Framework, group string, opts ...Option) *apiextensionsv1.CustomResourceDefinition {
 	suffix := framework.RandomSuffix()
-	name := fmt.Sprintf("e2e-test-%s-%s-crd", f.UniqueName, suffix)
-	kind := fmt.Sprintf("e2e-test-%s-%s-crd", f.UniqueName, suffix)
+	name := fmt.Sprintf("e2e-test-%s-%s-crd", f.BaseName, suffix)
+	kind := fmt.Sprintf("e2e-test-%s-%s-crd", f.BaseName, suffix)
 
 	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: name + "s." + group},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR fixes a test failure in ResourceQuota e2e tests for CRDs with long names. The test was generating CRD names that were too long by using `f.UniqueName`, which caused validation failures.

This issue arose after https://github.com/kubernetes/kubernetes/pull/131342 introduced the use of `UniqueName` instead of `BaseName` in `test/utils/crd/crd_util.go:CreateMultiVersionTestCRD` to fix a test flake. The resulting name length, combined with custom, longer namespace names used in our downstream CI, causes a permanent failure because the resource quota name exceeds the character limit:

```
> Enter [BeforeEach] [sig-api-machinery] ResourceQuota - set up framework | framework.go:200 @ 10/06/25 
(...)
STEP: Creating a Custom Resource Definition - k8s.io/kubernetes/test/e2e/apimachinery/resource_quota.go:660 @ 10/06/25 16:24:28.317
I1006 16:24:28.861526 231 resource_quota.go:677] Unexpected error: 
    <*errors.StatusError | 0xc003acd540>: 
    ResourceQuota "quota-for-e2e-test-e2e-resourcequota-2927-3281-crds" is invalid: spec.hard[count/e2e-test-e2e-resourcequota-2927-3281-crds.resourcequota.example.com]: Invalid value: "count/e2e-test-e2e-resourcequota-2927-3281-crds.resourcequota.example.com": name part must be no more than 63 characters
    {
        ErrStatus: 
            code: 422
            details:
              causes:
              - field: spec.hard[count/e2e-test-e2e-resourcequota-2927-3281-crds.resourcequota.example.com]
                message: 'Invalid value: "count/e2e-test-e2e-resourcequota-2927-3281-crds.resourcequota.example.com":
                  name part must be no more than 63 characters'
                reason: FieldValueInvalid
              kind: ResourceQuota
              name: quota-for-e2e-test-e2e-resourcequota-2927-3281-crds
            message: 'ResourceQuota "quota-for-e2e-test-e2e-resourcequota-2927-3281-crds" is invalid:
              spec.hard[count/e2e-test-e2e-resourcequota-2927-3281-crds.resourcequota.example.com]:
              Invalid value: "count/e2e-test-e2e-resourcequota-2927-3281-crds.resourcequota.example.com":
              name part must be no more than 63 characters'
            metadata: {}
            reason: Invalid
            status: Failure,
    }
```

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
