### PR TITLE
feat: add +k8s:enum declarative validation to ResourceClaim DeviceAllocationMode

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -40,12 +40,43 @@ type ValidateFunc func(ctx context.Context, obj runtime.Object) field.ErrorList
 type ValidateUpdateFunc func(ctx context.Context, obj, old runtime.Object) field.ErrorList
 
 // VerifyVersionedValidationEquivalence tests that all versions of an API return equivalent validation errors.
-func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object, subResources ...string) {
+// It accepts optional configuration to handle path normalization across API versions where structures differ.
+func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object, testConfigs ...ValidationTestConfig) {
 	t.Helper()
+
+	opts := &validationOption{}
+	for _, testcfg := range testConfigs {
+		testcfg(opts)
+	}
 
 	// Accumulate errors from all versioned validation, per version.
 	all := map[string]field.ErrorList{}
 	accumulate := func(t *testing.T, gv string, errs field.ErrorList) {
+		// If normalization rules are provided, apply them to the field paths of generated errors.
+		// This allows comparing errors between API versions that have structural differences
+		// (e.g. flattened vs nested fields).
+		// We must normalize in place before sorting.
+		for i := range errs {
+			currentPath := errs[i].Field
+			for _, rule := range opts.NormalizationRules {
+				normalized := rule.Regexp.ReplaceAllString(currentPath, rule.Replacement)
+				if normalized != currentPath {
+					errs[i].Field = normalized
+					// Apply only the first matching rule per error
+					break
+				}
+			}
+			// Re-sort the error list based primarily on the normalized field paths
+			// to ensure errors align correctly during index-by-index comparison,
+			// regardless of their original structure.
+			sort.Slice(errs, func(i, j int) bool {
+				if errs[i].Field != errs[j].Field {
+					return errs[i].Field < errs[j].Field
+				}
+				// Secondary sort by full error string for determinism when fields are equal
+				return errs[i].Error() < errs[j].Error()
+			})
+		}
 		all[gv] = errs
 	}
 	// Convert versioned object to internal format before validation.
@@ -58,7 +89,7 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 		return
 	}
 	if old == nil {
-		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, accumulate, subResources...)
+		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, accumulate, opts.SubResources...)
 	} else {
 		// Convert old versioned object to internal format before validation.
 		// runtimetest.RunUpdateValidationForEachVersion requires unversioned (internal) objects as input.
@@ -69,7 +100,7 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 		if internalOld == nil {
 			return
 		}
-		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, internalOld, accumulate, subResources...)
+		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, internalOld, accumulate, opts.SubResources...)
 	}
 
 	// Make a copy so we can modify it.
@@ -104,13 +135,19 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 			}
 			next := false
 			for i := range lv {
-				if l, r := lv[i], rv[i]; l.Type != r.Type || l.Detail != r.Detail {
-					t.Errorf("different errors\n%s: %v\n%s: %v", lk, fmtErrs(lv), rk, fmtErrs(rv))
+				// We don't use reflect.DeepEqual here because unversioned and versioned
+				// validation might have different bad values (e.g. pointer vs value).
+				// We also don't use ErrorMatcher here because it doesn't handle re-sorting
+				// required after normalization in multi-error scenarios within this specific loop structure.
+				l, r := lv[i], rv[i]
+				// Compare field (already normalized), type, detail, and origin.
+				if l.Type != r.Type || l.Field != r.Field || l.Detail != r.Detail || l.Origin != r.Origin {
+					t.Errorf("different errors at index %d\n%s: %v\n%s: %v", i, lk, l.Error(), rk, r.Error())
 					next = true
-					break
 				}
 			}
 			if next {
+				t.Errorf("complete error lists for context:\n%s: %v\n%s: %v", lk, fmtErrs(lv), rk, fmtErrs(rv))
 				continue
 			}
 		}
@@ -127,7 +164,7 @@ func fmtErrs(errs field.ErrorList) string {
 	}
 	buf := bytes.Buffer{}
 	for _, e := range errs {
-		buf.WriteString("\n")
+		buf.WriteString("\n\t")
 		buf.WriteString(strconv.Quote(e.Error()))
 	}
 
