### PR TITLE
Enforce either optional or required tag on apiserverinternal API group

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1694,6 +1694,11 @@
           "x-kubernetes-list-type": "set"
         }
       },
+      "required": [
+        "apiServerID",
+        "encodingVersion",
+        "decodableVersions"
+      ],
       "type": "object"
     },
     "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
@@ -1721,8 +1726,7 @@
         }
       },
       "required": [
-        "spec",
-        "status"
+        "metadata"
       ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
@@ -3558,6 +3562,9 @@
           "description": "status is the current information about the autoscaler."
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -3907,6 +3914,9 @@
           "description": "status is the current information about the autoscaler."
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -4350,6 +4360,9 @@
           "description": "Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -5506,6 +5519,9 @@
           "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -5605,6 +5621,9 @@
           "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -13666,6 +13685,9 @@
           "description": "spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -14423,6 +14445,9 @@
           "description": "spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -465,6 +465,9 @@
           "description": "spec defines the desired behavior of the ValidatingAdmissionPolicyBinding."
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
@@ -580,6 +580,9 @@
             "description": "spec defines the desired behavior of the ValidatingAdmissionPolicyBinding."
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
@@ -65,6 +65,9 @@
             "description": "status is the current information about the autoscaler."
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
@@ -244,6 +244,9 @@
             "description": "status is the current information about the autoscaler."
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -40,6 +40,9 @@
             "description": "Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1alpha2_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1alpha2_openapi.json
@@ -31,6 +31,9 @@
             "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1beta1_openapi.json
@@ -31,6 +31,9 @@
             "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
@@ -5,7 +5,6 @@
         "description": "An API server instance reports the version it can decode and the version it encodes objects to when persisting objects in the backend.",
         "properties": {
           "apiServerID": {
-            "default": "",
             "description": "The ID of the reporting API server.",
             "type": "string"
           },
@@ -19,7 +18,6 @@
             "x-kubernetes-list-type": "set"
           },
           "encodingVersion": {
-            "default": "",
             "description": "The API server encodes the object to this version when persisting it in the backend (e.g., etcd).",
             "type": "string"
           },

--- a/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
@@ -5,6 +5,7 @@
         "description": "An API server instance reports the version it can decode and the version it encodes objects to when persisting objects in the backend.",
         "properties": {
           "apiServerID": {
+            "default": "",
             "description": "The ID of the reporting API server.",
             "type": "string"
           },
@@ -18,6 +19,7 @@
             "x-kubernetes-list-type": "set"
           },
           "encodingVersion": {
+            "default": "",
             "description": "The API server encodes the object to this version when persisting it in the backend (e.g., etcd).",
             "type": "string"
           },
@@ -31,6 +33,11 @@
             "x-kubernetes-list-type": "set"
           }
         },
+        "required": [
+          "apiServerID",
+          "encodingVersion",
+          "decodableVersions"
+        ],
         "type": "object"
       },
       "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
