### PR TITLE
scheduler: use PVC status.phase instead of bind-completed annotation

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -773,7 +773,7 @@ func (b *volumeBinder) isPVCBound(logger klog.Logger, namespace, pvcName string)
 }
 
 func (b *volumeBinder) isPVCFullyBound(pvc *v1.PersistentVolumeClaim) bool {
-	return pvc.Spec.VolumeName != "" && metav1.HasAnnotation(pvc.ObjectMeta, volume.AnnBindCompleted)
+	return pvc.Spec.VolumeName != "" && pvc.Status.Phase == v1.ClaimBound
 }
 
 // arePodVolumesBound returns true if all volumes are fully bound

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -623,7 +623,7 @@ func makeTestPVC(name, size, node string, pvcBoundState int, pvName, resourceVer
 		metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, volume.AnnSelectedNode, node)
 		// don't fallthrough
 	case pvcBound:
-		metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, volume.AnnBindCompleted, "yes")
+		pvc.Status.Phase = v1.ClaimBound
 		fallthrough
 	case pvcPrebound:
 		pvc.Spec.VolumeName = pvName
@@ -1935,7 +1935,7 @@ func TestBindPodVolumes(t *testing.T) {
 				// Update PVC to be fully bound to PV
 				newPVC := pvc.DeepCopy()
 				newPVC.Spec.VolumeName = pv.Name
-				metav1.SetMetaDataAnnotation(&newPVC.ObjectMeta, volume.AnnBindCompleted, "yes")
+				newPVC.Status.Phase = v1.ClaimBound
 				if _, err := testEnv.client.CoreV1().PersistentVolumeClaims(newPVC.Namespace).Update(ctx, newPVC, metav1.UpdateOptions{}); err != nil {
 					t.Errorf("failed to update PVC %q: %v", newPVC.Name, err)
 				}
@@ -1959,7 +1959,7 @@ func TestBindPodVolumes(t *testing.T) {
 					return
 				}
 				newPVC.Spec.VolumeName = dynamicPV.Name
-				metav1.SetMetaDataAnnotation(&newPVC.ObjectMeta, volume.AnnBindCompleted, "yes")
+				newPVC.Status.Phase = v1.ClaimBound
 				if _, err := testEnv.client.CoreV1().PersistentVolumeClaims(newPVC.Namespace).Update(ctx, newPVC, metav1.UpdateOptions{}); err != nil {
 					t.Errorf("failed to update PVC %q: %v", newPVC.Name, err)
 				}
@@ -2023,7 +2023,7 @@ func TestBindPodVolumes(t *testing.T) {
 				// Update PVC to be fully bound to a PV with a different node
 				newPVC := pvcs[0].DeepCopy()
 				newPVC.Spec.VolumeName = pvNode2.Name
-				metav1.SetMetaDataAnnotation(&newPVC.ObjectMeta, volume.AnnBindCompleted, "yes")
+				newPVC.Status.Phase = v1.ClaimBound
 				if _, err := testEnv.client.CoreV1().PersistentVolumeClaims(newPVC.Namespace).Update(ctx, newPVC, metav1.UpdateOptions{}); err != nil {
 					t.Errorf("failed to update PVC %q: %v", newPVC.Name, err)
 				}

--- a/pkg/scheduler/framework/plugins/volumebinding/test_utils.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/test_utils.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/utils/ptr"
 )
 
@@ -122,7 +121,7 @@ func makePVC(name string, storageClassName string) pvcBuilder {
 
 func (pvcb pvcBuilder) withBoundPV(pvName string) pvcBuilder {
 	pvcb.PersistentVolumeClaim.Spec.VolumeName = pvName
-	metav1.SetMetaDataAnnotation(&pvcb.PersistentVolumeClaim.ObjectMeta, volume.AnnBindCompleted, "true")
+	pvcb.PersistentVolumeClaim.Status.Phase = v1.ClaimBound
 	return pvcb
 }
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -52,7 +52,6 @@ import (
 	clientcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
@@ -3465,7 +3464,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 			cs := clientsetfake.NewClientset()
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
 			for _, pvc := range test.pvcs {
-				metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, volume.AnnBindCompleted, "true")
+				pvc.Status.Phase = v1.ClaimBound
 				cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, &pvc, metav1.CreateOptions{})
 			}
 			for _, pv := range test.pvs {

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -958,9 +958,9 @@ func (p *PersistentVolumeClaimWrapper) Namespace(s string) *PersistentVolumeClai
 	return p
 }
 
-// Annotation sets a {k,v} pair to the inner PersistentVolumeClaim.
-func (p *PersistentVolumeClaimWrapper) Annotation(key, value string) *PersistentVolumeClaimWrapper {
-	metav1.SetMetaDataAnnotation(&p.ObjectMeta, key, value)
+// Phase sets `phase` as the status.phase of the inner PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) Phase(phase v1.PersistentVolumeClaimPhase) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.Status.Phase = phase
 	return p
 }
 

--- a/test/integration/scheduler/filters/filters_test.go
+++ b/test/integration/scheduler/filters/filters_test.go
@@ -33,7 +33,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/kubernetes/pkg/features"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutils "k8s.io/kubernetes/test/integration/util"
@@ -2306,8 +2305,8 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 				pvc, err := testutils.CreatePVC(cs, st.MakePersistentVolumeClaim().
 					Name("pvc-with-read-write-once-pod").
 					Namespace(ns).
-					// Annotation and volume name required for PVC to be considered bound.
-					Annotation(volume.AnnBindCompleted, "true").
+					// phase and volume name required for PVC to be considered bound.
+					Phase(v1.ClaimBound).
 					VolumeName(pv.Name).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 					Resources(storage).
@@ -2366,7 +2365,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 				_, err = testutils.CreatePVC(cs, st.MakePersistentVolumeClaim().
 					Name("pvc-has-non-existent-nodes").
 					Namespace(ns).
-					Annotation(volume.AnnBindCompleted, "true").
+					Phase(v1.ClaimBound).
 					VolumeName(pv.Name).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 					Resources(storage).
@@ -2417,7 +2416,7 @@ func TestUnschedulablePodBecomesSchedulable(t *testing.T) {
 				_, err = testutils.CreatePVC(cs, st.MakePersistentVolumeClaim().
 					Name("pvc-foo").
 					Namespace(ns).
-					Annotation(volume.AnnBindCompleted, "true").
+					Phase(v1.ClaimBound).
 					VolumeName(pv.Name).
 					AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 					Resources(storage).

--- a/test/integration/scheduler/preemption/misc/miscpreemption_test.go
+++ b/test/integration/scheduler/preemption/misc/miscpreemption_test.go
@@ -33,7 +33,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2"
 	configv1 "k8s.io/kube-scheduler/config/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -927,8 +926,8 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 	pvc1 := st.MakePersistentVolumeClaim().
 		Name("pvc-with-read-write-once-pod-1").
 		Namespace(testCtx.NS.Name).
-		// Annotation and volume name required for PVC to be considered bound.
-		Annotation(volume.AnnBindCompleted, "true").
+		// phase and volume name required for PVC to be considered bound.
+		Phase(v1.ClaimBound).
 		VolumeName(pv1.Name).
 		AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 		Resources(storage).
@@ -942,8 +941,8 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 	pvc2 := st.MakePersistentVolumeClaim().
 		Name("pvc-with-read-write-once-pod-2").
 		Namespace(testCtx.NS.Name).
-		// Annotation and volume name required for PVC to be considered bound.
-		Annotation(volume.AnnBindCompleted, "true").
+		// phase and volume name required for PVC to be considered bound.
+		Phase(v1.ClaimBound).
 		VolumeName(pv2.Name).
 		AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 		Resources(storage).

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -32,7 +32,6 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
-	"k8s.io/component-helpers/storage/volume"
 	configv1 "k8s.io/kube-scheduler/config/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
@@ -1051,14 +1050,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
 			st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1107,14 +1106,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
 			st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1163,7 +1162,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1179,7 +1178,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc2 := st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1215,14 +1214,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
 			st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
@@ -1237,7 +1236,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc2 := st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1266,14 +1265,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
 			st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1322,14 +1321,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
 			st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1375,7 +1374,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc2 := st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1403,7 +1402,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1443,7 +1442,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1484,7 +1483,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1520,7 +1519,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
 				VolumeName("pv1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
@@ -1563,7 +1562,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
 				VolumeName("pv1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
@@ -1619,7 +1618,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			}
 			pvc1 := st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -1662,7 +1661,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			pvc1 := st.MakePersistentVolumeClaim().
 				Name("pvc1").
 				VolumeName("pv1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj()
@@ -2142,7 +2141,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -2188,14 +2187,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
 			st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -2242,7 +2241,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -2265,7 +2264,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		TriggerFn: func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error) {
 			pvc := st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -2290,7 +2289,7 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
@@ -2344,14 +2343,14 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 		InitialPVCs: []*v1.PersistentVolumeClaim{
 			st.MakePersistentVolumeClaim().
 				Name("pvc1").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv1").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).
 				Obj(),
 			st.MakePersistentVolumeClaim().
 				Name("pvc2").
-				Annotation(volume.AnnBindCompleted, "true").
+				Phase(v1.ClaimBound).
 				VolumeName("pv2").
 				AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}).
 				Resources(v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}).

--- a/test/integration/volumescheduling/volume_binding_test.go
+++ b/test/integration/volumescheduling/volume_binding_test.go
@@ -186,92 +186,92 @@ func TestVolumeBinding(t *testing.T) {
 	}
 
 	for name, test := range cases {
-		klog.Infof("Running test %v", name)
-
-		// Create two StorageClasses
-		suffix := rand.String(4)
-		classes := map[string]*storagev1.StorageClass{}
-		classes[classImmediate] = makeStorageClass(fmt.Sprintf("immediate-%v", suffix), &modeImmediate)
-		classes[classWait] = makeStorageClass(fmt.Sprintf("wait-%v", suffix), &modeWait)
-		for _, sc := range classes {
-			if _, err := config.client.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create StorageClass %q: %v", sc.Name, err)
+		t.Run(name, func(t *testing.T) {
+			// Create two StorageClasses
+			suffix := rand.String(4)
+			classes := map[string]*storagev1.StorageClass{}
+			classes[classImmediate] = makeStorageClass(fmt.Sprintf("immediate-%v", suffix), &modeImmediate)
+			classes[classWait] = makeStorageClass(fmt.Sprintf("wait-%v", suffix), &modeWait)
+			for _, sc := range classes {
+				if _, err := config.client.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create StorageClass %q: %v", sc.Name, err)
+				}
 			}
-		}
 
-		// Create PVs
-		for _, pvConfig := range test.pvs {
-			pv := makePV(pvConfig.name, classes[pvConfig.scName].Name, pvConfig.preboundPVC, config.ns, pvConfig.node)
-			if _, err := config.client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
+			// Create PVs
+			for _, pvConfig := range test.pvs {
+				pv := makePV(pvConfig.name, classes[pvConfig.scName].Name, pvConfig.preboundPVC, config.ns, pvConfig.node)
+				if _, err := config.client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
+				}
 			}
-		}
 
-		for _, pvConfig := range test.unboundPvs {
-			pv := makePV(pvConfig.name, classes[pvConfig.scName].Name, pvConfig.preboundPVC, config.ns, pvConfig.node)
-			if _, err := config.client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
+			for _, pvConfig := range test.unboundPvs {
+				pv := makePV(pvConfig.name, classes[pvConfig.scName].Name, pvConfig.preboundPVC, config.ns, pvConfig.node)
+				if _, err := config.client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
+				}
 			}
-		}
 
-		// Wait for PVs to become available to avoid race condition in PV controller
-		// https://github.com/kubernetes/kubernetes/issues/85320
-		for _, pvConfig := range test.pvs {
-			if err := waitForPVPhase(config.client, pvConfig.name, v1.VolumeAvailable); err != nil {
-				t.Fatalf("PersistentVolume %q failed to become available: %v", pvConfig.name, err)
+			// Wait for PVs to become available to avoid race condition in PV controller
+			// https://github.com/kubernetes/kubernetes/issues/85320
+			for _, pvConfig := range test.pvs {
+				if err := waitForPVPhase(config.client, pvConfig.name, v1.VolumeAvailable); err != nil {
+					t.Fatalf("PersistentVolume %q failed to become available: %v", pvConfig.name, err)
+				}
 			}
-		}
 
-		for _, pvConfig := range test.unboundPvs {
-			if err := waitForPVPhase(config.client, pvConfig.name, v1.VolumeAvailable); err != nil {
-				t.Fatalf("PersistentVolume %q failed to become available: %v", pvConfig.name, err)
+			for _, pvConfig := range test.unboundPvs {
+				if err := waitForPVPhase(config.client, pvConfig.name, v1.VolumeAvailable); err != nil {
+					t.Fatalf("PersistentVolume %q failed to become available: %v", pvConfig.name, err)
+				}
 			}
-		}
 
-		// Create PVCs
-		for _, pvcConfig := range test.pvcs {
-			pvc := makePVC(pvcConfig.name, config.ns, &classes[pvcConfig.scName].Name, pvcConfig.preboundPV)
-			if _, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PersistentVolumeClaim %q: %v", pvc.Name, err)
+			// Create PVCs
+			for _, pvcConfig := range test.pvcs {
+				pvc := makePVC(pvcConfig.name, config.ns, &classes[pvcConfig.scName].Name, pvcConfig.preboundPV)
+				if _, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PersistentVolumeClaim %q: %v", pvc.Name, err)
+				}
 			}
-		}
-		for _, pvcConfig := range test.unboundPvcs {
-			pvc := makePVC(pvcConfig.name, config.ns, &classes[pvcConfig.scName].Name, pvcConfig.preboundPV)
-			if _, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PersistentVolumeClaim %q: %v", pvc.Name, err)
+			for _, pvcConfig := range test.unboundPvcs {
+				pvc := makePVC(pvcConfig.name, config.ns, &classes[pvcConfig.scName].Name, pvcConfig.preboundPV)
+				if _, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PersistentVolumeClaim %q: %v", pvc.Name, err)
+				}
 			}
-		}
 
-		// Create Pod
-		if _, err := config.client.CoreV1().Pods(config.ns).Create(context.TODO(), test.pod, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Failed to create Pod %q: %v", test.pod.Name, err)
-		}
-		if test.shouldFail {
-			if err := waitForPodUnschedulable(config.client, test.pod); err != nil {
-				t.Errorf("Pod %q was not unschedulable: %v", test.pod.Name, err)
+			// Create Pod
+			if _, err := config.client.CoreV1().Pods(config.ns).Create(context.TODO(), test.pod, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create Pod %q: %v", test.pod.Name, err)
 			}
-		} else {
-			if err := waitForPodToSchedule(config.client, test.pod); err != nil {
-				t.Errorf("Failed to schedule Pod %q: %v", test.pod.Name, err)
+			if test.shouldFail {
+				if err := waitForPodUnschedulable(config.client, test.pod); err != nil {
+					t.Errorf("Pod %q was not unschedulable: %v", test.pod.Name, err)
+				}
+			} else {
+				if err := waitForPodToSchedule(config.client, test.pod); err != nil {
+					t.Errorf("Failed to schedule Pod %q: %v", test.pod.Name, err)
+				}
 			}
-		}
 
-		// Validate PVC/PV binding
-		for _, pvc := range test.pvcs {
-			validatePVCPhase(t, config.client, pvc.name, config.ns, v1.ClaimBound, false)
-		}
-		for _, pvc := range test.unboundPvcs {
-			validatePVCPhase(t, config.client, pvc.name, config.ns, v1.ClaimPending, false)
-		}
-		for _, pv := range test.pvs {
-			validatePVPhase(t, config.client, pv.name, v1.VolumeBound)
-		}
-		for _, pv := range test.unboundPvs {
-			validatePVPhase(t, config.client, pv.name, v1.VolumeAvailable)
-		}
+			// Validate PVC/PV binding
+			for _, pvc := range test.pvcs {
+				validatePVCPhase(t, config.client, pvc.name, config.ns, v1.ClaimBound, false)
+			}
+			for _, pvc := range test.unboundPvcs {
+				validatePVCPhase(t, config.client, pvc.name, config.ns, v1.ClaimPending, false)
+			}
+			for _, pv := range test.pvs {
+				validatePVPhase(t, config.client, pv.name, v1.VolumeBound)
+			}
+			for _, pv := range test.unboundPvs {
+				validatePVPhase(t, config.client, pv.name, v1.VolumeAvailable)
+			}
 
-		// Force delete objects, but they still may not be immediately removed
-		deleteTestObjects(config.client, config.ns, deleteOption)
+			// Force delete objects, but they still may not be immediately removed
+			deleteTestObjects(config.client, config.ns, deleteOption)
+		})
 	}
 }
 
@@ -340,57 +340,57 @@ func TestVolumeBindingRescheduling(t *testing.T) {
 	}
 
 	for name, test := range cases {
-		klog.Infof("Running test %v", name)
-
-		if test.pod == nil {
-			t.Fatal("pod is required for this test")
-		}
-
-		// Create unbound pvc
-		for _, pvcConfig := range test.pvcs {
-			pvc := makePVC(pvcConfig.name, config.ns, &storageClassName, "")
-			if _, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PersistentVolumeClaim %q: %v", pvc.Name, err)
+		t.Run(name, func(t *testing.T) {
+			if test.pod == nil {
+				t.Fatal("pod is required for this test")
 			}
-		}
 
-		// Create PVs
-		for _, pvConfig := range test.pvs {
-			pv := makePV(pvConfig.name, sharedClasses[pvConfig.scName].Name, pvConfig.preboundPVC, config.ns, pvConfig.node)
-			if _, err := config.client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
+			// Create unbound pvc
+			for _, pvcConfig := range test.pvcs {
+				pvc := makePVC(pvcConfig.name, config.ns, &storageClassName, "")
+				if _, err := config.client.CoreV1().PersistentVolumeClaims(config.ns).Create(context.TODO(), pvc, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PersistentVolumeClaim %q: %v", pvc.Name, err)
+				}
 			}
-		}
 
-		// Create pod
-		if _, err := config.client.CoreV1().Pods(config.ns).Create(context.TODO(), test.pod, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Failed to create Pod %q: %v", test.pod.Name, err)
-		}
-
-		// Wait for pod is unschedulable.
-		klog.Infof("Waiting for pod is unschedulable")
-		if err := waitForPodUnschedulable(config.client, test.pod); err != nil {
-			t.Errorf("Failed as Pod %s was not unschedulable: %v", test.pod.Name, err)
-		}
-
-		// Trigger
-		test.trigger(config)
-
-		// Wait for pod is scheduled or unschedulable.
-		if !test.shouldFail {
-			klog.Infof("Waiting for pod is scheduled")
-			if err := waitForPodToSchedule(config.client, test.pod); err != nil {
-				t.Errorf("Failed to schedule Pod %q: %v", test.pod.Name, err)
+			// Create PVs
+			for _, pvConfig := range test.pvs {
+				pv := makePV(pvConfig.name, sharedClasses[pvConfig.scName].Name, pvConfig.preboundPVC, config.ns, pvConfig.node)
+				if _, err := config.client.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PersistentVolume %q: %v", pv.Name, err)
+				}
 			}
-		} else {
+
+			// Create pod
+			if _, err := config.client.CoreV1().Pods(config.ns).Create(context.TODO(), test.pod, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create Pod %q: %v", test.pod.Name, err)
+			}
+
+			// Wait for pod is unschedulable.
 			klog.Infof("Waiting for pod is unschedulable")
 			if err := waitForPodUnschedulable(config.client, test.pod); err != nil {
 				t.Errorf("Failed as Pod %s was not unschedulable: %v", test.pod.Name, err)
 			}
-		}
 
-		// Force delete objects, but they still may not be immediately removed
-		deleteTestObjects(config.client, config.ns, deleteOption)
+			// Trigger
+			test.trigger(config)
+
+			// Wait for pod is scheduled or unschedulable.
+			if !test.shouldFail {
+				klog.Infof("Waiting for pod is scheduled")
+				if err := waitForPodToSchedule(config.client, test.pod); err != nil {
+					t.Errorf("Failed to schedule Pod %q: %v", test.pod.Name, err)
+				}
+			} else {
+				klog.Infof("Waiting for pod is unschedulable")
+				if err := waitForPodUnschedulable(config.client, test.pod); err != nil {
+					t.Errorf("Failed as Pod %s was not unschedulable: %v", test.pod.Name, err)
+				}
+			}
+
+			// Force delete objects, but they still may not be immediately removed
+			deleteTestObjects(config.client, config.ns, deleteOption)
+		})
 	}
 }
 
@@ -1285,6 +1285,7 @@ func makeNode(index int) *v1.Node {
 }
 
 func validatePVCPhase(t *testing.T, client clientset.Interface, pvcName string, ns string, phase v1.PersistentVolumeClaimPhase, isProvisioned bool) {
+	t.Helper()
 	claim, err := client.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Failed to get PVC %v/%v: %v", ns, pvcName, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The scheduler now determines whether a PVC is bound by inspecting the PVC's status.phase, instead of relying on the `pv.kubernetes.io/bind-completed` annotation. The pv-controller (kube-controller-manager) is the only component
that writes and reads this annotation after the change.

This change should resolve the flaky test case TestVolumeBinding (immediate pvc prebound) which checks PVC status after pod bound.

Behavior change:
- Scheduler latency may increase slightly (a few milliseconds) because the scheduler may wait for an additional status update from the pv-controller.
- scheduler will reject PVCs at Lost status. We sometimes see this when a user creates a new PVC using an existing one as template but unintentionally preserved the annotation. This should not break anyone.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#134815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Scheduler now rejects Lost PVCs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
