### PR TITLE
KEP: 5495 - Add deprecation warning for ipvs

### DIFF
--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -191,6 +191,9 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 		ipts := utiliptables.NewBestEffort()
 
 		logger.Info("Using ipvs Proxier")
+		message := "The ipvs proxier is now deprecated and may be removed in a future release. Please use 'nftables' instead."
+		logger.Error(nil, message)
+		s.Recorder.Eventf(s.NodeRef, nil, v1.EventTypeWarning, "IPVSDeprecation", "StartKubeProxy", message)
 		if dualStack {
 			proxier, err = ipvs.NewDualStackProxier(
 				ctx,


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation

#### What this PR does / why we need it:

Add a warning when kube-proxy starts up in ipvs mode indicating that ipvs is being deprecated.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5495

#### Special notes for your reviewer:

This change feels small and meaningless, but at this point I guess it's more about communicating that ipvs is deprecated.

#### Does this PR introduce a user-facing change?
```release-note
Mark ipvs mode in kube-proxy as deprecated. ipvs mode in kube-proxy is deprecated and will be removed in a future version of Kubernetes. Users are encouraged to move to nftables.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
