### PR TITLE
Improve lifecycle and cleanup for the identity lease controller

### DIFF
--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -262,26 +262,31 @@ func (c completedConfig) New(name string, delegationTarget genericapiserver.Dele
 	})
 
 	if utilfeature.DefaultFeatureGate.Enabled(apiserverfeatures.APIServerIdentity) {
-		s.GenericAPIServer.AddPostStartHookOrDie("start-kube-apiserver-identity-lease-controller", func(hookContext genericapiserver.PostStartHookContext) error {
-			leaseName := s.GenericAPIServer.APIServerID
-			holderIdentity := s.GenericAPIServer.APIServerID + "_" + string(uuid.NewUUID())
+		leaseName := s.GenericAPIServer.APIServerID
+		holderIdentity := s.GenericAPIServer.APIServerID + "_" + string(uuid.NewUUID())
+		peeraddress := getPeerAddress(c.Extra.PeerAdvertiseAddress, c.Generic.PublicAddress, publicServicePort)
 
-			peeraddress := getPeerAddress(c.Extra.PeerAdvertiseAddress, c.Generic.PublicAddress, publicServicePort)
-			// must replace ':,[]' in [ip:port] to be able to store this as a valid label value
-			controller := lease.NewController(
-				clock.RealClock{},
-				client,
-				holderIdentity,
-				int32(IdentityLeaseDurationSeconds),
-				nil,
-				IdentityLeaseRenewIntervalPeriod,
-				leaseName,
-				metav1.NamespaceSystem,
-				// TODO: receive identity label value as a parameter when post start hook is moved to generic apiserver.
-				labelAPIServerHeartbeatFunc(name, peeraddress))
-			go controller.Run(hookContext)
+		// must replace ':,[]' in [ip:port] to be able to store this as a valid label value
+		controller := lease.NewController(
+			clock.RealClock{},
+			client,
+			holderIdentity,
+			int32(IdentityLeaseDurationSeconds),
+			nil,
+			IdentityLeaseRenewIntervalPeriod,
+			leaseName,
+			metav1.NamespaceSystem,
+			// TODO: receive identity label value as a parameter when post start hook is moved to generic apiserver.
+			labelAPIServerHeartbeatFunc(name, peeraddress),
+		)
+		s.GenericAPIServer.AddPostStartHookOrDie("start-kube-apiserver-identity-lease-controller", func(hookContext genericapiserver.PostStartHookContext) error {
+			return controller.Start(hookContext.Done())
+		})
+		s.GenericAPIServer.AddPreShutdownHookOrDie("stop-kube-apiserver-identity-lease-controller", func() error {
+			controller.Stop()
 			return nil
 		})
+
 		// TODO: move this into generic apiserver and make the lease identity value configurable
 		s.GenericAPIServer.AddPostStartHookOrDie("start-kube-apiserver-identity-lease-garbage-collector", func(hookContext genericapiserver.PostStartHookContext) error {
 			go apiserverleasegc.NewAPIServerLeaseGC(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Follow-up from [this](https://github.com/kubernetes/enhancements/pull/5519#discussion_r2417916725) discussion

This PR refactors the lease controller to add a complete lifecycle, including explicit cleanup for both graceful shutdown and crash recovery scenarios.

Previously, the lease controller had no dedicated shutdown or explicit startup cleanup logic:
- On **graceful shutdown**, the lease was never deleted. Cleanup relied on the slow process of lease expiration (default 1 hour).
- After a **crash**, recovery was dependent on the new apiserver instance eventually "reclaiming" the lease by winning an update race. This was less deterministic and could still lead to a window where a stale peer was discoverable.

This change introduces a more robust lifecycle into the `lease.Controller`:

- A new `Stop` method provides a graceful shutdown path, ensuring the lease is explicitly deleted when the apiserver terminates cleanly
- The new `Start` method now proactively deletes any stale lease on startup. This provides immediate and deterministic cleanup after a crash, preventing stale peer discovery far more effectively

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
issue:  https://github.com/kubernetes/enhancements/issues/1965

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

