### PR TITLE
Drop support for policyv1beta1.PodDisruptionBudget in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4878,8 +4878,8 @@ type PodDisruptionBudgetDescriber struct {
 
 func (p *PodDisruptionBudgetDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
 	var (
-		pdbv1      *policyv1.PodDisruptionBudget
-		err        error
+		pdbv1 *policyv1.PodDisruptionBudget
+		err   error
 	)
 
 	pdbv1, err = p.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -51,7 +51,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	policyv1 "k8s.io/api/policy/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -233,7 +232,6 @@ func describerMap(clientConfig *rest.Config) (map[schema.GroupKind]ResourceDescr
 		{Group: storagev1.GroupName, Kind: "StorageClass"}:                        &StorageClassDescriber{c},
 		{Group: storagev1.GroupName, Kind: "CSINode"}:                             &CSINodeDescriber{c},
 		{Group: storagev1.GroupName, Kind: "VolumeAttributesClass"}:               &VolumeAttributesClassDescriber{c},
-		{Group: policyv1beta1.GroupName, Kind: "PodDisruptionBudget"}:             &PodDisruptionBudgetDescriber{c},
 		{Group: policyv1.GroupName, Kind: "PodDisruptionBudget"}:                  &PodDisruptionBudgetDescriber{c},
 		{Group: rbacv1.GroupName, Kind: "Role"}:                                   &RoleDescriber{c},
 		{Group: rbacv1.GroupName, Kind: "ClusterRole"}:                            &ClusterRoleDescriber{c},
@@ -406,7 +404,6 @@ func init() {
 		describePersistentVolumeClaim,
 		describePod,
 		describePodDisruptionBudgetV1,
-		describePodDisruptionBudgetV1beta1,
 		describePriorityClass,
 		describeQuota,
 		describeReplicaSet,
@@ -4882,65 +4879,22 @@ type PodDisruptionBudgetDescriber struct {
 func (p *PodDisruptionBudgetDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
 	var (
 		pdbv1      *policyv1.PodDisruptionBudget
-		pdbv1beta1 *policyv1beta1.PodDisruptionBudget
 		err        error
 	)
 
 	pdbv1, err = p.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err == nil {
-		var events *corev1.EventList
-		if describerSettings.ShowEvents {
-			events, _ = searchEvents(p.CoreV1(), pdbv1, describerSettings.ChunkSize)
-		}
-		return describePodDisruptionBudgetV1(pdbv1, events)
+	if err != nil {
+		return "", err
 	}
 
-	// try falling back to v1beta1 in NotFound error cases
-	if apierrors.IsNotFound(err) {
-		pdbv1beta1, err = p.PolicyV1beta1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(p.CoreV1(), pdbv1, describerSettings.ChunkSize)
 	}
-	if err == nil {
-		var events *corev1.EventList
-		if describerSettings.ShowEvents {
-			events, _ = searchEvents(p.CoreV1(), pdbv1beta1, describerSettings.ChunkSize)
-		}
-		return describePodDisruptionBudgetV1beta1(pdbv1beta1, events)
-	}
-
-	return "", err
+	return describePodDisruptionBudgetV1(pdbv1, events)
 }
 
 func describePodDisruptionBudgetV1(pdb *policyv1.PodDisruptionBudget, events *corev1.EventList) (string, error) {
-	return tabbedString(func(out io.Writer) error {
-		w := NewPrefixWriter(out)
-		w.Write(LEVEL_0, "Name:\t%s\n", pdb.Name)
-		w.Write(LEVEL_0, "Namespace:\t%s\n", pdb.Namespace)
-
-		if pdb.Spec.MinAvailable != nil {
-			w.Write(LEVEL_0, "Min available:\t%s\n", pdb.Spec.MinAvailable.String())
-		} else if pdb.Spec.MaxUnavailable != nil {
-			w.Write(LEVEL_0, "Max unavailable:\t%s\n", pdb.Spec.MaxUnavailable.String())
-		}
-
-		if pdb.Spec.Selector != nil {
-			w.Write(LEVEL_0, "Selector:\t%s\n", metav1.FormatLabelSelector(pdb.Spec.Selector))
-		} else {
-			w.Write(LEVEL_0, "Selector:\t<unset>\n")
-		}
-		w.Write(LEVEL_0, "Status:\n")
-		w.Write(LEVEL_2, "Allowed disruptions:\t%d\n", pdb.Status.DisruptionsAllowed)
-		w.Write(LEVEL_2, "Current:\t%d\n", pdb.Status.CurrentHealthy)
-		w.Write(LEVEL_2, "Desired:\t%d\n", pdb.Status.DesiredHealthy)
-		w.Write(LEVEL_2, "Total:\t%d\n", pdb.Status.ExpectedPods)
-		if events != nil {
-			DescribeEvents(events, w)
-		}
-
-		return nil
-	})
-}
-
-func describePodDisruptionBudgetV1beta1(pdb *policyv1beta1.PodDisruptionBudget, events *corev1.EventList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", pdb.Name)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -40,7 +40,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	policyv1 "k8s.io/api/policy/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -4083,34 +4082,6 @@ func TestDescribeCSINode(t *testing.T) {
 		!strings.Contains(out, "node1") ||
 		!strings.Contains(out, "driver2") ||
 		!strings.Contains(out, "node2") {
-		t.Errorf("unexpected out: %s", out)
-	}
-}
-
-func TestDescribePodDisruptionBudgetV1beta1(t *testing.T) {
-	minAvailable := intstr.FromInt32(22)
-	f := fake.NewSimpleClientset(&policyv1beta1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         "ns1",
-			Name:              "pdb1",
-			CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
-		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
-			MinAvailable: &minAvailable,
-		},
-		Status: policyv1beta1.PodDisruptionBudgetStatus{
-			DisruptionsAllowed: 5,
-		},
-	})
-	s := PodDisruptionBudgetDescriber{f}
-	out, err := s.Describe("ns1", "pdb1", DescriberSettings{ShowEvents: true})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !strings.Contains(out, "pdb1") ||
-		!strings.Contains(out, "ns1") ||
-		!strings.Contains(out, "22") ||
-		!strings.Contains(out, "5") {
 		t.Errorf("unexpected out: %s", out)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
It cleans up deprecated `policyv1beta1.PodDisruptionBudget` so we will not have to modify `ResourceDescriber` logic for it when implementing https://github.com/kubernetes/kubectl/issues/1769 and https://github.com/kubernetes/kubernetes/pull/133498.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubectl/issues/1769

#### Does this PR introduce a user-facing change?
```release-note
Dropped support for policy/v1beta1 PodDisruptionBudget in kubectl
```