@@ -73,8 +80,7 @@
           }
         },
         "required": [
-          "spec",
-          "status"
+          "metadata"
         ],
         "type": "object",
         "x-kubernetes-group-version-kind": [

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -105,6 +105,9 @@
             "description": "spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1beta1_openapi.json
@@ -31,6 +31,9 @@
             "description": "spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -214,7 +214,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
-      - text: "must be marked as optional or required|is a non-pointer struct with no required fields. It must be marked as optional."
+      - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
@@ -229,7 +229,7 @@ linters:
       
       # The PodGroup.Policy field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
       # Validation makes this require at least one of the fields within to be set.
-      - text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields. It must be marked as optional."
+      - text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha1/types.go"
 
       - linters:

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -214,7 +214,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -444,7 +444,6 @@ linters:
             # nomaps:
             #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
             # optionalFields:
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.optionalfields:
             #  pointers:
             #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
             #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
@@ -455,7 +454,6 @@ linters:
             # optionalOrRequired:
             #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
             #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.
             # requiredFields:
             #   pointers:
             #    policy: SuggestFix | Warn # The policy for pointers in required fields. Defaults to `SuggestFix`.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -214,7 +214,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -213,7 +213,8 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
-      - text: "must be marked as optional or required"
+      # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
+      - text: "must be marked as optional or required|is a non-pointer struct with no required fields. It must be marked as optional."
         path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
@@ -405,6 +406,7 @@ linters:
               # - "nobools" # Bools do not evolve over time, should use enums instead.
               # - "nofloats" # Ensure floats are not used.
               - "nomaps" # Ensure maps are not used, unless they are `map[string]string` (for labels/annotations/etc).
+              - "nonpointerstructs" # Ensure non-pointer structs are correctly tagged as optional or required.
               - "nonullable" # Ensure fields are not marked as nullable.
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -224,6 +224,13 @@ linters:
       # jsontags: 'Port' must be capitalized for backward compatibility
       - text: 'jsontags: field DaemonEndpoint.Port json tag does not match'
         path: "staging/src/k8s.io/api/core/v1/types.go"
+      
+      # NonPointerStructs - Existing fields that are non-pointer structs but where the current rules are incorrect.
+      
+      # The PodGroup.Policy field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
+      # Validation makes this require at least one of the fields within to be set.
+      - text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields. It must be marked as optional."
+        path: "staging/src/k8s.io/api/scheduling/v1alpha1/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -235,6 +235,13 @@ linters:
       # jsontags: 'Port' must be capitalized for backward compatibility
       - text: 'jsontags: field DaemonEndpoint.Port json tag does not match'
         path: "staging/src/k8s.io/api/core/v1/types.go"
+      
+      # NonPointerStructs - Existing fields that are non-pointer structs but where the current rules are incorrect.
+      
+      # The PodGroup.Policy field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
+      # Validation makes this require at least one of the fields within to be set.
+      - text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields. It must be marked as optional."
+        path: "staging/src/k8s.io/api/scheduling/v1alpha1/types.go"
 
       - linters:
         - forbidigo

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -224,7 +224,8 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
-      - text: "must be marked as optional or required"
+      # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
+      - text: "must be marked as optional or required|is a non-pointer struct with no required fields. It must be marked as optional."
         path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
@@ -414,6 +415,7 @@ linters:
               # - "nobools" # Bools do not evolve over time, should use enums instead.
               # - "nofloats" # Ensure floats are not used.
               - "nomaps" # Ensure maps are not used, unless they are `map[string]string` (for labels/annotations/etc).
+              - "nonpointerstructs" # Ensure non-pointer structs are correctly tagged as optional or required.
               - "nonullable" # Ensure fields are not marked as nullable.
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -225,7 +225,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -453,7 +453,6 @@ linters:
             # nomaps:
             #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
             # optionalFields:
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.optionalfields:
             #  pointers:
             #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
             #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
@@ -464,7 +463,6 @@ linters:
             # optionalOrRequired:
             #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
             #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.
             # requiredFields:
             #   pointers:
             #    policy: SuggestFix | Warn # The policy for pointers in required fields. Defaults to `SuggestFix`.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -225,7 +225,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
-      - text: "must be marked as optional or required|is a non-pointer struct with no required fields. It must be marked as optional."
+      - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
@@ -240,7 +240,7 @@ linters:
       
       # The PodGroup.Policy field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
       # Validation makes this require at least one of the fields within to be set.
-      - text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields. It must be marked as optional."
+      - text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields."
         path: "staging/src/k8s.io/api/scheduling/v1alpha1/types.go"
 
       - linters:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -225,7 +225,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -90,7 +90,7 @@
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
-- text: "must be marked as optional or required|is a non-pointer struct with no required fields. It must be marked as optional."
+- text: "must be marked as optional or required|is a non-pointer struct with no required fields."
   path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
@@ -105,5 +105,5 @@
 
 # The PodGroup.Policy field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
 # Validation makes this require at least one of the fields within to be set.
-- text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields. It must be marked as optional."
+- text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields."
   path: "staging/src/k8s.io/api/scheduling/v1alpha1/types.go"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -100,3 +100,10 @@
 # jsontags: 'Port' must be capitalized for backward compatibility
 - text: 'jsontags: field DaemonEndpoint.Port json tag does not match'
   path: "staging/src/k8s.io/api/core/v1/types.go"
+
+# NonPointerStructs - Existing fields that are non-pointer structs but where the current rules are incorrect.
+
+# The PodGroup.Policy field is a union type, but is not marked up as a union, nor does nonpointerstructs understand unions today.
+# Validation makes this require at least one of the fields within to be set.
+- text: "nonpointerstructs: field PodGroup.Policy is a non-pointer struct with no required fields. It must be marked as optional."
+  path: "staging/src/k8s.io/api/scheduling/v1alpha1/types.go"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -89,7 +89,8 @@
   path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
-- text: "must be marked as optional or required"
+# The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
+- text: "must be marked as optional or required|is a non-pointer struct with no required fields. It must be marked as optional."
   path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -90,7 +90,7 @@
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 - text: "must be marked as optional or required"
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -90,7 +90,7 @@
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 - text: "must be marked as optional or required"
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|rbac|resource|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -12,6 +12,7 @@ linters:
     # - "nobools" # Bools do not evolve over time, should use enums instead.
     # - "nofloats" # Ensure floats are not used.
     - "nomaps" # Ensure maps are not used, unless they are `map[string]string` (for labels/annotations/etc).
+    - "nonpointerstructs" # Ensure non-pointer structs are correctly tagged as optional or required.
     - "nonullable" # Ensure fields are not marked as nullable.
     # - "nophase" # Ensure field names do not have the word "phase" in them.
     - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -51,7 +51,6 @@ lintersConfig:
   # nomaps:
   #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
   # optionalFields:
-  #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.optionalfields:
   #  pointers:
   #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
   #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
@@ -62,7 +61,6 @@ lintersConfig:
   # optionalOrRequired:
   #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
   #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 
-  #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.
   # requiredFields:
   #   pointers:
   #    policy: SuggestFix | Warn # The policy for pointers in required fields. Defaults to `SuggestFix`.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2448,6 +2448,7 @@ func schema_k8sio_api_admissionregistration_v1_ValidatingAdmissionPolicyBinding(
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -4043,6 +4044,7 @@ func schema_k8sio_api_admissionregistration_v1alpha1_ValidatingAdmissionPolicyBi
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -5645,6 +5647,7 @@ func schema_k8sio_api_admissionregistration_v1beta1_ValidatingAdmissionPolicyBin
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -7081,6 +7084,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 					"apiServerID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The ID of the reporting API server.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7088,6 +7092,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 					"encodingVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The API server encodes the object to this version when persisting it in the backend (e.g., etcd).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7133,6 +7138,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 						},
 					},
 				},
