### PR TITLE
Automated cherry pick of #134268: gce: Fix etcd manifest

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1955,10 +1955,14 @@ def resolve(host):
   fi
   sed -i -e "s@{{ *etcd_protocol *}}@$etcd_protocol@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_apiserver_protocol *}}@$etcd_apiserver_protocol@g" "${temp_file}"
-  sed -i -e "s@{{ *etcd_creds *}}@$etcd_creds@g" "${temp_file}"
+
+  etcd_creds_and_extra_args="${etcd_creds} ${etcd_apiserver_creds} ${etcd_extra_args}"
+  etcd_creds_and_extra_args=$(echo "$etcd_creds_and_extra_args" | awk '{for (i=1;i<=NF;i++) printf "\"%s\"%s", $i, (i<NF?", ":"") }')
+  etcdctl_certs=$(echo "$etcdctl_certs" | awk '{for (i=1; i<=NF; i++) printf "\"%s\",", $i }')
+
+  sed -i -e "s@{{ *etcd_creds_and_extra_args *}}@$etcd_creds_and_extra_args@g" "${temp_file}"
+
   sed -i -e "s@{{ *etcdctl_certs *}}@$etcdctl_certs@g" "${temp_file}"
-  sed -i -e "s@{{ *etcd_apiserver_creds *}}@$etcd_apiserver_creds@g" "${temp_file}"
-  sed -i -e "s@{{ *etcd_extra_args *}}@$etcd_extra_args@g" "${temp_file}"
   if [[ -n "${ETCD_VERSION:-}" ]]; then
     sed -i -e "s@{{ *pillar\.get('etcd_version', '\(.*\)') *}}@${ETCD_VERSION}@g" "${temp_file}"
   else
@@ -1972,6 +1976,7 @@ def resolve(host):
     container_security_context="\"securityContext\": {\"runAsUser\": ${ETCD_RUNASUSER}, \"runAsGroup\": ${ETCD_RUNASGROUP}, \"allowPrivilegeEscalation\": false, \"capabilities\": {\"drop\": [\"all\"]}},"
   fi
   sed -i -e "s@{{security_context}}@${container_security_context}@g" "${temp_file}"
+
   mv "${temp_file}" /etc/kubernetes/manifests
 }
 

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -25,10 +25,19 @@
       }
     },
     "command": [
-              "/bin/sh",
-              "-c",
-              "if [ -e /usr/local/bin/migrate-if-needed.sh ]; then /usr/local/bin/migrate-if-needed.sh 1>>/var/log/etcd{{ suffix }}.log 2>&1; fi; exec /usr/local/bin/etcd --name etcd-{{ hostname }} --listen-peer-urls {{ etcd_protocol }}://{{ host_ip }}:{{ server_port }} --initial-advertise-peer-urls {{ etcd_protocol }}://{{ hostname }}:{{ server_port }} --advertise-client-urls {{ etcd_apiserver_protocol }}://127.0.0.1:{{ port }} --listen-client-urls {{ etcd_apiserver_protocol }}://{{ listen_client_ip }}:{{ port }} {{ quota_bytes }} --data-dir /var/etcd/data{{ suffix }} --initial-cluster-state {{ cluster_state }} --initial-cluster {{ etcd_cluster }} {{ etcd_creds }} {{ etcd_apiserver_creds }} {{ etcd_extra_args }} 1>>/var/log/etcd{{ suffix }}.log 2>&1"
-            ],
+      "/usr/local/bin/etcd",
+      "--name=etcd-{{ hostname }}",
+      "--listen-peer-urls={{ etcd_protocol }}://{{ host_ip }}:{{ server_port }}",
+      "--initial-advertise-peer-urls={{ etcd_protocol }}://{{ hostname }}:{{ server_port }}",
+      "--advertise-client-urls={{ etcd_apiserver_protocol }}://127.0.0.1:{{ port }}",
+      "--listen-client-urls={{ etcd_apiserver_protocol }}://{{ listen_client_ip }}:{{ port }}",
+      "{{ quota_bytes }}",
+      "--data-dir=/var/etcd/data{{ suffix }}",
+      "--initial-cluster-state={{ cluster_state }}",
+      "--initial-cluster={{ etcd_cluster }}",
+      "--log-outputs=/var/log/etcd{{ suffix }}.log",
+      {{ etcd_creds_and_extra_args }}
+    ],
     "env": [
       { "name": "TARGET_STORAGE",
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
@@ -52,12 +61,6 @@
       { "name": "INITIAL_ADVERTISE_PEER_URLS",
         "value": "{{ etcd_protocol }}://{{ hostname }}:{{ server_port }}"
       },
-      { "name": "ETCD_CREDS",
-        "value": "{{ etcd_creds }}"
-      },
-      { "name": "ETCD_APISERVER_CREDS",
-        "value": "{{ etcd_apiserver_creds }}"
-      },
       { "name": "ETCD_SNAPSHOT_COUNT",
         "value": "10000"
       },
@@ -72,9 +75,12 @@
     "livenessProbe": {
       "exec": {
         "command": [
-          "/bin/sh",
-          "-c",
-          "set -x; exec /usr/local/bin/etcdctl --endpoints=127.0.0.1:{{ port }} {{ etcdctl_certs }} --command-timeout=15s endpoint health"
+          "/usr/local/bin/etcdctl",
+          "--endpoints=127.0.0.1:{{ port }}",
+          "--command-timeout=15s",
+          {{ etcdctl_certs }}
+          "endpoint",
+          "health"
         ]
       },
       "initialDelaySeconds": {{ liveness_probe_initial_delay }},


### PR DESCRIPTION
Cherry pick of #134268 on release-1.31.

#134268: gce: Fix etcd manifest

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```