### PR TITLE
Introduce pod queuing in endpoint/slice controllers

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -89,6 +89,7 @@ func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInf
 				Name: "endpoint",
 			},
 		),
+		podQueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey]()),
 		workerLoopPeriod: time.Second,
 	}
 
@@ -103,9 +104,9 @@ func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInf
 	e.servicesSynced = serviceInformer.Informer().HasSynced
 
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    e.addPod,
-		UpdateFunc: e.updatePod,
-		DeleteFunc: e.deletePod,
+		AddFunc:    func(obj interface{}) { e.onPodUpdate(nil, obj) },
+		UpdateFunc: e.onPodUpdate,
+		DeleteFunc: func(obj interface{}) { e.onPodUpdate(obj, nil) },
 	})
 	e.podLister = podInformer.Lister()
 	e.podsSynced = podInformer.Informer().HasSynced
@@ -162,6 +163,11 @@ type Controller struct {
 	// necessary.
 	queue workqueue.TypedRateLimitingInterface[string]
 
+	// podQueue is used to compute pod->services mapping and drive matching services into the service queue.
+	// This operation can be expensive when large number of services exist in the pod's namespace and
+	// label selection logic has to be evaluated against each service.
+	podQueue workqueue.TypedRateLimitingInterface[*endpointsliceutil.PodProjectionKey]
+
 	// workerLoopPeriod is the time between worker runs. The workers process the queue of service and pod changes.
 	workerLoopPeriod time.Duration
 
@@ -183,6 +189,7 @@ func (e *Controller) Run(ctx context.Context, workers int) {
 	defer e.eventBroadcaster.Shutdown()
 
 	defer e.queue.ShutDown()
+	defer e.podQueue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting endpoint controller")
@@ -194,6 +201,7 @@ func (e *Controller) Run(ctx context.Context, workers int) {
 
 	for i := 0; i < workers; i++ {
 		go wait.UntilWithContext(ctx, e.worker, e.workerLoopPeriod)
+		go wait.UntilWithContext(ctx, e.podWorker, e.workerLoopPeriod)
 	}
 
 	go func() {
@@ -202,20 +210,6 @@ func (e *Controller) Run(ctx context.Context, workers int) {
 	}()
 
 	<-ctx.Done()
-}
-
-// When a pod is added, figure out what services it will be a member of and
-// enqueue them. obj must have *v1.Pod type.
-func (e *Controller) addPod(obj interface{}) {
-	pod := obj.(*v1.Pod)
-	services, err := endpointsliceutil.GetPodServiceMemberships(e.serviceLister, pod)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Unable to get pod %s/%s's service memberships: %v", pod.Namespace, pod.Name, err))
-		return
-	}
-	for key := range services {
-		e.queue.AddAfter(key, e.endpointUpdatesBatchPeriod)
-	}
 }
 
 func podToEndpointAddressForService(svc *v1.Service, pod *v1.Pod) (*v1.EndpointAddress, error) {
@@ -249,25 +243,6 @@ func podToEndpointAddressForService(svc *v1.Service, pod *v1.Pod) (*v1.EndpointA
 	}, nil
 }
 
-// When a pod is updated, figure out what services it used to be a member of
-// and what services it will be a member of, and enqueue the union of these.
-// old and cur must be *v1.Pod types.
-func (e *Controller) updatePod(old, cur interface{}) {
-	services := endpointsliceutil.GetServicesToUpdateOnPodChange(e.serviceLister, old, cur)
-	for key := range services {
-		e.queue.AddAfter(key, e.endpointUpdatesBatchPeriod)
-	}
-}
-
-// When a pod is deleted, enqueue the services the pod used to be a member of.
-// obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (e *Controller) deletePod(obj interface{}) {
-	pod := endpointsliceutil.GetPodFromDeleteAction(obj)
-	if pod != nil {
-		e.addPod(pod)
-	}
-}
-
 // onServiceUpdate updates the Service Selector in the cache and queues the Service for processing.
 func (e *Controller) onServiceUpdate(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
@@ -286,6 +261,14 @@ func (e *Controller) onServiceDelete(obj interface{}) {
 		return
 	}
 	e.queue.Add(key)
+}
+
+// onPodUpdate enqueues the pod's projection key on Add/Update/Delete events, to find matching services later.
+func (e *Controller) onPodUpdate(old, cur interface{}) {
+	key := endpointsliceutil.GetPodUpdateProjectionKey(old, cur)
+	if key != nil {
+		e.podQueue.Add(key)
+	}
 }
 
 func (e *Controller) onEndpointsDelete(obj interface{}) {
@@ -546,6 +529,60 @@ func (e *Controller) syncService(ctx context.Context, key string) error {
 	if updatedEndpoints != nil && updatedEndpoints.ResourceVersion != currentEndpoints.ResourceVersion {
 		e.staleEndpointsTracker.Stale(currentEndpoints)
 	}
+	return nil
+}
+
+func (e *Controller) podWorker(ctx context.Context) {
+	for e.processNextPodWorkItem(ctx) {
+	}
+}
+
+func (e *Controller) processNextPodWorkItem(ctx context.Context) bool {
+	eKey, quit := e.podQueue.Get()
+	if quit {
+		return false
+	}
+	defer e.podQueue.Done(eKey)
+
+	logger := klog.FromContext(ctx)
+	err := e.syncPod(logger, eKey)
+	e.handlePodErr(logger, err, eKey)
+
+	return true
+}
+
+func (e *Controller) handlePodErr(logger klog.Logger, err error, key *endpointsliceutil.PodProjectionKey) {
+	if err == nil {
+		e.podQueue.Forget(key)
+		return
+	}
+
+	if e.podQueue.NumRequeues(key) < maxRetries {
+		logger.V(2).Info("Error syncing pod, retrying", "PodProjectionKey", *key)
+		e.podQueue.AddRateLimited(key)
+		return
+	}
+
+	logger.Info("Dropping pod out of the queue", "PodProjectionKey", *key)
+	e.podQueue.Forget(key)
+	utilruntime.HandleError(err)
+}
+
+func (e *Controller) syncPod(logger klog.Logger, key *endpointsliceutil.PodProjectionKey) error {
+	startTime := time.Now()
+	defer func() {
+		logger.V(4).Info("Finished syncing pod", "PodProjectionKey", *key, "elapsedTime", time.Since(startTime))
+	}()
+
+	servicesToUpdate, err := endpointsliceutil.GetServicesToUpdate(e.serviceLister, key)
+	if err != nil {
+		return err
+	}
+
+	for service := range servicesToUpdate {
+		e.queue.AddAfter(service, e.endpointUpdatesBatchPeriod)
+	}
+
 	return nil
 }
 

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -1930,7 +1930,7 @@ func TestPodUpdatesBatching(t *testing.T) {
 				resourceVersion++
 
 				endpoints.podStore.Update(newPod)
-				endpoints.updatePod(oldPod, newPod)
+				endpoints.onPodUpdate(oldPod, newPod)
 			}
 
 			time.Sleep(tc.finalDelay)
@@ -2039,7 +2039,7 @@ func TestPodAddsBatching(t *testing.T) {
 
 				p := testPod(ns, i, 1, true, ipv4only)
 				endpoints.podStore.Add(p)
-				endpoints.addPod(p)
+				endpoints.onPodUpdate(nil, p)
 			}
 
 			time.Sleep(tc.finalDelay)
@@ -2170,7 +2170,7 @@ func TestPodDeleteBatching(t *testing.T) {
 					t.Fatalf("Pod %q doesn't exist", update.podName)
 				}
 				endpoints.podStore.Delete(old)
-				endpoints.deletePod(old)
+				endpoints.onPodUpdate(old, nil)
 			}
 
 			time.Sleep(tc.finalDelay)
@@ -2582,7 +2582,7 @@ func TestMultiplePodChanges(t *testing.T) {
 	pod2.ResourceVersion = "2"
 	pod2.Status.Conditions[0].Status = v1.ConditionFalse
 	_ = controller.podStore.Update(pod2)
-	controller.updatePod(pod, pod2)
+	controller.onPodUpdate(pod, pod2)
 	// blockNextAction should eventually unblock once server gets endpoints request.
 	waitForChanReceive(t, 1*time.Second, blockNextAction, "Pod Update should have caused a request to be sent to the test server")
 	// The endpoints update hasn't been applied to the cache yet.
@@ -2590,7 +2590,7 @@ func TestMultiplePodChanges(t *testing.T) {
 	pod3.ResourceVersion = "3"
 	pod3.Status.Conditions[0].Status = v1.ConditionTrue
 	_ = controller.podStore.Update(pod3)
-	controller.updatePod(pod2, pod3)
+	controller.onPodUpdate(pod2, pod3)
 	// It shouldn't get endpoints request as the endpoints in the cache is out-of-date.
 	timer := time.NewTimer(100 * time.Millisecond)
 	select {

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -113,9 +113,8 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 				Name: "endpoint_slice",
 			},
 		),
-		topologyQueue: workqueue.NewTypedRateLimitingQueue[string](
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-		),
+		podQueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey]()),
+		topologyQueue:    workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		workerLoopPeriod: time.Second,
 	}
 
