### PR TITLE
Enable external VolumeGroupSnapshot tests

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -126,6 +126,29 @@ type driverDefinition struct {
 		FromExistingClassName string
 	}
 
+	// GroupSnapshotClass must be set to enable groupsnapshotting tests.
+	// The default is to not run those tests.
+	GroupSnapshotClass struct {
+		// FromName set to true enables the usage of a
+		// groupsnapshotter class with DriverInfo.Name as provisioner.
+		FromName bool
+
+		// FromFile is used only when FromName is false.  It
+		// loads a groupsnapshot class from the given .yaml or .json
+		// file. File names are resolved by the
+		// framework.testfiles package, which typically means
+		// that they can be absolute or relative to the test
+		// suite's --repo-root parameter.
+		//
+		// This can be used when the groupsnapshot class is meant to have
+		// additional parameters.
+		FromFile string
+
+		// FromExistingClassName specifies the name of a pre-installed
+		// GroupSnapshotClass that will be copied and used for the tests.
+		FromExistingClassName string
+	}
+
 	// InlineVolumes defines one or more volumes for use as inline
 	// ephemeral volumes. At least one such volume has to be
 	// defined to enable testing of inline ephemeral volumes.  If
@@ -392,6 +415,20 @@ func loadSnapshotClass(filename string) (*unstructured.Unstructured, error) {
 	return snapshotClass, nil
 }
 
