### PR TITLE
[go] Bump images, dependencies and versions to go 1.25.3 and distroless iptables

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.35.0-go1.25.1-bullseye.0
+v1.35.0-go1.25.3-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -89,9 +89,9 @@ readonly REMOTE_OUTPUT_BINPATH="${REMOTE_OUTPUT_SUBPATH}/bin"
 readonly REMOTE_OUTPUT_GOPATH="${REMOTE_OUTPUT_SUBPATH}/go"
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.8.2
-readonly __default_go_runner_version=v2.4.0-go1.25.1-bookworm.0
-readonly __default_setcap_version=bookworm-v1.0.4
+readonly __default_distroless_iptables_version=v0.8.4
+readonly __default_go_runner_version=v2.4.0-go1.25.3-bookworm.0
+readonly __default_setcap_version=bookworm-v1.0.6
 
 # The default image for all binaries which are dynamically linked.
 # Includes everything that is required by kube-proxy, which uses it

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -149,7 +149,7 @@ dependencies:
 
   # Base images
   - name: "registry.k8s.io/debian-base: dependents"
-    version: bookworm-v1.0.4
+    version: bookworm-v1.0.6
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -247,7 +247,7 @@ dependencies:
       match: pause\s
 
   - name: "registry.k8s.io/build-image/setcap: dependents"
-    version: bookworm-v1.0.4
+    version: bookworm-v1.0.6
     refPaths:
     - path: build/common.sh
       match: __default_setcap_version=

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -131,7 +131,7 @@ dependencies:
   # should also be updated, but go-runner is much harder to exploit and has
   # far less relevancy to go updates for Kubernetes more generally.
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.35.0-go1.25.1-bullseye.0
+    version: v1.35.0-go1.25.3-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -179,7 +179,7 @@ dependencies:
       match: registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.8.2
+    version: v0.8.4
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=
@@ -187,7 +187,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.4.0-go1.25.1-bookworm.0
+    version: v2.4.0-go1.25.3-bookworm.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -18,7 +18,7 @@ TEMP_DIR:=$(shell mktemp -d)
 VERSION=v9.1.8
 KUBECTL_VERSION?=v1.32.2
 
-BASEIMAGE=registry.k8s.io/build-image/debian-base-$(ARCH):bookworm-v1.0.4
+BASEIMAGE=registry.k8s.io/build-image/debian-base-$(ARCH):bookworm-v1.0.6
 
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3205,7 +3205,7 @@ spec:
   - name: vol
   containers:
   - name: pv-recycler
-    image: registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
+    image: registry.k8s.io/build-image/debian-base:bookworm-v1.0.6
     command:
     - /bin/sh
     args:

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -92,19 +92,19 @@ DOCKERFILE.windows = Dockerfile.windows
 DOCKERFILE := ${DOCKERFILE.${OS}}
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bookworm-v1.0.6
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.4
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.6
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.4
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.4
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.4
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6
 endif
 
 BASE.windows = mcr.microsoft.com/windows/nanoserver

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -997,7 +997,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:    "pv-recycler",
-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.4",
+					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.6",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
 					VolumeMounts: []v1.VolumeMount{

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -33,7 +33,7 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
-BASE_IMAGE_VERSION?=bookworm-v1.0.4
+BASE_IMAGE_VERSION?=bookworm-v1.0.6
 RUNNERIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
 TEMP_DIR:=$(shell mktemp -d -t conformance-XXXXXX)

--- a/test/images/nonroot/BASEIMAGE
+++ b/test/images/nonroot/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.4
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.4
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.4
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.4
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.4
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.6
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.4
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.4
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.4
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.4
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.4
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.6
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.4
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.4
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.4
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.4
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.6
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6

--- a/test/images/regression-issue-74839/BASEIMAGE
+++ b/test/images/regression-issue-74839/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.4
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.4
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.4
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.4
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.4
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.6
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.4
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.4
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.4
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.4
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.4
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.6
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.6
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.6
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.6
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.6
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -225,7 +225,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.8.2"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.8.4"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.5-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.3"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Bump images, dependencies and versions to go 1.25.3 and distroless iptables
- update debian-base and setcap

/assign @liggitt @dims @saschagrunert @puerco 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/4159

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubernetes is now built using Go 1.25.3
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
