### PR TITLE
Promote KUBECTL_COMMAND_HEADERS to stable

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -526,17 +526,10 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 //     RoundTripper. CommandHeaderRoundTripper adds X-Headers then delegates
 //     to standard RoundTripper.
 //
-// For beta, these hooks are updated unless the KUBECTL_COMMAND_HEADERS environment variable
-// is set, and the value of the env var is false (or zero).
 // See SIG CLI KEP 859 for more information:
 //
 //	https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/859-kubectl-headers
 func addCmdHeaderHooks(cmds *cobra.Command, kubeConfigFlags *genericclioptions.ConfigFlags) {
-	if cmdutil.CmdHeaders.IsDisabled() {
-		klog.V(5).Infoln("kubectl command headers turned off")
-		return
-	}
-	klog.V(5).Infoln("kubectl command headers turned on")
 	crt := &genericclioptions.CommandHeaderRoundTripper{}
 	existingPreRunE := cmds.PersistentPreRunE
 	// Add command parsing to the existing persistent pre-run function.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -26,10 +26,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd/plugin"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 func TestNormalizationFuncGlobalExistence(t *testing.T) {
@@ -359,47 +357,4 @@ func (h *testPluginHandler) Execute(executablePath string, cmdArgs, env []string
 	h.withArgs = cmdArgs
 	h.withEnv = env
 	return nil
-}
-
-func TestKubectlCommandHeadersHooks(t *testing.T) {
-	tests := map[string]struct {
-		envVar    string
-		addsHooks bool
-	}{
-		"empty environment variable; hooks added": {
-			envVar:    "",
-			addsHooks: true,
-		},
-		"random env var value; hooks added": {
-			envVar:    "foo",
-			addsHooks: true,
-		},
-		"true env var value; hooks added": {
-			envVar:    "true",
-			addsHooks: true,
-		},
-		"false env var value; hooks NOT added": {
-			envVar:    "false",
-			addsHooks: false,
-		},
-	}
-
-	for name, testCase := range tests {
-		t.Run(name, func(t *testing.T) {
-			cmds := &cobra.Command{}
-			kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
-			if kubeConfigFlags.WrapConfigFn != nil {
-				t.Fatal("expected initial nil WrapConfigFn")
-			}
-			t.Setenv(string(cmdutil.CmdHeaders), testCase.envVar)
-			addCmdHeaderHooks(cmds, kubeConfigFlags)
-			// Valdidate whether the hooks were added.
-			if testCase.addsHooks && kubeConfigFlags.WrapConfigFn == nil {
-				t.Error("after adding kubectl command header, expecting non-nil WrapConfigFn")
-			}
-			if !testCase.addsHooks && kubeConfigFlags.WrapConfigFn != nil {
-				t.Error("env var feature gate should have blocked setting WrapConfigFn")
-			}
-		})
-	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -425,12 +425,6 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 type FeatureGate string
 
 const (
-	// owner: @soltysh
-	// kep: https://kep.k8s.io/859
-	//
-	// HTTP headers with command name and flags used.
-	CmdHeaders FeatureGate = "KUBECTL_COMMAND_HEADERS"
-
 	// owner: @ardaguclu
 	// kep: https://kep.k8s.io/3104
 	//

--- a/test/cmd/results.sh
+++ b/test/cmd/results.sh
@@ -53,11 +53,6 @@ Error from server (NotFound): pods "no-such-pod" not found
 EOF
   kube::test::results::diff "${TEMP}/actual_stdout" "${TEMP}/actual_stderr" "$res" "${TEMP}/empty" "${TEMP}/expected_stderr" 1 "kubectl get pod/no-such-pod"
 
-  output_message=$(kubectl get namespace kube-system 2>&1 "${kube_flags[@]:?}")
-  kube::test::if_has_not_string "${output_message}" "command headers turned on"
-  output_message=$(kubectl get namespace kube-system 2>&1 "${kube_flags[@]:?}" -v=5)
-  kube::test::if_has_string "${output_message}" "command headers turned on"
-
   set +o nounset
   set +o errexit
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature
/sig cli

#### What this PR does / why we need it:
This promotes [KEP 859](https://github.com/kubernetes/enhancements/issues/859) functionality to stable

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/859

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
Promote kubectl command headers to stable
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/859
```
