### PR TITLE
refactor: remove beta StorageClass annotation and rename helper

### DIFF
--- a/pkg/apis/storage/util/helpers.go
+++ b/pkg/apis/storage/util/helpers.go
@@ -22,20 +22,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // marks a class as the default StorageClass
 const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
-// BetaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
-// TODO: remove Beta when no longer used
-const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
-
-// IsDefaultAnnotation returns a boolean if
-// the annotation is set
-// TODO: remove Beta when no longer needed
-func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
-		return true
-	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
-		return true
-	}
-
-	return false
+// HasDefaultAnnotation returns a boolean if the object metadata has the default annotation set.
+func HasDefaultAnnotation(obj metav1.ObjectMeta) bool {
+	return obj.Annotations[IsDefaultStorageClassAnnotation] == "true"
 }

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -2630,7 +2630,7 @@ func printStorageClass(obj *storage.StorageClass, options printers.GenerateOptio
 	}
 
 	name := obj.Name
-	if storageutil.IsDefaultAnnotation(obj.ObjectMeta) {
+	if storageutil.HasDefaultAnnotation(obj.ObjectMeta) {
 		name += " (default)"
 	}
 	provtype := obj.Provisioner

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -505,7 +505,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 func verifyDefaultStorageClass(ctx context.Context, c clientset.Interface, scName string, expectedDefault bool) {
 	sc, err := c.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	gomega.Expect(storageutil.IsDefaultAnnotation(sc.ObjectMeta)).To(gomega.Equal(expectedDefault))
+	gomega.Expect(storageutil.HasDefaultAnnotation(sc.ObjectMeta)).To(gomega.Equal(expectedDefault))
 }
 
 func updateDefaultStorageClass(ctx context.Context, c clientset.Interface, scName string, defaultStr string) {
@@ -513,13 +513,11 @@ func updateDefaultStorageClass(ctx context.Context, c clientset.Interface, scNam
 	framework.ExpectNoError(err)
 
 	if defaultStr == "" {
-		delete(sc.Annotations, storageutil.BetaIsDefaultStorageClassAnnotation)
 		delete(sc.Annotations, storageutil.IsDefaultStorageClassAnnotation)
 	} else {
 		if sc.Annotations == nil {
 			sc.Annotations = make(map[string]string)
 		}
-		sc.Annotations[storageutil.BetaIsDefaultStorageClassAnnotation] = defaultStr
 		sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = defaultStr
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR refactors StorageClass default annotation handling by:
1. Removing deprecated beta annotation support (`storageclass.beta.kubernetes.io/is-default-class`)
  - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#api-overview
3. Renaming `IsDefaultAnnotation` to `HasDefaultAnnotation` for better clarity
#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
