### PR TITLE
startupProbe reports failed check attempt as Warning, but it should b…

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -81,6 +81,11 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 
 // probe probes the container.
 func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+	return pb.probeWithContext(ctx, probeType, pod, status, container, containerID, 0, 0)
+}
+
+// probeWithContext probes the container with additional context about failure counts.
+func (pb *prober) probeWithContext(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, currentFailureCount int, failureThreshold int32) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -104,7 +109,17 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	if err != nil {
 		// Handle probe error
 		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
+
+		// For startup probes, only record warning events when the failure threshold is exceeded
+		// currentFailureCount is the count before this probe; this failure is the (currentFailureCount+1)th
+		if probeType == startup {
+			if failureThreshold > 0 && currentFailureCount >= int(failureThreshold)-1 {
+				pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored after exceeding maximum startup duration: %s", probeType, err)
+			}
+		} else {
+			// For liveness and readiness probes, maintain existing behavior
+			pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
+		}
 		return results.Failure, err
 	}
 
@@ -120,7 +135,18 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 	case probe.Failure:
 		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+
+		// For startup probes, only record warning events when the failure threshold is exceeded
+		// This prevents premature warning events during the expected startup period
+		// currentFailureCount is the count before this probe; this failure is the (currentFailureCount+1)th
+		if probeType == startup {
+			if failureThreshold > 0 && currentFailureCount >= int(failureThreshold)-1 {
+				pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed after exceeding maximum startup duration: %s", probeType, output)
+			}
+		} else {
+			// For liveness and readiness probes, maintain existing behavior
+			pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+		}
 		return results.Failure, nil
 
 	case probe.Unknown:

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -447,19 +447,21 @@ func TestRecordContainerEventUnknownStatus(t *testing.T) {
 func TestStartupProbeEventReporting(t *testing.T) {
 	// Test the core logic directly by verifying the conditions in the code
 	t.Run("Startup probe failure logic", func(t *testing.T) {
-		// Test cases for startup probe
+		// Test cases for startup probe. currentFailureCount is the count BEFORE the current probe;
+		// the current failure is the (currentFailureCount+1)th. We record when that total >= threshold.
 		testCases := []struct {
 			currentFailureCount int
 			failureThreshold    int32
 			shouldRecordEvent   bool
 		}{
-			{2, 3, false}, // Before threshold - no event
-			{3, 3, true},  // At threshold - event
-			{4, 3, true},  // After threshold - event
+			{0, 3, false}, // 1st failure - before threshold
+			{1, 3, false}, // 2nd failure - before threshold
+			{2, 3, true},  // 3rd failure - at threshold, record
+			{3, 3, true},  // 4th failure - after threshold, record
 		}
 
 		for _, tc := range testCases {
-			shouldRecord := tc.currentFailureCount >= int(tc.failureThreshold)
+			shouldRecord := tc.failureThreshold > 0 && tc.currentFailureCount >= int(tc.failureThreshold)-1
 			if shouldRecord != tc.shouldRecordEvent {
 				t.Errorf("For currentFailureCount=%d, failureThreshold=%d: expected shouldRecord=%v, got %v",
 					tc.currentFailureCount, tc.failureThreshold, tc.shouldRecordEvent, shouldRecord)

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -332,7 +332,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, err := w.probeManager.prober.probeWithContext(ctx, w.probeType, w.pod, status, w.container, w.containerID, w.resultRun, w.spec.FailureThreshold)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes the semantic issue where startup probe failures were generating premature warning events during the expected startup period. 

**Problem**: Startup probe failures were immediately recorded as Warning events in Kubelet, even though startup probes are designed to handle initial failures during container startup. This resulted in misleading warning events (e.g., 7 warnings for a 75-second startup time with failureThreshold=30, periodSeconds=10).

**Solution**: Modified the probe event recording logic to only generate warning events for startup probes when the failure threshold is exceeded (i.e., when the maximum startup duration is reached). This ensures that startup probe failures are only reported as warnings when the container truly fails to start within the configured maximum duration.

**Changes**:
- Added `probeWithContext` method to pass failure count and threshold context
- Modified failure handling logic to check if it's a startup probe and if threshold is exceeded
- Maintained existing behavior for liveness and readiness probes
- Added comprehensive tests to verify the fix

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #131346  <!-- Replace with actual issue number -->

#### Special notes for your reviewer:

- The fix maintains backward compatibility - liveness and readiness probes continue to work exactly as before
- Added comprehensive tests in `TestStartupProbeEventReporting` to verify the logic works correctly
- The solution is minimal and focused, only affecting the event recording logic for startup probes
- All existing tests pass, ensuring no regressions

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix startup probe premature warning events

Startup probe failures now only generate warning events when the failure threshold is exceeded (i.e., when the maximum startup duration is reached), rather than after every failure. This prevents misleading warning events during the expected startup period while maintaining proper error reporting when containers truly fail to start.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```