### PR TITLE
refactor(kubeadm): including dns addon version to signature

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -120,7 +120,7 @@ func runPlan(flagSet *pflag.FlagSet, flags *planFlags, args []string, printer ou
 		return cmdutil.TypeMismatchErr("allowExperimentalUpgrades", "bool")
 	}
 
-	availUpgrades, err := upgrade.GetAvailableUpgrades(versionGetter, *allowExperimentalUpgrades, *allowRCUpgrades, client, printer)
+	availUpgrades, err := upgrade.GetAvailableUpgrades(versionGetter, *allowExperimentalUpgrades, *allowRCUpgrades, printer)
 	if err != nil {
 		return errors.Wrap(err, "[upgrade/versions] FATAL")
 	}

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -21,11 +21,9 @@ import (
 	"strings"
 
 	versionutil "k8s.io/apimachinery/pkg/util/version"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
 )
 
@@ -74,7 +72,7 @@ type ClusterState struct {
 
 // GetAvailableUpgrades fetches all versions from the specified VersionGetter and computes which
 // kinds of upgrades can be performed
-func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesAllowed, rcUpgradesAllowed bool, client clientset.Interface, printer output.Printer) ([]Upgrade, error) {
+func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesAllowed, rcUpgradesAllowed bool, printer output.Printer) ([]Upgrade, error) {
 	printer.Printf("[upgrade] Fetching available versions to upgrade to\n")
 
 	// Collect the upgrades kubeadm can do in this list
@@ -145,7 +143,7 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 	}
 	isExternalEtcd := len(etcdVersions) == 0
 
-	dnsVersion, err := dns.DeployedDNSAddon(client)
+	dnsVersion, err := versionGetterImpl.DNSAddonVersion()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -17,19 +17,13 @@ limitations under the License.
 package upgrade
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
-	clientsetfake "k8s.io/client-go/kubernetes/fake"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
@@ -46,6 +40,8 @@ type fakeVersionGetter struct {
 	componentVersion       string
 	etcdVersion            string
 	isExternalEtcd         bool
+	coreDNSVersion         string
+	coreDNSError           error
 }
 
 var _ VersionGetter = &fakeVersionGetter{}
@@ -117,6 +113,10 @@ func (f *fakeVersionGetter) ComponentVersions(name string) (map[string][]string,
 	}, nil
 }
 
