### PR TITLE
Adding goroutine metrics for kubelet

### DIFF
--- a/pkg/kubelet/images/puller.go
+++ b/pkg/kubelet/images/puller.go
@@ -24,6 +24,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 
 type pullResult struct {
@@ -54,6 +55,8 @@ func newParallelImagePuller(imageService kubecontainer.ImageService, maxParallel
 
 func (pip *parallelImagePuller) pullImage(ctx context.Context, spec kubecontainer.ImageSpec, credentials []credentialprovider.TrackedAuthConfig, pullChan chan<- pullResult, podSandboxConfig *runtimeapi.PodSandboxConfig) {
 	go func() {
+		metrics.Goroutines.WithLabelValues(metrics.ImagePullingOperation).Inc()
+		defer metrics.Goroutines.WithLabelValues(metrics.ImagePullingOperation).Dec()
 		if pip.tokens != nil {
 			pip.tokens <- struct{}{}
 			defer func() { <-pip.tokens }()

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -176,6 +176,13 @@ const (
 	PodInfeasibleResizesKey          = "pod_infeasible_resizes_total"
 	PodInProgressResizesKey          = "pod_in_progress_resizes"
 	PodDeferredAcceptedResizesKey    = "pod_deferred_accepted_resizes_total"
+
+	// Metric key for goroutines.
+	GoroutinesKey = "goroutines"
+	// Below are possible values for the operation label of goroutines metric.
+	PodWorkerOperation         = "pod_worker"
+	ImagePullingOperation      = "image_pulling"
+	ContainerDeletionOperation = "container_deletion"
 )
 
 type imageSizeBucket struct {
@@ -1190,6 +1197,17 @@ var (
 		},
 		[]string{"retry_trigger"},
 	)
+
+	// Goroutines tracks the number of running goroutines split by the work they do.
+	Goroutines = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           GoroutinesKey,
+			Help:           "Number of running goroutines split by the work they do such as pod workers, image pulling, and container deletion.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"operation"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -1308,6 +1326,8 @@ func Register() {
 			legacyregistry.MustRegister(PodInProgressResizes)
 			legacyregistry.MustRegister(PodDeferredAcceptedResizes)
 		}
+
+		legacyregistry.MustRegister(Goroutines)
 	})
 }
 

--- a/pkg/kubelet/metrics/metrics_test.go
+++ b/pkg/kubelet/metrics/metrics_test.go
@@ -72,6 +72,30 @@ func TestImagePullDurationMetric(t *testing.T) {
 	})
 }
 
+func TestGoroutinesMetric(t *testing.T) {
+	t.Run("increment and decrement goroutines metric", func(t *testing.T) {
+		Register()
+		defer clearMetrics()
+
+		// Simulate pod worker goroutine
+		Goroutines.WithLabelValues(PodWorkerOperation).Inc()
+		Goroutines.WithLabelValues(PodWorkerOperation).Inc()
+
+		// Simulate image pulling goroutine
+		Goroutines.WithLabelValues(ImagePullingOperation).Inc()
+
+		// Simulate container deletion goroutine
+		Goroutines.WithLabelValues(ContainerDeletionOperation).Inc()
+
+		// Decrement metrics
+		Goroutines.WithLabelValues(PodWorkerOperation).Dec()
+		Goroutines.WithLabelValues(ImagePullingOperation).Dec()
+		Goroutines.WithLabelValues(ContainerDeletionOperation).Dec()
+		Goroutines.WithLabelValues(PodWorkerOperation).Dec()
+	})
+}
+
 func clearMetrics() {
 	ImagePullDuration.Reset()
+	Goroutines.Reset()
 }

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -967,6 +967,8 @@ func (p *podWorkers) UpdatePod(options UpdatePodOptions) {
 			// accept a context for shutdown
 			defer runtime.HandleCrash()
 			defer klog.V(3).InfoS("Pod worker has stopped", "podUID", uid)
+			metrics.Goroutines.WithLabelValues(metrics.PodWorkerOperation).Inc()
+			defer metrics.Goroutines.WithLabelValues(metrics.PodWorkerOperation).Dec()
 			p.podWorkerLoop(uid, outCh)
 		}()
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds granular goroutine tracking metrics to the kubelet to help identify sources of goroutine proliferation. Currently, while `go_goroutines{job="kubelet"}` shows the total goroutine count, there's no visibility into which operations are creating goroutines. This makes it difficult to diagnose and address "too many goroutine" alerts in production environments.

The PR introduces a new metric `kubelet_goroutines` with an `operation` label that tracks goroutines for three key kubelet operations:
- **Pod worker processes** (`pod_worker`) - tracks goroutines managing pod lifecycle
- **Image pulling** (`image_pulling`) - tracks goroutines pulling container images
- **Container deletion** (`container_deletion`) - tracks goroutines handling container cleanup and prestop hooks

This follows a similar pattern already implemented in kube-scheduler and provides actionable insights for operators to identify which kubelet operations are contributing to high goroutine counts.

#### Which issue(s) this PR is related to:

Fixes #127024

#### Special notes for your reviewer:

The metric is implemented as a `GaugeVec` with `ALPHA` stability level. Each operation increments the counter when a goroutine starts and decrements when it completes, providing an accurate real-time count of active goroutines per operation type.

The implementation adds minimal overhead - just an increment/decrement operation at goroutine creation/termination points.

#### Does this PR introduce a user-facing change?

```release-note
Added new `kubelet_goroutines` metric to track the number of running goroutines split by operation type (pod_worker, image_pulling, container_deletion), enabling better observability and debugging of kubelet goroutine usage.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
