### PR TITLE
KEP-5004: DRAExtendedResource metrics

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -1057,14 +1057,14 @@ func (collector *customCollector) CollectWithStability(ch chan<- metrics.Metric)
 		}
 		rcMetrics[resourceclaimmetrics.NumResourceClaimLabels{Allocated: allocated, AdminAccess: adminAccess, Source: source}]++
 	}
-	for label, count := range rcMetrics {
+	for rcLabels, count := range rcMetrics {
 		ch <- metrics.NewLazyConstMetric(
 			resourceclaimmetrics.NumResourceClaimsDesc,
 			metrics.GaugeValue,
 			float64(count),
-			label.Allocated,
-			label.AdminAccess,
-			label.Source,
+			rcLabels.Allocated,
+			rcLabels.AdminAccess,
+			rcLabels.Source,
 		)
 	}
 }

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -1177,8 +1177,8 @@ func newNumMetrics(lister resourcelisters.ResourceClaimLister) numMetrics {
 	}
 }
 
-func (em numMetrics) withUpdates(label resourceclaimmetrics.NumResourceClaimLabels, n float64) numMetrics {
-	em.metrics[label] += n
+func (em numMetrics) withUpdates(rcLabels resourceclaimmetrics.NumResourceClaimLabels, n float64) numMetrics {
+	em.metrics[rcLabels] += n
 	return numMetrics{
 		metrics: em.metrics,
 		lister:  em.lister,

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -71,12 +71,15 @@ var (
 	testClaimReservedTwice = reserveClaim(testClaimReserved, otherTestPod)
 	testClaimKey           = claimKeyPrefix + testClaim.Namespace + "/" + testClaim.Name
 
-	generatedTestClaim          = makeGeneratedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), nil)
-	generatedTestClaimAllocated = allocateClaim(generatedTestClaim)
-	generatedTestClaimReserved  = reserveClaim(generatedTestClaimAllocated, testPodWithResource)
+	templatedTestClaim          = makeTemplatedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), nil)
+	templatedTestClaimAllocated = allocateClaim(templatedTestClaim)
+	templatedTestClaimReserved  = reserveClaim(templatedTestClaimAllocated, testPodWithResource)
 
-	generatedTestClaimWithAdmin          = makeGeneratedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), ptr.To(true))
-	generatedTestClaimWithAdminAllocated = allocateClaim(generatedTestClaimWithAdmin)
+	templatedTestClaimWithAdmin          = makeTemplatedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), ptr.To(true))
+	templatedTestClaimWithAdminAllocated = allocateClaim(templatedTestClaimWithAdmin)
+
+	extendedTestClaim          = makeExtendedResourceClaim(testPodName, testNamespace, 1, makeOwnerReference(testPodWithResource, true))
+	extendedTestClaimAllocated = allocateClaim(extendedTestClaim)
 
 	conflictingClaim        = makeClaim(testPodName+"-"+podResourceClaimName, testNamespace, className, nil)
 	otherNamespaceClaim     = makeClaim(testPodName+"-"+podResourceClaimName, otherNamespace, className, nil)
@@ -88,7 +91,7 @@ var (
 		pod.Spec.NodeName = nodeName
 		pod.Status.ResourceClaimStatuses = append(pod.Status.ResourceClaimStatuses, v1.PodResourceClaimStatus{
 			Name:              pod.Spec.ResourceClaims[0].Name,
-			ResourceClaimName: &generatedTestClaim.Name,
+			ResourceClaimName: &templatedTestClaim.Name,
 		})
 		return pod
 	}()
