### PR TITLE
[release1.34]Automated cherry pick of #133310: authz tests- delay response in context cancelled scenario

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics_test.go
@@ -107,9 +107,16 @@ func TestAuthorizerMetrics(t *testing.T) {
 			if service.statusCode == 0 {
 				service.statusCode = 200
 			}
-			service.reviewHook = func(*authorizationv1.SubjectAccessReview) {
-				if scenario.canceledRequest {
+
+			testFinishedCtx, testFinishedCancel := context.WithCancel(context.Background())
+			defer testFinishedCancel()
+			if scenario.canceledRequest {
+				service.reviewHook = func(*authorizationv1.SubjectAccessReview) {
 					cancel()
+					// net/http transport still attempts to use a response if it's
+					// available right when it's handling context cancellation,
+					// we need to delay the response.
+					<-testFinishedCtx.Done()
 				}
 			}
 			service.allow = !scenario.authFakeServiceDeny
@@ -120,6 +127,9 @@ func TestAuthorizerMetrics(t *testing.T) {
 				return
 			}
 			defer server.Close()
+			// testFinishedCtx must be cancelled before we close the server, otherwise
+			// closing the server hangs on an active connection from the listener.
+			defer testFinishedCancel()
 
 			fakeAuthzMetrics := &fakeAuthorizerMetrics{}
 			wh, err := newV1Authorizer(server.URL, scenario.clientCert, scenario.clientKey, scenario.clientCA, 0, fakeAuthzMetrics, cel.NewDefaultCompiler(), []apiserver.WebhookMatchCondition{}, "")


### PR DESCRIPTION
The net/http transport checks for immediate response when its handling context cancellation. The unit test was racing with this check by responding too fast.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cherry pick of https://github.com/kubernetes/kubernetes/pull/133310 on release-1.34
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
