### PR TITLE
Fix DisableAllocatorDualWrite dependency on MultiCIDRServiceAllocator

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1999,6 +1999,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 //
 // Entries are alphabetized.
 var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]featuregate.Feature{
+	DisableAllocatorDualWrite:                {MultiCIDRServiceAllocator},
 	InPlacePodVerticalScalingAllocatedStatus: {InPlacePodVerticalScaling},
 	InPlacePodVerticalScalingExclusiveCPUs:   {InPlacePodVerticalScaling},
 	InPlacePodVerticalScalingExclusiveMemory: {InPlacePodVerticalScaling, MemoryManager},

--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -45,6 +45,10 @@ import (
 func TestCreateServiceSingleStackIPv4(t *testing.T) {
 	for _, enableMultiServiceCIDR := range []bool{false, true} {
 		for _, disableAllocatorDualWrite := range []bool{false, true} {
+			if !enableMultiServiceCIDR && disableAllocatorDualWrite {
+				// Inavlid configuration: DisableAllocatorDualWrite depends on MultiServiceCIDR
+				continue
+			}
 			t.Run(fmt.Sprintf("MultiServiceCIDR=%v DisableAllocatorDualWrite=%v", enableMultiServiceCIDR, disableAllocatorDualWrite), func(t *testing.T) {
 				// Create an IPv4 single stack control-plane
 				tCtx := ktesting.Init(t)
@@ -292,6 +296,10 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 func TestCreateServiceSingleStackIPv6(t *testing.T) {
 	for _, enableMultiServiceCIDR := range []bool{false, true} {
 		for _, disableAllocatorDualWrite := range []bool{false, true} {
+			if !enableMultiServiceCIDR && disableAllocatorDualWrite {
+				// Inavlid configuration: DisableAllocatorDualWrite depends on MultiServiceCIDR
+				continue
+			}
 			t.Run(fmt.Sprintf("MultiServiceCIDR=%v DisableAllocatorDualWrite=%v", enableMultiServiceCIDR, disableAllocatorDualWrite), func(t *testing.T) {
 				// Create an IPv6 only control-plane
 				tCtx := ktesting.Init(t)
@@ -526,6 +534,10 @@ func TestCreateServiceSingleStackIPv6(t *testing.T) {
 func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 	for _, enableMultiServiceCIDR := range []bool{false, true} {
 		for _, disableAllocatorDualWrite := range []bool{false, true} {
+			if !enableMultiServiceCIDR && disableAllocatorDualWrite {
+				// Inavlid configuration: DisableAllocatorDualWrite depends on MultiServiceCIDR
+				continue
+			}
 			t.Run(fmt.Sprintf("MultiServiceCIDR=%v DisableAllocatorDualWrite=%v", enableMultiServiceCIDR, disableAllocatorDualWrite), func(t *testing.T) {
 				// Create an IPv4IPv6 dual stack control-plane
 				tCtx := ktesting.Init(t)
@@ -808,6 +820,10 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 	for _, enableMultiServiceCIDR := range []bool{false, true} {
 		for _, disableAllocatorDualWrite := range []bool{false, true} {
+			if !enableMultiServiceCIDR && disableAllocatorDualWrite {
+				// Inavlid configuration: DisableAllocatorDualWrite depends on MultiServiceCIDR
+				continue
+			}
 			t.Run(fmt.Sprintf("MultiServiceCIDR=%v DisableAllocatorDualWrite=%v", enableMultiServiceCIDR, disableAllocatorDualWrite), func(t *testing.T) {
 				// Create an IPv6IPv4 dual stack control-plane
 				tCtx := ktesting.Init(t)

--- a/test/integration/servicecidr/allocator_test.go
+++ b/test/integration/servicecidr/allocator_test.go
@@ -61,11 +61,6 @@ func TestServiceAllocation(t *testing.T) {
 			ipAllocatorGate:      true,
 			disableDualWriteGate: true,
 		},
-		{
-			name:                 "disable dual write with bitmap allocator",
-			ipAllocatorGate:      false,
-			disableDualWriteGate: true,
-		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -296,6 +291,9 @@ func TestMigrateService(t *testing.T) {
 // TestSkewedAllocatorsRollback creating an apiserver with the new allocator and
 // later starting an old apiserver with the bitmap allocator.
 func TestSkewedAllocatorsRollback(t *testing.T) {
+	// TODO(#134606): Fix or remove this test.
+	t.Skip("Temporarily disabled: see http://issues.k8s.io/134606")
+
 	svc := func(i int) *v1.Service {
 		return &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -344,7 +342,7 @@ func TestSkewedAllocatorsRollback(t *testing.T) {
 			"--service-cluster-ip-range=10.0.0.0/24",
 			"--disable-admission-plugins=ServiceAccount",
 			"--emulated-version=1.33",
-			fmt.Sprintf("--feature-gates=%s=false,%s=true", features.MultiCIDRServiceAllocator, features.DisableAllocatorDualWrite)},
+			fmt.Sprintf("--feature-gates=%s=false,%s=false", features.MultiCIDRServiceAllocator, features.DisableAllocatorDualWrite)},
 		etcdOptions)
 	defer s2.TearDownFn()
 

--- a/test/integration/servicecidr/feature_enable_disable_test.go
+++ b/test/integration/servicecidr/feature_enable_disable_test.go
@@ -53,7 +53,7 @@ func TestEnableDisableServiceCIDR(t *testing.T) {
 			"--service-cluster-ip-range=10.0.0.0/24",
 			"--disable-admission-plugins=ServiceAccount",
 			"--emulated-version=1.33",
-			fmt.Sprintf("--feature-gates=%s=false", features.MultiCIDRServiceAllocator)},
+			fmt.Sprintf("--feature-gates=%s=false,%s=false", features.MultiCIDRServiceAllocator, features.DisableAllocatorDualWrite)},
 		etcdOptions)
 
 	client1, err := clientset.NewForConfig(s1.ClientConfig)
@@ -115,7 +115,7 @@ func TestEnableDisableServiceCIDR(t *testing.T) {
 			"--service-cluster-ip-range=10.0.0.0/24",
 			"--disable-admission-plugins=ServiceAccount",
 			"--emulated-version=1.33",
-			fmt.Sprintf("--feature-gates=%s=false", features.MultiCIDRServiceAllocator)},
+			fmt.Sprintf("--feature-gates=%s=false,%s=false", features.MultiCIDRServiceAllocator, features.DisableAllocatorDualWrite)},
 		etcdOptions)
 	defer s3.TearDownFn()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Mark `MultiCIDRServiceAllocator` as a feature gate dependency of `DisableAllocatorDualWrite`, and fix the associated integration tests.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/133912

#### Special notes for your reviewer:

This disables the `TestSkewedAllocatorsRollback` test. See https://github.com/kubernetes/kubernetes/issues/134606.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-soon
/assign @aojea 
/cc @liggitt 