### PR TITLE
KEP-4671: Implement Gang scheduling in kube-scheduler

### DIFF
--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -64,6 +64,9 @@ func applyFeatureGates(config *v1.Plugins) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
 		applyDynamicResources(config)
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.GangScheduling) {
+		applyGangScheduling(config)
+	}
 }
 
 func applyDynamicResources(config *v1.Plugins) {
@@ -82,6 +85,10 @@ func applyDynamicResources(config *v1.Plugins) {
 			break
 		}
 	}
+}
+
+func applyGangScheduling(config *v1.Plugins) {
+	config.MultiPoint.Enabled = append(config.MultiPoint.Enabled, v1.Plugin{Name: names.GangScheduling})
 }
 
 // mergePlugins merges the custom set into the given default one, handling disabled sets.

--- a/pkg/scheduler/apis/config/v1/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins_test.go
@@ -161,6 +161,39 @@ func TestApplyFeatureGates(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Feature gate GangScheduling enabled",
+			features: map[featuregate.Feature]bool{
+				features.GangScheduling:  true,
+				features.GenericWorkload: true,
+			},
+			wantConfig: &v1.Plugins{
+				MultiPoint: v1.PluginSet{
+					Enabled: []v1.Plugin{
+						{Name: names.SchedulingGates},
+						{Name: names.PrioritySort},
+						{Name: names.NodeUnschedulable},
+						{Name: names.NodeName},
+						{Name: names.TaintToleration, Weight: ptr.To[int32](3)},
+						{Name: names.NodeAffinity, Weight: ptr.To[int32](2)},
+						{Name: names.NodePorts},
+						{Name: names.NodeResourcesFit, Weight: ptr.To[int32](1)},
+						{Name: names.VolumeRestrictions},
+						{Name: names.NodeVolumeLimits},
+						{Name: names.VolumeBinding},
+						{Name: names.VolumeZone},
+						{Name: names.PodTopologySpread, Weight: ptr.To[int32](2)},
+						{Name: names.InterPodAffinity, Weight: ptr.To[int32](2)},
+						{Name: names.DynamicResources, Weight: ptr.To[int32](2)},
+						{Name: names.DefaultPreemption},
+						{Name: names.NodeResourcesBalancedAllocation, Weight: ptr.To[int32](1)},
+						{Name: names.ImageLocality, Weight: ptr.To[int32](1)},
+						{Name: names.DefaultBinder},
+						{Name: names.GangScheduling},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/scheduler/backend/workloadmanager/podgroupinfo.go
+++ b/pkg/scheduler/backend/workloadmanager/podgroupinfo.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadmanager
+
+import (
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+)
+
+// defaultSchedulingTimeoutDuration defines how long the gang pods should wait at the
+// Permit stage for a quorum before being rejected.
+const defaultSchedulingTimeoutDuration = 5 * time.Minute
+
+// podGroupKey uniquely identifies a specific instance of a PodGroup.
+type podGroupKey struct {
+	namespace    string
+	workloadName string
+	podGroupName string
+	replicaKey   string
+}
+
+func newPodGroupKey(namespace string, workloadRef *v1.WorkloadReference) podGroupKey {
+	return podGroupKey{
+		namespace:    namespace,
+		workloadName: workloadRef.Name,
+		podGroupName: workloadRef.PodGroup,
+		replicaKey:   workloadRef.PodGroupReplicaKey,
+	}
+}
+
+// podGroupInfo holds the runtime state of a pod group.
+type podGroupInfo struct {
+	lock sync.RWMutex
+	// allPods tracks all pods belonging to the group that are known to the scheduler.
+	allPods map[types.UID]*v1.Pod
+	// unscheduledPods tracks all pods that are unscheduled for this group,
+	// i.e., are neither assumed nor scheduled.
+	unscheduledPods sets.Set[types.UID]
+	// assumedPods tracks pods that have reached the Reserve stage and are waiting
+	// for the rest of the gang to arrive before being allowed to bind.
+	assumedPods sets.Set[types.UID]
+	// assignedPods tracks all pods belonging to the group that are assigned (bound).
+	assignedPods sets.Set[types.UID]
+	// schedulingDeadline stores the time at which the gang will time out.
+	// It is initialized when the first pod from the group enters the Permit stage.
+	schedulingDeadline *time.Time
+}
+
+func newPodGroupInfo() *podGroupInfo {
+	return &podGroupInfo{
+		allPods:         make(map[types.UID]*v1.Pod),
+		unscheduledPods: sets.New[types.UID](),
+		assumedPods:     sets.New[types.UID](),
+		assignedPods:    sets.New[types.UID](),
+	}
+}
+
+// addPod adds the pod to this group.
+// Depending on the NodeName, it can insert the pod to assignedPods set.
+func (pgs *podGroupInfo) addPod(pod *v1.Pod) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.allPods[pod.UID] = pod
+	if pod.Spec.NodeName != "" {
+		pgs.assignedPods.Insert(pod.UID)
+	} else {
+		pgs.unscheduledPods.Insert(pod.UID)
+	}
+}
+
+// updatePod updates the pod in this group.
+// In case of binding, it moves the pod to assignedPods.
+func (pgs *podGroupInfo) updatePod(oldPod, newPod *v1.Pod) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.allPods[newPod.UID] = newPod
+	if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" {
+		pgs.assignedPods.Insert(newPod.UID)
+		// Clear pod from unscheduled and assumed when it is assigned.
+		pgs.unscheduledPods.Delete(newPod.UID)
+		pgs.assumedPods.Delete(newPod.UID)
+	}
+}
+
+// deletePod completely deletes the pod from this group.
+func (pgs *podGroupInfo) deletePod(podUID types.UID) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	delete(pgs.allPods, podUID)
+	pgs.unscheduledPods.Delete(podUID)
+	pgs.assumedPods.Delete(podUID)
+	pgs.assignedPods.Delete(podUID)
+}
+
+// empty returns true when the group is empty.
+func (pgs *podGroupInfo) empty() bool {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	return len(pgs.allPods) == 0
+}
+
+// AllPods returns the UIDs of all pods known to the scheduler for this group.
+func (pgs *podGroupInfo) AllPods() sets.Set[types.UID] {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
+	return sets.KeySet(pgs.allPods)
+}
+
+// UnscheduledPods returns all pods that are unscheduled for this group,
+// i.e., are neither assumed nor assigned.
+// The returned map type corresponds to the argument of the PodActivator.Activate method.
+func (pgs *podGroupInfo) UnscheduledPods() map[string]*v1.Pod {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
+	unscheduledPods := make(map[string]*v1.Pod, len(pgs.unscheduledPods))
+	for podUID := range pgs.unscheduledPods {
+		pod := pgs.allPods[podUID]
+		unscheduledPods[pod.Name] = pod
+	}
+	return unscheduledPods
+}
+
+// AssumedPods returns the UIDs of all pods for this group in the assumed state,
+// i.e., passed the Reserve gate.
+func (pgs *podGroupInfo) AssumedPods() sets.Set[types.UID] {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
+	return pgs.assumedPods.Clone()
+}
+
+// AssignedPods returns the UIDs of all pods already assigned (bound) for this group.
+func (pgs *podGroupInfo) AssignedPods() sets.Set[types.UID] {
+	pgs.lock.RLock()
+	defer pgs.lock.RUnlock()
+
+	return pgs.assignedPods.Clone()
+}
+
+// SchedulingTimeout returns the remaining time until the pod group scheduling times out.
+// A new deadline is created if one doesn't exist, or if the previous one has expired.
+func (pgs *podGroupInfo) SchedulingTimeout() time.Duration {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	now := time.Now()
+	// A new deadline is set if one doesn't exist, or if the old one has passed.
+	// This allows a new attempt to form a gang after a previous attempt timed out.
+	if pgs.schedulingDeadline == nil || pgs.schedulingDeadline.Before(now) {
+		pgs.schedulingDeadline = ptr.To(now.Add(defaultSchedulingTimeoutDuration))
+	}
+	return pgs.schedulingDeadline.Sub(now)
+}
+
+// AssumePod marks a pod as having reached the Reserve stage.
+func (pgs *podGroupInfo) AssumePod(podUID types.UID) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.assumedPods.Insert(podUID)
+	pgs.unscheduledPods.Delete(podUID)
+}
+
+// ForgetPod removes a pod from the assumed state.
+func (pgs *podGroupInfo) ForgetPod(podUID types.UID) {
+	pgs.lock.Lock()
+	defer pgs.lock.Unlock()
+
+	pgs.unscheduledPods.Insert(podUID)
+	pgs.assumedPods.Delete(podUID)
+}

--- a/pkg/scheduler/backend/workloadmanager/podgroupinfo.go
+++ b/pkg/scheduler/backend/workloadmanager/podgroupinfo.go
@@ -26,9 +26,10 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// defaultSchedulingTimeoutDuration defines how long the gang pods should wait at the
+// DefaultSchedulingTimeoutDuration defines how long the gang pods should wait at the
 // Permit stage for a quorum before being rejected.
