### PR TITLE
use relative symlink for output path

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -661,7 +661,7 @@ kube::golang::place_bins() {
       platform_src=""
       rm -f "${THIS_PLATFORM_BIN}"
       mkdir -p "$(dirname "${THIS_PLATFORM_BIN}")"
-      ln -s "${KUBE_OUTPUT_BIN}/${platform}" "${THIS_PLATFORM_BIN}"
+      ln -s "../${_KUBE_OUTPUT_SUBPATH}/${_KUBE_OUTPUT_BIN_SUBPATH}/${platform}" "${THIS_PLATFORM_BIN}"
     fi
 
     V=3 kube::log::status "Placing binaries for ${platform} in ${KUBE_OUTPUT_BIN}/${platform}"

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -41,7 +41,8 @@ KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 # If it is specified, we'll use it in KUBE_OUTPUT.
 _KUBE_OUTPUT_SUBPATH="${KUBE_OUTPUT_SUBPATH:-_output/local}"
 export KUBE_OUTPUT="${KUBE_ROOT}/${_KUBE_OUTPUT_SUBPATH}"
-export KUBE_OUTPUT_BIN="${KUBE_OUTPUT}/bin"
+readonly _KUBE_OUTPUT_BIN_SUBPATH="bin"
+export KUBE_OUTPUT_BIN="${KUBE_OUTPUT}/${_KUBE_OUTPUT_BIN_SUBPATH}"
 export THIS_PLATFORM_BIN="${KUBE_ROOT}/_output/bin"
 
 # This controls rsync compression. Set to a value > 0 to enable rsync


### PR DESCRIPTION
resolves issues with creating symlinks inside the build container via bind mount instead of rsync-ing them out

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Ensures that we correctly set a valid symlink for `_output/bin` regardless of if the path is from the host or within the build container, following https://github.com/kubernetes/kubernetes/pull/134510

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/134622

#### Special notes for your reviewer:

Relative symlinks are resolved relative to the target linkfile itself, so we produce:

```console
# Build dockerized
$ build/run/sh make WHAT=ginkgo
<snip>

$ ls -la _output/bin
lrwxr-xr-x  1 bentheelder  primarygroup  37 Oct 15 13:11 _output/bin -> ../_output/dockerized/bin/linux/arm64

$ ls _output/bin/
ginkgo

# Build on host
$ make WHAT=ginkgo
<snip>

$ ls -la _output/bin
lrwxr-xr-x@ 1 bentheelder  primarygroup  33 Oct 15 13:17 _output/bin -> ../_output/local/bin/darwin/arm64

$ ls _output/bin/
ginkgo
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
