### PR TITLE
ensure permissions are consistent on dockerized binaries

### DIFF
--- a/build/server-image/Dockerfile
+++ b/build/server-image/Dockerfile
@@ -19,4 +19,4 @@ ARG BINARY
 
 
 FROM "${BASEIMAGE}"
-COPY ${BINARY} /usr/local/bin/${BINARY}
+COPY --chmod=755 ${BINARY} /usr/local/bin/${BINARY}

--- a/build/server-image/kube-apiserver/Dockerfile
+++ b/build/server-image/kube-apiserver/Dockerfile
@@ -20,7 +20,7 @@ ARG SETCAP_IMAGE
 # to setup qemu for the builder.
 FROM --platform=linux/$BUILDARCH ${SETCAP_IMAGE}
 ARG BINARY
-COPY ${BINARY} /${BINARY}
+COPY --chmod=755 ${BINARY} /${BINARY}
 # We apply cap_net_bind_service so that kube-apiserver can be run as
 # non-root and still listen on port less than 1024
 RUN setcap cap_net_bind_service=+ep /${BINARY}

--- a/build/server-image/kubectl/Dockerfile
+++ b/build/server-image/kubectl/Dockerfile
@@ -19,5 +19,5 @@ ARG BINARY
 
 
 FROM "${BASEIMAGE}"
-COPY ${BINARY} /bin/
+COPY --chmod=755 ${BINARY} /bin/
 ENTRYPOINT ["/bin/kubectl"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

@adrianmoisey reported issues with `kind build node-image && kind create cluster --image=kindest/node:latest` on master, while debugging he found that the binaries in the images were not executable

I think this may be a umask issue in the docker build environment (I can't repro with limactl, seems possibly related to docker desktop).

We should look into that, but I think it also makes sense to just enforce particular permissions when building the images.

This requires a buildx feature that wasn't available in older versions of Dockerfile, but we've been requiring buildx to build these images for a long time now anyhow (to ensure we can setcap binaries for rootless).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
