### PR TITLE
Remove mentioning of the APISelfSubjectReview gate

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/whoami.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/whoami.go
@@ -159,8 +159,7 @@ func NewCmdWhoAmI(restClientGetter genericclioptions.RESTClientGetter, streams g
 
 var (
 	notEnabledErr = fmt.Errorf(
-		"the selfsubjectreviews API is not enabled in the cluster\n" +
-			"enable APISelfSubjectReview feature gate and authentication.k8s.io/v1alpha1 or authentication.k8s.io/v1beta1 API")
+		"the selfsubjectreviews API is not enabled in the cluster")
 
 	forbiddenErr = fmt.Errorf(
 		"the selfsubjectreviews API is not enabled in the cluster or you do not have permission to call it")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The error message from kubectl is still referring to a removed feature gate,
this behavior is confusing to users.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