+func loadGroupSnapshotClass(filename string) (*unstructured.Unstructured, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	groupSnapshotClass := &unstructured.Unstructured{}
+
+	if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), data, groupSnapshotClass); err != nil {
+		return nil, fmt.Errorf("%s: %w", filename, err)
+	}
+
+	return groupSnapshotClass, nil
+}
+
 func (d *driverDefinition) GetSnapshotClass(ctx context.Context, e2econfig *storageframework.PerTestConfig, parameters map[string]string) *unstructured.Unstructured {
 	if !d.SnapshotClass.FromName && d.SnapshotClass.FromFile == "" && d.SnapshotClass.FromExistingClassName == "" {
 		e2eskipper.Skipf("Driver %q does not support snapshotting - skipping", d.DriverInfo.Name)
@@ -433,6 +470,49 @@ func (d *driverDefinition) GetSnapshotClass(ctx context.Context, e2econfig *stor
 	}
 
 	return utils.GenerateSnapshotClassSpec(snapshotter, parameters, ns)
+}
+
+func (d *driverDefinition) GetVolumeGroupSnapshotClass(ctx context.Context, e2econfig *storageframework.PerTestConfig, parameters map[string]string) *unstructured.Unstructured {
+	if !d.GroupSnapshotClass.FromName && d.GroupSnapshotClass.FromFile == "" && d.GroupSnapshotClass.FromExistingClassName == "" {
+		e2eskipper.Skipf("Driver %q does not support groupsnapshotting - skipping", d.DriverInfo.Name)
+	}
+
+	f := e2econfig.Framework
+	snapshotter := d.DriverInfo.Name
+	ns := e2econfig.Framework.Namespace.Name
+
+	switch {
+	case d.GroupSnapshotClass.FromName:
+		// Do nothing (just use empty parameters)
+	case d.GroupSnapshotClass.FromExistingClassName != "":
+		groupSnapshotClass, err := f.DynamicClient.Resource(utils.VolumeGroupSnapshotClassGVR).Get(ctx, d.GroupSnapshotClass.FromExistingClassName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "getting snapshot class %s", d.SnapshotClass.FromExistingClassName)
+
+		if params, ok := groupSnapshotClass.Object["parameters"].(map[string]interface{}); ok {
+			for k, v := range params {
+				parameters[k] = v.(string)
+			}
+		}
+
+		if snapshotProvider, ok := groupSnapshotClass.Object["driver"]; ok {
+			snapshotter = snapshotProvider.(string)
+		}
+	case d.GroupSnapshotClass.FromFile != "":
+		groupSnapshotClass, err := loadGroupSnapshotClass(d.GroupSnapshotClass.FromFile)
+		framework.ExpectNoError(err, "load groupsnapshot class from %s", d.GroupSnapshotClass.FromFile)
+
+		if params, ok := groupSnapshotClass.Object["parameters"].(map[string]interface{}); ok {
+			for k, v := range params {
+				parameters[k] = v.(string)
+			}
+		}
+
+		if snapshotProvider, ok := groupSnapshotClass.Object["driver"]; ok {
+			snapshotter = snapshotProvider.(string)
+		}
+	}
+
+	return utils.GenerateVolumeGroupSnapshotClassSpec(snapshotter, parameters, ns)
 }
 
 func (d *driverDefinition) GetVolumeAttributesClass(ctx context.Context, e2econfig *storageframework.PerTestConfig) *storagev1.VolumeAttributesClass {

--- a/test/e2e/storage/external/testdata/example.yaml
+++ b/test/e2e/storage/external/testdata/example.yaml
@@ -2,6 +2,9 @@ StorageClass:
   FromExistingClassName: example
 VolumeAttributesClass:
   FromExistingClassName: example-vac
+GroupSnapshotClass:
+  FromExistingClassName: example-gsc
+
 DriverInfo:
   Name: example
   RequiredAccessModes:
@@ -12,6 +15,7 @@ DriverInfo:
     exec: true
     block: true
     fsGroup: true
+    groupSnapshot: true
     topology: true
     controllerExpansion: true
     nodeExpansion: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Enable external CSI tests for the VolumeGroupSnapshot feature.

#### Special notes for your reviewer:
- To test the external tests, I tested against a cluster with the `hostpath.csi.k8s.io` installed:

<details>
<summary>&nbsp;&nbsp;&nbsp;&nbsp;<b>Click to Expand/Collapse Test Logs</b></summary>

```console
$ ginkgo --timeout=1h -v -focus='External.Storage.*\[Feature:volumegroupsnapshot\]' -skip='\[Serial\]|\[Disruptive\]|\[Feature:SELinux\]' ./_output/bin/e2e.test -- -provider=skeleton -kubeconfig=$HOME/.kube/config-kind -num-nodes=2 -storage.testdriver=$HOME/Downloads/testdriver.yaml
 I1016 11:23:44.758793 62997 external.go:217] Driver loaded from path [/Users/wangpenghao/Downloads/testdriver.yaml]: &{DriverInfo:{Name:hostpath.csi.k8s.io InTreePluginName: TestTags:[] MaxFileSize:0 SupportedSizeRange:{Max: Min:1Mi} SupportedFsType:map[:{}] SupportedMountOption:map[] RequiredMountOption:map[] Capabilities:map[FSResizeFromSourceNotSupported:true block:true controllerExpansion:true exec:true groupSnapshot:true multipods:true nodeExpansion:true offlineExpansion:true onlineExpansion:true persistence:true singleNodeVolume:true snapshotDataSource:true topology:true] RequiredAccessModes:[] TopologyKeys:[] NumAllowedTopologies:0 StressTestOptions:<nil> VolumeSnapshotStressTestOptions:<nil> VolumeModifyStressTestOptions:<nil> PerformanceTestOptions:<nil>} StorageClass:{FromName:true FromFile: FromExistingClassName:} VolumeAttributesClass:{FromName:false FromFile: FromExistingClassName:} SnapshotClass:{FromName:true FromFile: FromExistingClassName:} GroupSnapshotClass:{FromName:true FromFile: FromExistingClassName:} InlineVolumes:[] ClientNodeName: NodeSelectors:map[] Timeouts:map[]}
  I1016 11:23:44.931145   62997 e2e.go:109] Starting e2e run "09f25d65-ab5f-4aed-a8fb-f8c27e0860f0" on Ginkgo node 1
Running Suite: Kubernetes e2e suite - /Users/wangpenghao/Upstream/kubernetes/_output/bin
========================================================================================
Random Seed: 1760585024 - will randomize all specs

Will run 2 of 7512 specs
------------------------------
[ReportBeforeSuite] 
k8s.io/kubernetes/test/e2e/e2e_test.go:154
[ReportBeforeSuite] PASSED [0.000 seconds]
------------------------------
[SynchronizedBeforeSuite] 
k8s.io/kubernetes/test/e2e/e2e.go:69
  I1016 11:23:45.008234 62997 util.go:414] >>> kubeConfig: /Users/wangpenghao/.kube/config-kind
  I1016 11:23:45.009650 62997 helper.go:51] Waiting up to 30m0s for all (but 0) nodes to be schedulable
  I1016 11:23:45.053064 62997 e2e.go:142] Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
  I1016 11:23:45.055834 62997 e2e.go:153] 3 / 3 pods ready in namespace 'kube-system' in daemonset 'kindnet' (0 seconds elapsed)
  I1016 11:23:45.055853 62997 e2e.go:153] 3 / 3 pods ready in namespace 'kube-system' in daemonset 'kube-proxy' (0 seconds elapsed)
  I1016 11:23:45.055862 62997 e2e.go:245] e2e test version: v1.35.0-alpha.1.177+78830afba89f67
  I1016 11:23:45.057185 62997 e2e.go:254] kube-apiserver version: v1.35.0-alpha.0.616+4a843fca6f3f2c-dirty
  I1016 11:23:45.057223 62997 util.go:414] >>> kubeConfig: /Users/wangpenghao/.kube/config-kind
  I1016 11:23:45.060258 62997 e2e.go:383] Cluster IP family: ipv4
[SynchronizedBeforeSuite] PASSED [0.052 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
External Storage [Driver: hostpath.csi.k8s.io] [Testpattern:  (delete policy)] volumegroupsnapshottable [Feature:volumegroupsnapshot] VolumeGroupSnapshottable  should create snapshots for multiple volumes in a pod [Feature:volumegroupsnapshot]
k8s.io/kubernetes/test/e2e/storage/testsuites/volume_group_snapshottable.go:173
  STEP: Creating a kubernetes client @ 10/16/25 11:23:45.109
  I1016 11:23:45.109694 62997 util.go:414] >>> kubeConfig: /Users/wangpenghao/.kube/config-kind
  STEP: Building a namespace api object, basename volumegroupsnapshottable @ 10/16/25 11:23:45.11
  STEP: Waiting for a default service account to be provisioned in namespace @ 10/16/25 11:23:45.134
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 10/16/25 11:23:45.135
  I1016 11:23:45.137282 62997 volume_group_snapshottable.go:125] Creating resources for pod 0/0
  I1016 11:23:45.137302 62997 volume_resource.go:98] Creating resource for dynamic PV
  I1016 11:23:45.137344 62997 volume_resource.go:104] Using claimSize:1Mi, test suite supported size:{ 1Mi}, driver(hostpath.csi.k8s.io) supported size:{ 1Mi} 
  STEP: creating a StorageClass volumegroupsnapshottable-4462-e2e-scfxmw7 @ 10/16/25 11:23:45.137
  STEP: creating a claim @ 10/16/25 11:23:45.139
  I1016 11:23:45.139507 62997 pv.go:646] Warning: Making PVC: VolumeMode specified as invalid empty string, treating as nil
  I1016 11:23:45.142388 62997 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [hostpath.csi.k8s.iovvkfx] to have phase Bound
  I1016 11:23:45.144769 62997 pv.go:806] PersistentVolumeClaim hostpath.csi.k8s.iovvkfx found but phase is Pending instead of Bound.
  I1016 11:23:47.152914 62997 pv.go:801] PersistentVolumeClaim hostpath.csi.k8s.iovvkfx found and phase=Bound (2.010502458s)
  I1016 11:23:47.169638 62997 volume_resource.go:98] Creating resource for dynamic PV
  I1016 11:23:47.169736 62997 volume_resource.go:104] Using claimSize:1Mi, test suite supported size:{ 1Mi}, driver(hostpath.csi.k8s.io) supported size:{ 1Mi} 
  STEP: creating a StorageClass volumegroupsnapshottable-4462-e2e-scd7r6c @ 10/16/25 11:23:47.169
  STEP: creating a claim @ 10/16/25 11:23:47.175
  I1016 11:23:47.175172 62997 pv.go:646] Warning: Making PVC: VolumeMode specified as invalid empty string, treating as nil
  I1016 11:23:47.181530 62997 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [hostpath.csi.k8s.iomtc6r] to have phase Bound
  I1016 11:23:47.184500 62997 pv.go:806] PersistentVolumeClaim hostpath.csi.k8s.iomtc6r found but phase is Pending instead of Bound.
  I1016 11:23:49.190608 62997 pv.go:801] PersistentVolumeClaim hostpath.csi.k8s.iomtc6r found and phase=Bound (2.008953459s)
  I1016 11:23:49.208508 62997 volume_resource.go:98] Creating resource for dynamic PV
  I1016 11:23:49.208634 62997 volume_resource.go:104] Using claimSize:1Mi, test suite supported size:{ 1Mi}, driver(hostpath.csi.k8s.io) supported size:{ 1Mi} 
  STEP: creating a StorageClass volumegroupsnapshottable-4462-e2e-scxl2n5 @ 10/16/25 11:23:49.208
  STEP: creating a claim @ 10/16/25 11:23:49.213
  I1016 11:23:49.213566 62997 pv.go:646] Warning: Making PVC: VolumeMode specified as invalid empty string, treating as nil
  I1016 11:23:49.217296 62997 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [hostpath.csi.k8s.io56p7w] to have phase Bound
  I1016 11:23:49.219327 62997 pv.go:806] PersistentVolumeClaim hostpath.csi.k8s.io56p7w found but phase is Pending instead of Bound.
  I1016 11:23:51.228168 62997 pv.go:801] PersistentVolumeClaim hostpath.csi.k8s.io56p7w found and phase=Bound (2.01080775s)
  STEP: creating a VolumeGroupSnapshotClass @ 10/16/25 11:23:57.291
  STEP: creating a dynamic VolumeGroupSnapshot @ 10/16/25 11:23:57.302
  STEP: Waiting for group snapshot to be ready @ 10/16/25 11:23:57.308
  I1016 11:23:57.308593 62997 volume_group_snapshot.go:50] Waiting up to 50m0s for VolumeGroupSnapshot group-snapshot-kxfg2 to become ready
  I1016 11:23:57.311644 62997 volume_group_snapshot.go:61] VolumeGroupSnapshot group-snapshot-kxfg2 found but is not ready.
  I1016 11:23:59.320298 62997 volume_group_snapshot.go:70] VolumeSnapshot group-snapshot-kxfg2 found but is not ready.
  I1016 11:24:01.330802 62997 volume_group_snapshot.go:70] VolumeSnapshot group-snapshot-kxfg2 found but is not ready.
  I1016 11:24:03.339046 62997 volume_group_snapshot.go:70] VolumeSnapshot group-snapshot-kxfg2 found but is not ready.
  I1016 11:24:05.346184 62997 volume_group_snapshot.go:70] VolumeSnapshot group-snapshot-kxfg2 found but is not ready.
  I1016 11:24:07.355034 62997 volume_group_snapshot.go:66] VolumeSnapshot group-snapshot-kxfg2 found and is ready
  I1016 11:24:07.355268 62997 utils.go:695] WaitUntil finished successfully after 10.046558s
  STEP: Getting group snapshot and content @ 10/16/25 11:24:07.355
  STEP: verifying the snapshots in the group are ready to use @ 10/16/25 11:24:07.363
  I1016 11:24:39.568428 62997 delete.go:78] Deleting pod "snapshot-pod-2q4fd" in namespace "volumegroupsnapshottable-4462"
  I1016 11:24:39.586676 62997 delete.go:86] Wait up to 5m0s for pod "snapshot-pod-2q4fd" to be fully deleted
  I1016 11:25:11.707402 62997 delete.go:78] Deleting pod "snapshot-pod-gn7pb" in namespace "volumegroupsnapshottable-4462"
  I1016 11:25:11.721988 62997 delete.go:86] Wait up to 5m0s for pod "snapshot-pod-gn7pb" to be fully deleted
  I1016 11:25:43.857196 62997 delete.go:78] Deleting pod "snapshot-pod-c5b5n" in namespace "volumegroupsnapshottable-4462"
  I1016 11:25:43.867978 62997 delete.go:86] Wait up to 5m0s for pod "snapshot-pod-c5b5n" to be fully deleted
  I1016 11:26:16.003032 62997 volume_group_snapshottable.go:159] Deleting pod pod-4156e2be-3029-4b75-b243-71dd1d8996c2
  I1016 11:26:16.003100 62997 delete.go:78] Deleting pod "pod-4156e2be-3029-4b75-b243-71dd1d8996c2" in namespace "volumegroupsnapshottable-4462"
  I1016 11:26:16.012542 62997 delete.go:86] Wait up to 5m0s for pod "pod-4156e2be-3029-4b75-b243-71dd1d8996c2" to be fully deleted
  I1016 11:26:18.026215 62997 volume_group_snapshottable.go:165] Deleting volume hostpath.csi.k8s.iovvkfx
  STEP: Deleting pvc @ 10/16/25 11:26:18.026
  I1016 11:26:18.026344 62997 pv.go:205] Deleting PersistentVolumeClaim "hostpath.csi.k8s.iovvkfx"
  I1016 11:26:18.034551 62997 pv.go:863] Waiting up to 20m0s for PersistentVolume pvc-5260c535-350e-49b2-b669-ac552d15717f to get deleted
  I1016 11:26:18.041350 62997 pv.go:867] PersistentVolume pvc-5260c535-350e-49b2-b669-ac552d15717f found and phase=Bound (6.730584ms)
  I1016 11:26:23.050276 62997 pv.go:871] PersistentVolume pvc-5260c535-350e-49b2-b669-ac552d15717f was removed
  STEP: Deleting sc @ 10/16/25 11:26:23.05
  I1016 11:26:23.059308 62997 volume_group_snapshottable.go:165] Deleting volume hostpath.csi.k8s.iomtc6r
  STEP: Deleting pvc @ 10/16/25 11:26:23.059
  I1016 11:26:23.059644 62997 pv.go:205] Deleting PersistentVolumeClaim "hostpath.csi.k8s.iomtc6r"
  I1016 11:26:23.068285 62997 pv.go:863] Waiting up to 20m0s for PersistentVolume pvc-cee1f40a-2816-45ce-b67a-7e7182cfdeb6 to get deleted
  I1016 11:26:23.072471 62997 pv.go:867] PersistentVolume pvc-cee1f40a-2816-45ce-b67a-7e7182cfdeb6 found and phase=Bound (3.9685ms)
  I1016 11:26:28.081081 62997 pv.go:871] PersistentVolume pvc-cee1f40a-2816-45ce-b67a-7e7182cfdeb6 was removed
  STEP: Deleting sc @ 10/16/25 11:26:28.081
  I1016 11:26:28.092566 62997 volume_group_snapshottable.go:165] Deleting volume hostpath.csi.k8s.io56p7w
  STEP: Deleting pvc @ 10/16/25 11:26:28.092
  I1016 11:26:28.092791 62997 pv.go:205] Deleting PersistentVolumeClaim "hostpath.csi.k8s.io56p7w"
  I1016 11:26:28.099971 62997 pv.go:863] Waiting up to 20m0s for PersistentVolume pvc-10dc49c9-3635-4caa-a2e4-1afc10c3805b to get deleted
  I1016 11:26:28.103667 62997 pv.go:867] PersistentVolume pvc-10dc49c9-3635-4caa-a2e4-1afc10c3805b found and phase=Bound (3.561708ms)
  I1016 11:26:33.111512 62997 pv.go:871] PersistentVolume pvc-10dc49c9-3635-4caa-a2e4-1afc10c3805b was removed
  STEP: Deleting sc @ 10/16/25 11:26:33.111
  I1016 11:26:33.118697 62997 helper.go:125] Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "volumegroupsnapshottable-4462" for this suite. @ 10/16/25 11:26:33.124
• [168.023 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
External Storage [Driver: hostpath.csi.k8s.io] [Testpattern:  (delete policy)] volumegroupsnapshottable [Feature:volumegroupsnapshot] VolumeGroupSnapshottable  should create snapshots for multiple volumes in a pod [Feature:volumegroupsnapshot]
k8s.io/kubernetes/test/e2e/storage/testsuites/volume_group_snapshottable.go:173
  STEP: Creating a kubernetes client @ 10/16/25 11:26:33.148
  I1016 11:26:33.148412 62997 util.go:414] >>> kubeConfig: /Users/wangpenghao/.kube/config-kind
  STEP: Building a namespace api object, basename volumegroupsnapshottable @ 10/16/25 11:26:33.149
  STEP: Waiting for a default service account to be provisioned in namespace @ 10/16/25 11:26:33.158
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 10/16/25 11:26:33.16
  I1016 11:26:33.162528 62997 volume_group_snapshottable.go:125] Creating resources for pod 0/0
  I1016 11:26:33.162553 62997 volume_resource.go:98] Creating resource for dynamic PV
  I1016 11:26:33.162587 62997 volume_resource.go:104] Using claimSize:1Mi, test suite supported size:{ 1Mi}, driver(hostpath.csi.k8s.io) supported size:{ 1Mi} 
  STEP: creating a StorageClass volumegroupsnapshottable-8910-e2e-scwlgl4 @ 10/16/25 11:26:33.162
  STEP: creating a claim @ 10/16/25 11:26:33.164
  I1016 11:26:33.164602 62997 pv.go:646] Warning: Making PVC: VolumeMode specified as invalid empty string, treating as nil
  I1016 11:26:33.167916 62997 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [hostpath.csi.k8s.io2j6cb] to have phase Bound
  I1016 11:26:33.169586 62997 pv.go:806] PersistentVolumeClaim hostpath.csi.k8s.io2j6cb found but phase is Pending instead of Bound.
  I1016 11:26:35.175117 62997 pv.go:801] PersistentVolumeClaim hostpath.csi.k8s.io2j6cb found and phase=Bound (2.007162375s)
  I1016 11:26:35.189028 62997 volume_resource.go:98] Creating resource for dynamic PV
  I1016 11:26:35.189175 62997 volume_resource.go:104] Using claimSize:1Mi, test suite supported size:{ 1Mi}, driver(hostpath.csi.k8s.io) supported size:{ 1Mi} 
  STEP: creating a StorageClass volumegroupsnapshottable-8910-e2e-sc2q8j2 @ 10/16/25 11:26:35.189
  STEP: creating a claim @ 10/16/25 11:26:35.192
  I1016 11:26:35.193009 62997 pv.go:646] Warning: Making PVC: VolumeMode specified as invalid empty string, treating as nil
  I1016 11:26:35.196372 62997 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [hostpath.csi.k8s.io28zcl] to have phase Bound
  I1016 11:26:35.198072 62997 pv.go:806] PersistentVolumeClaim hostpath.csi.k8s.io28zcl found but phase is Pending instead of Bound.
  I1016 11:26:37.208761 62997 pv.go:801] PersistentVolumeClaim hostpath.csi.k8s.io28zcl found and phase=Bound (2.0123445s)
  I1016 11:26:37.233010 62997 volume_resource.go:98] Creating resource for dynamic PV
  I1016 11:26:37.233240 62997 volume_resource.go:104] Using claimSize:1Mi, test suite supported size:{ 1Mi}, driver(hostpath.csi.k8s.io) supported size:{ 1Mi} 
  STEP: creating a StorageClass volumegroupsnapshottable-8910-e2e-sc8wrj6 @ 10/16/25 11:26:37.233
  STEP: creating a claim @ 10/16/25 11:26:37.245
  I1016 11:26:37.245535 62997 pv.go:646] Warning: Making PVC: VolumeMode specified as invalid empty string, treating as nil
  I1016 11:26:37.250570 62997 pv.go:790] Waiting up to timeout=5m0s for PersistentVolumeClaims [hostpath.csi.k8s.iovnt9f] to have phase Bound
  I1016 11:26:37.253341 62997 pv.go:806] PersistentVolumeClaim hostpath.csi.k8s.iovnt9f found but phase is Pending instead of Bound.
  I1016 11:26:39.256900 62997 pv.go:801] PersistentVolumeClaim hostpath.csi.k8s.iovnt9f found and phase=Bound (2.006221584s)
  STEP: creating a VolumeGroupSnapshotClass @ 10/16/25 11:26:51.312
  STEP: creating a dynamic VolumeGroupSnapshot @ 10/16/25 11:26:51.324
  STEP: Waiting for group snapshot to be ready @ 10/16/25 11:26:51.331
  I1016 11:26:51.331331 62997 volume_group_snapshot.go:50] Waiting up to 50m0s for VolumeGroupSnapshot group-snapshot-fktww to become ready
  I1016 11:26:51.336002 62997 volume_group_snapshot.go:61] VolumeGroupSnapshot group-snapshot-fktww found but is not ready.
  I1016 11:26:53.343269 62997 volume_group_snapshot.go:70] VolumeSnapshot group-snapshot-fktww found but is not ready.
  I1016 11:26:55.349615 62997 volume_group_snapshot.go:70] VolumeSnapshot group-snapshot-fktww found but is not ready.
  I1016 11:26:57.357564 62997 volume_group_snapshot.go:70] VolumeSnapshot group-snapshot-fktww found but is not ready.
  I1016 11:26:59.364805 62997 volume_group_snapshot.go:66] VolumeSnapshot group-snapshot-fktww found and is ready
  I1016 11:26:59.364895 62997 utils.go:695] WaitUntil finished successfully after 8.0334795s
  STEP: Getting group snapshot and content @ 10/16/25 11:26:59.364
  STEP: verifying the snapshots in the group are ready to use @ 10/16/25 11:26:59.375
  I1016 11:27:31.601538 62997 delete.go:78] Deleting pod "snapshot-pod-kz5zz" in namespace "volumegroupsnapshottable-8910"
  I1016 11:27:31.616488 62997 delete.go:86] Wait up to 5m0s for pod "snapshot-pod-kz5zz" to be fully deleted
  I1016 11:28:03.755461 62997 delete.go:78] Deleting pod "snapshot-pod-dnl6v" in namespace "volumegroupsnapshottable-8910"
  I1016 11:28:03.770215 62997 delete.go:86] Wait up to 5m0s for pod "snapshot-pod-dnl6v" to be fully deleted
  I1016 11:28:35.939355 62997 delete.go:78] Deleting pod "snapshot-pod-qnhjt" in namespace "volumegroupsnapshottable-8910"
  I1016 11:28:35.948748 62997 delete.go:86] Wait up to 5m0s for pod "snapshot-pod-qnhjt" to be fully deleted
  I1016 11:29:08.095442 62997 volume_group_snapshottable.go:159] Deleting pod pod-5d0e56e9-bcf5-4f41-8755-7b8f9209878b
  I1016 11:29:08.096294 62997 delete.go:78] Deleting pod "pod-5d0e56e9-bcf5-4f41-8755-7b8f9209878b" in namespace "volumegroupsnapshottable-8910"
  I1016 11:29:08.108314 62997 delete.go:86] Wait up to 5m0s for pod "pod-5d0e56e9-bcf5-4f41-8755-7b8f9209878b" to be fully deleted
  I1016 11:29:12.129769 62997 volume_group_snapshottable.go:165] Deleting volume hostpath.csi.k8s.io2j6cb
  STEP: Deleting pvc @ 10/16/25 11:29:12.13
  I1016 11:29:12.130229 62997 pv.go:205] Deleting PersistentVolumeClaim "hostpath.csi.k8s.io2j6cb"
  I1016 11:29:12.140804 62997 pv.go:863] Waiting up to 20m0s for PersistentVolume pvc-89b51330-07a0-4fe5-aa3c-68eb507045e0 to get deleted
  I1016 11:29:12.145435 62997 pv.go:867] PersistentVolume pvc-89b51330-07a0-4fe5-aa3c-68eb507045e0 found and phase=Bound (4.393708ms)
  I1016 11:29:17.152730 62997 pv.go:871] PersistentVolume pvc-89b51330-07a0-4fe5-aa3c-68eb507045e0 was removed
  STEP: Deleting sc @ 10/16/25 11:29:17.153
  I1016 11:29:17.163558 62997 volume_group_snapshottable.go:165] Deleting volume hostpath.csi.k8s.io28zcl
  STEP: Deleting pvc @ 10/16/25 11:29:17.163
  I1016 11:29:17.163996 62997 pv.go:205] Deleting PersistentVolumeClaim "hostpath.csi.k8s.io28zcl"
  I1016 11:29:17.172355 62997 pv.go:863] Waiting up to 20m0s for PersistentVolume pvc-27e6a404-3a8c-476d-82a5-7ed7751b66c6 to get deleted
  I1016 11:29:17.178987 62997 pv.go:867] PersistentVolume pvc-27e6a404-3a8c-476d-82a5-7ed7751b66c6 found and phase=Bound (6.456334ms)
  I1016 11:29:22.185220 62997 pv.go:871] PersistentVolume pvc-27e6a404-3a8c-476d-82a5-7ed7751b66c6 was removed
  STEP: Deleting sc @ 10/16/25 11:29:22.185
  I1016 11:29:22.193767 62997 volume_group_snapshottable.go:165] Deleting volume hostpath.csi.k8s.iovnt9f
  STEP: Deleting pvc @ 10/16/25 11:29:22.193
  I1016 11:29:22.194062 62997 pv.go:205] Deleting PersistentVolumeClaim "hostpath.csi.k8s.iovnt9f"
  I1016 11:29:22.200945 62997 pv.go:863] Waiting up to 20m0s for PersistentVolume pvc-70f63571-a7c2-457c-b1b5-edd818ca1e26 to get deleted
  I1016 11:29:22.205215 62997 pv.go:867] PersistentVolume pvc-70f63571-a7c2-457c-b1b5-edd818ca1e26 found and phase=Bound (4.085708ms)
  I1016 11:29:27.216443 62997 pv.go:871] PersistentVolume pvc-70f63571-a7c2-457c-b1b5-edd818ca1e26 was removed
  STEP: Deleting sc @ 10/16/25 11:29:27.216
  I1016 11:29:27.224343 62997 helper.go:125] Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "volumegroupsnapshottable-8910" for this suite. @ 10/16/25 11:29:27.229
• [174.088 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[SynchronizedAfterSuite] 
k8s.io/kubernetes/test/e2e/e2e.go:80
  I1016 11:29:27.286059 62997 suites.go:34] Running AfterSuite actions on node 1
[SynchronizedAfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Invariant Metrics
k8s.io/kubernetes/test/e2e/invariants/metrics.go:46
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Kubernetes e2e suite report
k8s.io/kubernetes/test/e2e/e2e_test.go:158
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 2 of 7512 Specs in 342.279 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 7510 Skipped
PASS

Ginkgo ran 1 suite in 5m42.625533916s
Test Suite Passed
```
</details>

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
