### PR TITLE
do not allow concurrent volume processing for static pods with same name

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -1585,6 +1585,11 @@ func (p *fakePodStateProvider) ShouldPodRuntimeBeRemoved(uid kubetypes.UID) bool
 	return ok
 }
 
+func (p *fakePodStateProvider) IsPodForMirrorPodTerminatingByFullName(podFullname string) bool {
+	// this does not impact existing tests
+	return false
+}
+
 func createDswpWithVolumeWithCustomPluginMgr(pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim,
 	fakeVolumePluginMgr *volume.VolumePluginMgr) (*desiredStateOfWorldPopulator, kubepod.Manager, cache.DesiredStateOfWorld, *containertest.FakeRuntime, *fakePodStateProvider) {
 	fakeClient := &fake.Clientset{}

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -164,6 +164,7 @@ type VolumeManager interface {
 type PodStateProvider interface {
 	ShouldPodContainersBeTerminating(k8stypes.UID) bool
 	ShouldPodRuntimeBeRemoved(k8stypes.UID) bool
+	IsPodForMirrorPodTerminatingByFullName(podFullname string) bool
 }
 
 // PodManager is the subset of methods the manager needs to observe the actual state of the kubelet.

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -487,6 +487,11 @@ func (p *fakePodStateProvider) ShouldPodContainersBeTerminating(uid kubetypes.UI
 	return ok
 }
 
+func (p *fakePodStateProvider) IsPodForMirrorPodTerminatingByFullName(podFullname string) bool {
+	// this does not impact existing tests
+	return false
+}
+
 func newTestVolumeManager(t *testing.T, tmpDir string, podManager kubepod.Manager, kubeClient clientset.Interface, node *v1.Node) VolumeManager {
 	attachablePlug := &volumetest.FakeVolumePlugin{
 		PluginName: "fake",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Let's consider the scenario: we have two static pods with the same name, distinguishable by their uids, 1 and 2:
- a: pod with uid 1 starts
- b: pod with uid 1 is in `terminating` state
- c: pod with uid 2 is observed by pod worker, but it does not deem the pod ready to start yet 

while in this state, should the populator for the desired state of the world invoke `AddPodToVolume` for the volumes of pod with uid 2?

This PR has a test that exercises this scenario, and successfully reproduces the issue - `AddPodToVolume` is invoked for the volumes of pod with uid 2, while the pod with uid 1 is in `terminating` state.

This PR also has a fix - for a given pod from the pod manager, if a static pod with the same name is in `terminating` state, then the populator skips processing volumesof the given pod.

If we run the test without the fix, it fails:
```
go test -v -count=1 -race ./pkg/kubelet/ -run=TestStaticPodVolumeProcessShouldNotInterleave
=== RUN   TestStaticPodVolumeProcessShouldNotInterleave
I1014 11:26:39.300294   99537 pod_workers.go:788] "Pod is being synced for the first time" pod="static-pod-foo" podUID="1" updateType="update"
I1014 11:26:39.300372   99537 pod_workers.go:986] "Notifying pod of pending update" pod="static-pod-foo" podUID="1" workType="sync"
I1014 11:26:39.300535   99537 pod_workers.go:1256] "Processing pod event" pod="static-pod-foo" podUID="1" updateType="sync"
I1014 11:26:39.300615   99537 pod_workers.go:1361] "Processing pod event done" pod="static-pod-foo" podUID="1" updateType="sync"
I1014 11:26:39.311123   99537 desired_state_of_world_populator.go:328] "Added volume to desired state" pod="static-pod-foo" volumeName="vol1" volumeSpecName="vol1"
I1014 11:26:39.311175   99537 desired_state_of_world_populator.go:155] "Finished populating initial desired state of world"
I1014 11:26:39.311610   99537 pod_workers.go:1396] "Pod indicated lifecycle completed naturally and should now terminate" podUID="1"
I1014 11:26:39.311647   99537 pod_workers.go:788] "Pod is being synced for the first time" pod="static-pod-foo" podUID="2" updateType="update"
I1014 11:26:39.311687   99537 pod_workers.go:986] "Notifying pod of pending update" pod="static-pod-foo" podUID="2" workType="sync"
I1014 11:26:39.311730   99537 pod_workers.go:1200] "Pod cannot start yet" pod="static-pod-foo" podUID="2"
I1014 11:26:39.321738   99537 desired_state_of_world_populator.go:328] "Added volume to desired state" pod="static-pod-foo" volumeName="vol1" volumeSpecName="vol1"
    kubelet_volumes_test.go:965: did not expect AddPodToVolume to be invoked
    kubelet_volumes_test.go:969: did not expect pod-2 volume(s) to be processed while pod-1 is terminating - kubelet.recorded{added:[]types.UID{"2"}, error:""}
--- FAIL: TestStaticPodVolumeProcessShouldNotInterleave (0.02s)
FAIL
FAIL	k8s.io/kubernetes/pkg/kubelet	1.054s
FAIL
```

With the fix in place, the test passes since we are waiting for the static pod in `terminating` state to transition to `terminated` state.

#### Which issue(s) this PR is related to:

Fixes #134954

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
