### PR TITLE
Expose /readyz & /livez in kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -202,21 +202,23 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		logger.Error(err, "Unable to register configz")
 	}
 
-	// Setup any healthz checks we will want to use.
-	var checks []healthz.HealthChecker
+	// Setup any health checks we will want to use.
+	var readyzChecks []healthz.HealthChecker
 	var electionChecker *leaderelection.HealthzAdaptor
 	if c.ComponentConfig.Generic.LeaderElection.LeaderElect {
 		electionChecker = leaderelection.NewLeaderHealthzAdaptor(time.Second * 20)
-		checks = append(checks, electionChecker)
+		readyzChecks = append(readyzChecks, electionChecker)
 	}
-	healthzHandler := controllerhealthz.NewMutableHealthzHandler(checks...)
+
+	readyzHandler := controllerhealthz.NewMutableHealthzHandler(readyzChecks...)
 
 	// Start the controller manager HTTP server
 	// unsecuredMux is the handler for these controller *after* authn/authz filters have been applied
 	var unsecuredMux *mux.PathRecorderMux
 	if c.SecureServing != nil {
-		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, healthzHandler)
+		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, readyzChecks)
 		slis.SLIMetricsWithReset{}.Install(unsecuredMux)
+
 		if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentFlagz) {
 			if c.Flagz != nil {
 				flagz.Install(unsecuredMux, kubeControllerManager, c.Flagz)
@@ -253,7 +255,7 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		}
 
 		// Prepare all controllers in advance.
-		controllers, err := BuildControllers(ctx, controllerContext, controllerDescriptors, unsecuredMux, healthzHandler)
+		controllers, err := BuildControllers(ctx, controllerContext, controllerDescriptors, unsecuredMux, readyzHandler)
 		if err != nil {
 			logger.Error(err, "Error building controllers")
 			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
@@ -345,7 +347,7 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		if err != nil {
 			return err
 		}
-		healthzHandler.AddHealthChecker(healthz.NewInformerSyncHealthz(waitForSync))
+		readyzHandler.AddHealthChecker(healthz.NewInformerSyncHealthz(waitForSync))
 
 		go leaseCandidate.Run(ctx)
 	}
@@ -569,7 +571,7 @@ type HealthCheckAdder interface {
 // If the controller implements controller.HealthCheckable, though, the given check is used.
 // The controller can also implement controller.Debuggable, in which case the debug handler is registered with the given mux.
 func BuildControllers(ctx context.Context, controllerCtx ControllerContext, controllerDescriptors map[string]*ControllerDescriptor,
-	unsecuredMux *mux.PathRecorderMux, healthzHandler HealthCheckAdder) ([]Controller, error) {
+	unsecuredMux *mux.PathRecorderMux, readyzHandler HealthCheckAdder) ([]Controller, error) {
 	logger := klog.FromContext(ctx)
 	var (
 		controllers []Controller
@@ -642,7 +644,7 @@ func BuildControllers(ctx context.Context, controllerCtx ControllerContext, cont
 
 	// Register the checks.
 	if len(checks) > 0 {
-		healthzHandler.AddHealthChecker(checks...)
+		readyzHandler.AddHealthChecker(checks...)
 	}
 	return controllers, nil
 }

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -172,11 +172,11 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 	}
 
 	// Setup any health checks we will want to use.
-	var checks []healthz.HealthChecker
+	var readyzChecks []healthz.HealthChecker
 	var electionChecker *leaderelection.HealthzAdaptor
 	if c.ComponentConfig.Generic.LeaderElection.LeaderElect {
 		electionChecker = leaderelection.NewLeaderHealthzAdaptor(time.Second * 20)
-		checks = append(checks, electionChecker)
+		readyzChecks = append(readyzChecks, electionChecker)
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(cmfeatures.CloudControllerManagerWebhook) {
@@ -189,10 +189,10 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 		}
 	}
 
-	healthzHandler := controllerhealthz.NewMutableHealthzHandler(checks...)
+	readyzHandler := controllerhealthz.NewMutableHealthzHandler(readyzChecks...)
 	// Start the controller manager HTTP server
 	if c.SecureServing != nil {
-		unsecuredMux := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, healthzHandler)
+		unsecuredMux := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, readyzChecks)
 
 		slis.SLIMetricsWithReset{}.Install(unsecuredMux)
 
@@ -211,7 +211,7 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 		if err != nil {
 			klog.Fatalf("error building controller context: %v", err)
 		}
-		if err := startControllers(ctx, cloud, controllerContext, c, ctx.Done(), controllerInitializers, healthzHandler); err != nil {
+		if err := startControllers(ctx, cloud, controllerContext, c, ctx.Done(), controllerInitializers, readyzHandler); err != nil {
 			klog.Fatalf("error running controllers: %v", err)
 		}
 	}

--- a/staging/src/k8s.io/controller-manager/app/serve.go
+++ b/staging/src/k8s.io/controller-manager/app/serve.go
@@ -24,6 +24,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apiserver "k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -55,9 +56,11 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 }
 
 // NewBaseHandler takes in CompletedConfig and returns a handler.
-func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, healthzHandler http.Handler) *mux.PathRecorderMux {
+func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, readyzChecks []healthz.HealthChecker) *mux.PathRecorderMux {
 	mux := mux.NewPathRecorderMux("controller-manager")
-	mux.Handle("/healthz", healthzHandler)
+	healthz.InstallHandler(mux)
+	healthz.InstallLivezHandler(mux)
+	healthz.InstallReadyzHandler(mux, readyzChecks...)
 	if c.EnableProfiling {
 		routes.Profiling{}.Install(mux)
 		if c.EnableContentionProfiling {

--- a/test/integration/controllermanager/serving/healthcheck_test.go
+++ b/test/integration/controllermanager/serving/healthcheck_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"k8s.io/klog/v2/ktesting"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	kubecontrollermanageresting "k8s.io/kubernetes/cmd/kube-controller-manager/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestHealthEndpoints(t *testing.T) {
+	server, configStr, _, err := startTestAPIServer(t)
+	if err != nil {
+		t.Fatalf("Failed to start kube-apiserver server: %v", err)
+	}
+	defer server.TearDownFn()
+
+	apiserverConfig, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatalf("Failed to create kubeconfig file: %v", err)
+	}
+	defer func() {
+		_ = os.Remove(apiserverConfig.Name())
+	}()
+	if _, err = apiserverConfig.WriteString(configStr); err != nil {
+		t.Fatalf("Failed to write kubeconfig file: %v", err)
+	}
+
+	brokenConfigStr := strings.ReplaceAll(configStr, "127.0.0.1", "127.0.0.2")
+	brokenConfig, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatalf("Failed to create kubeconfig file: %v", err)
+	}
+	if _, err := brokenConfig.WriteString(brokenConfigStr); err != nil {
+		t.Fatalf("Failed to write kubeconfig file: %v", err)
+	}
+	defer func() {
+		_ = os.Remove(brokenConfig.Name())
+	}()
+
+	tests := []struct {
+		name             string
+		path             string
+		useBrokenConfig  bool
+		wantResponseCode int
+	}{
+		{
+			"/healthz",
+			"/healthz",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/livez",
+			"/livez",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/livez with ping check",
+			"/livez/ping",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/readyz",
+			"/readyz",
+			false,
+			http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			_, ctx := ktesting.NewTestContext(t)
+
+			configFile := apiserverConfig.Name()
+			if tt.useBrokenConfig {
+				configFile = brokenConfig.Name()
+			}
+			result, err := kubecontrollermanageresting.StartTestServer(
+				t,
+				ctx,
+				[]string{"--controllers=", "--kubeconfig", configFile, "--leader-elect=false", "--authorization-always-allow-paths", tt.path},
+			)
+
+			if err != nil {
+				t.Fatalf("Failed to start kube-controller-manager server: %v", err)
+			}
+			if result.TearDownFn != nil {
+				defer result.TearDownFn()
+			}
+
+			client, base, err := clientAndURLFromTestServer(result)
+			if err != nil {
+				t.Fatalf("Failed to get client from test server: %v", err)
+			}
+			req, err := http.NewRequest(http.MethodGet, base+tt.path, nil)
+			if err != nil {
+				t.Fatalf("Failed to request: %v", err)
+			}
+			r, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Failed to GET %s from component: %v", tt.path, err)
+			}
+
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("Failed to read response body: %v", err)
+			}
+			if err = r.Body.Close(); err != nil {
+				t.Fatalf("Failed to close response body: %v", err)
+			}
+			if got, expected := r.StatusCode, tt.wantResponseCode; got != expected {
+				t.Fatalf("Expected http %d at %s of component, got: %d %q", expected, tt.path, got, string(body))
+			}
+		})
+	}
+}
+
+// TODO: Make this a util function once there is a unified way to start a testing apiserver so that we can reuse it.
+func startTestAPIServer(t *testing.T) (server *kubeapiservertesting.TestServer, apiserverConfig, token string, err error) {
+	// Insulate this test from picking up in-cluster config when run inside a pod
+	// We can't assume we have permissions to write to /var/run/secrets/... from a unit test to mock in-cluster config for testing
+	originalHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+	if len(originalHost) > 0 {
+		if err = os.Setenv("KUBERNETES_SERVICE_HOST", ""); err != nil {
+			return
+		}
+		defer func() {
+			err = os.Setenv("KUBERNETES_SERVICE_HOST", originalHost)
+		}()
+	}
+
+	// Authenticate to apiserver via bearer token
+	token = "flwqkenfjasasdfmwerasd" // Fake token for testing.
+	var tokenFile *os.File
+	tokenFile, err = os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		return
+	}
+	if _, err = fmt.Fprintf(tokenFile, `%s,system:kube-controller-manager,system:kube-controller-manager,""`, token); err != nil {
+		return
+	}
+	if err = tokenFile.Close(); err != nil {
+		return
+	}
+
+	// Start apiserver
+	server = kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--token-auth-file", tokenFile.Name(),
+		"--authorization-mode", "AlwaysAllow",
+	}, framework.SharedEtcd())
+
+	apiserverConfig = fmt.Sprintf(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+    certificate-authority: %s
+  name: integration
+contexts:
+- context:
+    cluster: integration
+    user: kube-controller-manager
+  name: default-context
+current-context: default-context
+users:
+- name: kube-controller-manager
+  user:
+    token: %s
+`, server.ClientConfig.Host, server.ServerOpts.SecureServing.ServerCert.CertKey.CertFile, token)
+
+	return server, apiserverConfig, token, nil
+}
+
+func clientAndURLFromTestServer(s kubecontrollermanageresting.TestServer) (*http.Client, string, error) {
+	secureInfo := s.Config.SecureServing
+	secureOptions := s.Options.SecureServing
+	url := fmt.Sprintf("https://%s", secureInfo.Listener.Addr().String())
+	url = strings.ReplaceAll(url, "[::]", "127.0.0.1") // Switch to IPv4 because the self-signed cert does not support [::]
+
+	// Read the self-signed server cert from disk
+	pool := x509.NewCertPool()
+	serverCertPath := path.Join(secureOptions.ServerCert.CertDirectory, secureOptions.ServerCert.PairName+".crt")
+	serverCert, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read the server cert %q: %w", serverCertPath, err)
+	}
+	pool.AppendCertsFromPEM(serverCert)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
+	client := &http.Client{Transport: tr}
+	return client, url, nil
+}

--- a/test/integration/controllermanager/serving/main_test.go
+++ b/test/integration/controllermanager/serving/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -368,7 +368,7 @@ users:
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kube-controller-manager",
 		},
-		Paths: []string{"/configz", "/flagz", "/healthz", "/metrics"},
+		Paths: []string{"/configz", "/flagz", "/healthz", "/livez", "/metrics", "/readyz"},
 	}
 	statuszWantBodyBeta1 := &statuszv1beta1.Statusz{
 		TypeMeta: metav1.TypeMeta{
@@ -378,7 +378,7 @@ users:
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kube-controller-manager",
 		},
-		Paths: []string{"/configz", "/flagz", "/healthz", "/metrics"},
+		Paths: []string{"/configz", "/flagz", "/healthz", "/livez", "/metrics", "/readyz"},
 	}
 
 	flagzWantBodyText := "kube-controller-manager flagz\nWarning: This endpoint is not meant to be machine parseable"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR supersedes #125276 by @nayihz: 

> Adds a proper liveness and readiness endpoints to the kube-controller-manager.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #118158

#### Special notes for your reviewer:

I left the history of this branch messy for now in case that's useful to review the delta from the previous PR. I think the only outstanding comment there was https://github.com/kubernetes/kubernetes/pull/125276#discussion_r1626581970 which I've addressed as a separate commit here. I plan to rebase/squash before merging.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-controller-manager: exposed the /livez and /readz endpoints for health checks that are in compliance with https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