+				Required: []string{"apiServerID", "encodingVersion", "decodableVersions"},
 			},
 		},
 	}
@@ -7181,7 +7187,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_StorageVersion(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"spec", "status"},
+				Required: []string{"metadata"},
 			},
 		},
 		Dependencies: []string{
@@ -14380,6 +14386,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscaler(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -15351,6 +15358,7 @@ func schema_k8sio_api_autoscaling_v2_HorizontalPodAutoscaler(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -16092,6 +16100,7 @@ func schema_k8sio_api_batch_v1_CronJob(ref common.ReferenceCallback) common.Open
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -17011,6 +17020,7 @@ func schema_k8sio_api_batch_v1beta1_CronJob(ref common.ReferenceCallback) common
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -18564,6 +18574,7 @@ func schema_k8sio_api_coordination_v1alpha2_LeaseCandidate(ref common.ReferenceC
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -18759,6 +18770,7 @@ func schema_k8sio_api_coordination_v1beta1_LeaseCandidate(ref common.ReferenceCa
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -40734,6 +40746,7 @@ func schema_k8sio_api_networking_v1_IPAddress(ref common.ReferenceCallback) comm
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -42188,6 +42201,7 @@ func schema_k8sio_api_networking_v1beta1_IPAddress(ref common.ReferenceCallback)
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7084,7 +7084,6 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 					"apiServerID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The ID of the reporting API server.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7092,7 +7091,6 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 					"encodingVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The API server encodes the object to this version when persisting it in the backend (e.g., etcd).",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -604,6 +604,7 @@ message ValidatingAdmissionPolicyBinding {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the ValidatingAdmissionPolicyBinding.
+  // +required
   optional ValidatingAdmissionPolicyBindingSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -452,6 +452,7 @@ type ValidatingAdmissionPolicyBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the ValidatingAdmissionPolicyBinding.
+	// +required
 	Spec ValidatingAdmissionPolicyBindingSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
@@ -627,6 +627,7 @@ message ValidatingAdmissionPolicyBinding {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the ValidatingAdmissionPolicyBinding.
+  // +required
   optional ValidatingAdmissionPolicyBindingSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -392,6 +392,7 @@ type ValidatingAdmissionPolicyBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the ValidatingAdmissionPolicyBinding.
+	// +required
 	Spec ValidatingAdmissionPolicyBindingSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -853,6 +853,7 @@ message ValidatingAdmissionPolicyBinding {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired behavior of the ValidatingAdmissionPolicyBinding.
+  // +required
   optional ValidatingAdmissionPolicyBindingSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -405,6 +405,7 @@ type ValidatingAdmissionPolicyBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec defines the desired behavior of the ValidatingAdmissionPolicyBinding.
+	// +required
 	Spec ValidatingAdmissionPolicyBindingSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
@@ -32,33 +32,40 @@ option go_package = "k8s.io/api/apiserverinternal/v1alpha1";
 // encodes objects to when persisting objects in the backend.
 message ServerStorageVersion {
   // The ID of the reporting API server.
+  // +required
   optional string apiServerID = 1;
 
   // The API server encodes the object to this version when persisting it in
   // the backend (e.g., etcd).
+  // +required
   optional string encodingVersion = 2;
 
   // The API server can decode objects encoded in these versions.
   // The encodingVersion must be included in the decodableVersions.
   // +listType=set
+  // +required
   repeated string decodableVersions = 3;
 
   // The API server can serve these versions.
   // DecodableVersions must include all ServedVersions.
   // +listType=set
+  // +optional
   repeated string servedVersions = 4;
 }
 
 // Storage version of a specific resource.
 message StorageVersion {
   // The name is <group>.<resource>.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec is an empty spec. It is here to comply with Kubernetes API style.
+  // +optional
   optional StorageVersionSpec spec = 2;
 
   // API server instances report the version they can decode and the version they
   // encode objects to when persisting objects in the backend.
+  // +optional
   optional StorageVersionStatus status = 3;
 }
 
@@ -77,6 +84,7 @@ message StorageVersionCondition {
   optional int64 observedGeneration = 3;
 
   // Last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // The reason for the condition's last transition.

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
@@ -71,18 +71,18 @@ type StorageVersionStatus struct {
 type ServerStorageVersion struct {
 	// The ID of the reporting API server.
 	// +required
-	APIServerID string `json:"apiServerID" protobuf:"bytes,1,opt,name=apiServerID"`
+	APIServerID string `json:"apiServerID,omitempty" protobuf:"bytes,1,opt,name=apiServerID"`
 
 	// The API server encodes the object to this version when persisting it in
 	// the backend (e.g., etcd).
 	// +required
-	EncodingVersion string `json:"encodingVersion" protobuf:"bytes,2,opt,name=encodingVersion"`
+	EncodingVersion string `json:"encodingVersion,omitempty" protobuf:"bytes,2,opt,name=encodingVersion"`
 
 	// The API server can decode objects encoded in these versions.
 	// The encodingVersion must be included in the decodableVersions.
 	// +listType=set
 	// +required
-	DecodableVersions []string `json:"decodableVersions" protobuf:"bytes,3,opt,name=decodableVersions"`
+	DecodableVersions []string `json:"decodableVersions,omitempty" protobuf:"bytes,3,opt,name=decodableVersions"`
 
 	// The API server can serve these versions.
 	// DecodableVersions must include all ServedVersions.

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
@@ -28,13 +28,16 @@ import (
 type StorageVersion struct {
 	metav1.TypeMeta `json:",inline"`
 	// The name is <group>.<resource>.
+	// +required
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec is an empty spec. It is here to comply with Kubernetes API style.
+	// +optional
 	Spec StorageVersionSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// API server instances report the version they can decode and the version they
 	// encode objects to when persisting objects in the backend.
+	// +optional
 	Status StorageVersionStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
 }
 
@@ -67,20 +70,24 @@ type StorageVersionStatus struct {
 // encodes objects to when persisting objects in the backend.
 type ServerStorageVersion struct {
 	// The ID of the reporting API server.
-	APIServerID string `json:"apiServerID,omitempty" protobuf:"bytes,1,opt,name=apiServerID"`
+	// +required
+	APIServerID string `json:"apiServerID" protobuf:"bytes,1,opt,name=apiServerID"`
 
 	// The API server encodes the object to this version when persisting it in
 	// the backend (e.g., etcd).
-	EncodingVersion string `json:"encodingVersion,omitempty" protobuf:"bytes,2,opt,name=encodingVersion"`
+	// +required
+	EncodingVersion string `json:"encodingVersion" protobuf:"bytes,2,opt,name=encodingVersion"`
 
 	// The API server can decode objects encoded in these versions.
 	// The encodingVersion must be included in the decodableVersions.
 	// +listType=set
-	DecodableVersions []string `json:"decodableVersions,omitempty" protobuf:"bytes,3,opt,name=decodableVersions"`
+	// +required
+	DecodableVersions []string `json:"decodableVersions" protobuf:"bytes,3,opt,name=decodableVersions"`
 
 	// The API server can serve these versions.
 	// DecodableVersions must include all ServedVersions.
 	// +listType=set
+	// +optional
 	ServedVersions []string `json:"servedVersions,omitempty" protobuf:"bytes,4,opt,name=servedVersions"`
 }
 
@@ -111,6 +118,7 @@ type StorageVersionCondition struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
 	// Last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,4,opt,name=lastTransitionTime"`
 	// The reason for the condition's last transition.
 	// +required

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -148,7 +148,7 @@ message HorizontalPodAutoscaler {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-  // +optional
+  // +required
   optional HorizontalPodAutoscalerSpec spec = 2;
 
   // status is the current information about the autoscaler.

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -97,7 +97,7 @@ type HorizontalPodAutoscaler struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	// +optional
+	// +required
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is the current information about the autoscaler.

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -175,7 +175,7 @@ message HorizontalPodAutoscaler {
 
   // spec is the specification for the behaviour of the autoscaler.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-  // +optional
+  // +required
   optional HorizontalPodAutoscalerSpec spec = 2;
 
   // status is the current information about the autoscaler.

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -40,7 +40,7 @@ type HorizontalPodAutoscaler struct {
 
 	// spec is the specification for the behaviour of the autoscaler.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
-	// +optional
+	// +required
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is the current information about the autoscaler.

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -38,7 +38,7 @@ message CronJob {
 
   // Specification of the desired behavior of a cron job, including the schedule.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional CronJobSpec spec = 2;
 
   // Current status of a cron job.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -686,7 +686,7 @@ type CronJob struct {
 
 	// Specification of the desired behavior of a cron job, including the schedule.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec CronJobSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// Current status of a cron job.

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -39,7 +39,7 @@ message CronJob {
 
   // Specification of the desired behavior of a cron job, including the schedule.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional CronJobSpec spec = 2;
 
   // Current status of a cron job.

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -52,7 +52,7 @@ type CronJob struct {
 
 	// Specification of the desired behavior of a cron job, including the schedule.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec CronJobSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
 	// Current status of a cron job.

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -289,6 +289,7 @@ message PodCertificateRequest {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the details about the certificate being requested.
+  // +required
   optional PodCertificateRequestSpec spec = 2;
 
   // status contains the issued certificate, and a standard set of conditions.

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -374,6 +374,7 @@ type PodCertificateRequest struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec contains the details about the certificate being requested.
+	// +required
 	Spec PodCertificateRequestSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status contains the issued certificate, and a standard set of conditions.

--- a/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
@@ -38,7 +38,7 @@ message LeaseCandidate {
 
   // spec contains the specification of the Lease.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional LeaseCandidateSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/coordination/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/types.go
@@ -35,7 +35,7 @@ type LeaseCandidate struct {
 
 	// spec contains the specification of the Lease.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec LeaseCandidateSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
@@ -50,7 +50,7 @@ message LeaseCandidate {
 
   // spec contains the specification of the Lease.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional LeaseCandidateSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/coordination/v1beta1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types.go
@@ -106,7 +106,7 @@ type LeaseCandidate struct {
 
 	// spec contains the specification of the Lease.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec LeaseCandidateSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -87,7 +87,7 @@ message IPAddress {
 
   // spec is the desired state of the IPAddress.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional IPAddressSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -662,7 +662,7 @@ type IPAddress struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec is the desired state of the IPAddress.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec IPAddressSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -88,7 +88,7 @@ message IPAddress {
 
   // spec is the desired state of the IPAddress.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional IPAddressSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -447,7 +447,7 @@ type IPAddress struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// spec is the desired state of the IPAddress.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec IPAddressSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -70,6 +70,7 @@ message ClusterRoleBinding {
   // RoleRef can only reference a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // This field is immutable.
+  // +required
   optional RoleRef roleRef = 3;
 }
 
@@ -152,6 +153,7 @@ message RoleBinding {
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
   // This field is immutable.
+  // +required
   optional RoleRef roleRef = 3;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -146,6 +146,7 @@ type RoleBinding struct {
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// This field is immutable.
+	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`
 }
 
@@ -231,6 +232,7 @@ type ClusterRoleBinding struct {
 	// RoleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
 	// This field is immutable.
+	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`
 }
 

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -71,6 +71,7 @@ message ClusterRoleBinding {
 
   // RoleRef can only reference a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
+  // +required
   optional RoleRef roleRef = 3;
 }
 
@@ -156,6 +157,7 @@ message RoleBinding {
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
+  // +required
   optional RoleRef roleRef = 3;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -144,6 +144,7 @@ type RoleBinding struct {
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`
 }
 
@@ -228,6 +229,7 @@ type ClusterRoleBinding struct {
 
 	// RoleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`
 }
 

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -71,6 +71,7 @@ message ClusterRoleBinding {
 
   // RoleRef can only reference a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
+  // +required
   optional RoleRef roleRef = 3;
 }
 
@@ -157,6 +158,7 @@ message RoleBinding {
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
   // If the RoleRef cannot be resolved, the Authorizer must return an error.
+  // +required
   optional RoleRef roleRef = 3;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -152,6 +152,7 @@ type RoleBinding struct {
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`
 }
 
@@ -251,6 +252,7 @@ type ClusterRoleBinding struct {
 
 	// RoleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	// +required
 	RoleRef RoleRef `json:"roleRef" protobuf:"bytes,3,opt,name=roleRef"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -1586,6 +1586,7 @@ message ResourceSlice {
   // Contains the information published by the driver.
   //
   // Changing the spec automatically increments the metadata.generation number.
+  // +required
   optional ResourceSliceSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -79,6 +79,7 @@ type ResourceSlice struct {
 	// Contains the information published by the driver.
 	//
 	// Changing the spec automatically increments the metadata.generation number.
+	// +required
 	Spec ResourceSliceSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
@@ -140,6 +140,7 @@ message DeviceTaintRule {
   // Spec specifies the selector and one taint.
   //
   // Changing the spec automatically increments the metadata.generation number.
+  // +required
   optional DeviceTaintRuleSpec spec = 2;
 
   // Status provides information about what was requested in the spec.

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -201,6 +201,7 @@ type DeviceTaintRule struct {
 	// Spec specifies the selector and one taint.
 	//
 	// Changing the spec automatically increments the metadata.generation number.
+	// +required
 	Spec DeviceTaintRuleSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 
 	// Status provides information about what was requested in the spec.

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1613,6 +1613,7 @@ message ResourceSlice {
   // Contains the information published by the driver.
   //
   // Changing the spec automatically increments the metadata.generation number.
+  // +required
   optional ResourceSliceSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -82,6 +82,7 @@ type ResourceSlice struct {
 	// Contains the information published by the driver.
 	//
 	// Changing the spec automatically increments the metadata.generation number.
+	// +required
 	Spec ResourceSliceSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1598,6 +1598,7 @@ message ResourceSlice {
   // Contains the information published by the driver.
   //
   // Changing the spec automatically increments the metadata.generation number.
+  // +required
   optional ResourceSliceSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -82,6 +82,7 @@ type ResourceSlice struct {
 	// Contains the information published by the driver.
 	//
 	// Changing the spec automatically increments the metadata.generation number.
+	// +required
 	Spec ResourceSliceSpec `json:"spec" protobuf:"bytes,2,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -510,6 +510,7 @@ message VolumeAttachment {
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
   // +k8s:immutable
+  // +required
   optional VolumeAttachmentSpec spec = 2;
 
   // status represents status of the VolumeAttachment request.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -134,6 +134,7 @@ type VolumeAttachment struct {
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
 	// +k8s:immutable
+	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status represents status of the VolumeAttachment request.

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -135,6 +135,7 @@ message VolumeAttachment {
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
   // +k8s:immutable
+  // +required
   optional VolumeAttachmentSpec spec = 2;
 
   // status represents status of the VolumeAttachment request.

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -45,6 +45,7 @@ type VolumeAttachment struct {
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
 	// +k8s:immutable
+	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status represents status of the VolumeAttachment request.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -512,6 +512,7 @@ message VolumeAttachment {
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
   // +k8s:immutable
+  // +required
   optional VolumeAttachmentSpec spec = 2;
 
   // status represents status of the VolumeAttachment request.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -139,6 +139,7 @@ type VolumeAttachment struct {
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
 	// +k8s:immutable
+	// +required
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status represents status of the VolumeAttachment request.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -425,6 +425,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscaler(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -1443,7 +1443,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: apiServerID
       type:
         scalar: string
-      default: ""
     - name: decodableVersions
       type:
         list:
@@ -1453,7 +1452,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: encodingVersion
       type:
         scalar: string
-      default: ""
     - name: servedVersions
       type:
         list:

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -1443,6 +1443,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: apiServerID
       type:
         scalar: string
+      default: ""
     - name: decodableVersions
       type:
         list:
@@ -1452,6 +1453,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: encodingVersion
       type:
         scalar: string
+      default: ""
     - name: servedVersions
       type:
         list:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

This PR is the first in a wave of enabling enforcement that every API field should be marked either `+optional` XOR `+required`.

Starting with the `apiserverinternal` API group. I've marked each field that previously wasn't marked with optionality based on reviewing the storage implementation and the behaviour when the field is unspecified.

All other API groups are ignored for now (as there are another ~900 issues to fix), with the plan being to enable these groups 1:1 moving forward.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Relates to #134671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updates API server internal API group to improve openapi schema correctness for fields being optional or required
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
