### PR TITLE
Automated cherry pick of #132400: Fix namespace-aware orphan pod indexing

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -1083,6 +1083,11 @@ func AddPodNodeNameIndexer(podInformer cache.SharedIndexInformer) error {
 	})
 }
 
+// OrphanPodIndexKeyForNamespace returns the orphan pod index key for a specific namespace.
+func OrphanPodIndexKeyForNamespace(namespace string) string {
+	return OrphanPodIndexKey + "/" + namespace
+}
+
 // AddPodControllerUIDIndexer adds an indexer for Pod's controllerRef.UID to the given PodInformer.
 // This indexer is used to efficiently look up pods by their ControllerRef.UID
 func AddPodControllerUIDIndexer(podInformer cache.SharedIndexInformer) error {
@@ -1100,9 +1105,9 @@ func AddPodControllerUIDIndexer(podInformer cache.SharedIndexInformer) error {
 			if ref := metav1.GetControllerOf(pod); ref != nil {
 				return []string{string(ref.UID)}, nil
 			}
-			// If the Pod has no controller (i.e., it's orphaned), index it with the OrphanPodIndexKey
+			// If the Pod has no controller (i.e., it's orphaned), index it with the OrphanPodIndexKeyForNamespace
 			// This helps identify orphan pods for reconciliation and adoption by controllers
-			return []string{OrphanPodIndexKey}, nil
+			return []string{OrphanPodIndexKeyForNamespace(pod.Namespace)}, nil
 		},
 	})
 }

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -696,7 +696,7 @@ func (dsc *DaemonSetsController) getDaemonPodsFromCache(ds *apps.DaemonSet) ([]*
 	//  The OrphanPodIndexKey, which helps identify orphaned Pods that are not currently managed by any controller,
 	//   but may be adopted later on if they have matching labels with the Daemonset.
 	podsForDS := []*v1.Pod{}
-	for _, key := range []string{string(ds.UID), controller.OrphanPodIndexKey} {
+	for _, key := range []string{string(ds.UID), controller.OrphanPodIndexKeyForNamespace(ds.Namespace)} {
 		podObjs, err := dsc.podIndexer.ByIndex(controller.PodControllerUIDIndex, key)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Cherry pick of #132400 on release-1.33.

#132400: Fix namespace-aware orphan pod indexing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-controller-manager: Fixes a 1.33 regression in daemonset handling of orphaned pods
```