### PR TITLE
Remove year from copyright header boilerplate

### DIFF
--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.Makefile.txt
+++ b/hack/boilerplate/boilerplate.Makefile.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -103,26 +103,11 @@ def file_passes(filename, refs, regexs):
     # trim our file to the same number of lines as the reference file
     data = data[: len(ref)]
 
-    pattern = regexs["year"]
-    for line in data:
-        if pattern.search(line):
-            if generated:
-                print(
-                    f"File {filename} has the YEAR field, but it should not be in generated file",
-                    file=verbose_out,
-                )
-            else:
-                print(
-                    "File {filename} has the YEAR field, but missing the year of date",
-                    file=verbose_out,
-                )
-            return False
-
     if not generated:
-        # Replace all occurrences of the regex "2014|2015|2016|2017|2018" with "YEAR"
+        # Remove all occurrences of the year (regex "Copyright (2014|2015|2016|2017|2018) ")
         pattern = regexs["date"]
         for i, line in enumerate(data):
-            data[i], found = pattern.subn("YEAR", line)
+            data[i], found = pattern.subn("Copyright ", line)
             if found != 0:
                 break
 
@@ -203,18 +188,18 @@ def get_files(extensions):
 
 
 def get_dates():
-    years = datetime.datetime.now().year
-    return "(%s)" % "|".join(str(year) for year in range(2014, years + 1))
+    # After 2025, we no longer allow new files to include the year in the copyright header.
+    final_year = 2025
+    return " (%s) " % "|".join(str(year) for year in range(2014, final_year + 1))
 
 
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile("YEAR")
-    # get_dates return 2014, 2015, 2016, 2017, or 2018 until the current year
-    # as a regex like: "(2014|2015|2016|2017|2018)";
-    # company holder names can be anything
-    regexs["date"] = re.compile(get_dates())
+    # get_dates return 2014, 2015, 2016, 2017, ..., 2025
+    # as a regex like: "(2014|2015|2016|2017|2018|...|2025)";
+    regexs["date"] = re.compile("Copyright" + get_dates())
     # strip the following build constraints/tags:
     # //go:build
     # // +build \n\n

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate_test.py
+++ b/hack/boilerplate/boilerplate_test.py
@@ -50,4 +50,4 @@ class TestBoilerplate(unittest.TestCase):
 
         sys.stdout = old_stdout
 
-        self.assertEqual(output, ["././fail.go", "././fail.py"])
+        self.assertEqual(output, ["././fail.go", "././fail.py", "././fail_2026.go"])

--- a/hack/boilerplate/test/fail_2026.go
+++ b/hack/boilerplate/test/fail_2026.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,3 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package test

--- a/hack/boilerplate/test/pass_no_year.go
+++ b/hack/boilerplate/test/pass_no_year.go
@@ -14,3 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package test


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Per https://github.com/kubernetes/steering/issues/299, we no longer need to include the year in the copyright header. This PR removes the requirement from the boilerplate checker script.

This also forbids adding copyright headers with a year >= 2026. This seemed easier than detecting newly added files.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/steering/issues/299

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @BenTheElder 