### PR TITLE
Automated cherry pick of #134144: change klog to log volume name instead of entire spec in

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -252,7 +252,7 @@ func (c *csiAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.No
 }
 
 func (c *csiAttacher) GetDeviceMountPath(spec *volume.Spec) (string, error) {
-	klog.V(4).Info(log("attacher.GetDeviceMountPath(%v)", spec))
+	klog.V(4).Info(log("attacher.GetDeviceMountPath for volume(%s)", spec.Name()))
 	deviceMountPath, err := makeDeviceMountPath(c.plugin, spec)
 	if err != nil {
 		return "", errors.New(log("attacher.GetDeviceMountPath failed to make device mount path: %v", err))


### PR DESCRIPTION
Cherry pick of #134144 on release-1.34.

#134144: change klog to log volume name instead of entire spec in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.