+func (f *fakeVersionGetter) DNSAddonVersion() (string, error) {
+	return f.coreDNSVersion, f.coreDNSError
+}
+
 const fakeCurrentEtcdVersion = "3.1.12"
 
 func getEtcdVersion(v *versionutil.Version) string {
@@ -158,22 +158,20 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		expectedUpgrades            []Upgrade
 		allowExperimental, allowRCs bool
 		errExpected                 bool
-		beforeDNSVersion            string
-		deployDNSFailed             bool
 	}{
 		{
 			name: "no action needed, already up-to-date",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y0.String(),
-				componentVersion: v1Y0.String(),
-				kubeletVersion:   v1Y0.String(),
-				kubeadmVersion:   v1Y0.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y0.String(),
+				componentVersion:   v1Y0.String(),
+				kubeletVersion:     v1Y0.String(),
+				kubeadmVersion:     v1Y0.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y0.String(),
 				stableVersion:      v1Y0.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion:  fakeCurrentCoreDNSVersion,
 			expectedUpgrades:  nil,
 			allowExperimental: false,
 			errExpected:       false,
@@ -181,16 +179,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "get component version failed",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y0.String(),
-				componentVersion: "",
-				kubeletVersion:   v1Y0.String(),
-				kubeadmVersion:   v1Y0.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y0.String(),
+				componentVersion:   "",
+				kubeletVersion:     v1Y0.String(),
+				kubeadmVersion:     v1Y0.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y0.String(),
 				stableVersion:      v1Y0.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion:  fakeCurrentCoreDNSVersion,
 			expectedUpgrades:  nil,
 			allowExperimental: false,
 			errExpected:       true,
@@ -198,16 +196,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "there is version information about multiple components",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y0.String(),
-				componentVersion: "multiVersion",
-				kubeletVersion:   v1Y0.String(),
-				kubeadmVersion:   v1Y0.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y0.String(),
+				componentVersion:   "multiVersion",
+				kubeletVersion:     v1Y0.String(),
+				kubeadmVersion:     v1Y0.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y0.String(),
 				stableVersion:      v1Y0.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion:  fakeCurrentCoreDNSVersion,
 			expectedUpgrades:  nil,
 			allowExperimental: false,
 			errExpected:       true,
@@ -215,16 +213,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "get kubeadm version failed",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y0.String(),
-				componentVersion: v1Y0.String(),
-				kubeletVersion:   v1Y0.String(),
-				kubeadmVersion:   "",
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y0.String(),
+				componentVersion:   v1Y0.String(),
+				kubeletVersion:     v1Y0.String(),
+				kubeadmVersion:     "",
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y0.String(),
 				stableVersion:      v1Y0.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion:  fakeCurrentCoreDNSVersion,
 			expectedUpgrades:  nil,
 			allowExperimental: false,
 			errExpected:       true,
@@ -232,16 +230,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "get kubelet version failed",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y0.String(),
-				componentVersion: v1Y0.String(),
-				kubeletVersion:   "",
-				kubeadmVersion:   v1Y0.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y0.String(),
+				componentVersion:   v1Y0.String(),
+				kubeletVersion:     "",
+				kubeadmVersion:     v1Y0.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y0.String(),
 				stableVersion:      v1Y0.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion:  fakeCurrentCoreDNSVersion,
 			expectedUpgrades:  nil,
 			allowExperimental: false,
 			errExpected:       true,
@@ -249,16 +247,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "deploy DNS failed",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y0.String(),
-				componentVersion: v1Y0.String(),
-				kubeletVersion:   v1Y0.String(),
-				kubeadmVersion:   v1Y0.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y0.String(),
+				componentVersion:   v1Y0.String(),
+				kubeletVersion:     v1Y0.String(),
+				kubeadmVersion:     v1Y0.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y0.String(),
 				stableVersion:      v1Y0.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 
 			expectedUpgrades:  nil,
 			allowExperimental: false,
@@ -267,17 +265,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "get stable version from CI label failed",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y0.String(),
-				componentVersion: v1Y0.String(),
-				kubeletVersion:   v1Y0.String(),
-				kubeadmVersion:   v1Y0.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y0.String(),
+				componentVersion:   v1Y0.String(),
+				kubeletVersion:     v1Y0.String(),
+				kubeadmVersion:     v1Y0.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y0.String(),
 				stableVersion:      "",
+				coreDNSVersion:     "",
+				coreDNSError:       errors.New("multiple DNS addon deployment"),
 			},
-			beforeDNSVersion:  fakeCurrentCoreDNSVersion,
-			deployDNSFailed:   true,
 			expectedUpgrades:  nil,
 			allowExperimental: false,
 			errExpected:       true,
@@ -285,16 +282,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "simple patch version upgrade",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y1.String(),
-				componentVersion: v1Y1.String(),
-				kubeletVersion:   v1Y1.String(), // the kubelet are on the same version as the control plane
-				kubeadmVersion:   v1Y2.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y1.String(),
+				componentVersion:   v1Y1.String(),
+				kubeletVersion:     v1Y1.String(), // the kubelet are on the same version as the control plane
+				kubeadmVersion:     v1Y2.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y3.String(),
 				stableVersion:      v1Y3.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: fmt.Sprintf("version in the v%d.%d series", v1Y0.Major(), v1Y0.Minor()),
@@ -330,16 +327,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "simple patch version upgrade with external etcd",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y1.String(),
-				componentVersion: v1Y1.String(),
-				kubeletVersion:   v1Y1.String(), // the kubelet are on the same version as the control plane
-				kubeadmVersion:   v1Y2.String(),
-				isExternalEtcd:   true,
-
+				clusterVersion:     v1Y1.String(),
+				componentVersion:   v1Y1.String(),
+				kubeletVersion:     v1Y1.String(), // the kubelet are on the same version as the control plane
+				kubeadmVersion:     v1Y2.String(),
+				isExternalEtcd:     true,
 				stablePatchVersion: v1Y3.String(),
 				stableVersion:      v1Y3.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: fmt.Sprintf("version in the v%d.%d series", v1Y0.Major(), v1Y0.Minor()),
@@ -375,16 +372,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "no version provided to offline version getter does not change behavior",
 			vg: NewOfflineVersionGetter(&fakeVersionGetter{
-				clusterVersion:   v1Y1.String(),
-				componentVersion: v1Y1.String(),
-				kubeletVersion:   v1Y1.String(), // the kubelet are on the same version as the control plane
-				kubeadmVersion:   v1Y2.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y1.String(),
+				componentVersion:   v1Y1.String(),
+				kubeletVersion:     v1Y1.String(), // the kubelet are on the same version as the control plane
+				kubeadmVersion:     v1Y2.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y3.String(),
 				stableVersion:      v1Y3.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			}, ""),
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: fmt.Sprintf("version in the v%d.%d series", v1Y0.Major(), v1Y0.Minor()),
@@ -420,16 +417,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "minor version upgrade only",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y1.String(),
-				componentVersion: v1Y1.String(),
-				kubeletVersion:   v1Y1.String(), // the kubelet are on the same version as the control plane
-				kubeadmVersion:   v1Z0.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y1.String(),
+				componentVersion:   v1Y1.String(),
+				kubeletVersion:     v1Y1.String(), // the kubelet are on the same version as the control plane
+				kubeadmVersion:     v1Z0.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y1.String(),
 				stableVersion:      v1Z0.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "stable version",
@@ -465,16 +462,16 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "both minor version upgrade and patch version upgrade available",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y3.String(),
-				componentVersion: v1Y3.String(),
-				kubeletVersion:   v1Y3.String(), // the kubelet are on the same version as the control plane
-				kubeadmVersion:   v1Y5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y3.String(),
+				componentVersion:   v1Y3.String(),
+				kubeletVersion:     v1Y3.String(), // the kubelet are on the same version as the control plane
+				kubeadmVersion:     v1Y5.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y5.String(),
 				stableVersion:      v1Z1.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: fmt.Sprintf("version in the v%d.%d series", v1Y0.Major(), v1Y0.Minor()),
@@ -537,17 +534,17 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "allow experimental upgrades, but no upgrade available",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Z0alpha2.String(),
-				componentVersion: v1Z0alpha2.String(),
-				kubeletVersion:   v1Y5.String(),
-				kubeadmVersion:   v1Y5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Z0alpha2.String(),
+				componentVersion:   v1Z0alpha2.String(),
+				kubeletVersion:     v1Y5.String(),
+				kubeadmVersion:     v1Y5.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y5.String(),
 				stableVersion:      v1Y5.String(),
 				latestVersion:      v1Z0alpha2.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion:  fakeCurrentCoreDNSVersion,
 			expectedUpgrades:  nil,
 			allowExperimental: true,
 			errExpected:       false,
@@ -555,17 +552,17 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "upgrade to an unstable version should be supported",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Y5.String(),
-				componentVersion: v1Y5.String(),
-				kubeletVersion:   v1Y5.String(),
-				kubeadmVersion:   v1Y5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Y5.String(),
+				componentVersion:   v1Y5.String(),
+				kubeletVersion:     v1Y5.String(),
+				kubeadmVersion:     v1Y5.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y5.String(),
 				stableVersion:      v1Y5.String(),
 				latestVersion:      v1Z0alpha2.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "experimental version",
@@ -601,17 +598,17 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "upgrade from an unstable version to an unstable version should be supported",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1Z0alpha1.String(),
-				componentVersion: v1Z0alpha1.String(),
-				kubeletVersion:   v1Y5.String(),
-				kubeadmVersion:   v1Y5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:     v1Z0alpha1.String(),
+				componentVersion:   v1Z0alpha1.String(),
+				kubeletVersion:     v1Y5.String(),
+				kubeadmVersion:     v1Y5.String(),
+				etcdVersion:        fakeCurrentEtcdVersion,
 				stablePatchVersion: v1Y5.String(),
 				stableVersion:      v1Y5.String(),
 				latestVersion:      v1Z0alpha2.String(),
+				coreDNSVersion:     fakeCurrentCoreDNSVersion,
+				coreDNSError:       nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "experimental version",
@@ -647,18 +644,18 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "v1.X.0-alpha.0 should be ignored",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1X5.String(),
-				componentVersion: v1X5.String(),
-				kubeletVersion:   v1X5.String(),
-				kubeadmVersion:   v1X5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:         v1X5.String(),
+				componentVersion:       v1X5.String(),
+				kubeletVersion:         v1X5.String(),
+				kubeadmVersion:         v1X5.String(),
+				etcdVersion:            fakeCurrentEtcdVersion,
 				stablePatchVersion:     v1X5.String(),
 				stableVersion:          v1X5.String(),
 				latestDevBranchVersion: v1Z0beta1.String(),
 				latestVersion:          v1Y0alpha0.String(),
+				coreDNSVersion:         fakeCurrentCoreDNSVersion,
+				coreDNSError:           nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "experimental version",
@@ -694,18 +691,18 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "upgrade to an RC version should be supported",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1X5.String(),
-				componentVersion: v1X5.String(),
-				kubeletVersion:   v1X5.String(),
-				kubeadmVersion:   v1X5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:         v1X5.String(),
+				componentVersion:       v1X5.String(),
+				kubeletVersion:         v1X5.String(),
+				kubeadmVersion:         v1X5.String(),
+				etcdVersion:            fakeCurrentEtcdVersion,
 				stablePatchVersion:     v1X5.String(),
 				stableVersion:          v1X5.String(),
 				latestDevBranchVersion: v1Z0rc1.String(),
 				latestVersion:          v1Y0alpha1.String(),
+				coreDNSVersion:         fakeCurrentCoreDNSVersion,
+				coreDNSError:           nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "release candidate version",
@@ -741,18 +738,18 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "it is possible (but very uncommon) that the latest version from the previous branch is an rc and the current latest version is alpha.0. In that case, show the RC",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1X5.String(),
-				componentVersion: v1X5.String(),
-				kubeletVersion:   v1X5.String(),
-				kubeadmVersion:   v1X5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:         v1X5.String(),
+				componentVersion:       v1X5.String(),
+				kubeletVersion:         v1X5.String(),
+				kubeadmVersion:         v1X5.String(),
+				etcdVersion:            fakeCurrentEtcdVersion,
 				stablePatchVersion:     v1X5.String(),
 				stableVersion:          v1X5.String(),
 				latestDevBranchVersion: v1Z0rc1.String(),
 				latestVersion:          v1Y0alpha0.String(),
+				coreDNSVersion:         fakeCurrentCoreDNSVersion,
+				coreDNSError:           nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "experimental version", // Note that this is considered an experimental version in this uncommon scenario
@@ -788,18 +785,18 @@ func TestGetAvailableUpgrades(t *testing.T) {
 		{
 			name: "upgrade to an RC version should be supported. There may also be an even newer unstable version.",
 			vg: &fakeVersionGetter{
-				clusterVersion:   v1X5.String(),
-				componentVersion: v1X5.String(),
-				kubeletVersion:   v1X5.String(),
-				kubeadmVersion:   v1X5.String(),
-				etcdVersion:      fakeCurrentEtcdVersion,
-
+				clusterVersion:         v1X5.String(),
+				componentVersion:       v1X5.String(),
+				kubeletVersion:         v1X5.String(),
+				kubeadmVersion:         v1X5.String(),
+				etcdVersion:            fakeCurrentEtcdVersion,
 				stablePatchVersion:     v1X5.String(),
 				stableVersion:          v1X5.String(),
 				latestDevBranchVersion: v1Z0rc1.String(),
 				latestVersion:          v1Y0alpha1.String(),
+				coreDNSVersion:         fakeCurrentCoreDNSVersion,
+				coreDNSError:           nil,
 			},
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "release candidate version",
@@ -868,8 +865,9 @@ func TestGetAvailableUpgrades(t *testing.T) {
 				kubeletVersion:   v1Y0.String(),
 				kubeadmVersion:   v1Y1.String(),
 				etcdVersion:      fakeCurrentEtcdVersion,
+				coreDNSVersion:   fakeCurrentCoreDNSVersion,
+				coreDNSError:     nil,
 			}, v1Z1.String()),
-			beforeDNSVersion: fakeCurrentCoreDNSVersion,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: fmt.Sprintf("version in the v%d.%d series", v1Y0.Major(), v1Y0.Minor()),
@@ -906,12 +904,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 	// Kubernetes release.
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-
-			dnsName := constants.CoreDNSDeploymentName
-
-			client := newMockClientForTest(t, dnsName, rt.beforeDNSVersion, rt.deployDNSFailed)
-
-			actualUpgrades, actualErr := GetAvailableUpgrades(rt.vg, rt.allowExperimental, rt.allowRCs, client, &output.TextPrinter{})
+			actualUpgrades, actualErr := GetAvailableUpgrades(rt.vg, rt.allowExperimental, rt.allowRCs, &output.TextPrinter{})
 			if diff := cmp.Diff(rt.expectedUpgrades, actualUpgrades); len(diff) > 0 {
 				t.Errorf("failed TestGetAvailableUpgrades\n\texpected upgrades:\n%v\n\tgot:\n%v\n\tdiff:\n%v", rt.expectedUpgrades, actualUpgrades, diff)
 			}
@@ -1099,43 +1092,4 @@ func TestGetSuggestedEtcdVersion(t *testing.T) {
 			}
 		})
 	}
