### PR TITLE
Return error in case of discovery client failure

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -229,6 +229,9 @@ func (o *APIResourceOptions) RunAPIResources() error {
 		allResources = append(allResources, apiList)
 	}
 
+	if len(allResources) == 0 {
+		return utilerrors.NewAggregate(errs)
+	}
 	flatList := &metav1.APIResourceList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: allResources[0].APIVersion,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
On `kubectl api-resources` return an error in case Discovery Client fails. This avoids a panic during the array iteration.

The current failure can be reproduced as:
```
unset KUBECONFIG
kubectl api-resources
```

if no Kubernetes server can be reached, it will panic

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix panic on kubectl api-resources
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig cli
