### PR TITLE
Automated cherry pick of #134654: Include relevant dimensions in pod controller indexing

### DIFF
--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -1612,27 +1612,37 @@ func TestFilterPodsByOwner(t *testing.T) {
 		return pod
 	}
 
+	ownerKind := "OwnerKind"
+	ownerName := "ownerName"
 	cases := map[string]struct {
 		owner        *metav1.ObjectMeta
+		ownedOnly    bool
 		allPods      []*v1.Pod
 		wantPodsKeys sets.Set[string]
 	}{
 		"multiple Pods, some are owned by the owner": {
 			owner: &metav1.ObjectMeta{
 				Namespace: "ns1",
+				Name:      ownerName,
 				UID:       "abc",
 			},
 			allPods: []*v1.Pod{
 				newPod("a", "ns1", &metav1.OwnerReference{
 					UID:        "abc",
+					Kind:       ownerKind,
+					Name:       ownerName,
 					Controller: ptr.To(true),
 				}),
 				newPod("b", "ns1", &metav1.OwnerReference{
 					UID:        "def",
+					Kind:       ownerKind,
+					Name:       ownerName,
 					Controller: ptr.To(true),
 				}),
 				newPod("c", "ns1", &metav1.OwnerReference{
 					UID:        "abc",
+					Kind:       ownerKind,
+					Name:       ownerName,
 					Controller: ptr.To(true),
 				}),
 			},
@@ -1641,6 +1651,8 @@ func TestFilterPodsByOwner(t *testing.T) {
 		"orphan Pods in multiple namespaces": {
 			owner: &metav1.ObjectMeta{
 				Namespace: "ns1",
+				Name:      ownerName,
+				UID:       "abc",
 			},
 			allPods: []*v1.Pod{
 				newPod("a", "ns1", nil),
@@ -1651,6 +1663,7 @@ func TestFilterPodsByOwner(t *testing.T) {
 		"owned Pods and orphan Pods in the owner's namespace": {
 			owner: &metav1.ObjectMeta{
 				Namespace: "ns1",
+				Name:      ownerName,
 				UID:       "abc",
 			},
 			allPods: []*v1.Pod{
@@ -1658,10 +1671,61 @@ func TestFilterPodsByOwner(t *testing.T) {
 				newPod("b", "ns2", nil),
 				newPod("c", "ns1", &metav1.OwnerReference{
 					UID:        "abc",
+					Kind:       ownerKind,
+					Name:       ownerName,
 					Controller: ptr.To(true),
 				}),
 			},
 			wantPodsKeys: sets.New("ns1/a", "ns1/c"),
+		},
+		"exclude orphan pods, pods in mismatched ns,uid,kind,name,controller": {
+			owner: &metav1.ObjectMeta{
+				Namespace: "ns1",
+				Name:      ownerName,
+				UID:       "abc",
+			},
+			allPods: []*v1.Pod{
+				newPod("a", "ns1", nil),
+				newPod("other-ns-orphan", "ns2", nil),
+				newPod("other-ns-owned", "ns2", &metav1.OwnerReference{
+					UID:        "abc",
+					Kind:       ownerKind,
+					Name:       ownerName,
+					Controller: ptr.To(true),
+				}),
+				newPod("c", "ns1", &metav1.OwnerReference{
+					UID:        "abc",
+					Kind:       ownerKind,
+					Name:       ownerName,
+					Controller: ptr.To(true),
+				}),
+				newPod("other-uid", "ns1", &metav1.OwnerReference{
+					UID:        "other-uid",
+					Kind:       ownerKind,
+					Name:       ownerName,
+					Controller: ptr.To(true),
+				}),
+				newPod("other-kind", "ns1", &metav1.OwnerReference{
+					UID:        "abc",
+					Kind:       "OtherKind",
+					Name:       ownerName,
+					Controller: ptr.To(true),
+				}),
+				newPod("other-name", "ns1", &metav1.OwnerReference{
+					UID:        "abc",
+					Kind:       ownerKind,
+					Name:       "otherName",
+					Controller: ptr.To(true),
+				}),
+				newPod("non-controller", "ns1", &metav1.OwnerReference{
+					UID:        "abc",
+					Kind:       ownerKind,
+					Name:       ownerName,
+					Controller: ptr.To(false),
+				}),
+			},
+			ownedOnly:    true,
+			wantPodsKeys: sets.New("ns1/c"),
 		},
 	}
 	for name, tc := range cases {
@@ -1670,7 +1734,7 @@ func TestFilterPodsByOwner(t *testing.T) {
 			sharedInformers := informers.NewSharedInformerFactory(fakeClient, 0)
 			podInformer := sharedInformers.Core().V1().Pods()
 
-			err := AddPodControllerUIDIndexer(podInformer.Informer())
+			err := AddPodControllerIndexer(podInformer.Informer())
 			if err != nil {
 				t.Fatalf("failed to register indexer: %v", err)
 			}
@@ -1680,7 +1744,10 @@ func TestFilterPodsByOwner(t *testing.T) {
 					t.Fatalf("failed adding Pod to indexer: %v", err)
 				}
 			}
-			gotPods, _ := FilterPodsByOwner(podIndexer, tc.owner)
+			gotPods, err := FilterPodsByOwner(podIndexer, tc.owner, ownerKind, !tc.ownedOnly)
+			if err != nil {
+				t.Fatal(err)
+			}
 			gotPodKeys := sets.New[string]()
 			for _, pod := range gotPods {
 				gotPodKeys.Insert(pod.Namespace + "/" + pod.Name)

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -217,7 +217,7 @@ func NewDaemonSetsController(
 	dsc.podLister = podInformer.Lister()
 	dsc.podStoreSynced = podInformer.Informer().HasSynced
 	controller.AddPodNodeNameIndexer(podInformer.Informer())
-	controller.AddPodControllerUIDIndexer(podInformer.Informer())
+	controller.AddPodControllerIndexer(podInformer.Informer())
 	dsc.podIndexer = podInformer.Informer().GetIndexer()
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -699,7 +699,7 @@ func (dsc *DaemonSetsController) getDaemonPods(ctx context.Context, ds *apps.Dae
 		return nil, err
 	}
 	// List all pods indexed to DS UID and Orphan pods
-	pods, err := controller.FilterPodsByOwner(dsc.podIndexer, &ds.ObjectMeta)
+	pods, err := controller.FilterPodsByOwner(dsc.podIndexer, &ds.ObjectMeta, "DaemonSet", true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -226,7 +226,7 @@ func newControllerWithClock(ctx context.Context, podInformer coreinformers.PodIn
 	jm.podStore = podInformer.Lister()
 	jm.podStoreSynced = podInformer.Informer().HasSynced
 
-	err := controller.AddPodControllerUIDIndexer(podInformer.Informer())
+	err := controller.AddPodControllerIndexer(podInformer.Informer())
 	if err != nil {
 		return nil, fmt.Errorf("adding Pod controller UID indexer: %w", err)
 	}
@@ -769,7 +769,7 @@ func (jm *Controller) getPodsForJob(ctx context.Context, j *batch.Job) ([]*v1.Po
 	}
 
 	// list all pods managed by this Job using the pod indexer
-	pods, err := controller.FilterPodsByOwner(jm.podIndexer, &j.ObjectMeta)
+	pods, err := controller.FilterPodsByOwner(jm.podIndexer, &j.ObjectMeta, "Job", true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -2949,6 +2950,7 @@ func TestSyncJobWhenManagedBy(t *testing.T) {
 		TypeMeta: metav1.TypeMeta{Kind: "Job"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foobar",
+			UID:       "foobaruid",
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: batch.JobSpec{

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -220,7 +220,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 	})
 	rsc.podLister = podInformer.Lister()
 	rsc.podListerSynced = podInformer.Informer().HasSynced
-	controller.AddPodControllerUIDIndexer(podInformer.Informer()) //nolint:errcheck
+	controller.AddPodControllerIndexer(podInformer.Informer()) //nolint:errcheck
 	rsc.podIndexer = podInformer.Informer().GetIndexer()
 	rsc.syncHandler = rsc.syncReplicaSet
 
@@ -728,7 +728,7 @@ func (rsc *ReplicaSetController) syncReplicaSet(ctx context.Context, key string)
 	}
 
 	// List all pods indexed to RS UID and Orphan pods
-	allRSPods, err := controller.FilterPodsByOwner(rsc.podIndexer, &rs.ObjectMeta)
+	allRSPods, err := controller.FilterPodsByOwner(rsc.podIndexer, &rs.ObjectMeta, rsc.Kind, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -131,7 +131,7 @@ func NewStatefulSetController(
 	})
 	ssc.podLister = podInformer.Lister()
 	ssc.podListerSynced = podInformer.Informer().HasSynced
-	controller.AddPodControllerUIDIndexer(podInformer.Informer())
+	controller.AddPodControllerIndexer(podInformer.Informer())
 	ssc.podIndexer = podInformer.Informer().GetIndexer()
 	setInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -312,7 +312,7 @@ func (ssc *StatefulSetController) deletePod(logger klog.Logger, obj interface{})
 // NOTE: Returned Pods are pointers to objects from the cache.
 // If you need to modify one, you need to copy it first.
 func (ssc *StatefulSetController) getPodsForStatefulSet(ctx context.Context, set *apps.StatefulSet, selector labels.Selector) ([]*v1.Pod, error) {
-	podsForSts, err := controller.FilterPodsByOwner(ssc.podIndexer, &set.ObjectMeta)
+	podsForSts, err := controller.FilterPodsByOwner(ssc.podIndexer, &set.ObjectMeta, "StatefulSet", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #134654 on release-1.34.

#134654: Include relevant dimensions in pod controller indexing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-controller-manager: Resolves potential issues handling pods with incorrect uids in their ownerReference
```