### PR TITLE
feat: add +k8s:enum declarative validation to ResourceClaim DeviceTolerationOperator and DeviceTaintEffect

### DIFF
--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -89,6 +89,22 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
+	// type ResourceSlice
+	scheme.AddValidationFunc((*resourcev1.ResourceSlice)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ResourceSlice(ctx, op, nil /* fldPath */, obj.(*resourcev1.ResourceSlice), safe.Cast[*resourcev1.ResourceSlice](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type ResourceSliceList
+	scheme.AddValidationFunc((*resourcev1.ResourceSliceList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ResourceSliceList(ctx, op, nil /* fldPath */, obj.(*resourcev1.ResourceSliceList), safe.Cast[*resourcev1.ResourceSliceList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
 }
 
@@ -151,6 +167,36 @@ func Validate_AllocationResult(ctx context.Context, op operation.Operation, fldP
 
 	// field resourcev1.AllocationResult.NodeSelector has no validation
 	// field resourcev1.AllocationResult.AllocationTimestamp has no validation
+	return errs
+}
+
+// Validate_Device validates an instance of Device according
+// to declarative validation rules in the API schema.
+func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.Device) (errs field.ErrorList) {
+	// field resourcev1.Device.Name has no validation
+	// field resourcev1.Device.Attributes has no validation
+	// field resourcev1.Device.Capacity has no validation
+	// field resourcev1.Device.ConsumesCounters has no validation
+	// field resourcev1.Device.NodeName has no validation
+	// field resourcev1.Device.NodeSelector has no validation
+	// field resourcev1.Device.AllNodes has no validation
+
+	// field resourcev1.Device.Taints
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceTaint) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceTaint)...)
+			return
+		}(fldPath.Child("taints"), obj.Taints, safe.Field(oldObj, func(oldObj *resourcev1.Device) []resourcev1.DeviceTaint { return oldObj.Taints }))...)
+
+	// field resourcev1.Device.BindsToNode has no validation
+	// field resourcev1.Device.BindingConditions has no validation
+	// field resourcev1.Device.BindingFailureConditions has no validation
+	// field resourcev1.Device.AllowMultipleAllocations has no validation
 	return errs
 }
 
@@ -741,6 +787,38 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 	return errs
 }
 
+// Validate_DeviceTaint validates an instance of DeviceTaint according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceTaint) (errs field.ErrorList) {
+	// field resourcev1.DeviceTaint.Key has no validation
+	// field resourcev1.DeviceTaint.Value has no validation
+
+	// field resourcev1.DeviceTaint.Effect
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1.DeviceTaintEffect) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("effect"), &obj.Effect, safe.Field(oldObj, func(oldObj *resourcev1.DeviceTaint) *resourcev1.DeviceTaintEffect { return &oldObj.Effect }))...)
+
+	// field resourcev1.DeviceTaint.TimeAdded has no validation
+	return errs
+}
+
+var symbolsForDeviceTaintEffect = sets.New(resourcev1.DeviceTaintEffectNoExecute, resourcev1.DeviceTaintEffectNoSchedule)
+
+// Validate_DeviceTaintEffect validates an instance of DeviceTaintEffect according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTaintEffect(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceTaintEffect) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil)...)
+
+	return errs
+}
+
 // Validate_DeviceToleration validates an instance of DeviceToleration according
 // to declarative validation rules in the API schema.
 func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceToleration) (errs field.ErrorList) {
@@ -763,10 +841,45 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			return
 		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1.DeviceToleration) *string { return &oldObj.Key }))...)
 
-	// field resourcev1.DeviceToleration.Operator has no validation
+	// field resourcev1.DeviceToleration.Operator
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1.DeviceTolerationOperator) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTolerationOperator(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("operator"), &obj.Operator, safe.Field(oldObj, func(oldObj *resourcev1.DeviceToleration) *resourcev1.DeviceTolerationOperator {
+			return &oldObj.Operator
+		}))...)
+
 	// field resourcev1.DeviceToleration.Value has no validation
