### PR TITLE
feat(kal): enforce either optional or required tag on batch API group

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1690,6 +1690,11 @@
           "x-kubernetes-list-type": "set"
         }
       },
+      "required": [
+        "apiServerID",
+        "encodingVersion",
+        "decodableVersions"
+      ],
       "type": "object"
     },
     "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
@@ -1717,8 +1722,7 @@
         }
       },
       "required": [
-        "spec",
-        "status"
+        "metadata"
       ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
@@ -4430,8 +4434,7 @@
         }
       },
       "required": [
-        "schedule",
-        "jobTemplate"
+        "schedule"
       ],
       "type": "object"
     },
@@ -4518,10 +4521,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "status"
-      ],
       "type": "object"
     },
     "io.k8s.api.batch.v1.JobList": {
@@ -4634,9 +4633,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "template"
-      ],
       "type": "object"
     },
     "io.k8s.api.batch.v1.JobStatus": {
@@ -4726,9 +4722,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "rules"
-      ],
       "type": "object"
     },
     "io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -140,8 +140,7 @@
           }
         },
         "required": [
-          "schedule",
-          "jobTemplate"
+          "schedule"
         ],
         "type": "object"
       },
@@ -266,10 +265,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "status"
-        ],
         "type": "object"
       },
       "io.k8s.api.batch.v1.JobList": {
@@ -409,9 +404,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "template"
-        ],
         "type": "object"
       },
       "io.k8s.api.batch.v1.JobStatus": {
@@ -533,9 +525,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "rules"
-        ],
         "type": "object"
       },
       "io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement": {

--- a/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
@@ -5,6 +5,7 @@
         "description": "An API server instance reports the version it can decode and the version it encodes objects to when persisting objects in the backend.",
         "properties": {
           "apiServerID": {
+            "default": "",
             "description": "The ID of the reporting API server.",
             "type": "string"
           },
@@ -18,6 +19,7 @@
             "x-kubernetes-list-type": "set"
           },
           "encodingVersion": {
+            "default": "",
             "description": "The API server encodes the object to this version when persisting it in the backend (e.g., etcd).",
             "type": "string"
           },
@@ -31,6 +33,11 @@
             "x-kubernetes-list-type": "set"
           }
         },
+        "required": [
+          "apiServerID",
+          "encodingVersion",
+          "decodableVersions"
+        ],
         "type": "object"
       },
       "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
