### PR TITLE
refactor(apiextensions-apiserver): Make finalizingController controller context-aware

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -246,7 +246,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		go establishingController.RunWithContext(hookContext)
 		go nonStructuralSchemaController.RunWithContext(5, hookContext)
 		go apiApprovalController.RunWithContext(5, hookContext)
-		go finalizingController.Run(5, hookContext.Done())
+		go finalizingController.RunWithContext(5, hookContext)
 
 		discoverySyncedCh := make(chan struct{})
 		go discoveryController.Run(hookContext.Done(), discoverySyncedCh)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This change refactors the finalizingController in `apiextensions-apiserver` to add a new `RunWithContext` method, which accepts a `context.Context` for cancellation and contextual logging. The original `Run` method is preserved as a backward-compatible shim that converts a `stopCh` to a `context`.

This is part of the broader effort to enable contextual logging across all Kubernetes components, as tracked in #126379.

**Which issue(s) this PR fixes**:
Contributes to #126379

**Special notes for your reviewer**:
This is a standard refactoring to add a `...WithContext` API variant as per the contextual logging migration plan.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```