### PR TITLE
Add DV list keys on ResourceClaimStatus.Devices

### DIFF
--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -1013,8 +1013,14 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			if earlyReturn {
 				return // do not proceed
 			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1.AllocatedDeviceStatus, b resourcev1.AllocatedDeviceStatus) bool {
+				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
+			})...)
 			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_AllocatedDeviceStatus)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1.AllocatedDeviceStatus, b resourcev1.AllocatedDeviceStatus) bool {
+				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
+			}, validate.SemanticDeepEqual, Validate_AllocatedDeviceStatus)...)
 			return
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1.ResourceClaimStatus) []resourcev1.AllocatedDeviceStatus { return oldObj.Devices }))...)
 

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -1021,8 +1021,14 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			if earlyReturn {
 				return // do not proceed
 			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.AllocatedDeviceStatus, b resourcev1beta1.AllocatedDeviceStatus) bool {
+				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
+			})...)
 			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_AllocatedDeviceStatus)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta1.AllocatedDeviceStatus, b resourcev1beta1.AllocatedDeviceStatus) bool {
+				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
+			}, validate.SemanticDeepEqual, Validate_AllocatedDeviceStatus)...)
 			return
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceClaimStatus) []resourcev1beta1.AllocatedDeviceStatus {
 			return oldObj.Devices

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -1041,8 +1041,14 @@ func Validate_ResourceClaimStatus(ctx context.Context, op operation.Operation, f
 			if earlyReturn {
 				return // do not proceed
 			}
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.AllocatedDeviceStatus, b resourcev1beta2.AllocatedDeviceStatus) bool {
+				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
+			})...)
 			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_AllocatedDeviceStatus)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a resourcev1beta2.AllocatedDeviceStatus, b resourcev1beta2.AllocatedDeviceStatus) bool {
+				return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
+			}, validate.SemanticDeepEqual, Validate_AllocatedDeviceStatus)...)
 			return
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceClaimStatus) []resourcev1beta2.AllocatedDeviceStatus {
 			return oldObj.Devices

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -424,7 +424,7 @@ func validateResourceClaimStatusUpdate(status, oldStatus *resource.ResourceClaim
 			deviceID := structured.MakeDeviceID(device.Driver, device.Pool, device.Device)
 			return structured.MakeSharedDeviceID(deviceID, (*types.UID)(device.ShareID))
 		},
-		fldPath.Child("devices"))...)
+		fldPath.Child("devices"), uniquenessCovered)...)
 
 	// Now check for invariants that must be valid for a ResourceClaim.
 	if len(status.ReservedFor) > 0 {

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -1340,7 +1340,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 		"invalid-device-status-duplicate": {
 			wantFailures: field.ErrorList{
 				field.Duplicate(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "2001:db8::1/64"),
-				field.Duplicate(field.NewPath("status", "devices").Index(1), structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), nil)),
+				field.Duplicate(field.NewPath("status", "devices").Index(1), structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), nil)).MarkCoveredByDeclarative(),
 			},
 			oldClaim: func() *resource.ResourceClaim { return validAllocatedClaim }(),
 			update: func(claim *resource.ResourceClaim) *resource.ResourceClaim {
@@ -1369,7 +1369,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 		"invalid-device-status-duplicate-with-share-id": {
 			wantFailures: field.ErrorList{
 				field.Duplicate(field.NewPath("status", "devices").Index(1),
-					structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), ptr.To(goodShareID))),
+					structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), ptr.To(goodShareID))).MarkCoveredByDeclarative(),
 			},
 			oldClaim: func() *resource.ResourceClaim {
 				claim := validAllocatedClaim.DeepCopy()
@@ -1503,7 +1503,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 		"invalid-device-status-duplicate-disabled-feature-gate": {
 			wantFailures: field.ErrorList{
 				field.Duplicate(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "2001:db8::1/64"),
-				field.Duplicate(field.NewPath("status", "devices").Index(1), structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), nil)),
+				field.Duplicate(field.NewPath("status", "devices").Index(1), structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), nil)).MarkCoveredByDeclarative(),
 			},
 			oldClaim: func() *resource.ResourceClaim { return validAllocatedClaim }(),
 			update: func(claim *resource.ResourceClaim) *resource.ResourceClaim {
@@ -1532,7 +1532,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 		"invalid-device-status-duplicate-with-share-id-disabled-feature-gate": {
 			wantFailures: field.ErrorList{
 				field.Duplicate(field.NewPath("status", "devices").Index(1),
-					structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), ptr.To(goodShareID))),
+					structured.MakeSharedDeviceID(structured.MakeDeviceID(goodName, goodName, goodName), ptr.To(goodShareID))).MarkCoveredByDeclarative(),
 			},
 			oldClaim: func() *resource.ResourceClaim {
 				claim := validAllocatedClaim.DeepCopy()

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -1424,6 +1424,11 @@ message ResourceClaimStatus {
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
+  // +k8s:listType=map
+  // +k8s:listMapKey=driver
+  // +k8s:listMapKey=device
+  // +k8s:listMapKey=pool
+  // +k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1430,6 +1430,11 @@ type ResourceClaimStatus struct {
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
+	// +k8s:listType=map
+	// +k8s:listMapKey=driver
+	// +k8s:listMapKey=device
+	// +k8s:listMapKey=pool
+	// +k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1438,6 +1438,11 @@ message ResourceClaimStatus {
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
+  // +k8s:listType=map
+  // +k8s:listMapKey=driver
+  // +k8s:listMapKey=device
+  // +k8s:listMapKey=pool
+  // +k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1437,6 +1437,11 @@ type ResourceClaimStatus struct {
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
+	// +k8s:listType=map
+	// +k8s:listMapKey=driver
+	// +k8s:listMapKey=device
+	// +k8s:listMapKey=pool
+	// +k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1424,6 +1424,11 @@ message ResourceClaimStatus {
   // +listMapKey=pool
   // +listMapKey=shareID
   // +featureGate=DRAResourceClaimDeviceStatus
+  // +k8s:listType=map
+  // +k8s:listMapKey=driver
+  // +k8s:listMapKey=device
+  // +k8s:listMapKey=pool
+  // +k8s:listMapKey=shareID
   repeated AllocatedDeviceStatus devices = 4;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1430,6 +1430,11 @@ type ResourceClaimStatus struct {
 	// +listMapKey=pool
 	// +listMapKey=shareID
 	// +featureGate=DRAResourceClaimDeviceStatus
+	// +k8s:listType=map
+	// +k8s:listMapKey=driver
+	// +k8s:listMapKey=device
+	// +k8s:listMapKey=pool
+	// +k8s:listMapKey=shareID
 	Devices []AllocatedDeviceStatus `json:"devices,omitempty" protobuf:"bytes,4,opt,name=devices"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc.go
@@ -56,10 +56,20 @@ type StructSlice struct {
 	// +k8s:listMapKey=key
 	// +k8s:eachVal=+k8s:validateFalse="field MapSliceNonComparableField[*]"
 	MapSliceNonComparableField []NonComparableStructWithKey `json:"mapSliceNonComparableField"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=key
+	// +k8s:eachVal=+k8s:validateFalse="field MapSlicePtrKeyField[*]"
+	MapSlicePtrKeyField []PtrKeyStruct `json:"mapSlicePtrKeyField"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=key1
+	// +k8s:listMapKey=key2
+	// +k8s:eachVal=+k8s:validateFalse="field MapSliceMixedKeyField[*]"
+	MapSliceMixedKeyField []MixedKeyStruct `json:"mapSliceMixedKeyField"`
 }
 
 type StringType string
-
 type IntSliceType []int
 
 type ComparableStruct struct {
@@ -80,4 +90,17 @@ type ComparableStructWithKey struct {
 type NonComparableStructWithKey struct {
 	Key         string `json:"key"`
 	IntPtrField *int   `json:"intPtrField"`
+}
+
+// +k8s:validateFalse="type PtrKeyStruct"
+type PtrKeyStruct struct {
+	Key  *string `json:"key"`
+	Data string  `json:"data"`
+}
+
+// +k8s:validateFalse="type MixedKeyStruct"
+type MixedKeyStruct struct {
+	Key1 *string `json:"key1"`
+	Key2 string  `json:"key2"`
+	Data string  `json:"data"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc_test.go
@@ -34,8 +34,9 @@ func Test_StructSlice(t *testing.T) {
 		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: ptr.To(1)}},
 		MapSliceComparableField:       []ComparableStructWithKey{{Key: "x", IntField: 1}},
 		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "x", IntPtrField: ptr.To(1)}},
