### PR TITLE
refactor(scheduler): contextual logging — AddEventHandlerWithOptions, UntilWithContext, HandleCrashWithLogger

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -44,8 +44,8 @@ var (
 // "ctx" is the context that would close the background goroutine.
 func New(ctx context.Context, ttl time.Duration, apiDispatcher fwk.APIDispatcher) Cache {
 	logger := klog.FromContext(ctx)
-	cache := newCache(ctx, ttl, cleanAssumedPeriod, apiDispatcher)
-	cache.run(ctx, logger)
+	cache := newCache(logger, ttl, cleanAssumedPeriod, apiDispatcher)
+	go cache.run(ctx, logger)
 	return cache
 }
 
@@ -91,8 +91,7 @@ type podState struct {
 	bindingFinished bool
 }
 
-func newCache(ctx context.Context, ttl, period time.Duration, apiDispatcher fwk.APIDispatcher) *cacheImpl {
-	logger := klog.FromContext(ctx)
+func newCache(logger klog.Logger, ttl, period time.Duration, apiDispatcher fwk.APIDispatcher) *cacheImpl {
 	return &cacheImpl{
 		ttl:    ttl,
 		period: period,

--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -45,7 +45,7 @@ var (
 func New(ctx context.Context, ttl time.Duration, apiDispatcher fwk.APIDispatcher) Cache {
 	logger := klog.FromContext(ctx)
 	cache := newCache(logger, ttl, cleanAssumedPeriod, apiDispatcher)
-	go cache.run(ctx, logger)
+	cache.run(ctx, logger)
 	return cache
 }
 

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -232,10 +231,8 @@ func TestAssumePodScheduled(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			cache := newCache(ctx, time.Second, time.Second, nil)
+			logger, _ := ktesting.NewTestContext(t)
+			cache := newCache(logger, time.Second, time.Second, nil)
 			for _, pod := range tc.pods {
 				if err := cache.AssumePod(logger, pod); err != nil {
 					t.Fatalf("AssumePod failed: %v", err)
@@ -351,10 +348,8 @@ func TestExpirePod(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			cache := newCache(ctx, tc.ttl, time.Second, nil)
+			logger, _ := ktesting.NewTestContext(t)
+			cache := newCache(logger, tc.ttl, time.Second, nil)
 
 			for _, pod := range tc.pods {
 				if err := cache.AssumePod(logger, pod.pod); err != nil {
@@ -412,10 +407,8 @@ func TestAddPodWillConfirm(t *testing.T) {
 		),
 	}
 
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	cache := newCache(ctx, ttl, time.Second, nil)
+	logger, _ := ktesting.NewTestContext(t)
+	cache := newCache(logger, ttl, time.Second, nil)
 	for _, podToAssume := range test.podsToAssume {
 		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
 			t.Fatalf("assumePod failed: %v", err)
@@ -455,10 +448,8 @@ func TestDump(t *testing.T) {
 		podsToAdd:    []*v1.Pod{testPods[0]},
 	}
 
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	cache := newCache(ctx, ttl, time.Second, nil)
+	logger, _ := ktesting.NewTestContext(t)
+	cache := newCache(logger, ttl, time.Second, nil)
 	for _, podToAssume := range test.podsToAssume {
 		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
 			t.Errorf("assumePod failed: %v", err)
@@ -490,9 +481,7 @@ func TestDump(t *testing.T) {
 // even when the Pod is assumed one.
 func TestAddPodAlwaysUpdatesPodInfoInNodeInfo(t *testing.T) {
 	ttl := 10 * time.Second
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	logger, _ := ktesting.NewTestContext(t)
 	now := time.Now()
 	p1 := makeBasePod(t, "node1", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 
@@ -526,7 +515,7 @@ func TestAddPodAlwaysUpdatesPodInfoInNodeInfo(t *testing.T) {
 		},
 	}
 
-	cache := newCache(ctx, ttl, time.Second, nil)
+	cache := newCache(logger, ttl, time.Second, nil)
 	for _, podToAssume := range test.podsToAssume {
 		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
 			t.Fatalf("assumePod failed: %v", err)
@@ -582,10 +571,8 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 		},
 	}
 
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	cache := newCache(ctx, ttl, time.Second, nil)
+	logger, _ := ktesting.NewTestContext(t)
+	cache := newCache(logger, ttl, time.Second, nil)
 	for _, podToAssume := range test.podsToAssume {
 		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
 			t.Fatalf("assumePod failed: %v", err)
@@ -634,11 +621,9 @@ func TestAddPodAfterExpiration(t *testing.T) {
 		),
 	}
 
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	logger, _ := ktesting.NewTestContext(t)
 	now := time.Now()
-	cache := newCache(ctx, ttl, time.Second, nil)
+	cache := newCache(logger, ttl, time.Second, nil)
 	if err := assumeAndFinishBinding(logger, cache, test.pod, now); err != nil {
 		t.Fatalf("assumePod failed: %v", err)
 	}
@@ -700,10 +685,8 @@ func TestUpdatePod(t *testing.T) {
 		)},
 	}
 
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	cache := newCache(ctx, ttl, time.Second, nil)
+	logger, _ := ktesting.NewTestContext(t)
+	cache := newCache(logger, ttl, time.Second, nil)
 	for _, podToAdd := range test.podsToAdd {
 		if err := cache.AddPod(logger, podToAdd); err != nil {
 			t.Fatalf("AddPod failed: %v", err)
@@ -762,10 +745,8 @@ func TestUpdatePodAndGet(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			cache := newCache(ctx, ttl, time.Second, nil)
+			logger, _ := ktesting.NewTestContext(t)
+			cache := newCache(logger, ttl, time.Second, nil)
 			// trying to get an unknown pod should return an error
 			// podToUpdate has not been added yet
 			if _, err := cache.GetPod(tc.podToUpdate); err == nil {
@@ -844,11 +825,9 @@ func TestExpireAddUpdatePod(t *testing.T) {
 		)},
 	}
 
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	logger, _ := ktesting.NewTestContext(t)
 	now := time.Now()
-	cache := newCache(ctx, ttl, time.Second, nil)
+	cache := newCache(logger, ttl, time.Second, nil)
 	for _, podToAssume := range test.podsToAssume {
 		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
 			t.Fatalf("assumePod failed: %v", err)
@@ -906,10 +885,8 @@ func TestEphemeralStorageResource(t *testing.T) {
 			make(map[string]*fwk.ImageStateSummary),
 		),
 	}
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	cache := newCache(ctx, time.Second, time.Second, nil)
+	logger, _ := ktesting.NewTestContext(t)
+	cache := newCache(logger, time.Second, time.Second, nil)
 	if err := cache.AddPod(logger, test.pod); err != nil {
 		t.Fatalf("AddPod failed: %v", err)
 	}
@@ -959,11 +936,9 @@ func TestRemovePod(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+			logger, _ := ktesting.NewTestContext(t)
 			nodeName := pod.Spec.NodeName
-			cache := newCache(ctx, time.Second, time.Second, nil)
+			cache := newCache(logger, time.Second, time.Second, nil)
 			// Add/Assume pod succeeds even before adding the nodes.
 			if tt.assume {
 				if err := cache.AddPod(logger, pod); err != nil {
@@ -1009,11 +984,9 @@ func TestForgetPod(t *testing.T) {
 	pods := []*v1.Pod{basePod}
 	now := time.Now()
 	ttl := 10 * time.Second
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	logger, _ := ktesting.NewTestContext(t)
 
-	cache := newCache(ctx, ttl, time.Second, nil)
+	cache := newCache(logger, ttl, time.Second, nil)
 	for _, pod := range pods {
 		if err := assumeAndFinishBinding(logger, cache, pod, now); err != nil {
 			t.Fatalf("assumePod failed: %v", err)
@@ -1218,15 +1191,13 @@ func TestNodeOperators(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+			logger, _ := ktesting.NewTestContext(t)
 			node := tc.nodes[0]
 
 			imageStates := buildImageStates(tc.nodes)
 			expected := buildNodeInfo(node, tc.pods, imageStates)
 
-			cache := newCache(ctx, time.Second, time.Second, nil)
+			cache := newCache(logger, time.Second, time.Second, nil)
 			for _, nodeItem := range tc.nodes {
 				cache.AddNode(logger, nodeItem)
 			}
@@ -1717,10 +1688,7 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			cache = newCache(ctx, time.Second, time.Second, nil)
+			cache = newCache(logger, time.Second, time.Second, nil)
 			snapshot = NewEmptySnapshot()
 
 			for _, op := range test.operations {
@@ -1951,10 +1919,7 @@ func TestSchedulerCache_updateNodeInfoSnapshotList(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			cache = newCache(ctx, time.Second, time.Second, nil)
+			cache = newCache(logger, time.Second, time.Second, nil)
 			snapshot = NewEmptySnapshot()
 
 			test.operations(t)
@@ -2057,10 +2022,8 @@ func checkImageStateSummary(nodes map[string]*framework.NodeInfo, imageNames ...
 }
 
 func setupCacheOf1kNodes30kPods(b *testing.B) Cache {
-	logger, ctx := ktesting.NewTestContext(b)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	cache := newCache(ctx, time.Second, time.Second, nil)
+	logger, _ := ktesting.NewTestContext(b)
+	cache := newCache(logger, time.Second, time.Second, nil)
 	for i := 0; i < 1000; i++ {
 		nodeName := fmt.Sprintf("node-%d", i)
 		cache.AddNode(logger, st.MakeNode().Name(nodeName).Obj())
@@ -2077,11 +2040,9 @@ func setupCacheOf1kNodes30kPods(b *testing.B) Cache {
 }
 
 func setupCacheWithAssumedPods(b *testing.B, podNum int, assumedTime time.Time) *cacheImpl {
-	logger, ctx := ktesting.NewTestContext(b)
-	ctx, cancel := context.WithCancel(ctx)
+	logger, _ := ktesting.NewTestContext(b)
 	addedNodes := make(map[string]struct{})
-	defer cancel()
-	cache := newCache(ctx, time.Second, time.Second, nil)
+	cache := newCache(logger, time.Second, time.Second, nil)
 	for i := 0; i < podNum; i++ {
 		nodeName := fmt.Sprintf("node-%d", i/10)
 		if _, ok := addedNodes[nodeName]; !ok {

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -407,9 +407,13 @@ func (p *PriorityQueue) Run(logger klog.Logger) {
 	go p.backoffQ.waitUntilAlignedWithOrderingWindow(func() {
 		p.flushBackoffQCompleted(logger)
 	}, p.stop)
-	go wait.Until(func() {
-		p.flushUnschedulablePodsLeftover(logger)
-	}, 30*time.Second, p.stop)
+	go wait.UntilWithContext(
+		wait.ContextForChannel(p.stop),
+		func(ctx context.Context) {
+			p.flushUnschedulablePodsLeftover(logger)
+		},
+		30*time.Second,
+	)
 }
 
 // queueingStrategy indicates how the scheduling queue should enqueue the Pod from unschedulable pod pool.

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -240,7 +240,7 @@ func (sched *Scheduler) addPodToSchedulingQueue(pod *v1.Pod) {
 func (sched *Scheduler) syncPodWithDispatcher(pod *v1.Pod) *v1.Pod {
 	enrichedObj, err := sched.APIDispatcher.SyncObject(pod)
 	if err != nil {
-		utilruntime.HandleErrorWithLogger(sched.logger, err, "failed to sync pod with API dispatcher", "namespace", pod.Namespace, "name", pod.Name)
+		utilruntime.HandleErrorWithLogger(sched.logger, err, "failed to sync pod with API dispatcher", "pod", klog.KObj(pod))
 		return pod
 	}
 	enrichedPod, ok := enrichedObj.(*v1.Pod)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -603,9 +603,6 @@ func TestSchedulerGuaranteeNonNilNodeInSchedulingCycle(t *testing.T) {
 	var deleteNodeIndex int
 	deleteNodesOneRound := func(ctx context.Context) {
 		for i := 0; i < deleteNodeNumberPerRound; i++ {
-			if ctx.Err() != nil {
-				return
-			}
 			if deleteNodeIndex >= initialNodeNumber {
 				// all initial nodes are already deleted
 				return
@@ -623,9 +620,6 @@ func TestSchedulerGuaranteeNonNilNodeInSchedulingCycle(t *testing.T) {
 			return
 		}
 		for i := 0; i < createPodNumberPerRound; i++ {
-			if ctx.Err() != nil {
-				return
-			}
 			podName := fmt.Sprintf("pod%d", createPodIndex)
 			// Note: the node(specifiedNodeName) may already be deleted, which leads pod scheduled failed.
 			specifiedNodeName := fmt.Sprintf("node%d", random.Intn(initialNodeNumber))

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -636,9 +636,8 @@ func TestSchedulerGuaranteeNonNilNodeInSchedulingCycle(t *testing.T) {
 	// 1) One is responsible for deleting several nodes in each round;
 	// 2) Another is creating several pods in each round to trigger scheduling;
 	// Those two goroutines will stop until ctx.Done() is called, which means all waiting pods are scheduled at least once.
-	go wait.Until(deleteNodesOneRound, 10*time.Millisecond, ctx.Done())
-	go wait.Until(createPodsOneRound, 9*time.Millisecond, ctx.Done())
-
+	go wait.UntilWithContext(ctx, func(context.Context) { deleteNodesOneRound() }, 10*time.Millisecond)
+	go wait.UntilWithContext(ctx, func(context.Context) { createPodsOneRound() }, 9*time.Millisecond)
 	// Capture the events to wait all pods to be scheduled at least once.
 	allWaitSchedulingPods := sets.New[string]()
 	for i := 0; i < waitSchedulingPodNumber; i++ {

--- a/pkg/scheduler/util/assumecache/assume_cache.go
+++ b/pkg/scheduler/util/assumecache/assume_cache.go
@@ -519,7 +519,7 @@ func (c *AssumeCache) emitEvents() {
 			return
 		}
 		func() {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithLogger(c.logger)
 			deliver()
 		}()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Replace AddEventHandler with AddEventHandlerWithOptions and pass Logger via cache.HandlerOptions
- Replace wait.Until with wait.UntilWithContext
- Replace utilruntime.HandleCrash with HandleCrashWithLogger in AssumeCache
#### Which issue(s) this PR is related to:
Contributes to #126379
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
