### PR TITLE
Avoid no-change lambdas

### DIFF
--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -402,7 +402,6 @@ linters:
         - sloppyLen
         - typeSwitchVar
         - underef
-        - unlambda
         - unslice
         - valSwap
     revive:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -249,7 +249,6 @@ linters:
         - sloppyLen
         - typeSwitchVar
         - underef
-        - unlambda
         - unslice
         - valSwap
     {{- end}}

--- a/pkg/controller/deployment/progress.go
+++ b/pkg/controller/deployment/progress.go
@@ -152,7 +152,7 @@ func (dc *DeploymentController) getReplicaFailures(allRSs []*apps.ReplicaSet, ne
 }
 
 // used for unit testing
-var nowFn = func() time.Time { return time.Now() }
+var nowFn = time.Now
 
 // requeueStuckDeployment checks whether the provided deployment needs to be synced for a progress
 // check. It returns the time after the deployment will be requeued for the progress check, 0 if it

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -766,7 +766,7 @@ func DeploymentProgressing(deployment *apps.Deployment, newStatus *apps.Deployme
 }
 
 // used for unit testing
-var nowFn = func() time.Time { return time.Now() }
+var nowFn = time.Now
 
 // DeploymentTimedOut considers a deployment to have timed out once its condition that reports progress
 // is older than progressDeadlineSeconds or a Progressing condition with a TimedOutReason reason already

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -415,9 +415,7 @@ func toKubeContainerResources(statusResources *runtimeapi.ContainerResources) *k
 // Note: this function variable is being added here so it would be possible to mock
 // the cgroup version for unit tests by assigning a new mocked function into it. Without it,
 // the cgroup version would solely depend on the environment running the test.
-var isCgroup2UnifiedMode = func() bool {
-	return libcontainercgroups.IsCgroup2UnifiedMode()
-}
+var isCgroup2UnifiedMode = libcontainercgroups.IsCgroup2UnifiedMode
 
 // checkSwapControllerAvailability checks if swap controller is available.
 // It returns true if the swap controller is available, false otherwise.

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/definitions.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/definitions.go
@@ -40,9 +40,7 @@ type DefinitionsSchemaResolver struct {
 func NewDefinitionsSchemaResolver(getDefinitions common.GetOpenAPIDefinitions, schemes ...*runtime.Scheme) *DefinitionsSchemaResolver {
 	gvkToRef := make(map[schema.GroupVersionKind]string)
 	namer := openapi.NewDefinitionNamer(schemes...)
-	defs := getDefinitions(func(path string) spec.Ref {
-		return spec.MustCreateRef(path)
-	})
+	defs := getDefinitions(spec.MustCreateRef)
 	for name := range defs {
 		_, e := namer.GetDefinitionName(name)
 		gvks := extensionsToGVKs(e)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
@@ -24,7 +24,7 @@ import (
 )
 
 // metav1Now returns metav1.Now(), but allows override for unit testing
-var metav1Now = func() metav1.Time { return metav1.Now() }
+var metav1Now = metav1.Now
 
 // WipeObjectMetaSystemFields erases fields that are managed by the system on ObjectMeta.
 func WipeObjectMetaSystemFields(meta metav1.Object) {

--- a/staging/src/k8s.io/component-base/logs/logreduction/logreduction.go
+++ b/staging/src/k8s.io/component-base/logs/logreduction/logreduction.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-var nowfunc = func() time.Time { return time.Now() }
+var nowfunc = time.Now
 
 // LogReduction provides a filter for consecutive identical log messages;
 // a message will be printed no more than once per interval.

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/funcs.go
@@ -64,9 +64,7 @@ func WithBuiltinTemplateFuncs(tmpl *template.Template) *template.Template {
 			}
 			return buf.String(), nil
 		},
-		"split": func(s string, sep string) []string {
-			return strings.Split(s, sep)
-		},
+		"split": strings.Split,
 		"join": func(sep string, strs ...string) string {
 			return strings.Join(strs, sep)
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces functions that wrap another function with no change with a direct reference to the wrapped function, and enables the corresponding gocritic linter to enforce this.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