@@ -200,7 +237,7 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 	verifyValidationEquivalence(t, expectedErrs, func() field.ErrorList {
 		return validateFn(ctx, obj)
 	}, opts)
-	VerifyVersionedValidationEquivalence(t, obj, nil, opts.SubResources...)
+	VerifyVersionedValidationEquivalence(t, obj, nil, testConfigs...)
 }
 
 // VerifyUpdateValidationEquivalence provides a helper for testing the migration from
@@ -225,7 +262,7 @@ func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, o
 	verifyValidationEquivalence(t, expectedErrs, func() field.ErrorList {
 		return validateUpdateFn(ctx, obj, old)
 	}, opts)
-	VerifyVersionedValidationEquivalence(t, obj, old, opts.SubResources...)
+	VerifyVersionedValidationEquivalence(t, obj, old, testConfigs...)
 }
 
 // verifyValidationEquivalence is a generic helper that verifies validation equivalence with and without declarative validation.

--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	resourcevalidation "k8s.io/kubernetes/pkg/apis/resource/validation"
 )
 
 // FIXME: Automatically finds all group/versions supporting declarative validation, or add
@@ -50,14 +51,18 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 						t.Fatalf("could not create a %v: %s", kind, err)
 					}
 					f.Fill(obj)
-					VerifyVersionedValidationEquivalence(t, obj, nil)
+
+					var opts []ValidationTestConfig
+					opts = append(opts, WithNormalizationRules(resourcevalidation.ResourceNormalizationRules...))
+
+					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
 
 					old, err := legacyscheme.Scheme.New(gv.WithKind(kind))
 					if err != nil {
 						t.Fatalf("could not create a %v: %s", kind, err)
 					}
 					f.Fill(old)
-					VerifyVersionedValidationEquivalence(t, obj, old)
+					VerifyVersionedValidationEquivalence(t, obj, old, opts...)
 				}
 			}
 		})

--- a/pkg/apis/autoscaling/validation/declarative_validation_test.go
+++ b/pkg/apis/autoscaling/validation/declarative_validation_test.go
@@ -66,7 +66,7 @@ func TestScaleDeclarativeValidation(t *testing.T) {
 			obj, _ := legacyscheme.Scheme.ConvertToVersion(&tc.input, schema.GroupVersion{Group: apiGroup, Version: apiVersion})
 			tester.Test(t, tc.expectedErrs, legacyscheme.Scheme.Validate(ctx, nil, obj, "scale"))
 
-			apitesting.VerifyVersionedValidationEquivalence(t, &tc.input, nil, "scale")
+			apitesting.VerifyVersionedValidationEquivalence(t, &tc.input, nil, apitesting.WithSubResources("scale"))
 		})
 	}
 }

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -32,6 +32,7 @@ import (
 	validate "k8s.io/apimachinery/pkg/api/validate"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -162,6 +163,16 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 		}(safe.Value(fldPath, func() *field.Path { return fldPath.Child("resourcev1.DeviceConfiguration") }), &obj.DeviceConfiguration, safe.Field(oldObj, func(oldObj *resourcev1.DeviceAllocationConfiguration) *resourcev1.DeviceConfiguration {
 			return &oldObj.DeviceConfiguration
 		}))...)
+
+	return errs
+}
+
+var symbolsForDeviceAllocationMode = sets.New(resourcev1.DeviceAllocationModeAll, resourcev1.DeviceAllocationModeExactCount)
+
+// Validate_DeviceAllocationMode validates an instance of DeviceAllocationMode according
+// to declarative validation rules in the API schema.
+func Validate_DeviceAllocationMode(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceAllocationMode) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil)...)
 
 	return errs
 }
@@ -647,7 +658,20 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			return
 		}(fldPath.Child("selectors"), obj.Selectors, safe.Field(oldObj, func(oldObj *resourcev1.DeviceSubRequest) []resourcev1.DeviceSelector { return oldObj.Selectors }))...)
 
-	// field resourcev1.DeviceSubRequest.AllocationMode has no validation
+	// field resourcev1.DeviceSubRequest.AllocationMode
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1.DeviceAllocationMode) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceAllocationMode(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("allocationMode"), &obj.AllocationMode, safe.Field(oldObj, func(oldObj *resourcev1.DeviceSubRequest) *resourcev1.DeviceAllocationMode {
+			return &oldObj.AllocationMode
+		}))...)
+
 	// field resourcev1.DeviceSubRequest.Count has no validation
 
 	// field resourcev1.DeviceSubRequest.Tolerations