@@ -116,10 +119,10 @@ func TestSyncHandler(t *testing.T) {
 			pods:           []*v1.Pod{testPodWithResource},
 			templates:      []*resourceapi.ResourceClaimTemplate{template},
 			key:            podKey(testPodWithResource),
-			expectedClaims: []resourceapi.ResourceClaim{*generatedTestClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
@@ -136,10 +139,10 @@ func TestSyncHandler(t *testing.T) {
 			pods:           []*v1.Pod{testPodWithResource},
 			templates:      []*resourceapi.ResourceClaimTemplate{templateWithAdminAccess},
 			key:            podKey(testPodWithResource),
-			expectedClaims: []resourceapi.ResourceClaim{*generatedTestClaimWithAdmin},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaimWithAdmin},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaimWithAdmin.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaimWithAdmin.Name},
 				},
 			},
 			adminAccessEnabled: true,
@@ -150,17 +153,17 @@ func TestSyncHandler(t *testing.T) {
 			pods: []*v1.Pod{func() *v1.Pod {
 				pod := testPodWithResource.DeepCopy()
 				pod.Status.ResourceClaimStatuses = []v1.PodResourceClaimStatus{
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				}
 				return pod
 			}()},
 			templates:      []*resourceapi.ResourceClaimTemplate{template},
 			key:            podKey(testPodWithResource),
-			claims:         []*resourceapi.ResourceClaim{generatedTestClaim},
-			expectedClaims: []resourceapi.ResourceClaim{*generatedTestClaim},
+			claims:         []*resourceapi.ResourceClaim{templatedTestClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
@@ -170,16 +173,16 @@ func TestSyncHandler(t *testing.T) {
 			pods: []*v1.Pod{func() *v1.Pod {
 				pod := testPodWithResource.DeepCopy()
 				pod.Status.ResourceClaimStatuses = []v1.PodResourceClaimStatus{
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				}
 				return pod
 			}()},
 			templates:      []*resourceapi.ResourceClaimTemplate{template},
 			key:            podKey(testPodWithResource),
-			expectedClaims: []resourceapi.ResourceClaim{*generatedTestClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
@@ -195,11 +198,11 @@ func TestSyncHandler(t *testing.T) {
 			name:           "find-existing-claim-by-label",
 			pods:           []*v1.Pod{testPodWithResource},
 			key:            podKey(testPodWithResource),
-			claims:         []*resourceapi.ResourceClaim{generatedTestClaim},
-			expectedClaims: []resourceapi.ResourceClaim{*generatedTestClaim},
+			claims:         []*resourceapi.ResourceClaim{templatedTestClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
@@ -208,10 +211,10 @@ func TestSyncHandler(t *testing.T) {
 			name:          "find-created-claim-in-cache",
 			pods:          []*v1.Pod{testPodWithResource},
 			key:           podKey(testPodWithResource),
-			claimsInCache: []*resourceapi.ResourceClaim{generatedTestClaim},
+			claimsInCache: []*resourceapi.ResourceClaim{templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
@@ -241,10 +244,10 @@ func TestSyncHandler(t *testing.T) {
 			templates:      []*resourceapi.ResourceClaimTemplate{template},
 			key:            podKey(testPodWithResource),
 			claims:         []*resourceapi.ResourceClaim{otherNamespaceClaim},
-			expectedClaims: []resourceapi.ResourceClaim{*otherNamespaceClaim, *generatedTestClaim},
+			expectedClaims: []resourceapi.ResourceClaim{*otherNamespaceClaim, *templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
-					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
@@ -387,11 +390,11 @@ func TestSyncHandler(t *testing.T) {
 			pods:           []*v1.Pod{testPodWithNodeName},
 			key:            podKey(testPodWithNodeName),
 			templates:      []*resourceapi.ResourceClaimTemplate{template},
-			claims:         []*resourceapi.ResourceClaim{generatedTestClaimAllocated},
-			expectedClaims: []resourceapi.ResourceClaim{*generatedTestClaimReserved},
+			claims:         []*resourceapi.ResourceClaim{templatedTestClaimAllocated},
+			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaimReserved},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithNodeName.Name: {
-					{Name: testPodWithNodeName.Spec.ResourceClaims[0].Name, ResourceClaimName: &generatedTestClaim.Name},
+					{Name: testPodWithNodeName.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
@@ -517,7 +520,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	}
 	defer stopInformers()
 
-	em := newNumMetrics(claimInformer.Lister(), 0, 0, 0, 0)
+	em := newNumMetrics(claimInformer.Lister())
 
 	expectQueue := func(tCtx ktesting.TContext, expectedKeys []string) {
 		g := gomega.NewWithT(tCtx)
@@ -555,7 +558,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	expectQueue(tCtx, []string{})
 
 	_, err = claimClient.Create(tCtx, testClaim, metav1.CreateOptions{})
-	em = em.withUpdates(1, 0, 0, 0)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, 1)
 	ktesting.Step(tCtx, "create claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
@@ -572,7 +575,8 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	})
 
 	_, err = claimClient.Update(tCtx, testClaimAllocated, metav1.UpdateOptions{})
-	em = em.withUpdates(-1, 0, 1, 0)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, -1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, 1)
 	ktesting.Step(tCtx, "allocate claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
@@ -591,7 +595,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	otherClaimAllocated := testClaimAllocated.DeepCopy()
 	otherClaimAllocated.Name += "2"
 	_, err = claimClient.Create(tCtx, otherClaimAllocated, metav1.CreateOptions{})
-	em = em.withUpdates(0, 0, 1, 0)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, 1)
 	ktesting.Step(tCtx, "create allocated claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
@@ -599,7 +603,8 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	})
 
 	_, err = claimClient.Update(tCtx, testClaim, metav1.UpdateOptions{})
-	em = em.withUpdates(1, 0, -1, 0)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, 1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, -1)
 	ktesting.Step(tCtx, "deallocate claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
@@ -607,7 +612,7 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	})
 
 	err = claimClient.Delete(tCtx, testClaim.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(-1, 0, 0, 0)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, -1)
 	ktesting.Step(tCtx, "delete deallocated claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
@@ -615,21 +620,21 @@ func TestResourceClaimEventHandler(t *testing.T) {
 	})
 
 	err = claimClient.Delete(tCtx, otherClaimAllocated.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(0, 0, -1, 0)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, -1)
 	ktesting.Step(tCtx, "delete allocated claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
 		expectQueue(tCtx, []string{})
 	})
 
-	_, err = claimClient.Create(tCtx, generatedTestClaimWithAdmin, metav1.CreateOptions{})
-	em = em.withUpdates(0, 1, 0, 0)
+	_, err = claimClient.Create(tCtx, templatedTestClaimWithAdmin, metav1.CreateOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, 1)
 	ktesting.Step(tCtx, "create claim with admin access", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
 	})
 
-	modifiedClaim = generatedTestClaimWithAdmin.DeepCopy()
+	modifiedClaim = templatedTestClaimWithAdmin.DeepCopy()
 	modifiedClaim.Labels = map[string]string{"foo": "bar"}
 	_, err = claimClient.Update(tCtx, modifiedClaim, metav1.UpdateOptions{})
 	ktesting.Step(tCtx, "modify claim", func(tCtx ktesting.TContext) {
@@ -637,14 +642,15 @@ func TestResourceClaimEventHandler(t *testing.T) {
 		em.Consistently(tCtx)
 	})
 
-	_, err = claimClient.Update(tCtx, generatedTestClaimWithAdminAllocated, metav1.UpdateOptions{})
-	em = em.withUpdates(0, -1, 0, 1)
+	_, err = claimClient.Update(tCtx, templatedTestClaimWithAdminAllocated, metav1.UpdateOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, -1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, 1)
 	ktesting.Step(tCtx, "allocate claim with admin access", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
 	})
 
-	modifiedClaim = generatedTestClaimWithAdminAllocated.DeepCopy()
+	modifiedClaim = templatedTestClaimWithAdminAllocated.DeepCopy()
 	modifiedClaim.Labels = map[string]string{"foo": "bar2"}
 	_, err = claimClient.Update(tCtx, modifiedClaim, metav1.UpdateOptions{})
 	ktesting.Step(tCtx, "modify claim", func(tCtx ktesting.TContext) {
@@ -652,32 +658,63 @@ func TestResourceClaimEventHandler(t *testing.T) {
 		em.Consistently(tCtx)
 	})
 
-	otherClaimAllocated = generatedTestClaimWithAdminAllocated.DeepCopy()
+	otherClaimAllocated = templatedTestClaimWithAdminAllocated.DeepCopy()
 	otherClaimAllocated.Name += "2"
 	_, err = claimClient.Create(tCtx, otherClaimAllocated, metav1.CreateOptions{})
-	em = em.withUpdates(0, 0, 0, 1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, 1)
 	ktesting.Step(tCtx, "create allocated claim with admin access", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
 	})
 
-	_, err = claimClient.Update(tCtx, generatedTestClaimWithAdmin, metav1.UpdateOptions{})
-	em = em.withUpdates(0, 1, 0, -1)
+	_, err = claimClient.Update(tCtx, templatedTestClaimWithAdmin, metav1.UpdateOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, 1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, -1)
 	ktesting.Step(tCtx, "deallocate claim with admin access", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
 	})
 
-	err = claimClient.Delete(tCtx, generatedTestClaimWithAdmin.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(0, -1, 0, 0)
+	err = claimClient.Delete(tCtx, templatedTestClaimWithAdmin.Name, metav1.DeleteOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, -1)
 	ktesting.Step(tCtx, "delete deallocated claim with admin access", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
 	})
 
 	err = claimClient.Delete(tCtx, otherClaimAllocated.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(0, 0, 0, -1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, -1)
 	ktesting.Step(tCtx, "delete allocated claim with admin access", func(tCtx ktesting.TContext) {
+		tCtx.ExpectNoError(err)
+		em.Eventually(tCtx)
+	})
+
+	_, err = claimClient.Create(tCtx, extendedTestClaim, metav1.CreateOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, 1)
+	ktesting.Step(tCtx, "create extended resource claim", func(tCtx ktesting.TContext) {
+		tCtx.ExpectNoError(err)
+		em.Eventually(tCtx)
+	})
+
+	_, err = claimClient.Update(tCtx, extendedTestClaimAllocated, metav1.UpdateOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, -1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: "extended_resource"}, 1)
+	ktesting.Step(tCtx, "allocate extended resource claim", func(tCtx ktesting.TContext) {
+		tCtx.ExpectNoError(err)
+		em.Eventually(tCtx)
+	})
+
+	_, err = claimClient.Update(tCtx, extendedTestClaim, metav1.UpdateOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, 1)
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: "extended_resource"}, -1)
+	ktesting.Step(tCtx, "deallocate extended resource claim", func(tCtx ktesting.TContext) {
+		tCtx.ExpectNoError(err)
+		em.Eventually(tCtx)
+	})
+
+	err = claimClient.Delete(tCtx, extendedTestClaim.Name, metav1.DeleteOptions{})
+	em = em.withUpdates(resourceclaimmetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, -1)
+	ktesting.Step(tCtx, "delete extended resource claim", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
 		em.Eventually(tCtx)
 	})
