### PR TITLE
test/e2e: migrate VolumeAttributesClass from v1beta1 to v1

### DIFF
--- a/test/e2e/storage/framework/volume_resource.go
+++ b/test/e2e/storage/framework/volume_resource.go
@@ -24,7 +24,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +46,6 @@ type VolumeResource struct {
 	Pvc       *v1.PersistentVolumeClaim
 	Pv        *v1.PersistentVolume
 	Sc        *storagev1.StorageClass
-	Vac       *storagev1beta1.VolumeAttributesClass
 
 	Volume TestVolume
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

Optionally add one or more of the following kinds if applicable:

#### What this PR does / why we need it:

Update the storage test framework to use the stable v1 API for VolumeAttributesClass instead of the v1beta1 API.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
