### PR TITLE
Update --chunk-size flag, dropping the beta information

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -538,7 +538,7 @@ func AddApplyAnnotationVarFlags(cmd *cobra.Command, applyAnnotation *bool) {
 
 func AddChunkSizeFlag(cmd *cobra.Command, value *int64) {
 	cmd.Flags().Int64Var(value, "chunk-size", *value,
-		"Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.")
+		"Return large lists in chunks rather than all at once. Pass 0 to disable.")
 }
 
 func AddLabelSelectorFlagVar(cmd *cobra.Command, p *string) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation
/sig cli

#### What this PR does / why we need it:
The --chunk-size flag has been around since October 2017 (ihttps://github.com/kubernetes/kubernetes/commit/4780ad02978e7aea80f3b50ec20c9abeec13ce69) so it's about time we make it official.


#### Which issue(s) this PR is related to:
N/A 

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
kubectl describe, get, drain and events have the ability to set chunk-size using --chunk-size flag, which is now officially stable.
```
