### PR TITLE
fix(typo): 'staus' -> 'status' in read_write_deadline_test.go

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/read_write_deadline_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/read_write_deadline_test.go
@@ -470,7 +470,7 @@ func TestPerRequestWithClientReceivesContentFlushedBeforeDeadline(t *testing.T) 
 				// g) the client expects a response from the server since content
 				// has been written and flushed before the write deadline elapsed
 				if resp.StatusCode != http.StatusOK {
-					t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+					t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 				}
 				defer closeResponseBody(t, resp)
 
@@ -685,7 +685,7 @@ func TestPerRequestWithBodyReadShouldTimeoutAfterDeadline(t *testing.T) {
 				// f) sine the handler wrote a response, we expect
 				// the client to read it successfully.
 				if resp.StatusCode != http.StatusOK {
-					t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+					t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 				}
 				if got, err := io.ReadAll(resp.Body); err != nil || string(got) != msg {
 					t.Errorf("expected the client to read the response: want: %q, got: %q, error: %v", msg, string(got), err)
@@ -821,7 +821,7 @@ func TestPerRequestWithBodyReadShouldYieldPartialContentBeforeDeadline(t *testin
 
 			// i) the client receives a response since the handler terminates normally
 			if resp.StatusCode != http.StatusOK {
-				t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+				t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 			}
 			defer closeResponseBody(t, resp)
 
@@ -909,7 +909,7 @@ func TestPerRequestWithReadingEmptyBodyShouldNotYieldErrorAfterDeadline(t *testi
 				}
 				defer closeResponseBody(t, resp)
 				if resp.StatusCode != http.StatusOK {
-					t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+					t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 				}
 			}()
 
@@ -995,7 +995,7 @@ func TestPerRequestWithHijackedConnectionShouldResetDeadline(t *testing.T) {
 			return
 		}
 		if resp.StatusCode != http.StatusOK {
-			t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+			t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 		}
 		defer closeResponseBody(t, resp)
 		// e) verify that the client receives the message as expected
@@ -1120,7 +1120,7 @@ func TestPerRequestWithConnectionIsReused(t *testing.T) {
 				}
 
 				if resp.StatusCode != http.StatusOK {
-					t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+					t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 				}
 				defer closeResponseBody(t, resp)
 
@@ -1142,7 +1142,7 @@ func TestPerRequestWithConnectionIsReused(t *testing.T) {
 				}
 				defer closeResponseBody(t, resp)
 				if resp.StatusCode != http.StatusOK {
-					t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+					t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 				}
 			}()
 		})
@@ -1247,7 +1247,7 @@ func TestPerRequestWithSlowReader(t *testing.T) {
 
 		// d) client expects a response from the server
 		if resp.StatusCode != http.StatusOK {
-			t.Errorf("expected staus code: %d, but got: %d", http.StatusOK, resp.StatusCode)
+			t.Errorf("expected status code: %d, but got: %d", http.StatusOK, resp.StatusCode)
 		}
 		defer closeResponseBody(t, resp)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix a typo in a test error message: "staus" → "status" in staging/src/k8s.io/apiserver/pkg/endpoints/filters/read_write_deadline_test.go.

Behavior unchanged; test log message string only
Scope limited to a single file
#### Which issue(s) this PR is related to:
N/A


<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
