### PR TITLE
Automated cherry pick of #134715: kubeadm: add missing cluster-info context validation

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -692,7 +692,10 @@ func fetchInitConfigurationFromJoinConfiguration(cfg *kubeadmapi.JoinConfigurati
 	}
 
 	// Create the final KubeConfig file with the cluster name discovered after fetching the cluster configuration
-	_, clusterinfo := kubeconfigutil.GetClusterFromKubeConfig(tlsBootstrapCfg)
+	_, clusterinfo, err := kubeconfigutil.GetClusterFromKubeConfig(tlsBootstrapCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "the TLS bootstrap kubeconfig is malformed")
+	}
 	tlsBootstrapCfg.Clusters = map[string]*clientcmdapi.Cluster{
 		initConfiguration.ClusterName: clusterinfo,
 	}

--- a/cmd/kubeadm/app/cmd/util/join.go
+++ b/cmd/kubeadm/app/cmd/util/join.go
@@ -57,9 +57,9 @@ func getJoinCommand(kubeConfigFile, token, key string, controlPlane, skipTokenPr
 	}
 
 	// load the default cluster config
-	_, clusterConfig := kubeconfigutil.GetClusterFromKubeConfig(config)
-	if clusterConfig == nil {
-		return "", errors.New("failed to get default cluster config")
+	_, clusterConfig, err := kubeconfigutil.GetClusterFromKubeConfig(config)
+	if err != nil {
+		return "", errors.Wrapf(err, "malformed kubeconfig file: %s", kubeConfigFile)
 	}
 
 	// load CA certificates from the kubeconfig (either from PEM data or by file path)

--- a/cmd/kubeadm/app/cmd/util/join_test.go
+++ b/cmd/kubeadm/app/cmd/util/join_test.go
@@ -133,7 +133,7 @@ func TestGetJoinCommand(t *testing.T) {
 			kubeConfig:   &clientcmdapi.Config{},
 			token:        "test-token",
 			expectError:  true,
-			errorMessage: "failed to get default cluster config",
+			errorMessage: "the current context is invalid",
 		},
 		{
 			name:         "Error when CA certificate is invalid",

--- a/cmd/kubeadm/app/discovery/discovery.go
+++ b/cmd/kubeadm/app/discovery/discovery.go
@@ -23,6 +23,7 @@ import (
 
 	clientset "k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -52,7 +53,10 @@ func For(client clientset.Interface, cfg *kubeadmapi.JoinConfiguration) (*client
 	if len(cfg.Discovery.TLSBootstrapToken) != 0 {
 		klog.V(1).Info("[discovery] Using provided TLSBootstrapToken as authentication credentials for the join process")
 
-		_, clusterinfo := kubeconfigutil.GetClusterFromKubeConfig(config)
+		_, clusterinfo, err := kubeconfigutil.GetClusterFromKubeConfig(config)
+		if err != nil {
+			return nil, errors.Wrapf(err, "malformed kubeconfig in the %s ConfigMap", bootstrapapi.ConfigMapClusterInfo)
+		}
 		return kubeconfigutil.CreateWithToken(
 			clusterinfo.Server,
 			kubeadmapiv1.DefaultClusterName,

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -104,9 +104,9 @@ func retrieveValidatedConfigInfo(client clientset.Interface, cfg *kubeadmapi.Dis
 		return nil, errors.Wrapf(err, "couldn't parse the kubeconfig file in the %s ConfigMap", bootstrapapi.ConfigMapClusterInfo)
 	}
 
-	// The ConfigMap should contain a single cluster
-	if len(insecureConfig.Clusters) != 1 {
-		return nil, errors.Errorf("expected the kubeconfig file in the %s ConfigMap to have a single cluster, but it had %d", bootstrapapi.ConfigMapClusterInfo, len(insecureConfig.Clusters))
+	_, _, err = kubeconfigutil.GetClusterFromKubeConfig(insecureConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "malformed kubeconfig in the %s ConfigMap", bootstrapapi.ConfigMapClusterInfo)
 	}
 
 	// If no TLS root CA pinning was specified, we're done

--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -78,10 +78,12 @@ users: null
 		name                     string
 		tokenID                  string
 		tokenSecret              string
+		currentContextCluster    string
 		cfg                      *kubeadmapi.Discovery
 		configMap                *fakeConfigMap
 		delayedJWSSignaturePatch bool
 		expectedError            bool
+		expectedErrorString      string
 	}{
 		{
 			// This is the default behavior. The JWS signature is patched after the cluster-info ConfigMap is created
@@ -130,6 +132,24 @@ users: null
 				name: bootstrapapi.ConfigMapClusterInfo,
 				data: nil,
 			},
+		},
+		{
+			name:        "invalid: the kubeconfig in the configmap has the wrong current context",
+			tokenID:     "123456",
+			tokenSecret: "abcdef1234567890",
+			cfg: &kubeadmapi.Discovery{
+				BootstrapToken: &kubeadmapi.BootstrapTokenDiscovery{
+					Token:        "123456.abcdef1234567890",
+					CACertHashes: []string{caCertHash},
+				},
+			},
+			configMap: &fakeConfigMap{
+				name: bootstrapapi.ConfigMapClusterInfo,
+				data: nil,
+			},
+			currentContextCluster: "foo",
+			expectedError:         true,
+			expectedErrorString:   `malformed kubeconfig in the cluster-info ConfigMap: no matching cluster for the current context: token-bootstrap-client@somecluster`,
 		},
 		{
 			name:        "invalid: token format is invalid",
@@ -217,6 +237,13 @@ users: null
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			kubeconfig := buildSecureBootstrapKubeConfig("127.0.0.1", []byte(caCert), "somecluster")
+			if len(test.currentContextCluster) > 0 {
+				currentContext := kubeconfig.Contexts[kubeconfig.CurrentContext]
+				if currentContext == nil {
+					t.Fatal("unexpected nil current context")
+				}
+				currentContext.Cluster = test.currentContextCluster
+			}
 			kubeconfigBytes, err := clientcmd.Write(*kubeconfig)
 			if err != nil {
 				t.Fatalf("cannot marshal kubeconfig %v", err)
@@ -268,8 +295,13 @@ users: null
 				t.Errorf("expected error %v, got %v, error: %v", test.expectedError, err != nil, err)
 			}
 
-			// Return if an error is expected
 			if err != nil {
+				if len(test.expectedErrorString) > 0 && test.expectedErrorString != err.Error() {
+					t.Fatalf("expected error string: %s, got: %s",
+						test.expectedErrorString, err.Error())
+				}
+
+				// Return if an error is expected
 				return
 			}
 


### PR DESCRIPTION
Cherry pick of #134715 on release-1.33.

#134715: kubeadm: add missing cluster-info context validation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: avoid panicing if the user has malformed the kubeconfig in the cluster-info config map to not include a valid current context. Include proper validation at the appropriate locations and throw errors instead.
```