@@ -719,7 +743,28 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 			return
 		}(fldPath.Child("selectors"), obj.Selectors, safe.Field(oldObj, func(oldObj *resourcev1.ExactDeviceRequest) []resourcev1.DeviceSelector { return oldObj.Selectors }))...)
 
-	// field resourcev1.ExactDeviceRequest.AllocationMode has no validation
+	// field resourcev1.ExactDeviceRequest.AllocationMode
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1.DeviceAllocationMode) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceAllocationMode(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("allocationMode"), &obj.AllocationMode, safe.Field(oldObj, func(oldObj *resourcev1.ExactDeviceRequest) *resourcev1.DeviceAllocationMode {
+			return &oldObj.AllocationMode
+		}))...)
+
 	// field resourcev1.ExactDeviceRequest.Count has no validation
 	// field resourcev1.ExactDeviceRequest.AdminAccess has no validation
 

--- a/pkg/apis/resource/v1beta1/defaults.go
+++ b/pkg/apis/resource/v1beta1/defaults.go
@@ -35,6 +35,10 @@ func SetDefaults_DeviceRequest(obj *resourceapi.DeviceRequest) {
 	if obj.DeviceClassName == "" {
 		return
 	}
+	// Declarative defaulting (+default) is not used for AllocationMode here because
+	// v1beta1 uses a bespoke union structure. Applying an unconditional default
+	// would make valid "FirstAvailable" requests (where this field must be empty) invalid.
+	// Therefore, we rely on this manual defaulting logic.
 	if obj.AllocationMode == "" {
 		obj.AllocationMode = resourceapi.DeviceAllocationModeExactCount
 	}

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -32,6 +32,7 @@ import (
 	validate "k8s.io/apimachinery/pkg/api/validate"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -164,6 +165,16 @@ func Validate_DeviceAllocationConfiguration(ctx context.Context, op operation.Op
 		}(safe.Value(fldPath, func() *field.Path { return fldPath.Child("resourcev1beta1.DeviceConfiguration") }), &obj.DeviceConfiguration, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceAllocationConfiguration) *resourcev1beta1.DeviceConfiguration {
 			return &oldObj.DeviceConfiguration
 		}))...)
+
+	return errs
+}
+
+var symbolsForDeviceAllocationMode = sets.New(resourcev1beta1.DeviceAllocationModeAll, resourcev1beta1.DeviceAllocationModeExactCount)
+
+// Validate_DeviceAllocationMode validates an instance of DeviceAllocationMode according
+// to declarative validation rules in the API schema.
+func Validate_DeviceAllocationMode(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceAllocationMode) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceAllocationMode, nil)...)
 
 	return errs
 }
@@ -537,7 +548,28 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			return
 		}(fldPath.Child("selectors"), obj.Selectors, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequest) []resourcev1beta1.DeviceSelector { return oldObj.Selectors }))...)
 
-	// field resourcev1beta1.DeviceRequest.AllocationMode has no validation
+	// field resourcev1beta1.DeviceRequest.AllocationMode
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceAllocationMode) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceAllocationMode(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("allocationMode"), &obj.AllocationMode, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequest) *resourcev1beta1.DeviceAllocationMode {
+			return &oldObj.AllocationMode
+		}))...)
+
 	// field resourcev1beta1.DeviceRequest.Count has no validation
 	// field resourcev1beta1.DeviceRequest.AdminAccess has no validation
 
@@ -693,7 +725,20 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 			return oldObj.Selectors
 		}))...)
 
-	// field resourcev1beta1.DeviceSubRequest.AllocationMode has no validation
+	// field resourcev1beta1.DeviceSubRequest.AllocationMode
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceAllocationMode) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceAllocationMode(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("allocationMode"), &obj.AllocationMode, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceSubRequest) *resourcev1beta1.DeviceAllocationMode {
+			return &oldObj.AllocationMode
+		}))...)
+
 	// field resourcev1beta1.DeviceSubRequest.Count has no validation
 
 	// field resourcev1beta1.DeviceSubRequest.Tolerations

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -259,7 +259,7 @@ func validateDeviceAllocationMode(deviceAllocationMode resource.DeviceAllocation
 			allErrs = append(allErrs, field.Invalid(countFldPath, count, "must be greater than zero"))
 		}
 	default:
-		allErrs = append(allErrs, field.NotSupported(allocModeFldPath, deviceAllocationMode, []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).WithOrigin("enum").MarkCoveredByDeclarative())
+		allErrs = append(allErrs, field.NotSupported(allocModeFldPath, deviceAllocationMode, []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).MarkCoveredByDeclarative())
 	}
 	return allErrs
 }

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -268,6 +268,9 @@ func validateDeviceAllocationMode(deviceAllocationMode resource.DeviceAllocation
 			allErrs = append(allErrs, field.Invalid(countFldPath, count, "must be greater than zero"))
 		}
 	default:
+		// NOTE: Declarative validation does not (yet) enforce the real requiredness of this field
+		// because v1beta1 uses a bespoke form of union which makes this field truly optional
+		// in some cases and truly required in others. DO NOT REMOVE THIS CODE UNLESS THAT IS RESOLVED.
 		allErrs = append(allErrs, field.NotSupported(allocModeFldPath, deviceAllocationMode, []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).MarkCoveredByDeclarative())
 	}
 	return allErrs

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -48,6 +48,15 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
+// ResourceNormalizationRules handles the structural differences between v1beta1
+// (flattened fields) and v1/v1beta2 (fields under 'exactly') for validation error paths.
+var ResourceNormalizationRules = []field.NormalizationRule{
+	{
+		Regexp:      regexp.MustCompile(`spec.devices\.requests\[(\d+)\]\.(deviceClassName|selectors|allocationMode|count|adminAccess|tolerations)`),
+		Replacement: "spec.devices.requests[$1].exactly.$2",
+	},
+}
+
 var (
 	// validateResourceDriverName reuses the validation of a CSI driver because
 	// the allowed values are exactly the same.

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -259,7 +259,7 @@ func validateDeviceAllocationMode(deviceAllocationMode resource.DeviceAllocation
 			allErrs = append(allErrs, field.Invalid(countFldPath, count, "must be greater than zero"))
 		}
 	default:
-		allErrs = append(allErrs, field.NotSupported(allocModeFldPath, deviceAllocationMode, []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}))
+		allErrs = append(allErrs, field.NotSupported(allocModeFldPath, deviceAllocationMode, []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).WithOrigin("enum").MarkCoveredByDeclarative())
 	}
 	return allErrs
 }

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -412,7 +412,7 @@ func TestValidateClaim(t *testing.T) {
 		"allocation-mode": {
 			wantFailures: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(2).Child("exactly", "count"), int64(-1), "must be greater than zero"),
-				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(3).Child("exactly", "allocationMode"), resource.DeviceAllocationMode("other"), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}),
+				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(3).Child("exactly", "allocationMode"), resource.DeviceAllocationMode("other"), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).WithOrigin("enum").MarkCoveredByDeclarative(),
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(4).Child("exactly", "count"), int64(2), "must not be specified when allocationMode is 'All'"),
 				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(5), "foo").MarkCoveredByDeclarative(),
 			},
@@ -636,7 +636,7 @@ func TestValidateClaim(t *testing.T) {
 			wantFailures: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("name"), badName, "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
 				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), ""),
-				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"), resource.DeviceAllocationMode(""), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}),
+				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"), resource.DeviceAllocationMode(""), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).WithOrigin("enum").MarkCoveredByDeclarative(),
 			},
 			claim: func() *resource.ResourceClaim {
 				claim := testClaim(goodName, goodNS, validClaimSpecWithFirstAvailable)

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -412,7 +412,7 @@ func TestValidateClaim(t *testing.T) {
 		"allocation-mode": {
 			wantFailures: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(2).Child("exactly", "count"), int64(-1), "must be greater than zero"),
-				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(3).Child("exactly", "allocationMode"), resource.DeviceAllocationMode("other"), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).WithOrigin("enum").MarkCoveredByDeclarative(),
+				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(3).Child("exactly", "allocationMode"), resource.DeviceAllocationMode("other"), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).MarkCoveredByDeclarative(),
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(4).Child("exactly", "count"), int64(2), "must not be specified when allocationMode is 'All'"),
 				field.Duplicate(field.NewPath("spec", "devices", "requests").Index(5), "foo").MarkCoveredByDeclarative(),
 			},