-}
-
-func newMockClientForTest(t *testing.T, dnsName string, dnsVersion string, multiDNS bool) *clientsetfake.Clientset {
-	client := clientsetfake.NewSimpleClientset()
-	createDeployment := func(name string) {
-		_, err := client.AppsV1().Deployments(metav1.NamespaceSystem).Create(context.TODO(), &apps.Deployment{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Deployment",
-				APIVersion: "apps/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      dnsName + name,
-				Namespace: "kube-system",
-				Labels: map[string]string{
-					"k8s-app": "kube-dns",
-				},
-			},
-			Spec: apps.DeploymentSpec{
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
-							{
-								Image: "test:" + dnsVersion + name,
-							},
-						},
-					},
-				},
-			},
-		}, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("error creating deployment: %v", err)
-		}
-	}
-
-	createDeployment("")
-	if multiDNS {
-		createDeployment("dns2")
-	}
-	return client
 }

--- a/cmd/kubeadm/app/phases/upgrade/versiongetter.go
+++ b/cmd/kubeadm/app/phases/upgrade/versiongetter.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/component-base/version"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/image"
@@ -46,6 +47,8 @@ type VersionGetter interface {
 	KubeletVersions() (map[string][]string, error)
 	// ComponentVersions should return a map with a version and a list of node names that describes how many a given control-plane components there are for that version
 	ComponentVersions(string) (map[string][]string, error)
+	// DNSAddonVersion returns, if deployed, the CoreDNS image tag
+	DNSAddonVersion() (string, error)
 }
 
 // KubeVersionGetter handles the version-fetching mechanism from external sources