@@ -73,8 +80,7 @@
           }
         },
         "required": [
-          "spec",
-          "status"
+          "metadata"
         ],
         "type": "object",
         "x-kubernetes-group-version-kind": [

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -146,7 +146,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -146,7 +146,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -143,6 +143,14 @@ linters:
         path: "staging/src/k8s.io/api/resource/"
       - text: "Conditions field in AllocatedDeviceStatus has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,5,rep,name=conditions\"`"
         path: "staging/src/k8s.io/api/resource/"
+      
+      # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
+      - text: "must be marked as optional or required"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+      
+      # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
+      - text: "field Error must not be marked as both optional and required"
+        path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
 
   default: standard
   enable: # please keep this alphabetized
@@ -303,7 +311,7 @@ linters:
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               # - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
               # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
-              # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+              - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
@@ -324,7 +332,6 @@ linters:
             # nomaps:
             #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
             # optionalFields:
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.optionalfields:
             #  pointers:
             #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
             #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
@@ -335,7 +342,6 @@ linters:
             # optionalOrRequired:
             #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
             #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.
             # requiredFields:
             #   pointers:
             #    policy: SuggestFix | Warn # The policy for pointers in required fields. Defaults to `SuggestFix`.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,7 @@ linters:
       
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -159,6 +159,14 @@ linters:
         path: "staging/src/k8s.io/api/resource/"
       - text: "Conditions field in AllocatedDeviceStatus has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,5,rep,name=conditions\"`"
         path: "staging/src/k8s.io/api/resource/"
+      
+      # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
+      - text: "must be marked as optional or required"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+      
+      # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
+      - text: "field Error must not be marked as both optional and required"
+        path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
 
   default: none
   enable: # please keep this alphabetized
@@ -317,7 +325,7 @@ linters:
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               # - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
               # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
-              # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+              - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
@@ -338,7 +346,6 @@ linters:
             # nomaps:
             #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
             # optionalFields:
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.optionalfields:
             #  pointers:
             #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
             #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
@@ -349,7 +356,6 @@ linters:
             # optionalOrRequired:
             #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
             #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 
-            #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.
             # requiredFields:
             #   pointers:
             #    policy: SuggestFix | Warn # The policy for pointers in required fields. Defaults to `SuggestFix`.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -22,7 +22,7 @@
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 - text: "must be marked as optional or required"
-  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -22,7 +22,7 @@
 
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 - text: "must be marked as optional or required"
-  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -19,3 +19,11 @@
   path: "staging/src/k8s.io/api/resource/"
 - text: "Conditions field in AllocatedDeviceStatus has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,5,rep,name=conditions\"`"
   path: "staging/src/k8s.io/api/resource/"
+
+# OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
+- text: "must be marked as optional or required"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apidiscovery|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+
+# OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
+- text: "field Error must not be marked as both optional and required"
+  path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -15,7 +15,7 @@ linters:
     # - "nophase" # Ensure field names do not have the word "phase" in them.
     # - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
     # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
-    # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+    - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
     # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
     - "ssatags" # Ensure lists have a listType tag.
     # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.
@@ -36,7 +36,6 @@ lintersConfig:
   # nomaps:
   #   policy: AllowStringToStringMaps # Determines how the linter should handle maps of basic types. Maps of objects are always disallowed.
   # optionalFields:
-  #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.optionalfields:
   #  pointers:
   #    preference: Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
   #    policy: SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
@@ -47,7 +46,6 @@ lintersConfig:
   # optionalOrRequired:
   #   preferredOptionalMarker: optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
   #   preferredRequiredMarker: required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`. 
-  #   policy: AllowOptionalFields # Determines how the linter should handle optional fields.
   # requiredFields:
   #   pointers:
   #    policy: SuggestFix | Warn # The policy for pointers in required fields. Defaults to `SuggestFix`.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7099,6 +7099,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 					"apiServerID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The ID of the reporting API server.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7106,6 +7107,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 					"encodingVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The API server encodes the object to this version when persisting it in the backend (e.g., etcd).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7151,6 +7153,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_ServerStorageVersion(ref common
 						},
 					},
 				},
+				Required: []string{"apiServerID", "encodingVersion", "decodableVersions"},
 			},
 		},
 	}
@@ -7199,7 +7202,7 @@ func schema_k8sio_api_apiserverinternal_v1alpha1_StorageVersion(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"spec", "status"},
+				Required: []string{"metadata"},
 			},
 		},
 		Dependencies: []string{
@@ -18240,7 +18243,6 @@ func schema_k8sio_api_batch_v1_JobCondition(ref common.ReferenceCallback) common
 						},
 					},
 				},
