### PR TITLE
Automated cherry pick of #132533: DRA: fix deleting orphaned ResourceClaim on startup

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -338,7 +338,7 @@ func (ec *Controller) podNeedsWork(pod *v1.Pod) (bool, string) {
 }
 
 func (ec *Controller) enqueueResourceClaim(logger klog.Logger, oldObj, newObj interface{}) {
-	deleted := newObj != nil
+	deleted := newObj == nil
 	if d, ok := oldObj.(cache.DeletedFinalStateUnknown); ok {
 		oldObj = d.Obj
 	}


### PR DESCRIPTION
Cherry pick of #132533 on release-1.33.

#132533: DRA: fix deleting orphaned ResourceClaim on startup

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```