### PR TITLE
kubelet: synchronously fetch node and retry on NodeAffinity admission errors

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package allocation
 
 import (
+	"context"
 	"fmt"
 	goruntime "runtime"
 	"strings"
@@ -1826,7 +1827,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 	)
 	allocationManager.SetContainerRuntime(runtime)
 
-	getNode := func() (*v1.Node, error) {
+	getNode := func(context.Context, bool) (*v1.Node, error) {
 		return &v1.Node{
 			Status: v1.NodeStatus{
 				Capacity: v1.ResourceList{

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1034,7 +1034,7 @@ func NewMainKubelet(ctx context.Context,
 	handlers = append(handlers, klet.containerManager.GetAllocateResourcesPodAdmitHandler())
 
 	criticalPodAdmissionHandler := preemption.NewCriticalPodAdmissionHandler(klet.getAllocatedPods, killPodNow(klet.podWorkers, kubeDeps.Recorder), kubeDeps.Recorder)
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.getNodeAnyWay, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources))
 	// apply functional Option's
 	for _, opt := range kubeDeps.Options {
 		opt(klet)
@@ -1106,6 +1106,7 @@ type Kubelet struct {
 	hostname string
 
 	nodeName        types.NodeName
+	cachedNode      *v1.Node
 	runtimeCache    kubecontainer.RuntimeCache
 	kubeClient      clientset.Interface
 	heartbeatClient clientset.Interface

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -299,10 +299,8 @@ func (kl *Kubelet) GetNode() (*v1.Node, error) {
 // in which case return a manufactured nodeInfo representing a node with no pods,
 // zero capacity, and the default labels.
 func (kl *Kubelet) getNodeAnyWay() (*v1.Node, error) {
-	if kl.kubeClient != nil {
-		if n, err := kl.nodeLister.Get(string(kl.nodeName)); err == nil {
-			return n, nil
-		}
+	if n, err := kl.GetNode(); err == nil {
+		return n, nil
 	}
 	return kl.initialNode(context.TODO())
 }

--- a/pkg/kubelet/kubelet_nodecache.go
+++ b/pkg/kubelet/kubelet_nodecache.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"context"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+// GetCachedNode returns the node object either from the cache or by making a synchronous
+// call to the API server based on the useCache parameter.
+func (kl *Kubelet) GetCachedNode(ctx context.Context, useCache bool) (*v1.Node, error) {
+	if useCache {
+		return kl.getCachedNode(ctx)
+	}
+	return kl.getNodeSync()
+}
+
+// getCachedNode compares the currently cached node to the node in the informer,
+// and returns the newer one.
+func (kl *Kubelet) getCachedNode(ctx context.Context) (*v1.Node, error) {
+	logger := klog.FromContext(ctx)
+	informerNode, err := kl.GetNode()
+	if err != nil {
+		if kl.cachedNode != nil {
+			logger.Error(err, "failed to list node; using cached node")
+			return kl.cachedNode, nil
+		}
+		return kl.initialNode(ctx)
+	}
+
+	if kl.cachedNode == nil {
+		kl.cachedNode = informerNode
+		return informerNode, nil
+	}
+
+	isNewer, err := isNewer(informerNode, kl.cachedNode)
+	if err != nil {
+		// In error cases, default to the informer node.
+		logger.Error(err, "failed to check if node is newer; using informer node")
+		kl.cachedNode = informerNode
+	}
+	if isNewer {
+		kl.cachedNode = informerNode
+	}
+	return kl.cachedNode, nil
+}
+
+// getNodeSync forces a refresh of the cache by making a synchronous call to the API server
+// for the most recent node info.
+func (kl *Kubelet) getNodeSync() (*v1.Node, error) {
+	if kl.kubeClient == nil {
+		return kl.initialNode(context.Background())
+	}
+	node, err := kl.kubeClient.CoreV1().Nodes().Get(context.Background(), string(kl.nodeName), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	kl.cachedNode = node
+	return node, nil
+}
+
+// isNewer checks if the informer node is newer than the cached node based on the ResourceVersion.
+func isNewer(informerNode, cachedNode *v1.Node) (bool, error) {
+	if informerNode == cachedNode {
+		return true, nil
+	}
+	informerVersion, err := getObjVersion(informerNode)
+	if err != nil {
+		return false, err
+	}
+	cachedVersion, err := getObjVersion(cachedNode)
+	if err != nil {
+		return false, err
+	}
+	return informerVersion > cachedVersion, nil
+}
+
+func getObjVersion(n *v1.Node) (int64, error) {
+	objResourceVersion, err := strconv.ParseInt(n.ResourceVersion, 10, 64)
+	if err != nil {
+		return -1, err
+	}
+	return objResourceVersion, nil
+}

--- a/pkg/kubelet/kubelet_nodecache_test.go
+++ b/pkg/kubelet/kubelet_nodecache_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetCachedNode(t *testing.T) {
+	tests := []struct {
+		name               string
+		informerNode       *v1.Node
+		cachedNode         *v1.Node
+		nodeListerErr      error
+		expectedNode       *v1.Node
+		expectedErr        bool
+		expectedCachedNode *v1.Node
+	}{
+		{
+			name:         "informer node is newer",
+			informerNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
+			cachedNode:   &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+
+			expectedNode:       &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
+			expectedCachedNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
+		},
+		{
+			name:         "cached node is newer",
+			informerNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			cachedNode:   &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
+
+			expectedNode:       &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
+			expectedCachedNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
+		},
+		{
+			name:         "resource versions are the same",
+			informerNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			cachedNode:   &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+
+			expectedNode:       &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			expectedCachedNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+		},
+		{
+			name:         "informer node cannot be parsed, default to informer node",
+			informerNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "abc"}},
+			cachedNode:   &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+
+			expectedNode:       &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "abc"}},
+			expectedCachedNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "abc"}},
+		},
+		{
+			name:         "cached node cannot be parsed, default to informer node",
+			informerNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			cachedNode:   &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "abc"}},
+
+			expectedNode:       &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			expectedCachedNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+		},
+		{
+			name:         "cached node is nil, use informer node",
+			informerNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			cachedNode:   nil,
+
+			expectedNode:       &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			expectedCachedNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+		},
+		{
+			name:          "node lister returns error, use cached node",
+			informerNode:  nil,
+			cachedNode:    &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			nodeListerErr: fmt.Errorf("test error"),
+
+			expectedNode:       &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			expectedErr:        false,
+			expectedCachedNode: &v1.Node{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+		},
+		{
+			name:          "node lister returns error, cached node is nil, default to initialNode",
+			informerNode:  nil,
+			cachedNode:    nil,
+			nodeListerErr: fmt.Errorf("test error"),
+
+			expectedNode:       nil, // This will be filled in by the test logic below.
+			expectedErr:        false,
+			expectedCachedNode: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kl := Kubelet{
+				cachedNode: test.cachedNode,
+				nodeLister: newFakeNodeLister(test.nodeListerErr, test.informerNode),
+				kubeClient: &fake.Clientset{},
+			}
+			if test.expectedNode == nil {
+				var err error
+				test.expectedNode, err = kl.initialNode(context.TODO())
+				if err != nil {
+					test.expectedErr = true
+				}
+			}
+
+			actualNode, err := kl.GetCachedNode(context.Background(), true)
+
+			if (err != nil) != test.expectedErr {
+				t.Errorf("GetCachedNode() unexpected error status: %v, expected error: %v", err, test.expectedErr)
+			}
+			if !reflect.DeepEqual(actualNode, test.expectedNode) {
+				t.Errorf("GetCachedNode() = %v, expected %v", actualNode, test.expectedNode)
+			}
+			if !reflect.DeepEqual(kl.cachedNode, test.expectedCachedNode) {
+				t.Errorf("kl.cachedNode after GetCachedNode() = %v, expected %v", kl.cachedNode, test.expectedCachedNode)
+			}
+		})
+	}
+}
+
+type fakeNodeLister struct {
+	node *v1.Node
+	err  error
+}
+
+func newFakeNodeLister(err error, node *v1.Node) *fakeNodeLister {
+	ret := &fakeNodeLister{}
+	ret.node = node
+	ret.err = err
+	return ret
+}
+
+func (l *fakeNodeLister) List(selector labels.Selector) (ret []*v1.Node, err error) {
+	return []*v1.Node{l.node}, l.err
+}
+
+func (l *fakeNodeLister) Get(name string) (*v1.Node, error) {
+	return l.node, l.err
+}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -412,7 +412,7 @@ func newTestKubeletWithImageList(
 	handlers = append(handlers, shutdownManager)
 
 	// Add this as cleanup predicate pod admitter
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.getNodeAnyWay, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))
 
 	if !excludeAdmitHandlers {
 		kubelet.allocationManager.AddPodAdmitHandlers(handlers)
@@ -1230,7 +1230,7 @@ func TestHandlePluginResources(t *testing.T) {
 	}
 
 	// add updatePluginResourcesFunc to admission handler, to test it's behavior.
-	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.getNodeAnyWay, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc)})
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc)})
 
 	recorder := record.NewFakeRecorder(20)
 	nodeRef := &v1.ObjectReference{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If the informer cache is stale, it is possible for kubelet to reject a node with `NodeAffinity failed` errors after a pod is scheduled to it. More details are in https://github.com/kubernetes/kubernetes/issues/133997.

This PR updates kubelet to implement a node cache interface. When the admit handlers run into a node affinity issue, the kubelet will now synchronously fetch the node from the api server, update its internal cache accordingly, and try again.

2 commits:
1. A tiny simplification of `getNodeAnyway` - I dug into the history a bit and found that this function was written the way it is because there _used_ to be polling in `GetNode` that we wanted to avoid, but that polling no longer exists.
2. Update the predicate admit handler to use the new node caching methods to fetch the node synchronously on admission failure and try again.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/133997

#### Special notes for your reviewer

There was some talk about backporting this into 1.34. It ended up being a pretty small, largely self-contained change so I think it would be safe to do so if we wanted to. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a very old issue where kubelet rejects pods with NodeAffinityFailed due to a stale informer cache.
```