-				Required: []string{"type", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -18585,7 +18587,6 @@ func schema_k8sio_api_batch_v1_PodFailurePolicy(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"rules"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
@@ -32,33 +32,40 @@ option go_package = "k8s.io/api/apiserverinternal/v1alpha1";
 // encodes objects to when persisting objects in the backend.
 message ServerStorageVersion {
   // The ID of the reporting API server.
+  // +required
   optional string apiServerID = 1;
 
   // The API server encodes the object to this version when persisting it in
   // the backend (e.g., etcd).
+  // +required
   optional string encodingVersion = 2;
 
   // The API server can decode objects encoded in these versions.
   // The encodingVersion must be included in the decodableVersions.
   // +listType=set
+  // +required
   repeated string decodableVersions = 3;
 
   // The API server can serve these versions.
   // DecodableVersions must include all ServedVersions.
   // +listType=set
+  // +optional
   repeated string servedVersions = 4;
 }
 
 // Storage version of a specific resource.
 message StorageVersion {
   // The name is <group>.<resource>.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec is an empty spec. It is here to comply with Kubernetes API style.
+  // +optional
   optional StorageVersionSpec spec = 2;
 
   // API server instances report the version they can decode and the version they
   // encode objects to when persisting objects in the backend.
+  // +optional
   optional StorageVersionStatus status = 3;
 }
 
@@ -77,6 +84,7 @@ message StorageVersionCondition {
   optional int64 observedGeneration = 3;
 
   // Last time the condition transitioned from one status to another.
+  // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // The reason for the condition's last transition.

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
@@ -28,13 +28,16 @@ import (
 type StorageVersion struct {
 	metav1.TypeMeta `json:",inline"`
 	// The name is <group>.<resource>.
+	// +required
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec is an empty spec. It is here to comply with Kubernetes API style.
+	// +optional
 	Spec StorageVersionSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// API server instances report the version they can decode and the version they
 	// encode objects to when persisting objects in the backend.
+	// +optional
 	Status StorageVersionStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
 }
 
@@ -67,20 +70,24 @@ type StorageVersionStatus struct {
 // encodes objects to when persisting objects in the backend.
 type ServerStorageVersion struct {
 	// The ID of the reporting API server.
-	APIServerID string `json:"apiServerID,omitempty" protobuf:"bytes,1,opt,name=apiServerID"`
+	// +required
+	APIServerID string `json:"apiServerID" protobuf:"bytes,1,opt,name=apiServerID"`
 
 	// The API server encodes the object to this version when persisting it in
 	// the backend (e.g., etcd).
-	EncodingVersion string `json:"encodingVersion,omitempty" protobuf:"bytes,2,opt,name=encodingVersion"`
+	// +required
+	EncodingVersion string `json:"encodingVersion" protobuf:"bytes,2,opt,name=encodingVersion"`
 
 	// The API server can decode objects encoded in these versions.
 	// The encodingVersion must be included in the decodableVersions.
 	// +listType=set
-	DecodableVersions []string `json:"decodableVersions,omitempty" protobuf:"bytes,3,opt,name=decodableVersions"`
+	// +required
+	DecodableVersions []string `json:"decodableVersions" protobuf:"bytes,3,opt,name=decodableVersions"`
 
 	// The API server can serve these versions.
 	// DecodableVersions must include all ServedVersions.
 	// +listType=set
+	// +optional
 	ServedVersions []string `json:"servedVersions,omitempty" protobuf:"bytes,4,opt,name=servedVersions"`
 }
 
@@ -111,6 +118,7 @@ type StorageVersionCondition struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
 	// Last time the condition transitioned from one status to another.
+	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,4,opt,name=lastTransitionTime"`
 	// The reason for the condition's last transition.
 	// +required

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -55,12 +55,14 @@ message CronJobList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CronJobs.
+  // +required
   repeated CronJob items = 2;
 }
 
 // CronJobSpec describes how the job execution will look like and when it will actually run.
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+  // +required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
@@ -95,6 +97,7 @@ message CronJobSpec {
   optional bool suspend = 4;
 
   // Specifies the job that will be created when executing a CronJob.
+  // +required
   optional JobTemplateSpec jobTemplate = 5;
 
   // The number of successful finished jobs to retain. Value must be non-negative integer.
@@ -145,9 +148,11 @@ message Job {
 // JobCondition describes current state of a job.
 message JobCondition {
   // Type of job condition, Complete or Failed.
+  // +optional
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.
+  // +optional
   optional string status = 2;
 
   // Last time the condition was checked.
@@ -273,6 +278,7 @@ message JobSpec {
   // Describes the pod that will be created when executing a job.
   // The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+  // +required
   optional .k8s.io.api.core.v1.PodTemplateSpec template = 6;
 
   // ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -458,6 +464,7 @@ message JobStatus {
 
   // The number of active pods which have a Ready condition and are not
   // terminating (without a deletionTimestamp).
+  // +optional
   optional int32 ready = 9;
 }
 
@@ -482,6 +489,7 @@ message PodFailurePolicy {
   // counter of pod failures is incremented and it is checked against
   // the backoffLimit. At most 20 elements are allowed.
   // +listType=atomic
+  // +optional
   repeated PodFailurePolicyRule rules = 1;
 }
 
@@ -511,6 +519,7 @@ message PodFailurePolicyOnExitCodesRequirement {
   //   by the 'containerName' field) is not in the set of specified values.
   // Additional values are considered to be added in the future. Clients should
   // react to an unknown operator by assuming the requirement is not satisfied.
+  // +required
   optional string operator = 2;
 
   // Specifies the set of values. Each returned container exit code (might be
@@ -519,6 +528,7 @@ message PodFailurePolicyOnExitCodesRequirement {
   // and must not contain duplicates. Value '0' cannot be used for the In operator.
   // At least one element is required. At most 255 elements are allowed.
   // +listType=set
+  // +required
   repeated int32 values = 3;
 }
 
@@ -527,6 +537,7 @@ message PodFailurePolicyOnExitCodesRequirement {
 message PodFailurePolicyOnPodConditionsPattern {
   // Specifies the required Pod condition type. To match a pod condition
   // it is required that specified type equals the pod condition type.
+  // +required
   optional string type = 1;
 
   // Specifies the required Pod condition status. To match a pod condition
@@ -552,6 +563,7 @@ message PodFailurePolicyRule {
   //   counter towards the .backoffLimit is incremented.
   // Additional values are considered to be added in the future. Clients should
   // react to an unknown action by skipping the rule.
+  // +required
   optional string action = 1;
 
   // Represents the requirement on the container exit codes.
@@ -575,6 +587,7 @@ message SuccessPolicy {
   // Additionally, these rules are evaluated in order; Once the Job meets one of the rules,
   // other rules are ignored. At most 20 elements are allowed.
   // +listType=atomic
+  // +required
   repeated SuccessPolicyRule rules = 1;
 }
 

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -96,7 +96,6 @@ type JobList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of Jobs.
-	// +required
 	Items []Job `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -256,7 +255,7 @@ type PodFailurePolicy struct {
 	// counter of pod failures is incremented and it is checked against
 	// the backoffLimit. At most 20 elements are allowed.
 	// +listType=atomic
-	// +required
+	// +optional
 	Rules []PodFailurePolicyRule `json:"rules" protobuf:"bytes,1,opt,name=rules"`
 }
 
@@ -407,7 +406,7 @@ type JobSpec struct {
 	// Describes the pod that will be created when executing a job.
 	// The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-	// +required
+	// +optional
 	Template corev1.PodTemplateSpec `json:"template" protobuf:"bytes,6,opt,name=template"`
 
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -654,10 +653,10 @@ const (
 // JobCondition describes current state of a job.
 type JobCondition struct {
 	// Type of job condition, Complete or Failed.
-	// +required
+	// +optional
 	Type JobConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=JobConditionType"`
 	// Status of the condition, one of True, False, Unknown.
-	// +required
+	// +optional
 	Status corev1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// Last time the condition was checked.
 	// +optional
@@ -765,7 +764,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty" protobuf:"varint,4,opt,name=suspend"`
 
 	// Specifies the job that will be created when executing a CronJob.
-	// +required
+	// +optional
 	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 
 	// The number of successful finished jobs to retain. Value must be non-negative integer.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -96,6 +96,7 @@ type JobList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of Jobs.
+	// +required
 	Items []Job `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -188,6 +189,7 @@ type PodFailurePolicyOnExitCodesRequirement struct {
 	//   by the 'containerName' field) is not in the set of specified values.
 	// Additional values are considered to be added in the future. Clients should
 	// react to an unknown operator by assuming the requirement is not satisfied.
+	// +required
 	Operator PodFailurePolicyOnExitCodesOperator `json:"operator" protobuf:"bytes,2,req,name=operator"`
 
 	// Specifies the set of values. Each returned container exit code (might be
@@ -196,6 +198,7 @@ type PodFailurePolicyOnExitCodesRequirement struct {
 	// and must not contain duplicates. Value '0' cannot be used for the In operator.
 	// At least one element is required. At most 255 elements are allowed.
 	// +listType=set
+	// +required
 	Values []int32 `json:"values" protobuf:"varint,3,rep,name=values"`
 }
 
@@ -204,6 +207,7 @@ type PodFailurePolicyOnExitCodesRequirement struct {
 type PodFailurePolicyOnPodConditionsPattern struct {
 	// Specifies the required Pod condition type. To match a pod condition
 	// it is required that specified type equals the pod condition type.
+	// +required
 	Type corev1.PodConditionType `json:"type" protobuf:"bytes,1,req,name=type"`
 
 	// Specifies the required Pod condition status. To match a pod condition
@@ -229,6 +233,7 @@ type PodFailurePolicyRule struct {
 	//   counter towards the .backoffLimit is incremented.
 	// Additional values are considered to be added in the future. Clients should
 	// react to an unknown action by skipping the rule.
+	// +required
 	Action PodFailurePolicyAction `json:"action" protobuf:"bytes,1,req,name=action"`
 
 	// Represents the requirement on the container exit codes.
@@ -251,6 +256,7 @@ type PodFailurePolicy struct {
 	// counter of pod failures is incremented and it is checked against
 	// the backoffLimit. At most 20 elements are allowed.
 	// +listType=atomic
+	// +required
 	Rules []PodFailurePolicyRule `json:"rules" protobuf:"bytes,1,opt,name=rules"`
 }
 
@@ -263,6 +269,7 @@ type SuccessPolicy struct {
 	// Additionally, these rules are evaluated in order; Once the Job meets one of the rules,
 	// other rules are ignored. At most 20 elements are allowed.
 	// +listType=atomic
+	// +required
 	Rules []SuccessPolicyRule `json:"rules" protobuf:"bytes,1,opt,name=rules"`
 }
 
@@ -400,6 +407,7 @@ type JobSpec struct {
 	// Describes the pod that will be created when executing a job.
 	// The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+	// +required
 	Template corev1.PodTemplateSpec `json:"template" protobuf:"bytes,6,opt,name=template"`
 
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -585,6 +593,7 @@ type JobStatus struct {
 
 	// The number of active pods which have a Ready condition and are not
 	// terminating (without a deletionTimestamp).
+	// +optional
 	Ready *int32 `json:"ready,omitempty" protobuf:"varint,9,opt,name=ready"`
 }
 
@@ -645,8 +654,10 @@ const (
 // JobCondition describes current state of a job.
 type JobCondition struct {
 	// Type of job condition, Complete or Failed.
+	// +required
 	Type JobConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=JobConditionType"`
 	// Status of the condition, one of True, False, Unknown.
+	// +required
 	Status corev1.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
 	// Last time the condition was checked.
 	// +optional
@@ -711,6 +722,7 @@ type CronJobList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of CronJobs.
+	// +required
 	Items []CronJob `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -718,6 +730,7 @@ type CronJobList struct {
 type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	// +required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
@@ -752,6 +765,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty" protobuf:"varint,4,opt,name=suspend"`
 
 	// Specifies the job that will be created when executing a CronJob.
+	// +required
 	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 
 	// The number of successful finished jobs to retain. Value must be non-negative integer.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -406,7 +406,7 @@ type JobSpec struct {
 	// Describes the pod that will be created when executing a job.
 	// The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-	// +optional
+	// +required
 	Template corev1.PodTemplateSpec `json:"template" protobuf:"bytes,6,opt,name=template"`
 
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -764,7 +764,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty" protobuf:"varint,4,opt,name=suspend"`
 
 	// Specifies the job that will be created when executing a CronJob.
-	// +optional
+	// +required
 	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 
 	// The number of successful finished jobs to retain. Value must be non-negative integer.

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -62,6 +62,7 @@ message CronJobList {
 // CronJobSpec describes how the job execution will look like and when it will actually run.
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+  // +required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
@@ -96,6 +97,7 @@ message CronJobSpec {
   optional bool suspend = 4;
 
   // Specifies the job that will be created when executing a CronJob.
+  // +required
   optional JobTemplateSpec jobTemplate = 5;
 
   // The number of successful finished jobs to retain.

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -77,6 +77,7 @@ type CronJobList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of CronJobs.
+	// +required
 	Items []CronJob `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -84,6 +85,7 @@ type CronJobList struct {
 type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	// +required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
@@ -118,6 +120,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty" protobuf:"varint,4,opt,name=suspend"`
 
 	// Specifies the job that will be created when executing a CronJob.
+	// +required
 	JobTemplate JobTemplateSpec `json:"jobTemplate" protobuf:"bytes,5,opt,name=jobTemplate"`
 
 	// The number of successful finished jobs to retain.

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -77,7 +77,6 @@ type CronJobList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of CronJobs.
-	// +required
 	Items []CronJob `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -1443,6 +1443,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: apiServerID
       type:
         scalar: string
+      default: ""
     - name: decodableVersions
       type:
         list:
@@ -1452,6 +1453,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: encodingVersion
       type:
         scalar: string
+      default: ""
     - name: servedVersions
       type:
         list:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is part of a series of PRs for enabling enforcement that every API field should be marked either +optional XOR +required.

This PR marks currently missing fields as +optional or +required for the `batch` API group. I've marked each field that previously wasn't marked with optionality based on reviewing the storage implementation and the behaviour when the field is unspecified.

#### Which issue(s) this PR is related to:
Relates to https://github.com/kubernetes/kubernetes/issues/134671
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This PR is stacked on top of https://github.com/kubernetes/kubernetes/pull/134675.  Merge this PR AFTER that PR is merged.

KAL output for `batch` without the optoinalrequired changes in this PR (showing what KAL flagged prior): https://gist.github.com/aaron-prindle/4a7aec96960154029a4730507682aa4c

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