@@ -823,7 +860,7 @@ func makeClaim(name, namespace, classname string, owner *metav1.OwnerReference) 
 	return claim
 }
 
-func makeGeneratedClaim(podClaimName, generateName, namespace, classname string, createCounter int, owner *metav1.OwnerReference, adminAccess *bool) *resourceapi.ResourceClaim {
+func makeTemplatedClaim(podClaimName, generateName, namespace, classname string, createCounter int, owner *metav1.OwnerReference, adminAccess *bool) *resourceapi.ResourceClaim {
 	claim := &resourceapi.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:         fmt.Sprintf("%s-%d", generateName, createCounter),
@@ -849,6 +886,23 @@ func makeGeneratedClaim(podClaimName, generateName, namespace, classname string,
 				},
 			},
 		}
+	}
+
+	return claim
+}
+
+func makeExtendedResourceClaim(podName, namespace string, createCounter int, owner *metav1.OwnerReference) *resourceapi.ResourceClaim {
+	generateName := podName + "-extended-resources-"
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         fmt.Sprintf("%s-%d", generateName, createCounter),
+			GenerateName: generateName,
+			Namespace:    namespace,
+			Annotations:  map[string]string{"resource.kubernetes.io/extended-resource-claim": "true"},
+		},
+	}
+	if owner != nil {
+		claim.OwnerReferences = []metav1.OwnerReference{*owner}
 	}
 
 	return claim
