### PR TITLE
Helper function to standardize the PCIBusID device attribute for DRA drivers

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/attribute.go
@@ -30,6 +30,13 @@ const (
 	// referring to a PCIe (Peripheral Component Interconnect Express) Root Complex.
 	// This attribute can be used to identify devices that share the same PCIe Root Complex.
 	StandardDeviceAttributePCIeRoot resourceapi.QualifiedName = StandardDeviceAttributePrefix + "pcieRoot"
+
+	// StandardDeviceAttributePCIBusID is a standard device attribute name
+	// which describes the PCI Bus address of the PCI device.
+	// The value is a string value in the extended BDF notation (Domain:Bus:Device.Function),
+	// referring to a PCI (Peripheral Component Interconnect) device.
+	// This attribute can be used to identify PCI devices.
+	StandardDeviceAttributePCIBusID resourceapi.QualifiedName = StandardDeviceAttributePrefix + "pciBusID"
 )
 
 // DeviceAttribute represents a device attribute name and its value

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
@@ -136,6 +136,61 @@ func TestGetPCIeRootAttributePCIBusID(t *testing.T) {
 	}
 }
 
+func TestGetPCIBusIDAttribute(t *testing.T) {
+	pciBusID := "0000:02:00.0"
+	expectedAttribute := DeviceAttribute{
+		Name:  StandardDeviceAttributePCIBusID,
+		Value: resourceapi.DeviceAttribute{StringValue: ptr.To(pciBusID)},
+	}
+
+	tests := map[string]struct {
+		address           string
+		expectedAttribute *DeviceAttribute
+		expectsError      bool
+		expectedErrMsg    string
+	}{
+		"valid": {
+			address:           pciBusID,
+			expectedAttribute: &expectedAttribute,
+			expectsError:      false,
+		},
+		"invalid empty PCI Bus ID": {
+			address:           "",
+			expectedAttribute: nil,
+			expectsError:      true,
+			expectedErrMsg:    "PCI Bus ID cannot be empty",
+		},
+		"invalid PCI Bus ID format": {
+			address:           "invalid-pci-id",
+			expectedAttribute: nil,
+			expectsError:      true,
+			expectedErrMsg:    "invalid PCI Bus ID format: invalid-pci-id",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetPCIBusIDAttribute(test.address)
+			if test.expectsError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if !strings.Contains(err.Error(), test.expectedErrMsg) {
+					t.Errorf("Expected error message to contain %q, got %q", test.expectedErrMsg, err.Error())
+					return
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, *test.expectedAttribute) {
+				t.Errorf("Expected attribute %v, got %v", test.expectedAttribute, got)
+			}
+		})
+	}
+}
+
 func touchFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR introduces a new helper function to standardize the PCI Bus ID attribute for PCI devices so that DRA drivers can publish them in a consistent way. This will provide a reliable mechanism for consumers to request PCI devices.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #134569

KEP: https://github.com/kubernetes/enhancements/issues/4381

KEP update PR: https://github.com/kubernetes/enhancements/pull/5669

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/pull/5669
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
