### PR TITLE
[KEP-4639] Graduate image volumes to GA

### DIFF
--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -3312,7 +3313,8 @@ func TestSetDefaultServiceInternalTrafficPolicy(t *testing.T) {
 }
 
 func TestSetDefaults_Volume(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ImageVolume, true)
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.35"))
+
 	for desc, tc := range map[string]struct {
 		given, expected *v1.Volume
 	}{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1272,6 +1272,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	ImageVolume: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.GA},
 	},
 
 	InPlacePodVerticalScaling: {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -559,7 +559,7 @@ func (f *FakeRuntime) GetContainerStatus(_ context.Context, _ types.UID, _ kubec
 	defer f.Unlock()
 
 	f.CalledFunctions = append(f.CalledFunctions, "GetContainerStatus")
-	return nil, f.Err
+	return &kubecontainer.Status{}, f.Err
 }
 
 func (f *FakeRuntime) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Container) kubetypes.SwapBehavior {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -114,7 +114,8 @@ type containerTemplate struct {
 // makeAndSetFakePod is a helper function to create and set one fake sandbox for a pod and
 // one fake container for each of its container.
 func makeAndSetFakePod(t *testing.T, m *kubeGenericRuntimeManager, fakeRuntime *apitest.FakeRuntimeService,
-	pod *v1.Pod) (*apitest.FakePodSandbox, []*apitest.FakeContainer) {
+	pod *v1.Pod,
+) (*apitest.FakePodSandbox, []*apitest.FakeContainer) {
 	sandbox := makeFakePodSandbox(t, m, sandboxTemplate{
 		pod:       pod,
 		createdAt: fakeCreatedAt,
@@ -171,7 +172,6 @@ func makeFakePodSandbox(t *testing.T, m *kubeGenericRuntimeManager, template san
 		podSandBoxStatus.Network.AdditionalIps = additionalPodIPs
 	}
 	return podSandBoxStatus
-
 }
 
 // makeFakePodSandboxes creates a group of fake pod sandboxes based on the sandbox templates.
@@ -2980,7 +2980,6 @@ func TestToKubeContainerImageVolumes(t *testing.T) {
 
 func TestGetImageVolumes(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ImageVolume, true)
 
 	_, _, manager, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
@@ -3256,7 +3255,8 @@ func TestDoPodResizeAction(t *testing.T) {
 								UsageBytes: ptr.To[uint64](10),
 							},
 						}},
-					}},
+					},
+				},
 			}
 
 			updateInfo := containerToUpdateInfo{
@@ -3547,10 +3547,9 @@ func TestValidatePodResizeAction(t *testing.T) {
 }
 
 func TestIncrementImageVolumeMetrics(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ImageVolume, true)
-	legacyregistry.MustRegister(metrics.ImageVolumeRequestedTotal)
-	legacyregistry.MustRegister(metrics.ImageVolumeMountedSucceedTotal)
-	legacyregistry.MustRegister(metrics.ImageVolumeMountedErrorsTotal)
+	legacyregistry.Register(metrics.ImageVolumeRequestedTotal)      //nolint:errcheck
+	legacyregistry.Register(metrics.ImageVolumeMountedSucceedTotal) //nolint:errcheck
+	legacyregistry.Register(metrics.ImageVolumeMountedErrorsTotal)  //nolint:errcheck
 
 	testCases := map[string]struct {
 		err          error
@@ -3570,13 +3569,13 @@ func TestIncrementImageVolumeMetrics(t *testing.T) {
 				"mount3": {Image: "image3"},
 			},
 			wants: `
-				# HELP kubelet_image_volume_mounted_errors_total [ALPHA] Number of failed image volume mounts.
+				# HELP kubelet_image_volume_mounted_errors_total [BETA] Number of failed image volume mounts.
 				# TYPE kubelet_image_volume_mounted_errors_total counter
         		kubelet_image_volume_mounted_errors_total 0
-        		# HELP kubelet_image_volume_mounted_succeed_total [ALPHA] Number of successful image volume mounts.
+        		# HELP kubelet_image_volume_mounted_succeed_total [BETA] Number of successful image volume mounts.
         		# TYPE kubelet_image_volume_mounted_succeed_total counter
         		kubelet_image_volume_mounted_succeed_total 2
-        		# HELP kubelet_image_volume_requested_total [ALPHA] Number of requested image volumes.
+        		# HELP kubelet_image_volume_requested_total [BETA] Number of requested image volumes.
         		# TYPE kubelet_image_volume_requested_total counter
         		kubelet_image_volume_requested_total 3
 			`,
@@ -3594,13 +3593,13 @@ func TestIncrementImageVolumeMetrics(t *testing.T) {
 				"mount3": {Image: "image3"},
 			},
 			wants: `
-				# HELP kubelet_image_volume_mounted_errors_total [ALPHA] Number of failed image volume mounts.
+				# HELP kubelet_image_volume_mounted_errors_total [BETA] Number of failed image volume mounts.
 				# TYPE kubelet_image_volume_mounted_errors_total counter
         		kubelet_image_volume_mounted_errors_total 2
-        		# HELP kubelet_image_volume_mounted_succeed_total [ALPHA] Number of successful image volume mounts.
+        		# HELP kubelet_image_volume_mounted_succeed_total [BETA] Number of successful image volume mounts.
         		# TYPE kubelet_image_volume_mounted_succeed_total counter
         		kubelet_image_volume_mounted_succeed_total 0
-        		# HELP kubelet_image_volume_requested_total [ALPHA] Number of requested image volumes.
+        		# HELP kubelet_image_volume_requested_total [BETA] Number of requested image volumes.
         		# TYPE kubelet_image_volume_requested_total counter
         		kubelet_image_volume_requested_total 3
 			`,
@@ -3618,13 +3617,13 @@ func TestIncrementImageVolumeMetrics(t *testing.T) {
 				"mount3": {Image: "image3"},
 			},
 			wants: `
-				# HELP kubelet_image_volume_mounted_errors_total [ALPHA] Number of failed image volume mounts.
+				# HELP kubelet_image_volume_mounted_errors_total [BETA] Number of failed image volume mounts.
 				# TYPE kubelet_image_volume_mounted_errors_total counter
         		kubelet_image_volume_mounted_errors_total 0
-        		# HELP kubelet_image_volume_mounted_succeed_total [ALPHA] Number of successful image volume mounts.
+        		# HELP kubelet_image_volume_mounted_succeed_total [BETA] Number of successful image volume mounts.
         		# TYPE kubelet_image_volume_mounted_succeed_total counter
         		kubelet_image_volume_mounted_succeed_total 2
-        		# HELP kubelet_image_volume_requested_total [ALPHA] Number of requested image volumes.
+        		# HELP kubelet_image_volume_requested_total [BETA] Number of requested image volumes.
         		# TYPE kubelet_image_volume_requested_total counter
         		kubelet_image_volume_requested_total 3
 			`,
@@ -3635,13 +3634,13 @@ func TestIncrementImageVolumeMetrics(t *testing.T) {
 			},
 			imageVolumes: kubecontainer.ImageVolumes{},
 			wants: `
-				# HELP kubelet_image_volume_mounted_errors_total [ALPHA] Number of failed image volume mounts.
+				# HELP kubelet_image_volume_mounted_errors_total [BETA] Number of failed image volume mounts.
 				# TYPE kubelet_image_volume_mounted_errors_total counter
         		kubelet_image_volume_mounted_errors_total 0
-        		# HELP kubelet_image_volume_mounted_succeed_total [ALPHA] Number of successful image volume mounts.
+        		# HELP kubelet_image_volume_mounted_succeed_total [BETA] Number of successful image volume mounts.
         		# TYPE kubelet_image_volume_mounted_succeed_total counter
         		kubelet_image_volume_mounted_succeed_total 0
-        		# HELP kubelet_image_volume_requested_total [ALPHA] Number of requested image volumes.
+        		# HELP kubelet_image_volume_requested_total [BETA] Number of requested image volumes.
         		# TYPE kubelet_image_volume_requested_total counter
         		kubelet_image_volume_requested_total 0
 			`,

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -1101,7 +1101,7 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           ImageVolumeRequestedTotalKey,
 			Help:           "Number of requested image volumes.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 
@@ -1111,7 +1111,7 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           ImageVolumeMountedSucceedTotalKey,
 			Help:           "Number of successful image volume mounts.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 
@@ -1121,7 +1121,7 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           ImageVolumeMountedErrorsTotalKey,
 			Help:           "Number of failed image volume mounts.",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -659,6 +659,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.33"
+  - default: true
+    lockToDefault: false
+    preRelease: GA
+    version: "1.35"
 - name: InPlacePodVerticalScaling
   versionedSpecs:
   - default: false

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2874,6 +2874,14 @@
     lifecycle of a container.
   release: v1.19
   file: test/e2e/common/node/expansion.go
+- testname: Image Volume
+  codename: '[sig-node] [Conformance] ImageVolume should succeed with pod and pull
+    policy of Always [Conformance]'
+  description: Create a Pod using an image volume and a pull policy of Always. This
+    test verifies that the image volume functionality is available by default and
+    works as intended.
+  release: v1.35
+  file: test/e2e/common/node/image_volume.go
 - testname: CRUD operations for deviceclasses
   codename: '[sig-node] [DRA] CRUD Tests resource.k8s.io/v1 DeviceClass [Conformance]'
   description: kube-apiserver must support create/update/list/patch/delete operations

--- a/test/e2e/common/node/image_volume.go
+++ b/test/e2e/common/node/image_volume.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/opencontainers/selinux/go-selinux"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe(framework.WithConformance(), "ImageVolume", func() {
+	f := framework.NewDefaultFramework("image-volume")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	volumeImage := imageutils.GetE2EImage(imageutils.Kitten)
+
+	const (
+		podName             = "test-pod"
+		containerName       = "test-container"
+		volumeName          = "volume"
+		volumePathPrefix    = "/volume"
+		defaultSELinuxUser  = "system_u"
+		defaultSELinuxRole  = "system_r"
+		defaultSELinuxType  = "svirt_lxc_net_t" // that's the SELinux type used by Debian/Ubuntu. Keep it for maximum test compatibility.
+		defaultSELinuxLevel = "s0:c1,c5"
+	)
+
+	createPod := func(ctx context.Context, podName, nodeName string, volumes []v1.Volume, volumeMounts []v1.VolumeMount, selinuxOptions *v1.SELinuxOptions) {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: f.Namespace.Name,
+			},
+			Spec: v1.PodSpec{
+				NodeName:      nodeName,
+				RestartPolicy: v1.RestartPolicyAlways,
+				SecurityContext: &v1.PodSecurityContext{
+					SELinuxOptions: selinuxOptions,
+				},
+				Containers: []v1.Container{
+					{
+						Name:         containerName,
+						Image:        imageutils.GetE2EImage(imageutils.BusyBox),
+						Command:      []string{"/bin/sh", "-c", "while true; do echo test; sleep 1; done"},
+						VolumeMounts: volumeMounts,
+					},
+				},
+				Volumes: volumes,
+			},
+		}
+
+		ginkgo.By(fmt.Sprintf("Creating a pod (%s/%s)", f.Namespace.Name, podName))
+		e2epod.NewPodClient(f).Create(ctx, pod)
+	}
+
+	verifyFileContents := func(podName, volumePath string) {
+		ginkgo.By(fmt.Sprintf("Verifying the volume mount contents for path: %s", volumePath))
+
+		firstFileContents := e2epod.ExecCommandInContainer(f, podName, containerName, "/bin/cat", filepath.Join(volumePath, "data.json"))
+		gomega.Expect(firstFileContents).To(gomega.ContainSubstring("kitten.jpg"))
+
+		secondFileContents := e2epod.ExecCommandInContainer(f, podName, containerName, "/bin/cat", filepath.Join(volumePath, "etc", "os-release"))
+		gomega.Expect(secondFileContents).To(gomega.ContainSubstring("Alpine Linux"))
+	}
+
+	/*
+		Release: v1.35
+		Testname: Image Volume
+		Description: Create a Pod using an image volume and a pull policy of Always.
+		This test verifies that the image volume functionality is available by default and works as intended.
+	*/
+	framework.ConformanceIt("should succeed with pod and pull policy of Always", func(ctx context.Context) {
+		var selinuxOptions *v1.SELinuxOptions
+		if selinux.GetEnabled() {
+			selinuxOptions = &v1.SELinuxOptions{
+				User:  defaultSELinuxUser,
+				Role:  defaultSELinuxRole,
+				Type:  defaultSELinuxType,
+				Level: defaultSELinuxLevel,
+			}
+			ginkgo.By(fmt.Sprintf("Using SELinux on pod: %v", selinuxOptions))
+		}
+
+		createPod(ctx,
+			podName,
+			"",
+			[]v1.Volume{{Name: volumeName, VolumeSource: v1.VolumeSource{Image: &v1.ImageVolumeSource{Reference: volumeImage, PullPolicy: v1.PullAlways}}}},
+			[]v1.VolumeMount{{Name: volumeName, MountPath: volumePathPrefix}},
+			selinuxOptions,
+		)
+
+		ginkgo.By(fmt.Sprintf("Waiting for the pod (%s/%s) to be running", f.Namespace.Name, podName))
+		err := e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, podName, f.Namespace.Name)
+		framework.ExpectNoError(err, "Failed to await for the pod to be running: (%s/%s)", f.Namespace.Name, podName)
+
+		verifyFileContents(podName, volumePathPrefix)
+	})
+})

