### PR TITLE
KEP-4781: Restarting kubelet does not change pod status

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -128,6 +128,11 @@ const (
 	// Enables kubelet to detect CSI volume condition and send the event of the abnormal volume to the corresponding pod that is using it.
 	CSIVolumeHealth featuregate.Feature = "CSIVolumeHealth"
 
+	// owner: @HirazawaUi
+	//
+	// Enabling this feature gate will cause the pod's status to change due to a kubelet restart.
+	ChangeContainerStatusOnKubeletRestart = "ChangeContainerStatusOnKubeletRestart"
+
 	// owner: @sanposhiho @wojtek-t
 	// kep: https://kep.k8s.io/5278
 	//
@@ -1112,6 +1117,11 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	ChangeContainerStatusOnKubeletRestart: {
+		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Deprecated},
+	},
+
 	ClearingNominatedNodeNameAfterBinding: {
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
 	},
@@ -2035,6 +2045,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	CSIServiceAccountTokenSecrets: {},
 
 	CSIVolumeHealth: {},
+
+	ChangeContainerStatusOnKubeletRestart: {},
 
 	ClearingNominatedNodeNameAfterBinding: {},
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2408,6 +2408,14 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			oldStatusPtr = &oldStatus
 		}
 		status := convertContainerStatus(cStatus, oldStatusPtr)
+		if !utilfeature.DefaultFeatureGate.Enabled(features.ChangeContainerStatusOnKubeletRestart) {
+			if cStatus.State == kubecontainer.ContainerStateRunning {
+				if oldStatus, ok := oldStatuses[status.Name]; ok && oldStatus.Started != nil {
+					status.Started = oldStatus.Started
+				}
+			}
+		}
+
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 			allocatedContainer := kubecontainer.GetContainerSpec(pod, cName)
 			if allocatedContainer != nil {

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -778,4 +779,141 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
+}
+
+func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	tests := []struct {
+		name           string
+		featureEnabled bool
+		isRestart      bool
+		probeType      probeType
+		initialValue   results.Result
+		expectSet      bool
+	}{
+		{
+			name:           "feature enabled, is restart, readiness",
+			featureEnabled: true,
+			isRestart:      true,
+			probeType:      readiness,
+			initialValue:   results.Failure,
+			expectSet:      true,
+		},
+		{
+			name:           "feature enabled, is restart, liveness",
+			featureEnabled: true,
+			isRestart:      true,
+			probeType:      liveness,
+			initialValue:   results.Success,
+			expectSet:      true,
+		},
+		{
+			name:           "feature enabled, is restart, startup",
+			featureEnabled: true,
+			isRestart:      true,
+			probeType:      startup,
+			initialValue:   results.Unknown,
+			expectSet:      true,
+		},
+		{
+			name:           "feature enabled, not restart, readiness",
+			featureEnabled: true,
+			isRestart:      false,
+			probeType:      readiness,
+			initialValue:   results.Failure,
+			expectSet:      true,
+		},
+		{
+			name:           "feature enabled, not restart, liveness",
+			featureEnabled: true,
+			isRestart:      false,
+			probeType:      liveness,
+			initialValue:   results.Success,
+			expectSet:      true,
+		},
+		{
+			name:           "feature enabled, not restart, startup",
+			featureEnabled: true,
+			isRestart:      false,
+			probeType:      startup,
+			initialValue:   results.Unknown,
+			expectSet:      true,
+		},
+		{
+			name:           "feature disabled, is restart, readiness",
+			featureEnabled: false,
+			isRestart:      true,
+			probeType:      readiness,
+			expectSet:      false,
+		},
+		{
+			name:           "feature disabled, is restart, liveness",
+			featureEnabled: false,
+			isRestart:      true,
+			probeType:      liveness,
+			expectSet:      false,
+		},
+		{
+			name:           "feature disabled, is restart, startup",
+			featureEnabled: false,
+			isRestart:      true,
+			probeType:      startup,
+			expectSet:      false,
+		},
+		{
+			name:           "feature disabled, not restart, readiness",
+			featureEnabled: false,
+			isRestart:      false,
+			probeType:      readiness,
+			initialValue:   results.Failure,
+			expectSet:      true,
+		},
+		{
+			name:           "feature disabled, not restart, liveness",
+			featureEnabled: false,
+			isRestart:      false,
+			probeType:      liveness,
+			initialValue:   results.Success,
+			expectSet:      true,
+		},
+		{
+			name:           "feature disabled, not restart, startup",
+			featureEnabled: false,
+			isRestart:      false,
+			probeType:      startup,
+			initialValue:   results.Unknown,
+			expectSet:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ChangeContainerStatusOnKubeletRestart, tc.featureEnabled)
+
+			m := newTestManager()
+			podStatus := getTestRunningStatus()
+			podStatus.ContainerStatuses[0].ContainerID = "test://container-id"
+			if tc.isRestart {
+				podStatus.ContainerStatuses[0].State.Running.StartedAt = metav1.Time{Time: m.start.Add(-5 * time.Minute)}
+			} else {
+				podStatus.ContainerStatuses[0].State.Running.StartedAt = metav1.Time{Time: m.start.Add(5 * time.Minute)}
+			}
+
+			w := newTestWorker(m, tc.probeType, v1.Probe{InitialDelaySeconds: 1000})
+			m.statusManager.SetPodStatus(logger, w.pod, podStatus)
+
+			w.doProbe(ctx)
+
+			containerID := kubecontainer.ParseContainerID(podStatus.ContainerStatuses[0].ContainerID)
+			result, ok := resultsManager(m, tc.probeType).Get(containerID)
+
+			if ok != tc.expectSet {
+				t.Errorf("Expected result to be set: %v, but got: %v", tc.expectSet, ok)
+			}
+			if tc.expectSet && result != tc.initialValue {
+				t.Errorf("Expected result %v, but got: %v", tc.initialValue, result)
+			}
+		})
+	}
 }

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -175,6 +175,16 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.32"
+- name: ChangeContainerStatusOnKubeletRestart
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: GA
+    version: "1.0"
+  - default: false
+    lockToDefault: false
+    preRelease: Deprecated
+    version: "1.35"
 - name: ClearingNominatedNodeNameAfterBinding
   versionedSpecs:
   - default: false

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -41,7 +41,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/printers"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 )
 