+		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: ptr.To("x"), Data: "y"}},
+		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: ptr.To("x"), Key2: "y", Data: "z"}},
 	}
-
 	st.Value(invalidStructSlice).ExpectValidateFalseByPath(map[string][]string{
 		"atomicSliceStringField[0]":        {"field AtomicSliceStringField[*]"},
 		"atomicSliceTypeField[0]":          {"field AtomicSliceTypeField[*]"},
@@ -45,6 +46,8 @@ func Test_StructSlice(t *testing.T) {
 		"setSliceNonComparableField[0]":    {"field SetSliceNonComparableField[*]", "type NonComparableStruct"},
 		"mapSliceComparableField[0]":       {"field MapSliceComparableField[*]"},
 		"mapSliceNonComparableField[0]":    {"field MapSliceNonComparableField[*]", "type NonComparableStructWithKey"},
+		"mapSlicePtrKeyField[0]":           {"field MapSlicePtrKeyField[*]", "type PtrKeyStruct"},
+		"mapSliceMixedKeyField[0]":         {"field MapSliceMixedKeyField[*]", "type MixedKeyStruct"},
 	})
 
 	// No changes.
@@ -60,6 +63,8 @@ func Test_StructSlice(t *testing.T) {
 		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: ptr.To(1)}},
 		MapSliceComparableField:       []ComparableStructWithKey{{Key: "x", IntField: 1}},
 		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "x", IntPtrField: ptr.To(1)}},
