### PR TITLE
Fix missing involvedObject.apiVersion in event

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -236,10 +235,10 @@ func newProxyServer(ctx context.Context, config *kubeproxyconfig.KubeProxyConfig
 	s.Recorder = s.Broadcaster.NewRecorder(proxyconfigscheme.Scheme, kubeProxy)
 
 	s.NodeRef = &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      s.NodeName,
-		UID:       types.UID(s.NodeName),
-		Namespace: "",
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       s.NodeName,
+		Namespace:  "",
 	}
 
 	if len(config.HealthzBindAddress) > 0 {

--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -28,7 +28,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -320,9 +319,9 @@ func (cm *containerManagerImpl) validateNodeAllocatable() error {
 // Using ObjectReference for events as the node maybe not cached; refer to #42701 for detail.
 func nodeRefFromNode(nodeName string) *v1.ObjectReference {
 	return &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      nodeName,
-		UID:       types.UID(nodeName),
-		Namespace: "",
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       nodeName,
+		Namespace:  "",
 	}
 }

--- a/pkg/kubelet/cm/node_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/node_container_manager_linux_test.go
@@ -402,6 +402,54 @@ func getEphemeralStorageResourceList(storage string) v1.ResourceList {
 	return res
 }
 
+func TestNodeRefFromNode(t *testing.T) {
+	testCases := []struct {
+		name     string
+		nodeName string
+		expected *v1.ObjectReference
+	}{
+		{
+			name:     "normal node name",
+			nodeName: "test-node",
+			expected: &v1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       "test-node",
+				Namespace:  "",
+			},
+		},
+		{
+			name:     "empty node name",
+			nodeName: "",
+			expected: &v1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       "",
+				UID:        "",
+				Namespace:  "",
+			},
+		},
+		{
+			name:     "node name with special characters",
+			nodeName: "test-node-123.domain.local",
+			expected: &v1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       "test-node-123.domain.local",
+				Namespace:  "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := nodeRefFromNode(tc.nodeName)
+
+			assert.Equal(t, tc.expected, result, "test case %q failed", tc.name)
+		})
+	}
+}
+
 func TestGetCgroupConfig(t *testing.T) {
 	cases := []struct {
 		name                  string

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -548,10 +548,10 @@ func NewMainKubelet(ctx context.Context,
 
 	// construct a node reference used for events
 	nodeRef := &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      string(nodeName),
-		UID:       types.UID(nodeName),
-		Namespace: "",
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       string(nodeName),
+		Namespace:  "",
 	}
 
 	oomWatcher, err := oomwatcher.NewWatcher(kubeDeps.Recorder)

--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -136,10 +136,10 @@ func (hcs *server) SyncServices(newServices map[types.NamespacedName]uint16) err
 			if hcs.recorder != nil {
 				hcs.recorder.Eventf(
 					&v1.ObjectReference{
-						Kind:      "Service",
-						Namespace: nsn.Namespace,
-						Name:      nsn.Name,
-						UID:       types.UID(nsn.String()),
+						APIVersion: "v1",
+						Kind:       "Service",
+						Namespace:  nsn.Namespace,
+						Name:       nsn.Name,
 					}, nil, api.EventTypeWarning, "FailedToStartServiceHealthcheck", "Listen", msg)
 			}
 			klog.ErrorS(err, "Failed to start healthcheck", "node", hcs.nodeName, "service", nsn, "port", port)

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/events"
@@ -76,10 +75,10 @@ func NewHollowProxy(
 			Broadcaster: broadcaster,
 			Recorder:    recorder,
 			NodeRef: &v1.ObjectReference{
-				Kind:      "Node",
-				Name:      nodeName,
-				UID:       types.UID(nodeName),
-				Namespace: "",
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       nodeName,
+				Namespace:  "",
 			},
 		},
 	}

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -163,10 +163,11 @@ func (c *CloudNodeLifecycleController) MonitorNodes(ctx context.Context) {
 			klog.V(2).Infof("deleting node since it is no longer present in cloud provider: %s", node.Name)
 
 			ref := &v1.ObjectReference{
-				Kind:      "Node",
-				Name:      node.Name,
-				UID:       types.UID(node.UID),
-				Namespace: "",
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       node.Name,
+				UID:        node.UID,
+				Namespace:  "",
 			}
 
 			c.recorder.Eventf(ref, v1.EventTypeNormal, deleteNodeEvent,

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -307,10 +307,11 @@ func (rc *RouteController) reconcile(ctx context.Context, nodes []*v1.Node, rout
 						if rc.recorder != nil {
 							rc.recorder.Eventf(
 								&v1.ObjectReference{
-									Kind:      "Node",
-									Name:      string(nodeName),
-									UID:       types.UID(nodeName),
-									Namespace: "",
+									APIVersion: "v1",
+									Kind:       "Node",
+									Name:       string(nodeName),
+									UID:        node.UID,
+									Namespace:  "",
 								}, v1.EventTypeWarning, "FailedToCreateRoute", msg)
 							klog.V(4).Info(msg)
 							return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup
/sig node
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix missing involvedObject.apiVersion in event
`kubectl events --request-timeout=1 --for Node/127.0.0.1` works as expected and produces the intended output.
```
kubectl events --request-timeout=1 --for Node/127.0.0.1
LAST SEEN           TYPE     REASON                    OBJECT           MESSAGE
24m (x6 over 24m)   Normal   NodeHasSufficientMemory   Node/127.0.0.1   Node 127.0.0.1 status is now: NodeHasSufficientMemory
24m (x6 over 24m)   Normal   NodeHasNoDiskPressure     Node/127.0.0.1   Node 127.0.0.1 status is now: NodeHasNoDiskPressure
24m (x6 over 24m)   Normal   NodeHasSufficientPID      Node/127.0.0.1   Node 127.0.0.1 status is now: NodeHasSufficientPID
24m                 Normal   NodeReady                 Node/127.0.0.1   Node 127.0.0.1 status is now: NodeReady
24m                 Normal   RegisteredNode            Node/127.0.0.1   Node 127.0.0.1 event: Registered Node 127.0.0.1 in Controller
```
#### Which issue(s) this PR is related to:
Fixes #134490
<!--
Please link relevant issues to help with tracking.
Fixes #134490
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
kube-proxy event：
```yaml
- action: StartKubeProxy
  apiVersion: v1
  eventTime: "2025-10-12T05:37:42.229600Z"
  firstTimestamp: null
  involvedObject:
# apiVersion is missing
    kind: Node
    name: 127.0.0.1
    uid: 127.0.0.1
  kind: Event
  lastTimestamp: null
  metadata:
    creationTimestamp: "2025-10-12T05:37:42Z"
    name: 127.0.0.1.186da7bd9efa6ccd
    namespace: default
    resourceVersion: "315"
    uid: de76ce3a-9490-491c-b78e-206aa5d782f3
  reason: Starting
  reportingComponent: kube-proxy
  reportingInstance: kube-proxy-node1
  source: {}
  type: Normal

```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The involvedObject.apiVersion is now populated on Events created for Nodes and Pods
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
