### PR TITLE
e2e framework: inject also information about feature gate dependencies

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -269,8 +269,10 @@ func transformGinkgoNodeArgs(nodeType types.NodeType, offset ginkgo.Offset, text
 // based on the previously added labels.
 //
 // The initial set contains the labels defined in the E2E framework. Feature
-// gate stability texts (Alpha, Beta, etc.) get added when we encounter them
-// to avoid making assumptions about what those strings are.
+// gate stability texts (Alpha, Beta, etc.) and feature gate dependencies
+// get added when we encounter them
+// to avoid making assumptions about what those strings are or because
+// they simply aren't known upfront.
 var leafNodeLabels = sets.New[string](
 	"Conformance",
 	"Disruptive",
@@ -304,27 +306,56 @@ func expandGinkgoArgs(leafNode bool, offset ginkgo.Offset, text string, args []a
 		allLabels.Insert(label)
 	}
 
+	featureDependencies := utilfeature.DefaultMutableFeatureGate.Dependencies()
+
+	// addFeatureGate handles feature gates:
+	// - The [Feature:<name>] text for the directly named feature gate gets
+	//   inserted in place because the test name may depend on it.
+	// - The text for dependencies gets added at the end (additional information).
+	// - Meta data like [Beta] always gets added at the end.
+	var addFeatureGate func(name featuregate.Feature, spec featuregate.FeatureSpec, direct bool)
+	addFeatureGate = func(name featuregate.Feature, spec featuregate.FeatureSpec, direct bool) {
+		fullLabel := "FeatureGate:" + string(name)
+		addLabel(fullLabel)
+		if direct {
+			texts = append(texts, fmt.Sprintf("[%s]", fullLabel))
+		} else {
+			leafNodeLabels.Insert(fullLabel)
+		}
+
+		// We use mixed case (i.e. Beta instead of BETA). GA feature gates have no level string.
+		var level string
+		if spec.PreRelease != "" {
+			level = string(spec.PreRelease)
+			level = strings.ToUpper(level[0:1]) + strings.ToLower(level[1:])
+			addLabel(level)
+			leafNodeLabels.Insert(level)
+		}
+		if !spec.Default {
+			addLabel("Feature:OffByDefault")
+		}
+		if level == "Beta" && !spec.Default {
+			// Not embedded in text!
+			ginkgoArgs = append(ginkgoArgs, ginkgo.Label("BetaOffByDefault"))
+		}
+
+		// Also add dependencies, recursively.
+		for _, name := range featureDependencies[name] {
+			spec := utilfeature.DefaultMutableFeatureGate.GetAll()[name]
+			addFeatureGate(name, spec, false)
+		}
+	}
+
 	haveEmptyStrings := false
 	for _, arg := range args {
 		switch arg := arg.(type) {
+		case featureGate:
+			addFeatureGate(arg.name, arg.spec, true)
 		case label:
 			fullLabel := strings.Join(arg.parts, ":")
 			addLabel(fullLabel)
 			if !leafNodeLabels.Has(fullLabel) {
 				texts = append(texts, fmt.Sprintf("[%s]", fullLabel))
-			}
-			if arg.alphaBetaLevel != "" {
-				leafNodeLabels.Insert(arg.alphaBetaLevel)
-				addLabel(arg.alphaBetaLevel)
-			}
-			if arg.offByDefault {
-				addLabel("Feature:OffByDefault")
-				// Alphas are always off by default but we may want to select
-				// betas based on defaulted-ness.
-				if arg.alphaBetaLevel == "Beta" {
-					// Not embedded in text, only as Ginkgo label!
-					ginkgoArgs = append(ginkgoArgs, ginkgo.Label("BetaOffByDefault"))
-				}
 			}
 			if arg.parts[0] == "KubeletMinVersion" {
 				ginkgoArgs = append(ginkgoArgs, ginkgo.ComponentSemVerConstraint("kubelet", ">="+arg.parts[1]))
@@ -563,23 +594,17 @@ func (f *Framework) WithFeatureGate(featureGate featuregate.Feature) interface{}
 	return withFeatureGate(featureGate)
 }
 
-func withFeatureGate(featureGate featuregate.Feature) interface{} {
-	spec, ok := utilfeature.DefaultMutableFeatureGate.GetAll()[featureGate]
+func withFeatureGate(name featuregate.Feature) interface{} {
+	spec, ok := utilfeature.DefaultMutableFeatureGate.GetAll()[name]
 	if !ok {
-		RecordBug(NewBug(fmt.Sprintf("WithFeatureGate: the feature gate %q is unknown", featureGate), 2))
+		RecordBug(NewBug(fmt.Sprintf("WithFeatureGate: the feature gate %q is unknown", name), 2))
 	}
+	return featureGate{name, spec}
+}
 
-	// We use mixed case (i.e. Beta instead of BETA). GA feature gates have no level string.
-	var level string
-	if spec.PreRelease != "" {
-		level = string(spec.PreRelease)
-		level = strings.ToUpper(level[0:1]) + strings.ToLower(level[1:])
-	}
-
-	l := newLabel("FeatureGate", string(featureGate))
-	l.offByDefault = !spec.Default
-	l.alphaBetaLevel = level
-	return l
+type featureGate struct {
+	name featuregate.Feature
+	spec featuregate.FeatureSpec
 }
 
 // WithEnvironment specifies that a certain test or group of tests only works
@@ -750,25 +775,11 @@ func withKubeletMinVersion(version string) interface{} {
 type label struct {
 	// parts get concatenated with ":" to build the full label.
 	parts []string
-	// explanation gets set for each label to help developers
-	// who pass a label to a ginkgo function. They need to use
-	// the corresponding framework function instead.
-	explanation string
-
-	// TODO: the fields below are only used for FeatureGates, we may want to refactor
-
-	// alphaBetaLevel is "Alpha", "Beta" or empty for GA features
-	// It gets added as [<level>] [Feature:<level>]
-	// to the test name and as Feature:<level> to the labels.
-	alphaBetaLevel string
-	// set based on featuregate default state
-	offByDefault bool
 }
 
 func newLabel(parts ...string) label {
 	return label{
-		parts:       parts,
-		explanation: "If you see this as part of an 'Unknown Decorator' error from Ginkgo, then you need to replace the ginkgo.It/Context/Describe call with the corresponding framework.It/Context/Describe or (if available) f.It/Context/Describe.",
+		parts: parts,
 	}
 }
 
@@ -777,19 +788,21 @@ func newLabel(parts ...string) label {
 // of WithSerial(), the result will be false. False is also returned
 // when a parameter is some completely different value.
 func TagsEqual(a, b interface{}) bool {
-	al, ok := a.(label)
-	if !ok {
+	switch a := a.(type) {
+	case label:
+		b, ok := b.(label)
+		if !ok {
+			return false
+		}
+		return slices.Equal(a.parts, b.parts)
+	case featureGate:
+		b, ok := b.(featureGate)
+		if !ok {
+			return false
+		}
+		return a == b
+	default:
+		// Unknown tag, cannot compare.
 		return false
 	}
-	bl, ok := b.(label)
-	if !ok {
-		return false
-	}
-	if al.alphaBetaLevel != bl.alphaBetaLevel {
-		return false
-	}
-	if al.offByDefault != bl.offByDefault {
-		return false
-	}
-	return slices.Equal(al.parts, bl.parts)
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The motivation is to show feature gate dependencies (https://github.com/kubernetes/kubernetes/pull/133697/files#r2353291583).

This shouldn't substantially change which tests run in jobs (an on-by-default beta feature can only depend on other on-by-default features, for example), it just makes the FeatureGate list in the test name more complete.

The additional feature gate names are treated like additional meta data and get added at the end of the full test name.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/pull/133697/files#r2353291583, https://github.com/kubernetes/kubernetes/pull/133912#pullrequestreview-3341990541

#### Special notes for your reviewer:

A word diff of the `-list-tests` output for this PR confirms that the only changes are the additional feature gate names:

```diff
diff --git a/tmp/before b/tmp/after
index 671b61315c8..5b1492a877e 100644
--- a/tmp/before
+++ b/tmp/after
@@ -247 +247 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    apps/job.go:1337: [sig-apps] Job containers restarted by container restart policy should not trigger PodFailurePolicy [FeatureGate:ContainerRestartRules] [Beta] {+[FeatureGate:ContainerRestartRules]+} [NodeConformance]
@@ -256 +256 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    apps/job.go:1382: [sig-apps] Job should create Workload and PodGroup for gang-eligible Job [FeatureGate:GenericWorkload] [FeatureGate:WorkloadWithJob] [Alpha] [Feature:OffByDefault] {+[FeatureGate:GenericWorkload]+}
@@ -333,6 +333,6 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    auth/projected_podcertificate.go:232: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should fail pod startup when MaxExpirationSeconds exceeds maximum (91d) [Beta] [Feature:OffByDefault] {+[FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors] [FeatureGate:ClusterTrustBundle]+}
    auth/projected_podcertificate.go:251: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should fail pod startup when MaxExpirationSeconds is less than minimum (1h) [Beta] [Feature:OffByDefault] {+[FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors] [FeatureGate:ClusterTrustBundle]+}
    auth/projected_podcertificate.go:161: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should issue certificate with default life time (24h) when MaxExpirationSeconds is not set [Beta] [Feature:OffByDefault] {+[FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors] [FeatureGate:ClusterTrustBundle]+}
    auth/projected_podcertificate.go:196: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should issue certificate with specified duration (1h) when MaxExpirationSeconds is set [Beta] [Feature:OffByDefault] {+[FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors] [FeatureGate:ClusterTrustBundle]+}
    auth/projected_podcertificate.go:73: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should allow server and client pods to establish an mTLS connection [Beta] [Feature:OffByDefault] {+[FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors] [FeatureGate:ClusterTrustBundle]+}
    auth/projected_podcertificate.go:112: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should honor UserAnnotations for SPIFFE URI path [Beta] [Feature:OffByDefault] {+[FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors] [FeatureGate:ClusterTrustBundle]+}
@@ -364,9 +364,9 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    auth/projected_clustertrustbundle.go:266: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be able to mount a big number (>100) of CTBs [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:71: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be able to mount a single ClusterTrustBundle by name [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:238: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be able to specify multiple CTB volumes [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels can combine all signer CTBs with an empty label selector [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels can combine multiple CTBs with signer name and label selector [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels should start if only signer name and explicit label selector matches nothing + optional=true [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels should start if only signer name and nil label selector + optional=true [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:193: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should prevent a pod from starting if: sets optional=false and no trust bundle matches query [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
    auth/projected_clustertrustbundle.go:193: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should prevent a pod from starting if: sets optional=false and the configured CTB does not exist [Beta] [Feature:OffByDefault] {+[FeatureGate:ClusterTrustBundle]+}
@@ -410,2 +410,2 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    autoscaling/horizontal_pod_autoscaling.go:79: [sig-autoscaling] [Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) Deployment (Pod-level Resources ContainerResource Metric) [FeatureGate:PodLevelResources] Should scale from 1 pod to 3 pods and then from 3 pods to 5 pods using Average Utilization for aggregation [Beta] {+[FeatureGate:PodLevelResources]+}
    autoscaling/horizontal_pod_autoscaling.go:73: [sig-autoscaling] [Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) Deployment (Pod-level Resources Resource Metric) [FeatureGate:PodLevelResources] Should scale from 1 pod to 3 pods and then from 3 pods to 5 pods using Average Utilization for aggregation [Beta] {+[FeatureGate:PodLevelResources]+}
@@ -829,2 +829,2 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    common/node/downwardapi.go:425: [sig-node] Downward API [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Downward API tests for pod level resources should provide default limits.cpu/memory from pod level resources [Beta] {+[FeatureGate:PodLevelResources]+}
    common/node/downwardapi.go:484: [sig-node] Downward API [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Downward API tests for pod level resources should provide default limits.cpu/memory from pod level resources or node allocatable [Beta] {+[FeatureGate:PodLevelResources]+}
@@ -894,159 +894,159 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    common/node/pod_level_resources_resize.go:111: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:110: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:108: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:109: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:114: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing only pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:115: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing only pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:117: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:116: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing pod-level cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:112: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:113: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart + resize initContainers resizing pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:111: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:110: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:108: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:109: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:114: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing only pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:115: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing only pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:117: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:116: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing pod-level cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:112: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:113: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu & mem restart resizing pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:111: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:110: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:108: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:109: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:114: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing only pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:115: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing only pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:117: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:116: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing pod-level cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:112: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:113: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy cpu restart resizing pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:111: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:110: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:108: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:109: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:114: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing only pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:115: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing only pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:117: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:116: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing pod-level cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:112: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:113: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy mem restart resizing pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:111: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:110: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:108: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:109: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:114: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing only pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:115: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing only pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:117: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:116: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing pod-level cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:112: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:113: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart + resize initContainers resizing pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:111: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:110: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:108: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:109: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:114: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing only pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:115: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing only pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:117: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:116: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing pod-level cpu & mem in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:112: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing pod-level cpu [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:113: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR guaranteed qos - 1 container with resize policy no restart resizing pod-level mem [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:254: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:255: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:251: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:250: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:253: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:252: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:261: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing pod-level all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:262: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:258: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing pod-level cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:257: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing pod-level cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:260: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing pod-level mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:259: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing pod-level mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:263: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing pod-level requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:256: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu & mem restart resizing requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:254: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:255: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:251: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:250: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:253: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:252: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:261: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing pod-level all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:262: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:258: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing pod-level cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:257: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing pod-level cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:260: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing pod-level mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:259: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing pod-level mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:263: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing pod-level requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:256: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy cpu restart resizing requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:254: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:255: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:251: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:250: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:253: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:252: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:261: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing pod-level all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:262: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:258: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing pod-level cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:257: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing pod-level cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:260: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing pod-level mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:259: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing pod-level mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:263: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing pod-level requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:256: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy mem restart resizing requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:254: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:255: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:251: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:250: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:253: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:252: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:261: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing pod-level all resources in the same direction [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:262: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing pod-level cpu & mem in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:258: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing pod-level cpu limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:257: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing pod-level cpu requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:260: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing pod-level mem limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:259: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing pod-level mem requests [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:263: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing pod-level requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:256: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] PLR pod-level burstable pods - 1 container with all requests & limits set and resize policy no restart resizing requests & limits in opposite directions [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:283: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] burstable pods - extended 6 containers - various operations performed (including adding limits and requests) [MinimumKubeletVersion:1.34] [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:346: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] burstable pods - extended resize with equivalents [MinimumKubeletVersion:1.34] [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:370: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] burstable pods - pod-level resources pod-level resize with equivalents [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:387: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] burstable pods - pod-level resources pod-level resize with limits add [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:421: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] burstable pods - pod-level resources pod-level resize with no container requests and limits [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:404: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] burstable pods - pod-level resources pod-level resize with requests and limits add [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:525: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] decrease pod-level memory limit below usage [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:136: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] pod-level guaranteed pods with multiple containers 3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on c3 - net increase [MinimumKubeletVersion:1.34] [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:166: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] pod-level guaranteed pods with multiple containers 3 containers - increase cpu & mem on c1, decrease cpu & mem on c2, c3 - net decrease [MinimumKubeletVersion:1.34] [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:196: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] pod-level guaranteed pods with multiple containers 3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2) [MinimumKubeletVersion:1.34] [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/pod_level_resources_resize.go:649: [sig-node] PLR Pod InPlace Resize [FeatureGate:InPlacePodLevelResourcesVerticalScaling] should not emit ResizeCompleted event on initial creation [KubeletMinVersion:1.36] [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures] [FeatureGate:PodLevelResources]+}
    common/node/container_restart_policy.go:387: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should allow multiple RestartAllContainers actions and not introduce a loop [Beta] {+[FeatureGate:ContainerRestartRules] [FeatureGate:NodeDeclaredFeatures]+}
    common/node/container_restart_policy.go:440: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart all containers on a previously restarted regular container exit [Beta] {+[FeatureGate:ContainerRestartRules] [FeatureGate:NodeDeclaredFeatures]+}
    common/node/container_restart_policy.go:196: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart all containers on regular container exit [Beta] {+[FeatureGate:ContainerRestartRules] [FeatureGate:NodeDeclaredFeatures]+}
    common/node/container_restart_policy.go:260: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart all containers on sidecar container exit [Beta] {+[FeatureGate:ContainerRestartRules] [FeatureGate:NodeDeclaredFeatures]+}
    common/node/container_restart_policy.go:324: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart init and sidecar containers on init container exit [Beta] {+[FeatureGate:ContainerRestartRules] [FeatureGate:NodeDeclaredFeatures]+}
    common/node/container_restart_policy.go:78: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should not restart container on rule mismatch, container restart policy Never [Beta] {+[FeatureGate:ContainerRestartRules]+}
    common/node/container_restart_policy.go:131: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on container-level restart policy Always [Beta] {+[FeatureGate:ContainerRestartRules]+}
    common/node/container_restart_policy.go:109: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on container-level restart policy Never [Beta] {+[FeatureGate:ContainerRestartRules]+}
    common/node/container_restart_policy.go:153: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on pod-level restart policy Always when no container-level restart policy [Beta] {+[FeatureGate:ContainerRestartRules]+}
    common/node/container_restart_policy.go:47: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on rule match [Beta] {+[FeatureGate:ContainerRestartRules]+}
    node/pod_resize.go:698: [sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-1 {+[FeatureGate:InPlacePodVerticalScaling]+} [Serial]
    node/pod_resize.go:821: [sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-2 {+[FeatureGate:InPlacePodVerticalScaling]+} [Serial]
    node/pod_resize.go:1044: [sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-3 {+[FeatureGate:InPlacePodVerticalScaling]+} [Serial]
    node/pod_resize.go:331: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test exceed maximum CPU {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:342: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test exceed maximum Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:353: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test exceed maximum Memory and CPU {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:364: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test request below min CPU {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:386: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test request below min CPU and min Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:375: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test request below min Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:461: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid decrease of CPU {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:477: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid decrease of CPU and Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:445: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid decrease of Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:397: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid increase of CPU {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:429: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid increase of CPU and Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:413: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid increase of Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:136: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test exceed maximum CPU {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:158: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test exceed maximum CPU and Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:147: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test exceed maximum Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:201: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test valid increase for both CPU and Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:169: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test valid increase of CPU {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:185: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test valid increase of Memory {+[FeatureGate:InPlacePodVerticalScaling]+}
    node/pod_resize.go:496: [sig-node] Pod InPlace Resize Container (scheduler-focused) [FeatureGate:InPlacePodVerticalScaling] pod-resize-scheduler-tests {+[FeatureGate:InPlacePodVerticalScaling]+} [Serial]
@@ -1122,21 +1122,21 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    common/node/pod_resize.go:695: [sig-node] Pod InPlace Resize Init Container [FeatureGate:InPlacePodVerticalScalingInitContainers] should support resizing a non-sidecar init container [Beta] {+[FeatureGate:InPlacePodVerticalScaling] [FeatureGate:NodeDeclaredFeatures]+}
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] BestEffort QoS no pod resources, no container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod with yet some other container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, 1 container with resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, no container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, partial requests in pod level resources, 1 container with guaranteed resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources limits, container resources limits [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources limits, container resources requests [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests and limits, container resources limits [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests and limits, container resources requests [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources limits [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources requests [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources requests and limits [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources requests and partial limits [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, no container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, partial container resources limits [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod with only container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod with other container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod, 1 container with resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod, no container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod, pod resources limits, no container resources [Beta] {+[FeatureGate:PodLevelResources]+} [Serial]
@@ -1296 +1296 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:232: [sig-node] [DRA] CRUD Tests resource.k8s.io/v1alpha3 ResourcePoolStatusRequest [FeatureGate:DRAResourcePoolStatus] [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
@@ -1298,25 +1298,25 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:2837: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must accurately populate ExtendedResourceClaimStatus [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2734: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must cleanup extended resource claims when pods complete [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2744: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must cleanup extended resource claims when pods fail [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2787: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must prevent overcommitment of extended resources [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2904: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must process extended resource after Device Class creation [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2824: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must reject pod with invalid extended resource name [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2591: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with both implicit and explicit extended resource with one container two resources [KubeletMinVersion:1.35] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2608: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with explicit extended resource with one container one resource [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2631: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with explicit extended resource with one container three resources [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2682: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with explicit extended resource with three containers multiple resources each [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2650: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with explicit extended resource with three containers one resource each [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2880: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with extended resource requesting zero [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2486: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with extended resource with resource quota [KubeletMinVersion:1.35] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2622: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run a pod with implicit extended resource with one container one resource [KubeletMinVersion:1.35] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2942: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] must run pods with extended resource on dra nodes and device plugin nodes [KubeletMinVersion:1.35] [Beta] {+[FeatureGate:DynamicResourceAllocation]+} [Serial]
    dra/dra.go:2757: [sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Feature:DynamicResourceAllocation] process extended resources after device plugin uninstall [KubeletMinVersion:1.35] [Beta] {+[FeatureGate:DynamicResourceAllocation]+} [Serial]
    dra/dra.go:4014: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should clear NodeName when pool has slices on different nodes [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:3839: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should filter by pool name [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:3943: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should not reprocess after status is set [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:3810: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should populate status for all matching pools [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:631: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should reflect allocated devices after pod is scheduled [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:589: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should report pool status with correct device counts [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:3917: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should return empty pools for unknown driver [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:3978: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should set NodeName when all slices share the same node [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:3890: [sig-node] [DRA] control plane [FeatureGate:DRAResourcePoolStatus] should truncate results when limit is reached [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation]+}
@@ -1346,16 +1346,16 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:2083: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAConsumableCapacity] must allow multiple allocations and consume capacity [KubeletMinVersion:1.34] [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2213: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] DeviceTaintRule evicts pod [FeatureGate:DRADeviceTaintRules] [Beta] [Feature:OffByDefault] {+[FeatureGate:DRADeviceTaints] [FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2382: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] NoExecute can be tolerated [Beta] {+[FeatureGate:DRADeviceTaints] [FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2375: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] NoExecute keeps pod pending [Beta] {+[FeatureGate:DRADeviceTaints] [FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2201: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] NoSchedule can be tolerated [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2194: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] NoSchedule keeps pod pending [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2299: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] [FeatureGate:DRAWorkloadResourceClaims] [FeatureGate:GenericWorkload] [KubeletMinVersion:1.36] DeviceTaintRule evicts pod with PodGroup claim [FeatureGate:DRADeviceTaintRules] [Alpha] [Beta] [Feature:OffByDefault] {+[FeatureGate:DRADeviceTaints] [FeatureGate:DynamicResourceAllocation] [FeatureGate:GenericWorkload]+}
    dra/dra.go:2285: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] [FeatureGate:DRAWorkloadResourceClaims] [FeatureGate:GenericWorkload] [KubeletMinVersion:1.36] NoSchedule can be tolerated for PodGroup claims [Alpha] [Beta] [Feature:OffByDefault] {+[FeatureGate:DRADeviceTaints] [FeatureGate:DynamicResourceAllocation] [FeatureGate:GenericWorkload]+}
    dra/dra.go:2276: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] [FeatureGate:DRAWorkloadResourceClaims] [FeatureGate:GenericWorkload] [KubeletMinVersion:1.36] NoSchedule keeps pod with PodGroup claim pending [Alpha] [Beta] [Feature:OffByDefault] {+[FeatureGate:DRADeviceTaints] [FeatureGate:DynamicResourceAllocation] [FeatureGate:GenericWorkload]+}
    dra/dra.go:2022: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPartitionableDevices] must consume and free up counters [Beta] {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:1593: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] chooses the correct subrequest subject to constraints {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:1680: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] filters config correctly for multiple devices {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:1437: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] selects the first subrequest that can be satisfied {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:1510: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] uses the config for the selected subrequest {+[FeatureGate:DynamicResourceAllocation]+}
    dra/dra.go:2142: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:GenericWorkload] [FeatureGate:DRAWorkloadResourceClaims] [KubeletMinVersion:1.36] allocates devices for PodGroups [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation] [FeatureGate:GenericWorkload]+}
    dra/dra.go:2153: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:GenericWorkload] [FeatureGate:DRAWorkloadResourceClaims] [KubeletMinVersion:1.36] generates claims from templates for PodGroups [Alpha] [Feature:OffByDefault] {+[FeatureGate:DynamicResourceAllocation] [FeatureGate:GenericWorkload]+}
@@ -1394 +1394 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:3624: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] should report device health with custom messages [KubeletMinVersion:1.36] [FeatureGate:ResourceHealthStatusMessage] [Beta] {+[FeatureGate:DynamicResourceAllocation] [FeatureGate:ResourceHealthStatus]+}
@@ -1399 +1399 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:1834: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] with v1beta1 API supports requests with alternatives [FeatureGate:DRAPrioritizedList] {+[FeatureGate:DynamicResourceAllocation]+}
@@ -1401 +1401 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:1915: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] with v1beta2 API supports requests with alternatives [FeatureGate:DRAPrioritizedList] {+[FeatureGate:DynamicResourceAllocation]+}
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
