### PR TITLE
DRA device taints: fix toleration of NoExecute

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -246,14 +246,26 @@ func allDeviceRequest(name, class string) wrapDeviceRequest {
 	}
 }
 
-func subRequest(name, class string, count int64, selectors ...resourceapi.DeviceSelector) resourceapi.DeviceSubRequest {
-	return resourceapi.DeviceSubRequest{
+func subRequest(name, class string, count int64, fields ...any) resourceapi.DeviceSubRequest {
+	subRequest := resourceapi.DeviceSubRequest{
 		Name:            name,
 		Count:           count,
 		AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 		DeviceClassName: class,
-		Selectors:       selectors,
 	}
+
+	for _, field := range fields {
+		switch typedField := field.(type) {
+		case resourceapi.DeviceSelector:
+			subRequest.Selectors = append(subRequest.Selectors, typedField)
+		case resourceapi.DeviceToleration:
+			subRequest.Tolerations = append(subRequest.Tolerations, typedField)
+		default:
+			panic(fmt.Sprintf("unsupported field for DeviceSubRequest: %T", field))
+		}
+	}
+
+	return subRequest
 }
 
 type wrapDeviceRequest struct{ resourceapi.DeviceRequest }
@@ -566,12 +578,13 @@ func (in wrapResourceSlice) withCounterSet(counterSets ...resourceapi.CounterSet
 	return wrapResourceSlice{ResourceSlice: inResourceSlice}
 }
 
-func deviceAllocationResult(request, driver, pool, device string, adminAccess bool) resourceapi.DeviceRequestAllocationResult {
+func deviceAllocationResult(request, driver, pool, device string, adminAccess bool, tolerations ...resourceapi.DeviceToleration) resourceapi.DeviceRequestAllocationResult {
 	r := resourceapi.DeviceRequestAllocationResult{
-		Request: request,
-		Driver:  driver,
-		Pool:    pool,
-		Device:  device,
+		Request:     request,
+		Driver:      driver,
+		Pool:        pool,
+		Device:      device,
+		Tolerations: tolerations,
 	}
 	if adminAccess {
 		r.AdminAccess = &adminAccess
@@ -791,7 +804,7 @@ func toCounters(counters map[string]resource.Quantity) map[string]resourceapi.Co
 // deviceRequestAllocationResultWithBindingConditions returns an DeviceRequestAllocationResult object for testing purposes,
 // specifying the driver, pool, device, usage restriction, binding conditions,
 // binding failure conditions, and binding timeout.
-func deviceRequestAllocationResultWithBindingConditions(request, driver, pool, device string, bindingConditions, bindingFailureConditions []string) resourceapi.DeviceRequestAllocationResult {
+func deviceRequestAllocationResultWithBindingConditions(request, driver, pool, device string, bindingConditions, bindingFailureConditions []string, tolerations ...resourceapi.DeviceToleration) resourceapi.DeviceRequestAllocationResult {
 	return resourceapi.DeviceRequestAllocationResult{
 		Request:                  request,
 		Driver:                   driver,
@@ -799,6 +812,7 @@ func deviceRequestAllocationResultWithBindingConditions(request, driver, pool, d
 		Device:                   device,
 		BindingConditions:        bindingConditions,
 		BindingFailureConditions: bindingFailureConditions,
+		Tolerations:              tolerations,
 	}
 }
 
@@ -842,6 +856,11 @@ func TestAllocator(t *testing.T,
 		Key:      taintKey,
 		Value:    taintValue2,
 		Effect:   resourceapi.DeviceTaintEffectNoExecute,
+	}
+	tolerationNoScheduleKey1 := resourceapi.DeviceToleration{
+		Operator: resourceapi.DeviceTolerationOpExists,
+		Key:      "key1",
+		Effect:   resourceapi.DeviceTaintEffectNoSchedule,
 	}
 
 	testcases := map[string]struct {
@@ -3448,7 +3467,27 @@ func TestAllocator(t *testing.T,
 			node: node(node1, region1),
 			expectResults: []any{allocationResult(
 				localNodeSelector(node1),
-				deviceAllocationResult(req0, driverA, pool1, device2, false), // Only second device's taints are tolerated.
+				deviceAllocationResult(req0, driverA, pool1, device2, false, tolerationNoExecute), // Only second device's taints are tolerated.
+			)},
+		},
+		"tainted-two-devices-prioritized-list-tolerated": {
+			features: Features{
+				DeviceTaints:    true,
+				PrioritizedList: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, requestWithPrioritizedList(req0,
+				subRequest(subReq0, classA, 1),
+				subRequest(subReq1, classA, 1, tolerationNoExecute),
+			))),
+			classes: objects(class(classA, driverA)),
+			slices: unwrap(slice(slice1, node1, pool1, driverA,
+				device(device1, nil, nil).withTaints(taintNoSchedule),
+				device(device2, nil, nil).withTaints(taintNoExecute),
+			)),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0SubReq1, driverA, pool1, device2, false, tolerationNoExecute), // Only second device's taints are tolerated.
 			)},
 		},
 		"tainted-one-device-two-taints-both-tolerated": {
@@ -3463,7 +3502,7 @@ func TestAllocator(t *testing.T,
 			node: node(node1, region1),
 			expectResults: []any{allocationResult(
 				localNodeSelector(node1),
-				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device1, false, tolerationNoSchedule, tolerationNoExecute),
 			)},
 		},
 		"tainted-disabled": {
@@ -4142,11 +4181,7 @@ func TestAllocator(t *testing.T,
 				DeviceTaints:         true,
 			},
 			claimsToAllocate: objects(
-				claimWithRequests(claim0, nil, request(req0, classA, 2)).withTolerations(resourceapi.DeviceToleration{
-					Operator: resourceapi.DeviceTolerationOpExists,
-					Key:      "key1",
-					Effect:   resourceapi.DeviceTaintEffectNoSchedule,
-				}),
+				claimWithRequests(claim0, nil, request(req0, classA, 2)).withTolerations(tolerationNoScheduleKey1),
 			),
 			classes: objects(class(classA, driverA)),
 			slices: unwrap(
@@ -4180,8 +4215,8 @@ func TestAllocator(t *testing.T,
 				resourceapi.AllocationResult{
 					Devices: resourceapi.DeviceAllocationResult{
 						Results: []resourceapi.DeviceRequestAllocationResult{
-							deviceRequestAllocationResultWithBindingConditions(req0, driverA, pool1, device1, []string{"IsPrepare"}, []string{"BindingFailed"}),
-							deviceRequestAllocationResultWithBindingConditions(req0, driverA, pool1, device2, nil, nil),
+							deviceRequestAllocationResultWithBindingConditions(req0, driverA, pool1, device1, []string{"IsPrepare"}, []string{"BindingFailed"}, tolerationNoScheduleKey1),
+							deviceRequestAllocationResultWithBindingConditions(req0, driverA, pool1, device2, nil, nil, tolerationNoScheduleKey1),
 						},
 					},
 					NodeSelector: localNodeSelector(node1),

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -368,6 +368,7 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				Pool:             internal.id.Pool.String(),
 				Device:           internal.id.Device.String(),
 				AdminAccess:      internal.adminAccess,
+				Tolerations:      internal.lookupRequest(claim).tolerations(),
 				ShareID:          internal.shareID,
 				ConsumedCapacity: consumedCapacity,
 			}
@@ -667,11 +668,36 @@ type internalDeviceResult struct {
 	adminAccess      *bool
 }
 
-func (i internalDeviceResult) requestName() string {
-	if i.parentRequest == "" {
-		return i.request
+func (idr internalDeviceResult) requestName() string {
+	if idr.parentRequest == "" {
+		return idr.request
 	}
-	return fmt.Sprintf("%s/%s", i.parentRequest, i.request)
+	return fmt.Sprintf("%s/%s", idr.parentRequest, idr.request)
+}
+
+func (idr internalDeviceResult) lookupRequest(claim *resourceapi.ResourceClaim) requestAccessor {
+	requestName := idr.request
+	if idr.parentRequest != "" {
+		requestName = idr.parentRequest
+	}
+	for i := range claim.Spec.Devices.Requests {
+		request := &claim.Spec.Devices.Requests[i]
+		if request.Name != requestName {
+			continue
+		}
+		if idr.parentRequest == "" {
+			// No need to check sub-requests.
+			return &exactDeviceRequestAccessor{request}
+		}
+		for j := range request.FirstAvailable {
+			subRequest := &request.FirstAvailable[j]
+			if subRequest.Name != idr.request {
+				continue
+			}
+			return &deviceSubRequestAccessor{subRequest}
+		}
+	}
+	return nil
 }
 
 type constraint interface {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -291,6 +291,7 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 				Pool:        internal.id.Pool.String(),
 				Device:      internal.id.Device.String(),
 				AdminAccess: internal.adminAccess,
+				Tolerations: internal.lookupRequest(claim).tolerations(),
 			}
 		}
 
@@ -554,11 +555,36 @@ type internalDeviceResult struct {
 	adminAccess   *bool
 }
 
-func (i internalDeviceResult) requestName() string {
-	if i.parentRequest == "" {
-		return i.request
+func (idr internalDeviceResult) requestName() string {
+	if idr.parentRequest == "" {
+		return idr.request
 	}
-	return fmt.Sprintf("%s/%s", i.parentRequest, i.request)
+	return fmt.Sprintf("%s/%s", idr.parentRequest, idr.request)
+}
+
+func (idr internalDeviceResult) lookupRequest(claim *resourceapi.ResourceClaim) requestAccessor {
+	requestName := idr.request
+	if idr.parentRequest != "" {
+		requestName = idr.parentRequest
+	}
+	for i := range claim.Spec.Devices.Requests {
+		request := &claim.Spec.Devices.Requests[i]
+		if request.Name != requestName {
+			continue
+		}
+		if idr.parentRequest == "" {
+			// No need to check sub-requests.
+			return &exactDeviceRequestAccessor{request}
+		}
+		for j := range request.FirstAvailable {
+			subRequest := &request.FirstAvailable[j]
+			if subRequest.Name != idr.request {
+				continue
+			}
+			return &deviceSubRequestAccessor{subRequest}
+		}
+	}
+	return nil
 }
 
 type constraint interface {

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1830,13 +1830,13 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 		}))
 		b := drautils.NewBuilder(f, driver)
 
-		f.It("DeviceTaint keeps pod pending", func(ctx context.Context) {
+		f.It("NoSchedule keeps pod pending", func(ctx context.Context) {
 			pod, template := b.PodInline()
 			b.Create(ctx, pod, template)
 			framework.ExpectNoError(e2epod.WaitForPodNameUnschedulableInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
 		})
 
-		f.It("DeviceToleration enables pod scheduling", func(ctx context.Context) {
+		f.It("NoSchedule can be tolerated", func(ctx context.Context) {
 			pod, template := b.PodInline()
 			template.Spec.Spec.Devices.Requests[0].Exactly.Tolerations = []resourceapi.DeviceToleration{{
 				Effect:   resourceapi.DeviceTaintEffectNoSchedule,
@@ -1906,6 +1906,36 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 				"Reason":  gomega.Equal("DeletionByDeviceTaintManager"),
 				"Message": gomega.Equal("Device Taint manager: deleting due to NoExecute taint"),
 			}))))
+		})
+	})
+
+	framework.Context("kubelet", feature.DynamicResourceAllocation, f.WithFeatureGate(features.DRADeviceTaints), func() {
+		nodes := drautils.NewNodes(f, 1, 1)
+		driver := drautils.NewDriver(f, nodes, drautils.NetworkResources(10, false), drautils.TaintAllDevices(resourceapi.DeviceTaint{
+			Key:    "example.com/taint",
+			Value:  "tainted",
+			Effect: resourceapi.DeviceTaintEffectNoExecute,
+		}))
+		b := drautils.NewBuilder(f, driver)
+
+		f.It("NoExecute keeps pod pending", func(ctx context.Context) {
+			pod, template := b.PodInline()
+			b.Create(ctx, pod, template)
+			framework.ExpectNoError(e2epod.WaitForPodNameUnschedulableInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		})
+
+		f.It("NoExecute can be tolerated", func(ctx context.Context) {
+			pod, template := b.PodInline()
+			template.Spec.Spec.Devices.Requests[0].Exactly.Tolerations = []resourceapi.DeviceToleration{{
+				Effect:   resourceapi.DeviceTaintEffectNoExecute,
+				Operator: resourceapi.DeviceTolerationOpExists,
+				// No key: tolerate *all* taints with this effect.
+			}}
+			b.Create(ctx, pod, template)
+			b.TestPod(ctx, f, pod)
+
+			// Testing the pod is slow enough that the test fails when the pod gets evicted unexpectedly,
+			// We don't need to a "Consistently" here.
 		})
 	})
 

--- a/test/e2e/dra/test-driver/deploy/example/devicetaintrule.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/devicetaintrule.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   # The entire hardware installation is broken.
   # Evict all pods and don't schedule new ones.
-  selector:
-    driver: dra.example.com
+  deviceSelector:
+    driver: test-driver.cdi.k8s.io
   taint:
-    key: dra.example.com/health
+    key: dra.example.com/unhealthy
     value: "Down"
     effect: NoExecute

--- a/test/e2e/dra/test-driver/deploy/example/pod-external-toleration.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external-toleration.yaml
@@ -1,0 +1,41 @@
+# One external resource claim, one pod, two containers.
+# One container uses resource, one does not.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: external-claim
+spec:
+  devices:
+    requests:
+    - name: my-device
+      exactly:
+        deviceClassName: example
+        tolerations:
+        - key: "dra.example.com/unhealthy"
+          operator: "Exists"
+          effect: "NoExecute"
+    config:
+    - opaque:
+        driver: test-driver.cdi.k8s.io
+        parameters:
+          a: b
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-external-claim
+spec:
+  restartPolicy: Never
+  containers:
+  - name: with-resource
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
+    resources:
+      claims:
+      - name: resource
+  - name: without-resource
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
+  resourceClaims:
+  - name: resource
+    resourceClaimName: external-claim


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As usual, consumers of an allocated claim react to the information stored in the status. In this case, the scheduler did not copy the tolerations into the status and as a result a pod with a toleration for NoExecute got scheduled and then immediately evicted.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/134434
KEP: https://github.com/kubernetes/enhancements/issues/5055

#### Special notes for your reviewer:

Some additional logging gets added to make the handling easier to track in the eviction controller. Example YAMLs allow reproducing the use case manually.

#### Does this PR introduce a user-facing change?
```release-note
DRA Device Taints: tolerating a NoExecute did not work because the scheduler did not inform the eviction controller about the toleration, so the scheduled pod got evicted almost immediately.
```
