### PR TITLE
feat: Enable declarative validation for secret

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -7482,6 +7482,7 @@
             "type": "object"
           },
           "type": {
+            "default": "Opaque",
             "description": "Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types",
             "type": "string"
           }

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -262,11 +262,6 @@ func SetDefaults_DownwardAPIVolumeSource(obj *v1.DownwardAPIVolumeSource) {
 		obj.DefaultMode = &perm
 	}
 }
-func SetDefaults_Secret(obj *v1.Secret) {
-	if obj.Type == "" {
-		obj.Type = v1.SecretTypeOpaque
-	}
-}
 func SetDefaults_ProjectedVolumeSource(obj *v1.ProjectedVolumeSource) {
 	if obj.DefaultMode == nil {
 		perm := int32(v1.ProjectedVolumeSourceDefaultMode)

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -1269,7 +1269,9 @@ func SetObjectDefaults_ResourceQuotaList(in *corev1.ResourceQuotaList) {
 }
 
 func SetObjectDefaults_Secret(in *corev1.Secret) {
-	SetDefaults_Secret(in)
+	if in.Type == "" {
+		in.Type = "Opaque"
+	}
 }
 
 func SetObjectDefaults_SecretList(in *corev1.SecretList) {

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -183,7 +183,9 @@ func Validate_Secret(ctx context.Context, op operation.Operation, fldPath *field
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			// optional fields with default values are effectively required
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -48,6 +48,14 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
+	// type Secret
+	scheme.AddValidationFunc((*corev1.Secret)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_Secret(ctx, op, nil /* fldPath */, obj.(*corev1.Secret), safe.Cast[*corev1.Secret](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
 }
 
@@ -132,5 +140,53 @@ func Validate_ReplicationControllerSpec(ctx context.Context, op operation.Operat
 
 	// field corev1.ReplicationControllerSpec.Selector has no validation
 	// field corev1.ReplicationControllerSpec.Template has no validation
+	return errs
+}
+
+// Validate_Secret validates an instance of Secret according
+// to declarative validation rules in the API schema.
+func Validate_Secret(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *corev1.Secret) (errs field.ErrorList) {
+	// field corev1.Secret.TypeMeta has no validation
+	// field corev1.Secret.ObjectMeta has no validation
+
+	// field corev1.Secret.Immutable
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *bool, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("immutable"), obj.Immutable, safe.Field(oldObj, func(oldObj *corev1.Secret) *bool { return oldObj.Immutable }), oldObj != nil)...)
+
+	// field corev1.Secret.Data has no validation
+	// field corev1.Secret.StringData has no validation
+
+	// field corev1.Secret.Type
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *corev1.SecretType, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("type"), &obj.Type, safe.Field(oldObj, func(oldObj *corev1.Secret) *corev1.SecretType { return &oldObj.Type }), oldObj != nil)...)
+
 	return errs
 }

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -179,6 +179,10 @@ func Validate_Secret(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7842,7 +7842,7 @@ func ValidateSecret(secret *core.Secret) field.ErrorList {
 func ValidateSecretUpdate(newSecret, oldSecret *core.Secret) field.ErrorList {
 	allErrs := ValidateObjectMetaUpdate(&newSecret.ObjectMeta, &oldSecret.ObjectMeta, field.NewPath("metadata"))
 
-	allErrs = append(allErrs, ValidateImmutableField(newSecret.Type, oldSecret.Type, field.NewPath("type"))...)
+	allErrs = append(allErrs, ValidateImmutableField(newSecret.Type, oldSecret.Type, field.NewPath("type")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	if oldSecret.Immutable != nil && *oldSecret.Immutable {
 		if newSecret.Immutable == nil || !*newSecret.Immutable {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("immutable"), "field is immutable when `immutable` is set"))

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -31081,6 +31081,7 @@ func schema_k8sio_api_core_v1_Secret(ref common.ReferenceCallback) common.OpenAP
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types",
+							Default:     "Opaque",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/registry/core/secret/declarative_validation_test.go
+++ b/pkg/registry/core/secret/declarative_validation_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+var apiVersions = []string{"v1"}
+
+const (
+	testSecretName = "test-secret"
+	testNamespace  = "default"
+)
+
+func TestDeclarativeValidateForDeclarative(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		testDeclarativeValidateForDeclarative(t, apiVersion)
+	}
+}
+
+func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: apiVersion,
+		Resource:   "secrets",
+	})
+
+	testCases := map[string]struct {
+		input        api.Secret
+		expectedErrs field.ErrorList
+	}{
+		"valid opaque secret": {
+			input: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakData(map[string][]byte{"key": []byte("value")}),
+			),
+		},
+		"valid tls secret": {
+			input: makeValidSecret(
+				tweakName("test-tls"),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeTLS),
+				tweakData(map[string][]byte{
+					api.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+					api.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"),
+				}),
+			),
+		},
+		"valid immutable secret": {
+			input: makeValidSecret(
+				tweakName("test-immutable"),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakImmutable(true),
+				tweakData(map[string][]byte{"key": []byte("value")}),
+			),
+		},
+	}
+
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestValidateUpdateForDeclarative(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		testValidateUpdateForDeclarative(t, apiVersion)
+	}
+}
+
+func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: apiVersion,
+		Resource:   "secrets",
+	})
+
+	testCases := map[string]struct {
+		old          api.Secret
+		update       api.Secret
+		expectedErrs field.ErrorList
+	}{
+		"valid update of secret data": {
+			old: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakData(map[string][]byte{"key": []byte("old-value")}),
+			),
+			update: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakData(map[string][]byte{"key": []byte("new-value")}),
+			),
+		},
+		"valid update to make secret immutable": {
+			old: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakData(map[string][]byte{"key": []byte("value")}),
+			),
+			update: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakImmutable(true),
+				tweakData(map[string][]byte{"key": []byte("value")}),
+			),
+		},
+		"valid update of labels": {
+			old: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakLabels(map[string]string{"app": "v1"}),
+			),
+			update: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakLabels(map[string]string{"app": "v2"}),
+			),
+		},
+		"invalid update - type changed": {
+			old: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeOpaque),
+				tweakData(map[string][]byte{"key": []byte("value")}),
+			),
+			update: makeValidSecret(
+				tweakName(testSecretName),
+				tweakNamespace(testNamespace),
+				tweakType(api.SecretTypeTLS),
+				tweakData(map[string][]byte{
+					api.TLSCertKey:       []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"),
+					api.TLSPrivateKeyKey: []byte("-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"),
+				}),
+			),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("type"), api.SecretTypeTLS, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+	}
+
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.old.ResourceVersion = "1"
+			tc.update.ResourceVersion = "1"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+func makeValidSecret(mutators ...func(*api.Secret)) api.Secret {
+	secret := api.Secret{
+		ObjectMeta: metav1.ObjectMeta{},
+		Type:       api.SecretTypeOpaque,
+	}
+	for _, mutate := range mutators {
+		mutate(&secret)
+	}
+	return secret
+}
+
+func tweakName(name string) func(*api.Secret) {
+	return func(s *api.Secret) {
+		s.ObjectMeta.Name = name
+	}
+}
+
+func tweakNamespace(namespace string) func(*api.Secret) {
+	return func(s *api.Secret) {
+		s.ObjectMeta.Namespace = namespace
+	}
+}
+
+func tweakType(secretType api.SecretType) func(*api.Secret) {
+	return func(s *api.Secret) {
+		s.Type = secretType
+	}
+}
+
+func tweakData(data map[string][]byte) func(*api.Secret) {
+	return func(s *api.Secret) {
+		s.Data = data
+	}
+}
+
+func tweakImmutable(immutable bool) func(*api.Secret) {
+	return func(s *api.Secret) {
+		s.Immutable = &immutable
+	}
+}
+
+func tweakLabels(labels map[string]string) func(*api.Secret) {
+	return func(s *api.Secret) {
+		s.ObjectMeta.Labels = labels
+	}
+}

