### PR TITLE
KEP-4622: promote topology manager `max-allowable-numa-nodes` to GA

### DIFF
--- a/pkg/kubelet/cm/topologymanager/policy_options.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options.go
@@ -32,12 +32,11 @@ const (
 )
 
 var (
-	alphaOptions = sets.New[string]()
-	betaOptions  = sets.New[string](
-		MaxAllowableNUMANodes,
-	)
+	alphaOptions  = sets.New[string]()
+	betaOptions   = sets.New[string]()
 	stableOptions = sets.New[string](
 		PreferClosestNUMANodes,
+		MaxAllowableNUMANodes,
 	)
 )
 

--- a/pkg/kubelet/cm/topologymanager/policy_options_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options_test.go
@@ -60,23 +60,13 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 			},
 		},
 		{
-			description:       "return TopologyManagerOptions with MaxAllowableNUMANodes set to 12",
-			featureGate:       pkgfeatures.TopologyManagerPolicyBetaOptions,
-			featureGateEnable: true,
+			description: "return TopologyManagerOptions with MaxAllowableNUMANodes set to 12",
 			expectedOptions: PolicyOptions{
 				MaxAllowableNUMANodes: 12,
 			},
 			policyOptions: map[string]string{
 				MaxAllowableNUMANodes: "12",
 			},
-		},
-		{
-			description: "fail to set option when TopologyManagerPolicyBetaOptions feature gate is not set",
-			featureGate: pkgfeatures.TopologyManagerPolicyBetaOptions,
-			policyOptions: map[string]string{
-				MaxAllowableNUMANodes: "8",
-			},
-			expectedErr: fmt.Errorf("topology manager policy beta-level options not enabled,"),
 		},
 		{
 			description: "return empty TopologyManagerOptions",
@@ -93,9 +83,7 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 			expectedErr: fmt.Errorf("bad value for option"),
 		},
 		{
-			description:       "fail to parse options with error MaxAllowableNUMANodes",
-			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
-			featureGateEnable: true,
+			description: "fail to parse options with error MaxAllowableNUMANodes",
 			policyOptions: map[string]string{
 				MaxAllowableNUMANodes: "can't parse to int",
 			},
@@ -219,6 +207,18 @@ func TestPolicyOptionsAvailable(t *testing.T) {
 		},
 		{
 			option:            PreferClosestNUMANodes,
+			featureGate:       pkgfeatures.TopologyManagerPolicyBetaOptions,
+			featureGateEnable: false,
+			expectedAvailable: true,
+		},
+		{
+			option:            PreferClosestNUMANodes,
+			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
+			featureGateEnable: false,
+			expectedAvailable: true,
+		},
+		{
+			option:            MaxAllowableNUMANodes,
 			featureGate:       pkgfeatures.TopologyManagerPolicyBetaOptions,
 			featureGateEnable: false,
 			expectedAvailable: true,

--- a/pkg/kubelet/cm/topologymanager/policy_options_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -141,8 +142,8 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 		},
 	}
 
-	betaOptions.Insert(fancyBetaOption)
-	alphaOptions.Insert(fancyAlphaOption)
+	setTopologyManagerOptionsDuringTest(t, betaOptions, fancyBetaOption)
+	setTopologyManagerOptionsDuringTest(t, alphaOptions, fancyAlphaOption)
 
 	logger, _ := ktesting.NewTestContext(t)
 
@@ -164,6 +165,14 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setTopologyManagerOptionsDuringTest(t *testing.T, optionGroup sets.Set[string], opts ...string) {
+	t.Helper()
+	t.Cleanup(func() {
+		optionGroup.Delete(opts...)
+	})
+	optionGroup.Insert(opts...)
 }
 
 func TestPolicyDefaultsAvailable(t *testing.T) {
@@ -243,8 +252,8 @@ func TestPolicyOptionsAvailable(t *testing.T) {
 			expectedAvailable: false,
 		},
 	}
-	betaOptions.Insert(fancyBetaOption)
-	alphaOptions.Insert(fancyAlphaOption)
+	setTopologyManagerOptionsDuringTest(t, betaOptions, fancyBetaOption)
+	setTopologyManagerOptionsDuringTest(t, alphaOptions, fancyAlphaOption)
 	for _, testCase := range testCases {
 		t.Run(testCase.option, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, testCase.featureGate, testCase.featureGateEnable)

--- a/pkg/kubelet/cm/topologymanager/policy_options_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options_test.go
@@ -154,7 +154,9 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 			}
 			opts, err := NewPolicyOptions(logger, tcase.policyOptions)
 			if tcase.expectedErr != nil {
-				if !strings.Contains(err.Error(), tcase.expectedErr.Error()) {
+				if err == nil {
+					t.Errorf("expected error %v, got no error", tcase.expectedErr)
+				} else if !strings.Contains(err.Error(), tcase.expectedErr.Error()) {
 					t.Errorf("Unexpected error message. Have: %s, wants %s", err.Error(), tcase.expectedErr.Error())
 				}
 				return


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
part of the GA graduation.
This KEP is a quite trivial one needed to quickly unblock a limitation.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/4622

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
Promote the Topology Manager policy option max-allowable-numa-nodes to GA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4622
```
