### PR TITLE
Fix node conformance tests with fake registry

### DIFF
--- a/test/e2e/common/node/container.go
+++ b/test/e2e/common/node/container.go
@@ -43,6 +43,7 @@ type ConformanceContainer struct {
 	RestartPolicy    v1.RestartPolicy
 	Volumes          []v1.Volume
 	ImagePullSecrets []string
+	NodeName         string
 
 	PodClient          *e2epod.PodClient
 	podName            string
@@ -65,6 +66,7 @@ func (cc *ConformanceContainer) Create(ctx context.Context) {
 			Containers: []v1.Container{
 				cc.Container,
 			},
+			NodeName:         cc.NodeName,
 			SecurityContext:  cc.PodSecurityContext,
 			Volumes:          cc.Volumes,
 			ImagePullSecrets: imagePullSecrets,

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -263,7 +263,7 @@ while true; do sleep 1; done
 			var registrySetup bool
 			registryAddress := net.JoinHostPort("localhost", "5000")
 			ginkgo.BeforeEach(func(ctx context.Context) {
-				_, err := e2eregistry.SetupRegistry(ctx, f)
+				_, err := e2eregistry.SetupRegistry(ctx, f, false)
 				framework.ExpectNoError(err)
 			})
 

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -265,13 +265,10 @@ while true; do sleep 1; done
 
 				registryAddress, _, err = e2eregistry.SetupRegistry(ctx, f, false)
 				framework.ExpectNoError(err)
-			})
-
-			ginkgo.AfterEach(func(ctx context.Context) {
-				if len(registryAddress) == 0 {
-					return
-				}
-				f.DeleteNamespace(ctx, f.Namespace.Name) // we need to wait for the registry to be removed and so we need to delete the whole NS early (before the actual cleanup)
+				// we need to wait for the registry to be removed and so we need to delete the whole NS ourselves
+				ginkgo.DeferCleanup(func(ctx context.Context) {
+					f.DeleteNamespace(ctx, f.Namespace.Name)
+				})
 			})
 
 			// Images used for ConformanceContainer are not added into NodePrePullImageList, because this test is

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"path"
 	"time"
