### PR TITLE
Use fast policy refresh interval for TestParamRef

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -360,6 +360,7 @@ func setupTestCommon(
 	matcher generic.PolicyMatcher,
 	shouldStartInformers bool,
 ) *generic.PolicyTestContext[*validating.Policy, *validating.PolicyBinding, validating.Validator] {
+	t.Cleanup(generic.SetPolicyRefreshIntervalForTests(10 * time.Millisecond))
 	testContext, testContextCancel, err := generic.NewPolicyTestContext(
 		t,
 		validating.NewValidatingAdmissionPolicyAccessor,
@@ -1508,7 +1509,6 @@ func TestParamRef(t *testing.T) {
 						}
 
 						t.Run(name, func(t *testing.T) {
-							t.Parallel()
 							// Test creating a policy with a cluster or namesapce-scoped param
 							// and binding with the provided configuration. Test will ensure
 							// that the provided configuration is capable of matching


### PR DESCRIPTION
/kind flake

#### What this PR does / why we need it:

Fixes https://github.com/kubernetes/kubernetes/issues/132029

#### Which issue(s) this PR is related to:

Switch from a 1s to 10ms policy refresh rate for tests to avoid flakes.

Also parallel so that this test setting is not clobbered by races. This was causing data races after fixing the policy refresh interval, so we need to run in serial to avoid the race and use the fast refresh.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
