### PR TITLE
kubeadm: improve the etcd version mapping

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -499,12 +499,12 @@ var (
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	// If you are updating the versions in this map, make sure to also update:
 	// - MinExternalEtcdVersion: with the minimum etcd version from this map.
-	// - DefaultEtcdVersion: with etcd version used for the current k8s release.
+	// - DefaultEtcdVersion: with etcd version used for the current k8s release (0).
+	// The maximum length of the map should be 2, as kubeadm supports a maximum skew of -1
+	// with the control plane version.
 	SupportedEtcdVersion = map[uint8]string{
-		32: "3.5.24-0",
-		33: "3.5.24-0",
-		34: "3.5.24-0",
-		35: "3.6.5-0",
+		uint8(getSkewedKubernetesVersion(-1).Minor()): "3.5.24-0",
+		uint8(getSkewedKubernetesVersion(0).Minor()):  "3.6.5-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -99,7 +99,7 @@ func TestGetStaticPodFilepath(t *testing.T) {
 }
 
 func TestEtcdSupportedVersionLength(t *testing.T) {
-	const max = 4
+	const max = 2
 	if len(SupportedEtcdVersion) > max {
 		t.Fatalf("SupportedEtcdVersion must not include more than %d versions", max)
 	}
@@ -107,8 +107,7 @@ func TestEtcdSupportedVersionLength(t *testing.T) {
 
 func TestEtcdSupportedVersion(t *testing.T) {
 	var supportedEtcdVersion = map[uint8]string{
-		16: "3.3.17-0",
-		17: "3.4.3-0",
+		17: "3.3.17-0",
 		18: "3.4.3-0",
 	}
 	var tests = []struct {
@@ -136,13 +135,13 @@ func TestEtcdSupportedVersion(t *testing.T) {
 			expectedError:     false,
 		},
 		{
-			kubernetesVersion: "v1.16.0",
+			kubernetesVersion: "1.17.2",
 			expectedVersion:   version.MustParseSemantic("3.3.17-0"),
 			expectedWarning:   false,
 			expectedError:     false,
 		},
 		{
-			kubernetesVersion: "1.17.2",
+			kubernetesVersion: "1.18.1",
 			expectedVersion:   version.MustParseSemantic("3.4.3-0"),
 			expectedWarning:   false,
 			expectedError:     false,

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -63,22 +63,22 @@ func GetDNSImage(cfg *kubeadmapi.ClusterConfiguration) string {
 }
 
 // GetEtcdImage generates and returns the image for etcd
-func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration) string {
+func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration, supportedEtcdVersion map[uint8]string) string {
 	// Etcd uses default image repository by default
 	etcdImageRepository := cfg.ImageRepository
 	// unless an override is specified
 	if cfg.Etcd.Local != nil && cfg.Etcd.Local.ImageRepository != "" {
 		etcdImageRepository = cfg.Etcd.Local.ImageRepository
 	}
-	etcdImageTag := GetEtcdImageTag(cfg)
+	etcdImageTag := GetEtcdImageTag(cfg, supportedEtcdVersion)
 	return GetGenericImage(etcdImageRepository, constants.Etcd, etcdImageTag)
 }
 
 // GetEtcdImageTag generates and returns the image tag for etcd
-func GetEtcdImageTag(cfg *kubeadmapi.ClusterConfiguration) string {
+func GetEtcdImageTag(cfg *kubeadmapi.ClusterConfiguration, supportedEtcdVersion map[uint8]string) string {
 	// Etcd uses an imageTag that corresponds to the etcd version matching the Kubernetes version
 	etcdImageTag := constants.DefaultEtcdVersion
-	etcdVersion, warning, err := constants.EtcdSupportedVersion(constants.SupportedEtcdVersion, cfg.KubernetesVersion)
+	etcdVersion, warning, err := constants.EtcdSupportedVersion(supportedEtcdVersion, cfg.KubernetesVersion)
 	if err == nil {
 		etcdImageTag = etcdVersion.String()
 	}
@@ -119,7 +119,7 @@ func GetControlPlaneImages(cfg *kubeadmapi.ClusterConfiguration) []string {
 
 	// if etcd is not external then add the image as it will be required
 	if cfg.Etcd.Local != nil {
-		images = append(images, GetEtcdImage(cfg))
+		images = append(images, GetEtcdImage(cfg, constants.SupportedEtcdVersion))
 	}
 
 	return images

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -149,7 +149,7 @@ func TestGetEtcdImage(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		actual := GetEtcdImage(rt.cfg)
+		actual := GetEtcdImage(rt.cfg, constants.SupportedEtcdVersion)
 		if actual != rt.expected {
 			t.Errorf(
 				"failed GetEtcdImage:\n\texpected: %s\n\t  actual: %s",

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -285,14 +285,15 @@ func TestCreateLocalEtcdStaticPodManifestFileWithPatches(t *testing.T) {
 
 func TestGetEtcdCommand(t *testing.T) {
 	var tests = []struct {
-		name             string
-		advertiseAddress string
-		k8sVersion       string
-		etcdImageTag     string
-		nodeName         string
-		extraArgs        []kubeadmapi.Arg
-		initialCluster   []etcdutil.Member
-		expected         []string
+		name                 string
+		advertiseAddress     string
+		k8sVersion           string
+		etcdImageTag         string
+		nodeName             string
+		extraArgs            []kubeadmapi.Arg
+		initialCluster       []etcdutil.Member
+		supportedEtcdVersion map[uint8]string
+		expected             []string
 	}{
 		{
 			name:             "Default args - with empty etcd initial cluster",
@@ -416,6 +417,10 @@ func TestGetEtcdCommand(t *testing.T) {
 			advertiseAddress: "1.2.3.4",
 			k8sVersion:       "1.33.0",
 			nodeName:         "bar",
+			supportedEtcdVersion: map[uint8]string{
+				33: "3.5.24",
+				34: "3.6.5",
+			},
 			expected: []string{
 				"etcd",
 				"--name=bar",
@@ -514,7 +519,10 @@ func TestGetEtcdCommand(t *testing.T) {
 					},
 				},
 			}
-			actual := getEtcdCommand(cfg, endpoint, rt.nodeName, rt.initialCluster)
+			if len(rt.supportedEtcdVersion) == 0 {
+				rt.supportedEtcdVersion = kubeadmconstants.SupportedEtcdVersion
+			}
+			actual := getEtcdCommand(cfg, endpoint, rt.nodeName, rt.initialCluster, rt.supportedEtcdVersion)
 			sort.Strings(actual)
 			sort.Strings(rt.expected)
 			if !reflect.DeepEqual(actual, rt.expected) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

For historic reasons kubeadm kept track of a skew of 2+ etcd version in a map in the constants.go file.

This is really not required because kubeadm supports only 2 version of etcd mapped to two Kubernetes versions, which are essentially the control plane versions.

Refactor the constants.go map to only include 2 versions. Make sure that's reflected in a unit test.

Instead of pinning the versions as literal numbers, start using the version we get on build time.

Adapt various unit tests and functions to allow this change to work, since during unit tests we need actual values and the build versions are not populated. This is achieved by requiring the functions to accept a map[uint8]string used for testing.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

 NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