-	// field resourcev1.DeviceToleration.Effect has no validation
+
+	// field resourcev1.DeviceToleration.Effect
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1.DeviceTaintEffect) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("effect"), &obj.Effect, safe.Field(oldObj, func(oldObj *resourcev1.DeviceToleration) *resourcev1.DeviceTaintEffect { return &oldObj.Effect }))...)
+
 	// field resourcev1.DeviceToleration.TolerationSeconds has no validation
+	return errs
+}
+
+var symbolsForDeviceTolerationOperator = sets.New(resourcev1.DeviceTolerationOpEqual, resourcev1.DeviceTolerationOpExists)
+
+// Validate_DeviceTolerationOperator validates an instance of DeviceTolerationOperator according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTolerationOperator(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceTolerationOperator) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil)...)
+
 	return errs
 }
 
@@ -1090,5 +1203,73 @@ func Validate_ResourceClaimTemplateSpec(ctx context.Context, op operation.Operat
 			return
 		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *resourcev1.ResourceClaimTemplateSpec) *resourcev1.ResourceClaimSpec { return &oldObj.Spec }))...)
 
+	return errs
+}
+
+// Validate_ResourceSlice validates an instance of ResourceSlice according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSlice(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.ResourceSlice) (errs field.ErrorList) {
+	// field resourcev1.ResourceSlice.TypeMeta has no validation
+	// field resourcev1.ResourceSlice.ObjectMeta has no validation
+
+	// field resourcev1.ResourceSlice.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1.ResourceSliceSpec) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ResourceSliceSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *resourcev1.ResourceSlice) *resourcev1.ResourceSliceSpec { return &oldObj.Spec }))...)
+
+	return errs
+}
+
+// Validate_ResourceSliceList validates an instance of ResourceSliceList according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSliceList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.ResourceSliceList) (errs field.ErrorList) {
+	// field resourcev1.ResourceSliceList.TypeMeta has no validation
+	// field resourcev1.ResourceSliceList.ListMeta has no validation
+
+	// field resourcev1.ResourceSliceList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.ResourceSlice) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_ResourceSlice)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *resourcev1.ResourceSliceList) []resourcev1.ResourceSlice { return oldObj.Items }))...)
+
+	return errs
+}
+
+// Validate_ResourceSliceSpec validates an instance of ResourceSliceSpec according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.ResourceSliceSpec) (errs field.ErrorList) {
+	// field resourcev1.ResourceSliceSpec.Driver has no validation
+	// field resourcev1.ResourceSliceSpec.Pool has no validation
+	// field resourcev1.ResourceSliceSpec.NodeName has no validation
+	// field resourcev1.ResourceSliceSpec.NodeSelector has no validation
+	// field resourcev1.ResourceSliceSpec.AllNodes has no validation
+
+	// field resourcev1.ResourceSliceSpec.Devices
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1.Device) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device)...)
+			return
+		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1.ResourceSliceSpec) []resourcev1.Device { return oldObj.Devices }))...)
+
+	// field resourcev1.ResourceSliceSpec.PerDeviceNodeSelection has no validation
+	// field resourcev1.ResourceSliceSpec.SharedCounters has no validation
 	return errs
 }

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -89,6 +89,22 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
+	// type ResourceSlice
+	scheme.AddValidationFunc((*resourcev1beta1.ResourceSlice)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ResourceSlice(ctx, op, nil /* fldPath */, obj.(*resourcev1beta1.ResourceSlice), safe.Cast[*resourcev1beta1.ResourceSlice](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type ResourceSliceList
+	scheme.AddValidationFunc((*resourcev1beta1.ResourceSliceList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ResourceSliceList(ctx, op, nil /* fldPath */, obj.(*resourcev1beta1.ResourceSliceList), safe.Cast[*resourcev1beta1.ResourceSliceList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
 }
 
@@ -153,6 +169,55 @@ func Validate_AllocationResult(ctx context.Context, op operation.Operation, fldP
 
 	// field resourcev1beta1.AllocationResult.NodeSelector has no validation
 	// field resourcev1beta1.AllocationResult.AllocationTimestamp has no validation
+	return errs
+}
+
+// Validate_BasicDevice validates an instance of BasicDevice according
+// to declarative validation rules in the API schema.
+func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.BasicDevice) (errs field.ErrorList) {
+	// field resourcev1beta1.BasicDevice.Attributes has no validation
+	// field resourcev1beta1.BasicDevice.Capacity has no validation
+	// field resourcev1beta1.BasicDevice.ConsumesCounters has no validation
+	// field resourcev1beta1.BasicDevice.NodeName has no validation
+	// field resourcev1beta1.BasicDevice.NodeSelector has no validation
+	// field resourcev1beta1.BasicDevice.AllNodes has no validation
+
+	// field resourcev1beta1.BasicDevice.Taints
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceTaint) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceTaint)...)
+			return
+		}(fldPath.Child("taints"), obj.Taints, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []resourcev1beta1.DeviceTaint { return oldObj.Taints }))...)
+
+	// field resourcev1beta1.BasicDevice.BindsToNode has no validation
+	// field resourcev1beta1.BasicDevice.BindingConditions has no validation
+	// field resourcev1beta1.BasicDevice.BindingFailureConditions has no validation
+	// field resourcev1beta1.BasicDevice.AllowMultipleAllocations has no validation
+	return errs
+}
+
+// Validate_Device validates an instance of Device according
+// to declarative validation rules in the API schema.
+func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.Device) (errs field.ErrorList) {
+	// field resourcev1beta1.Device.Name has no validation
+
+	// field resourcev1beta1.Device.Basic
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.BasicDevice) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_BasicDevice(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("basic"), obj.Basic, safe.Field(oldObj, func(oldObj *resourcev1beta1.Device) *resourcev1beta1.BasicDevice { return oldObj.Basic }))...)
+
 	return errs
 }
 