-const defaultSchedulingTimeoutDuration = 5 * time.Minute
+// Variable is exported only for testing purposes.
+var DefaultSchedulingTimeoutDuration = 5 * time.Minute
 
 // podGroupKey uniquely identifies a specific instance of a PodGroup.
 type podGroupKey struct {
@@ -172,7 +173,7 @@ func (pgs *podGroupInfo) SchedulingTimeout() time.Duration {
 	// A new deadline is set if one doesn't exist, or if the old one has passed.
 	// This allows a new attempt to form a gang after a previous attempt timed out.
 	if pgs.schedulingDeadline == nil || pgs.schedulingDeadline.Before(now) {
-		pgs.schedulingDeadline = ptr.To(now.Add(defaultSchedulingTimeoutDuration))
+		pgs.schedulingDeadline = ptr.To(now.Add(DefaultSchedulingTimeoutDuration))
 	}
 	return pgs.schedulingDeadline.Sub(now)
 }

--- a/pkg/scheduler/backend/workloadmanager/podgroupinfo_test.go
+++ b/pkg/scheduler/backend/workloadmanager/podgroupinfo_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadmanager
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/utils/ptr"
+)
+
+func TestPodGroupInfo_AssumeForget(t *testing.T) {
+	pgi := newPodGroupInfo()
+	pod := st.MakePod().Namespace("ns1").Name("p1").UID("p1").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+
+	pgi.addPod(pod)
+	if pgi.AssumedPods().Has(pod.UID) {
+		t.Fatal("AssumedPods should be initially empty")
+	}
+	if !pgi.unscheduledPods.Has(pod.UID) {
+		t.Fatal("Pod should be initially in UnscheduledPods")
+	}
+
+	pgi.AssumePod(pod.UID)
+	if !pgi.AssumedPods().Has(pod.UID) {
+		t.Fatal("Pod should be in AssumedPods after AssumePod")
+	}
+	if pgi.unscheduledPods.Has(pod.UID) {
+		t.Fatal("UnscheduledPods should be empty after AssumePod")
+	}
+
+	pgi.ForgetPod(pod.UID)
+	if pgi.AssumedPods().Has(pod.UID) {
+		t.Fatal("Pod should not be in AssumedPods after ForgetPod")
+	}
+	if !pgi.unscheduledPods.Has(pod.UID) {
+		t.Fatal("Pod should be in UnscheduledPods after ForgetPod")
+	}
+}
+
+func TestPodGroupInfo_SchedulingTimeout(t *testing.T) {
+	pgi := newPodGroupInfo()
+
+	timeout := pgi.SchedulingTimeout()
+	if pgi.schedulingDeadline == nil {
+		t.Fatal("Scheduling deadline should be set after SchedulingTimeout call, but is nil")
+	}
+	if timeout <= 0 {
+		t.Errorf("Expected positive timeout duration, got %v", timeout)
+	}
+
+	deadline := *pgi.schedulingDeadline
+	newTimeout := pgi.SchedulingTimeout()
+	if !deadline.Equal(*pgi.schedulingDeadline) {
+		t.Errorf("Previous deadline should not be changed: previous: %v, current: %v", deadline, *pgi.schedulingDeadline)
+	}
+	if newTimeout >= timeout {
+		t.Errorf("Expected lower timeout duration: previous: %v, current: %v", timeout, newTimeout)
+	}
+
+	pgi.schedulingDeadline = ptr.To(time.Now().Add(-1 * time.Second))
+	newTimeout = pgi.SchedulingTimeout()
+	if deadline.Equal(*pgi.schedulingDeadline) {
+		t.Error("Deadline should be reset after it has expired, but it wasn't")
+	}
+	if newTimeout <= 0 {
+		t.Errorf("Expected positive timeout duration after reset, got %v", timeout)
+	}
+}

--- a/pkg/scheduler/backend/workloadmanager/workloadmanager.go
+++ b/pkg/scheduler/backend/workloadmanager/workloadmanager.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadmanager
+
+import (
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	fwk "k8s.io/kube-scheduler/framework"
+)
+
+// WorkloadManager is the central source of truth for the state of pods belonging to Workload objects.
+// It is designed to be driven explicitly by the scheduler's event handlers to ensure thread safety
+// and avoid race conditions with the main scheduling queue.
+// Note: The current implementation assumes that pod.Spec.Workload is immutable.
+// Allowing mutability would require changes to the manager, e.g., by properly handling pod updates.
+type WorkloadManager interface {
+	fwk.WorkloadManager
+
+	// AddPod is called by the scheduler when a Pod/Add event is observed.
+	AddPod(pod *v1.Pod)
+	// UpdatePod is called by the scheduler when a Pod/Update event is observed.
+	UpdatePod(oldPod, newPod *v1.Pod)
+	// DeletePod is called by the scheduler when a Pod/Delete event is observed.
+	DeletePod(pod *v1.Pod)
+}
+
+// workloadManager is the concrete implementation of the WorkloadManager.
+type workloadManager struct {
+	lock sync.RWMutex
+
+	// podGroupInfos stores the runtime state for each known pod group.
+	podGroupInfos map[podGroupKey]*podGroupInfo
+}
+
+// New initializes a new workload manager and returns it.
+func New() *workloadManager {
+	return &workloadManager{
+		podGroupInfos: make(map[podGroupKey]*podGroupInfo),
+	}
+}
+
+// AddPod adds a pod to the workload manager if it has a workload reference.
+// Pod is added to the available pods set for its corresponding pod group.
+func (wm *workloadManager) AddPod(pod *v1.Pod) {
+	if pod.Spec.WorkloadRef == nil {
+		return
+	}
+	wm.lock.Lock()
+	defer wm.lock.Unlock()
+
+	key := newPodGroupKey(pod.Namespace, pod.Spec.WorkloadRef)
+	info, ok := wm.podGroupInfos[key]
+	if !ok {
+		info = newPodGroupInfo()
+		wm.podGroupInfos[key] = info
+	}
+	info.addPod(pod)
+}
+
+// UpdatePod updates a pod in the workload manager if it has a workload reference.
+// Note: The current implementation assumes that newPod.Spec.Workload is immutable.
+func (wm *workloadManager) UpdatePod(oldPod, newPod *v1.Pod) {
+	if newPod.Spec.WorkloadRef == nil {
+		return
+	}
+	wm.lock.Lock()
+	defer wm.lock.Unlock()
+
+	key := newPodGroupKey(newPod.Namespace, newPod.Spec.WorkloadRef)
+	info, ok := wm.podGroupInfos[key]
+	if !ok {
+		// Shouldn't happen, but handling this case gracefully.
+		info = newPodGroupInfo()
+		wm.podGroupInfos[key] = info
+		info.addPod(newPod)
+		return
+	}
+	info.updatePod(oldPod, newPod)
+}
+
+// DeletePod removes a pod from the workload manager if it has a workload reference.
+// Pod is removed from the pods sets for its corresponding pod group.
+func (wm *workloadManager) DeletePod(pod *v1.Pod) {
+	if pod.Spec.WorkloadRef == nil {
+		return
+	}
+	wm.lock.Lock()
+	defer wm.lock.Unlock()
+
+	key := newPodGroupKey(pod.Namespace, pod.Spec.WorkloadRef)
+	info, ok := wm.podGroupInfos[key]
+	if !ok {
+		// The pod group may have already been cleaned up, or the pod was never added.
+		return
+	}
+	info.deletePod(pod.UID)
+	// Clean up the map entry if no pods are left in the group.
+	if info.empty() {
+		delete(wm.podGroupInfos, key)
+	}
+}
+
+// PodGroupInfo returns the state of a pod group.
+func (wm *workloadManager) PodGroupInfo(namespace string, workloadRef *v1.WorkloadReference) (fwk.PodGroupInfo, error) {
+	wm.lock.RLock()
+	defer wm.lock.RUnlock()
+
+	state, ok := wm.podGroupInfos[newPodGroupKey(namespace, workloadRef)]
+	if !ok {
+		return nil, fmt.Errorf("internal pod group state doesn't exist for a pod's workload")
+	}
+	return state, nil
+}

