### PR TITLE
Add k8s-label-key format for toleration key

### DIFF
--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -555,7 +555,21 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 
 	// field resourcev1.DeviceRequestAllocationResult.Device has no validation
 	// field resourcev1.DeviceRequestAllocationResult.AdminAccess has no validation
-	// field resourcev1.DeviceRequestAllocationResult.Tolerations has no validation
+
+	// field resourcev1.DeviceRequestAllocationResult.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1.DeviceRequestAllocationResult) []resourcev1.DeviceToleration {
+			return oldObj.Tolerations
+		}))...)
+
 	// field resourcev1.DeviceRequestAllocationResult.BindingConditions has no validation
 	// field resourcev1.DeviceRequestAllocationResult.BindingFailureConditions has no validation
 
@@ -609,8 +623,49 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 
 	// field resourcev1.DeviceSubRequest.AllocationMode has no validation
 	// field resourcev1.DeviceSubRequest.Count has no validation
-	// field resourcev1.DeviceSubRequest.Tolerations has no validation
+
+	// field resourcev1.DeviceSubRequest.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1.DeviceSubRequest) []resourcev1.DeviceToleration { return oldObj.Tolerations }))...)
+
 	// field resourcev1.DeviceSubRequest.Capacity has no validation
+	return errs
+}
+
+// Validate_DeviceToleration validates an instance of DeviceToleration according
+// to declarative validation rules in the API schema.
+func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceToleration) (errs field.ErrorList) {
+	// field resourcev1.DeviceToleration.Key
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1.DeviceToleration) *string { return &oldObj.Key }))...)
+
+	// field resourcev1.DeviceToleration.Operator has no validation
+	// field resourcev1.DeviceToleration.Value has no validation
+	// field resourcev1.DeviceToleration.Effect has no validation
+	// field resourcev1.DeviceToleration.TolerationSeconds has no validation
 	return errs
 }
 
@@ -641,7 +696,19 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 	// field resourcev1.ExactDeviceRequest.AllocationMode has no validation
 	// field resourcev1.ExactDeviceRequest.Count has no validation
 	// field resourcev1.ExactDeviceRequest.AdminAccess has no validation
-	// field resourcev1.ExactDeviceRequest.Tolerations has no validation
+
+	// field resourcev1.ExactDeviceRequest.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1.ExactDeviceRequest) []resourcev1.DeviceToleration { return oldObj.Tolerations }))...)
+
 	// field resourcev1.ExactDeviceRequest.Capacity has no validation
 	return errs
 }

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -540,7 +540,20 @@ func Validate_DeviceRequest(ctx context.Context, op operation.Operation, fldPath
 			return oldObj.FirstAvailable
 		}))...)
 
-	// field resourcev1beta1.DeviceRequest.Tolerations has no validation
+	// field resourcev1beta1.DeviceRequest.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequest) []resourcev1beta1.DeviceToleration {
+			return oldObj.Tolerations
+		}))...)
+
 	// field resourcev1beta1.DeviceRequest.Capacity has no validation
 	return errs
 }
@@ -590,6 +603,8 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			if earlyReturn {
 				return // do not proceed
 			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
 			return
 		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceRequestAllocationResult) []resourcev1beta1.DeviceToleration {
 			return oldObj.Tolerations
@@ -650,8 +665,51 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 
 	// field resourcev1beta1.DeviceSubRequest.AllocationMode has no validation
 	// field resourcev1beta1.DeviceSubRequest.Count has no validation
-	// field resourcev1beta1.DeviceSubRequest.Tolerations has no validation
+
+	// field resourcev1beta1.DeviceSubRequest.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceSubRequest) []resourcev1beta1.DeviceToleration {
+			return oldObj.Tolerations
+		}))...)
+
 	// field resourcev1beta1.DeviceSubRequest.Capacity has no validation
+	return errs
+}
+
+// Validate_DeviceToleration validates an instance of DeviceToleration according
+// to declarative validation rules in the API schema.
+func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceToleration) (errs field.ErrorList) {
+	// field resourcev1beta1.DeviceToleration.Key
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceToleration) *string { return &oldObj.Key }))...)
+
+	// field resourcev1beta1.DeviceToleration.Operator has no validation
+	// field resourcev1beta1.DeviceToleration.Value has no validation
+	// field resourcev1beta1.DeviceToleration.Effect has no validation
+	// field resourcev1beta1.DeviceToleration.TolerationSeconds has no validation
 	return errs
 }
 

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -567,7 +567,21 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 
 	// field resourcev1beta2.DeviceRequestAllocationResult.Device has no validation
 	// field resourcev1beta2.DeviceRequestAllocationResult.AdminAccess has no validation
-	// field resourcev1beta2.DeviceRequestAllocationResult.Tolerations has no validation
+
+	// field resourcev1beta2.DeviceRequestAllocationResult.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceRequestAllocationResult) []resourcev1beta2.DeviceToleration {
+			return oldObj.Tolerations
+		}))...)
+
 	// field resourcev1beta2.DeviceRequestAllocationResult.BindingConditions has no validation
 	// field resourcev1beta2.DeviceRequestAllocationResult.BindingFailureConditions has no validation
 
@@ -623,8 +637,51 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 
 	// field resourcev1beta2.DeviceSubRequest.AllocationMode has no validation
 	// field resourcev1beta2.DeviceSubRequest.Count has no validation