+		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: ptr.To("x"), Data: "y"}},
+		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: ptr.To("x"), Key2: "y", Data: "z"}},
 	}).OldValue(&StructSlice{
 		AtomicSliceStringField:        []StringType{"", "x"},
 		AtomicSliceTypeField:          IntSliceType{1, 2},
@@ -69,8 +74,9 @@ func Test_StructSlice(t *testing.T) {
 		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: ptr.To(2)}, {IntPtrField: ptr.To(1)}},
 		MapSliceComparableField:       []ComparableStructWithKey{{Key: "y", IntField: 2}, {Key: "x", IntField: 1}},
 		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "y", IntPtrField: ptr.To(2)}, {Key: "x", IntPtrField: ptr.To(1)}},
-	}).ExpectValidateFalseByPath(map[string][]string{
-		"atomicSliceStringField[0]":        {"field AtomicSliceStringField[*]"},
+		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: ptr.To("a"), Data: "b"}, {Key: ptr.To("x"), Data: "y"}},
+		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: ptr.To("a"), Key2: "b", Data: "c"}, {Key1: ptr.To("x"), Key2: "y", Data: "z"}},
+	}).ExpectValidateFalseByPath(map[string][]string{"atomicSliceStringField[0]": {"field AtomicSliceStringField[*]"},
 		"atomicSliceTypeField[0]":          {"field AtomicSliceTypeField[*]"},
 		"atomicSliceComparableField[0]":    {"field AtomicSliceComparableField[*]"},
 		"atomicSliceNonComparableField[0]": {"field AtomicSliceNonComparableField[*]", "type NonComparableStruct"},
@@ -82,10 +88,14 @@ func Test_StructSlice(t *testing.T) {
 		SetSliceNonComparableField: []NonComparableStruct{{IntPtrField: ptr.To(2)}, {IntPtrField: ptr.To(1)}},
 		MapSliceComparableField:    []ComparableStructWithKey{{Key: "y", IntField: 2}, {Key: "x", IntField: 1}},
 		MapSliceNonComparableField: []NonComparableStructWithKey{{Key: "y", IntPtrField: ptr.To(2)}, {Key: "x", IntPtrField: ptr.To(1)}},
+		MapSlicePtrKeyField:        []PtrKeyStruct{{Key: ptr.To("b"), Data: "2"}, {Key: ptr.To("a"), Data: "1"}},
+		MapSliceMixedKeyField:      []MixedKeyStruct{{Key1: ptr.To("b"), Key2: "2", Data: "B"}, {Key1: ptr.To("a"), Key2: "1", Data: "A"}},
 	}).OldValue(&StructSlice{
 		SetSliceComparableField:    []ComparableStruct{{IntField: 1}, {IntField: 2}},
 		SetSliceNonComparableField: []NonComparableStruct{{IntPtrField: ptr.To(1)}, {IntPtrField: ptr.To(2)}},
 		MapSliceComparableField:    []ComparableStructWithKey{{Key: "x", IntField: 1}, {Key: "y", IntField: 2}},
 		MapSliceNonComparableField: []NonComparableStructWithKey{{Key: "x", IntPtrField: ptr.To(1)}, {Key: "y", IntPtrField: ptr.To(2)}},
+		MapSlicePtrKeyField:        []PtrKeyStruct{{Key: ptr.To("a"), Data: "1"}, {Key: ptr.To("b"), Data: "2"}},
+		MapSliceMixedKeyField:      []MixedKeyStruct{{Key1: ptr.To("a"), Key2: "1", Data: "A"}, {Key1: ptr.To("b"), Key2: "2", Data: "B"}},
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc.go
@@ -41,6 +41,19 @@ type Struct struct {
 	// +k8s:listMapKey=boolKey
 	// +k8s:item(boolKey: true, stringKey: "target", intKey: 42)=+k8s:validateFalse="item OutOfOrder[boolKey=42,stringKey=target,intKey=42]"
 	OutOfOrder []Item `json:"outOfOrder"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=stringKey
+	// +k8s:listMapKey=intKey
+	// +k8s:listMapKey=boolKey
+	// +k8s:item(stringKey: "target-ptr", intKey: 42, boolKey: true)=+k8s:validateFalse="item PtrItems[stringKey=target-ptr,intKey=42,boolKey=true]"
+	PtrItems []PtrItem `json:"ptrItems"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=stringPtrKey
+	// +k8s:listMapKey=stringKey
+	// +k8s:item(stringPtrKey: "target-ptr", stringKey: "target")=+k8s:validateFalse="item MixedPtrItems"
+	MixedPtrItems []MixedPtrItem `json:"mixedPtrItems"`
 }
 
 type Item struct {
@@ -48,4 +61,17 @@ type Item struct {
 	IntKey    int    `json:"intKey"`
 	BoolKey   bool   `json:"boolKey"`
 	Data      string `json:"data"`
+}
+
+type PtrItem struct {
+	StringKey *string `json:"stringKey"`
+	IntKey    int     `json:"intKey"`
+	BoolKey   bool    `json:"boolKey"`
+	Data      string  `json:"data"`
+}
+
+type MixedPtrItem struct {
+	StringPtrKey *string `json:"stringPtrKey"`
+	StringKey    string  `json:"stringKey"`
+	Data         string  `json:"data"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc_test.go
@@ -18,6 +18,8 @@ package multiplekeys
 
 import (
 	"testing"
+
+	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -71,4 +73,30 @@ func Test(t *testing.T) {
 			{StringKey: "other", IntKey: 1, BoolKey: false},
 		},
 	}).ExpectValid()
+
+	st.Value(&Struct{
+		PtrItems: []PtrItem{
+			{StringKey: ptr.To("target-ptr"), IntKey: 42, BoolKey: true, Data: "match"},
+			{StringKey: ptr.To("target-ptr"), IntKey: 42, BoolKey: false, Data: "no match, bool differs"},
+			{StringKey: ptr.To("target-ptr"), IntKey: 99, BoolKey: true, Data: "no match, int differs"},
+			{StringKey: ptr.To("other"), IntKey: 42, BoolKey: true, Data: "no match, string differs"},
+			{StringKey: nil, IntKey: 42, BoolKey: true, Data: "no match, nil string"},
+		},
+	}).ExpectValidateFalseByPath(map[string][]string{
+		`ptrItems[0]`: {
+			"item PtrItems[stringKey=target-ptr,intKey=42,boolKey=true]",
+		},
+	})
+
+	st.Value(&Struct{
+		MixedPtrItems: []MixedPtrItem{
+			{StringPtrKey: ptr.To("target-ptr"), StringKey: "target", Data: "match"},
+			{StringPtrKey: ptr.To("target-ptr"), StringKey: "other", Data: "no match"},
+			{StringPtrKey: nil, StringKey: "target", Data: "no match"},
+		},
+	}).ExpectValidateFalseByPath(map[string][]string{
+		`mixedPtrItems[0]`: {
+			"item MixedPtrItems",
+		},
+	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc.go
@@ -57,6 +57,11 @@ type Struct struct {
 	// +k8s:listMapKey=key
 	// +k8s:item(key: "target")=+k8s:validateFalse="item AtomicUniqueMapItems[key=target]"
 	AtomicUniqueMapItems []Item `json:"atomicUniqueMapItems"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=key
+	// +k8s:item(key: "target-ptr")=+k8s:validateFalse="item PtrKeyItems[key=target-ptr]"
+	PtrKeyItems []PtrKeyItem `json:"ptrKeyItems"`
 }
 
 type StructWithNestedTypedef struct {
@@ -94,4 +99,9 @@ type StringAlias string
 type NestedTypedefItem struct {
 	Key  StringAlias `json:"key"`
 	Name string      `json:"name"`
+}
+
+type PtrKeyItem struct {
+	Key  *string `json:"key"`
+	Data string  `json:"data"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc_test.go
@@ -18,6 +18,8 @@ package singlekey
 
 import (
 	"testing"
+
+	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -141,5 +143,25 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		AtomicUniqueMapItems: nil,
+	}).ExpectValid()
+
+	st.Value(&Struct{
+		PtrKeyItems: []PtrKeyItem{
+			{Key: ptr.To("a"), Data: "d1"},
+			{Key: ptr.To("target-ptr"), Data: "d2"},
+			{Key: nil, Data: "d3"},
+		},
+	}).ExpectValidateFalseByPath(map[string][]string{
+		`ptrKeyItems[1]`: {
+			"item PtrKeyItems[key=target-ptr]",
+		},
+	})
+
+	st.Value(&Struct{
+		PtrKeyItems: []PtrKeyItem{
+			{Key: ptr.To("a"), Data: "d1"},
+			{Key: ptr.To("b"), Data: "d2"},
+			{Key: nil, Data: "d3"},
+		},
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/zz_generated.validations.go
@@ -164,6 +164,26 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("atomicUniqueMapItems"), obj.AtomicUniqueMapItems, safe.Field(oldObj, func(oldObj *Struct) []Item { return oldObj.AtomicUniqueMapItems }))...)
 
+	// field Struct.PtrKeyItems
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []PtrKeyItem) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a PtrKeyItem, b PtrKeyItem) bool {
+				return ((a.Key == nil && b.Key == nil) || (a.Key != nil && b.Key != nil && *a.Key == *b.Key))
+			})...)
+			func() { // cohort {"key": "target-ptr"}
+				errs = append(errs, validate.SliceItem(ctx, op, fldPath, obj, oldObj, func(item *PtrKeyItem) bool { return item.Key != nil && *item.Key == "target-ptr" }, validate.SemanticDeepEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *PtrKeyItem) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "item PtrKeyItems[key=target-ptr]")
+				})...)
+			}()
+			return
+		}(fldPath.Child("ptrKeyItems"), obj.PtrKeyItems, safe.Field(oldObj, func(oldObj *Struct) []PtrKeyItem { return oldObj.PtrKeyItems }))...)
+
 	return errs
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
@@ -53,6 +53,18 @@ type Struct struct {
 	// +k8s:listMapKey=key2Field
 	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListNonComparableField[*]"
 	ListNonComparableField []NonComparableStruct `json:"listNonComparableField"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=key1Field
+	// +k8s:listMapKey=key2Field
+	// +k8s:item(key1Field: "target-ptr", key2Field: 42)=+k8s:validateFalse="item ListPtrKeyField[key1Field=target-ptr,key2Field=42]"
+	ListPtrKeyField []PtrKeyStruct `json:"listPtrKeyField"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=stringPtrKey
+	// +k8s:listMapKey=stringKey
+	// +k8s:item(stringPtrKey: "target-ptr", stringKey: "target")=+k8s:validateFalse="item ListMixedPtrKeyField"
+	ListMixedPtrKeyField []MixedPtrKeyStruct `json:"listMixedPtrKeyField"`
 }
 
 type OtherStruct struct {
@@ -73,3 +85,15 @@ type NonComparableStruct struct {
 // +k8s:listMapKey=key1Field
 // +k8s:listMapKey=key2Field
 type ListType []OtherStruct
+
+type PtrKeyStruct struct {
+	Key1Field *string `json:"key1Field"`
+	Key2Field int     `json:"key2Field"`
+	DataField string  `json:"dataField"`
+}
+
+type MixedPtrKeyStruct struct {
+	StringPtrKey *string `json:"stringPtrKey"`
+	StringKey    string  `json:"stringKey"`
+	DataField    string  `json:"dataField"`
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
@@ -49,6 +49,10 @@ type Struct struct {
 	// +k8s:listMapKey=keyField
 	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListNonComparableField[*]"
 	ListNonComparableField []NonComparableStruct `json:"listNonComparableField"`
+
+	// +k8s:listType=map
+	// +k8s:listMapKey=keyField
+	ListPtrKeyField []PtrKeyStruct `json:"listPtrKeyField"`
 }
 
 type OtherStruct struct {
@@ -61,6 +65,11 @@ type OtherTypedefStruct OtherStruct
 type NonComparableStruct struct {
 	KeyField       string  `json:"keyField"`
 	StringPtrField *string `json:"stringPtrField"`
+}
+
+type PtrKeyStruct struct {
+	KeyField  *string `json:"keyField"`
+	DataField string  `json:"dataField"`
 }
 
 // +k8s:listType=map

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
@@ -162,3 +162,20 @@ func TestRatcheting(t *testing.T) {
 	st.Value(&struct1).OldValue(&struct2).ExpectValid()
 	st.Value(&struct2).OldValue(&struct1).ExpectValid()
 }
+
+func TestUniquenessPtrKey(t *testing.T) {
+	st := localSchemeBuilder.Test(t)
+
+	st.Value(&Struct{
+		ListPtrKeyField: []PtrKeyStruct{
+			{ptr.To("key1"), "one"},
+			{ptr.To("key2"), "two"},
+			{ptr.To("key2"), "three"}, // duplicate key
+			{nil, "four"},
+			{nil, "five"}, // duplicate nil key
+		},
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+		field.Duplicate(field.NewPath("listPtrKeyField").Index(2), nil),
+		field.Duplicate(field.NewPath("listPtrKeyField").Index(4), nil),
+	})
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
@@ -158,5 +158,20 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("listNonComparableField"), obj.ListNonComparableField, safe.Field(oldObj, func(oldObj *Struct) []NonComparableStruct { return oldObj.ListNonComparableField }))...)
 
+	// field Struct.ListPtrKeyField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []PtrKeyStruct) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a PtrKeyStruct, b PtrKeyStruct) bool {
+				return ((a.KeyField == nil && b.KeyField == nil) || (a.KeyField != nil && b.KeyField != nil && *a.KeyField == *b.KeyField))
+			})...)
+			return
+		}(fldPath.Child("listPtrKeyField"), obj.ListPtrKeyField, safe.Field(oldObj, func(oldObj *Struct) []PtrKeyStruct { return oldObj.ListPtrKeyField }))...)
+
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/doc.go
@@ -60,6 +60,26 @@ type Struct struct {
 	// +k8s:listMapKey=key
 	// +k8s:customUnique
 	CustomUniqueListWithTypeMap []Item `json:"customUniqueListWithTypeMap"`
+
+	// unique=map with pointer key
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=key
+	SliceMapFieldWithPtrKey []PtrKeyStruct `json:"sliceMapFieldWithPtrKey"`
+
+	// unique=map with mixed (pointer and primitive) keys
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=key1
+	// +k8s:listMapKey=key2
+	SliceMapFieldWithMixedKeys []ItemWithMixedKeys `json:"sliceMapFieldWithMixedKeys"`
+
+	// unique=map with multiple pointer keys
+	// +k8s:listType=atomic
+	// +k8s:unique=map
+	// +k8s:listMapKey=key1
+	// +k8s:listMapKey=key2
+	SliceMapFieldWithMultiplePtrKeys []ItemWithMultiplePtrKeys `json:"sliceMapFieldWithMultiplePtrKeys"`
 }
 
 type Item struct {
@@ -71,4 +91,21 @@ type ItemWithMultipleKeys struct {
 	Key1 string `json:"key1"`
 	Key2 string `json:"key2"`
 	Data string `json:"data"`
+}
+
+type PtrKeyStruct struct {
+	Key  *string `json:"key"`
+	Data string  `json:"data"`
+}
+
+type ItemWithMixedKeys struct {
+	Key1 *string `json:"key1"`
+	Key2 string  `json:"key2"`
+	Data string  `json:"data"`
+}
+
+type ItemWithMultiplePtrKeys struct {
+	Key1 *string `json:"key1"`
+	Key2 *string `json:"key2"`
+	Data string  `json:"data"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/doc_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 )
 
 func TestUnique(t *testing.T) {
@@ -45,26 +46,42 @@ func TestUnique(t *testing.T) {
 		},
 		CustomUniqueListWithTypeSet: []string{"a", "b", "a"},
 		CustomUniqueListWithTypeMap: []Item{{Key: "a"}, {Key: "b"}, {Key: "a"}},
+		SliceMapFieldWithPtrKey: []PtrKeyStruct{
+			{Key: ptr.To("a"), Data: "first"},
+			{Key: ptr.To("b"), Data: "second"},
+		},
+		SliceMapFieldWithMixedKeys: []ItemWithMixedKeys{
+			{Key1: ptr.To("a"), Key2: "x", Data: "first"},
+			{Key1: ptr.To("a"), Key2: "y", Data: "second"},
+		},
+		SliceMapFieldWithMultiplePtrKeys: []ItemWithMultiplePtrKeys{
+			{Key1: ptr.To("a"), Key2: ptr.To("x"), Data: "first"},
+			{Key1: ptr.To("a"), Key2: ptr.To("y"), Data: "second"},
+		},
 	}).ExpectValid()
 
 	// Test empty lists
 	st.Value(&Struct{
-		PrimitiveListUniqueSet:        []string{},
-		SliceMapFieldWithMultipleKeys: []ItemWithMultipleKeys{},
-		AtomicListUniqueSet:           []Item{},
-		AtomicListUniqueMap:           []Item{},
-		CustomUniqueListWithTypeSet:   []string{},
-		CustomUniqueListWithTypeMap:   []Item{},
+		PrimitiveListUniqueSet:           []string{},
+		SliceMapFieldWithMultipleKeys:    []ItemWithMultipleKeys{},
+		AtomicListUniqueSet:              []Item{},
+		AtomicListUniqueMap:              []Item{},
+		CustomUniqueListWithTypeSet:      []string{},
+		CustomUniqueListWithTypeMap:      []Item{},
+		SliceMapFieldWithMixedKeys:       []ItemWithMixedKeys{},
+		SliceMapFieldWithMultiplePtrKeys: []ItemWithMultiplePtrKeys{},
 	}).ExpectValid()
 
 	// Test single element lists
 	st.Value(&Struct{
-		PrimitiveListUniqueSet:        []string{"single"},
-		SliceMapFieldWithMultipleKeys: []ItemWithMultipleKeys{{Key1: "a", Key2: "b", Data: "one"}},
-		AtomicListUniqueSet:           []Item{{Key: "single", Data: "one"}},
-		AtomicListUniqueMap:           []Item{{Key: "single", Data: "one"}},
-		CustomUniqueListWithTypeSet:   []string{"single"},
-		CustomUniqueListWithTypeMap:   []Item{{Key: "single"}},
+		PrimitiveListUniqueSet:           []string{"single"},
+		SliceMapFieldWithMultipleKeys:    []ItemWithMultipleKeys{{Key1: "a", Key2: "b", Data: "one"}},
+		AtomicListUniqueSet:              []Item{{Key: "single", Data: "one"}},
+		AtomicListUniqueMap:              []Item{{Key: "single", Data: "one"}},
+		CustomUniqueListWithTypeSet:      []string{"single"},
+		CustomUniqueListWithTypeMap:      []Item{{Key: "single"}},
+		SliceMapFieldWithMixedKeys:       []ItemWithMixedKeys{{Key1: ptr.To("a"), Key2: "b", Data: "one"}},
+		SliceMapFieldWithMultiplePtrKeys: []ItemWithMultiplePtrKeys{{Key1: ptr.To("a"), Key2: ptr.To("b"), Data: "one"}},
 	}).ExpectValid()
 
 	// Test duplicate values (should fail validation)
@@ -87,6 +104,21 @@ func TestUnique(t *testing.T) {
 		},
 		CustomUniqueListWithTypeSet: []string{"a", "b", "a"},
 		CustomUniqueListWithTypeMap: []Item{{Key: "a"}, {Key: "b"}, {Key: "a"}},
+		SliceMapFieldWithPtrKey: []PtrKeyStruct{
+			{Key: ptr.To("a"), Data: "first"},
+			{Key: ptr.To("b"), Data: "second"},
+			{Key: ptr.To("a"), Data: "third"},
+		},
+		SliceMapFieldWithMixedKeys: []ItemWithMixedKeys{
+			{Key1: ptr.To("a"), Key2: "x", Data: "first"},
+			{Key1: ptr.To("a"), Key2: "y", Data: "second"},
+			{Key1: ptr.To("a"), Key2: "x", Data: "third"},
+		},
+		SliceMapFieldWithMultiplePtrKeys: []ItemWithMultiplePtrKeys{
+			{Key1: ptr.To("a"), Key2: ptr.To("x"), Data: "first"},
+			{Key1: ptr.To("a"), Key2: ptr.To("y"), Data: "second"},
+			{Key1: ptr.To("a"), Key2: ptr.To("x"), Data: "third"},
+		},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Duplicate(field.NewPath("primitiveListUniqueSet").Index(3), nil),
 		field.Duplicate(field.NewPath("primitiveListUniqueSet").Index(4), nil),
@@ -94,6 +126,9 @@ func TestUnique(t *testing.T) {
 		field.Duplicate(field.NewPath("sliceMapFieldWithMultipleKeys").Index(2), nil),
 		field.Duplicate(field.NewPath("atomicListUniqueSet").Index(2), nil),
 		field.Duplicate(field.NewPath("atomicListUniqueMap").Index(2), nil),
+		field.Duplicate(field.NewPath("sliceMapFieldWithPtrKey").Index(2), nil),
+		field.Duplicate(field.NewPath("sliceMapFieldWithMixedKeys").Index(2), nil),
+		field.Duplicate(field.NewPath("sliceMapFieldWithMultiplePtrKeys").Index(2), nil),
 	})
 
 	// Test with zero values and empty strings
@@ -131,6 +166,18 @@ func TestRatcheting(t *testing.T) {
 		},
 		CustomUniqueListWithTypeSet: []string{"a", "b", "a"},
 		CustomUniqueListWithTypeMap: []Item{{Key: "a"}, {Key: "b"}, {Key: "a"}},
+		SliceMapFieldWithPtrKey: []PtrKeyStruct{
+			{Key: ptr.To("a"), Data: "first"},
+			{Key: ptr.To("b"), Data: "second"},
+		},
+		SliceMapFieldWithMixedKeys: []ItemWithMixedKeys{
+			{Key1: ptr.To("a"), Key2: "x", Data: "first"},
+			{Key1: ptr.To("a"), Key2: "y", Data: "second"},
+		},
+		SliceMapFieldWithMultiplePtrKeys: []ItemWithMultiplePtrKeys{
+			{Key1: ptr.To("a"), Key2: ptr.To("x"), Data: "first"},
+			{Key1: ptr.To("a"), Key2: ptr.To("y"), Data: "second"},
+		},
 	}
 
 	// Same data, different order.
@@ -150,6 +197,18 @@ func TestRatcheting(t *testing.T) {
 		},
 		CustomUniqueListWithTypeSet: []string{"a", "a", "b"},
 		CustomUniqueListWithTypeMap: []Item{{Key: "a"}, {Key: "a"}, {Key: "b"}},
+		SliceMapFieldWithPtrKey: []PtrKeyStruct{
+			{Key: ptr.To("b"), Data: "second"},
+			{Key: ptr.To("a"), Data: "first"},
+		},
+		SliceMapFieldWithMixedKeys: []ItemWithMixedKeys{
+			{Key1: ptr.To("a"), Key2: "y", Data: "second"},
+			{Key1: ptr.To("a"), Key2: "x", Data: "first"},
+		},
+		SliceMapFieldWithMultiplePtrKeys: []ItemWithMultiplePtrKeys{
+			{Key1: ptr.To("a"), Key2: ptr.To("y"), Data: "second"},
+			{Key1: ptr.To("a"), Key2: ptr.To("x"), Data: "first"},
+		},
 	}
 
 	// Test that reordering doesn't trigger validation errors

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/unique/zz_generated.validations.go
@@ -120,5 +120,50 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("customUniqueListWithTypeMap"), obj.CustomUniqueListWithTypeMap, safe.Field(oldObj, func(oldObj *Struct) []Item { return oldObj.CustomUniqueListWithTypeMap }))...)
 
