### PR TITLE
Fixing unit test flakes on windows for DRA plugin tests

### DIFF
--- a/pkg/kubelet/cm/dra/plugin/registration_test.go
+++ b/pkg/kubelet/cm/dra/plugin/registration_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package plugin
 
 import (
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -201,12 +201,12 @@ func TestRegistrationHandler(t *testing.T) {
 
 			service := drapb.DRAPluginService
 			tmp := t.TempDir()
-			endpointA := path.Join(tmp, socketFileA)
+			endpointA := filepath.Join(tmp, socketFileA)
 			teardownA, err := setupFakeGRPCServer(service, endpointA)
 			require.NoError(t, err)
 			tCtx.Cleanup(teardownA)
 
-			endpoint := path.Join(tmp, test.socketFile)
+			endpoint := filepath.Join(tmp, test.socketFile)
 			teardown, err := setupFakeGRPCServer(service, endpoint)
 			require.NoError(t, err)
 			tCtx.Cleanup(teardown)
@@ -314,7 +314,7 @@ func TestConnectionHandling(t *testing.T) {
 			requireNoSlices(tCtx)
 
 			// Run GRPC service.
-			endpoint := path.Join(t.TempDir(), "dra.sock")
+			endpoint := filepath.Join(t.TempDir(), "dra.sock")
 			teardown, err := setupFakeGRPCServer(service, endpoint)
 			require.NoError(t, err)
 			defer teardown()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind regression
-->

#### What this PR does / why we need it:

Fixing flakes when running the DRA plugin unit tests on Windows.

When running on Windows we occasionally see the following failure:

```bash
{Failed  === RUN   TestConnectionHandling/no-wipe-on-reconnect
=== PAUSE TestConnectionHandling/no-wipe-on-reconnect
=== CONT  TestConnectionHandling/no-wipe-on-reconnect
    registration_test.go:348: 
        	Error Trace:	C:/kubernetes/pkg/kubelet/cm/dra/plugin/registration_test.go:348
        	Error:      	Received unexpected error:
        	            	listen unix C:\Users\azureuser\AppData\Local\Temp\TestConnectionHandlingno-wipe-on-reconnect2002014513\001/dra.sock: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.
        	Test:       	TestConnectionHandling/no-wipe-on-reconnect
--- FAIL: TestConnectionHandling/no-wipe-on-reconnect (0.02s)

=== RUN   TestConnectionHandling
=== PAUSE TestConnectionHandling
=== CONT  TestConnectionHandling
--- FAIL: TestConnectionHandling (0.00s)
}
```

ex: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-windows-master/1980285334872657920

This is happening because there is a race where the test server doesn't wait for `teardown()` to finish so sockets were not always getting cleaned up before trying to create a new socket.

This also uses `filepath.Join()` instead of `path.Join()` to ensure we get the correct paths separators on Windows


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
