### PR TITLE
Promote KEP-5311 (Relaxed validation for Services names) to beta

### DIFF
--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -2930,9 +2930,18 @@ func TestAllowRelaxedServiceNameValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Test feature with gate disabled
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RelaxedServiceNameValidation, false)
 			got := allowRelaxedServiceNameValidation(tc.ingress)
 			if got != tc.expect {
 				t.Errorf("allowRelaxedServiceNameValidation() = %v, want %v", got, tc.expect)
+			}
+
+			// Test feature with gate enabled - it should always return true
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RelaxedServiceNameValidation, true)
+			got = allowRelaxedServiceNameValidation(tc.ingress)
+			if got != true {
+				t.Errorf("allowRelaxedServiceNameValidation() = %v, want %v", got, true)
 			}
 		})
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1570,6 +1570,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	RelaxedServiceNameValidation: {
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	ReloadKubeletServerCertificateFile: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1321,6 +1321,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.34"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.35"
 - name: ReloadKubeletServerCertificateFile
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Promote Relaxed validation for Services names to Beta

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5311

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote Relaxed validation for Services names to beta (enabled by default)

Promote `RelaxedServiceNameValidation` feature to beta (enabled by default)
The  names of new Services names are validation with `NameIsDNSLabel()`,
relaxing the  pre-existing validation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5311
```
