### PR TITLE
Fix HPA test flake by allowing helper to retry on collision 

### DIFF
--- a/test/e2e/framework/get.go
+++ b/test/e2e/framework/get.go
@@ -104,6 +104,7 @@ func ShouldRetry(err error) (retry bool, retryAfter time.Duration) {
 	if apierrors.IsTimeout(err) ||
 		apierrors.IsTooManyRequests(err) ||
 		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsConflict(err) ||
 		errors.Is(err, io.EOF) ||
 		errors.As(err, &transientError{}) {
 		return true, 0


### PR DESCRIPTION




<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake 
#### What this PR does / why we need it:

Deflake `: [sig-autoscaling] [Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) CustomResourceDefinition Should scale with a CRD targetRef`

What:
-  Deflakes HPA test case by making the test framework `ShouldRetry()` helper regard a conflict as something that can be retried (which seemed reasonable, as that's what a controller would do?) 

Why: 
 - [This HPA test case](https://github.com/kubernetes/kubernetes/blob/3b632270e9b866ee8bf62e89377ae95987671b49/test/e2e/autoscaling/horizontal_pod_autoscaling.go#L147) occasionally flakes because over in [autoscaling_utils.go](https://github.com/kubernetes/kubernetes/blob/3b632270e9b866ee8bf62e89377ae95987671b49/test/e2e/framework/autoscaling/autoscaling_utils.go#L480) GetReplicas writes the number of replicas into the status potentially _after_ the HPA controller updates the custom resource, which will cause the test to fail: 
```
{  fail [k8s.io/kubernetes/test/e2e/autoscaling/horizontal_pod_autoscaling.go:211]: timeout waiting 15m0s for 2 replicas: Told to stop trying after 60.251s.
Unexpected final error while getting int: Operation cannot be fulfilled on testcrds.autoscalinge2e.example.com "foo-crd": the object has been modified; please apply your changes to the latest version and try again
At one point, however, the function did return successfully.
Yet, Eventually failed because the matcher was not satisfied:
Expected
    <int>: 1
to equal
    <int>: 2}
```

- Yes, it's weird that `GetReplicas()` modifies the replicas, but that looked like it was our hack to get around the fact that there isn't a controller for the custom type, and the HPA needs that information to scale. 


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

- If the blast radius of this is too large because of how widely the helper is used, and we generally do want collisions to be hard failures, we could probably add a status subresource to the custom resource and use `UpdateStatus` instead of `Update` instead? 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