@@ -130,9 +129,9 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 	c.servicesSynced = serviceInformer.Informer().HasSynced
 
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.addPod,
-		UpdateFunc: c.updatePod,
-		DeleteFunc: c.deletePod,
+		AddFunc:    func(obj interface{}) { c.onPodUpdate(nil, obj) },
+		UpdateFunc: c.onPodUpdate,
+		DeleteFunc: func(obj interface{}) { c.onPodUpdate(obj, nil) },
 	})
 	c.podLister = podInformer.Lister()
 	c.podsSynced = podInformer.Informer().HasSynced
@@ -244,6 +243,11 @@ type Controller struct {
 	// necessary.
 	serviceQueue workqueue.TypedRateLimitingInterface[string]
 
+	// podQueue is used to compute pod->services mapping and drive matching services into serviceQueue.
+	// This operation can be expensive when large number of services exist in the pod's namespace and
+	// label selection logic has to be evaluated against each service.
+	podQueue workqueue.TypedRateLimitingInterface[*endpointsliceutil.PodProjectionKey]
+
 	// topologyQueue is used to trigger a topology cache update and checking node
 	// topology distribution.
 	topologyQueue workqueue.TypedRateLimitingInterface[string]
@@ -275,6 +279,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	defer c.eventBroadcaster.Shutdown()
 
 	defer c.serviceQueue.ShutDown()
+	defer c.podQueue.ShutDown()
 	defer c.topologyQueue.ShutDown()
 
 	logger := klog.FromContext(ctx)
@@ -288,6 +293,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	logger.V(2).Info("Starting service queue worker threads", "total", workers)
 	for i := 0; i < workers; i++ {
 		go wait.Until(func() { c.serviceQueueWorker(logger) }, c.workerLoopPeriod, ctx.Done())
+		go wait.Until(func() { c.podQueueWorker(logger) }, c.workerLoopPeriod, ctx.Done())
 	}
 	logger.V(2).Info("Starting topology queue worker threads", "total", 1)
 	go wait.Until(func() { c.topologyQueueWorker(logger) }, c.workerLoopPeriod, ctx.Done())
@@ -436,6 +442,59 @@ func (c *Controller) syncService(logger klog.Logger, key string) error {
 	return nil
 }
 
+func (c *Controller) podQueueWorker(logger klog.Logger) {
+	for c.processNextPodWorkItem(logger) {
+	}
+}
+
+func (c *Controller) processNextPodWorkItem(logger klog.Logger) bool {
+	cKey, quit := c.podQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.podQueue.Done(cKey)
+
+	err := c.syncPod(logger, cKey)
+	c.handlePodErr(logger, err, cKey)
+
+	return true
+}
+
+func (c *Controller) handlePodErr(logger klog.Logger, err error, key *endpointsliceutil.PodProjectionKey) {
+	if err == nil {
+		c.podQueue.Forget(key)
+		return
+	}
+
+	if c.podQueue.NumRequeues(key) < maxRetries {
+		logger.V(2).Info("Error syncing pod, retrying", "PodProjectionKey", *key)
+		c.podQueue.AddRateLimited(key)
+		return
+	}
+
+	logger.Info("Dropping pod out of the queue", "PodProjectionKey", *key)
+	c.podQueue.Forget(key)
+	utilruntime.HandleError(err)
+}
+
+func (c *Controller) syncPod(logger klog.Logger, key *endpointsliceutil.PodProjectionKey) error {
+	startTime := time.Now()
+	defer func() {
+		logger.V(4).Info("Finished syncing pod", "PodProjectionKey", *key, "elapsedTime", time.Since(startTime))
+	}()
+
+	servicesToUpdate, err := endpointsliceutil.GetServicesToUpdate(c.serviceLister, key)
+	if err != nil {
+		return err
+	}
+
+	for service := range servicesToUpdate {
+		c.serviceQueue.AddAfter(service, c.endpointUpdatesBatchPeriod)
+	}
+
+	return nil
+}
+
 // onServiceUpdate updates the Service Selector in the cache and queues the Service for processing.
 func (c *Controller) onServiceUpdate(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
@@ -456,6 +515,14 @@ func (c *Controller) onServiceDelete(obj interface{}) {
 	}
 
 	c.serviceQueue.Add(key)
+}
+
+// onPodUpdate enqueues the pod's projection key on Add/Update/Delete events, to find matching services later.
+func (c *Controller) onPodUpdate(old, cur interface{}) {
+	key := endpointsliceutil.GetPodUpdateProjectionKey(old, cur)
+	if key != nil {
+		c.podQueue.Add(key)
+	}
 }
 
 // onEndpointSliceAdd queues a sync for the relevant Service for a sync if the
@@ -529,34 +596,6 @@ func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.Endpo
 		delay = c.endpointUpdatesBatchPeriod
 	}
 	c.serviceQueue.AddAfter(key, delay)
