### PR TITLE
DRA: Populate Requests field in FromClass device configs

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -715,12 +715,18 @@ func matchNodeSelectorRequirement(requirement v1.NodeSelectorRequirement) types.
 }
 
 func allocationResultWithConfig(selector *v1.NodeSelector, driver string, source resourceapi.AllocationConfigSource, attribute string, results ...resourceapi.DeviceRequestAllocationResult) resourceapi.AllocationResult {
+	var requests []string
+	if source == resourceapi.AllocationConfigSourceClass && len(results) > 0 {
+		// For FromClass configs, set Requests to the request name
+		requests = []string{results[0].Request}
+	}
 	return resourceapi.AllocationResult{
 		Devices: resourceapi.DeviceAllocationResult{
 			Results: results,
 			Config: []resourceapi.DeviceAllocationConfiguration{
 				{
 					Source:              source,
+					Requests:            requests,
 					DeviceConfiguration: deviceConfiguration(driver, attribute),
 				},
 			},
@@ -2264,7 +2270,7 @@ func TestAllocator(t *testing.T,
 				[]resourceapi.DeviceAllocationConfiguration{
 					{
 						Source:              resourceapi.AllocationConfigSourceClass,
-						Requests:            nil,
+						Requests:            []string{req0},
 						DeviceConfiguration: deviceConfiguration(driverB, "bar"),
 					},
 				},

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -399,10 +399,12 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 
 			class := requestData.class
 			if class != nil {
+				request := &claim.Spec.Devices.Requests[requestIndex]
+				requestName := request.Name
 				for _, config := range class.Spec.Config {
 					allocationResult.Devices.Config = append(allocationResult.Devices.Config, resourceapi.DeviceAllocationConfiguration{
 						Source:              resourceapi.AllocationConfigSourceClass,
-						Requests:            nil, // All of them...
+						Requests:            []string{requestName},
 						DeviceConfiguration: config.DeviceConfiguration,
 					})
 				}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -307,10 +307,12 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 
 			class := requestData.class
 			if class != nil {
+				request := &claim.Spec.Devices.Requests[requestIndex]
+				requestName := request.Name
 				for _, config := range class.Spec.Config {
 					allocationResult.Devices.Config = append(allocationResult.Devices.Config, resourceapi.DeviceAllocationConfiguration{
 						Source:              resourceapi.AllocationConfigSourceClass,
-						Requests:            nil, // All of them...
+						Requests:            []string{requestName},
 						DeviceConfiguration: config.DeviceConfiguration,
 					})
 				}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -297,10 +297,12 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 
 			class := requestData.class
 			if class != nil {
+				request := &claim.Spec.Devices.Requests[requestIndex]
+				requestName := request.Name
 				for _, config := range class.Spec.Config {
 					allocationResult.Devices.Config = append(allocationResult.Devices.Config, resourceapi.DeviceAllocationConfiguration{
 						Source:              resourceapi.AllocationConfigSourceClass,
-						Requests:            nil, // All of them...
+						Requests:            []string{requestName},
 						DeviceConfiguration: config.DeviceConfiguration,
 					})
 				}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

Fixes #134789

When creating a ResourceClaim with multiple requests using different DeviceClasses, each class's config needs to specify which request(s) it applies to via the `Requests` field. Previously, this field was left as `nil` for configs with `Source: FromClass`, causing DRA drivers to be unable to identify which configuration belongs to which request.

This PR populates the `Requests` field with the appropriate request name when configs come from DeviceClass:
- For regular requests: sets `Requests` to `[requestName]`
- For subrequests: sets `Requests` to `[parentRequestName]` (since the config applies to the entire request)

**Which issue(s) this PR fixes:**

Fixes #134789

**Special notes for your reviewer:**

This affects all three allocator implementations (stable, incubating, experimental). The fix is minimal and consistent across all versions.

The test helper `allocationResultWithConfig` was updated to automatically set the `Requests` field for `FromClass` configs, and the `prioritized-list-class-config` test expectation was corrected to reflect the proper behavior.

**Does this PR introduce a user-facing change?**
```release-note
DRA: Fixed ResourceClaim allocation to populate the Requests field in DeviceAllocationConfiguration when config source is FromClass, enabling DRA drivers to correctly identify which request each configuration applies to.
```

**Additional documentation:**
None