### PR TITLE
Enhance README with Kubernetes extension details

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -58,3 +58,81 @@ For example:
 
 Some of the definitions may have these extensions. For more information about PatchStrategy and PatchMergeKey see
 [strategic-merge-patch](https://git.k8s.io/community/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
+
+### `x-kubernetes-list-type`
+
+Some definitions may have `x-kubernetes-list-type`.  
+This extension specifies how lists are merged when Kubernetes objects are combined (for example, during updates or patches).  
+Possible values are:
+
+- `"atomic"` – treat the entire list as one unit; replacing the list replaces all elements.  
+- `"set"` – treat the list as a set; merge items based on equality.  
+- `"map"` – treat the list as a map; keys come from the field defined in `x-kubernetes-list-map-keys`.  
+
+For example:
+
+```json
+{
+  "x-kubernetes-list-type": "map",
+  "x-kubernetes-list-map-keys": ["name"]
+}
+```
+
+See [Kubernetes API conventions (lists and maps)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md) for more.
+
+### `x-kubernetes-list-map-keys`
+
+This extension sets which field(s) identify elements uniquely for x-kubernetes-list-type: map.
+It allows merging list entries based on those key fields.
+
+For example:
+
+```json
+{
+  "x-kubernetes-list-type": "map",
+  "x-kubernetes-list-map-keys": ["name"]
+}
+```
+
+Here, "name" acts as the key for each map entry.
+See [API conventions – merge strategy](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#merge-strategy) for details.
+
+
+### `x-kubernetes-map-type`
+
+Some definitions may have x-kubernetes-map-type.
+This extension describes how maps should merge:
+ • "atomic" – replace entire map
+ • "granular" – merge map entries individually
+
+For example:
+
+```json
+{
+  "x-kubernetes-map-type": "granular"
+}
+```
+See Kubernetes [API conventions (maps section)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#maps) for details.
+
+
+### `x-kubernetes-unions`
+
+Some definitions may have x-kubernetes-unions.
+This extension describes mutually exclusive fields (union-like behavior).
+Only one field in that union can be set.
+
+For example:
+
+```json
+{
+  "x-kubernetes-unions": [
+    {
+      "discriminator": "type",
+      "fields": ["intValue", "stringValue"]
+    }
+  ]
+}
+```
+
+This ensures only one of "intValue" or "stringValue" is specified based on the type discriminator.
+See Kubernetes [API conventions (union types)](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#union-types) for more.


### PR DESCRIPTION
What type of PR is this?
/kind documentation

Which issue(s) this PR fixes:
Fixes [#131724](tg://search_hashtag?hashtag=131724)

What this PR does / why we need it:
Adds missing documentation for OpenAPI extensions:
- x-kubernetes-list-type
- x-kubernetes-list-map-keys
- x-kubernetes-map-type
- x-kubernetes-unions

Each section includes examples and links to API conventions for reference.

Special notes for your reviewer:
NONE

Does this PR introduce a user-facing change?:
NONE