@@ -260,15 +259,16 @@ while true; do sleep 1; done
 		})
 
 		framework.Context("when running a container with a new image", framework.WithSerial(), func() {
-			var registrySetup bool
-			registryAddress := net.JoinHostPort("localhost", "5000")
+			var registryAddress string
 			ginkgo.BeforeEach(func(ctx context.Context) {
-				_, err := e2eregistry.SetupRegistry(ctx, f, false)
+				var err error
+
+				registryAddress, _, err = e2eregistry.SetupRegistry(ctx, f, false)
 				framework.ExpectNoError(err)
 			})
 
 			ginkgo.AfterEach(func(ctx context.Context) {
-				if !registrySetup {
+				if len(registryAddress) == 0 {
 					return
 				}
 				f.DeleteNamespace(ctx, f.Namespace.Name) // we need to wait for the registry to be removed and so we need to delete the whole NS early (before the actual cleanup)

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -19,10 +19,13 @@ package node
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/kubelet/images"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -259,7 +262,7 @@ while true; do sleep 1; done
 			// Images used for ConformanceContainer are not added into NodePrePullImageList, because this test is
 			// testing image pulling, these images don't need to be prepulled. The ImagePullPolicy
 			// is v1.PullAlways, so it won't be blocked by framework image pre-pull list check.
-			imagePullTest := func(ctx context.Context, image string, expectedPhase v1.PodPhase, expectedPullStatus bool, windowsImage bool) {
+			imagePullTest := func(ctx context.Context, image string, hasSecret bool, expectedPhase v1.PodPhase, expectedPullStatus bool, windowsImage bool) {
 				command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
 				if windowsImage {
 					// -t: Ping the specified host until stopped.
@@ -275,7 +278,34 @@ while true; do sleep 1; done
 					},
 					RestartPolicy: v1.RestartPolicyNever,
 				}
-
+				if hasSecret {
+					// The service account only has pull permission
+					auth := `
+{
+	"auths": {
+		"https://gcr.io": {
+			"auth": "X2pzb25fa2V5OnsKICAidHlwZSI6ICJzZXJ2aWNlX2FjY291bnQiLAogICJwcm9qZWN0X2lkIjogImF1dGhlbnRpY2F0ZWQtaW1hZ2UtcHVsbGluZyIsCiAgInByaXZhdGVfa2V5X2lkIjogImI5ZjJhNjY0YWE5YjIwNDg0Y2MxNTg2MDYzZmVmZGExOTIyNGFjM2IiLAogICJwcml2YXRlX2tleSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzdTSG5LVEVFaVlMamZcbkpmQVBHbUozd3JCY2VJNTBKS0xxS21GWE5RL3REWGJRK2g5YVl4aldJTDhEeDBKZTc0bVovS01uV2dYRjVLWlNcbm9BNktuSU85Yi9SY1NlV2VpSXRSekkzL1lYVitPNkNjcmpKSXl4anFWam5mVzJpM3NhMzd0OUE5VEZkbGZycm5cbjR6UkpiOWl4eU1YNGJMdHFGR3ZCMDNOSWl0QTNzVlo1ODhrb1FBZmgzSmhhQmVnTWorWjRSYko0aGVpQlFUMDNcbnZVbzViRWFQZVQ5RE16bHdzZWFQV2dydDZOME9VRGNBRTl4bGNJek11MjUzUG4vSzgySFpydEx4akd2UkhNVXhcbng0ZjhwSnhmQ3h4QlN3Z1NORit3OWpkbXR2b0wwRmE3ZGducFJlODZWRDY2ejNZenJqNHlLRXRqc2hLZHl5VWRcbkl5cVhoN1JSQWdNQkFBRUNnZ0VBT3pzZHdaeENVVlFUeEFka2wvSTVTRFVidi9NazRwaWZxYjJEa2FnbmhFcG9cbjFJajJsNGlWMTByOS9uenJnY2p5VlBBd3pZWk1JeDFBZVF0RDdoUzRHWmFweXZKWUc3NkZpWFpQUm9DVlB6b3VcbmZyOGRDaWFwbDV0enJDOWx2QXNHd29DTTdJWVRjZmNWdDdjRTEyRDNRS3NGNlo3QjJ6ZmdLS251WVBmK0NFNlRcbmNNMHkwaCtYRS9kMERvSERoVy96YU1yWEhqOFRvd2V1eXRrYmJzNGYvOUZqOVBuU2dET1lQd2xhbFZUcitGUWFcbkpSd1ZqVmxYcEZBUW14M0Jyd25rWnQzQ2lXV2lGM2QrSGk5RXRVYnRWclcxYjZnK1JRT0licWFtcis4YlJuZFhcbjZWZ3FCQWtKWjhSVnlkeFVQMGQxMUdqdU9QRHhCbkhCbmM0UW9rSXJFUUtCZ1FEMUNlaWN1ZGhXdGc0K2dTeGJcbnplanh0VjFONDFtZHVjQnpvMmp5b1dHbzNQVDh3ckJPL3lRRTM0cU9WSi9pZCs4SThoWjRvSWh1K0pBMDBzNmdcblRuSXErdi9kL1RFalk4MW5rWmlDa21SUFdiWHhhWXR4UjIxS1BYckxOTlFKS2ttOHRkeVh5UHFsOE1veUdmQ1dcbjJ2aVBKS05iNkhabnY5Q3lqZEo5ZzJMRG5RS0JnUUREcVN2eURtaGViOTIzSW96NGxlZ01SK205Z2xYVWdTS2dcbkVzZlllbVJmbU5XQitDN3ZhSXlVUm1ZNU55TXhmQlZXc3dXRldLYXhjK0krYnFzZmx6elZZdFpwMThNR2pzTURcbmZlZWZBWDZCWk1zVXQ3Qmw3WjlWSjg1bnRFZHFBQ0xwWitaLzN0SVJWdWdDV1pRMWhrbmxHa0dUMDI0SkVFKytcbk55SDFnM2QzUlFLQmdRQ1J2MXdKWkkwbVBsRklva0tGTkh1YTBUcDNLb1JTU1hzTURTVk9NK2xIckcxWHJtRjZcbkMwNGNTKzQ0N0dMUkxHOFVUaEpKbTRxckh0Ti9aK2dZOTYvMm1xYjRIakpORDM3TVhKQnZFYTN5ZUxTOHEvK1JcbjJGOU1LamRRaU5LWnhQcG84VzhOSlREWTVOa1BaZGh4a2pzSHdVNGRTNjZwMVRESUU0MGd0TFpaRFFLQmdGaldcbktyblFpTnEzOS9iNm5QOFJNVGJDUUFKbmR3anhTUU5kQTVmcW1rQTlhRk9HbCtqamsxQ1BWa0tNSWxLSmdEYkpcbk9heDl2OUc2Ui9NSTFIR1hmV3QxWU56VnRocjRIdHNyQTB0U3BsbWhwZ05XRTZWejZuQURqdGZQSnMyZUdqdlhcbmpQUnArdjhjY21MK3dTZzhQTGprM3ZsN2VlNXJsWWxNQndNdUdjUHhBb0dBZWRueGJXMVJMbVZubEFpSEx1L0xcbmxtZkF3RFdtRWlJMFVnK1BMbm9Pdk81dFE1ZDRXMS94RU44bFA0cWtzcGtmZk1Rbk5oNFNZR0VlQlQzMlpxQ1RcbkpSZ2YwWGpveXZ2dXA5eFhqTWtYcnBZL3ljMXpmcVRaQzBNTzkvMVVjMWJSR2RaMmR5M2xSNU5XYXA3T1h5Zk9cblBQcE5Gb1BUWGd2M3FDcW5sTEhyR3pNPVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuIiwKICAiY2xpZW50X2VtYWlsIjogImltYWdlLXB1bGxpbmdAYXV0aGVudGljYXRlZC1pbWFnZS1wdWxsaW5nLmlhbS5nc2VydmljZWFjY291bnQuY29tIiwKICAiY2xpZW50X2lkIjogIjExMzc5NzkxNDUzMDA3MzI3ODcxMiIsCiAgImF1dGhfdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi9hdXRoIiwKICAidG9rZW5fdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi90b2tlbiIsCiAgImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9vYXV0aDIvdjEvY2VydHMiLAogICJjbGllbnRfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9yb2JvdC92MS9tZXRhZGF0YS94NTA5L2ltYWdlLXB1bGxpbmclNDBhdXRoZW50aWNhdGVkLWltYWdlLXB1bGxpbmcuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iCn0=",
+			"email": "image-pulling@authenticated-image-pulling.iam.gserviceaccount.com"
+		}
+	}
+}`
+					// we might be told to use a different docker config JSON.
+					if framework.TestContext.DockerConfigFile != "" {
+						contents, err := os.ReadFile(framework.TestContext.DockerConfigFile)
+						framework.ExpectNoError(err)
+						auth = string(contents)
+					}
+					secret := &v1.Secret{
+						Data: map[string][]byte{v1.DockerConfigJsonKey: []byte(auth)},
+						Type: v1.SecretTypeDockerConfigJson,
+					}
+					secret.Name = "image-pull-secret-" + string(uuid.NewUUID())
+					ginkgo.By("create image pull secret")
+					_, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
+					framework.ExpectNoError(err)
+					ginkgo.DeferCleanup(f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete, secret.Name, metav1.DeleteOptions{})
+					container.ImagePullSecrets = []string{secret.Name}
+				}
 				// checkContainerStatus checks whether the container status matches expectation.
 				checkContainerStatus := func(ctx context.Context) error {
 					status, err := container.GetStatus(ctx)
@@ -340,24 +370,29 @@ while true; do sleep 1; done
 
 			f.It("should not be able to pull image from invalid registry", f.WithNodeConformance(), func(ctx context.Context) {
 				image := imageutils.GetE2EImage(imageutils.InvalidRegistryImage)
-				imagePullTest(ctx, image, v1.PodPending, true, false)
+				imagePullTest(ctx, image, false, v1.PodPending, true, false)
 			})
 
 			f.It("should be able to pull image", f.WithNodeConformance(), func(ctx context.Context) {
 				// NOTE(claudiub): The agnhost image is supposed to work on both Linux and Windows.
 				image := imageutils.GetE2EImage(imageutils.Agnhost)
-				imagePullTest(ctx, image, v1.PodRunning, false, false)
+				imagePullTest(ctx, image, false, v1.PodRunning, false, false)
 			})
 
-			// TODO: https://github.com/kubernetes/kubernetes/issues/130271
-			// Switch this to use a locally hosted private image and not depend on this host
 			f.It("should not be able to pull from private registry without secret", f.WithNodeConformance(), func(ctx context.Context) {
 				image := imageutils.GetE2EImage(imageutils.AuthenticatedAlpine)
-				imagePullTest(ctx, image, v1.PodPending, true, false)
+				imagePullTest(ctx, image, false, v1.PodPending, true, false)
 			})
 
-			// TODO: https://github.com/kubernetes/kubernetes/issues/130271
-			// Add a sustainable test for pulling with a private registry secret
+			f.It("should be able to pull from private registry with secret", f.WithNodeConformance(), func(ctx context.Context) {
+				image := imageutils.GetE2EImage(imageutils.AuthenticatedAlpine)
+				isWindows := false
+				if framework.NodeOSDistroIs("windows") {
+					image = imageutils.GetE2EImage(imageutils.AuthenticatedWindowsNanoServer)
+					isWindows = true
+				}
+				imagePullTest(ctx, image, true, v1.PodRunning, false, isWindows)
+			})
 		})
 	})
 })

--- a/test/e2e/framework/registry/.import-restrictions
+++ b/test/e2e/framework/registry/.import-restrictions
@@ -1,0 +1,14 @@
+rules:
+  # Using k8s packages, other framework helpers and the public API should be good enough.
+  #
+  # public API
+  - selectorRegexp: ^k8s[.]io/(api|apimachinery|client-go|component-base|klog|pod-security-admission|utils)
+    allowedPrefixes: [ "" ]
+
+  # test helpers
+  - selectorRegexp: ^k8s[.]io/kubernetes/test
+    allowedPrefixes: [ "" ]
+
+  # stdlib
+  - selectorRegexp: ^[a-z]+(/|$)
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/registry/registry.go
+++ b/test/e2e/framework/registry/registry.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/pod-security-admission/api"
+	"k8s.io/pod-security-admission/test"
+	"k8s.io/utils/ptr"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2edaemonset "k8s.io/kubernetes/test/e2e/framework/daemonset"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+const (
+	dockerCredsFmt = `{
+	"auths": {
+		"%s": {
+			"auth": "%s"
+		}
+	}
+}`
+	user1creds = "dXNlcjpwYXNzd29yZA==" // user:password
+)
+
+func SetupRegistry(ctx context.Context, f *framework.Framework) ([]string, error) {
+	pod, err := test.GetMinimalValidLinuxPod(api.LevelRestricted, api.MajorMinorVersion(1, 22))
+	if err != nil {
+		return nil, err
+	}
+
+	pod.Spec.InitContainers = nil
+	pod.Spec.Containers[0].Name = "registry"
+	pod.Spec.Containers[0].Image = imageutils.GetE2EImage(imageutils.Agnhost)
+	pod.Spec.Containers[0].ImagePullPolicy = v1.PullIfNotPresent
+	pod.Spec.Containers[0].Args = []string{"fake-registry-server", "--private"}
+	pod.Spec.Containers[0].Ports = []v1.ContainerPort{
+		{
+			Name:          "http",
+			ContainerPort: 5000,
+			HostPort:      5000,
+		},
+	}
+	pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To[int64](5123)
+
+	podTestLabel := "test-registry-pod-" + f.UniqueName
+	labels := map[string]string{"kube-e2e": podTestLabel}
+	daemonset := e2edaemonset.NewDaemonSet("", "", labels, nil, nil, nil)
+	daemonset.GenerateName = "test-registry-"
+	daemonset.Spec.Template.Spec = pod.Spec
+
+	daemonset, err = f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Create(ctx, daemonset, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 120*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, daemonset)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "kube-e2e=" + podTestLabel})
+	if err != nil {
+		return nil, err
+	}
+	podNodes := make([]string, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		podNodes = append(podNodes, pod.Spec.NodeName)
+	}
+
+	return podNodes, nil
+}
+
+func User1DockerSecret(registryAddress string) *v1.Secret {
+	return &v1.Secret{
+		Type: v1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			v1.DockerConfigJsonKey: fmt.Appendf(nil, dockerCredsFmt, "http://"+registryAddress, user1creds),
+		},
+	}
+}

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/kubelet/images"
+	"k8s.io/kubernetes/test/e2e/common/node"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/e2e_node/services"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+var _ = SIGDescribe("Container Runtime Conformance Test", func() {
+	f := framework.NewDefaultFramework("runtime-conformance")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	ginkgo.Describe("container runtime conformance blackbox test", func() {
+
+		ginkgo.Context("when running a container with a new image", func() {
+			// For the future security scans:
+			// The service account only has pull permission.
+			// The container repo is only made private to test private container pulling.
+			// All container images in the repo are public container images
+			// TODO: The long term plan is to come up with the alternative solution to test it:
+			// https://github.com/kubernetes/kubernetes/issues/130271
+			auth := `
+{
+	"auths": {
+		"https://gcr.io": {
+			"auth": "X2pzb25fa2V5OnsKICAidHlwZSI6ICJzZXJ2aWNlX2FjY291bnQiLAogICJwcm9qZWN0X2lkIjogImF1dGhlbnRpY2F0ZWQtaW1hZ2UtcHVsbGluZyIsCiAgInByaXZhdGVfa2V5X2lkIjogImI5ZjJhNjY0YWE5YjIwNDg0Y2MxNTg2MDYzZmVmZGExOTIyNGFjM2IiLAogICJwcml2YXRlX2tleSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzdTSG5LVEVFaVlMamZcbkpmQVBHbUozd3JCY2VJNTBKS0xxS21GWE5RL3REWGJRK2g5YVl4aldJTDhEeDBKZTc0bVovS01uV2dYRjVLWlNcbm9BNktuSU85Yi9SY1NlV2VpSXRSekkzL1lYVitPNkNjcmpKSXl4anFWam5mVzJpM3NhMzd0OUE5VEZkbGZycm5cbjR6UkpiOWl4eU1YNGJMdHFGR3ZCMDNOSWl0QTNzVlo1ODhrb1FBZmgzSmhhQmVnTWorWjRSYko0aGVpQlFUMDNcbnZVbzViRWFQZVQ5RE16bHdzZWFQV2dydDZOME9VRGNBRTl4bGNJek11MjUzUG4vSzgySFpydEx4akd2UkhNVXhcbng0ZjhwSnhmQ3h4QlN3Z1NORit3OWpkbXR2b0wwRmE3ZGducFJlODZWRDY2ejNZenJqNHlLRXRqc2hLZHl5VWRcbkl5cVhoN1JSQWdNQkFBRUNnZ0VBT3pzZHdaeENVVlFUeEFka2wvSTVTRFVidi9NazRwaWZxYjJEa2FnbmhFcG9cbjFJajJsNGlWMTByOS9uenJnY2p5VlBBd3pZWk1JeDFBZVF0RDdoUzRHWmFweXZKWUc3NkZpWFpQUm9DVlB6b3VcbmZyOGRDaWFwbDV0enJDOWx2QXNHd29DTTdJWVRjZmNWdDdjRTEyRDNRS3NGNlo3QjJ6ZmdLS251WVBmK0NFNlRcbmNNMHkwaCtYRS9kMERvSERoVy96YU1yWEhqOFRvd2V1eXRrYmJzNGYvOUZqOVBuU2dET1lQd2xhbFZUcitGUWFcbkpSd1ZqVmxYcEZBUW14M0Jyd25rWnQzQ2lXV2lGM2QrSGk5RXRVYnRWclcxYjZnK1JRT0licWFtcis4YlJuZFhcbjZWZ3FCQWtKWjhSVnlkeFVQMGQxMUdqdU9QRHhCbkhCbmM0UW9rSXJFUUtCZ1FEMUNlaWN1ZGhXdGc0K2dTeGJcbnplanh0VjFONDFtZHVjQnpvMmp5b1dHbzNQVDh3ckJPL3lRRTM0cU9WSi9pZCs4SThoWjRvSWh1K0pBMDBzNmdcblRuSXErdi9kL1RFalk4MW5rWmlDa21SUFdiWHhhWXR4UjIxS1BYckxOTlFKS2ttOHRkeVh5UHFsOE1veUdmQ1dcbjJ2aVBKS05iNkhabnY5Q3lqZEo5ZzJMRG5RS0JnUUREcVN2eURtaGViOTIzSW96NGxlZ01SK205Z2xYVWdTS2dcbkVzZlllbVJmbU5XQitDN3ZhSXlVUm1ZNU55TXhmQlZXc3dXRldLYXhjK0krYnFzZmx6elZZdFpwMThNR2pzTURcbmZlZWZBWDZCWk1zVXQ3Qmw3WjlWSjg1bnRFZHFBQ0xwWitaLzN0SVJWdWdDV1pRMWhrbmxHa0dUMDI0SkVFKytcbk55SDFnM2QzUlFLQmdRQ1J2MXdKWkkwbVBsRklva0tGTkh1YTBUcDNLb1JTU1hzTURTVk9NK2xIckcxWHJtRjZcbkMwNGNTKzQ0N0dMUkxHOFVUaEpKbTRxckh0Ti9aK2dZOTYvMm1xYjRIakpORDM3TVhKQnZFYTN5ZUxTOHEvK1JcbjJGOU1LamRRaU5LWnhQcG84VzhOSlREWTVOa1BaZGh4a2pzSHdVNGRTNjZwMVRESUU0MGd0TFpaRFFLQmdGaldcbktyblFpTnEzOS9iNm5QOFJNVGJDUUFKbmR3anhTUU5kQTVmcW1rQTlhRk9HbCtqamsxQ1BWa0tNSWxLSmdEYkpcbk9heDl2OUc2Ui9NSTFIR1hmV3QxWU56VnRocjRIdHNyQTB0U3BsbWhwZ05XRTZWejZuQURqdGZQSnMyZUdqdlhcbmpQUnArdjhjY21MK3dTZzhQTGprM3ZsN2VlNXJsWWxNQndNdUdjUHhBb0dBZWRueGJXMVJMbVZubEFpSEx1L0xcbmxtZkF3RFdtRWlJMFVnK1BMbm9Pdk81dFE1ZDRXMS94RU44bFA0cWtzcGtmZk1Rbk5oNFNZR0VlQlQzMlpxQ1RcbkpSZ2YwWGpveXZ2dXA5eFhqTWtYcnBZL3ljMXpmcVRaQzBNTzkvMVVjMWJSR2RaMmR5M2xSNU5XYXA3T1h5Zk9cblBQcE5Gb1BUWGd2M3FDcW5sTEhyR3pNPVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuIiwKICAiY2xpZW50X2VtYWlsIjogImltYWdlLXB1bGxpbmdAYXV0aGVudGljYXRlZC1pbWFnZS1wdWxsaW5nLmlhbS5nc2VydmljZWFjY291bnQuY29tIiwKICAiY2xpZW50X2lkIjogIjExMzc5NzkxNDUzMDA3MzI3ODcxMiIsCiAgImF1dGhfdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi9hdXRoIiwKICAidG9rZW5fdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi90b2tlbiIsCiAgImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9vYXV0aDIvdjEvY2VydHMiLAogICJjbGllbnRfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9yb2JvdC92MS9tZXRhZGF0YS94NTA5L2ltYWdlLXB1bGxpbmclNDBhdXRoZW50aWNhdGVkLWltYWdlLXB1bGxpbmcuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iCn0=",
+			"email": "image-pulling@authenticated-image-pulling.iam.gserviceaccount.com"
+		}
+	}
+}`
+			// The following images are not added into NodePrePullImageList, because this test is
+			// testing image pulling, these images don't need to be prepulled. The ImagePullPolicy
+			// is v1.PullAlways, so it won't be blocked by framework image pre-pull list check.
+			for _, testCase := range []struct {
+				description string
+				image       string
+				phase       v1.PodPhase
+				waiting     bool
+			}{
+				{
+					description: "should be able to pull from private registry with credential provider",
+					image:       "gcr.io/authenticated-image-pulling/alpine:3.7",
+					phase:       v1.PodRunning,
+					waiting:     false,
+				},
+			} {
+				testCase := testCase
+				f.It(testCase.description+"", f.WithNodeConformance(), func(ctx context.Context) {
+					name := "image-pull-test"
+					command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
+					container := node.ConformanceContainer{
+						PodClient: e2epod.NewPodClient(f),
+						Container: v1.Container{
+							Name:    name,
+							Image:   testCase.image,
+							Command: command,
+							// PullAlways makes sure that the image will always be pulled even if it is present before the test.
+							ImagePullPolicy: v1.PullAlways,
+						},
+						RestartPolicy: v1.RestartPolicyNever,
+					}
+
+					configFile := filepath.Join(services.KubeletRootDirectory, "config.json")
+					err := os.WriteFile(configFile, []byte(auth), 0644)
+					framework.ExpectNoError(err)
+					defer os.Remove(configFile)
+
+					// checkContainerStatus checks whether the container status matches expectation.
+					checkContainerStatus := func(ctx context.Context) error {
+						status, err := container.GetStatus(ctx)
+						if err != nil {
+							return fmt.Errorf("failed to get container status: %w", err)
+						}
+						// We need to check container state first. The default pod status is pending, If we check
+						// pod phase first, and the expected pod phase is Pending, the container status may not
+						// even show up when we check it.
+						// Check container state
+						if !testCase.waiting {
+							if status.State.Running == nil {
+								return fmt.Errorf("expected container state: Running, got: %q",
+									node.GetContainerState(status.State))
+							}
+						}
+						if testCase.waiting {
+							if status.State.Waiting == nil {
+								return fmt.Errorf("expected container state: Waiting, got: %q",
+									node.GetContainerState(status.State))
+							}
+							reason := status.State.Waiting.Reason
+							if reason != images.ErrImagePull.Error() &&
+								reason != images.ErrImagePullBackOff.Error() {
+								return fmt.Errorf("unexpected waiting reason: %q", reason)
+							}
+						}
+						// Check pod phase
+						phase, err := container.GetPhase(ctx)
+						if err != nil {
+							return fmt.Errorf("failed to get pod phase: %w", err)
+						}
+						if phase != testCase.phase {
+							return fmt.Errorf("expected pod phase: %q, got: %q", testCase.phase, phase)
+						}
+						return nil
+					}
+					// The image registry is not stable, which sometimes causes the test to fail. Add retry mechanism to make this
+					// less flaky.
+					const flakeRetry = 3
+					for i := 1; i <= flakeRetry; i++ {
+						var err error
+						ginkgo.By("create the container")
+						container.Create(ctx)
+						ginkgo.By("check the container status")
+						for start := time.Now(); time.Since(start) < node.ContainerStatusRetryTimeout; time.Sleep(node.ContainerStatusPollInterval) {
+							if err = checkContainerStatus(ctx); err == nil {
+								break
+							}
+						}
+						ginkgo.By("delete the container")
+						_ = container.Delete(ctx)
+						if err == nil {
+							break
+						}
+						if i < flakeRetry {
+							framework.Logf("No.%d attempt failed: %v, retrying...", i, err)
+						} else {
+							framework.Failf("All %d attempts failed: %v", flakeRetry, err)
+						}
+					}
+				})
+			}
+		})
+	})
+})

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/common/node"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eregistry "k8s.io/kubernetes/test/e2e/framework/registry"
 	"k8s.io/kubernetes/test/e2e_node/services"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -36,62 +37,66 @@ import (
 
 var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 	f := framework.NewDefaultFramework("runtime-conformance")
-	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged // custom registry pods need HostPorts
 
 	ginkgo.Describe("container runtime conformance blackbox test", func() {
 
 		ginkgo.Context("when running a container with a new image", func() {
-			// For the future security scans:
-			// The service account only has pull permission.
-			// The container repo is only made private to test private container pulling.
-			// All container images in the repo are public container images
-			// TODO: The long term plan is to come up with the alternative solution to test it:
-			// https://github.com/kubernetes/kubernetes/issues/130271
-			auth := `
-{
-	"auths": {
-		"https://gcr.io": {
-			"auth": "X2pzb25fa2V5OnsKICAidHlwZSI6ICJzZXJ2aWNlX2FjY291bnQiLAogICJwcm9qZWN0X2lkIjogImF1dGhlbnRpY2F0ZWQtaW1hZ2UtcHVsbGluZyIsCiAgInByaXZhdGVfa2V5X2lkIjogImI5ZjJhNjY0YWE5YjIwNDg0Y2MxNTg2MDYzZmVmZGExOTIyNGFjM2IiLAogICJwcml2YXRlX2tleSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzdTSG5LVEVFaVlMamZcbkpmQVBHbUozd3JCY2VJNTBKS0xxS21GWE5RL3REWGJRK2g5YVl4aldJTDhEeDBKZTc0bVovS01uV2dYRjVLWlNcbm9BNktuSU85Yi9SY1NlV2VpSXRSekkzL1lYVitPNkNjcmpKSXl4anFWam5mVzJpM3NhMzd0OUE5VEZkbGZycm5cbjR6UkpiOWl4eU1YNGJMdHFGR3ZCMDNOSWl0QTNzVlo1ODhrb1FBZmgzSmhhQmVnTWorWjRSYko0aGVpQlFUMDNcbnZVbzViRWFQZVQ5RE16bHdzZWFQV2dydDZOME9VRGNBRTl4bGNJek11MjUzUG4vSzgySFpydEx4akd2UkhNVXhcbng0ZjhwSnhmQ3h4QlN3Z1NORit3OWpkbXR2b0wwRmE3ZGducFJlODZWRDY2ejNZenJqNHlLRXRqc2hLZHl5VWRcbkl5cVhoN1JSQWdNQkFBRUNnZ0VBT3pzZHdaeENVVlFUeEFka2wvSTVTRFVidi9NazRwaWZxYjJEa2FnbmhFcG9cbjFJajJsNGlWMTByOS9uenJnY2p5VlBBd3pZWk1JeDFBZVF0RDdoUzRHWmFweXZKWUc3NkZpWFpQUm9DVlB6b3VcbmZyOGRDaWFwbDV0enJDOWx2QXNHd29DTTdJWVRjZmNWdDdjRTEyRDNRS3NGNlo3QjJ6ZmdLS251WVBmK0NFNlRcbmNNMHkwaCtYRS9kMERvSERoVy96YU1yWEhqOFRvd2V1eXRrYmJzNGYvOUZqOVBuU2dET1lQd2xhbFZUcitGUWFcbkpSd1ZqVmxYcEZBUW14M0Jyd25rWnQzQ2lXV2lGM2QrSGk5RXRVYnRWclcxYjZnK1JRT0licWFtcis4YlJuZFhcbjZWZ3FCQWtKWjhSVnlkeFVQMGQxMUdqdU9QRHhCbkhCbmM0UW9rSXJFUUtCZ1FEMUNlaWN1ZGhXdGc0K2dTeGJcbnplanh0VjFONDFtZHVjQnpvMmp5b1dHbzNQVDh3ckJPL3lRRTM0cU9WSi9pZCs4SThoWjRvSWh1K0pBMDBzNmdcblRuSXErdi9kL1RFalk4MW5rWmlDa21SUFdiWHhhWXR4UjIxS1BYckxOTlFKS2ttOHRkeVh5UHFsOE1veUdmQ1dcbjJ2aVBKS05iNkhabnY5Q3lqZEo5ZzJMRG5RS0JnUUREcVN2eURtaGViOTIzSW96NGxlZ01SK205Z2xYVWdTS2dcbkVzZlllbVJmbU5XQitDN3ZhSXlVUm1ZNU55TXhmQlZXc3dXRldLYXhjK0krYnFzZmx6elZZdFpwMThNR2pzTURcbmZlZWZBWDZCWk1zVXQ3Qmw3WjlWSjg1bnRFZHFBQ0xwWitaLzN0SVJWdWdDV1pRMWhrbmxHa0dUMDI0SkVFKytcbk55SDFnM2QzUlFLQmdRQ1J2MXdKWkkwbVBsRklva0tGTkh1YTBUcDNLb1JTU1hzTURTVk9NK2xIckcxWHJtRjZcbkMwNGNTKzQ0N0dMUkxHOFVUaEpKbTRxckh0Ti9aK2dZOTYvMm1xYjRIakpORDM3TVhKQnZFYTN5ZUxTOHEvK1JcbjJGOU1LamRRaU5LWnhQcG84VzhOSlREWTVOa1BaZGh4a2pzSHdVNGRTNjZwMVRESUU0MGd0TFpaRFFLQmdGaldcbktyblFpTnEzOS9iNm5QOFJNVGJDUUFKbmR3anhTUU5kQTVmcW1rQTlhRk9HbCtqamsxQ1BWa0tNSWxLSmdEYkpcbk9heDl2OUc2Ui9NSTFIR1hmV3QxWU56VnRocjRIdHNyQTB0U3BsbWhwZ05XRTZWejZuQURqdGZQSnMyZUdqdlhcbmpQUnArdjhjY21MK3dTZzhQTGprM3ZsN2VlNXJsWWxNQndNdUdjUHhBb0dBZWRueGJXMVJMbVZubEFpSEx1L0xcbmxtZkF3RFdtRWlJMFVnK1BMbm9Pdk81dFE1ZDRXMS94RU44bFA0cWtzcGtmZk1Rbk5oNFNZR0VlQlQzMlpxQ1RcbkpSZ2YwWGpveXZ2dXA5eFhqTWtYcnBZL3ljMXpmcVRaQzBNTzkvMVVjMWJSR2RaMmR5M2xSNU5XYXA3T1h5Zk9cblBQcE5Gb1BUWGd2M3FDcW5sTEhyR3pNPVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuIiwKICAiY2xpZW50X2VtYWlsIjogImltYWdlLXB1bGxpbmdAYXV0aGVudGljYXRlZC1pbWFnZS1wdWxsaW5nLmlhbS5nc2VydmljZWFjY291bnQuY29tIiwKICAiY2xpZW50X2lkIjogIjExMzc5NzkxNDUzMDA3MzI3ODcxMiIsCiAgImF1dGhfdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi9hdXRoIiwKICAidG9rZW5fdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi90b2tlbiIsCiAgImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9vYXV0aDIvdjEvY2VydHMiLAogICJjbGllbnRfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9yb2JvdC92MS9tZXRhZGF0YS94NTA5L2ltYWdlLXB1bGxpbmclNDBhdXRoZW50aWNhdGVkLWltYWdlLXB1bGxpbmcuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iCn0=",
-			"email": "image-pulling@authenticated-image-pulling.iam.gserviceaccount.com"
-		}
-	}
-}`
+			registryAddress := "localhost:5000"
+			auth := e2eregistry.User1DockerSecret(registryAddress).Data[v1.DockerConfigJsonKey]
 			// The following images are not added into NodePrePullImageList, because this test is
 			// testing image pulling, these images don't need to be prepulled. The ImagePullPolicy
 			// is v1.PullAlways, so it won't be blocked by framework image pre-pull list check.
 			for _, testCase := range []struct {
-				description string
-				image       string
-				phase       v1.PodPhase
-				waiting     bool
+				description  string
+				image        string
+				setupRegisty bool
+				phase        v1.PodPhase
+				waiting      bool
 			}{
 				{
-					description: "should be able to pull from private registry with credential provider",
-					image:       "gcr.io/authenticated-image-pulling/alpine:3.7",
-					phase:       v1.PodRunning,
-					waiting:     false,
+					description:  "should be able to pull from private registry with credential provider",
+					image:        registryAddress + "/pause:testing",
+					setupRegisty: true,
+					phase:        v1.PodRunning,
+					waiting:      false,
 				},
 			} {
-				testCase := testCase
+				var podNodes []string
+				ginkgo.BeforeEach(func(ctx context.Context) {
+					var err error
+					if testCase.setupRegisty {
+						podNodes, err = e2eregistry.SetupRegistry(ctx, f, true)
+						framework.ExpectNoError(err)
+					}
+				})
+				ginkgo.AfterEach(func(ctx context.Context) {
+					if !testCase.setupRegisty {
+						return
+					}
+					f.DeleteNamespace(ctx, f.Namespace.Name) // we need to wait for the registry to be removed and so we need to delete the whole NS early (before the actual cleanup)
+				})
+
 				f.It(testCase.description+"", f.WithNodeConformance(), func(ctx context.Context) {
 					name := "image-pull-test"
-					command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
 					container := node.ConformanceContainer{
 						PodClient: e2epod.NewPodClient(f),
 						Container: v1.Container{
-							Name:    name,
-							Image:   testCase.image,
-							Command: command,
+							Name:  name,
+							Image: testCase.image,
 							// PullAlways makes sure that the image will always be pulled even if it is present before the test.
 							ImagePullPolicy: v1.PullAlways,
 						},
 						RestartPolicy: v1.RestartPolicyNever,
 					}
+					if testCase.setupRegisty {
+						container.NodeName = podNodes[0]
+					}
 
 					configFile := filepath.Join(services.KubeletRootDirectory, "config.json")
 					err := os.WriteFile(configFile, []byte(auth), 0644)
 					framework.ExpectNoError(err)
-					defer os.Remove(configFile)
+					defer func() { framework.ExpectNoError(os.Remove(configFile)) }()
 
 					// checkContainerStatus checks whether the container status matches expectation.
 					checkContainerStatus := func(ctx context.Context) error {

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -64,15 +64,16 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 				var podNodes []string
 				ginkgo.BeforeEach(func(ctx context.Context) {
 					var err error
-					if testCase.setupRegisty {
-						registryAddress, podNodes, err = e2eregistry.SetupRegistry(ctx, f, true)
-						framework.ExpectNoError(err)
+					if !testCase.setupRegisty {
+						return
 					}
-				})
-				ginkgo.AfterEach(func(ctx context.Context) {
-					if testCase.setupRegisty {
-						f.DeleteNamespace(ctx, f.Namespace.Name) // we need to wait for the registry to be removed and so we need to delete the whole NS early (before the actual cleanup)
-					}
+
+					registryAddress, podNodes, err = e2eregistry.SetupRegistry(ctx, f, true)
+					framework.ExpectNoError(err)
+					// we need to wait for the registry to be removed and so we need to delete the whole NS ourselves
+					ginkgo.DeferCleanup(func(ctx context.Context) {
+						f.DeleteNamespace(ctx, f.Namespace.Name)
+					})
 				})
 
 				f.It(testCase.description+"", f.WithNodeConformance(), func(ctx context.Context) {

--- a/test/images/.permitted-images
+++ b/test/images/.permitted-images
@@ -3,6 +3,10 @@
 # We are aiming to consolidate on: registry.k8s.io/e2e-test-images/agnhost
 # The sources for which are in test/images/agnhost.
 # If agnhost is missing functionality for your tests, please reach out to SIG Testing.
+#
+# TODO: remove gcr.io/k8s-authenticated-test/agnhost and set up a cluster-local
+#       private registry via test/e2e/framework/registry.SetupRegistry() to test
+#       private image pulls
 gcr.io/k8s-authenticated-test/agnhost
 invalid.registry.k8s.io/invalid/alpine
 registry.k8s.io/build-image/distroless-iptables

--- a/test/images/.permitted-images
+++ b/test/images/.permitted-images
@@ -3,8 +3,6 @@
 # We are aiming to consolidate on: registry.k8s.io/e2e-test-images/agnhost
 # The sources for which are in test/images/agnhost.
 # If agnhost is missing functionality for your tests, please reach out to SIG Testing.
-gcr.io/authenticated-image-pulling/alpine
-gcr.io/authenticated-image-pulling/windows-nanoserver
 gcr.io/k8s-authenticated-test/agnhost
 invalid.registry.k8s.io/invalid/alpine
 registry.k8s.io/build-image/distroless-iptables

--- a/test/images/.permitted-images
+++ b/test/images/.permitted-images
@@ -4,6 +4,7 @@
 # The sources for which are in test/images/agnhost.
 # If agnhost is missing functionality for your tests, please reach out to SIG Testing.
 gcr.io/authenticated-image-pulling/alpine
+gcr.io/authenticated-image-pulling/windows-nanoserver
 gcr.io/k8s-authenticated-test/agnhost
 invalid.registry.k8s.io/invalid/alpine
 registry.k8s.io/build-image/distroless-iptables

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -33,7 +33,6 @@ import (
 
 // RegistryList holds public and private image registries
 type RegistryList struct {
-	GcAuthenticatedRegistry  string `yaml:"gcAuthenticatedRegistry"`
 	PromoterE2eRegistry      string `yaml:"promoterE2eRegistry"`
 	BuildImageRegistry       string `yaml:"buildImageRegistry"`
 	InvalidRegistry          string `yaml:"invalidRegistry"`
@@ -389,8 +388,6 @@ func replaceRegistryInImageURLWithList(imageURL string, reg RegistryList) (strin
 		registryAndUser = reg.PromoterE2eRegistry
 	case initRegistry.BuildImageRegistry:
 		registryAndUser = reg.BuildImageRegistry
-	case initRegistry.GcAuthenticatedRegistry:
-		registryAndUser = reg.GcAuthenticatedRegistry
 	case initRegistry.DockerLibraryRegistry:
 		registryAndUser = reg.DockerLibraryRegistry
 	case initRegistry.CloudProviderGcpRegistry:

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -129,17 +129,13 @@ func readFromURL(url string, writer io.Writer) error {
 
 var (
 	initRegistry = RegistryList{
-		// TODO: https://github.com/kubernetes/kubernetes/issues/130271
-		// Eliminate GcAuthenticatedRegistry.
-		GcAuthenticatedRegistry: "gcr.io/authenticated-image-pulling",
-		PromoterE2eRegistry:     "registry.k8s.io/e2e-test-images",
-		BuildImageRegistry:      "registry.k8s.io/build-image",
-		InvalidRegistry:         "invalid.registry.k8s.io/invalid",
-		GcEtcdRegistry:          "registry.k8s.io",
-		GcRegistry:              "registry.k8s.io",
-		SigStorageRegistry:      "registry.k8s.io/sig-storage",
-		// TODO: https://github.com/kubernetes/kubernetes/issues/130271
-		// Eliminate PrivateRegistry.
+		GcAuthenticatedRegistry:  "gcr.io/authenticated-image-pulling",
+		PromoterE2eRegistry:      "registry.k8s.io/e2e-test-images",
+		BuildImageRegistry:       "registry.k8s.io/build-image",
+		InvalidRegistry:          "invalid.registry.k8s.io/invalid",
+		GcEtcdRegistry:           "registry.k8s.io",
+		GcRegistry:               "registry.k8s.io",
+		SigStorageRegistry:       "registry.k8s.io/sig-storage",
 		PrivateRegistry:          "gcr.io/k8s-authenticated-test",
 		DockerLibraryRegistry:    "docker.io/library",
 		CloudProviderGcpRegistry: "registry.k8s.io/cloud-provider-gcp",
@@ -158,17 +154,15 @@ const (
 	// Agnhost image
 	Agnhost
 	// AgnhostPrivate image
-	// TODO: https://github.com/kubernetes/kubernetes/issues/130271
-	// Eliminate this.
 	AgnhostPrivate
 	// APIServer image
 	APIServer
 	// AppArmorLoader image
 	AppArmorLoader
 	// AuthenticatedAlpine image
-	// TODO: https://github.com/kubernetes/kubernetes/issues/130271
-	// Eliminate this.
 	AuthenticatedAlpine
+	// AuthenticatedWindowsNanoServer image
+	AuthenticatedWindowsNanoServer
 	// BusyBox image
 	BusyBox
 	// DistrolessIptables Image
@@ -222,6 +216,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.56"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
+	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
@@ -269,7 +264,7 @@ func GetMappedImageConfigs(originalImageConfigs map[ImageID]Config, repo string)
 	for i, config := range originalImageConfigs {
 		switch i {
 		case InvalidRegistryImage, AuthenticatedAlpine,
-			AgnhostPrivate:
+			AuthenticatedWindowsNanoServer, AgnhostPrivate:
 			// These images are special and can't be run out of the cloud - some because they
 			// are authenticated, and others because they are not real images. Tests that depend
 			// on these images can't be run without access to the public internet.

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -129,6 +129,8 @@ func readFromURL(url string, writer io.Writer) error {
 
 var (
 	initRegistry = RegistryList{
+		// TODO: https://github.com/kubernetes/kubernetes/issues/130271
+		// Eliminate PrivateRegistry.
 		PromoterE2eRegistry:      "registry.k8s.io/e2e-test-images",
 		BuildImageRegistry:       "registry.k8s.io/build-image",
 		InvalidRegistry:          "invalid.registry.k8s.io/invalid",

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -129,7 +129,6 @@ func readFromURL(url string, writer io.Writer) error {
 
 var (
 	initRegistry = RegistryList{
-		GcAuthenticatedRegistry:  "gcr.io/authenticated-image-pulling",
 		PromoterE2eRegistry:      "registry.k8s.io/e2e-test-images",
 		BuildImageRegistry:       "registry.k8s.io/build-image",
 		InvalidRegistry:          "invalid.registry.k8s.io/invalid",
@@ -159,10 +158,6 @@ const (
 	APIServer
 	// AppArmorLoader image
 	AppArmorLoader
-	// AuthenticatedAlpine image
-	AuthenticatedAlpine
-	// AuthenticatedWindowsNanoServer image
-	AuthenticatedWindowsNanoServer
 	// BusyBox image
 	BusyBox
 	// DistrolessIptables Image
@@ -213,10 +208,8 @@ const (
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
 	configs[AgnhostPrev] = Config{list.PromoterE2eRegistry, "agnhost", "2.55"}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.56"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.57"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
-	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
-	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
@@ -263,8 +256,7 @@ func GetMappedImageConfigs(originalImageConfigs map[ImageID]Config, repo string)
 	configs := make(map[ImageID]Config)
 	for i, config := range originalImageConfigs {
 		switch i {
-		case InvalidRegistryImage, AuthenticatedAlpine,
-			AuthenticatedWindowsNanoServer, AgnhostPrivate:
+		case InvalidRegistryImage, AgnhostPrivate:
 			// These images are special and can't be run out of the cloud - some because they
 			// are authenticated, and others because they are not real images. Tests that depend
 			// on these images can't be run without access to the public internet.

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -56,20 +56,16 @@ func BenchmarkReplaceRegistryInImageURL(b *testing.B) {
 		}, {
 			in:  "registry.k8s.io/build-image/test:latest",
 			out: "test.io/build/test:latest",
-		}, {
-			in:  "gcr.io/authenticated-image-pulling/test:latest",
-			out: "test.io/gcAuth/test:latest",
 		},
 	}
 	reg := RegistryList{
-		DockerLibraryRegistry:   "test.io/library",
-		GcRegistry:              "test.io",
-		PrivateRegistry:         "test.io/k8s-authenticated-test",
-		SigStorageRegistry:      "test.io/sig-storage",
-		InvalidRegistry:         "test.io/invalid",
-		PromoterE2eRegistry:     "test.io/promoter",
-		BuildImageRegistry:      "test.io/build",
-		GcAuthenticatedRegistry: "test.io/gcAuth",
+		DockerLibraryRegistry: "test.io/library",
+		GcRegistry:            "test.io",
+		PrivateRegistry:       "test.io/k8s-authenticated-test",
+		SigStorageRegistry:    "test.io/sig-storage",
+		InvalidRegistry:       "test.io/invalid",
+		PromoterE2eRegistry:   "test.io/promoter",
+		BuildImageRegistry:    "test.io/build",
 	}
 	for i := 0; i < b.N; i++ {
 		tt := registryTests[i%len(registryTests)]
@@ -114,9 +110,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 			in:  "registry.k8s.io/build-image/test:latest",
 			out: "test.io/build/test:latest",
 		}, {
-			in:  "gcr.io/authenticated-image-pulling/test:latest",
-			out: "test.io/gcAuth/test:latest",
-		}, {
 			in:        "unknwon.io/google-samples/test:latest",
 			expectErr: fmt.Errorf("Registry: unknwon.io/google-samples is missing in test/utils/image/manifest.go, please add the registry, otherwise the test will fail on air-gapped clusters"),
 		},
@@ -124,14 +117,13 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 
 	// Set custom registries
 	reg := RegistryList{
-		DockerLibraryRegistry:   "test.io/library",
-		GcRegistry:              "test.io",
-		PrivateRegistry:         "test.io/k8s-authenticated-test",
-		SigStorageRegistry:      "test.io/sig-storage",
-		InvalidRegistry:         "test.io/invalid",
-		PromoterE2eRegistry:     "test.io/promoter",
-		BuildImageRegistry:      "test.io/build",
-		GcAuthenticatedRegistry: "test.io/gcAuth",
+		DockerLibraryRegistry: "test.io/library",
+		GcRegistry:            "test.io",
+		PrivateRegistry:       "test.io/k8s-authenticated-test",
+		SigStorageRegistry:    "test.io/sig-storage",
+		InvalidRegistry:       "test.io/invalid",
+		PromoterE2eRegistry:   "test.io/promoter",
+		BuildImageRegistry:    "test.io/build",
 	}
 
 	for _, tt := range registryTests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
This PR brings back node conformance tests that were removed in https://github.com/kubernetes/kubernetes/pull/133262

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/130271

#### Special notes for your reviewer:
The test run:
1. run the agnhost fake registry in a deployment
    1a. the registry pods use HostIP as localhost registries are trusted by containerd for insecure comms
2. label the nodes the registries run on (=> needs Serialized for these tests because of cluster-global side effects)
3. run a Pod with node selector on these nodes, the Pod has a container that requests `localhost:5000/pause` image
4. clean the labels from the nodes

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