-}
-
-func (c *Controller) addPod(obj interface{}) {
-	pod := obj.(*v1.Pod)
-	services, err := endpointsliceutil.GetPodServiceMemberships(c.serviceLister, pod)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Unable to get pod %s/%s's service memberships: %v", pod.Namespace, pod.Name, err))
-		return
-	}
-	for key := range services {
-		c.serviceQueue.AddAfter(key, c.endpointUpdatesBatchPeriod)
-	}
-}
-
-func (c *Controller) updatePod(old, cur interface{}) {
-	services := endpointsliceutil.GetServicesToUpdateOnPodChange(c.serviceLister, old, cur)
-	for key := range services {
-		c.serviceQueue.AddAfter(key, c.endpointUpdatesBatchPeriod)
-	}
-}
-
-// When a pod is deleted, enqueue the services the pod used to be a member of
-// obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (c *Controller) deletePod(obj interface{}) {
-	pod := endpointsliceutil.GetPodFromDeleteAction(obj)
-	if pod != nil {
-		c.addPod(pod)
-	}
 }
 
 func (c *Controller) addNode() {

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -1410,7 +1410,7 @@ func TestPodAddsBatching(t *testing.T) {
 
 				p := newPod(i, ns, true, 0, false)
 				esController.podStore.Add(p)
-				esController.addPod(p)
+				esController.onPodUpdate(nil, p)
 			}
 
 			time.Sleep(tc.finalDelay)
@@ -1559,7 +1559,7 @@ func TestPodUpdatesBatching(t *testing.T) {
 				resourceVersion++
 
 				esController.podStore.Update(newPod)
-				esController.updatePod(oldPod, newPod)
+				esController.onPodUpdate(oldPod, newPod)
 			}
 
 			time.Sleep(tc.finalDelay)
@@ -1687,7 +1687,7 @@ func TestPodDeleteBatching(t *testing.T) {
 				require.NoError(t, err, "error while retrieving old value of %q: %v", update.podName, err)
 				assert.True(t, exists, "pod should exist")
 				esController.podStore.Delete(old)
-				esController.deletePod(old)
+				esController.onPodUpdate(old, nil)
 			}
 
 			time.Sleep(tc.finalDelay)

--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -47,22 +47,103 @@ var semanticIgnoreResourceVersion = conversion.EqualitiesOrDie(
 	},
 )
 