--- a/pkg/scheduler/backend/workloadmanager/workloadmanager_test.go
+++ b/pkg/scheduler/backend/workloadmanager/workloadmanager_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadmanager
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+)
+
+func TestWorkloadManager_AddPod(t *testing.T) {
+	p1 := st.MakePod().Namespace("ns1").Name("p1").UID("p1").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+	// Assigned
+	p2 := st.MakePod().Namespace("ns1").Name("p2").UID("p2").Node("node1").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+	// Different ns
+	p3 := st.MakePod().Namespace("ns2").Name("p3").UID("p3").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+	nonWorkloadPod := st.MakePod().Namespace("ns1").Name("non-workload").Obj()
+
+	tests := []struct {
+		name     string
+		initPods []*v1.Pod
+		podToAdd *v1.Pod
+
+		expectedPodGroups       int
+		expectInAllPods         bool
+		expectInUnscheduledPods bool
+		expectInAssumedPods     bool
+		expectInAssignedPods    bool
+	}{
+		{
+			name:                    "adding an unscheduled pod",
+			podToAdd:                p1,
+			expectedPodGroups:       1,
+			expectInAllPods:         true,
+			expectInUnscheduledPods: true,
+		},
+		{
+			name:                 "adding an assigned pod",
+			podToAdd:             p2,
+			expectedPodGroups:    1,
+			expectInAllPods:      true,
+			expectInAssignedPods: true,
+		},
+		{
+			name:                    "adding pod with different namespace",
+			initPods:                []*v1.Pod{p1},
+			podToAdd:                p3,
+			expectedPodGroups:       2,
+			expectInAllPods:         true,
+			expectInUnscheduledPods: true,
+		},
+		{
+			name:              "adding a non-workload pod is a no-op",
+			podToAdd:          nonWorkloadPod,
+			expectedPodGroups: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := New()
+			for _, p := range tt.initPods {
+				manager.AddPod(p)
+			}
+
+			manager.AddPod(tt.podToAdd)
+
+			gotPodGroups := len(manager.podGroupInfos)
+			if gotPodGroups != tt.expectedPodGroups {
+				t.Fatalf("Expected %v pod group(s), got %v", tt.expectedPodGroups, gotPodGroups)
+			}
+			if gotPodGroups == 0 {
+				return
+			}
+			info, err := manager.PodGroupInfo(tt.podToAdd.Namespace, tt.podToAdd.Spec.WorkloadRef)
+			if err != nil {
+				t.Fatalf("Unexpected error getting pod group info: %v", err)
+			}
+			if inAll := info.AllPods().Has(tt.podToAdd.UID); inAll != tt.expectInAllPods {
+				t.Errorf("Unexpected AllPods state, want: %v, got: %v", tt.expectInAllPods, inAll)
+			}
+			if inAssumed := info.AssumedPods().Has(tt.podToAdd.UID); inAssumed != tt.expectInAssumedPods {
+				t.Errorf("Unexpected AssumedPods state, want: %v, got: %v", tt.expectInAssumedPods, inAssumed)
+			}
+			if inAssigned := info.AssignedPods().Has(tt.podToAdd.UID); inAssigned != tt.expectInAssignedPods {
+				t.Errorf("Unexpected AssignedPods state, want: %v, got: %v", tt.expectInAssignedPods, inAssigned)
+			}
+		})
+	}
+}
+
+func TestWorkloadManager_UpdatePod(t *testing.T) {
+	pod := st.MakePod().Namespace("ns1").Name("p1").UID("p1").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+	updatedPod := st.MakePod().Namespace("ns1").Name("p1").UID("p1").Labels(map[string]string{"foo": "bar"}).
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+
+	assignedPod := st.MakePod().Namespace("ns1").Name("p2").UID("p2").Node("node1").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+	updatedAssignedPod := st.MakePod().Namespace("ns1").Name("p2").UID("p2").Node("node1").Labels(map[string]string{"foo": "bar"}).
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+
+	nonWorkloadPod := st.MakePod().Namespace("ns1").Name("non-workload").Obj()
+	updatedNonWorkloadPod := st.MakePod().Namespace("ns1").Name("non-workload").Labels(map[string]string{"foo": "bar"}).Obj()
+
+	tests := []struct {
+		name      string
+		assumePod bool
+		oldPod    *v1.Pod
+		newPod    *v1.Pod
+
+		expectInAllPods         bool
+		expectInUnscheduledPods bool
+		expectInAssumedPods     bool
+		expectInAssignedPods    bool
+	}{
+		{
+			name:                    "updating an unscheduled pod",
+			oldPod:                  pod,
+			newPod:                  updatedPod,
+			expectInAllPods:         true,
+			expectInUnscheduledPods: true,
+		},
+		{
+			name:                "updating an assumed pod",
+			assumePod:           true,
+			oldPod:              pod,
+			newPod:              updatedPod,
+			expectInAllPods:     true,
+			expectInAssumedPods: true,
+		},
+		{
+			name:                 "updating an assigned pod",
+			oldPod:               assignedPod,
+			newPod:               updatedAssignedPod,
+			expectInAllPods:      true,
+			expectInAssignedPods: true,
+		},
+		{
+			name:                 "binding an unscheduled pod",
+			oldPod:               pod,
+			newPod:               assignedPod,
+			expectInAllPods:      true,
+			expectInAssignedPods: true,
+		},
+		{
+			name:                 "binding an assumed pod",
+			assumePod:            true,
+			oldPod:               pod,
+			newPod:               assignedPod,
+			expectInAllPods:      true,
+			expectInAssignedPods: true,
+		},
+		{
+			name:   "updating a non-workload pod is a no-op",
+			oldPod: nonWorkloadPod,
+			newPod: updatedNonWorkloadPod,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := New()
+
+			manager.AddPod(tt.oldPod)
+			if tt.assumePod {
+				info, err := manager.PodGroupInfo(tt.oldPod.Namespace, tt.oldPod.Spec.WorkloadRef)
+				if err != nil {
+					t.Fatalf("Unexpected error getting pod group info: %v", err)
+				}
+				info.AssumePod(tt.oldPod.UID)
+			}
+
+			manager.UpdatePod(tt.oldPod, tt.newPod)
+
+			gotPodGroups := len(manager.podGroupInfos)
+			if gotPodGroups == 0 {
+				if tt.expectInAllPods {
+					t.Fatalf("Expected pod group, but got none")
+				}
+				return
+			}
+			if !tt.expectInAllPods {
+				t.Fatalf("Expected no pod groups, but got %v", gotPodGroups)
+			}
+			info, err := manager.PodGroupInfo(tt.newPod.Namespace, tt.newPod.Spec.WorkloadRef)
+			if err != nil {
+				t.Fatalf("Unexpected error getting pod group info: %v", err)
+			}
+			if inAll := info.AllPods().Has(tt.newPod.UID); inAll != tt.expectInAllPods {
+				t.Errorf("Unexpected AllPods state, want: %v, got: %v", tt.expectInAllPods, inAll)
+			}
+			if inAssumed := info.AssumedPods().Has(tt.newPod.UID); inAssumed != tt.expectInAssumedPods {
+				t.Errorf("Unexpected AssumedPods state, want: %v, got: %v", tt.expectInAssumedPods, inAssumed)
+			}
+			if inAssigned := info.AssignedPods().Has(tt.newPod.UID); inAssigned != tt.expectInAssignedPods {
+				t.Errorf("Unexpected AssignedPods state, want: %v, got: %v", tt.expectInAssignedPods, inAssigned)
+			}
+		})
+	}
+}
+
+func TestWorkloadManager_DeletePod(t *testing.T) {
+	p1 := st.MakePod().Namespace("ns1").Name("p1").UID("p1").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+	p2 := st.MakePod().Namespace("ns1").Name("p2").UID("p2").
+		WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+
+	tests := []struct {
+		name        string
+		initPods    []*v1.Pod
+		podToDelete *v1.Pod
+
+		expectedPodGroups int
+	}{
+		{
+			name:              "deleting a pod from a group with multiple pods",
+			initPods:          []*v1.Pod{p1, p2},
+			podToDelete:       p1,
+			expectedPodGroups: 1,
+		},
+		{
+			name:        "deleting the last pod cleans up the info",
+			initPods:    []*v1.Pod{p1},
+			podToDelete: p1,
+		},
+		{
+			name:        "deleting a non-existent pod is a no-op",
+			podToDelete: p1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := New()
+			for _, p := range tt.initPods {
+				manager.AddPod(p)
+			}
+			manager.DeletePod(tt.podToDelete)
+
+			gotPodGroups := len(manager.podGroupInfos)
+			if gotPodGroups != tt.expectedPodGroups {
+				t.Fatalf("Expected %v pod group(s), got %v", tt.expectedPodGroups, gotPodGroups)
+			}
+			if gotPodGroups == 0 {
+				return
+			}
+			info, err := manager.PodGroupInfo(tt.podToDelete.Namespace, tt.podToDelete.Spec.WorkloadRef)
+			if err != nil {
+				t.Fatalf("Unexpected error getting pod group info: %v", err)
+			}
+			if len(info.AllPods()) == 0 {
+				t.Errorf("Expected AllPods to be non-empty")
+			}
+			if info.AllPods().Has(p1.UID) {
+				t.Errorf("Expected pod to be deleted")
+			}
+		})
+	}
+}

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	resourcealphaapi "k8s.io/api/resource/v1alpha3"
+	schedulingapi "k8s.io/api/scheduling/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -443,6 +444,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 		enableDRADeviceTaints     bool
 		enableDRADeviceTaintRules bool
 		enableDRAExtendedResource bool
+		enableGenericWorkload     bool
 		expectStaticInformers     map[reflect.Type]bool
 		expectDynamicInformers    map[schema.GroupVersionResource]bool
 	}{
@@ -529,21 +531,31 @@ func TestAddAllEventHandlers(t *testing.T) {
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
 		},
 		{
-			name: "DRA extended resource enabled with DRA manager",
+			name: "Workload events disabled",
 			gvkMap: map[fwk.EventResource]fwk.ActionType{
-				fwk.ResourceClaim: fwk.Add,
-				fwk.ResourceSlice: fwk.Add,
-				fwk.DeviceClass:   fwk.Add,
+				fwk.Workload: fwk.Add,
 			},
-			enableDRA:                 true,
-			enableDRAExtendedResource: true,
+			expectStaticInformers: map[reflect.Type]bool{
+				reflect.TypeOf(&v1.Pod{}):       true,
+				reflect.TypeOf(&v1.Node{}):      true,
+				reflect.TypeOf(&v1.Namespace{}): true,
+			},
+			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
+		},
+		{
+			name: "Workload events enabled",
+			gvkMap: map[fwk.EventResource]fwk.ActionType{
+				fwk.Workload: fwk.Add,
+			},
+			enableDRA:             true,
+			enableGenericWorkload: true,
 			expectStaticInformers: map[reflect.Type]bool{
 				reflect.TypeOf(&v1.Pod{}):                    true,
 				reflect.TypeOf(&v1.Node{}):                   true,
 				reflect.TypeOf(&v1.Namespace{}):              true,
 				reflect.TypeOf(&resourceapi.ResourceClaim{}): true,
 				reflect.TypeOf(&resourceapi.ResourceSlice{}): true,
-				reflect.TypeOf(&resourceapi.DeviceClass{}):   true,
+				reflect.TypeOf(&schedulingapi.Workload{}):    true,
 			},
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
 		},
@@ -615,6 +627,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 			} else {
 				// Making this depend on the emulated version avoids "cannot set feature gate DRADeviceTaintRules to false, feature is PreAlpha at emulated version 1.34".
 				overrides[features.DRADeviceTaintRules] = tt.enableDRADeviceTaintRules
+				overrides[features.GenericWorkload] = tt.enableGenericWorkload
 			}
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, overrides)
 

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -47,6 +47,7 @@ type Features struct {
 	EnablePodLevelResources                      bool
 	EnableStorageCapacityScoring                 bool
 	EnableNodeDeclaredFeatures                   bool
+	EnableGangScheduling                         bool
 }
 
 // NewSchedulerFeaturesFromGates copies the current state of the feature gates into the struct.
