### PR TITLE
make .go-version independent of kube-cross

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -140,7 +140,6 @@ dependencies:
   #
   # This entry is a stub of the major version to allow dependency checks to
   # pass when building Kubernetes using a pre-release of Golang.
-
   - name: "golang: 1.<major>"
     version: 1.25
     refPaths:

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -120,9 +120,20 @@ dependencies:
     version: 1.25.1
     refPaths:
     - path: .go-version
-    - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
       match: 'default-go-version\: \d+.\d+(alpha|beta|rc)?\.?(\d+)?'
+
+  # This should ideally be updated to match the golang version
+  # but we can dynamically fetch go if the base image is out of date.
+  # This allows us to ship go updates more quickly.
+  #
+  # NOTE: To fully patch all binaries, go-runner and the related base images
+  # should also be updated, but go-runner is much harder to exploit and has
+  # far less relevancy to go updates for Kubernetes more generally.
+  - name: "registry.k8s.io/kube-cross: dependents"
+    version: v1.35.0-go1.25.1-bullseye.0
+    refPaths:
+    - path: build/build-image/cross/VERSION
 
   # Golang pre-releases are denoted as `1.y<pre-release stage>`
   # Example: go1.16rc1
@@ -136,11 +147,6 @@ dependencies:
     - path: build/build-image/cross/VERSION
     - path: hack/lib/golang.sh
       match: minimum_go_version=go([0-9]+\.[0-9]+)
-
-  - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.35.0-go1.25.1-bullseye.0
-    refPaths:
-    - path: build/build-image/cross/VERSION
 
   # Base images
   - name: "registry.k8s.io/debian-base: dependents"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Ensures we can bump .go-version to update the build for core go release binaries without waiting on kube-cross updates.

We will already dynamically fetch go via GOTOOLCHAIN using the version available in kube-cross, so kube-cross updates are just an optimization that does not need to block rapid patching. 

Past work has made this possible, it was just blocked on build/dependencies.yaml not permitting it.

The version bump was already decoupled from the container base images, which are less likely to have go related vulnerabilities, and can be updated in parallel to sorting out bumping go for the core binaries.

See for example https://github.com/kubernetes/kubernetes/pull/134487 which this PR was broken out of, where there turned out to be some regressions in go 1.25.2 that we didn't know while waiting on the image bumps.

Next time we file a .go-version bump first and then work on the image bumps if there are no issues / the work can be split.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

See https://github.com/kubernetes/kubernetes/pull/134487

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig release
FYI @kubernetes/release-engineering 