### PR TITLE
Verify if pod has ongoing async preemption before evicting pods

### DIFF
--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -138,6 +138,10 @@ type Evaluator struct {
 	// preempting is a set that records the pods that are currently triggering preemption asynchronously,
 	// which is used to prevent the pods from entering the scheduling cycle meanwhile.
 	preempting sets.Set[types.UID]
+	// lastVictimsPendingPreemption is a map that records the victim pods that are currently being preempted for a given preemptor pod,
+	// with a condition that the preemptor is waiting for one last victim to be preempted. This is used together with `preempting`
+	// to prevent the pods from entering the scheduling cycle while waiting for preemption to complete.
+	lastVictimsPendingPreemption map[types.UID]pendingVictim
 
 	// PreemptPod is a function that actually makes API calls to preempt a specific Pod.
 	// This is exposed to be replaced during tests.
@@ -146,18 +150,24 @@ type Evaluator struct {
 	Interface
 }
 
+type pendingVictim struct {
+	namespace string
+	name      string
+}
+
 func NewEvaluator(pluginName string, fh fwk.Handle, i Interface, enableAsyncPreemption bool) *Evaluator {
 	podLister := fh.SharedInformerFactory().Core().V1().Pods().Lister()
 	pdbLister := fh.SharedInformerFactory().Policy().V1().PodDisruptionBudgets().Lister()
 
 	ev := &Evaluator{
-		PluginName:            pluginName,
-		Handler:               fh,
-		PodLister:             podLister,
-		PdbLister:             pdbLister,
-		Interface:             i,
-		enableAsyncPreemption: enableAsyncPreemption,
-		preempting:            sets.New[types.UID](),
+		PluginName:                   pluginName,
+		Handler:                      fh,
+		PodLister:                    podLister,
+		PdbLister:                    pdbLister,
+		Interface:                    i,
+		enableAsyncPreemption:        enableAsyncPreemption,
+		preempting:                   sets.New[types.UID](),
+		lastVictimsPendingPreemption: make(map[types.UID]pendingVictim),
 	}
 
 	// PreemptPod actually makes API calls to preempt a specific Pod.
@@ -216,7 +226,27 @@ func (ev *Evaluator) IsPodRunningPreemption(podUID types.UID) bool {
 	ev.mu.RLock()
 	defer ev.mu.RUnlock()
 
-	return ev.preempting.Has(podUID)
+	if !ev.preempting.Has(podUID) {
+		return false
+	}
+
+	victim, ok := ev.lastVictimsPendingPreemption[podUID]
+	if !ok {
+		// Pod has not triggered preemption of the last victim yet.
+		return true
+	}
+	// Pod is waiting for preemption of one last victim. We can check if the victim has already been deleted.
+	victimPod, err := ev.PodLister.Pods(victim.namespace).Get(victim.name)
+	if err != nil {
+		// Victim already deleted, preemption is done.
+		return false
+	}
+	if victimPod.DeletionTimestamp != nil {
+		// Victim deletion has started, preemption is done.
+		return false
+	}
+	// Preemption of the last pod is still ongoing.
+	return true
 }
 
 // Preempt returns a PostFilterResult carrying suggested nominatedNodeName, along with a Status.
@@ -536,6 +566,7 @@ func (ev *Evaluator) prepareCandidateAsync(c Candidate, pod *v1.Pod, pluginName 
 	ev.mu.Unlock()
 
 	go func() {
+		logger := klog.FromContext(ctx)
 		startTime := time.Now()
 		result := metrics.GoroutineResultSuccess
 		defer metrics.PreemptionGoroutinesDuration.WithLabelValues(result).Observe(metrics.SinceInSeconds(startTime))
@@ -561,6 +592,13 @@ func (ev *Evaluator) prepareCandidateAsync(c Candidate, pod *v1.Pod, pluginName 
 			// We do not return as this error is not critical.
 		}
 
+		if len(victimPods) == 0 {
+			ev.mu.Lock()
+			ev.preempting.Delete(pod.UID)
+			ev.mu.Unlock()
+			return
+		}
+
 		if len(victimPods) > 1 {
 			// We can evict all victims in parallel, but the last one.
 			// We have to remove the pod from the preempting map before the last one is evicted
@@ -568,6 +606,9 @@ func (ev *Evaluator) prepareCandidateAsync(c Candidate, pod *v1.Pod, pluginName 
 			// we remove this pod from the preempting map,
 			// and the pod could end up stucking at the unschedulable pod pool
 			// by all the pod removal events being ignored.
+			// In order to prevent requesting preemption of the same pod multiple times for the same preemptor,
+			// preemptor is marked as "waiting for preemption of a victim" (by adding it to preempting map) and
+			// for optimization purposes the last victim is recorded in lastVictimsPendingPreemption.
 			ev.Handler.Parallelizer().Until(ctx, len(victimPods)-1, preemptPod, ev.PluginName)
 			if err := errCh.ReceiveError(); err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption")
@@ -575,14 +616,20 @@ func (ev *Evaluator) prepareCandidateAsync(c Candidate, pod *v1.Pod, pluginName 
 			}
 		}
 
+		lastVictim := victimPods[len(victimPods)-1]
 		ev.mu.Lock()
-		delete(ev.preempting, pod.UID)
+		ev.lastVictimsPendingPreemption[pod.UID] = pendingVictim{namespace: lastVictim.Namespace, name: lastVictim.Name}
 		ev.mu.Unlock()
 
-		if err := ev.PreemptPod(ctx, c, pod, victimPods[len(victimPods)-1], pluginName); err != nil {
+		if err := ev.PreemptPod(ctx, c, pod, lastVictim, pluginName); err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption")
 			result = metrics.GoroutineResultError
 		}
+
+		ev.mu.Lock()
+		ev.preempting.Delete(pod.UID)
+		delete(ev.lastVictimsPendingPreemption, pod.UID)
+		ev.mu.Unlock()
 
 		logger.V(2).Info("Async Preemption finished completely", "preemptor", klog.KObj(pod), "node", c.Name(), "result", result)
 	}()

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -39,18 +39,19 @@ import (
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
-	"k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
+	apicache "k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
+	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
@@ -1235,5 +1236,354 @@ func TestRemoveNominatedNodeName(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestPrepareCandidateAsyncSetsPreemptingSets(t *testing.T) {
+	var (
+		node1Name            = "node1"
+		defaultSchedulerName = "default-scheduler"
+	)
+
+	var (
+		victim1 = st.MakePod().Name("victim1").UID("victim1").
+			Node(node1Name).SchedulerName(defaultSchedulerName).Priority(midPriority).
+			Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+			Obj()
+
+		victim2 = st.MakePod().Name("victim2").UID("victim2").
+			Node(node1Name).SchedulerName(defaultSchedulerName).Priority(midPriority).
+			Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+			Obj()
+
+		preemptor = st.MakePod().Name("preemptor").UID("preemptor").
+				SchedulerName(defaultSchedulerName).Priority(highPriority).
+				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+				Obj()
+		testPods = []*v1.Pod{
+			victim1,
+			victim2,
+		}
+		nodeNames = []string{node1Name}
+	)
+
+	tests := []struct {
+		name       string
+		candidate  *fakeCandidate
+		lastVictim *v1.Pod
+		preemptor  *v1.Pod
+	}{
+		{
+			name: "no victims",
+			candidate: &fakeCandidate{
+				victims: &extenderv1.Victims{},
+			},
+			lastVictim: nil,
+			preemptor:  preemptor,
+		},
+		{
+			name: "one victim",
+			candidate: &fakeCandidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						victim1,
+					},
+				},
+			},
+			lastVictim: victim1,
+			preemptor:  preemptor,
+		},
+		{
+			name: "two victims",
+			candidate: &fakeCandidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						victim1,
+						victim2,
+					},
+				},
+			},
+			lastVictim: victim2,
+			preemptor:  preemptor,
+		},
+	}
+
+	for _, asyncAPICallsEnabled := range []bool{true, false} {
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%v (Async API calls enabled: %v)", tt.name, asyncAPICallsEnabled), func(t *testing.T) {
+				metrics.Register()
+				logger, ctx := ktesting.NewTestContext(t)
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
+				nodes := make([]*v1.Node, len(nodeNames))
+				for i, nodeName := range nodeNames {
+					nodes[i] = st.MakeNode().Name(nodeName).Capacity(veryLargeRes).Obj()
+				}
+				registeredPlugins := append([]tf.RegisterPluginFunc{
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New)},
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				)
+				var objs []runtime.Object
+				for _, pod := range testPods {
+					objs = append(objs, pod)
+				}
+
+				cs := clientsetfake.NewClientset(objs...)
+
+				informerFactory := informers.NewSharedInformerFactory(cs, 0)
+				eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: cs.EventsV1()})
+
+				var apiDispatcher *apidispatcher.APIDispatcher
+				if asyncAPICallsEnabled {
+					apiDispatcher = apidispatcher.New(cs, 16, apicalls.Relevances)
+					apiDispatcher.Run(logger)
+					defer apiDispatcher.Close()
+				}
+
+				fwk, err := tf.NewFramework(
+					ctx,
+					registeredPlugins, "",
+					frameworkruntime.WithClientSet(cs),
+					frameworkruntime.WithAPIDispatcher(apiDispatcher),
+					frameworkruntime.WithLogger(logger),
+					frameworkruntime.WithInformerFactory(informerFactory),
+					frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+					frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(testPods, nodes)),
+					frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, "test-scheduler")),
+					frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				informerFactory.Start(ctx.Done())
+				fakePreemptionScorePostFilterPlugin := &FakePreemptionScorePostFilterPlugin{}
+				if asyncAPICallsEnabled {
+					cache := internalcache.New(ctx, 100*time.Millisecond, apiDispatcher)
+					fwk.SetAPICacher(apicache.New(nil, cache))
+				}
+
+				pe := NewEvaluator("FakePreemptionScorePostFilter", fwk, fakePreemptionScorePostFilterPlugin, true /* asyncPreemptionEnabled */)
+				// preemptPodCallsCounter helps verify if the last victim pod gets preempted after other victims.
+				preemptPodCallsCounter := 0
+				preemptFunc := pe.PreemptPod
+				pe.PreemptPod = func(ctx context.Context, c Candidate, preemptor, victim *v1.Pod, pluginName string) error {
+					// Verify contents of the sets: preempting and lastVictimsPendingPreemption before preemption of subsequent pods.
+					pe.mu.RLock()
+					preemptPodCallsCounter++
+
+					if !pe.preempting.Has(tt.preemptor.UID) {
+						t.Errorf("Expected preempting set to be contain %v before preempting victim %v but got set: %v", tt.preemptor.UID, victim.Name, pe.preempting)
+					}
+
+					victimCount := len(tt.candidate.Victims().Pods)
+					if victim.Name == tt.lastVictim.Name {
+						if victimCount != preemptPodCallsCounter {
+							t.Errorf("Expected PreemptPod for last victim %v to be called last (call no. %v), but it was called as no. %v", victim.Name, victimCount, preemptPodCallsCounter)
+						}
+						if v, ok := pe.lastVictimsPendingPreemption[tt.preemptor.UID]; !ok || tt.lastVictim.Name != v.name {
+							t.Errorf("Expected lastVictimsPendingPreemption map to contain victim %v for preemptor UID %v when preempting the last victim, but got map: %v",
+								tt.lastVictim.Name, tt.preemptor.UID, pe.lastVictimsPendingPreemption)
+						}
+					} else {
+						if preemptPodCallsCounter >= victimCount {
+							t.Errorf("Expected PreemptPod for victim %v to be called earlier, but it was called as last - no. %v", victim.Name, preemptPodCallsCounter)
+						}
+						if _, ok := pe.lastVictimsPendingPreemption[tt.preemptor.UID]; ok {
+							t.Errorf("Expected lastVictimsPendingPreemption map to not contain values for preemptor UID %v when not preempting the last victim, but got map: %v",
+								tt.preemptor.UID, pe.lastVictimsPendingPreemption)
+						}
+					}
+					pe.mu.RUnlock()
+
+					return preemptFunc(ctx, c, preemptor, victim, pluginName)
+				}
+
+				pe.mu.RLock()
+				if len(pe.preempting) > 0 {
+					t.Errorf("Expected preempting set to be empty before prepareCandidateAsync but got %v", pe.preempting)
+				}
+				if len(pe.lastVictimsPendingPreemption) > 0 {
+					t.Errorf("Expected lastVictimsPendingPreemption map to be empty before prepareCandidateAsync but got %v", pe.lastVictimsPendingPreemption)
+				}
+				pe.mu.RUnlock()
+
+				pe.prepareCandidateAsync(tt.candidate, tt.preemptor, "test-plugin")
+
+				// Perform the checks when there are no victims left to preempt.
+				t.Log("Waiting for async preemption goroutine to finish cleanup...")
+				err = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 2*time.Second, false, func(ctx context.Context) (bool, error) {
+					// Check if the preemptor is removed from the ev.preempting set.
+					pe.mu.RLock()
+					defer pe.mu.RUnlock()
+					return !pe.preempting.Has(tt.preemptor.UID), nil
+				})
+				if err != nil {
+					t.Errorf("Timed out waiting for preemptingSet to become empty. %v", err)
+				}
+
+				pe.mu.RLock()
+				if _, ok := pe.lastVictimsPendingPreemption[tt.preemptor.UID]; ok {
+					t.Errorf("Expected lastVictimsPendingPreemption map to not contain values for %v after completing preemption, but got map: %v",
+						tt.preemptor.UID, pe.lastVictimsPendingPreemption)
+				}
+				if victimCount := len(tt.candidate.Victims().Pods); victimCount != preemptPodCallsCounter {
+					t.Errorf("Expected PreemptPod to be called %v times during prepareCandidateAsync but got %v", victimCount, preemptPodCallsCounter)
+				}
+				pe.mu.RUnlock()
+			})
+		}
+	}
+}
+
+// fakePodLister helps test IsPodRunningPreemption logic without worrying about cache synchronization issues.
+// Current list of pods is set using field pods.
+type fakePodLister struct {
+	corelisters.PodLister
+	pods map[string]*v1.Pod
+}
+
+func (m *fakePodLister) Pods(namespace string) corelisters.PodNamespaceLister {
+	return &fakePodNamespaceLister{pods: m.pods}
+}
+
+// fakePodNamespaceLister helps test IsPodRunningPreemption logic without worrying about cache synchronization issues.
+// Current list of pods is set using field pods.
+type fakePodNamespaceLister struct {
+	corelisters.PodNamespaceLister
+	pods map[string]*v1.Pod
+}
+
+func (m *fakePodNamespaceLister) Get(name string) (*v1.Pod, error) {
+	if pod, ok := m.pods[name]; ok {
+		return pod, nil
+	}
+	// Important: Return the standard IsNotFound error for a fake cache miss.
+	return nil, apierrors.NewNotFound(v1.Resource("pods"), name)
+}
+
+func TestIsPodRunningPreemption(t *testing.T) {
+	var (
+		victim1 = st.MakePod().Name("victim1").UID("victim1").
+			Node("node").SchedulerName("sch").Priority(midPriority).
+			Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+			Obj()
+
+		victim2 = st.MakePod().Name("victim2").UID("victim2").
+			Node("node").SchedulerName("sch").Priority(midPriority).
+			Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+			Obj()
+
+		victimWithDeletionTimestamp = st.MakePod().Name("victim-deleted").UID("victim-deleted").
+						Node("node").SchedulerName("sch").Priority(midPriority).
+						Terminating().
+						Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+						Obj()
+	)
+
+	tests := []struct {
+		name            string
+		preemptorUID    types.UID
+		preemptingSet   sets.Set[types.UID]
+		lastVictimSet   map[types.UID]pendingVictim
+		podsInPodLister map[string]*v1.Pod
+		expectedResult  bool
+	}{
+		{
+			name:           "preemptor not in preemptingSet",
+			preemptorUID:   "preemptor",
+			preemptingSet:  sets.New[types.UID](),
+			lastVictimSet:  map[types.UID]pendingVictim{},
+			expectedResult: false,
+		},
+		{
+			name:          "preemptor not in preemptingSet, lastVictimSet not empty",
+			preemptorUID:  "preemptor",
+			preemptingSet: sets.New[types.UID](),
+			lastVictimSet: map[types.UID]pendingVictim{
+				"preemptor": {
+					namespace: "ns",
+					name:      "victim1",
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name:          "preemptor in preemptingSet, no lastVictim for preemptor",
+			preemptorUID:  "preemptor",
+			preemptingSet: sets.New[types.UID]("preemptor"),
+			lastVictimSet: map[types.UID]pendingVictim{
+				"otherPod": {
+					namespace: "ns",
+					name:      "victim1",
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name:          "preemptor in preemptingSet, victim in lastVictimSet, not in PodLister",
+			preemptorUID:  "preemptor",
+			preemptingSet: sets.New[types.UID]("preemptor"),
+			lastVictimSet: map[types.UID]pendingVictim{
+				"preemptor": {
+					namespace: "ns",
+					name:      "victim1",
+				},
+			},
+			podsInPodLister: map[string]*v1.Pod{},
+			expectedResult:  false,
+		},
+		{
+			name:          "preemptor in preemptingSet, victim in lastVictimSet and in PodLister",
+			preemptorUID:  "preemptor",
+			preemptingSet: sets.New[types.UID]("preemptor"),
+			lastVictimSet: map[types.UID]pendingVictim{
+				"preemptor": {
+					namespace: "ns",
+					name:      "victim1",
+				},
+			},
+			podsInPodLister: map[string]*v1.Pod{
+				"victim1": victim1,
+				"victim2": victim2,
+			},
+			expectedResult: true,
+		},
+		{
+			name:          "preemptor in preemptingSet, victim in lastVictimSet and in PodLister with deletion timestamp",
+			preemptorUID:  "preemptor",
+			preemptingSet: sets.New[types.UID]("preemptor"),
+			lastVictimSet: map[types.UID]pendingVictim{
+				"preemptor": {
+					namespace: "ns",
+					name:      "victim-deleted",
+				},
+			},
+			podsInPodLister: map[string]*v1.Pod{
+				"victim1":        victim1,
+				"victim-deleted": victimWithDeletionTimestamp,
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.name), func(t *testing.T) {
+
+			fakeLister := &fakePodLister{
+				pods: tt.podsInPodLister,
+			}
+			pe := Evaluator{
+				PodLister:                    fakeLister,
+				preempting:                   tt.preemptingSet,
+				lastVictimsPendingPreemption: tt.lastVictimSet,
+			}
+
+			if result := pe.IsPodRunningPreemption(tt.preemptorUID); tt.expectedResult != result {
+				t.Errorf("Expected IsPodRunningPreemption to return %v but got %v", tt.expectedResult, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Before triggering preemption check if the pod is waiting for preemption of any victim, including the last victim. This is to prevent requesting preemption of the same victim by the same preemptor multiple times.

PR also adds an integration test that verifies the following scenario:
Pod P requests preemption of victims on node N1.
While pod P is waiting for the last of preemptions to complete, a higher priority pod H gets scheduled on N1, taking the resources needed by pod P.
Pod P waits until the last requested preemption completes, goes back to activeQ and triggers preemptions on node N2 (instead of getting stuck in unschedulable queue).
Pod P gets successfully bound on N2.


#### Which issue(s) this PR is related to:
#134249
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix issue in asynchronous preemption: Scheduler checks if preemption is ongoing for a pod before initiating new preemption calls
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
