### PR TITLE
cluster/gce/gci: revert PATH change when using custom runc

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -610,7 +610,7 @@ function install-containerd-cos {
     if download-robust "runc ${COS_INSTALL_RUNC_VERSION}" "${temp_dir}" \
        "https://github.com/opencontainers/runc/releases/download/${COS_INSTALL_RUNC_VERSION}/runc.${HOST_ARCH}"; then
       cp "${temp_dir}/runc.${HOST_ARCH}" /home/containerd/bin/runc && chmod 755 /home/containerd/bin/runc
-      sed -i "/\[Service\]/a Environment=PATH=/home/containerd/bin:\$PATH" /etc/systemd/system/containerd.service
+      sed -i "/\[Service\]/a Environment=PATH=/home/containerd/bin:$PATH" /etc/systemd/system/containerd.service
     fi
     rm -rf "${temp_dir}"
   fi


### PR DESCRIPTION
Commit 6031ff29c144fe16e98f6fcb1d7201634f9a173e
("make containerd download more robust") updated the containerd systemd unit to use `Environment=PATH=/home/containerd/bin:$PATH`. However, environment variables are not evaluated in systemd units in that way. This resulted in containerd running with the literal value `/home/containerd/bin:$PATH` for its PATH, breaking containerd (it could not access the apparmor_parser program).

The old way passes the PATH that configure.sh runs with to containerd, which is not optimal, but at least it doesn't break the tests. Let's revert to the old way.

#### What type of PR is this?

/kind bug
/kind regression
/kind failing-test

#### What this PR does / why we need it:

Fixes failing tests in CI

#### Which issue(s) this PR is related to:

Not aware of an issue associated with this