-	// field resourcev1beta2.DeviceSubRequest.Tolerations has no validation
+
+	// field resourcev1beta2.DeviceSubRequest.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceSubRequest) []resourcev1beta2.DeviceToleration {
+			return oldObj.Tolerations
+		}))...)
+
 	// field resourcev1beta2.DeviceSubRequest.Capacity has no validation
+	return errs
+}
+
+// Validate_DeviceToleration validates an instance of DeviceToleration according
+// to declarative validation rules in the API schema.
+func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceToleration) (errs field.ErrorList) {
+	// field resourcev1beta2.DeviceToleration.Key
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.LabelKey(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceToleration) *string { return &oldObj.Key }))...)
+
+	// field resourcev1beta2.DeviceToleration.Operator has no validation
+	// field resourcev1beta2.DeviceToleration.Value has no validation
+	// field resourcev1beta2.DeviceToleration.Effect has no validation
+	// field resourcev1beta2.DeviceToleration.TolerationSeconds has no validation
 	return errs
 }
 
@@ -657,7 +714,21 @@ func Validate_ExactDeviceRequest(ctx context.Context, op operation.Operation, fl
 	// field resourcev1beta2.ExactDeviceRequest.AllocationMode has no validation
 	// field resourcev1beta2.ExactDeviceRequest.Count has no validation
 	// field resourcev1beta2.ExactDeviceRequest.AdminAccess has no validation
-	// field resourcev1beta2.ExactDeviceRequest.Tolerations has no validation
+
+	// field resourcev1beta2.ExactDeviceRequest.Tolerations
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceToleration) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceToleration)...)
+			return
+		}(fldPath.Child("tolerations"), obj.Tolerations, safe.Field(oldObj, func(oldObj *resourcev1beta2.ExactDeviceRequest) []resourcev1beta2.DeviceToleration {
+			return oldObj.Tolerations
+		}))...)
+
 	// field resourcev1beta2.ExactDeviceRequest.Capacity has no validation
 	return errs
 }

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1359,7 +1359,7 @@ func validateDeviceToleration(toleration resource.DeviceToleration, fldPath *fie
 	var allErrs field.ErrorList
 
 	if toleration.Key != "" {
-		allErrs = append(allErrs, metav1validation.ValidateLabelName(toleration.Key, fldPath.Child("key"))...)
+		allErrs = append(allErrs, metav1validation.ValidateLabelName(toleration.Key, fldPath.Child("key")).MarkCoveredByDeclarative()...)
 	}
 	switch toleration.Operator {
 	case resource.DeviceTolerationOpExists:

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -788,7 +788,7 @@ func TestValidateClaim(t *testing.T) {
 
 					field.NotSupported(fldPath.Index(4).Child("operator"), resource.DeviceTolerationOperator("some-other-op"), []resource.DeviceTolerationOperator{resource.DeviceTolerationOpEqual, resource.DeviceTolerationOpExists}),
 
-					field.Invalid(fldPath.Index(5).Child("key"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
+					field.Invalid(fldPath.Index(5).Child("key"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").MarkCoveredByDeclarative(),
 					field.Invalid(fldPath.Index(5).Child("value"), badName, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"),
 					field.NotSupported(fldPath.Index(5).Child("effect"), resource.DeviceTaintEffect("some-other-effect"), []resource.DeviceTaintEffect{resource.DeviceTaintEffectNoExecute, resource.DeviceTaintEffectNoSchedule}),
 				)

--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -60,6 +60,10 @@ var resourceClaimNormalizationRules = []field.NormalizationRule{
 		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.selectors`),
 		Replacement: "spec.devices.requests[$1].exactly.selectors",
 	},
+	{
+		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.tolerations`),
+		Replacement: "spec.devices.requests[$1].exactly.tolerations",
+	},
 }
 
 // NewStrategy is the default logic that applies when creating and updating ResourceClaim objects.

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -1084,6 +1084,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
+  // +k8s:optional
+  // +k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1311,6 +1311,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
+	// +k8s:optional
+	// +k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1207,6 +1207,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
+  // +k8s:optional
+  // +k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1318,6 +1318,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
+	// +k8s:optional
+	// +k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1084,6 +1084,8 @@ message DeviceToleration {
   // Must be a label name.
   //
   // +optional
+  // +k8s:optional
+  // +k8s:format=k8s-label-key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -1311,6 +1311,8 @@ type DeviceToleration struct {
 	// Must be a label name.
 	//
 	// +optional
+	// +k8s:optional
+	// +k8s:format=k8s-label-key
 	Key string `json:"key,omitempty" protobuf:"bytes,1,opt,name=key"`
 
 	// Operator represents a key's relationship to the value.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds validation to the `key` field of the `DeviceToleration` struct across different API versions (`v1`, `v1beta1`, `v1beta2`). By adding the `+k8s:format=k8s-label-key` annotation, it enforces that the toleration key must be a valid Kubernetes label key.

This change is necessary to ensure that only valid keys are used in device tolerations, preventing potential errors and inconsistencies. The PR also includes:

*   Updated generated validation files.
*   New test cases in `declarative_validation_test.go` to cover valid and invalid toleration keys.
*   A normalization rule in `strategy.go` to handle the new validation.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The core change is the addition of the `+k8s:format=k8s-label-key` annotation to the `DeviceToleration` struct in the API type definitions. Most of the other changes are generated as a result of this. Please review the new test cases to ensure they adequately cover the new validation logic.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
````
