### PR TITLE
Enable DV for resourceslice

### DIFF
--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -194,8 +194,51 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 		}(fldPath.Child("taints"), obj.Taints, safe.Field(oldObj, func(oldObj *resourcev1.Device) []resourcev1.DeviceTaint { return oldObj.Taints }))...)
 
 	// field resourcev1.Device.BindsToNode has no validation
-	// field resourcev1.Device.BindingConditions has no validation
-	// field resourcev1.Device.BindingFailureConditions has no validation
+
+	// field resourcev1.Device.BindingConditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("bindingConditions"), obj.BindingConditions, safe.Field(oldObj, func(oldObj *resourcev1.Device) []string { return oldObj.BindingConditions }))...)
+
+	// field resourcev1.Device.BindingFailureConditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("bindingFailureConditions"), obj.BindingFailureConditions, safe.Field(oldObj, func(oldObj *resourcev1.Device) []string { return oldObj.BindingFailureConditions }))...)
+
 	// field resourcev1.Device.AllowMultipleAllocations has no validation
 	return errs
 }
@@ -735,6 +778,9 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -752,6 +798,9 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			earlyReturn := false
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
 				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -873,6 +922,15 @@ func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *
 			// don't revalidate unchanged data
 			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
@@ -1337,6 +1395,14 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			// don't revalidate unchanged data
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device)...)

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -195,8 +195,51 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 		}(fldPath.Child("taints"), obj.Taints, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []resourcev1beta1.DeviceTaint { return oldObj.Taints }))...)
 
 	// field resourcev1beta1.BasicDevice.BindsToNode has no validation
-	// field resourcev1beta1.BasicDevice.BindingConditions has no validation
-	// field resourcev1beta1.BasicDevice.BindingFailureConditions has no validation
+
+	// field resourcev1beta1.BasicDevice.BindingConditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("bindingConditions"), obj.BindingConditions, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []string { return oldObj.BindingConditions }))...)
+
+	// field resourcev1beta1.BasicDevice.BindingFailureConditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("bindingFailureConditions"), obj.BindingFailureConditions, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []string { return oldObj.BindingFailureConditions }))...)
+
 	// field resourcev1beta1.BasicDevice.AllowMultipleAllocations has no validation
 	return errs
 }
@@ -819,6 +862,9 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -836,6 +882,9 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			earlyReturn := false
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
 				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -961,6 +1010,15 @@ func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *
 			// don't revalidate unchanged data
 			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
@@ -1370,6 +1428,14 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			// don't revalidate unchanged data
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device)...)

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -196,8 +196,51 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 		}(fldPath.Child("taints"), obj.Taints, safe.Field(oldObj, func(oldObj *resourcev1beta2.Device) []resourcev1beta2.DeviceTaint { return oldObj.Taints }))...)
 
 	// field resourcev1beta2.Device.BindsToNode has no validation
-	// field resourcev1beta2.Device.BindingConditions has no validation
-	// field resourcev1beta2.Device.BindingFailureConditions has no validation
+
+	// field resourcev1beta2.Device.BindingConditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("bindingConditions"), obj.BindingConditions, safe.Field(oldObj, func(oldObj *resourcev1beta2.Device) []string { return oldObj.BindingConditions }))...)
+
+	// field resourcev1beta2.Device.BindingFailureConditions
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("bindingFailureConditions"), obj.BindingFailureConditions, safe.Field(oldObj, func(oldObj *resourcev1beta2.Device) []string { return oldObj.BindingFailureConditions }))...)
+
 	// field resourcev1beta2.Device.AllowMultipleAllocations has no validation
 	return errs
 }