@@ -74,5 +75,6 @@ func NewSchedulerFeaturesFromGates(featureGate featuregate.FeatureGate) Features
 		EnableDRAPartitionableDevices:                featureGate.Enabled(features.DRAPartitionableDevices),
 		EnableStorageCapacityScoring:                 featureGate.Enabled(features.StorageCapacityScoring),
 		EnableNodeDeclaredFeatures:                   featureGate.Enabled(features.NodeDeclaredFeatures),
+		EnableGangScheduling:                         featureGate.Enabled(features.GangScheduling),
 	}
 }

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gangscheduling
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha1"
+	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+)
+
+const (
+	// Name is the name of the plugin used in the plugin registry and configurations.
+	Name = names.GangScheduling
+)
+
+// GangScheduling is a plugin that enforces "all-or-nothing" scheduling for pods
+// belonging to a Workload with a Gang scheduling policy.
+type GangScheduling struct {
+	handle         fwk.Handle
+	workloadLister schedulinglisters.WorkloadLister
+}
+
+var _ fwk.EnqueueExtensions = &GangScheduling{}
+var _ fwk.PreEnqueuePlugin = &GangScheduling{}
+var _ fwk.ReservePlugin = &GangScheduling{}
+var _ fwk.PermitPlugin = &GangScheduling{}
+
+// New initializes a new plugin and returns it.
+func New(_ context.Context, _ runtime.Object, fh fwk.Handle, fts feature.Features) (fwk.Plugin, error) {
+	return &GangScheduling{
+		handle:         fh,
+		workloadLister: fh.SharedInformerFactory().Scheduling().V1alpha1().Workloads().Lister(),
+	}, nil
+}
+
+// Name returns name of the plugin.
+func (pl *GangScheduling) Name() string {
+	return Name
+}
+
+// EventsToRegister returns the possible events that may make a Pod failed by this plugin schedulable.
+func (pl *GangScheduling) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		// A new pod being added might be the one that completes a gang, meeting its MinCount requirement.
+		// Workload reference is immutable, so there is no need to subscribe on Pod/Update event.
+		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodAdded},
+		// A Workload being added can be making a waiting gang schedulable.
+		// Workload's PodGroups are immutable, so there's no need to handle Workload/Update event.
+		{Event: fwk.ClusterEvent{Resource: fwk.Workload, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterWorkloadAdded},
+	}, nil
+}
+
+// matchingWorkloadReference returns true if two pods belong to the same workload, including their pod group and replica key.
+func matchingWorkloadReference(pod1, pod2 *v1.Pod) bool {
+	return pod1.Spec.WorkloadRef != nil && pod2.Spec.WorkloadRef != nil && pod1.Namespace == pod2.Namespace && *pod1.Spec.WorkloadRef == *pod2.Spec.WorkloadRef
+}
+
+func (pl *GangScheduling) isSchedulableAfterPodAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	_, addedPod, err := util.As[*v1.Pod](oldObj, newObj)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	if !matchingWorkloadReference(pod, addedPod) {
+		logger.V(5).Info("another pod was added but it doesn't match the target pod's workload",
+			"pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef, "addedPod", klog.KObj(addedPod), "addedWorkloadRef", pod.Spec.WorkloadRef)
+		return fwk.QueueSkip, nil
+	}
+
+	logger.V(5).Info("another pod was added and it matches the target pod's workload, which may make the pod schedulable",
+		"pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef, "addedPod", klog.KObj(addedPod), "addedWorkloadRef", pod.Spec.WorkloadRef)
+	return fwk.Queue, nil
+}
+
+func (pl *GangScheduling) isSchedulableAfterWorkloadAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	_, addedWorkload, err := util.As[*schedulingapi.Workload](oldObj, newObj)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	if pod.Spec.WorkloadRef == nil || pod.Namespace != addedWorkload.Namespace || pod.Spec.WorkloadRef.Name != addedWorkload.Name {
+		logger.V(5).Info("workload was added but it doesn't match the target pod's workloadRef",
+			"pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef, "addedWorkload", klog.KObj(addedWorkload))
+		return fwk.QueueSkip, nil
+	}
+
+	logger.V(5).Info("workload was added and it matches the target pod's workload, which may make the pod schedulable",
+		"pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef, "addedWorkload", klog.KObj(addedWorkload))
+	return fwk.Queue, nil
+}
+
+// PreEnqueue checks if the pod belongs to a gang and, if so, whether the gang has met its MinCount of available pods.
+// If not, the pod is rejected until more pods arrive.
+func (pl *GangScheduling) PreEnqueue(ctx context.Context, pod *v1.Pod) *fwk.Status {
+	if pod.Spec.WorkloadRef == nil {
+		return nil
+	}
+
+	namespace := pod.Namespace
+	workloadRef := pod.Spec.WorkloadRef
+
+	workload, err := pl.workloadLister.Workloads(namespace).Get(workloadRef.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// The pod is unschedulable until its Workload object is created.
+			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("waiting for pods's workload %q to appear in scheduling queue", workloadRef.Name))
+		}
+		klog.FromContext(ctx).Error(err, "Failed to get workload", "pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef)
+		return fwk.AsStatus(fmt.Errorf("failed to get workload %s/%s", namespace, workloadRef.Name))
+	}
+
+	policy, ok := podGroupPolicy(workload, workloadRef.PodGroup)
+	if !ok {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("pod group %q doesn't exist for a workload %q", workloadRef.PodGroup, workload.Name))
+	}
+	// This plugin only cares about pods with a Gang scheduling policy.
+	if policy.Gang == nil {
+		return nil
+	}
+
+	podGroupInfo, err := pl.handle.WorkloadManager().PodGroupInfo(namespace, workloadRef)
+	if err != nil {
+		return fwk.AsStatus(err)
+	}
+	allPods := podGroupInfo.AllPods()
+	if len(allPods) < int(policy.Gang.MinCount) {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue")
+	}
+
+	// The quorum is met, allow the pod to enter the scheduling queue.
+	return nil
+}
+
+// Reserve is called after a node has been selected for the pod. For gang pods,
+// this stage marks the pod as "assumed" in the WorkloadManager,
+// contributing to the count of pods ready to be co-scheduled at the Permit stage.
+func (pl *GangScheduling) Reserve(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	if pod.Spec.WorkloadRef == nil {
+		return nil
+	}
+	podGroupInfo, err := pl.handle.WorkloadManager().PodGroupInfo(pod.Namespace, pod.Spec.WorkloadRef)
+	if err != nil {
+		return fwk.AsStatus(err)
+	}
+	podGroupInfo.AssumePod(pod.UID)
+	return nil
+}
+
+// Unreserve removes the gang pod from the "assumed" state in the WorkloadManager,
+// ensuring it doesn't count towards the Permit quorum.
+func (pl *GangScheduling) Unreserve(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeName string) {
+	if pod.Spec.WorkloadRef == nil {
+		return
+	}
+	podGroupInfo, err := pl.handle.WorkloadManager().PodGroupInfo(pod.Namespace, pod.Spec.WorkloadRef)
+	if err != nil {
+		utilruntime.HandleErrorWithContext(ctx, err, "Failed to get pod group info", "pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef)
+		return
+	}
+	podGroupInfo.ForgetPod(pod.UID)
+}
+
+// podGroupPolicy is a helper to find the policy for a specific pod group name in a workload.
+func podGroupPolicy(workload *schedulingapi.Workload, podGroupName string) (schedulingapi.PodGroupPolicy, bool) {
+	for _, podGroup := range workload.Spec.PodGroups {
+		if podGroup.Name == podGroupName {
+			return podGroup.Policy, true
+		}
+	}
+	return schedulingapi.PodGroupPolicy{}, false
+}
+
+// Permit forces all pods in a gang to wait at this stage. Once the number of waiting (assumed) pods
+// reaches the gang's MinCount, all pods in the gang are permitted to proceed to binding simultaneously.
+func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
+	if pod.Spec.WorkloadRef == nil {
+		return nil, 0
+	}
+
+	logger := klog.FromContext(ctx)
+	namespace := pod.Namespace
+	workloadRef := pod.Spec.WorkloadRef
+
+	workload, err := pl.workloadLister.Workloads(namespace).Get(workloadRef.Name)
+	if err != nil {
+		// It's likely that the workload was removed or another error happened.
+		// Returning error to retry the Pod when the Workload is added again.
+		return fwk.AsStatus(fmt.Errorf("failed to get workload %s/%s: %w", namespace, workloadRef.Name, err)), 0
+	}
+
+	policy, ok := podGroupPolicy(workload, workloadRef.PodGroup)
+	if !ok {
+		return fwk.AsStatus(fmt.Errorf("pod group %q doesn't exist for a workload %q", workloadRef.PodGroup, workload.Name)), 0
+	}
+	// This plugin only cares about pods with a Gang scheduling policy.
+	if policy.Gang == nil {
+		return nil, 0
+	}
+
+	podGroupInfo, err := pl.handle.WorkloadManager().PodGroupInfo(namespace, workloadRef)
+	if err != nil {
+		return fwk.AsStatus(err), 0
+	}
+	assumedPods := podGroupInfo.AssumedPods()
+	assumedOrAssignedPods := assumedPods.Union(podGroupInfo.AssignedPods())
+	if len(assumedOrAssignedPods) < int(policy.Gang.MinCount) {
+		// Activate unscheduled pods from this pod group in case they were waiting for this pod to be scheduled.
+		unscheduledPods := podGroupInfo.UnscheduledPods()
+		pl.handle.Activate(klog.FromContext(ctx), unscheduledPods)
+		logger.V(4).Info("Quorum is not met for a gang. Waiting for another pod to allow", "pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef, "activatedPods", len(unscheduledPods))
+		return fwk.NewStatus(fwk.Wait, "waiting for minCount pods from a gang to be waiting on permit"), podGroupInfo.SchedulingTimeout()
+	}
+
+	logger.V(4).Info("Quorum is met for a gang. Allowing other pods from a gang waiting on permit", "pod", klog.KObj(pod), "workloadRef", pod.Spec.WorkloadRef, "allowedPods", len(assumedPods))
+
+	// The quorum is met. Allow this pod and signal all other waiting pods from the same gang to proceed.
+	for podUID := range assumedPods {
+		waitingPod := pl.handle.GetWaitingPod(podUID)
+		if waitingPod != nil {
+			waitingPod.Allow(Name)
+		}
+	}
+
+	return nil, 0
+}

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gangscheduling
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/backend/workloadmanager"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+)
+
+func Test_isSchedulableAfterPodAdded(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		newPod       *v1.Pod
+		expectedHint fwk.QueueingHint
+	}{
+		{
+			name:         "add a newPod which matches the pod's workload and pod group",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			newPod:       st.MakePod().WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "add a newPod which matches the pod's workload, pod group and replica key",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg", PodGroupReplicaKey: "3"}).Obj(),
+			newPod:       st.MakePod().WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg", PodGroupReplicaKey: "3"}).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "add a newPod which doesn't match the pod's namespace",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			newPod:       st.MakePod().Namespace("foo").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "add a newPod which doesn't match the pod's workload name",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			newPod:       st.MakePod().WorkloadRef(&v1.WorkloadReference{Name: "w2", PodGroup: "pg"}).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "add a newPod which doesn't match the pod's pod group name",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			newPod:       st.MakePod().WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg2"}).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "add a newPod which doesn't match the pod's replica key",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg", PodGroupReplicaKey: "3"}).Obj(),
+			newPod:       st.MakePod().WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg", PodGroupReplicaKey: "4"}).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			p, err := New(ctx, nil, fh, feature.Features{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			actualHint, err := p.(*GangScheduling).isSchedulableAfterPodAdded(logger, tc.pod, nil, tc.newPod)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isSchedulableAfterWorkloadAdded(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		newWorkload  *schedulingapi.Workload
+		expectedHint fwk.QueueingHint
+	}{
+		{
+			name:         "add a workload which matches the pod's workload name",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			newWorkload:  st.MakeWorkload().Name("w1").PodGroup(st.MakePodGroup().Name("pg").MinCount(1).Obj()).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "add a workload which doesn't match the pod's workload name",
+			pod:          st.MakePod().Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w2", PodGroup: "pg"}).Obj(),
+			newWorkload:  st.MakeWorkload().Name("w1").PodGroup(st.MakePodGroup().Name("pg").MinCount(1).Obj()).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "add a workload which doesn't match the pod's workload namespace",
+			pod:          st.MakePod().Namespace("ns1").Name("p").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg"}).Obj(),
+			newWorkload:  st.MakeWorkload().Namespace("ns2").Name("w1").PodGroup(st.MakePodGroup().Name("pg").MinCount(1).Obj()).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			p, err := New(ctx, nil, fh, feature.Features{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			actualHint, err := p.(*GangScheduling).isSchedulableAfterWorkloadAdded(logger, tc.pod, nil, tc.newWorkload)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type podActivatorMock struct {
+	activatedPods []*v1.Pod
+}
+
+func (pam *podActivatorMock) Activate(_ klog.Logger, pods map[string]*v1.Pod) {
+	for _, pod := range pods {
+		pam.activatedPods = append(pam.activatedPods, pod)
+	}
+}
+
+func TestGangSchedulingFlow(t *testing.T) {
+	workload := st.MakeWorkload().Namespace("ns1").Name("gang-wl").
+		PodGroup(st.MakePodGroup().Name("pg1").MinCount(3).Obj()).
+		PodGroup(st.MakePodGroup().Name("pg2").MinCount(4).Obj()).Obj()
+
+	basicPolicyWorkload := st.MakeWorkload().Namespace("ns1").Name("basic-wl").
+		PodGroup(st.MakePodGroup().Name("pg1").BasicPolicy().Obj()).Obj()
+
+	p1 := st.MakePod().Namespace("ns1").Name("p1").UID("p1").
+		WorkloadRef(&v1.WorkloadReference{Name: "gang-wl", PodGroup: "pg1"}).Obj()
+	p2 := st.MakePod().Namespace("ns1").Name("p2").UID("p2").
+		WorkloadRef(&v1.WorkloadReference{Name: "gang-wl", PodGroup: "pg1"}).Obj()
+	p3 := st.MakePod().Namespace("ns1").Name("p3").UID("p3").
+		WorkloadRef(&v1.WorkloadReference{Name: "gang-wl", PodGroup: "pg1"}).Obj()
+
+	p4 := st.MakePod().Namespace("ns1").Name("p4").UID("p4").
+		WorkloadRef(&v1.WorkloadReference{Name: "gang-wl", PodGroup: "pg2"}).Obj()
+
+	p5 := st.MakePod().Namespace("ns1").Name("p5").UID("p5").
+		WorkloadRef(&v1.WorkloadReference{Name: "gang-wl", PodGroup: "pg1", PodGroupReplicaKey: "2"}).Obj()
+
+	basicPolicyPod := st.MakePod().Namespace("ns1").Name("basic-pod").UID("basic-pod").
+		WorkloadRef(&v1.WorkloadReference{Name: "basic-wl", PodGroup: "pg1"}).Obj()
+
+	nonGangPod := st.MakePod().Namespace("ns1").Name("non-gang").UID("non-gang").Obj()
+
+	tests := []struct {
+		name                 string
+		pod                  *v1.Pod
+		initialPods          []*v1.Pod
+		initialWorkloads     []*schedulingapi.Workload
+		podsWaitingOnPermit  []*v1.Pod
+		wantPreEnqueueStatus *fwk.Status
+		wantPermitStatus     *fwk.Status
+		wantActivatedPods    []*v1.Pod
+		wantAllowedPods      []types.UID
+	}{
+		{
+			name:                 "non-gang pod succeeds immediately",
+			pod:                  nonGangPod,
+			initialWorkloads:     []*schedulingapi.Workload{workload, basicPolicyWorkload},
+			wantPreEnqueueStatus: nil,
+			wantPermitStatus:     nil,
+		},
+		{
+			name:                 "basic policy pod succeeds immediately",
+			pod:                  basicPolicyPod,
+			initialWorkloads:     []*schedulingapi.Workload{workload, basicPolicyWorkload},
+			wantPreEnqueueStatus: nil,
+			wantPermitStatus:     nil,
+		},
+		{
+			name:                 "gang pod fails PreEnqueue when workload is not yet created",
+			pod:                  p1,
+			initialPods:          []*v1.Pod{p2, p3, p4, p5},
+			initialWorkloads:     []*schedulingapi.Workload{},
+			wantPreEnqueueStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for pods's workload \"gang-wl\" to appear in scheduling queue"),
+		},
+		{
+			name:                 "gang pod fails PreEnqueue when quorum is not met",
+			pod:                  p1,
+			initialPods:          []*v1.Pod{p2, p4, p5}, // Only p1 and p2 exist from their gang, minCount is 3.
+			initialWorkloads:     []*schedulingapi.Workload{workload},
+			wantPreEnqueueStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
+		},
+		{
+			name:                 "gang pod passes PreEnqueue, but waits at Permit",
+			pod:                  p1,
+			initialPods:          []*v1.Pod{p2, p3, p4, p5}, // All pods are available.
+			initialWorkloads:     []*schedulingapi.Workload{workload},
+			podsWaitingOnPermit:  []*v1.Pod{p2, p4, p5},
+			wantPreEnqueueStatus: nil,
+			wantActivatedPods:    []*v1.Pod{p3},
+			// At Permit, p1 will be assumed, but the count (2) is less than the quorum (3), so it must wait.
+			wantPermitStatus: fwk.NewStatus(fwk.Wait, "waiting for minCount pods from a gang to be waiting on permit"),
+		},
+		{
+			name:                 "final gang pod arrives at Permit and allows all waiting pods from a gang",
+			pod:                  p1, // p3 is the pod being scheduled in this cycle.
+			initialPods:          []*v1.Pod{p2, p3, p4, p5},
+			initialWorkloads:     []*schedulingapi.Workload{workload},
+			podsWaitingOnPermit:  []*v1.Pod{p2, p3, p4, p5},
+			wantPreEnqueueStatus: nil,
+			wantPermitStatus:     nil,
+			wantAllowedPods:      []types.UID{"p1", "p2", "p3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			manager := workloadmanager.New()
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+			workloadInformer := informerFactory.Scheduling().V1alpha1().Workloads()
+
+			fakeActivator := &podActivatorMock{}
+
+			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithWorkloadManager(manager),
+				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+				frameworkruntime.WithPodActivator(fakeActivator),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			// Populate informers and manager state for the test case.
+			for _, wl := range tt.initialWorkloads {
+				err := workloadInformer.Informer().GetStore().Add(wl)
+				if err != nil {
+					t.Fatalf("Failed to add workload %s to store: %v", wl.Name, err)
+				}
+			}
+			for _, p := range tt.initialPods {
+				manager.AddPod(p)
+			}
+			manager.AddPod(tt.pod)
+
+			p, err := New(ctx, nil, fh, feature.Features{EnableGangScheduling: true})
+			if err != nil {
+				t.Fatalf("Failed to create plugin: %v", err)
+			}
+			pl := p.(*GangScheduling)
+
+			gotPreEnqueueStatus := pl.PreEnqueue(ctx, tt.pod)
+			if diff := cmp.Diff(tt.wantPreEnqueueStatus, gotPreEnqueueStatus); diff != "" {
+				t.Fatalf("Unexpected PreEnqueue status (-want,+got):\n%s", diff)
+			}
+			if !gotPreEnqueueStatus.IsSuccess() {
+				// Pod is rejected.
+				return
+			}
+
+			// Simulate that other pods have already hit Permit and are now waiting.
+			for _, p := range tt.podsWaitingOnPermit {
+				// Run Reserve and Permit for these pods to get them into the "assumed" state inside the manager.
+				status := pl.Reserve(ctx, nil, p, "some-node")
+				if !status.IsSuccess() {
+					t.Fatalf("Unexpected Reserve status for pod %q: %v", p.Name, status)
+				}
+				status, _ = pl.Permit(ctx, nil, p, "some-node")
+				if status.Code() != fwk.Wait {
+					t.Fatalf("Expected Wait status while permitting a pod %q: %v", p.Name, status)
+				}
+			}
+
+			status := pl.Reserve(ctx, nil, tt.pod, "some-node")
+			if !status.IsSuccess() {
+				t.Fatalf("Unexpected Reserve status: %v", status)
+			}
+
+			// Clear activated pods to assert those activated in tt.pod Permit.
+			fakeActivator.activatedPods = nil
+
+			gotPermitStatus, _ := pl.Permit(ctx, nil, tt.pod, "some-node")
+			if diff := cmp.Diff(tt.wantPermitStatus, gotPermitStatus); diff != "" {
+				t.Fatalf("Unexpected Permit status (-want, +got):\n%s", diff)
+			}
+			if gotPermitStatus.Code() == fwk.Wait {
+				// Pod waits for others from a gang. Simulate its eventual Unreserve.
+				pl.Unreserve(ctx, nil, tt.pod, "some-node")
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantActivatedPods, fakeActivator.activatedPods); diff != "" {
+				t.Errorf("Unexpected activated pods (-want, +got):\n%s", diff)
+			}
+			for _, p := range tt.wantAllowedPods {
+				if wp := fh.GetWaitingPod(p); wp != nil {
+					t.Errorf("Expected pod %q to be allowed", p)
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/plugins/names/names.go
+++ b/pkg/scheduler/framework/plugins/names/names.go
@@ -21,6 +21,7 @@ const (
 	DefaultBinder                   = "DefaultBinder"
 	DefaultPreemption               = "DefaultPreemption"
 	DynamicResources                = "DynamicResources"
+	GangScheduling                  = "GangScheduling"
 	ImageLocality                   = "ImageLocality"
 	InterPodAffinity                = "InterPodAffinity"
 	NodeAffinity                    = "NodeAffinity"

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
 	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/gangscheduling"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/imagelocality"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
@@ -67,6 +68,7 @@ func NewInTreeRegistry() runtime.Registry {
 		defaultbinder.Name:                   defaultbinder.New,
 		defaultpreemption.Name:               runtime.FactoryAdapter(fts, defaultpreemption.New),
 		schedulinggates.Name:                 runtime.FactoryAdapter(fts, schedulinggates.New),
+		gangscheduling.Name:                  runtime.FactoryAdapter(fts, gangscheduling.New),
 	}
 
 	return registry

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -78,6 +78,7 @@ type frameworkImpl struct {
 	eventRecorder    events.EventRecorder
 	informerFactory  informers.SharedInformerFactory
 	sharedDRAManager fwk.SharedDRAManager
+	workloadManager  fwk.WorkloadManager
 	logger           klog.Logger
 
 	sharedCSIManager fwk.CSIManager
@@ -145,6 +146,7 @@ type frameworkOptions struct {
 	parallelizer           parallelize.Parallelizer
 	waitingPods            *waitingPodsMap
 	apiDispatcher          *apidispatcher.APIDispatcher
+	workloadManager        fwk.WorkloadManager
 	logger                 *klog.Logger
 }
 
@@ -244,6 +246,13 @@ func WithAPIDispatcher(apiDispatcher *apidispatcher.APIDispatcher) Option {
 	}
 }
 
+// WithWorkloadManager sets Workload manager for the scheduling frameworkImpl.
+func WithWorkloadManager(workloadManager fwk.WorkloadManager) Option {
+	return func(o *frameworkOptions) {
+		o.workloadManager = workloadManager
+	}
+}
+
 // CaptureProfile is a callback to capture a finalized profile.
 type CaptureProfile func(config.KubeSchedulerProfile)
 
@@ -312,6 +321,7 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 		PodNominator:         options.podNominator,
 		PodActivator:         options.podActivator,
 		apiDispatcher:        options.apiDispatcher,
+		workloadManager:      options.workloadManager,
 		parallelizer:         options.parallelizer,
 		logger:               logger,
 	}
@@ -1735,6 +1745,11 @@ func (f *frameworkImpl) SharedDRAManager() fwk.SharedDRAManager {
 // SharedCSIManager returns the SharedCSIManager of the framework.
 func (f *frameworkImpl) SharedCSIManager() fwk.CSIManager {
 	return f.sharedCSIManager
+}
+
+// WorkloadManager returns the WorkloadManager of the framework.
+func (f *frameworkImpl) WorkloadManager() fwk.WorkloadManager {
+	return f.workloadManager
 }
 
 func (f *frameworkImpl) pluginsNeeded(plugins *config.Plugins) sets.Set[string] {

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -76,6 +76,7 @@ var (
 		fwk.ResourceClaim,
 		fwk.ResourceSlice,
 		fwk.DeviceClass,
+		fwk.Workload,
 	}
 )
 
@@ -142,7 +143,7 @@ func MatchAnyClusterEvent(ce fwk.ClusterEvent, incomingEvents []fwk.ClusterEvent
 }
 
 func UnrollWildCardResource() []fwk.ClusterEventWithHint {
-	return []fwk.ClusterEventWithHint{
+	events := []fwk.ClusterEventWithHint{
 		{Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.All}},
 		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.All}},
 		{Event: fwk.ClusterEvent{Resource: fwk.PersistentVolume, ActionType: fwk.All}},
@@ -154,6 +155,10 @@ func UnrollWildCardResource() []fwk.ClusterEventWithHint {
 		{Event: fwk.ClusterEvent{Resource: fwk.ResourceClaim, ActionType: fwk.All}},
 		{Event: fwk.ClusterEvent{Resource: fwk.DeviceClass, ActionType: fwk.All}},
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
+		events = append(events, fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.Workload, ActionType: fwk.All}})
+	}
+	return events
 }
 
 // NodeInfo is node level aggregated information.

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -849,6 +850,12 @@ func (p *PodWrapper) Overhead(rl v1.ResourceList) *PodWrapper {
 	return p
 }
 
+// WorkloadRef sets workloadRef of the inner pod.
+func (p *PodWrapper) WorkloadRef(workloadRef *v1.WorkloadReference) *PodWrapper {
+	p.Spec.WorkloadRef = workloadRef
+	return p
+}
+
 // NodeWrapper wraps a Node inside.
 type NodeWrapper struct{ v1.Node }
 
@@ -1525,4 +1532,69 @@ func (c *VolumeAttachmentWrapper) Source(source storagev1.VolumeAttachmentSource
 func (c *VolumeAttachmentWrapper) Attached(attached bool) *VolumeAttachmentWrapper {
 	c.Status.Attached = attached
 	return c
+}
+
+// WorkloadWrapper wraps a Workload inside.
+type WorkloadWrapper struct{ schedulingapi.Workload }
+
+// MakeWorkload creates a Workload wrapper.
+func MakeWorkload() *WorkloadWrapper {
+	return &WorkloadWrapper{}
+}
+
+// Obj returns the inner Workload.
+func (wrapper *WorkloadWrapper) Obj() *schedulingapi.Workload {
+	return &wrapper.Workload
+}
+
+// Name sets `name` as the name of the inner Workload.
+func (wrapper *WorkloadWrapper) Name(name string) *WorkloadWrapper {
+	wrapper.SetName(name)
+	return wrapper
+}
+
+// Namespace sets `namespace` as the namespace of the inner Workload.
+func (wrapper *WorkloadWrapper) Namespace(namespace string) *WorkloadWrapper {
+	wrapper.SetNamespace(namespace)
+	return wrapper
+}
+
+// PodGroup injects the pod group into the inner Workload.
+func (wrapper *WorkloadWrapper) PodGroup(pg *schedulingapi.PodGroup) *WorkloadWrapper {
+	wrapper.Spec.PodGroups = append(wrapper.Spec.PodGroups, *pg)
+	return wrapper
+}
+
+// PodGroupWrapper wraps a PodGroup inside.
+type PodGroupWrapper struct{ schedulingapi.PodGroup }
+
+// MakePodGroup creates a PodGroup wrapper.
+func MakePodGroup() *PodGroupWrapper {
+	return &PodGroupWrapper{}
+}
+
+// Obj returns the inner PodGroup.
+func (wrapper *PodGroupWrapper) Obj() *schedulingapi.PodGroup {
+	return &wrapper.PodGroup
+}
+
+// Name sets `name` as the name of the inner PodGroup.
+func (wrapper *PodGroupWrapper) Name(name string) *PodGroupWrapper {
+	wrapper.PodGroup.Name = name
+	return wrapper
+}
+
+// MinCount sets the MinCount for the Gang scheduling policy.
+func (wrapper *PodGroupWrapper) MinCount(count int32) *PodGroupWrapper {
+	if wrapper.Policy.Gang == nil {
+		wrapper.Policy.Gang = &schedulingapi.GangSchedulingPolicy{}
+	}
+	wrapper.Policy.Gang.MinCount = count
+	return wrapper
+}
+
+// BasicPolicy sets the PodGroup policy to Basic.
+func (wrapper *PodGroupWrapper) BasicPolicy() *PodGroupWrapper {
+	wrapper.Policy.Basic = &schedulingapi.BasicSchedulingPolicy{}
+	return wrapper
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -66,6 +66,7 @@ const (
 	internalAPIServerGroup       = "internal.apiserver.k8s.io"
 	admissionRegistrationGroup   = "admissionregistration.k8s.io"
 	storageVersionMigrationGroup = "storagemigration.k8s.io"
+	schedulingGroup              = "scheduling.k8s.io"
 )
 
 func addDefaultMetadata(obj runtime.Object) {
@@ -648,6 +649,9 @@ func ClusterRoles() []rbacv1.ClusterRole {
 		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules) {
 			kubeSchedulerRules = append(kubeSchedulerRules, rbacv1helpers.NewRule(Read...).Groups(resourceGroup).Resources("devicetaintrules").RuleOrDie())
 		}
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
+		kubeSchedulerRules = append(kubeSchedulerRules, rbacv1helpers.NewRule(Read...).Groups(schedulingGroup).Resources("workloads").RuleOrDie())
 	}
 	roles = append(roles, rbacv1.ClusterRole{
 		// a role to use for the kube-scheduler

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles-featuregates.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles-featuregates.yaml
@@ -976,6 +976,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - scheduling.k8s.io
+    resources:
+    - workloads
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -693,6 +693,9 @@ type Handle interface {
 	// Use this to ensure the scheduler's view of the cluster remains consistent.
 	// This is non-nil if the SchedulerAsyncAPICalls feature gate is enabled.
 	APICacher() APICacher
+
+	// WorkloadManager can be used to provide workload-aware scheduling.
+	WorkloadManager() WorkloadManager
 }
 
 // Parallelizer helps run scheduling operations in parallel chunks where possible, to improve performance and CPU utilization.

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -170,6 +170,7 @@ const (
 	ResourceClaim         EventResource = "resource.k8s.io/ResourceClaim"
 	ResourceSlice         EventResource = "resource.k8s.io/ResourceSlice"
 	DeviceClass           EventResource = "resource.k8s.io/DeviceClass"
+	Workload              EventResource = "scheduling.k8s.io/Workload"
 
 	// WildCard is a special EventResource to match all resources.
 	// e.g., If you register `{Resource: "*", ActionType: All}` in EventsToRegister,

--- a/test/integration/scheduler/gang/gang_test.go
+++ b/test/integration/scheduler/gang/gang_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gang
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler"
+	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
+	workloadmanager "k8s.io/kubernetes/pkg/scheduler/backend/workloadmanager"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+// podInUnschedulablePods checks if the given Pod is in the unschedulable pods pool.
+func podInUnschedulablePods(t *testing.T, queue queue.SchedulingQueue, podName string) bool {
+	t.Helper()
+	unschedPods := queue.UnschedulablePods()
+	for _, pod := range unschedPods {
+		if pod.Name == podName {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGangScheduling(t *testing.T) {
+	node := st.MakeNode().Name("node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
+
+	workload := st.MakeWorkload().Name("workload").PodGroup(st.MakePodGroup().Name("pg").MinCount(3).Obj()).Obj()
+
+	p1 := st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").
+		WorkloadRef(&v1.WorkloadReference{Name: "workload", PodGroup: "pg"}).Obj()
+	p2 := st.MakePod().Name("p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").
+		WorkloadRef(&v1.WorkloadReference{Name: "workload", PodGroup: "pg"}).Obj()
+	p3 := st.MakePod().Name("p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").
+		WorkloadRef(&v1.WorkloadReference{Name: "workload", PodGroup: "pg"}).Obj()
+	blockerPod := st.MakePod().Name("blocker").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").
+		ZeroTerminationGracePeriod().Obj()
+
+	// step represents a single step in a test scenario.
+	type step struct {
+		name                         string
+		createWorkload               *schedulingapi.Workload
+		createPods                   []*v1.Pod
+		deletePods                   []string
+		waitForPodsGatedOnPreEnqueue []string
+		waitForPodsUnschedulable     []string
+		waitForPodsScheduled         []string
+	}
+
+	tests := []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name: "gang schedules when workload and resources are available",
+			steps: []step{
+				{
+					name:           "Create the Workload object",
+					createWorkload: workload,
+				},
+				{
+					name:       "Create all pods belonging to the gang",
+					createPods: []*v1.Pod{p1, p2, p3},
+				},
+				{
+					name:                 "Verify all gang pods are scheduled successfully",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+			},
+		},
+		{
+			name: "gang waits for quorum to start, then schedules",
+			steps: []step{
+				{
+					name:           "Create the Workload object",
+					createWorkload: workload,
+				},
+				{
+					name:       "Create subset of pods belonging to the gang",
+					createPods: []*v1.Pod{p1, p2},
+				},
+				{
+					name:                         "Verify pods are gated at PreEnqueue (no quorum)",
+					waitForPodsGatedOnPreEnqueue: []string{"p1", "p2"},
+				},
+				{
+					name:       "Create the last pod belonging to the gang to unblock PreEnqueue",
+					createPods: []*v1.Pod{p3},
+				},
+				{
+					name:                 "Verify all gang pods are scheduled successfully",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+			},
+		},
+		{
+			name: "gang waits for workload, then for resources, then schedules",
+			steps: []step{
+				{
+					name:       "Create the resource-blocking pod",
+					createPods: []*v1.Pod{blockerPod},
+				},
+				{
+					name:                 "Schedule the resource-blocking pod",
+					waitForPodsScheduled: []string{"blocker"},
+				},
+				{
+					name:       "Create gang pods before Workload is created",
+					createPods: []*v1.Pod{p1, p2, p3},
+				},
+				{
+					name:                         "Verify pods are gated at PreEnqueue (no Workload object)",
+					waitForPodsGatedOnPreEnqueue: []string{"p1", "p2", "p3"},
+				},
+				{
+					name:           "Create the Workload to unblock PreEnqueue",
+					createWorkload: workload,
+				},
+				{
+					name:                     "Verify pods become unschedulable (Permit timeout due to resource blocker)",
+					waitForPodsUnschedulable: []string{"p1", "p2", "p3"},
+				},
+				{
+					name:       "Delete the resource-blocking pod",
+					deletePods: []string{"blocker"},
+				},
+				{
+					name:                 "Verify the entire gang is now scheduled",
+					waitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+				features.GangScheduling:  true,
+			})
+
+			workloadmanager.DefaultSchedulingTimeoutDuration = 5 * time.Second
+
+			testCtx := testutils.InitTestSchedulerWithNS(t, "gang-scheduling",
+				// disable backoff
+				scheduler.WithPodMaxBackoffSeconds(0),
+				scheduler.WithPodInitialBackoffSeconds(0))
+
+			cs, ns := testCtx.ClientSet, testCtx.NS.Name
+
+			_, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create node: %v", err)
+			}
+
+			for i, step := range tt.steps {
+				t.Logf("Executing step %d: %s", i, step.name)
+				switch {
+				case step.createPods != nil:
+					for _, pod := range step.createPods {
+						p := pod.DeepCopy()
+						p.Namespace = ns
+						if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{}); err != nil {
+							t.Fatalf("Step %d: Failed to create pod %s: %v", i, p.Name, err)
+						}
+					}
+				case step.createWorkload != nil:
+					w := step.createWorkload.DeepCopy()
+					w.Namespace = ns
+					if _, err := cs.SchedulingV1alpha1().Workloads(ns).Create(testCtx.Ctx, w, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("Step %d: Failed to create workload %s: %v", i, w.Name, err)
+					}
+				case step.deletePods != nil:
+					for _, podName := range step.deletePods {
+						if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, podName, metav1.DeleteOptions{}); err != nil {
+							t.Fatalf("Step %d: Failed to delete pod %s: %v", i, podName, err)
+						}
+					}
+				case step.waitForPodsGatedOnPreEnqueue != nil:
+					for _, podName := range step.waitForPodsGatedOnPreEnqueue {
+						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+							func(_ context.Context) (bool, error) {
+								return podInUnschedulablePods(t, testCtx.Scheduler.SchedulingQueue, podName), nil
+							},
+						)
+						if err != nil {
+							t.Fatalf("Step %d: Failed to wait for pod %s to be in unschedulable pods pool: %v", i, podName, err)
+						}
+					}
+				case step.waitForPodsUnschedulable != nil:
+					for _, podName := range step.waitForPodsUnschedulable {
+						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+							testutils.PodUnschedulable(cs, ns, podName))
+						if err != nil {
+							t.Fatalf("Step %d: Failed to wait for pod %s to be unschedulable: %v", i, podName, err)
+						}
+					}
+				case step.waitForPodsScheduled != nil:
+					for _, podName := range step.waitForPodsScheduled {
+						err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+							testutils.PodScheduled(cs, ns, podName))
+						if err != nil {
+							t.Fatalf("Step %d: Failed to wait for pod %s to be scheduled: %v", i, podName, err)
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/test/integration/scheduler/gang/main_test.go
+++ b/test/integration/scheduler/gang/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gang
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,6 +50,13 @@ import (
 	testutils "k8s.io/kubernetes/test/integration/util"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
+)
+
+type rejectingPhase string
+
+const (
+	rejectingPhasePreEnqueue      rejectingPhase = "PreEnqueue"
+	rejectingPhaseSchedulingCycle rejectingPhase = "SchedulingCycle"
 )
 
 type CoreResourceEnqueueTestCase struct {
@@ -77,9 +85,19 @@ type CoreResourceEnqueueTestCase struct {
 	InitialVolumeAttachment []*storagev1.VolumeAttachment
 	// InitialDeviceClasses are the list of DeviceClass to be created at first.
 	InitialDeviceClasses []*resourceapi.DeviceClass
+	// InitialWorkloads is the list of Workloads to be created at first.
+	InitialWorkloads []*schedulingapi.Workload
 	// Pods are the list of Pods to be created.
 	// All of them are expected to be unschedulable at first.
 	Pods []*v1.Pod
+	// ExpectedInitialRejectingPhase specifies how Pods are supposed to be initially rejected.
+	// rejectingPhase could be either "PreEnqueue" or "SchedulingCycle". Depending on the value:
+	// - "PreEnqueue": test case waits for the Pods to be observed by the scheduler
+	//   and put in the unschedulable pods pool, being blocked at the PreEnqueue gate.
+	// - "SchedulingCycle": test case lets pods experience scheduling cycle once,
+	//   being rejected by PreFilter or Filter gates.
+	// Defaults to "SchedulingCycle".
+	ExpectedInitialRejectingPhase rejectingPhase
 	// TriggerFn is the function that triggers the event to move Pods.
 	// It returns the map keyed with ClusterEvents to be triggered by this function,
 	// and valued with the number of triggering of the event.
@@ -98,6 +116,9 @@ type CoreResourceEnqueueTestCase struct {
 	EnableDRAExtendedResource bool
 	// EnableNodeDeclaredFeatures indicates if the test case runs with the NodeDeclaredFeatures feature gate enabled.
 	EnableNodeDeclaredFeatures bool
+	// EnableGangScheduling indicates wether the test case should run with feature gates
+	// GenericWorkload and GangScheduling enabled or not.
+	EnableGangScheduling bool
 }
 
 var (
@@ -133,7 +154,8 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			}
 			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}: 1}, nil
 		},
-		WantRequeuedPods: sets.New("pod2"),
+		WantRequeuedPods:          sets.New("pod2"),
+		EnableSchedulingQueueHint: sets.New(true),
 	},
 	{
 		Name:          "Pod rejected by the PodAffinity plugin is requeued when a new Node is created and turned to ready",
@@ -2581,6 +2603,53 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		},
 		WantRequeuedPods: sets.Set[string]{},
 	},
+	{
+		Name:          "Pod rejected by the GangScheduling plugin is requeued when a new pod with matching workload reference is created",
+		EnablePlugins: []string{names.GangScheduling},
+		InitialNodes: []*v1.Node{
+			st.MakeNode().Name("fake-node1").Obj(),
+		},
+		InitialWorkloads: []*schedulingapi.Workload{
+			st.MakeWorkload().Name("w1").PodGroup(st.MakePodGroup().Name("pg1").MinCount(2).Obj()).Obj(),
+		},
+		Pods: []*v1.Pod{
+			st.MakePod().Name("pod1").Container("image").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj(),
+			st.MakePod().Name("pod2").Container("image").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg2"}).Obj(),
+		},
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
+			pod := st.MakePod().Name("pod3").Container("image").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj()
+			if _, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, pod, metav1.CreateOptions{}); err != nil {
+				return nil, fmt.Errorf("failed to create Pod %q: %w", pod.Name, err)
+			}
+			return map[fwk.ClusterEvent]uint64{framework.EventUnscheduledPodAdd: 1}, nil
+		},
+		ExpectedInitialRejectingPhase: rejectingPhasePreEnqueue,
+		WantRequeuedPods:              sets.New("pod1", "pod3"),
+		EnableSchedulingQueueHint:     sets.New(true),
+		EnableGangScheduling:          true,
+	},
+	{
+		Name:          "Pod rejected by the GangScheduling plugin is requeued when a matching workload is created",
+		EnablePlugins: []string{names.GangScheduling},
+		InitialNodes: []*v1.Node{
+			st.MakeNode().Name("fake-node1").Obj(),
+		},
+		Pods: []*v1.Pod{
+			st.MakePod().Name("pod1").Container("image").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg1"}).Obj(),
+			st.MakePod().Name("pod2").Container("image").WorkloadRef(&v1.WorkloadReference{Name: "w1", PodGroup: "pg2"}).Obj(),
+		},
+		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
+			workload := st.MakeWorkload().Name("w1").PodGroup(st.MakePodGroup().Name("pg1").MinCount(1).Obj()).Obj()
+			if _, err := testCtx.ClientSet.SchedulingV1alpha1().Workloads(testCtx.NS.Name).Create(testCtx.Ctx, workload, metav1.CreateOptions{}); err != nil {
+				return nil, fmt.Errorf("failed to create Workload %q: %w", workload.Name, err)
+			}
+			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Workload, ActionType: fwk.Add}: 1}, nil
+		},
+		ExpectedInitialRejectingPhase: rejectingPhasePreEnqueue,
+		WantRequeuedPods:              sets.New("pod1"),
+		EnableSchedulingQueueHint:     sets.New(true),
+		EnableGangScheduling:          true,
+	},
 }
 
 // TestCoreResourceEnqueue verify Pods failed by in-tree default plugins can be
@@ -2608,7 +2677,12 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 			ndffeatures.AllFeatures = originalAllFeatures
 		}()
 	}
-
+	if tt.EnableGangScheduling {
+		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+			features.GenericWorkload: true,
+			features.GangScheduling:  true,
+		})
+	}
 	logger, _ := ktesting.NewTestContext(t)
 
 	opts := []scheduler.Option{scheduler.WithPodInitialBackoffSeconds(0), scheduler.WithPodMaxBackoffSeconds(0)}
@@ -2709,6 +2783,13 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 		}
 	}
 
+	for _, wl := range tt.InitialWorkloads {
+		wl.Namespace = ns
+		if _, err := cs.SchedulingV1alpha1().Workloads(ns).Create(testCtx.Ctx, wl, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create a Workload %q: %v", wl.Name, err)
+		}
+	}
+
 	for _, pod := range tt.InitialPods {
 		if _, err := cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create an initial Pod %q: %v", pod.Name, err)
@@ -2721,34 +2802,47 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 		}
 	}
 
-	// Wait for the tt.Pods to be present in the scheduling active queue.
-	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-		pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
-		return len(pendingPods) == len(tt.Pods) && len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == len(tt.Pods), nil
-	}); err != nil {
-		t.Fatalf("Failed to wait for all pods to be present in the scheduling queue: %v", err)
-	}
-
-	t.Log("Confirmed Pods in the scheduling queue, starting to schedule them")
-
-	// Pop all pods out. They should become unschedulable.
-	for i := 0; i < len(tt.Pods); i++ {
-		testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
-	}
-	// Wait for the tt.Pods to be still present in the scheduling (unschedulable) queue.
-	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-		activePodsCount := len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ())
-		if activePodsCount > 0 {
-			return false, fmt.Errorf("active queue was expected to be empty, but found %v Pods", activePodsCount)
+	switch tt.ExpectedInitialRejectingPhase {
+	case rejectingPhasePreEnqueue:
+		// Wait for the tt.Pods to be unschedulable in the scheduling queue.
+		if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+			pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
+			return len(pendingPods) == len(tt.Pods) && len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == 0, nil
+		}); err != nil {
+			t.Fatalf("Failed to wait for all pods to be present in the scheduling queue: %v", err)
+		}
+		t.Log("All pods are waiting as unschedulable, will trigger triggerFn")
+	case rejectingPhaseSchedulingCycle:
+		fallthrough
+	default: // Defaults to rejectingPhaseSchedulingCycle.
+		// Wait for the tt.Pods to be present in the scheduling active queue.
+		if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+			pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
+			return len(pendingPods) == len(tt.Pods) && len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == len(tt.Pods), nil
+		}); err != nil {
+			t.Fatalf("Failed to wait for all pods to be present in the scheduling queue: %v", err)
 		}
 
