### PR TITLE
Promote ContainerRestartRules to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1128,6 +1128,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	ContainerRestartRules: {
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	ContainerStopSignals: {

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -63,6 +63,36 @@ func getTestRunningStatusWithStarted(started bool) v1.PodStatus {
 	return podStatus
 }
 
+func getTestRunningStatusWithFailedContainer() v1.PodStatus {
+	return v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{{
+			Name:        testContainerName,
+			ContainerID: testContainerID.String(),
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{
+					ExitCode: 1,
+				},
+			},
+		}},
+	}
+}
+
+func getTestRunningStatusWithSucceededContainer() v1.PodStatus {
+	return v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{{
+			Name:        testContainerName,
+			ContainerID: testContainerID.String(),
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{
+					ExitCode: 0,
+				},
+			},
+		}},
+	}
+}
+
 func getTestPod() *v1.Pod {
 	container := v1.Container{
 		Name: testContainerName,

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -270,7 +270,10 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 
 		// Abort if the container will not be restarted.
 		if utilfeature.DefaultFeatureGate.Enabled(features.ContainerRestartRules) {
-			return c.State.Terminated != nil || podutil.IsContainerRestartable(w.pod.Spec, w.container)
+			if c.State.Terminated == nil {
+				return true
+			}
+			return podutil.ContainerShouldRestart(w.container, w.pod.Spec, c.State.Terminated.ExitCode)
 		}
 		return c.State.Terminated == nil ||
 			w.pod.Spec.RestartPolicy != v1.RestartPolicyNever ||

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -263,6 +263,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.34"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.35"
 - name: ContainerStopSignals
   versionedSpecs:
   - default: false


### PR DESCRIPTION
Fix prober not running properly with containerRestartRules and add unit test coverage

#### What type of PR is this?

/kind feature
/kind bug

#### What this PR does / why we need it:

Promotes ContainerRestartRules to beta.

Fix a probe bug behind the feature gate. The bug caused probes to keep running even if the container has terminated and is not restartable. 

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5307

#### Special notes for your reviewer:

Promoting ContainerRestartRules to beta

#### Does this PR introduce a user-facing change?

```release-note
Enable the feature gate `ContainerRestartRules` by default. The ContainerRestartRules feature is promoted to beta. Fixing a bug in this feature that caused probes continue to run even if the container has terminated and is not restartable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5307
- [Usage]: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-restart-rules
```
