### PR TITLE
[InPlacePodVerticalScaling] emit more events when the pod resize status changes

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -46,26 +46,27 @@ type FakePod struct {
 // FakeRuntime is a fake container runtime for testing.
 type FakeRuntime struct {
 	sync.Mutex
-	CalledFunctions   []string
-	PodList           []*FakePod
-	AllPodList        []*FakePod
-	ImageList         []kubecontainer.Image
-	ImageFsStats      []*runtimeapi.FilesystemUsage
-	ContainerFsStats  []*runtimeapi.FilesystemUsage
-	APIPodStatus      v1.PodStatus
-	PodStatus         kubecontainer.PodStatus
-	StartedPods       []string
-	KilledPods        []string
-	StartedContainers []string
-	KilledContainers  []string
-	RuntimeStatus     *kubecontainer.RuntimeStatus
-	VersionInfo       string
-	APIVersionInfo    string
-	RuntimeType       string
-	SyncResults       *kubecontainer.PodSyncResult
-	Err               error
-	InspectErr        error
-	StatusErr         error
+	CalledFunctions     []string
+	PodList             []*FakePod
+	AllPodList          []*FakePod
+	ImageList           []kubecontainer.Image
+	ImageFsStats        []*runtimeapi.FilesystemUsage
+	ContainerFsStats    []*runtimeapi.FilesystemUsage
+	APIPodStatus        v1.PodStatus
+	PodStatus           kubecontainer.PodStatus
+	StartedPods         []string
+	KilledPods          []string
+	StartedContainers   []string
+	KilledContainers    []string
+	RuntimeStatus       *kubecontainer.RuntimeStatus
+	VersionInfo         string
+	APIVersionInfo      string
+	RuntimeType         string
+	PodResizeInProgress bool
+	SyncResults         *kubecontainer.PodSyncResult
+	Err                 error
+	InspectErr          error
+	StatusErr           error
 	// If BlockImagePulls is true, then all PullImage() calls will be blocked until
 	// UnblockImagePulls() is called. This is used to simulate image pull latency
 	// from container runtime.
@@ -570,5 +571,5 @@ func (f *FakeRuntime) GetContainerSwapBehavior(pod *v1.Pod, container *v1.Contai
 }
 
 func (f *FakeRuntime) IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kubecontainer.PodStatus) bool {
-	return false
+	return f.PodResizeInProgress
 }

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -37,6 +37,8 @@ const (
 	ResizeDeferred                 = "ResizeDeferred"
 	ResizeInfeasible               = "ResizeInfeasible"
 	ResizeCompleted                = "ResizeCompleted"
+	ResizeStarted                  = "ResizeStarted"
+	ResizeError                    = "ResizeError"
 )
 
 // Image event reason list

--- a/pkg/kubelet/events/resize_test.go
+++ b/pkg/kubelet/events/resize_test.go
@@ -28,78 +28,38 @@ import (
 )
 
 func TestPodResizeCompletedMsg(t *testing.T) {
-	type testResources struct {
-		cpuReq, cpuLim, memReq, memLim int64
-	}
-	type testContainer struct {
-		allocated               testResources
-		nonSidecarInit, sidecar bool
-		isRunning               bool
-	}
-
 	tests := []struct {
-		name                        string
-		containers                  []testContainer
-		expectPodResizeCompletedMsg string
+		name               string
+		containers         []testContainer
+		observedGeneration int64
+		expected           string
 	}{{
 		name: "simple running container",
 		containers: []testContainer{{
-			allocated: testResources{100, 100, 100, 100},
-			isRunning: true,
+			resources: testResources{100, 100, 100, 100},
 		}},
-		expectPodResizeCompletedMsg: `Pod resize completed: {"containers":[{"name":"c0","resources":{"limits":{"cpu":"100m","memory":"100"},"requests":{"cpu":"100m","memory":"100"}}}]}`,
+		observedGeneration: 1,
+		expected:           `Pod resize completed: {"containers":[{"name":"c0","resources":{"limits":{"cpu":"100m","memory":"100"},"requests":{"cpu":"100m","memory":"100"}}}],"generation":1}`,
 	}, {
 		name: "several containers",
 		containers: []testContainer{{
-			allocated: testResources{cpuReq: 100, cpuLim: 200},
+			resources: testResources{cpuReq: 100, cpuLim: 200},
 			sidecar:   true,
-			isRunning: true,
 		}, {
-			allocated: testResources{memReq: 100, memLim: 200},
-			isRunning: true,
+			resources: testResources{memReq: 100, memLim: 200},
 		}, {
-			allocated: testResources{cpuReq: 200, memReq: 100},
-			isRunning: true,
+			resources: testResources{cpuReq: 200, memReq: 100},
 		}},
-		expectPodResizeCompletedMsg: `Pod resize completed: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}]}`,
+		observedGeneration: 2,
+		expected:           `Pod resize completed: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}],"generation":2}`,
 	}, {
 		name: "best-effort pod",
 		containers: []testContainer{{
-			allocated: testResources{},
-			isRunning: true,
+			resources: testResources{},
 		}},
-		expectPodResizeCompletedMsg: `Pod resize completed: {"containers":[{"name":"c0","resources":{}}]}`,
+		observedGeneration: 3,
+		expected:           `Pod resize completed: {"containers":[{"name":"c0","resources":{}}],"generation":3}`,
 	}}
-
-	mkRequirements := func(r testResources) v1.ResourceRequirements {
-		res := v1.ResourceRequirements{
-			Requests: v1.ResourceList{},
-			Limits:   v1.ResourceList{},
-		}
-		if r.cpuReq != 0 {
-			res.Requests[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuReq, resource.DecimalSI)
-		}
-		if r.cpuLim != 0 {
-			res.Limits[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuLim, resource.DecimalSI)
-		}
-		if r.memReq != 0 {
-			res.Requests[v1.ResourceMemory] = *resource.NewQuantity(r.memReq, resource.DecimalSI)
-		}
-		if r.memLim != 0 {
-			res.Limits[v1.ResourceMemory] = *resource.NewQuantity(r.memLim, resource.DecimalSI)
-		}
-		return res
-	}
-	mkContainer := func(index int, c testContainer) v1.Container {
-		container := v1.Container{
-			Name:      fmt.Sprintf("c%d", index),
-			Resources: mkRequirements(c.allocated),
-		}
-		if c.sidecar {
-			container.RestartPolicy = ptr.To(v1.ContainerRestartPolicyAlways)
-		}
-		return container
-	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -112,7 +72,7 @@ func TestPodResizeCompletedMsg(t *testing.T) {
 
 			for i, c := range test.containers {
 				// Add the container to the pod
-				container := mkContainer(i, c)
+				container := mkContainer(i, c.resources, c.sidecar)
 				if c.nonSidecarInit || c.sidecar {
 					pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
 				} else {
@@ -120,9 +80,266 @@ func TestPodResizeCompletedMsg(t *testing.T) {
 				}
 			}
 
-			// Verify pod resize completed event is emitted
-			msg := PodResizeCompletedMsg(pod)
-			assert.Equal(t, test.expectPodResizeCompletedMsg, msg)
+			msg := PodResizeCompletedMsg(pod, test.observedGeneration)
+			assert.Equal(t, test.expected, msg)
 		})
 	}
+}
+
+func TestPodResizeStartedMsg(t *testing.T) {
+	tests := []struct {
+		name               string
+		allocated          []testContainer
+		actual             []testContainer
+		observedGeneration int64
+		expected           string
+	}{
+		{
+			name:               "simple running container",
+			allocated:          []testContainer{{resources: testResources{100, 100, 100, 100}}},
+			actual:             []testContainer{{resources: testResources{50, 50, 50, 50}}},
+			observedGeneration: 1,
+			expected:           `Pod resize started: {"containers":[{"name":"c0","resources":{"limits":{"cpu":"100m","memory":"100"},"requests":{"cpu":"100m","memory":"100"}}}],"generation":1}`,
+		}, {
+			name: "several containers",
+			allocated: []testContainer{
+				{resources: testResources{cpuReq: 100, cpuLim: 200}, sidecar: true},
+				{resources: testResources{memReq: 100, memLim: 200}},
+				{resources: testResources{cpuReq: 200, memReq: 100}},
+			},
+			actual: []testContainer{
+				{resources: testResources{cpuReq: 50, cpuLim: 100}, sidecar: true},
+				{resources: testResources{cpuReq: 50, cpuLim: 100}},
+				{resources: testResources{cpuReq: 50, cpuLim: 100}},
+			},
+			observedGeneration: 2,
+			expected:           `Pod resize started: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}],"generation":2}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			allocatedPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					UID:  "12345",
+				},
+			}
+
+			for i, c := range test.actual {
+				actual := mkContainer(i, c.resources, c.sidecar)
+				if c.nonSidecarInit || c.sidecar {
+					allocatedPod.Status.InitContainerStatuses = append(allocatedPod.Status.InitContainerStatuses, v1.ContainerStatus{
+						Name:      actual.Name,
+						Resources: &actual.Resources,
+					})
+				} else {
+					allocatedPod.Status.ContainerStatuses = append(allocatedPod.Status.ContainerStatuses, v1.ContainerStatus{
+						Name:      actual.Name,
+						Resources: &actual.Resources,
+					})
+				}
+			}
+
+			for i, c := range test.allocated {
+				allocated := mkContainer(i, c.resources, c.sidecar)
+				if c.nonSidecarInit || c.sidecar {
+					allocatedPod.Spec.InitContainers = append(allocatedPod.Spec.InitContainers, allocated)
+				} else {
+					allocatedPod.Spec.Containers = append(allocatedPod.Spec.Containers, allocated)
+				}
+			}
+
+			msg := PodResizeStartedMsg(allocatedPod, test.observedGeneration)
+			assert.Equal(t, test.expected, msg)
+		})
+	}
+}
+
+func TestPodResizeErrorMsg(t *testing.T) {
+	tests := []struct {
+		name               string
+		allocated          []testContainer
+		actual             []testContainer
+		observedGeneration int64
+		errMsg             string
+		expected           string
+	}{
+		{
+			name:               "simple running container",
+			allocated:          []testContainer{{resources: testResources{100, 100, 100, 100}}},
+			actual:             []testContainer{{resources: testResources{50, 50, 50, 50}}},
+			observedGeneration: 1,
+			errMsg:             "some error occurred",
+			expected:           `Pod resize error: {"containers":[{"name":"c0","resources":{"limits":{"cpu":"100m","memory":"100"},"requests":{"cpu":"100m","memory":"100"}}}],"generation":1,"error":"some error occurred"}`,
+		}, {
+			name: "several containers",
+			allocated: []testContainer{
+				{resources: testResources{cpuReq: 100, cpuLim: 200}, sidecar: true},
+				{resources: testResources{memReq: 100, memLim: 200}},
+				{resources: testResources{cpuReq: 200, memReq: 100}},
+			},
+			actual: []testContainer{
+				{resources: testResources{cpuReq: 50, cpuLim: 100}, sidecar: true},
+				{resources: testResources{cpuReq: 50, cpuLim: 100}},
+				{resources: testResources{cpuReq: 50, cpuLim: 100}},
+			},
+			observedGeneration: 2,
+			errMsg:             "some error occurred",
+			expected:           `Pod resize error: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}],"generation":2,"error":"some error occurred"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			allocatedPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					UID:  "12345",
+				},
+			}
+
+			for i, c := range test.actual {
+				actual := mkContainer(i, c.resources, c.sidecar)
+				if c.nonSidecarInit || c.sidecar {
+					allocatedPod.Status.InitContainerStatuses = append(allocatedPod.Status.InitContainerStatuses, v1.ContainerStatus{
+						Name:      actual.Name,
+						Resources: &actual.Resources,
+					})
+				} else {
+					allocatedPod.Status.ContainerStatuses = append(allocatedPod.Status.ContainerStatuses, v1.ContainerStatus{
+						Name:      actual.Name,
+						Resources: &actual.Resources,
+					})
+				}
+			}
+
+			for i, c := range test.allocated {
+				allocated := mkContainer(i, c.resources, c.sidecar)
+				if c.nonSidecarInit || c.sidecar {
+					allocatedPod.Spec.InitContainers = append(allocatedPod.Spec.InitContainers, allocated)
+				} else {
+					allocatedPod.Spec.Containers = append(allocatedPod.Spec.Containers, allocated)
+				}
+			}
+
+			msg := PodResizeErrorMsg(allocatedPod, test.observedGeneration, test.errMsg)
+			assert.Equal(t, test.expected, msg)
+		})
+	}
+}
+
+func TestPodResizePendingMsg(t *testing.T) {
+	tests := []struct {
+		name               string
+		desired            []testContainer
+		allocated          []testContainer
+		reason             string
+		message            string
+		observedGeneration int64
+		expected           string
+	}{
+		{
+			name:               "simple running container",
+			desired:            []testContainer{{resources: testResources{100, 100, 100, 100}}},
+			allocated:          []testContainer{{resources: testResources{50, 50, 50, 50}}},
+			observedGeneration: 1,
+			reason:             "Deferred",
+			message:            "Node didn't have enough resource: memory",
+			expected:           `Pod resize Deferred: {"containers":[{"name":"c0","resources":{"limits":{"cpu":"100m","memory":"100"},"requests":{"cpu":"100m","memory":"100"}}}],"generation":1,"error":"Node didn't have enough resource: memory"}`,
+		}, {
+			name: "several containers",
+			desired: []testContainer{
+				{resources: testResources{cpuReq: 100, cpuLim: 200}, sidecar: true},
+				{resources: testResources{memReq: 100, memLim: 200}},
+				{resources: testResources{cpuReq: 200, memReq: 100}},
+			},
+			allocated: []testContainer{
+				{resources: testResources{cpuReq: 50, cpuLim: 100}, sidecar: true},
+				{resources: testResources{cpuReq: 50, cpuLim: 100}},
+				{resources: testResources{cpuReq: 50, cpuLim: 100}},
+			},
+			observedGeneration: 2,
+			reason:             "Infeasible",
+			message:            "In-place resize of containers with swap is not supported",
+			expected:           `Pod resize Infeasible: {"initContainers":[{"name":"c0","resources":{"limits":{"cpu":"200m"},"requests":{"cpu":"100m"}}}],"containers":[{"name":"c1","resources":{"limits":{"memory":"200"},"requests":{"memory":"100"}}},{"name":"c2","resources":{"requests":{"cpu":"200m","memory":"100"}}}],"generation":2,"error":"In-place resize of containers with swap is not supported"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			allocatedPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					UID:  "12345",
+				},
+			}
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					UID:  "12345",
+				},
+			}
+
+			for i, c := range test.allocated {
+				allocated := mkContainer(i, c.resources, c.sidecar)
+				if c.nonSidecarInit || c.sidecar {
+					allocatedPod.Spec.InitContainers = append(allocatedPod.Spec.InitContainers, allocated)
+				} else {
+					allocatedPod.Spec.Containers = append(allocatedPod.Spec.Containers, allocated)
+				}
+			}
+
+			for i, c := range test.desired {
+				desired := mkContainer(i, c.resources, c.sidecar)
+				if c.nonSidecarInit || c.sidecar {
+					pod.Spec.InitContainers = append(pod.Spec.InitContainers, desired)
+				} else {
+					pod.Spec.Containers = append(pod.Spec.Containers, desired)
+				}
+			}
+
+			msg := PodResizePendingMsg(pod, test.reason, test.message, test.observedGeneration)
+			assert.Equal(t, test.expected, msg)
+		})
+	}
+}
+
+type testResources struct {
+	cpuReq, cpuLim, memReq, memLim int64
+}
+type testContainer struct {
+	resources               testResources
+	nonSidecarInit, sidecar bool
+}
+
+func mkRequirements(r testResources) v1.ResourceRequirements {
+	res := v1.ResourceRequirements{
+		Requests: v1.ResourceList{},
+		Limits:   v1.ResourceList{},
+	}
+	if r.cpuReq != 0 {
+		res.Requests[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuReq, resource.DecimalSI)
+	}
+	if r.cpuLim != 0 {
+		res.Limits[v1.ResourceCPU] = *resource.NewMilliQuantity(r.cpuLim, resource.DecimalSI)
+	}
+	if r.memReq != 0 {
+		res.Requests[v1.ResourceMemory] = *resource.NewQuantity(r.memReq, resource.DecimalSI)
+	}
+	if r.memLim != 0 {
+		res.Limits[v1.ResourceMemory] = *resource.NewQuantity(r.memLim, resource.DecimalSI)
+	}
+	return res
+}
+
+func mkContainer(index int, resources testResources, sidecar bool) v1.Container {
+	container := v1.Container{
+		Name:      fmt.Sprintf("c%d", index),
+		Resources: mkRequirements(resources),
+	}
+	if sidecar {
+		container.RestartPolicy = ptr.To(v1.ContainerRestartPolicyAlways)
+	}
+	return container
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1947,12 +1947,10 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		// Check whether a resize is in progress so we can set the PodResizeInProgressCondition accordingly.
 		if kl.containerRuntime.IsPodResizeInProgress(pod, podStatus) {
 			kl.statusManager.SetPodResizeInProgressCondition(pod.UID, "", "", pod.Generation)
-		} else if kl.statusManager.ClearPodResizeInProgressCondition(pod.UID) {
+		} else if generation, cleared := kl.statusManager.ClearPodResizeInProgressCondition(pod.UID); cleared {
 			// (Allocated == Actual) => clear the resize in-progress status.
-			if kl.recorder != nil {
-				msg := events.PodResizeCompletedMsg(pod)
-				kl.recorder.Eventf(pod, v1.EventTypeNormal, events.ResizeCompleted, msg)
-			}
+			msg := events.PodResizeCompletedMsg(pod, generation)
+			kl.recorder.Eventf(pod, v1.EventTypeNormal, events.ResizeCompleted, msg)
 		}
 		// TODO(natasha41575): There is a race condition here, where the goroutine in the
 		// allocation manager may allocate a new resize and unconditionally set the
@@ -2114,7 +2112,10 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		for _, r := range result.SyncResults {
 			if r.Action == kubecontainer.ResizePodInPlace && r.Error != nil {
 				// If the condition already exists, the observedGeneration does not get updated.
-				kl.statusManager.SetPodResizeInProgressCondition(pod.UID, v1.PodReasonError, r.Message, pod.Generation)
+				if generation, updated := kl.statusManager.SetPodResizeInProgressCondition(pod.UID, v1.PodReasonError, r.Message, pod.Generation); updated {
+					msg := events.PodResizeErrorMsg(pod, generation, r.Message)
+					kl.recorder.Eventf(pod, v1.EventTypeWarning, events.ResizeError, msg)
+				}
 			}
 		}
 	}

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -455,7 +455,7 @@ func createPodWorkers() (*podWorkers, *containertest.FakeRuntime, map[types.UID]
 		time.Second,
 		time.Millisecond,
 		fakeCache,
-		allocation.NewInMemoryManager(cm.NodeConfig{}, nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(cm.NodeConfig{}, nil, nil, nil, nil, nil, nil, nil),
 	)
 	workers := w.(*podWorkers)
 	workers.clock = clock
@@ -2135,7 +2135,7 @@ func TestFakePodWorkers(t *testing.T) {
 		time.Second,
 		time.Second,
 		fakeCache,
-		allocation.NewInMemoryManager(cm.NodeConfig{}, nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(cm.NodeConfig{}, nil, nil, nil, nil, nil, nil, nil),
 	)
 	fakePodWorkers := &fakePodWorkers{
 		syncPodFn: kubeletForFakeWorkers.SyncPod,

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -20,6 +20,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -156,19 +157,23 @@ type Manager interface {
 	GetPodResizeConditions(podUID types.UID) []*v1.PodCondition
 
 	// SetPodResizePendingCondition caches the last PodResizePending condition for the pod.
-	SetPodResizePendingCondition(podUID types.UID, reason, message string, observedGeneration int64)
+	// It returns true if the condition reason or observedGeneration is modified as a result of this call.
+	SetPodResizePendingCondition(podUID types.UID, reason, message string, observedGeneration int64) bool
 
 	// SetPodResizeInProgressCondition caches the last PodResizeInProgress condition for the pod.
 	// This function does not update observedGeneration if the condition already exists, nor does
 	// it allow the reason or message to be cleared.
-	SetPodResizeInProgressCondition(podUID types.UID, reason, message string, observedGeneration int64)
+	// It returns true if the condition is modified as a result of this call, and it returns
+	// the observedGeneration of the condition.
+	SetPodResizeInProgressCondition(podUID types.UID, reason, message string, observedGeneration int64) (int64, bool)
 
 	// ClearPodResizePendingCondition clears the PodResizePending condition for the pod from the cache.
 	ClearPodResizePendingCondition(podUID types.UID)
 
 	// ClearPodResizeInProgressCondition clears the PodResizeInProgress condition for the pod from the cache.
-	// Returns true if the condition was cleared, false if it was not set.
-	ClearPodResizeInProgressCondition(podUID types.UID) bool
+	// If the condition was cleared, it returns the observedGeneration of the cleared condition and true.
+	// Otherwise it returns zero and false.
+	ClearPodResizeInProgressCondition(podUID types.UID) (int64, bool)
 
 	// IsPodResizeDeferred returns true if the pod resize is currently deferred.
 	IsPodResizeDeferred(podUID types.UID) bool
@@ -269,30 +274,35 @@ func (m *manager) GetPodResizeConditions(podUID types.UID) []*v1.PodCondition {
 }
 
 // SetPodResizePendingCondition caches the last PodResizePending condition for the pod.
-func (m *manager) SetPodResizePendingCondition(podUID types.UID, reason, message string, observedGeneration int64) {
+// It returns true if the condition reason or observedGeneration is modified as a result of this call.
+func (m *manager) SetPodResizePendingCondition(podUID types.UID, reason, message string, observedGeneration int64) bool {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 
-	alreadyPending := m.podResizeConditions[podUID].PodResizePending != nil
+	previousCondition := m.podResizeConditions[podUID].PodResizePending
 
 	m.podResizeConditions[podUID] = podResizeConditions{
 		PodResizePending:    updatedPodResizeCondition(v1.PodResizePending, m.podResizeConditions[podUID].PodResizePending, reason, message, observedGeneration),
 		PodResizeInProgress: m.podResizeConditions[podUID].PodResizeInProgress,
 	}
 
-	if !alreadyPending {
+	if previousCondition == nil {
 		m.recordPendingResizeCount()
+		return true
+	} else {
+		return previousCondition.Reason != reason || previousCondition.ObservedGeneration != observedGeneration
 	}
 }
 
 // This function does not update observedGeneration if the condition already exists, nor does
 // it allow the reason or message to be cleared.
-func (m *manager) SetPodResizeInProgressCondition(podUID types.UID, reason, message string, observedGeneration int64) {
+// It returns true if the condition is modified as a result of this call, and it returns
+// the observedGeneration of the condition.
+func (m *manager) SetPodResizeInProgressCondition(podUID types.UID, reason, message string, observedGeneration int64) (int64, bool) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 
-	alreadyInProgress := m.podResizeConditions[podUID].PodResizeInProgress != nil
-
+	previousCondition := m.podResizeConditions[podUID].PodResizeInProgress
 	if c := m.podResizeConditions[podUID].PodResizeInProgress; c != nil {
 		// Preserve the old reason, message if they exist.
 		if reason == "" && message == "" {
@@ -309,9 +319,15 @@ func (m *manager) SetPodResizeInProgressCondition(podUID types.UID, reason, mess
 		PodResizePending:    m.podResizeConditions[podUID].PodResizePending,
 	}
 
-	if !alreadyInProgress {
+	if previousCondition == nil {
 		m.recordInProgressResizeCount()
+	} else {
+		// Ignore lastProbeTime when comparing conditions.
+		previousCondition.LastProbeTime = m.podResizeConditions[podUID].PodResizeInProgress.LastProbeTime
+		previousCondition.LastTransitionTime = m.podResizeConditions[podUID].PodResizeInProgress.LastTransitionTime
 	}
+
+	return observedGeneration, !reflect.DeepEqual(previousCondition, m.podResizeConditions[podUID].PodResizeInProgress)
 }
 
 // ClearPodResizePendingCondition clears the PodResizePending condition for the pod from the cache.
@@ -332,22 +348,24 @@ func (m *manager) ClearPodResizePendingCondition(podUID types.UID) {
 }
 
 // ClearPodResizeInProgressCondition clears the PodResizeInProgress condition for the pod from the cache.
-// Returns true if the condition was cleared, false if it was not set.
-func (m *manager) ClearPodResizeInProgressCondition(podUID types.UID) bool {
+// If the condition was cleared, it returns the observedGeneration of the cleared condition and true.
+// Otherwise it returns zero and false.
+func (m *manager) ClearPodResizeInProgressCondition(podUID types.UID) (int64, bool) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 
 	if m.podResizeConditions[podUID].PodResizeInProgress == nil {
-		return false
+		return 0, false
 	}
 
+	generation := m.podResizeConditions[podUID].PodResizeInProgress.ObservedGeneration
 	m.podResizeConditions[podUID] = podResizeConditions{
 		PodResizePending:    m.podResizeConditions[podUID].PodResizePending,
 		PodResizeInProgress: nil,
 	}
 
 	m.recordInProgressResizeCount()
-	return true
+	return generation, true
 }
 
 func (m *manager) BackfillPodResizeConditions(pods []*v1.Pod) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Rather than emitting an event every single time it was possible that there was a change to the resize status, I focused on making sure we emit events for these transitions:

```
  Warning  ResizeDeferred    9s    kubelet            Pod resize Deferred: {"containers":[{"name":"nginx","resources":{"requests":{"cpu":"1"}}}],"generation":2,"error":"Node didn't have enough resource: cpu, requested: 1000, used: 7100, capacity: 8000"}
  Normal   ResizeStarted     2s    kubelet            Pod resize started: {"containers":[{"name":"nginx","resources":{"requests":{"cpu":"1"}}}],"generation":2}
  Warning  ResizeError       2s    kubelet            Pod resize error: {"containers":[{"name":"nginx","resources":{"requests":{"cpu":"1"}}}],"generation":2,"error":"Could not actuate resize due to xxx"}
  Normal   ResizeCompleted   1s    kubelet            Pod resize completed: {"containers":[{"name":"nginx","resources":{"requests":{"cpu":"1"}}}],"generation":2}
```

Events are not recorded when:
- A pending resize is reverted.
- The message associated with a deferred resize changes. This is to avoid spam; the message reports the node’s current availability, which can frequently change. 
- Maybe there are other cases that I’m not thinking of?

Open questions: 
- I added observedGeneration to the event message, but is this useful ?
- The in progress / pending ones display the desired & current resources in this PR, but should they just show the desired ??

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/133528

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When resizing pods, more events will be emitted when the pod's resize status changes.
```

/sig node
