### PR TITLE
Clean up OWNERS for all api machinery owned controllers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,12 @@
 aliases:
+  sig-api-machinery-approvers:
+    - deads2k
+    - jpbetz
+    - sttts
+  sig-api-machinery-reviewers:
+    - deads2k
+    - jpbetz
+    - sttts
   # Note: sig-architecture-approvers has approval on root files (including go.mod/go.sum) until https://github.com/kubernetes/test-infra/pull/21398 is resolved.
   # People with approve rights via this alias should defer dependency update PRs to dep-approvers.
   sig-architecture-approvers:

--- a/pkg/controller/garbagecollector/OWNERS
+++ b/pkg/controller/garbagecollector/OWNERS
@@ -1,13 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - caesarxuchao
-  - deads2k
+  - sig-api-machinery-approvers
 reviewers:
-  - caesarxuchao
-  - deads2k
-  - jpbetz
+  - sig-api-machinery-reviewers
 labels:
   - sig/api-machinery
 emeritus_approvers:
+  - caesarxuchao
   - lavalamp

--- a/pkg/controller/storageversiongc/OWNERS
+++ b/pkg/controller/storageversiongc/OWNERS
@@ -1,10 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - enj
   - sig-api-machinery-approvers
 reviewers:
-  - derekwaynecarr
-  - smarterclayton
   - sig-api-machinery-reviewers
 labels:
   - sig/api-machinery

--- a/pkg/controller/storageversionmigrator/OWNERS
+++ b/pkg/controller/storageversionmigrator/OWNERS
@@ -1,6 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+  - enj
+  - sig-api-machinery-approvers
 reviewers:
   - michaelasp
+  - sig-api-machinery-reviewers
 labels:
   - sig/api-machinery

--- a/pkg/controller/validatingadmissionpolicystatus/OWNERS
+++ b/pkg/controller/validatingadmissionpolicystatus/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+  - sig-api-machinery-approvers
 reviewers:
-  - jiahuif
+  - sig-api-machinery-reviewers
 labels:
   - sig/api-machinery


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I'd copied the OWNERS file from the namespace controller to the SVM controller in https://github.com/kubernetes/kubernetes/pull/134759 but turns out that doesn't give API Machinery leads ownership.  So this fixes ALL controller OWNERS files for API Machinery.

```release-note
NONE
```

/sig api-machinery