### PR TITLE
fix(kubelet_node_status): remove the node.Spec.Unschedulable check

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
-	taintutil "k8s.io/kubernetes/pkg/util/taints"
 	volutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
@@ -322,17 +321,6 @@ func (kl *Kubelet) initialNode(ctx context.Context) (*v1.Node, error) {
 
 	nodeTaints := make([]v1.Taint, len(kl.registerWithTaints))
 	copy(nodeTaints, kl.registerWithTaints)
-	unschedulableTaint := v1.Taint{
-		Key:    v1.TaintNodeUnschedulable,
-		Effect: v1.TaintEffectNoSchedule,
-	}
-
-	// Taint node with TaintNodeUnschedulable when initializing
-	// node to avoid race condition; refer to #63897 for more detail.
-	if node.Spec.Unschedulable &&
-		!taintutil.TaintExists(nodeTaints, &unschedulableTaint) {
-		nodeTaints = append(nodeTaints, unschedulableTaint)
-	}
 
 	if kl.externalCloudProvider {
 		taint := v1.Taint{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
after removing the register schedulable flag, it seems we might have missed something. 

this code will never be executed.

#### Which issue(s) this PR is related to:

PR #122384 /cc @carlory 
PR #63897 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
"NONE"

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
"NONE"