@@ -671,3 +673,169 @@ func checkMirrorPodRecreated(ctx context.Context, cl clientset.Interface, name, 
 	}
 	return nil
 }
+
+var _ = SIGDescribe("MirrorPod", framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("mirror-pod-serial")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	ginkgo.Context("when kubelet restarts", func() {
+		var ns, podPath, staticPodName, mirrorPodName string
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			ns = f.Namespace.Name
+			staticPodName = "static-pod-" + string(uuid.NewUUID())
+			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
+			podPath = kubeletCfg.StaticPodPath
+
+			ginkgo.By("create the static pod")
+			podSpec := v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "container",
+						Image:   defaultImage,
+						Command: []string{"sleep", "3600"},
+						StartupProbe: &v1.Probe{
+							ProbeHandler: v1.ProbeHandler{
+								Exec: &v1.ExecAction{
+									Command: []string{"/bin/true"},
+								},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       1,
+						},
+						ReadinessProbe: &v1.Probe{
+							ProbeHandler: v1.ProbeHandler{
+								Exec: &v1.ExecAction{
+									Command: []string{"/bin/true"},
+								},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       1,
+						},
+					},
+				},
+			}
+
+			err := createStaticPodWithSpec(podPath, staticPodName, ns, podSpec)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("wait for the mirror pod to be running")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return checkMirrorPodRunning(ctx, f.ClientSet, mirrorPodName, ns)
+			}, 2*time.Minute, time.Second*4).Should(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			ginkgo.By("delete the static pod")
+			err := deleteStaticPod(podPath, staticPodName, ns)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("wait for the mirror pod to disappear")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return checkMirrorPodDisappear(ctx, f.ClientSet, mirrorPodName, ns)
+			}, 2*time.Minute, time.Second*4).Should(gomega.Succeed())
+		})
+
+		f.It("should not change container status", f.WithNodeConformance(), func(ctx context.Context) {
+			ginkgo.By("Waiting for the pod to be running and ready")
+			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, ns, mirrorPodName, "PodReady", f.Timeouts.PodStart,
+				func(p *v1.Pod) (bool, error) {
+					if p.Status.Phase != v1.PodRunning {
+						return false, nil
+					}
+					for _, cond := range p.Status.Conditions {
+						if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+							return true, nil
+						}
+					}
+					return false, nil
+				})
+			framework.ExpectNoError(err)
+
+			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, mirrorPodName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Double check the initial state before starting the concurrent check")
+			gomega.Expect(pod.Status.ContainerStatuses).ToNot(gomega.BeEmpty())
+			for _, status := range pod.Status.ContainerStatuses {
+				gomega.Expect(status.RestartCount).To(gomega.BeZero())
+				gomega.Expect(status.Started).ToNot(gomega.BeNil())
+				gomega.Expect(*status.Started).To(gomega.BeTrueBecause("The Started field should be set to true when a pod enters the Ready condition."))
+				gomega.Expect(status.Ready).To(gomega.BeTrueBecause("The Ready field should be set to true when a pod enters the Ready condition."))
+			}
+
+			// The grace period for kubelet startup is 10 seconds, so we wait here for 11 seconds.
+			time.Sleep(time.Second * 11)
+
+			stopCh := make(chan struct{})
+			errCh := make(chan error, 1)
+			go func() {
+				defer ginkgo.GinkgoRecover()
+				watcher, err := f.ClientSet.CoreV1().Pods(ns).Watch(ctx, metav1.ListOptions{
+					FieldSelector: "metadata.name=" + mirrorPodName,
+				})
+				if err != nil {
+					errCh <- fmt.Errorf("failed to watch pod: %w", err)
+					return
+				}
+				defer watcher.Stop()
+
+				for {
+					select {
+					case event, ok := <-watcher.ResultChan():
+						if !ok {
+							return
+						}
+						if event.Type != watch.Modified {
+							continue
+						}
+						p, ok := event.Object.(*v1.Pod)
+						if !ok {
+							continue
+						}
+
+						if p.Status.Phase != v1.PodRunning {
+							errCh <- fmt.Errorf("pod phase is %v, expected %v", p.Status.Phase, v1.PodRunning)
+							return
+						}
+						if len(p.Status.ContainerStatuses) < len(pod.Spec.Containers) {
+							continue
+						}
+						for _, containerStatus := range p.Status.ContainerStatuses {
+							if containerStatus.RestartCount > 0 {
+								errCh <- fmt.Errorf("container %q restarted %d times", containerStatus.Name, containerStatus.RestartCount)
+								return
+							}
+							if containerStatus.Started == nil || !*containerStatus.Started {
+								errCh <- fmt.Errorf("container %q started status is not true", containerStatus.Name)
+								return
+							}
+							if !containerStatus.Ready {
+								errCh <- fmt.Errorf("container %q ready status is not true", containerStatus.Name)
+								return
+							}
+						}
+					case <-stopCh:
+						close(errCh)
+						return
+					}
+				}
+			}()
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+			restartKubelet(ctx)
+
+			ginkgo.By("ensuring kubelet is healthy")
+			gomega.Eventually(ctx, func() bool {
+				return kubeletHealthCheck(kubeletHealthCheckURL)
+			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
+
+			// Let the goroutine run for a few more seconds to catch any delayed changes
+			time.Sleep(5 * time.Second)
+			close(stopCh)
+
+			for err := range errCh {
+				framework.ExpectNoError(err, "pod status check failed during kubelet restart")
+			}
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since KEP-4781 has been merged, we will advance this feature during the v1.35 cycle.

This "feature/bug fix" was proposed to prevent changes in pod status caused by kubelet restarts.

It introduces a feature gate named `ChangeContainerStatusOnKubeletRestart`. When the `ChangeContainerStatusOnKubeletRestart` feature gate is disabled, the pod status will not be changed upon kubelet restart. Users can opt out of this fix/behavior by enabling the `ChangeContainerStatusOnKubeletRestart `feature gate.

This is achieved by defaulting the `ContainerStatuses.Ready` and `ContainerStatuses.Started` fields to their pre-restart states and preventing the doProbe mechanism from setting initial values (which are Failure or Unknown) for the readiness and startup probes.

For detailed design, please refer to: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4781-kublet-restart-pod-status#design-details

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #100277
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #100277

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add the `ChangeContainerStatusOnKubeletRestart` feature gate. The feature gate defaults to disabled. When the feature gate is disabled, the kubelet does not change the pod status upon restart, and pods will not re-run startup probes after kubelet restart.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4781
```