@@ -982,11 +1036,8 @@ func createResourceClaimReactor() func(action k8stesting.Action) (handled bool, 
 }
 
 type numMetrics struct {
-	notAllocated                float64
-	notAllocatedWithAdminAccess float64
-	allocated                   float64
-	allocatedWithAdminAccess    float64
-	lister                      resourcelisters.ResourceClaimLister
+	metrics map[resourceclaimmetrics.NumResourceClaimLabels]float64
+	lister  resourcelisters.ResourceClaimLister
 }
 
 func getNumMetric(lister resourcelisters.ResourceClaimLister, logger klog.Logger) (em numMetrics, err error) {
@@ -1006,6 +1057,8 @@ func getNumMetric(lister resourcelisters.ResourceClaimLister, logger klog.Logger
 
 	metricName := "resourceclaim_controller_resource_claims"
 
+	em = newNumMetrics(lister)
+
 	for _, mf := range gatheredMetrics {
 		if mf.GetName() != metricName {
 			continue
@@ -1018,18 +1071,14 @@ func getNumMetric(lister resourcelisters.ResourceClaimLister, logger klog.Logger
 
 			allocated := labels["allocated"]
 			adminAccess := labels["admin_access"]
+			source := labels["source"]
 			value := metric.GetGauge().GetValue()
 
-			switch {
-			case allocated == "false" && adminAccess == "false":
-				em.notAllocated = value
-			case allocated == "false" && adminAccess == "true":
-				em.notAllocatedWithAdminAccess = value
-			case allocated == "true" && adminAccess == "false":
-				em.allocated = value
-			case allocated == "true" && adminAccess == "true":
-				em.allocatedWithAdminAccess = value
-			}
+			em.metrics[resourceclaimmetrics.NumResourceClaimLabels{
+				Allocated:   allocated,
+				AdminAccess: adminAccess,
+				Source:      source,
+			}] = value
 		}
 	}
 
@@ -1109,23 +1158,30 @@ func setupMetrics() {
 	resourceclaimmetrics.ResourceClaimCreate.Reset()
 }
 
-func newNumMetrics(lister resourcelisters.ResourceClaimLister, notAllocated, notAllocatedWithAdmin, allocated, allocatedWithAdmin float64) numMetrics {
+func newNumMetrics(lister resourcelisters.ResourceClaimLister) numMetrics {
+	metrics := make(map[resourceclaimmetrics.NumResourceClaimLabels]float64)
+	for _, allocated := range []string{"false", "true"} {
+		for _, adminAccess := range []string{"false", "true"} {
+			for _, source := range []string{"", "extended_resource", "resource_claim_template"} {
+				metrics[resourceclaimmetrics.NumResourceClaimLabels{
+					Allocated:   allocated,
+					AdminAccess: adminAccess,
+					Source:      source,
+				}] = 0
+			}
+		}
+	}
 	return numMetrics{
-		notAllocated:                notAllocated,
-		notAllocatedWithAdminAccess: notAllocatedWithAdmin,
-		allocated:                   allocated,
-		allocatedWithAdminAccess:    allocatedWithAdmin,
-		lister:                      lister,
+		metrics: metrics,
+		lister:  lister,
 	}
 }
 
-func (em numMetrics) withUpdates(notAllocatedDelta, notAllocatedWithAdminDelta, allocatedDelta, allocatedWithAdminDelta float64) numMetrics {
+func (em numMetrics) withUpdates(label resourceclaimmetrics.NumResourceClaimLabels, n float64) numMetrics {
+	em.metrics[label] += n
 	return numMetrics{
-		notAllocated:                em.notAllocated + notAllocatedDelta,
-		notAllocatedWithAdminAccess: em.notAllocatedWithAdminAccess + notAllocatedWithAdminDelta,
-		allocated:                   em.allocated + allocatedDelta,
-		allocatedWithAdminAccess:    em.allocatedWithAdminAccess + allocatedWithAdminDelta,
-		lister:                      em.lister,
+		metrics: em.metrics,
+		lister:  em.lister,
 	}
 }
 

--- a/pkg/controller/resourceclaim/metrics/metrics.go
+++ b/pkg/controller/resourceclaim/metrics/metrics.go
@@ -47,10 +47,14 @@ var (
 	)
 
 	// NumResourceClaimsDesc tracks the number of ResourceClaims,
-	// categorized by their allocation status and admin access.
+	// categorized by their allocation status, admin access, and source.
+	// Source can be 'resource_claim_template' (created from a template),
+	// 'extended_resource' (extended resources), or empty (manually created by a user).
 	NumResourceClaimsDesc = metrics.NewDesc(
 		metrics.BuildFQName("", ResourceClaimSubsystem, "resource_claims"),
-		"Number of ResourceClaims, categorized by allocation status and admin access",
+		"Number of ResourceClaims, categorized by allocation status, admin access, and source. "+
+			"Source can be 'resource_claim_template' (created from a template), "+
+			"'extended_resource' (extended resources), or empty (manually created by a user).",
 		[]string{"allocated", "admin_access", "source"}, nil,
 		metrics.ALPHA, "")
 )

--- a/pkg/controller/resourceclaim/metrics/metrics.go
+++ b/pkg/controller/resourceclaim/metrics/metrics.go
@@ -26,6 +26,12 @@ import (
 // ResourceClaimSubsystem - subsystem name used for ResourceClaim creation
 const ResourceClaimSubsystem = "resourceclaim_controller"
 
+type NumResourceClaimLabels struct {
+	Allocated   string
+	AdminAccess string
+	Source      string
+}
+
 var (
 	// ResourceClaimCreate tracks the total number of
 	// ResourceClaims creation requests
@@ -45,7 +51,7 @@ var (
 	NumResourceClaimsDesc = metrics.NewDesc(
 		metrics.BuildFQName("", ResourceClaimSubsystem, "resource_claims"),
 		"Number of ResourceClaims, categorized by allocation status and admin access",
-		[]string{"allocated", "admin_access"}, nil,
+		[]string{"allocated", "admin_access", "source"}, nil,
 		metrics.ALPHA, "")
 )
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -53,6 +53,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
 	"k8s.io/kubernetes/pkg/util/slice"
@@ -1477,8 +1478,10 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, ind
 		var err error
 		claim, err = pl.clientset.ResourceV1().ResourceClaims(claim.Namespace).Create(ctx, claim, metav1.CreateOptions{})
 		if err != nil {
+			metrics.ResourceClaimCreatesTotal.WithLabelValues("failure").Inc()
 			return nil, fmt.Errorf("create claim for extended resources %v: %w", klog.KObj(claim), err)
 		}
+		metrics.ResourceClaimCreatesTotal.WithLabelValues("success").Inc()
 		resourceClaimModified = true
 		logger.V(5).Info("created claim for extended resources", "pod", klog.KObj(pod), "node", nodeName, "resourceclaim", klog.Format(claim))
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -45,9 +45,9 @@ import (
 	cgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
 	"k8s.io/dynamic-resource-allocation/structured"
@@ -1430,7 +1430,7 @@ func TestPlugin(t *testing.T) {
 			want:                               want{},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.ErrorContains(t, err, "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 		"extended-resource-name-with-zero-allocatable": {
@@ -1481,7 +1481,7 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.ErrorContains(t, err, "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 		"extended-resource-name-with-resources": {
@@ -1503,8 +1503,8 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), metric["success"])
+				require.NoError(t, err)
+				require.Equal(t, 1, int(metric["success"]))
 			},
 		},
 		"implicit-extended-resource-name-with-resources": {
@@ -1526,8 +1526,8 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), metric["success"])
+				require.NoError(t, err)
+				require.Equal(t, 1, int(metric["success"]))
 			},
 		},
 		"implicit-extended-resource-name-two-containers-with-resources": {
@@ -1549,8 +1549,8 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), metric["success"])
+				require.NoError(t, err)
+				require.Equal(t, 1, int(metric["success"]))
 			},
 		},
 		"extended-resource-name-with-resources-fail-patch": {
@@ -1574,8 +1574,8 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), metric["success"])
+				require.NoError(t, err)
+				require.Equal(t, 1, int(metric["success"]))
 			},
 		},
 		"extended-resource-name-with-resources-has-claim": {
@@ -1597,7 +1597,7 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.ErrorContains(t, err, "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 		"extended-resource-name-with-resources-delete-claim": {
@@ -1619,7 +1619,7 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.ErrorContains(t, err, "not found")
+				require.ErrorContains(t, err, "not found")
 			},
 		},
 		"extended-resource-name-bind-failure": {
@@ -1641,8 +1641,8 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), metric["success"])
+				require.NoError(t, err)
+				require.Equal(t, 1, int(metric["success"]))
 			},
 		},
 		"extended-resource-name-skip-bind": {
@@ -1658,8 +1658,8 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), metric["success"])
+				require.NoError(t, err)
+				require.Equal(t, 1, int(metric["success"]))
 			},
 		},
 		"extended-resource-name-claim-creation-failure": {
@@ -1689,8 +1689,8 @@ func TestPlugin(t *testing.T) {
 			},
 			metrics: func(t *testing.T, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "scheduler_resourceclaim_creates_total", map[string]string{}, "status")
-				assert.NoError(t, err)
-				assert.Equal(t, float64(1), metric["failure"])
+				require.NoError(t, err)
+				require.Equal(t, 1, int(metric["failure"]))
 			},
 		},
 		"canceled": {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -127,6 +127,9 @@ var (
 	AsyncAPICallDuration *metrics.HistogramVec
 	AsyncAPIPendingCalls *metrics.GaugeVec
 
+	// The below is only available when the DRAExtendedResource feature gate is enabled.
+	ResourceClaimCreatesTotal *metrics.CounterVec
+
 	// metricsList is a list of all metrics that should be registered always, regardless of any feature gate's value.
 	metricsList []metrics.Registerable
 )
@@ -153,6 +156,9 @@ func Register() {
 				AsyncAPICallDuration,
 				AsyncAPIPendingCalls,
 			)
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.DRAExtendedResource) {
+			RegisterMetrics(ResourceClaimCreatesTotal)
 		}
 	})
 }
@@ -376,6 +382,15 @@ func InitMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"call_type"})
+
+	ResourceClaimCreatesTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "resourceclaim_creates_total",
+			Help:           "Number of ResourceClaims creation requests within scheduler",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"status"})
 
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds new metrics for DRAExtendedResource.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #133758

KEP: https://github.com/kubernetes/enhancements/issues/5004

#### Special notes for your reviewer:

cc @yliaog 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new `source` label in `resourceclaim_controller_resource_claims`.
Added a new metrics for DRAExtendedResource `scheduler_resourceclaim_creates_total`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/5004
```