--- a/pkg/registry/core/secret/declarative_validation_test.go
+++ b/pkg/registry/core/secret/declarative_validation_test.go
@@ -165,7 +165,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 				}),
 			),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("type"), api.SecretTypeTLS, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("type"), api.SecretTypeTLS, "field is immutable").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5855,6 +5855,7 @@ message Secret {
   // More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
   // +optional
   // +k8s:optional
+  // +k8s:alpha(since: "1.36")=+k8s:immutable
   optional string type = 3;
 }
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5833,6 +5833,7 @@ message Secret {
   // If not set to true, the field can be modified at any time.
   // Defaulted to nil.
   // +optional
+  // +k8s:optional
   optional bool immutable = 5;
 
   // Data contains the secret data. Each key must consist of alphanumeric
@@ -5853,6 +5854,7 @@ message Secret {
   // Used to facilitate programmatic handling of secret data.
   // More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
   // +optional
+  // +k8s:optional
   optional string type = 3;
 }
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5856,6 +5856,7 @@ message Secret {
   // +optional
   // +k8s:optional
   // +k8s:alpha(since: "1.36")=+k8s:immutable
+  // +default="Opaque"
   optional string type = 3;
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7965,6 +7965,7 @@ type Secret struct {
 	// More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
 	// +optional
 	// +k8s:optional
+	// +k8s:alpha(since: "1.36")=+k8s:immutable
 	Type SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7966,6 +7966,7 @@ type Secret struct {
 	// +optional
 	// +k8s:optional
 	// +k8s:alpha(since: "1.36")=+k8s:immutable
+	// +default="Opaque"
 	Type SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7943,6 +7943,7 @@ type Secret struct {
 	// If not set to true, the field can be modified at any time.
 	// Defaulted to nil.
 	// +optional
+	// +k8s:optional
 	Immutable *bool `json:"immutable,omitempty" protobuf:"varint,5,opt,name=immutable"`
 
 	// Data contains the secret data. Each key must consist of alphanumeric
@@ -7963,6 +7964,7 @@ type Secret struct {
 	// Used to facilitate programmatic handling of secret data.
 	// More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
 	// +optional
+	// +k8s:optional
 	Type SecretType `json:"type,omitempty" protobuf:"bytes,3,opt,name=type,casttype=SecretType"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -7807,6 +7807,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: type
       type:
         scalar: string
+      default: Opaque
 - name: io.k8s.api.core.v1.SecretEnvSource
   map:
     fields:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

##### Updates Secret strategy:

Modifies the Secret resource's strategy file (pkg/registry/core/secret/strategy.go) to invoke the newly generated declarative validation in the Validate and ValidateUpdate methods.

##### Enables declarative validation testing:
Adds relevant test file to enable and verify the new declarative validation logic for Secret, ensuring tests cover various secret types (Opaque, TLS, Basic Auth, SSH Auth, Docker Config), immutability, and update scenarios.

#### Which issue(s) this PR is related to:
part of https://github.com/kubernetes/kubernetes/issues/134280

#### Special notes for your reviewer:

Code generation and fuzz testing are already enabled for Secret as it is part of the core API group (group="", version="v1"), which is already registered in pkg/api/testing/validation_test.go.

#### Does this PR introduce a user-facing change?

No, it only enables the internal declarative validation framework and associated testing for Secret. Existing functionality will remain the same until validation rules are migrated.

#### Additional documentation, e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

[KEP]: 

https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md