+	// field Struct.SliceMapFieldWithPtrKey
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []PtrKeyStruct) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a PtrKeyStruct, b PtrKeyStruct) bool {
+				return ((a.Key == nil && b.Key == nil) || (a.Key != nil && b.Key != nil && *a.Key == *b.Key))
+			})...)
+			return
+		}(fldPath.Child("sliceMapFieldWithPtrKey"), obj.SliceMapFieldWithPtrKey, safe.Field(oldObj, func(oldObj *Struct) []PtrKeyStruct { return oldObj.SliceMapFieldWithPtrKey }))...)
+
+	// field Struct.SliceMapFieldWithMixedKeys
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []ItemWithMixedKeys) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a ItemWithMixedKeys, b ItemWithMixedKeys) bool {
+				return ((a.Key1 == nil && b.Key1 == nil) || (a.Key1 != nil && b.Key1 != nil && *a.Key1 == *b.Key1)) && a.Key2 == b.Key2
+			})...)
+			return
+		}(fldPath.Child("sliceMapFieldWithMixedKeys"), obj.SliceMapFieldWithMixedKeys, safe.Field(oldObj, func(oldObj *Struct) []ItemWithMixedKeys { return oldObj.SliceMapFieldWithMixedKeys }))...)
+
+	// field Struct.SliceMapFieldWithMultiplePtrKeys
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []ItemWithMultiplePtrKeys) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			// lists with map semantics require unique keys
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a ItemWithMultiplePtrKeys, b ItemWithMultiplePtrKeys) bool {
+				return ((a.Key1 == nil && b.Key1 == nil) || (a.Key1 != nil && b.Key1 != nil && *a.Key1 == *b.Key1)) && ((a.Key2 == nil && b.Key2 == nil) || (a.Key2 != nil && b.Key2 != nil && *a.Key2 == *b.Key2))
+			})...)
+			return
+		}(fldPath.Child("sliceMapFieldWithMultiplePtrKeys"), obj.SliceMapFieldWithMultiplePtrKeys, safe.Field(oldObj, func(oldObj *Struct) []ItemWithMultiplePtrKeys { return oldObj.SliceMapFieldWithMultiplePtrKeys }))...)
+
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
@@ -68,10 +68,10 @@ const (
 
 // listMetadata collects information about a single list with map or set semantics.
 type listMetadata struct {
-	ownership listOwnership // For now we don't use it for generation.
-	semantic  listSemantic
-	keyFields []string // For semantic == map.
-	keyNames  []string // For semantic == map.
+	ownership  listOwnership // For now we don't use it for generation.
+	semantic   listSemantic
+	keyMembers []*types.Member // For semantic == map.
+	keyNames   []string        // For semantic == map.
 
 	// customUnique indicates that k8s:customUnique is set on this list.
 	// It disables generation of uniqueness validation for this list.
@@ -92,13 +92,23 @@ func (lm *listMetadata) makeListMapMatchFunc(t *types.Type) FunctionLiteral {
 	}
 	buf := strings.Builder{}
 	buf.WriteString("return ")
-	// Note: this does not handle pointer fields, which are not
-	// supposed to be used as listMap keys.
-	for i, fld := range lm.keyFields {
+
+	for i, memb := range lm.keyMembers {
 		if i > 0 {
 			buf.WriteString(" && ")
 		}
-		buf.WriteString(fmt.Sprintf("a.%s == b.%s", fld, fld))
+		fldName := memb.Name
+
+		if memb.Type.Kind == types.Pointer {
+			// Dereference pointers for comparison.
+			// This is tricky because they could be nil.
+			// Two keys are equal if all their fields are equal.
+			// For pointer fields, that means either both are nil,
+			// or neither is nil and the pointed-to values are equal.
+			buf.WriteString(fmt.Sprintf("((a.%s == nil && b.%s == nil) || (a.%s != nil && b.%s != nil && *a.%s == *b.%s))", fldName, fldName, fldName, fldName, fldName, fldName))
+		} else {
+			buf.WriteString(fmt.Sprintf("a.%s == b.%s", fldName, fldName))
+		}
 	}
 	matchFn.Body = buf.String()
 	return matchFn
@@ -210,13 +220,18 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, tag codetags
 		return Validations{}, fmt.Errorf("only lists of structs can be list-maps")
 	}
 
-	var fieldName string
-	if memb := util.GetMemberByJSON(util.NativeType(t.Elem), tag.Value); memb == nil {
+	var memb *types.Member
+	if m := util.GetMemberByJSON(util.NativeType(t.Elem), tag.Value); m == nil {
 		return Validations{}, fmt.Errorf("no field for JSON name %q", tag.Value)
-	} else if k := util.NativeType(memb.Type).Kind; k != types.Builtin {
-		return Validations{}, fmt.Errorf("only primitive types can be list-map keys (%s)", k)
 	} else {
-		fieldName = memb.Name
+		keyType := m.Type
+		if keyType.Kind == types.Pointer {
+			keyType = keyType.Elem
+		}
+		if util.NativeType(keyType).Kind != types.Builtin {
+			return Validations{}, fmt.Errorf("only primitive types and pointers to primitive types can be list-map keys, not %s", m.Type.String())
+		}
+		memb = m
 	}
 
 	lm := lmktv.byPath[context.Path.String()]
@@ -224,7 +239,7 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, tag codetags
 		lm = &listMetadata{}
 		lmktv.byPath[context.Path.String()] = lm
 	}
-	lm.keyFields = append(lm.keyFields, fieldName)
+	lm.keyMembers = append(lm.keyMembers, memb)
 	lm.keyNames = append(lm.keyNames, tag.Value)
 
 	// This tag doesn't generate any validations.  It just accumulates
@@ -461,12 +476,12 @@ func (lv listValidator) check(lm *listMetadata) error {
 	// Check some fundamental constraints on list tags.
 
 	// If we have listMapKey but no map semantics, that's an error
-	if len(lm.keyFields) > 0 && lm.semantic != semanticMap {
+	if len(lm.keyMembers) > 0 && lm.semantic != semanticMap {
 		return fmt.Errorf("found listMapKey without listType=map or unique=map")
 	}
 
 	// If we have map semantics but no keys, that's an error
-	if lm.semantic == semanticMap && len(lm.keyFields) == 0 {
+	if lm.semantic == semanticMap && len(lm.keyMembers) == 0 {
 		return fmt.Errorf("found listType=map or unique=map without listMapKey")
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR enables the use of pointer fields as keys in `listType=map` lists in the Kubernetes API. Currently, fields of pointer types cannot be used as keys for lists with `listType=map` semantics. This PR lifts that restriction by updating the code generator and validation logic to correctly handle pointer types in `listMapKey`s.

The key changes are:
- The `validation-gen` code generator is updated to handle pointer types in `listMapKey` by checking for `nil` and dereferencing pointers before comparison.
- The `ResourceClaimStatus.Devices` field is updated to use `listType=map` with a composite key that includes the `shareID` field, which is a pointer type.
- New test cases have been added to verify the functionality of using pointer fields in `listMapKey`s.

This change provides more flexibility in defining API types by allowing the use of pointer fields as keys in maps, which is useful in scenarios where a key field can be optional.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5073
```
