### PR TITLE
Add shortname 'ic' for IngressClass resource

### DIFF
--- a/pkg/registry/networking/ingressclass/storage/storage.go
+++ b/pkg/registry/networking/ingressclass/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
@@ -52,4 +53,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	}
 
 	return &REST{store}, nil
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+func (r *REST) ShortNames() []string {
+	return []string{"ic"}
 }

--- a/pkg/registry/networking/ingressclass/storage/storage_test.go
+++ b/pkg/registry/networking/ingressclass/storage/storage_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
+	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
+	networkingapi "k8s.io/kubernetes/pkg/apis/networking"
+	_ "k8s.io/kubernetes/pkg/apis/networking/install"
+	"k8s.io/kubernetes/pkg/registry/registrytest"
+)
+
+func newStorage(t *testing.T) (*REST, *etcd3testing.EtcdTestServer) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, networkingapi.GroupName)
+	restOptions := generic.RESTOptions{
+		StorageConfig:           etcdStorage,
+		Decorator:               generic.UndecoratedStorage,
+		DeleteCollectionWorkers: 1,
+		ResourcePrefix:          "ingressclasses",
+	}
+	ingressClassStorage, err := NewREST(restOptions)
+	if err != nil {
+		t.Fatalf("unexpected error from REST storage: %v", err)
+	}
+	return ingressClassStorage, server
+}
+
+func validNewIngressClass(name string) *networkingapi.IngressClass {
+	return &networkingapi.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: networkingapi.IngressClassSpec{
+			Controller: "example.com/ingress-controller",
+		},
+	}
+}
+
+func TestCreate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
+	ingressClass := validNewIngressClass("foo")
+	ingressClass.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo"}
+	test.TestCreate(
+		// valid
+		ingressClass,
+		// invalid
+		&networkingapi.IngressClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "*BadName!"},
+			Spec: networkingapi.IngressClassSpec{
+				Controller: "example.com/controller",
+			},
+		},
+	)
+}
+
+func TestUpdate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
+	apiGroup := "k8s.example.com"
+	scope := "Namespace"
+	namespace := "default"
+	test.TestUpdate(
+		// valid
+		validNewIngressClass("foo"),
+		// updateFunc - Parameters can be changed
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*networkingapi.IngressClass)
+			object.Spec.Parameters = &networkingapi.IngressClassParametersReference{
+				APIGroup:  &apiGroup,
+				Kind:      "IngressParameters",
+				Name:      "external-lb",
+				Scope:     &scope,
+				Namespace: &namespace,
+			}
+			return object
+		},
+		//invalid update - Controller is immutable
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*networkingapi.IngressClass)
+			object.Spec.Controller = "example.com/different-controller"
+			return object
+		},
+	)
+}
+
+func TestDelete(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
+	test.TestDelete(validNewIngressClass("foo"))
+}
+
+func TestGet(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
+	test.TestGet(validNewIngressClass("foo"))
+}
+
+func TestList(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
+	test.TestList(validNewIngressClass("foo"))
+}
+
+func TestWatch(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
+	test.TestWatch(
+		validNewIngressClass("foo"),
+		// matching labels
+		[]labels.Set{},
+		// not matching labels
+		[]labels.Set{
+			{"foo": "bar"},
+		},
+		// matching fields
+		[]fields.Set{
+			{"metadata.name": "foo"},
+		},
+		// not matching fields
+		[]fields.Set{
+			{"metadata.name": "bar"},
+		},
+	)
+}
+
+func TestShortNames(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	expected := []string{"ic"}
+	registrytest.AssertShortNames(t, storage, expected)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
this PR adds the shortname `ic` for IngressClass resources, improving consistency with other Kubernetes resources like StorageClass (`sc`), Service (`svc`), and ConfigMap (`cm`).

**Usage example:**
```bash
# Before: users must type the full resource name
kubectl get ingressclass
kubectl describe ingressclass nginx

# After: users can use the shortname
kubectl get ic
kubectl describe ic nginx
```

#### Which issue(s) this PR is related to:

Fixes #134527

#### Special notes for your reviewer:
- The shortname implementation follows the same pattern as StorageClass in `pkg/registry/storage/storageclass/storage/storage.go`
- Added complete storage layer tests (Create, Update, Delete, Get, List, Watch, ShortNames) which were previously missing for IngressClass

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
IngressClass now supports the shortname 'ic', allowing users to use `kubectl get ic` instead of `kubectl get ingressclass`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