@@ -128,6 +131,11 @@ func (g *KubeVersionGetter) KubeletVersions() (map[string][]string, error) {
 		kubeletVersions[kver] = append(kubeletVersions[kver], node.Name)
 	}
 	return kubeletVersions, nil
+}
+
+// DNSAddonVersion returns the CoreDNS image deployed in the cluster, or an error in case of multiple instances.
+func (g *KubeVersionGetter) DNSAddonVersion() (string, error) {
+	return dns.DeployedDNSAddon(g.client)
 }
 
 // ComponentVersions gets the versions of the control-plane components in the cluster.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Although `kubeadm` has not been designed to run as a library, the code base can still be imported and used via public functions.

The `kubeadm` function `GetAvailableUpgrades` can be used to extract the available upgrades for the given Control Plane, and it allows some mocking using the `VersionGetter` interface, which allows extensibility (e.g.: in case of air-gapped environments, or the need to interact with specific network desigs).

The `VersionGetter` already reports the following signatures:
- `ClusterVersion`
- `KubeadmVersion`
- `VersionFromCILabel`
- `KubeletVersions`
- `ComponentVersions`

Some of the functions must interact with the API Server to extract information, and having them wrapped in an interface is vital; however, the `GetAvailableUpgrades` is not providing any interface to extract the CoreDNS version.

https://github.com/kubernetes/kubernetes/blob/8cd57a9e6f07d2446910d493781557b6cd4d6b99/cmd/kubeadm/app/phases/upgrade/compute.go#L148-L151

The proposed changes extend the signature for the `VersionGetter` since it's responsible for retrieving component versions, and CoreDNS/DNS is part of those.

A positive outcome for implementing this would be able to reuse the function `GetAvailableUpgrades` by implementing a new `VersionGetter` when the state for the given cluster has been "frozen" (e.g.: Control Plane scaled to zero): otherwise, a `fakeClient` should be used since it's injected currently from the function signature, and it's just used for such a purpose. Thus, we could decrease the number of arguments and achieve more elegance and maintainability in the code.

#### Which issue(s) this PR is related to:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE