### PR TITLE
Enable Declarative Validation for ConfigMap

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -403,7 +403,7 @@ func ValidateObjectMeta(meta *metav1.ObjectMeta, requiresNamespace bool, nameFn 
 	allErrs := apimachineryvalidation.ValidateObjectMeta(meta, requiresNamespace, apimachineryvalidation.ValidateNameFunc(nameFn), fldPath)
 	// run additional checks for the finalizer name
 	for i := range meta.Finalizers {
-		allErrs = append(allErrs, validateKubeFinalizerName(string(meta.Finalizers[i]), fldPath.Child("finalizers").Index(i))...)
+		allErrs = append(allErrs, validateKubeFinalizerName(string(meta.Finalizers[i]), fldPath.Child("finalizers").Index(i))...).MarkCoveredByDeclarative()
 	}
 	return allErrs
 }

--- a/pkg/registry/core/configmap/declarative_validation_test.go
+++ b/pkg/registry/core/configmap/declarative_validation_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestDeclarativeValidateForDeclarative(t *testing.T) {
+	testDeclarativeValidateForDeclarative(t, "v1")
+}
+
+func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: apiVersion,
+	})
+	testCases := map[string]struct {
+		input        api.ConfigMap
+		expectedErrs field.ErrorList
+	}{
+		// TODO: Add test cases
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			actualErrs := Strategy.Validate(ctx, &tc.input)
+			t.Logf("DEBUG: actualErrs for %s: %#v", k, actualErrs)
+			t.Logf("DEBUG: expectedErrs for %s: %#v", k, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestValidateUpdateForDeclarative(t *testing.T) {
+	testValidateUpdateForDeclarative(t, "v1")
+}
+
+func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: apiVersion,
+	})
+	testCases := map[string]struct {
+		old          api.ConfigMap
+		update       api.ConfigMap
+		expectedErrs field.ErrorList
+	}{
+		// TODO: Add test cases
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.old.ObjectMeta.ResourceVersion = "1"
+			tc.update.ObjectMeta.ResourceVersion = "1"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}

--- a/pkg/registry/core/configmap/declarative_validation_test.go
+++ b/pkg/registry/core/configmap/declarative_validation_test.go
@@ -45,18 +45,18 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 		},
 		"invalid name with underscore": {
 			input: mkValidConfigMap(func(cm *api.ConfigMap) {
-				cm.ObjectMeta.Name = "invalid_name" 
+				cm.ObjectMeta.Name = "invalid_name"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "invalid_name", "must be a DNS-1123 subdomain"),
+				field.Invalid(field.NewPath("metadata", "name"), "invalid_name", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 		},
 		"invalid name with uppercase": {
 			input: mkValidConfigMap(func(cm *api.ConfigMap) {
-				cm.ObjectMeta.Name = "InvalidName" 
+				cm.ObjectMeta.Name = "InvalidName"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "InvalidName", "must be a DNS-1123 subdomain"),
+				field.Invalid(field.NewPath("metadata", "name"), "InvalidName", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 		},
 		"invalid name with special character": {
@@ -64,7 +64,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 				cm.ObjectMeta.Name = "invalid@name"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "invalid@name", "must be a DNS-1123 subdomain"),
+				field.Invalid(field.NewPath("metadata", "name"), "invalid@name", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 		},
 		// TODO: Add more test cases
@@ -101,7 +101,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 				cm.ObjectMeta.Name = "invalid_name"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "invalid_name", "must be a DNS-1123 subdomain"),
+				field.Invalid(field.NewPath("metadata", "name"), "invalid_name", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 		},
 		"invalid name with uppercase in update": {
@@ -110,7 +110,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 				cm.ObjectMeta.Name = "InvalidName"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "InvalidName", "must be a DNS-1123 subdomain"),
+				field.Invalid(field.NewPath("metadata", "name"), "InvalidName", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 		},
 		"invalid name with special character in update": {
@@ -119,7 +119,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 				cm.ObjectMeta.Name = "invalid@name"
 			}),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "invalid@name", "must be a DNS-1123 subdomain"),
+				field.Invalid(field.NewPath("metadata", "name"), "invalid@name", "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 		},
 		// TODO: Add more test cases

--- a/pkg/registry/core/configmap/strategy.go
+++ b/pkg/registry/core/configmap/strategy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,8 +61,9 @@ func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	cfg := obj.(*api.ConfigMap)
+	allErrs := validation.ValidateConfigMap(cfg)
 
-	return validation.ValidateConfigMap(cfg)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, cfg, nil, allErrs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -83,8 +85,9 @@ func (strategy) PrepareForUpdate(ctx context.Context, newObj, oldObj runtime.Obj
 
 func (strategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldCfg, newCfg := oldObj.(*api.ConfigMap), newObj.(*api.ConfigMap)
+	allErrs := validation.ValidateConfigMapUpdate(newCfg, oldCfg)
 
-	return validation.ValidateConfigMapUpdate(newCfg, oldCfg)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newCfg, oldCfg, allErrs, operation.Update)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/core/v1/doc.go
+++ b/staging/src/k8s.io/api/core/v1/doc.go
@@ -19,7 +19,8 @@ limitations under the License.
 // +k8s:protobuf-gen=package
 // +k8s:prerelease-lifecycle-gen=true
 // +k8s:openapi-model-package=io.k8s.api.core.v1
-
+// +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-input=k8s.io/api/core/v1
 // +groupName=
 
 // Package v1 is the v1 version of the core API.

--- a/staging/src/k8s.io/api/core/v1/doc.go
+++ b/staging/src/k8s.io/api/core/v1/doc.go
@@ -19,8 +19,6 @@ limitations under the License.
 // +k8s:protobuf-gen=package
 // +k8s:prerelease-lifecycle-gen=true
 // +k8s:openapi-model-package=io.k8s.api.core.v1
-// +k8s:validation-gen=TypeMeta
-// +k8s:validation-gen-input=k8s.io/api/core/v1
 // +groupName=
 
 // Package v1 is the v1 version of the core API.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -522,6 +522,8 @@ message ComponentStatusList {
 message ConfigMap {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+  // +k8s:subfield(name)=+k8s:optional
+  // +k8s:subfield(name)=+k8s:format=k8s-long-name
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7934,7 +7934,6 @@ type ConfigMap struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +k8s:subfield(name)=+k8s:optional
-	// +k8s:subfield(name)=+k8s:format=k8s-long-name
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7933,6 +7933,8 @@ type ConfigMap struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +k8s:subfield(name)=+k8s:optional
+	// +k8s:subfield(name)=+k8s:format=k8s-long-name
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

1. **Updates ConfigMap strategy:**
Modifies the ConfigMap resource's strategy file (pkg/registry/core/configmap/strategy.go) to invoke the newly generated declarative validation in the Validate and ValidateUpdate methods.

2.  **Enables declarative validation testing:**
Adds relevant test file to enable and verify the new declarative validation logic for ConfigMap, ensuring tests cover validation key format, size, duplicates, and immutability.

**Which issue(s) this PR is related to:**
part of https://github.com/kubernetes/kubernetes/issues/134280

**Special notes for your reviewer:**
This PR does not migrate any validations, validation rules migration would be introduced in separate PRs.

**Does this PR introduce a user-facing change?**
No, it only enables the internal declarative validation framework and associated testing for ConfigMap. Existing functionality will remain the same until validation rules are migrated

**Additional documentation, e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

> https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md