@@ -636,7 +636,7 @@ func TestValidateClaim(t *testing.T) {
 			wantFailures: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("name"), badName, "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
 				field.Required(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), ""),
-				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"), resource.DeviceAllocationMode(""), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).WithOrigin("enum").MarkCoveredByDeclarative(),
+				field.NotSupported(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"), resource.DeviceAllocationMode(""), []resource.DeviceAllocationMode{resource.DeviceAllocationModeAll, resource.DeviceAllocationModeExactCount}).MarkCoveredByDeclarative(),
 			},
 			claim: func() *resource.ResourceClaim {
 				claim := testClaim(goodName, goodNS, validClaimSpecWithFirstAvailable)

--- a/pkg/registry/core/replicationcontroller/storage/scale_declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/storage/scale_declarative_validation_test.go
@@ -111,7 +111,7 @@ func TestValidateScaleForDeclarative(t *testing.T) {
 			equivalenceMatcher := field.ErrorMatcher{}.ByType().ByField()
 			equivalenceMatcher.Test(t, imperativeErrs, declarativeTakeoverErrs)
 
-			apitesting.VerifyVersionedValidationEquivalence(t, &tc.input, nil, "scale")
+			apitesting.VerifyVersionedValidationEquivalence(t, &tc.input, nil, apitesting.WithSubResources("scale"))
 		})
 	}
 }

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -264,7 +264,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				).WithOrigin("enum"),
+				),
 			},
 		},
 		"valid DeviceAllocationMode - FirstAvailable": {
@@ -277,7 +277,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 					field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"),
 					resource.DeviceAllocationMode("InvalidMode"),
 					[]string{"All", "ExactCount"},
-				).WithOrigin("enum"),
+				),
 			},
 		},
 		// TODO: Add more test cases

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/resource"
+	"k8s.io/kubernetes/pkg/apis/resource/validation"
 	pointer "k8s.io/utils/ptr"
 )
 
@@ -284,7 +285,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs, apitesting.WithNormalizationRules(resourceClaimNormalizationRules...))
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
 }
@@ -595,7 +596,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		t.Run(k, func(t *testing.T) {
 			tc.old.ResourceVersion = "1"
 			tc.update.ResourceVersion = "2"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithNormalizationRules(resourceClaimNormalizationRules...))
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
 }

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -254,7 +254,6 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key"),
 			},
 		},
-		// TODO: Add more test cases
 		"valid DeviceAllocationMode - All": {
 			input: mkValidResourceClaim(tweakExactlyAllocationMode(resource.DeviceAllocationModeAll, 0)),
 		},
@@ -281,6 +280,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				).WithOrigin("enum"),
 			},
 		},