@@ -751,6 +794,9 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -768,6 +814,9 @@ func Validate_DeviceRequestAllocationResult(ctx context.Context, op operation.Op
 			earlyReturn := false
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4); len(e) != 0 {
 				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -893,6 +942,15 @@ func Validate_DeviceTaint(ctx context.Context, op operation.Operation, fldPath *
 			// don't revalidate unchanged data
 			if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
@@ -1371,6 +1429,14 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 			// don't revalidate unchanged data
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device)...)

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1366,9 +1366,9 @@ func validateDeviceTaint(taint resource.DeviceTaint, fldPath *field.Path) field.
 	}
 	switch {
 	case taint.Effect == "":
-		allErrs = append(allErrs, field.Required(fldPath.Child("effect"), "")) // Required in a taint.
+		allErrs = append(allErrs, field.Required(fldPath.Child("effect"), "").MarkCoveredByDeclarative()) // Required in a taint.
 	case !validDeviceTaintEffects.Has(taint.Effect):
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), taint.Effect, sets.List(validDeviceTaintEffects)))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("effect"), taint.Effect, sets.List(validDeviceTaintEffects)).MarkCoveredByDeclarative())
 	}
 
 	return allErrs

--- a/pkg/apis/resource/validation/validation_devicetaintrule_test.go
+++ b/pkg/apis/resource/validation/validation_devicetaintrule_test.go
@@ -296,7 +296,7 @@ func TestValidateDeviceTaint(t *testing.T) {
 		},
 		"invalid-taint": {
 			wantFailures: field.ErrorList{
-				field.Required(field.NewPath("spec", "taint", "effect"), ""),
+				field.Required(field.NewPath("spec", "taint", "effect"), "").MarkCoveredByDeclarative(),
 			},
 			taintRule: func() *resourceapi.DeviceTaintRule {
 				claim := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -493,11 +493,11 @@ func TestValidateResourceSlice(t *testing.T) {
 				return field.ErrorList{
 					field.Invalid(fldPath.Index(2).Child("key"), "", "name part must be non-empty"),
 					field.Invalid(fldPath.Index(2).Child("key"), "", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
-					field.Required(fldPath.Index(2).Child("effect"), ""),
+					field.Required(fldPath.Index(2).Child("effect"), "").MarkCoveredByDeclarative(),
 
 					field.Invalid(fldPath.Index(3).Child("key"), badName, "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
 					field.Invalid(fldPath.Index(3).Child("value"), badName, "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"),
-					field.NotSupported(fldPath.Index(3).Child("effect"), resourceapi.DeviceTaintEffect("some-other-op"), []resourceapi.DeviceTaintEffect{resourceapi.DeviceTaintEffectNoExecute, resourceapi.DeviceTaintEffectNoSchedule}),
+					field.NotSupported(fldPath.Index(3).Child("effect"), resourceapi.DeviceTaintEffect("some-other-op"), []resourceapi.DeviceTaintEffect{resourceapi.DeviceTaintEffectNoExecute, resourceapi.DeviceTaintEffectNoSchedule}).MarkCoveredByDeclarative(),
 				}
 			}(),
 			slice: func() *resourceapi.ResourceSlice {

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceslice
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/resource"
+	_ "k8s.io/kubernetes/pkg/apis/resource/install"
+	"k8s.io/kubernetes/pkg/apis/resource/validation"
+	"k8s.io/utils/ptr"
+)
+
+var apiVersions = []string{"v1", "v1beta1", "v1beta2"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "resource.k8s.io",
+				APIVersion: apiVersion,
+				Resource:   "ResourceSlice",
+			})
+
+			strategy := Strategy
+
+			testCases := map[string]struct {
+				input        resource.ResourceSlice
+				expectedErrs field.ErrorList
+			}{
+				"valid": {
+					input: mkResourceSlice(),
+				},
+				// spec.devices[%d].bindingConditions
+				"valid: one binding condition": {
+					input: mkResourceSlice(tweakBindingConditions(1)),
+				},
+				"valid: at limit binding conditions": {
+					input: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize)),
+				},
+				"invalid: too many binding conditions": {
+					input: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems"),
+					},
+				},
+				// spec.devices[%d].bindingFailureConditions
+				"valid: one binding failure conditions": {
+					input: mkResourceSlice(tweakBindingFailureConditions(1)),
+				},
+				"valid: at limit binding failure conditions": {
+					input: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize)),
+				},
+				"invalid: too many binding failure conditions": {
+					input: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems"),
+					},
+				},
+				// spec.Devices[%d].Taints[%d].Effect
+				"valid: taint NoSchedule": {
+					input: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoSchedule))),
+				},
+				"valid: taint NoExecute": {
+					input: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoExecute))),
+				},
+				"invalid: taint Invalid": {
+					input: mkResourceSlice(tweakDeviceTaintEffect("Invalid")),
+					expectedErrs: field.ErrorList{
+						field.NotSupported(
+							field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"),
+							resource.DeviceTaintEffect("Invalid"), []string{}),
+					},
+				},
+				"invalid: taint empty": {
+					input: mkResourceSlice(tweakDeviceTaintEffect("")),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), ""),
+					},
+				},
+				// TODO: Add more test cases
+			}
+
+			for k, tc := range testCases {
+				t.Run(k, func(t *testing.T) {
+					apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy.Validate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
+				})
+			}
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:   "resource.k8s.io",
+				APIVersion: apiVersion,
+				Resource:   "ResourceSlice",
+			})
+
+			strategy := Strategy
+
+			testCases := map[string]struct {
+				old          resource.ResourceSlice
+				update       resource.ResourceSlice
+				expectedErrs field.ErrorList
+			}{
+				"valid no changes": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(),
+				},
+				// spec.devices[%d].bindingConditions
+				"valid update: at limit binding conditions": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize)),
+				},
+				"invalid update:update with too many binding conditions": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakBindingConditions(resource.BindingConditionsMaxSize + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingConditions"), resource.BindingConditionsMaxSize+1, resource.BindingConditionsMaxSize).WithOrigin("maxItems"),
+					},
+				},
+				// spec.devices[%d].bindingFailureConditions
+				"valid update: at limit binding failure conditions": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize)),
+				},
+				"update with too many binding failure conditions": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakBindingFailureConditions(resource.BindingFailureConditionsMaxSize + 1)),
+					expectedErrs: field.ErrorList{
+						field.TooMany(field.NewPath("spec", "devices").Index(0).Child("bindingFailureConditions"), resource.BindingFailureConditionsMaxSize+1, resource.BindingFailureConditionsMaxSize).WithOrigin("maxItems"),
+					},
+				},
+				// spec.devices.taints.effect
+				"valid update: NoSchedule taint effect": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoSchedule))),
+				},
+				"valid update: NoExecute taint effect": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakDeviceTaintEffect(string(resource.DeviceTaintEffectNoExecute))),
+				},
+				"invalid update: unsupported taint effect": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakDeviceTaintEffect("InvalidEffect")),
+					expectedErrs: field.ErrorList{
+						field.NotSupported(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), "InvalidEffect", []string{string(resource.DeviceTaintEffectNoSchedule), string(resource.DeviceTaintEffectNoExecute)}),
+					},
+				},
+				"invalid update: empty taint effect": {
+					old:    mkResourceSlice(),
+					update: mkResourceSlice(tweakDeviceTaintEffect("")),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("taints").Index(0).Child("effect"), ""),
+					},
+				},
+			}
+			for k, tc := range testCases {
+				t.Run(k, func(t *testing.T) {
+					tc.old.ResourceVersion = "1"
+					tc.update.ResourceVersion = "1"
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
+				})
+			}
+		})
+	}
+}
+
+func mkResourceSlice(mutators ...func(*resource.ResourceSlice)) resource.ResourceSlice {
+	rs := resource.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-slice",
+		},
+		Spec: resource.ResourceSliceSpec{
+			Driver:   "test.driver.io",
+			NodeName: ptr.To("test-node"),
+			Pool: resource.ResourcePool{
+				Name:               "test-pool",
+				ResourceSliceCount: 5,
+			},
+			Devices: []resource.Device{
+				{
+					Name: "device-1",
+					Taints: []resource.DeviceTaint{
+						{
+							Key:    "key1",
+							Value:  "value1",
+							Effect: resource.DeviceTaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, mutate := range mutators {
+		mutate(&rs)
+	}
+	return rs
+}
+
+func tweakBindingFailureConditions(count int) func(*resource.ResourceSlice) {
+	return func(rs *resource.ResourceSlice) {
+		if rs.Spec.Devices[0].BindingConditions == nil {
+			rs.Spec.Devices[0].BindingConditions = []string{"conditions"}
+		}
+		rs.Spec.Devices[0].BindingFailureConditions = []string{}
+		for i := 0; i < count; i++ {
+			rs.Spec.Devices[0].BindingFailureConditions = append(rs.Spec.Devices[0].BindingFailureConditions, fmt.Sprintf("failure-condition-%d", i))
+		}
+	}
+}
+
+func tweakBindingConditions(count int) func(*resource.ResourceSlice) {
+	return func(rs *resource.ResourceSlice) {
+		if rs.Spec.Devices[0].BindingFailureConditions == nil {
+			rs.Spec.Devices[0].BindingFailureConditions = []string{"failure-conditions"}
+		}
+		rs.Spec.Devices[0].BindingConditions = []string{}
+		for i := 0; i < count; i++ {
+			rs.Spec.Devices[0].BindingConditions = append(rs.Spec.Devices[0].BindingConditions, fmt.Sprintf("condition-%d", i))
+		}
+	}
+}
+
+func tweakDeviceTaintEffect(effect string) func(*resource.ResourceSlice) {
+	return func(rs *resource.ResourceSlice) {
+		rs.Spec.Devices[0].Taints[0].Effect = resource.DeviceTaintEffect(effect)
+	}
+}

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -429,6 +429,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
+  // +k8s:maxItems=4
   repeated string bindingConditions = 10;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -445,6 +447,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
+  // +k8s:maxItems=4
   repeated string bindingFailureConditions = 11;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -901,6 +905,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
   // +k8s:maxItems=4
   repeated string bindingConditions = 7;
 
@@ -913,6 +918,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
   // +k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
@@ -1088,6 +1094,7 @@ message DeviceTaint {
   // nodes is not valid here.
   //
   // +required
+  // +k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
@@ -1620,6 +1627,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Device devices = 6;
 
   // PerDeviceNodeSelection defines whether the access from nodes to

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -153,6 +153,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Devices []Device `json:"devices" protobuf:"bytes,6,name=devices"`
 
 	// PerDeviceNodeSelection defines whether the access from nodes to
@@ -367,6 +368,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
+	// +k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,10,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -383,6 +386,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
+	// +k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,11,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -629,6 +634,7 @@ type DeviceTaint struct {
 	// nodes is not valid here.
 	//
 	// +required
+	// +k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -1596,6 +1602,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
 	// +k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
@@ -1608,6 +1615,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
 	// +k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -221,6 +221,8 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
+  // +k8s:maxItems=4
   repeated string bindingConditions = 9;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -237,6 +239,8 @@ message BasicDevice {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
+  // +k8s:maxItems=4
   repeated string bindingFailureConditions = 10;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -1024,6 +1028,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
   // +k8s:maxItems=4
   repeated string bindingConditions = 7;
 
@@ -1036,6 +1041,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
   // +k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
@@ -1212,6 +1218,7 @@ message DeviceTaint {
   // nodes is not valid here.
   //
   // +required
+  // +k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
@@ -1634,6 +1641,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Device devices = 6;
 
   // PerDeviceNodeSelection defines whether the access from nodes to

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -153,6 +153,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Devices []Device `json:"devices" protobuf:"bytes,6,name=devices"`
 
 	// PerDeviceNodeSelection defines whether the access from nodes to
@@ -379,6 +380,8 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
+	// +k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,9,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -395,6 +398,8 @@ type BasicDevice struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
+	// +k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,10,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -633,6 +638,7 @@ type DeviceTaint struct {
 	// nodes is not valid here.
 	//
 	// +required
+	// +k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -1604,6 +1610,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
 	// +k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
@@ -1616,6 +1623,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
 	// +k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -429,6 +429,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
+  // +k8s:maxItems=4
   repeated string bindingConditions = 10;
 
   // BindingFailureConditions defines the conditions for binding failure.
@@ -445,6 +447,8 @@ message Device {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
+  // +k8s:maxItems=4
   repeated string bindingFailureConditions = 11;
 
   // AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -901,6 +905,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
   // +k8s:maxItems=4
   repeated string bindingConditions = 7;
 
@@ -913,6 +918,7 @@ message DeviceRequestAllocationResult {
   // +optional
   // +listType=atomic
   // +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+  // +k8s:optional
   // +k8s:maxItems=4
   repeated string bindingFailureConditions = 8;
 
@@ -1088,6 +1094,7 @@ message DeviceTaint {
   // nodes is not valid here.
   //
   // +required
+  // +k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
@@ -1620,6 +1627,7 @@ message ResourceSliceSpec {
   //
   // +optional
   // +listType=atomic
+  // +k8s:optional
   repeated Device devices = 6;
 
   // PerDeviceNodeSelection defines whether the access from nodes to

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -153,6 +153,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +k8s:optional
 	Devices []Device `json:"devices" protobuf:"bytes,6,name=devices"`
 
 	// PerDeviceNodeSelection defines whether the access from nodes to
@@ -367,6 +368,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
+	// +k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,10,rep,name=bindingConditions"`
 
 	// BindingFailureConditions defines the conditions for binding failure.
@@ -383,6 +386,8 @@ type Device struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
+	// +k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,11,rep,name=bindingFailureConditions"`
 
 	// AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.
@@ -629,6 +634,7 @@ type DeviceTaint struct {
 	// nodes is not valid here.
 	//
 	// +required
+	// +k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -1596,6 +1602,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
 	// +k8s:maxItems=4
 	BindingConditions []string `json:"bindingConditions,omitempty" protobuf:"bytes,7,rep,name=bindingConditions"`
 
@@ -1608,6 +1615,7 @@ type DeviceRequestAllocationResult struct {
 	// +optional
 	// +listType=atomic
 	// +featureGate=DRADeviceBindingConditions,DRAResourceClaimDeviceStatus
+	// +k8s:optional
 	// +k8s:maxItems=4
 	BindingFailureConditions []string `json:"bindingFailureConditions,omitempty" protobuf:"bytes,8,rep,name=bindingFailureConditions"`
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR enables declarative validation for the `resource.k8s.io/v1`, `resource.k8s.io/v1beta1`, and `resource.k8s.io/v1beta2` `ResourceSlice` APIs. This is part of the ongoing effort for [KEP-5073](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen) to convert Kubernetes native types to use declarative validation.

The main changes are:
- The `ResourceSlice` strategy is updated to use `rest.ValidateDeclarativelyWithMigrationChecks` for create and update operations.
- Declarative validation tags (`+k8s:maxItems=4`) have been added to the `BindingConditions` and `BindingFailureConditions` fields in the `Device` struct for all API versions.
- A new declarative validation test file is added for `ResourceSlice` to verify the new validations.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This change enables declarative validation for the `ResourceSlice` API as part of the KEP-5073 effort. The implementation is straightforward, replacing the existing validation calls with declarative validation checks in the `strategy.go` file and adding a new test file to cover the declarative validation rules.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- [KEP-5073]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen
