### PR TITLE
golangci-lint: no need to enable deprecatedComment

### DIFF
--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -394,7 +394,6 @@ linters:
       enabled-checks:
         - equalFold
         - boolExprSimplify
-        - deprecatedComment
     revive:
       # Only these rules are enabled.
       rules:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -241,7 +241,6 @@ linters:
       enabled-checks:
         - equalFold
         - boolExprSimplify
-        - deprecatedComment
     {{- end}}
     revive:
       # Only these rules are enabled.


### PR DESCRIPTION
Noticed this when running lint by hand.  This is enabled by default, but linter warns about it.

/kind cleanup

```release-note
NONE
```