+		// TODO: Add more test cases
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -256,10 +256,10 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		},
 		// TODO: Add more test cases
 		"valid DeviceAllocationMode - All": {
-			input: mkValidResourceClaim(tweakAllocationMode(resource.DeviceAllocationModeAll, 0)),
+			input: mkValidResourceClaim(tweakExactlyAllocationMode(resource.DeviceAllocationModeAll, 0)),
 		},
 		"invalid DeviceAllocationMode - Exactly": {
-			input: mkValidResourceClaim(tweakAllocationMode("InvalidMode", 1)),
+			input: mkValidResourceClaim(tweakExactlyAllocationMode("InvalidMode", 1)),
 			expectedErrs: field.ErrorList{
 				field.NotSupported(
 					field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "allocationMode"),
@@ -427,7 +427,7 @@ func tweakFirstAvailable(items int) func(*resource.ResourceClaim) {
 	}
 }
 
-func tweakAllocationMode(mode resource.DeviceAllocationMode, count int64) func(*resource.ResourceClaim) {
+func tweakExactlyAllocationMode(mode resource.DeviceAllocationMode, count int64) func(*resource.ResourceClaim) {
 	return func(rc *resource.ResourceClaim) {
 		if len(rc.Spec.Devices.Requests) > 0 && rc.Spec.Devices.Requests[0].Exactly != nil {
 			rc.Spec.Devices.Requests[0].Exactly.AllocationMode = mode

--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -57,8 +57,8 @@ var resourceClaimNormalizationRules = []field.NormalizationRule{
 	{
 		// The "exactly" struct was added in v1beta2. In earlier API
 		// versions, its fields were directly part of the DeviceRequest.
-		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.selectors`),
-		Replacement: "spec.devices.requests[$1].exactly.selectors",
+		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.(selectors|allocationMode|count|adminAccess)`),
+		Replacement: "spec.devices.requests[$1].exactly.$2",
 	},
 	{
 		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.tolerations`),

--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -57,12 +57,10 @@ var resourceClaimNormalizationRules = []field.NormalizationRule{
 	{
 		// The "exactly" struct was added in v1beta2. In earlier API
 		// versions, its fields were directly part of the DeviceRequest.
-		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.(selectors|allocationMode|count|adminAccess)`),
+		// This normalizes v1beta1 paths to look like v1beta2/v1 paths
+		// for comparison.
+		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.(deviceClassName|selectors|allocationMode|count|adminAccess|tolerations)`),
 		Replacement: "spec.devices.requests[$1].exactly.$2",
-	},
-	{
-		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.tolerations`),
-		Replacement: "spec.devices.requests[$1].exactly.tolerations",
 	},
 }
 

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -1180,6 +1180,7 @@ message ExactDeviceRequest {
   // requests with unknown modes.
   //
   // +optional
+  // +k8s:optional
   optional string allocationMode = 3;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -871,6 +871,7 @@ type ExactDeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
+	// +k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1083,6 +1084,7 @@ const (
 )
 
 // +enum
+// +k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -844,6 +844,7 @@ message DeviceRequest {
   // requests with unknown modes.
   //
   // +optional
+  // +k8s:optional
   optional string allocationMode = 4;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -842,6 +842,7 @@ type DeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
+	// +k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,4,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1090,6 +1091,7 @@ const (
 )
 
 // +enum
+// +k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1180,6 +1180,7 @@ message ExactDeviceRequest {
   // requests with unknown modes.
   //
   // +optional
+  // +k8s:optional
   optional string allocationMode = 3;
 
   // Count is used only when the count mode is "ExactCount". Must be greater than zero.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -871,6 +871,7 @@ type ExactDeviceRequest struct {
 	// requests with unknown modes.
 	//
 	// +optional
+	// +k8s:optional
 	AllocationMode DeviceAllocationMode `json:"allocationMode,omitempty" protobuf:"bytes,3,opt,name=allocationMode"`
 
 	// Count is used only when the count mode is "ExactCount". Must be greater than zero.
@@ -1083,6 +1084,7 @@ const (
 )
 
 // +enum
+// +k8s:enum
 type DeviceAllocationMode string
 
 // Valid [DeviceRequest.CountMode] values.

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
@@ -33,7 +33,7 @@ func Enum[T ~string](_ context.Context, op operation.Operation, fldPath *field.P
 		return nil
 	}
 	if !validValues.Has(*value) || isExcluded(op, exclusions, *value) {
-		return field.ErrorList{field.NotSupported[T](fldPath, *value, supportedValues(op, validValues, exclusions)).WithOrigin("enum")}
+		return field.ErrorList{field.NotSupported[T](fldPath, *value, supportedValues(op, validValues, exclusions))}
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
@@ -33,7 +33,7 @@ func Enum[T ~string](_ context.Context, op operation.Operation, fldPath *field.P
 		return nil
 	}
 	if !validValues.Has(*value) || isExcluded(op, exclusions, *value) {
-		return field.ErrorList{field.NotSupported[T](fldPath, *value, supportedValues(op, validValues, exclusions))}
+		return field.ErrorList{field.NotSupported[T](fldPath, *value, supportedValues(op, validValues, exclusions)).WithOrigin("enum")}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR migrates a section of hand-written validation logic for ResourceClaim DeviceAllocationMode to declarative validation using the +k8s:enum tag.

#### Which issue(s) this PR is related to:
Builds on https://github.com/kubernetes/kubernetes/pull/134072
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
/sig api-machinery

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```
