### PR TITLE
apimachinery: Use informer.RunWithContext in various components

### DIFF
--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
@@ -285,7 +285,7 @@ func (p *ClusterTrustBundlePublisher[T]) Run(ctx context.Context) {
 	}()
 
 	wg.Go(func() {
-		p.ctbInformer.Run(ctx.Done())
+		p.ctbInformer.RunWithContext(ctx)
 	})
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, p.ctbListerSynced) {

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
@@ -274,7 +274,7 @@ func TestCTBPublisherSync(t *testing.T) {
 				t.Fatalf("failed to assert the controller for the beta API")
 			}
 
-			go controller.ctbInformer.Run(testCtx.Done())
+			go controller.ctbInformer.RunWithContext(testCtx)
 			if !cache.WaitForCacheSync(testCtx.Done(), controller.ctbInformer.HasSynced) {
 				t.Fatal("timed out waiting for informer to sync")
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
apimachinery: Use informer.RunWithContext in various components

This change updates several components owned by SIG API Machinery to use the new context-aware `informer.RunWithContext` function instead of the legacy `Run` method.

The following components are updated:
- The ClusterTrustBundle publisher controller and its test.
- The client-go metadata informer.
This is part of the broader effort to enable contextual logging across all Kubernetes components, as tracked in #126379.

**Which issue(s) this PR fixes**:
Contributes to #126379

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```