-// GetPodServiceMemberships returns a set of Service keys for Services that have
-// a selector matching the given pod.
-func GetPodServiceMemberships(serviceLister v1listers.ServiceLister, pod *v1.Pod) (sets.String, error) {
-	set := sets.String{}
-	services, err := serviceLister.Services(pod.Namespace).List(labels.Everything())
-	if err != nil {
-		return set, err
+// PodProjectionKey encapsulates all pod information required to find services that may need their endpoints to be updated.
+type PodProjectionKey struct {
+	Namespace  string
+	Labels     labels.Set // this is set to the pod's current labels
+	OldLabels  labels.Set // this is set if the pod's labels changed (in an Update event)
+	PodChanged bool       // set to true if the pod's fields changed in a way that may affect its endpoints membership
+}
+
+func GetPodUpdateProjectionKey(oldObj, newObj interface{}) *PodProjectionKey {
+	newPod := getPodFromObject(newObj)
+	oldPod := getPodFromObject(oldObj)
+	if newPod == nil && oldPod == nil {
+		utilruntime.HandleError(fmt.Errorf("unexpected pod event with both old/new values as nil, ignoring"))
+		return nil
+	}
+	if oldPod == nil {
+		return &PodProjectionKey{
+			Namespace: newPod.Namespace,
+			Labels:    labels.Set(newPod.Labels),
+		}
+	}
+	if newPod == nil {
+		return &PodProjectionKey{
+			Namespace: oldPod.Namespace,
+			Labels:    labels.Set(oldPod.Labels),
+		}
 	}
 
+	// If we reached here, both old/new pod objects are non-nil, so it's an update event.
+	// Safe to ignore pod informer resync events as service informer already handles resync for all services.
+	if newPod.ResourceVersion == oldPod.ResourceVersion {
+		return nil
+	}
+
+	podChanged, labelsChanged := podEndpointsChanged(oldPod, newPod)
+
+	// If both the pod and labels are unchanged, no update is needed.
+	if !podChanged && !labelsChanged {
+		return nil
+	}
+
+	// If only the pod has changed, projection key can be created with just the new pod.
+	if !labelsChanged {
+		return &PodProjectionKey{
+			Namespace: newPod.Namespace,
+			Labels:    labels.Set(newPod.Labels),
+		}
+	}
+
+	// The pod labels have changed, so the projection key needs to include both its old/new labels.
+	// Additionally, PodChanged field indicates if union/diff of matching services should be reconciled.
+	return &PodProjectionKey{
+		Namespace:  newPod.Namespace,
+		Labels:     labels.Set(newPod.Labels),
+		OldLabels:  labels.Set(oldPod.Labels),
+		PodChanged: podChanged,
+	}
+}
+
+func GetServicesToUpdate(serviceLister v1listers.ServiceLister, key *PodProjectionKey) (sets.String, error) {
+	if key == nil {
+		return nil, nil
+	}
+
+	services, err := getServicesForPod(serviceLister, key.Namespace, key.Labels)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the pod's labels changed in an update event, we'll need to consider all the affected services.
+	if key.OldLabels != nil {
+		oldServices, err := getServicesForPod(serviceLister, key.Namespace, key.OldLabels)
+		if err != nil {
+			return nil, err
+		}
+
+		services = determineNeededServiceUpdates(oldServices, services, key.PodChanged)
+	}
+
+	return services, nil
+}
+
+// getServicesForPod returns a set of services matching the given pod's namespace and labels (via service selector).
+func getServicesForPod(serviceLister v1listers.ServiceLister, namespace string, podLabels labels.Set) (sets.String, error) {
+	services, err := serviceLister.Services(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	set := sets.String{}
 	for _, service := range services {
 		if service.Spec.Selector == nil {
-			// if the service has a nil selector this means selectors match nothing, not everything.
+			// If the service has a nil selector this means selectors match nothing, not everything.
 			continue
 		}
 
-		if labels.ValidatedSetSelector(service.Spec.Selector).Matches(labels.Set(pod.Labels)) {
+		if labels.ValidatedSetSelector(service.Spec.Selector).Matches(podLabels) {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(service)
 			if err != nil {
 				return nil, err
@@ -158,47 +239,11 @@ func podEndpointsChanged(oldPod, newPod *v1.Pod) (bool, bool) {
 	return false, labelsChanged
 }
 
-// GetServicesToUpdateOnPodChange returns a set of Service keys for Services
-// that have potentially been affected by a change to this pod.
-func GetServicesToUpdateOnPodChange(serviceLister v1listers.ServiceLister, old, cur interface{}) sets.String {
-	newPod := cur.(*v1.Pod)
-	oldPod := old.(*v1.Pod)
-	if newPod.ResourceVersion == oldPod.ResourceVersion {
-		// Periodic resync will send update events for all known pods.
-		// Two different versions of the same pod will always have different RVs
-		return sets.String{}
+func getPodFromObject(obj interface{}) *v1.Pod {
+	if obj == nil {
+		return nil
 	}
-
-	podChanged, labelsChanged := podEndpointsChanged(oldPod, newPod)
-
-	// If both the pod and labels are unchanged, no update is needed
-	if !podChanged && !labelsChanged {
-		return sets.String{}
-	}
-
-	services, err := GetPodServiceMemberships(serviceLister, newPod)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to get pod %s/%s's service memberships: %v", newPod.Namespace, newPod.Name, err))
-		return sets.String{}
-	}
-
-	if labelsChanged {
-		oldServices, err := GetPodServiceMemberships(serviceLister, oldPod)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("unable to get pod %s/%s's service memberships: %v", oldPod.Namespace, oldPod.Name, err))
-		}
-		services = determineNeededServiceUpdates(oldServices, services, podChanged)
-	}
-
-	return services
-}
-
-// GetPodFromDeleteAction returns a pointer to a pod if one can be derived from
-// obj (could be a *v1.Pod, or a DeletionFinalStateUnknown marker item).
-func GetPodFromDeleteAction(obj interface{}) *v1.Pod {
 	if pod, ok := obj.(*v1.Pod); ok {
-		// Enqueue all the services that the pod used to be a member of.
-		// This is the same thing we do when we add a pod.
 		return pod
 	}
 	// If we reached here it means the pod was deleted but its final state is unrecorded.

--- a/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
@@ -330,7 +330,7 @@ func genSimpleSvc(namespace, name string) *v1.Service {
 	}
 }
 
-func TestGetPodServiceMemberships(t *testing.T) {
+func TestGetPodServicesToUpdate(t *testing.T) {
 	fakeInformerFactory := informers.NewSharedInformerFactory(&fake.Clientset{}, 0*time.Second)
 	for i := 0; i < 3; i++ {
 		service := &v1.Service{
@@ -394,9 +394,9 @@ func TestGetPodServiceMemberships(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			services, err := GetPodServiceMemberships(fakeInformerFactory.Core().V1().Services().Lister(), test.pod)
+			services, err := GetServicesToUpdate(fakeInformerFactory.Core().V1().Services().Lister(), GetPodUpdateProjectionKey(test.pod, nil))
 			if err != nil {
-				t.Errorf("Error from cache.GetPodServiceMemberships: %v", err)
+				t.Errorf("Error from cache.GetServicesToUpdate: %v", err)
 			} else if !services.Equal(test.expect) {
 				t.Errorf("Expect service %v, but got %v", test.expect, services)
 			}
@@ -404,7 +404,7 @@ func TestGetPodServiceMemberships(t *testing.T) {
 	}
 }
 
-func BenchmarkGetPodServiceMemberships(b *testing.B) {
+func BenchmarkGetPodServicesToUpdate(b *testing.B) {
 	// init fake service informer.
 	fakeInformerFactory := informers.NewSharedInformerFactory(&fake.Clientset{}, 0*time.Second)
 	for i := 0; i < 1000; i++ {
@@ -435,9 +435,9 @@ func BenchmarkGetPodServiceMemberships(b *testing.B) {
 	expect := sets.NewString("test/service-0")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		services, err := GetPodServiceMemberships(fakeInformerFactory.Core().V1().Services().Lister(), pod)
+		services, err := GetServicesToUpdate(fakeInformerFactory.Core().V1().Services().Lister(), GetPodUpdateProjectionKey(pod, nil))
 		if err != nil {
-			b.Fatalf("Error from GetPodServiceMemberships(): %v", err)
+			b.Fatalf("Error from GetServicesToUpdate(): %v", err)
 		}
 		if len(services) != len(expect) {
 			b.Errorf("Expect services size %d, but got: %v", len(expect), len(services))


### PR DESCRIPTION
Both endpoints/endpointslice controllers have a bottleneck in their pod informer event handling, where we iterate through all services in the pod's namespace to find matching ones via label-selector computation ([xref](https://github.com/kubernetes/kubernetes/blob/e8a356c5f1f0ba02209a2d406e19bd15c384ce0e/pkg/controller/endpointslice/endpointslice_controller.go#L534-L551)). This is slow (in ms) when there are 100s of services in the namespace (e.g. LWS statefulset replicas):

```
I1006 22:25:16.179183      12 trace.go:236] Trace[1420876789]: &quot;RealFIFO Pop Process&quot; ID:default&#x2f;giant-cobb2-main-d11-1-off-786f899d4d-dpmpmw-0,Depth:265194,Reason:slow event handlers blocking the queue (06-Oct-2025 22:25:15.828) (total time: 350ms): Trace[1420876789]: [350.260153ms] [350.260153ms] END
I1006 22:25:16.440614      12 trace.go:236] Trace[391478592]: &quot;RealFIFO Pop Process&quot; ID:default&#x2f;margay-200k-kl-58b6dd895-xhk7bw-0,Depth:261199,Reason:slow event handlers blocking the queue (06-Oct-2025 22:25:16.316) (total time: 124ms): Trace[391478592]: [124.063878ms] [124.063878ms] END
I1006 22:25:16.796273      12 trace.go:236] Trace[1279142405]: &quot;RealFIFO Pop Process&quot; ID:default&#x2f;margay-200k-prompt-rollout-cf8ccc9fc-z775f,Depth:257202,Reason:slow event handlers blocking the queue (06-Oct-2025 22:25:16.645) (total time: 150ms): Trace[1279142405]: [150.904727ms] [150.904727ms] END
I1006 22:25:15.136025      12 trace.go:236] Trace[1249058846]: &quot;RealFIFO Pop Process&quot; ID:asl3&#x2f;wrane-kl-htps-text-prompt-64576ff6bb-xpbm5w-3,Depth:278185,Reason:slow event handlers blocking the queue (06-Oct-2025 22:25:14.869) (total time: 266ms): Trace[1249058846]: [266.881053ms] [266.881053ms] END 
```

This `slow event handlers blocking the queue` is not just bad for these controllers, but also others that consume pod events under the shared informer. And unlike controllers like replicaset/job/daemonset where the pod's ownerRefs allow for efficient parent lookup, there isn't a good way to do the same for service lookup. Adding some kind of indexer on services isn't gonna help much either as an arbitrary set of label selectors could match a given pod's labels. This PR gets us quite far though by making the pod->service lookup async via workqueue + worker parallelism. The memory overhead of the queue should be low, as it just holds a projection of the pod's fields relevant for service lookup.

/kind bug
/sig network
/triage accepted

```release-note
Endpoints/endpointslice controllers perform much better when there are a large number of services in a single namespace
```
