### PR TITLE
Add nil check in reconcileElectionStep

### DIFF
--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -318,7 +318,7 @@ func (c *Controller) reconcileElectionStep(ctx context.Context, leaseNN types.Na
 
 	var ackedCandidates []*v1beta1.LeaseCandidate
 	for _, candidate := range candidates {
-		if candidate.Spec.RenewTime.Add(electionDuration).After(now) {
+		if candidate.Spec.RenewTime != nil && candidate.Spec.RenewTime.Add(electionDuration).After(now) {
 			ackedCandidates = append(ackedCandidates, candidate)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a nil pointer dereference in the leader election controller. The code was calling `Add()` on `candidate.Spec.RenewTime` without checking if it's nil, causing the controller to panic when collecting acked candidates during election.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a defensive fix. While RenewTime should normally be set during operation, edge cases during candidate initialization or updates could result in nil values.

#### Does this PR introduce a user-facing change?
```release-note
NONE