-		pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
-		return len(pendingPods) == len(tt.Pods), nil
-	}); err != nil {
-		t.Fatalf("Failed to wait for all pods to remain in the scheduling queue after scheduling attempts: %v", err)
-	}
+		t.Log("Confirmed Pods in the scheduling queue, starting to schedule them")
 
-	t.Log("finished initial schedulings for all Pods, will trigger triggerFn")
+		// Pop all pods out. They should become unschedulable.
+		for i := 0; i < len(tt.Pods); i++ {
+			testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
+		}
+		// Wait for the tt.Pods to be still present in the scheduling (unschedulable) queue.
+		if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+			activePodsCount := len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ())
+			if activePodsCount > 0 {
+				return false, fmt.Errorf("active queue was expected to be empty, but found %v Pods", activePodsCount)
+			}
+
+			pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
+			return len(pendingPods) == len(tt.Pods), nil
+		}); err != nil {
+			t.Fatalf("Failed to wait for all pods to remain in the scheduling queue after scheduling attempts: %v", err)
+		}
+		t.Log("finished initial schedulings for all Pods, will trigger triggerFn")
+	}
 
 	legacyregistry.Reset() // reset the metric before triggering
 	wantTriggeredEvents, err := tt.TriggerFn(testCtx)

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	schedulingapiv1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -518,6 +519,11 @@ func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interf
 					// Cannot enable the resourceapi.SchemeGroupVersion when emulating < 1.34 unless
 					// we enable --runtime-config-emulation-forward-compatible.
 					options.GenericServerRunOptions.RuntimeConfigEmulationForwardCompatible = true
+				}
+			}
+			if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
+				options.APIEnablement.RuntimeConfig = cliflag.ConfigurationMap{
+					schedulingapiv1alpha1.SchemeGroupVersion.String(): "true",
 				}
 			}
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds gang scheduling plugin and basic workload awareness (using dedicated manager) to kube-scheduler based on [KEP-4671](https://github.com/kubernetes/enhancements/issues/4671). This is a second PR for this KEP. First one, with the API, is #134564.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Part of https://github.com/kubernetes/kubernetes/issues/134471
Fixes #134475
Fixes #134476
Fixes #134477

KEP: https://github.com/kubernetes/enhancements/issues/4671

#### Special notes for your reviewer:

_**This PR is dedicated for kube-scheduler changes. For API review, please post the comments in #134564. Six first commits are part of #134564, so please filter changes of this PR appropriately.**_

This PR may be merged with the #134564 depending on review efficiency.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduced GangScheduling kube-scheduler plugin to enable "all-or-nothing" scheduling. Workload API in scheduling.k8s.io/v1alpha1 is used to express the desired policy.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4671-gang-scheduling
```