@@ -810,6 +875,38 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 	return errs
 }
 
+// Validate_DeviceTaint validates an instance of DeviceTaint according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTaint) (errs field.ErrorList) {
+	// field resourcev1beta1.DeviceTaint.Key has no validation
+	// field resourcev1beta1.DeviceTaint.Value has no validation
+
+	// field resourcev1beta1.DeviceTaint.Effect
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTaintEffect) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("effect"), &obj.Effect, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceTaint) *resourcev1beta1.DeviceTaintEffect { return &oldObj.Effect }))...)
+
+	// field resourcev1beta1.DeviceTaint.TimeAdded has no validation
+	return errs
+}
+
+var symbolsForDeviceTaintEffect = sets.New(resourcev1beta1.DeviceTaintEffectNoExecute, resourcev1beta1.DeviceTaintEffectNoSchedule)
+
+// Validate_DeviceTaintEffect validates an instance of DeviceTaintEffect according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTaintEffect(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTaintEffect) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil)...)
+
+	return errs
+}
+
 // Validate_DeviceToleration validates an instance of DeviceToleration according
 // to declarative validation rules in the API schema.
 func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceToleration) (errs field.ErrorList) {
@@ -832,10 +929,47 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			return
 		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceToleration) *string { return &oldObj.Key }))...)
 
-	// field resourcev1beta1.DeviceToleration.Operator has no validation
+	// field resourcev1beta1.DeviceToleration.Operator
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTolerationOperator) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTolerationOperator(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("operator"), &obj.Operator, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceToleration) *resourcev1beta1.DeviceTolerationOperator {
+			return &oldObj.Operator
+		}))...)
+
 	// field resourcev1beta1.DeviceToleration.Value has no validation
-	// field resourcev1beta1.DeviceToleration.Effect has no validation
+
+	// field resourcev1beta1.DeviceToleration.Effect
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTaintEffect) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("effect"), &obj.Effect, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceToleration) *resourcev1beta1.DeviceTaintEffect {
+			return &oldObj.Effect
+		}))...)
+
 	// field resourcev1beta1.DeviceToleration.TolerationSeconds has no validation
+	return errs
+}
+
+var symbolsForDeviceTolerationOperator = sets.New(resourcev1beta1.DeviceTolerationOpEqual, resourcev1beta1.DeviceTolerationOpExists)
+
+// Validate_DeviceTolerationOperator validates an instance of DeviceTolerationOperator according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTolerationOperator(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceTolerationOperator) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil)...)
+
 	return errs
 }
 
@@ -1102,5 +1236,73 @@ func Validate_ResourceClaimTemplateSpec(ctx context.Context, op operation.Operat
 			return &oldObj.Spec
 		}))...)
 
+	return errs
+}
+
+// Validate_ResourceSlice validates an instance of ResourceSlice according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSlice(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.ResourceSlice) (errs field.ErrorList) {
+	// field resourcev1beta1.ResourceSlice.TypeMeta has no validation
+	// field resourcev1beta1.ResourceSlice.ObjectMeta has no validation
+
+	// field resourcev1beta1.ResourceSlice.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta1.ResourceSliceSpec) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ResourceSliceSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceSlice) *resourcev1beta1.ResourceSliceSpec { return &oldObj.Spec }))...)
+
+	return errs
+}
+
+// Validate_ResourceSliceList validates an instance of ResourceSliceList according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSliceList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.ResourceSliceList) (errs field.ErrorList) {
+	// field resourcev1beta1.ResourceSliceList.TypeMeta has no validation
+	// field resourcev1beta1.ResourceSliceList.ListMeta has no validation
+
+	// field resourcev1beta1.ResourceSliceList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.ResourceSlice) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_ResourceSlice)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceSliceList) []resourcev1beta1.ResourceSlice { return oldObj.Items }))...)
+
+	return errs
+}
+
+// Validate_ResourceSliceSpec validates an instance of ResourceSliceSpec according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.ResourceSliceSpec) (errs field.ErrorList) {
+	// field resourcev1beta1.ResourceSliceSpec.Driver has no validation
+	// field resourcev1beta1.ResourceSliceSpec.Pool has no validation
+	// field resourcev1beta1.ResourceSliceSpec.NodeName has no validation
+	// field resourcev1beta1.ResourceSliceSpec.NodeSelector has no validation
+	// field resourcev1beta1.ResourceSliceSpec.AllNodes has no validation
+
+	// field resourcev1beta1.ResourceSliceSpec.Devices
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.Device) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device)...)
+			return
+		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceSliceSpec) []resourcev1beta1.Device { return oldObj.Devices }))...)
+
+	// field resourcev1beta1.ResourceSliceSpec.PerDeviceNodeSelection has no validation
+	// field resourcev1beta1.ResourceSliceSpec.SharedCounters has no validation
 	return errs
 }

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -89,6 +89,22 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
+	// type ResourceSlice
+	scheme.AddValidationFunc((*resourcev1beta2.ResourceSlice)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ResourceSlice(ctx, op, nil /* fldPath */, obj.(*resourcev1beta2.ResourceSlice), safe.Cast[*resourcev1beta2.ResourceSlice](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type ResourceSliceList
+	scheme.AddValidationFunc((*resourcev1beta2.ResourceSliceList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ResourceSliceList(ctx, op, nil /* fldPath */, obj.(*resourcev1beta2.ResourceSliceList), safe.Cast[*resourcev1beta2.ResourceSliceList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
 }
 
@@ -153,6 +169,36 @@ func Validate_AllocationResult(ctx context.Context, op operation.Operation, fldP
 
 	// field resourcev1beta2.AllocationResult.NodeSelector has no validation
 	// field resourcev1beta2.AllocationResult.AllocationTimestamp has no validation
+	return errs
+}
+
+// Validate_Device validates an instance of Device according
+// to declarative validation rules in the API schema.
+func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.Device) (errs field.ErrorList) {
+	// field resourcev1beta2.Device.Name has no validation
+	// field resourcev1beta2.Device.Attributes has no validation
+	// field resourcev1beta2.Device.Capacity has no validation
+	// field resourcev1beta2.Device.ConsumesCounters has no validation
+	// field resourcev1beta2.Device.NodeName has no validation
+	// field resourcev1beta2.Device.NodeSelector has no validation
+	// field resourcev1beta2.Device.AllNodes has no validation
+
+	// field resourcev1beta2.Device.Taints
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceTaint) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceTaint)...)
+			return
+		}(fldPath.Child("taints"), obj.Taints, safe.Field(oldObj, func(oldObj *resourcev1beta2.Device) []resourcev1beta2.DeviceTaint { return oldObj.Taints }))...)
+
+	// field resourcev1beta2.Device.BindsToNode has no validation
+	// field resourcev1beta2.Device.BindingConditions has no validation
+	// field resourcev1beta2.Device.BindingFailureConditions has no validation
+	// field resourcev1beta2.Device.AllowMultipleAllocations has no validation
 	return errs
 }
 
@@ -761,6 +807,38 @@ func Validate_DeviceSubRequest(ctx context.Context, op operation.Operation, fldP
 	return errs
 }
 
+// Validate_DeviceTaint validates an instance of DeviceTaint according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTaint) (errs field.ErrorList) {
+	// field resourcev1beta2.DeviceTaint.Key has no validation
+	// field resourcev1beta2.DeviceTaint.Value has no validation
+
+	// field resourcev1beta2.DeviceTaint.Effect
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTaintEffect) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("effect"), &obj.Effect, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceTaint) *resourcev1beta2.DeviceTaintEffect { return &oldObj.Effect }))...)
+
+	// field resourcev1beta2.DeviceTaint.TimeAdded has no validation
+	return errs
+}
+
+var symbolsForDeviceTaintEffect = sets.New(resourcev1beta2.DeviceTaintEffectNoExecute, resourcev1beta2.DeviceTaintEffectNoSchedule)
+
+// Validate_DeviceTaintEffect validates an instance of DeviceTaintEffect according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTaintEffect(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTaintEffect) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil)...)
+
+	return errs
+}
+
 // Validate_DeviceToleration validates an instance of DeviceToleration according
 // to declarative validation rules in the API schema.
 func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceToleration) (errs field.ErrorList) {
@@ -783,10 +861,47 @@ func Validate_DeviceToleration(ctx context.Context, op operation.Operation, fldP
 			return
 		}(fldPath.Child("key"), &obj.Key, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceToleration) *string { return &oldObj.Key }))...)
 
-	// field resourcev1beta2.DeviceToleration.Operator has no validation
+	// field resourcev1beta2.DeviceToleration.Operator
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTolerationOperator) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTolerationOperator(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("operator"), &obj.Operator, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceToleration) *resourcev1beta2.DeviceTolerationOperator {
+			return &oldObj.Operator
+		}))...)
+
 	// field resourcev1beta2.DeviceToleration.Value has no validation
-	// field resourcev1beta2.DeviceToleration.Effect has no validation
+
+	// field resourcev1beta2.DeviceToleration.Effect
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTaintEffect) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("effect"), &obj.Effect, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceToleration) *resourcev1beta2.DeviceTaintEffect {
+			return &oldObj.Effect
+		}))...)
+
 	// field resourcev1beta2.DeviceToleration.TolerationSeconds has no validation
+	return errs
+}
+
+var symbolsForDeviceTolerationOperator = sets.New(resourcev1beta2.DeviceTolerationOpEqual, resourcev1beta2.DeviceTolerationOpExists)
+
+// Validate_DeviceTolerationOperator validates an instance of DeviceTolerationOperator according
+// to declarative validation rules in the API schema.
+func Validate_DeviceTolerationOperator(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceTolerationOperator) (errs field.ErrorList) {
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTolerationOperator, nil)...)
+
 	return errs
 }
 
@@ -1122,5 +1237,73 @@ func Validate_ResourceClaimTemplateSpec(ctx context.Context, op operation.Operat
 			return &oldObj.Spec
 		}))...)
 
