### PR TITLE
Drop loopback clients if unused

### DIFF
--- a/cmd/kube-controller-manager/app/config/config.go
+++ b/cmd/kube-controller-manager/app/config/config.go
@@ -35,8 +35,6 @@ type Config struct {
 	ComponentConfig kubectrlmgrconfig.KubeControllerManagerConfiguration
 
 	SecureServing *apiserver.SecureServingInfo
-	// LoopbackClientConfig is a config for a privileged loopback connection
-	LoopbackClientConfig *restclient.Config
 
 	Authentication apiserver.AuthenticationInfo
 	Authorization  apiserver.AuthorizationInfo
@@ -69,8 +67,6 @@ type CompletedConfig struct {
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
 func (c *Config) Complete() *CompletedConfig {
 	cc := completedConfig{c}
-
-	apiserver.AuthorizeClientBearerToken(c.LoopbackClientConfig, &c.Authentication, &c.Authorization)
 
 	return &CompletedConfig{&cc}
 }

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -100,7 +100,7 @@ type KubeControllerManagerOptions struct {
 	TTLAfterFinishedController                *TTLAfterFinishedControllerOptions
 	ValidatingAdmissionPolicyStatusController *ValidatingAdmissionPolicyStatusControllerOptions
 
-	SecureServing  *apiserveroptions.SecureServingOptionsWithLoopback
+	SecureServing  *apiserveroptions.SecureServingOptions
 	Authentication *apiserveroptions.DelegatingAuthenticationOptions
 	Authorization  *apiserveroptions.DelegatingAuthorizationOptions
 	Metrics        *metrics.Options
@@ -217,7 +217,7 @@ func NewKubeControllerManagerOptions() (*KubeControllerManagerOptions, error) {
 		ValidatingAdmissionPolicyStatusController: &ValidatingAdmissionPolicyStatusControllerOptions{
 			&componentConfig.ValidatingAdmissionPolicyStatusController,
 		},
-		SecureServing:            apiserveroptions.NewSecureServingOptions().WithLoopback(),
+		SecureServing:            apiserveroptions.NewSecureServingOptions(),
 		Authentication:           apiserveroptions.NewDelegatingAuthenticationOptions(),
 		Authorization:            apiserveroptions.NewDelegatingAuthorizationOptions(),
 		Metrics:                  metrics.NewOptions(),
@@ -410,7 +410,7 @@ func (s *KubeControllerManagerOptions) ApplyTo(c *kubecontrollerconfig.Config, a
 	if err := s.ValidatingAdmissionPolicyStatusController.ApplyTo(&c.ComponentConfig.ValidatingAdmissionPolicyStatusController); err != nil {
 		return err
 	}
-	if err := s.SecureServing.ApplyTo(&c.SecureServing, &c.LoopbackClientConfig); err != nil {
+	if err := s.SecureServing.ApplyTo(&c.SecureServing); err != nil {
 		return err
 	}
 	if s.SecureServing.BindPort != 0 || s.SecureServing.Listener != nil {

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -423,7 +423,7 @@ func TestAddFlags(t *testing.T) {
 				PairName:      "kube-controller-manager",
 			},
 			HTTP2MaxStreamsPerConnection: 47,
-		}).WithLoopback(),
+		}),
 		Authentication: &apiserveroptions.DelegatingAuthenticationOptions{
 			CacheTTL:            10 * time.Second,
 			TokenRequestTimeout: 10 * time.Second,

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -29,7 +29,6 @@ import (
 	utilcompatibility "k8s.io/apiserver/pkg/util/compatibility"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/component-base/compatibility"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -52,11 +51,10 @@ type TearDownFunc func()
 
 // TestServer return values supplied by kube-test-ApiServer
 type TestServer struct {
-	LoopbackClientConfig *restclient.Config // Rest client config using the magic token
-	Options              *options.KubeControllerManagerOptions
-	Config               *kubecontrollerconfig.Config
-	TearDownFn           TearDownFunc // TearDown function
-	TmpDir               string       // Temp Dir used, by the apiserver
+	Options    *options.KubeControllerManagerOptions
+	Config     *kubecontrollerconfig.Config
+	TearDownFn TearDownFunc // TearDown function
+	TmpDir     string       // Temp Dir used, by the apiserver
 }
 
 // StartTestServer starts a kube-controller-manager. A rest client config and a tear-down func,
@@ -156,7 +154,7 @@ func StartTestServer(t *testing.T, ctx context.Context, customFlags []string) (r
 	}(ctx)
 
 	logger.Info("Waiting for /healthz to be ok...")
-	client, err := kubernetes.NewForConfig(config.LoopbackClientConfig)
+	client, err := kubernetes.NewForConfig(config.Kubeconfig)
 	if err != nil {
 		return result, fmt.Errorf("failed to create a client: %v", err)
 	}
@@ -182,7 +180,6 @@ func StartTestServer(t *testing.T, ctx context.Context, customFlags []string) (r
 	}
 
 	// from here the caller must call tearDown
-	result.LoopbackClientConfig = config.LoopbackClientConfig
 	result.Options = s
 	result.Config = config
 	result.TearDownFn = tearDown

--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -39,9 +39,6 @@ type Config struct {
 	// ComponentConfig is the scheduler server's configuration object.
 	ComponentConfig kubeschedulerconfig.KubeSchedulerConfiguration
 
-	// LoopbackClientConfig is a config for a privileged loopback connection
-	LoopbackClientConfig *restclient.Config
-
 	Authentication apiserver.AuthenticationInfo
 	Authorization  apiserver.AuthorizationInfo
 	SecureServing  *apiserver.SecureServingInfo
@@ -80,8 +77,6 @@ type CompletedConfig struct {
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
 func (c *Config) Complete() CompletedConfig {
 	cc := completedConfig{c}
-
-	apiserver.AuthorizeClientBearerToken(c.LoopbackClientConfig, &c.Authentication, &c.Authorization)
 
 	return CompletedConfig{&cc}
 }

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -61,7 +61,7 @@ type Options struct {
 	// The default values.
 	ComponentConfig *kubeschedulerconfig.KubeSchedulerConfiguration
 
-	SecureServing  *apiserveroptions.SecureServingOptionsWithLoopback
+	SecureServing  *apiserveroptions.SecureServingOptions
 	Authentication *apiserveroptions.DelegatingAuthenticationOptions
 	Authorization  *apiserveroptions.DelegatingAuthorizationOptions
 	Metrics        *metrics.Options
@@ -98,7 +98,7 @@ func NewOptions() *Options {
 
 func NewOptionsWithComponentGlobalsRegistry(componentGlobalsRegistry basecompatibility.ComponentGlobalsRegistry) *Options {
 	o := &Options{
-		SecureServing:  apiserveroptions.NewSecureServingOptions().WithLoopback(),
+		SecureServing:  apiserveroptions.NewSecureServingOptions(),
 		Authentication: apiserveroptions.NewDelegatingAuthenticationOptions(),
 		Authorization:  apiserveroptions.NewDelegatingAuthorizationOptions(),
 		Deprecated: &DeprecatedOptions{
@@ -250,7 +250,7 @@ func (o *Options) ApplyTo(logger klog.Logger, c *schedulerappconfig.Config) erro
 	}
 	c.KubeConfig = kubeConfig
 
-	if err := o.SecureServing.ApplyTo(&c.SecureServing, &c.LoopbackClientConfig); err != nil {
+	if err := o.SecureServing.ApplyTo(&c.SecureServing); err != nil {
 		return err
 	}
 	if o.SecureServing != nil && (o.SecureServing.BindPort != 0 || o.SecureServing.Listener != nil) {

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -306,7 +306,7 @@ profiles:
 						PairName:      "kube-scheduler",
 					},
 					HTTP2MaxStreamsPerConnection: 47,
-				}).WithLoopback(),
+				}),
 				Authentication: &apiserveroptions.DelegatingAuthenticationOptions{
 					CacheTTL:   10 * time.Second,
 					ClientCert: apiserveroptions.ClientCertAuthenticationOptions{},
@@ -413,7 +413,7 @@ profiles:
 						PairName:      "kube-scheduler",
 					},
 					HTTP2MaxStreamsPerConnection: 47,
-				}).WithLoopback(),
+				}),
 				Authentication: &apiserveroptions.DelegatingAuthenticationOptions{
 					CacheTTL:   10 * time.Second,
 					ClientCert: apiserveroptions.ClientCertAuthenticationOptions{},
@@ -487,7 +487,7 @@ profiles:
 						PairName:      "kube-scheduler",
 					},
 					HTTP2MaxStreamsPerConnection: 47,
-				}).WithLoopback(),
+				}),
 				Authentication: &apiserveroptions.DelegatingAuthenticationOptions{
 					CacheTTL: 10 * time.Second,
 					RequestHeader: apiserveroptions.RequestHeaderAuthenticationOptions{


### PR DESCRIPTION
kube-controller-manager and kube-scheduler do not use the configured loopback clients. Drop them.

/kind cleanup

```release-note
NONE
```