### PR TITLE
KEP-5607: Allow hostNetwork pods to use user namespace

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3898,9 +3898,12 @@ func validateHostUsers(spec *core.PodSpec, fldPath *field.Path, opts PodValidati
 	// know of any good use case and we can always enable them later.
 
 	// Note we already validated above spec.SecurityContext is not nil.
-	if spec.SecurityContext.HostNetwork {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("hostNetwork"), "when `hostUsers` is false"))
+	if !opts.AllowUserNamespacesHostNetworkSupport {
+		if spec.SecurityContext.HostNetwork {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("hostNetwork"), "when `hostUsers` is false"))
+		}
 	}
+
 	if spec.SecurityContext.HostPID {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("HostPID"), "when `hostUsers` is false"))
 	}
@@ -4431,6 +4434,8 @@ type PodValidationOptions struct {
 	AllowContainerRestartPolicyRules bool
 	// Allow user namespaces with volume devices, even though they will not function properly (should only be tolerated in updates of objects which already have this invalid configuration).
 	AllowUserNamespacesWithVolumeDevices bool
+	// Allow hostNetwork pods to use user namespaces
+	AllowUserNamespacesHostNetworkSupport bool
 }
 
 // validatePodMetadataAndSpec tests if required fields in the pod.metadata and pod.spec are set,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -990,6 +990,12 @@ const (
 	// Proxies client to an apiserver capable of serving the request in the event of version skew.
 	UnknownVersionInteroperabilityProxy featuregate.Feature = "UnknownVersionInteroperabilityProxy"
 
+	// owner: @HirazawaUi
+	// kep: https://kep.k8s.io/5607
+	//
+	// Allow hostNetwork pods to use user namespaces
+	UserNamespacesHostNetworkSupport featuregate.Feature = "UserNamespacesHostNetworkSupport"
+
 	// owner: @rata, @giuseppe
 	// kep: https://kep.k8s.io/127
 	//
@@ -1755,6 +1761,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	UserNamespacesHostNetworkSupport: {
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	UserNamespacesSupport: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
@@ -2298,6 +2308,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	TranslateStreamCloseWebsocketRequests: {},
 
 	UnknownVersionInteroperabilityProxy: {},
+
+	UserNamespacesHostNetworkSupport: {UserNamespacesSupport},
 
 	UserNamespacesSupport: {},
 

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1839,6 +1839,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.28"
+- name: UserNamespacesHostNetworkSupport
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.35"
 - name: UserNamespacesSupport
   versionedSpecs:
   - default: false

--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -129,6 +129,81 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 		})
 
+		f.It("must create a user namespace and use host network when hostUsers is false and hostNetwork is true [LinuxOnly]", feature.UserNamespacesHostNetworkSupport, framework.WithFeatureGate(features.UserNamespacesHostNetworkSupport),
+			feature.UserNamespacesSupport, framework.WithFeatureGate(features.UserNamespacesSupport), func(ctx context.Context) {
+				// with hostUsers=false the pod must use a new user namespace.
+				// with hostNetwork=true the pod must use the host network namespace.
+				podClient := e2epod.PodClientNS(f, f.Namespace.Name)
+
+				// Schedule pods on the same node to ensure they share the same host network namespace.
+				targetNode, err := findLinuxNode(ctx, f)
+				framework.ExpectNoError(err, "Error finding Linux node")
+
+				makePodForHostNetTest := func(nodeName string) *v1.Pod {
+					return &v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "userns-hostnet-" + string(uuid.NewUUID()),
+						},
+						Spec: v1.PodSpec{
+							NodeName: nodeName,
+							Containers: []v1.Container{
+								{
+									Name:    containerName,
+									Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+									Command: []string{"sh", "-c", "cat /proc/self/uid_map && readlink /proc/self/ns/net"},
+								},
+							},
+							RestartPolicy: v1.RestartPolicyNever,
+							HostUsers:     ptr.To(false),
+							HostNetwork:   true,
+						},
+					}
+				}
+
+				createdPod1 := podClient.Create(ctx, makePodForHostNetTest(targetNode.Name))
+				createdPod2 := podClient.Create(ctx, makePodForHostNetTest(targetNode.Name))
+				ginkgo.DeferCleanup(func(ctx context.Context) {
+					ginkgo.By("delete the pods")
+					podClient.DeleteSync(ctx, createdPod1.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+					podClient.DeleteSync(ctx, createdPod2.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+				})
+				getLogs := func(pod *v1.Pod) (string, string, error) {
+					err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart)
+					if err != nil {
+						return "", "", err
+					}
+					podStatus, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+					if err != nil {
+						return "", "", err
+					}
+					logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podStatus.Name, containerName)
+					if err != nil {
+						return "", "", err
+					}
+					parts := strings.Split(strings.TrimSpace(logs), "\n")
+					if len(parts) != 2 {
+						return "", "", fmt.Errorf("expected 2 lines of logs, got %d: %q", len(parts), logs)
+					}
+					return parts[0], parts[1], nil
+				}
+
+				uidMap1, netNs1, err := getLogs(createdPod1)
+				framework.ExpectNoError(err)
+				uidMap2, netNs2, err := getLogs(createdPod2)
+				framework.ExpectNoError(err)
+
+				// 65536 is the size used for a user namespace.  Verify that the value is present
+				// in the /proc/self/uid_map file.
+				gomega.Expect(uidMap1).To(gomega.ContainSubstring("65536"), "user namespace not created for pod1")
+				gomega.Expect(uidMap2).To(gomega.ContainSubstring("65536"), "user namespace not created for pod2")
+
+				// Check they are in different user namespaces.
+				gomega.Expect(uidMap1).NotTo(gomega.Equal(uidMap2), "two different pods are running with the same user namespace configuration")
+
+				// Check they are in the same network namespace (the host's one).
+				gomega.Expect(netNs1).To(gomega.Equal(netNs2), "two different pods with hostNetwork=true should be in the same network namespace, but they are not. NetNS1: %s, NetNS2: %s", netNs1, netNs2)
+			})
+
 		f.It("must create the user namespace in the configured hostUID/hostGID range [LinuxOnly]", feature.UserNamespacesSupport, framework.WithFeatureGate(features.UserNamespacesSupport), func(ctx context.Context) {
 			// We need to check with the binary "getsubuids" the mappings for the kubelet.
 			// If something is not present, we skip the test as the node wasn't configured to run this test.

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -455,6 +455,11 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	Upgrade = framework.WithFeature(framework.ValidFeatures.Add("Upgrade"))
 
+	// Owner: sig-node
+	// Test marked with this feature must run on nodes where container runtime allows to pods with hostNetwork to use user namespaces.
+	// This feature can be removed once Containerd and CRI-O both added this support.
+	UserNamespacesHostNetworkSupport = framework.WithFeature(framework.ValidFeatures.Add("UserNamespacesHostNetworkSupport"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	UserNamespacesSupport = framework.WithFeature(framework.ValidFeatures.Add("UserNamespacesSupport"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Since [KEP-5607](https://github.com/kubernetes/enhancements/pull/5608) has been merged, we will advance this feature during the v1.35 cycle.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
While investigating the `crio` implementation, I found that the combination of `crio` and `crun` already supports the use of `hostNetwork` with `user ns`. Therefore, I've added an e2e test and created a corresponding e2e feature. I will later add a test job for it in the test-infra repo, which will use only `crio` (without requiring additional debugging, since `crio` uses `crun` as the underlying runtime by default).



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add the `UserNamespacesHostNetworkSupport` feature gate. The feature gate defaults to disabled. When the feature gate is enabled, will allow `hostNetwork` pods to use `user namespace`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5607
```
