### PR TITLE
Add missing docs for x-kubernetes OpenAPI extensions

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -58,3 +58,14 @@ For example:
 
 Some of the definitions may have these extensions. For more information about PatchStrategy and PatchMergeKey see
 [strategic-merge-patch](https://git.k8s.io/community/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
+
+### Kubernetes-specific OpenAPI extensions
+
+Kubernetes uses several custom OpenAPI extensions to describe additional schema behavior.
+
+| Extension | Type | Description |
+|-----------|------|-------------|
+| `x-kubernetes-list-type` | string | Defines how lists are treated — possible values are `atomic`, `set`, or `map`. |
+| `x-kubernetes-map-key` | string | Used when `x-kubernetes-list-type` is set to `map`. Specifies which field in the list acts as the unique key. |
+| `x-kubernetes-unions` | boolean | Indicates that a structure is a union type (only one of the fields may be set). |
+


### PR DESCRIPTION
This PR adds documentation for three Kubernetes-specific OpenAPI extensions:

- `x-kubernetes-list-type`
- `x-kubernetes-map-key`
- `x-kubernetes-unions`

These extensions are used to define additional schema behavior in Kubernetes API objects.

Fixes: #131724
```release-note
NONE
