### PR TITLE
Automated cherry pick of #134456: With new changes we will also have a VolumeModifying condition

### DIFF
--- a/test/e2e/framework/pv/wait.go
+++ b/test/e2e/framework/pv/wait.go
@@ -76,10 +76,15 @@ func WaitForPersistentVolumeClaimModificationFailure(ctx context.Context, c clie
 	desiredClass := ptr.Deref(claim.Spec.VolumeAttributesClassName, "")
 
 	var match = func(claim *v1.PersistentVolumeClaim) bool {
+		foundErrorCondition := false
 		for _, condition := range claim.Status.Conditions {
-			if condition.Type != v1.PersistentVolumeClaimVolumeModifyVolumeError {
-				return false
+			if condition.Type == v1.PersistentVolumeClaimVolumeModifyVolumeError {
+				foundErrorCondition = true
 			}
+		}
+		// if no error found it must be an error
+		if !foundErrorCondition {
+			return false
 		}
 
 		// check if claim's current volume attributes class is NOT desired one, and has appropriate ModifyVolumeStatus


### PR DESCRIPTION
Cherry pick of #134456 on release-1.34.

#134456: With new changes we will also have a VolumeModifying condition

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```