### PR TITLE
pkg/controller: Use informer.RunWithContext in tests

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -6667,7 +6667,7 @@ func TestWatchPods(t *testing.T) {
 	}
 	// Start only the pod watcher and the workqueue, send a watch event,
 	// and make sure it hits the sync method for the right job.
-	go sharedInformerFactory.Core().V1().Pods().Informer().Run(ctx.Done())
+	go sharedInformerFactory.Core().V1().Pods().Informer().RunWithContext(ctx)
 	go manager.Run(ctx, 1)
 
 	pods := newPodList(1, v1.PodRunning, testJob)
@@ -6693,7 +6693,7 @@ func TestWatchOrphanPods(t *testing.T) {
 	manager.jobStoreSynced = alwaysReady
 
 	podInformer := sharedInformers.Core().V1().Pods().Informer()
-	go podInformer.Run(ctx.Done())
+	go podInformer.RunWithContext(ctx)
 	cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced)
 	go manager.Run(ctx, 1)
 
@@ -6764,7 +6764,7 @@ func TestSyncOrphanPod(t *testing.T) {
 	manager.jobStoreSynced = alwaysReady
 
 	podInformer := sharedInformers.Core().V1().Pods().Informer()
-	go podInformer.Run(ctx.Done())
+	go podInformer.RunWithContext(ctx)
 	cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced)
 	go manager.Run(ctx, 1)
 
@@ -7717,7 +7717,7 @@ func TestFinalizersRemovedExpectations(t *testing.T) {
 		t.Errorf("Different expectations for removed finalizers after syncJob (-want,+got):\n%s", diff)
 	}
 
-	go sharedInformers.Core().V1().Pods().Informer().Run(ctx.Done())
+	go sharedInformers.Core().V1().Pods().Informer().RunWithContext(ctx)
 	cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced)
 
 	// Make sure the first syncJob sets the expectations, even after the caches synced.

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -710,7 +710,7 @@ func TestWatchPods(t *testing.T) {
 
 	// Start only the pod watcher and the workqueue, send a watch event,
 	// and make sure it hits the sync method for the right ReplicaSet.
-	go informers.Core().V1().Pods().Informer().Run(stopCh)
+	go informers.Core().V1().Pods().Informer().RunWithContext(ctx)
 	go manager.Run(ctx, 1)
 
 	pods := newPodList(nil, 1, v1.PodRunning, labelMap, testRSSpec, "pod")


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
pkg/controller: Use informer.RunWithContext in tests

This change updates the job and replicaset controller tests to use the new context-aware `informer.RunWithContext` function instead of the legacy `Run` method.

This is part of the broader effort to enable contextual logging across all Kubernetes components, as tracked in #126379.

**Which issue(s) this PR fixes**:
Contributes to #126379

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```