+	return errs
+}
+
+// Validate_ResourceSlice validates an instance of ResourceSlice according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSlice(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.ResourceSlice) (errs field.ErrorList) {
+	// field resourcev1beta2.ResourceSlice.TypeMeta has no validation
+	// field resourcev1beta2.ResourceSlice.ObjectMeta has no validation
+
+	// field resourcev1beta2.ResourceSlice.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *resourcev1beta2.ResourceSliceSpec) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ResourceSliceSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceSlice) *resourcev1beta2.ResourceSliceSpec { return &oldObj.Spec }))...)
+
+	return errs
+}
+
+// Validate_ResourceSliceList validates an instance of ResourceSliceList according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSliceList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.ResourceSliceList) (errs field.ErrorList) {
+	// field resourcev1beta2.ResourceSliceList.TypeMeta has no validation
+	// field resourcev1beta2.ResourceSliceList.ListMeta has no validation
+
+	// field resourcev1beta2.ResourceSliceList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.ResourceSlice) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_ResourceSlice)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceSliceList) []resourcev1beta2.ResourceSlice { return oldObj.Items }))...)
+
+	return errs
+}
+
+// Validate_ResourceSliceSpec validates an instance of ResourceSliceSpec according
+// to declarative validation rules in the API schema.
+func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.ResourceSliceSpec) (errs field.ErrorList) {
+	// field resourcev1beta2.ResourceSliceSpec.Driver has no validation
+	// field resourcev1beta2.ResourceSliceSpec.Pool has no validation
+	// field resourcev1beta2.ResourceSliceSpec.NodeName has no validation
+	// field resourcev1beta2.ResourceSliceSpec.NodeSelector has no validation
+	// field resourcev1beta2.ResourceSliceSpec.AllNodes has no validation
+
+	// field resourcev1beta2.ResourceSliceSpec.Devices
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.Device) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device)...)
+			return
+		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceSliceSpec) []resourcev1beta2.Device { return oldObj.Devices }))...)
+
+	// field resourcev1beta2.ResourceSliceSpec.PerDeviceNodeSelection has no validation
+	// field resourcev1beta2.ResourceSliceSpec.SharedCounters has no validation
 	return errs
 }

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1366,7 +1366,7 @@ func validateDeviceTaint(taint resource.DeviceTaint, fldPath *field.Path) field.
 	case taint.Effect == "":
 		allErrs = append(allErrs, field.Required(fldPath.Child("effect"), "")) // Required in a taint.
 	case !validDeviceTaintEffects.Has(taint.Effect):
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), taint.Effect, sets.List(validDeviceTaintEffects)).MarkCoveredByDeclarative())
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), taint.Effect, sets.List(validDeviceTaintEffects)))
 	}
 
 	return allErrs

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -55,6 +55,11 @@ var ResourceNormalizationRules = []field.NormalizationRule{
 		Regexp:      regexp.MustCompile(`spec.devices\.requests\[(\d+)\]\.(deviceClassName|selectors|allocationMode|count|adminAccess|tolerations)`),
 		Replacement: "spec.devices.requests[$1].exactly.$2",
 	},
+	{
+		// This v1beta1 'basic' to flattened rule is to support ResourceSlice
+		Regexp:      regexp.MustCompile(`spec.devices\[(\d+)\]\.basic\.`),
+		Replacement: "spec.devices[$1].",
+	},
 }
 
 var (
@@ -1361,7 +1366,7 @@ func validateDeviceTaint(taint resource.DeviceTaint, fldPath *field.Path) field.
 	case taint.Effect == "":
 		allErrs = append(allErrs, field.Required(fldPath.Child("effect"), "")) // Required in a taint.
 	case !validDeviceTaintEffects.Has(taint.Effect):
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), taint.Effect, sets.List(validDeviceTaintEffects)))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), taint.Effect, sets.List(validDeviceTaintEffects)).MarkCoveredByDeclarative())
 	}
 
 	return allErrs
