### PR TITLE
build: build by running kube-cross directly should leverage a potential KUBE_GIT_VERSION_FILE

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -489,6 +489,12 @@ function kube::build::run_build_command_ex() {
     docker_run_opts+=(--cgroup-parent "${DOCKER_CGROUP_PARENT}")
   fi
 
+  if [[ -n "${KUBE_GIT_VERSION_FILE:-}" ]]; then
+    kube::version::get_version_vars
+    kube::version::save_version_vars "${KUBE_ROOT}/.dockerized-kube-version-defs"
+    docker_run_opts+=(--env 'KUBE_GIT_VERSION_FILE=/go/src/k8s.io/kubernetes/.dockerized-kube-version-defs')
+  fi
+
   # If we have stdin we can run interactive.  This allows things like 'shell.sh'
   # to work.  However, if we run this way and don't have stdin, then it ends up
   # running in a daemon-ish mode.  So if we don't have a stdin, we explicitly

--- a/build/common.sh
+++ b/build/common.sh
@@ -61,6 +61,8 @@ KUBE_CROSS_IMAGE="${KUBE_CROSS_IMAGE:-"${KUBE_BASE_IMAGE_REGISTRY}/kube-cross"}"
 readonly KUBE_CROSS_IMAGE
 KUBE_CROSS_VERSION="${KUBE_CROSS_VERSION:-"${KUBE_BUILD_IMAGE_CROSS_TAG}"}"
 readonly KUBE_CROSS_VERSION
+KUBE_CROSS_CONTAINER_ROOT="/go/src/k8s.io/kubernetes"
+readonly KUBE_CROSS_CONTAINER_ROOT
 
 # Here we map the output directories across both the local and remote _output
 # directories:
@@ -462,10 +464,10 @@ function kube::build::run_build_command_ex() {
     --env "GOGCFLAGS=${GOGCFLAGS:-}"
     --env "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-}"
     # mount source code / output dir
-    --volume "${KUBE_ROOT}:/go/src/k8s.io/kubernetes"
+    --volume "${KUBE_ROOT}:${KUBE_CROSS_CONTAINER_ROOT}"
     # env migrated from build-image, we could consider setting this in kube-cross
     --env 'KUBE_OUTPUT_SUBPATH=_output/dockerized'
-    --workdir /go/src/k8s.io/kubernetes
+    --workdir "${KUBE_CROSS_CONTAINER_ROOT}"
     --env 'GIT_AUTHOR_EMAIL=nobody@k8s.io'
     --env 'GIT_AUTHOR_NAME=kube-build-image'
   )
@@ -489,10 +491,10 @@ function kube::build::run_build_command_ex() {
     docker_run_opts+=(--cgroup-parent "${DOCKER_CGROUP_PARENT}")
   fi
 
+  # copy KUBE_GIT_VERSION_FILE to .dockerized-kube-version-defs and set environment variable.
   if [[ -n "${KUBE_GIT_VERSION_FILE:-}" ]]; then
-    kube::version::get_version_vars
-    kube::version::save_version_vars "${KUBE_ROOT}/.dockerized-kube-version-defs"
-    docker_run_opts+=(--env 'KUBE_GIT_VERSION_FILE=/go/src/k8s.io/kubernetes/.dockerized-kube-version-defs')
+    cp "${KUBE_GIT_VERSION_FILE}" "${KUBE_ROOT}/.dockerized-kube-version-defs"
+    docker_run_opts+=(--env "KUBE_GIT_VERSION_FILE=${KUBE_CROSS_CONTAINER_ROOT}/.dockerized-kube-version-defs")
   fi
 
   # If we have stdin we can run interactive.  This allows things like 'shell.sh'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

Not sure if it should be called a regression.

#### What this PR does / why we need it:

Since #134510 got merged, building using `kind build node-image` from source results in ignoring build variables set via `KUBE_GIT_VERSION_FILE`.

This PR writes them to KUBE_ROOT and sets it inside the kube-cross container.

#### Which issue(s) this PR is related to:

We hit an issue since this PR merged https://github.com/kubernetes/kubernetes/pull/134510 that our built node images resulted in showing a version with `-dirty` suffix.

In CAPI we create kind images using e.g. `kind build node-image --image "kindest/node:v1.35.0-alpha.1.149_e21082468a3b49`. 

Before that we checkout the relevant branch, set the env var `KUBE_GIT_VERSION_FILE`  to point to a custom file named `build-version` in the root of the k/k folder to overwrite the following:

```
export KUBE_GIT_MAJOR=1
export KUBE_GIT_MINOR=35
export KUBE_GIT_VERSION=v1.35.0-alpha.1.149+e21082468a3b49
export KUBE_GIT_TREE_STATE=clean
```

Since the build now happens inside the kube-cross, especially when compiling the kubelet, this information is not passed in.

Because we created the `build-version` file (value for `KUBE_GIT_VERSION_FILE` ) inside the root of the checked out k/k repo, we get a `KUBE_GIT_TREE_STATE=dirty` , and nodes created with that image report a version of *-dirty  instead of using the provided build information.

cc @BenTheElder @dims (because I think you both engaged on the PR which introduced the change)

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
