### PR TITLE
kubelet: fix nil pointer in pod cert manager

### DIFF
--- a/pkg/kubelet/podcertificate/podcertificatemanager.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager.go
@@ -415,7 +415,7 @@ func (m *IssuingManager) handleProjection(ctx context.Context, key projectionKey
 			// remember creating the PCR, then we must be in case 2.  Return to
 			// credStateInitial so we create a new PCR.
 			rec.curState = &credStateInitial{}
-			return fmt.Errorf("PodCertificateRequest %q appears to have been deleted", pcr.ObjectMeta.Namespace+"/"+pcr.ObjectMeta.Name)
+			return fmt.Errorf("PodCertificateRequest %q appears to have been deleted", key.Namespace+"/"+state.pcrName)
 		} else if err != nil {
 			return fmt.Errorf("while getting PodCertificateRequest %q: %w", key.Namespace+"/"+state.pcrName, err)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:
https://storage.googleapis.com/k8s-triage/index.html?text=handleProjection
```
Failed
=== RUN   TestFullFlow
        	goroutine 115 [running]:
        	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x25c8618, 0xc000253080}, {0x1eec100, 0x3c8bb80})
        		C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xbc
        	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x25c8650, 0xc000029630}, {0x1eec100, 0x3c8bb80}, {0x0, 0x0, 0xc000063730?})
        		C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x116
        	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x25c8650, 0xc000029630}, {0x0, 0x0, 0x0})
        		C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:78 +0x5a
        	panic({0x1eec100?, 0x3c8bb80?})
        		C:/Program Files/Go/src/runtime/panic.go:792 +0x132
        	k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).handleProjection(0xc0001f8be0, {0x25c8650, 0xc000029630}, {{0x22ad43a, 0xb}, {0x22aa1f1, 0x8}, {0x0, 0x0}, {0x22ad42f, ...}, ...})
        		C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:425 +0x1999
        	k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).processNextProjection(0xc0001f8be0, {0x25c8650, 0xc000029630})
        		C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:300 +0x253
        	k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).runProjectionProcessor(...)
        		C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:289
        	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x25c8650?, 0xc000029630?}, 0xc000252c90?)
        		C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:255 +0x51
        	k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x25c8650, 0xc000029630}, 0xc000317830, {0x25a5de0, 0xc000252c90}, 0x1)
        		C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:256 +0xe5
        	k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x25c8650, 0xc000029630}, 0xc000317830, 0x3b9aca00, 0x0, 0x1)
        		C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:223 +0x8f
        	k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
        		C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:172
        	created by k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).Run in goroutine 61
        		C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:280 +0x251
         >
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x48 pc=0x1c1a9f9]

goroutine 115 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x25c8650, 0xc000029630}, {0x1eec100, 0x3c8bb80}, {0x0, 0x0, 0xc000063730?})
	C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:114 +0x1a9
k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x25c8650, 0xc000029630}, {0x0, 0x0, 0x0})
	C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:78 +0x5a
panic({0x1eec100?, 0x3c8bb80?})
	C:/Program Files/Go/src/runtime/panic.go:792 +0x132
k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).handleProjection(0xc0001f8be0, {0x25c8650, 0xc000029630}, {{0x22ad43a, 0xb}, {0x22aa1f1, 0x8}, {0x0, 0x0}, {0x22ad42f, ...}, ...})
	C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:425 +0x1999
k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).processNextProjection(0xc0001f8be0, {0x25c8650, 0xc000029630})
	C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:300 +0x253
k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).runProjectionProcessor(...)
	C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:289
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x25c8650?, 0xc000029630?}, 0xc000252c90?)
	C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:255 +0x51
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x25c8650, 0xc000029630}, 0xc000317830, {0x25a5de0, 0xc000252c90}, 0x1)
	C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:256 +0xe5
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x25c8650, 0xc000029630}, 0xc000317830, 0x3b9aca00, 0x0, 0x1)
	C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:223 +0x8f
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
	C:/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:172
created by k8s.io/kubernetes/pkg/kubelet/podcertificate.(*IssuingManager).Run in goroutine 61
	C:/kubernetes/pkg/kubelet/podcertificate/podcertificatemanager.go:280 +0x251

```

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:

The nil pointer bug was found in the UT flake like https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit/1977754872354705408.

Test was added https://github.com/kubernetes/kubernetes/pull/128010 in July.

#### Does this PR introduce a user-facing change?

```release-note
None
```