@@ -1383,13 +1388,13 @@ func validateDeviceToleration(toleration resource.DeviceToleration, fldPath *fie
 	case "":
 		allErrs = append(allErrs, field.Required(fldPath.Child("operator"), ""))
 	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("operator"), toleration.Operator, validDeviceTolerationOperators))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("operator"), toleration.Operator, validDeviceTolerationOperators).MarkCoveredByDeclarative())
 	}
 	switch {
 	case toleration.Effect == "":
 		// Optional in a toleration.
 	case !validDeviceTaintEffects.Has(toleration.Effect):
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), toleration.Effect, sets.List(validDeviceTaintEffects)))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), toleration.Effect, sets.List(validDeviceTaintEffects)).MarkCoveredByDeclarative())
 	}
 
 	return allErrs

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -786,11 +786,11 @@ func TestValidateClaim(t *testing.T) {
 				allErrs = append(allErrs,
 					field.Required(fldPath.Index(3).Child("operator"), ""),
 
-					field.NotSupported(fldPath.Index(4).Child("operator"), resource.DeviceTolerationOperator("some-other-op"), []resource.DeviceTolerationOperator{resource.DeviceTolerationOpEqual, resource.DeviceTolerationOpExists}),
+					field.NotSupported(fldPath.Index(4).Child("operator"), resource.DeviceTolerationOperator("some-other-op"), []resource.DeviceTolerationOperator{resource.DeviceTolerationOpEqual, resource.DeviceTolerationOpExists}).MarkCoveredByDeclarative(),
 
 					field.Invalid(fldPath.Index(5).Child("key"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").MarkCoveredByDeclarative(),
 					field.Invalid(fldPath.Index(5).Child("value"), badName, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"),
-					field.NotSupported(fldPath.Index(5).Child("effect"), resource.DeviceTaintEffect("some-other-effect"), []resource.DeviceTaintEffect{resource.DeviceTaintEffectNoExecute, resource.DeviceTaintEffectNoSchedule}),
+					field.NotSupported(fldPath.Index(5).Child("effect"), resource.DeviceTaintEffect("some-other-effect"), []resource.DeviceTaintEffect{resource.DeviceTaintEffectNoExecute, resource.DeviceTaintEffectNoSchedule}).MarkCoveredByDeclarative(),
 				)
 				return allErrs
 			}(),

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -497,7 +497,7 @@ func TestValidateResourceSlice(t *testing.T) {
 
 					field.Invalid(fldPath.Index(3).Child("key"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
 					field.Invalid(fldPath.Index(3).Child("value"), badName, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"),
-					field.NotSupported(fldPath.Index(3).Child("effect"), resourceapi.DeviceTaintEffect("some-other-op"), []resourceapi.DeviceTaintEffect{resourceapi.DeviceTaintEffectNoExecute, resourceapi.DeviceTaintEffectNoSchedule}).MarkCoveredByDeclarative(),
+					field.NotSupported(fldPath.Index(3).Child("effect"), resourceapi.DeviceTaintEffect("some-other-op"), []resourceapi.DeviceTaintEffect{resourceapi.DeviceTaintEffectNoExecute, resourceapi.DeviceTaintEffectNoSchedule}),
 				}
 			}(),
 			slice: func() *resourceapi.ResourceSlice {

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -497,7 +497,7 @@ func TestValidateResourceSlice(t *testing.T) {
 
 					field.Invalid(fldPath.Index(3).Child("key"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
 					field.Invalid(fldPath.Index(3).Child("value"), badName, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"),
-					field.NotSupported(fldPath.Index(3).Child("effect"), resourceapi.DeviceTaintEffect("some-other-op"), []resourceapi.DeviceTaintEffect{resourceapi.DeviceTaintEffectNoExecute, resourceapi.DeviceTaintEffectNoSchedule}),
+					field.NotSupported(fldPath.Index(3).Child("effect"), resourceapi.DeviceTaintEffect("some-other-op"), []resourceapi.DeviceTaintEffect{resourceapi.DeviceTaintEffectNoExecute, resourceapi.DeviceTaintEffectNoSchedule}).MarkCoveredByDeclarative(),
 				}
 			}(),
 			slice: func() *resourceapi.ResourceSlice {

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -650,6 +650,7 @@ type DeviceTaint struct {
 }
 
 // +enum
+// +k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -1365,6 +1366,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
+// +k8s:enum
 type DeviceTolerationOperator string
 
 const (

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -654,6 +654,7 @@ type DeviceTaint struct {
 }
 
 // +enum
+// +k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -1372,6 +1373,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
+// +k8s:enum
 type DeviceTolerationOperator string
 
 const (

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -650,6 +650,7 @@ type DeviceTaint struct {
 }
 
 // +enum
+// +k8s:enum
 type DeviceTaintEffect string
 
 const (
@@ -1365,6 +1366,7 @@ type DeviceToleration struct {
 // A toleration operator is the set of operators that can be used in a toleration.
 //
 // +enum
+// +k8s:enum
 type DeviceTolerationOperator string
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/kubernetes/kubernetes/pull/134555#top
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR migrates a section of hand-written validation logic for ResourceClaim DeviceTolerationOperator and DeviceTaintEffect to declarative validation using the +k8s:enum tag.

#### Which issue(s) this PR is related to:
Builds on https://github.com/kubernetes/kubernetes/pull/134072
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```