--- a/test/e2e_node/image_volume.go
+++ b/test/e2e_node/image_volume.go
@@ -23,15 +23,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/opencontainers/selinux/go-selinux"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/images"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -41,8 +40,8 @@ import (
 )
 
 // Run this single test locally using a running CRI-O instance by:
-// make test-e2e-node CONTAINER_RUNTIME_ENDPOINT="unix:///var/run/crio/crio.sock" TEST_ARGS='--ginkgo.focus="ImageVolume" --feature-gates=ImageVolume=true --service-feature-gates=ImageVolume=true --kubelet-flags="--cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --fail-swap-on=false"'
-var _ = SIGDescribe("ImageVolume", feature.ImageVolume, func() {
+// make test-e2e-node CONTAINER_RUNTIME_ENDPOINT="unix:///var/run/crio/crio.sock" TEST_ARGS='--ginkgo.focus="ImageVolume" --kubelet-flags="--cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --fail-swap-on=false"'
+var _ = SIGDescribe(framework.WithNodeConformance(), "ImageVolume", func() {
 	f := framework.NewDefaultFramework("image-volume-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
@@ -60,9 +59,32 @@ var _ = SIGDescribe("ImageVolume", feature.ImageVolume, func() {
 		defaultSELinuxLevel = "s0:c1,c5"
 	)
 
-	ginkgo.BeforeEach(func(ctx context.Context) {
-		e2eskipper.SkipUnlessFeatureGateEnabled(features.ImageVolume)
-	})
+	// TODO: remove when containerd 2.2 is available on all node e2e test platforms.
+	requireContainerdVersion := func(givenVersion string) {
+		runtime, _, err := getCRIClient()
+		framework.ExpectNoError(err, "Failed to get CRI client")
+
+		resp, err := runtime.Version(context.Background(), "")
+		framework.ExpectNoError(err, "Failed to get runtime version")
+
+		// Other runtimes like CRI-O do not need to enforce any version requirement.
+		if resp.GetRuntimeName() != "containerd" {
+			return
+		}
+
+		// Throw away any version suffix which just causes semver parsing issues.
+		version, _, _ := strings.Cut(resp.GetRuntimeVersion(), "-")
+
+		parsedVersion, err := semver.ParseTolerant(version)
+		framework.ExpectNoError(err, "Failed to parse CRI runtime version: "+version)
+
+		requiredVersion, err := semver.ParseTolerant(givenVersion)
+		framework.ExpectNoError(err, "Failed to parse required CRI runtime version")
+
+		if parsedVersion.LT(requiredVersion) {
+			e2eskipper.Skipf("runtime containerd is version %q, but test requires at least %q", resp.GetRuntimeVersion(), requiredVersion)
+		}
+	}
 
 	createPod := func(ctx context.Context, podName, nodeName string, volumes []v1.Volume, volumeMounts []v1.VolumeMount, selinuxOptions *v1.SELinuxOptions) {
 		pod := &v1.Pod{
@@ -101,6 +123,10 @@ var _ = SIGDescribe("ImageVolume", feature.ImageVolume, func() {
 		secondFileContents := e2epod.ExecCommandInContainer(f, podName, containerName, "/bin/cat", filepath.Join(volumePath, "etc", "os-release"))
 		gomega.Expect(secondFileContents).To(gomega.ContainSubstring("Alpine Linux"))
 	}
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		requireContainerdVersion("2.1")
+	})
 
 	f.It("should succeed with pod and pull policy of Always", func(ctx context.Context) {
 		var selinuxOptions *v1.SELinuxOptions
@@ -276,16 +302,7 @@ var _ = SIGDescribe("ImageVolume", feature.ImageVolume, func() {
 
 	f.Context("subPath", func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			runtime, _, err := getCRIClient()
-			framework.ExpectNoError(err, "Failed to get CRI client")
-
-			version, err := runtime.Version(context.Background(), "")
-			framework.ExpectNoError(err, "Failed to get runtime version")
-
-			// TODO: enable the subpath tests if containerd main branch has support for it.
-			if version.GetRuntimeName() != "cri-o" {
-				e2eskipper.Skip("runtime is not CRI-O")
-			}
+			requireContainerdVersion("2.2")
 		})
 
 		f.It("should succeed when using a valid subPath", func(ctx context.Context) {

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -183,6 +183,21 @@
   help: The count of hidden metrics.
   type: Counter
   stabilityLevel: BETA
+- name: image_volume_mounted_errors_total
+  subsystem: kubelet
+  help: Number of failed image volume mounts.
+  type: Counter
+  stabilityLevel: BETA
+- name: image_volume_mounted_succeed_total
+  subsystem: kubelet
+  help: Number of successful image volume mounts.
+  type: Counter
+  stabilityLevel: BETA
+- name: image_volume_requested_total
+  subsystem: kubelet
+  help: Number of requested image volumes.
+  type: Counter
+  stabilityLevel: BETA
 - name: feature_enabled
   namespace: kubernetes
   help: This metric records the data about the stage and enablement of a k8s feature.


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Graduate image volume source to GA.
#### Which issue(s) this PR is related to:
Refers to https://github.com/kubernetes/enhancements/pull/5450

#### Special notes for your reviewer:

- [x] Graduate the feature to GA / stable
- [x] Update the metrics to BETA
- [x] Move existing e2e tests to node conformance
- [x] Create a simple conformance test that creates a pod using an image volume and verifies the output.

#### Does this PR introduce a user-facing change?

```release-note
Graduate image volume source to GA, which is now enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4639-oci-volume-source/README.md
```
