### PR TITLE
scheduler: KEP-5007 Add BindingTimeout args to DynamicResources plugin

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -68495,6 +68495,12 @@ func schema_k8sio_kube_scheduler_config_v1_DynamicResourcesArgs(ref common.Refer
 							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
 						},
 					},
+					"bindingTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "BindingTimeout limits how long the PreBind extension point may wait for ResourceClaim device BindingConditions to become satisfied when such conditions are present. While waiting, the scheduler periodically checks device status. If the timeout elapses before all required conditions are true (or any bindingFailureConditions become true), the allocation is cleared and the Pod re-enters scheduling queue. Note that the same or other node may be chosen if feasible; otherwise the Pod is placed in the unschedulable queue and retried based on cluster changes and backoff.\n\nDefaults & feature gates:\n  - Defaults to 10 minutes when the DRADeviceBindingConditions feature gate is enabled.\n  - Has effect only when BOTH DRADeviceBindingConditions and\n    DRAResourceClaimDeviceStatus are enabled; otherwise omit this field.\n  - When DRADeviceBindingConditions is disabled, setting this field is considered an error.\n\nValid values:\n  - >=1s (non-zero). No upper bound is enforced.\n\nTuning guidance:\n  - Lower values reduce time-to-retry when devices aren’t ready but can\n    increase churn if drivers typically need longer to report readiness.\n  - Review scheduler latency metrics (e.g. PreBind duration in\n    `scheduler_framework_extension_point_duration_seconds`) and driver\n    readiness behavior before tightening this timeout.",
+							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
+						},
+					},
 				},
 				Required: []string{"filterTimeout"},
 			},

--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -57,6 +57,7 @@ profiles:
   - name: DynamicResources
     args:
       filterTimeout: 10s
+      bindingTimeout: 30s
   - name: InterPodAffinity
     args:
       hardPodAffinityWeight: 5
@@ -107,7 +108,10 @@ profiles:
 						},
 						{
 							Name: "DynamicResources",
-							Args: &config.DynamicResourcesArgs{FilterTimeout: &metav1.Duration{Duration: 10 * time.Second}},
+							Args: &config.DynamicResourcesArgs{
+								FilterTimeout:  &metav1.Duration{Duration: 10 * time.Second},
+								BindingTimeout: &metav1.Duration{Duration: 30 * time.Second},
+							},
 						},
 						{
 							Name: "InterPodAffinity",

--- a/pkg/scheduler/apis/config/types_pluginargs.go
+++ b/pkg/scheduler/apis/config/types_pluginargs.go
@@ -257,6 +257,33 @@ type DynamicResourcesArgs struct {
 	//
 	// Setting it to zero completely disables the timeout.
 	FilterTimeout *metav1.Duration
+
+	// BindingTimeout limits how long the PreBind extension point may wait for
+	// ResourceClaim device BindingConditions to become satisfied when such
+	// conditions are present. While waiting, the scheduler periodically checks
+	// device status. If the timeout elapses before all required conditions are
+	// true (or any bindingFailureConditions become true), the allocation is
+	// cleared and the Pod re-enters scheduling queue. Note that the same or other node may be
+	// chosen if feasible; otherwise the Pod is placed in the unschedulable queue and
+	// retried based on cluster changes and backoff.
+	//
+	// Defaults & feature gates:
+	//   - Defaults to 10 minutes when the DRADeviceBindingConditions feature gate is enabled.
+	//   - Has effect only when BOTH DRADeviceBindingConditions and
+	//     DRAResourceClaimDeviceStatus are enabled; otherwise omit this field.
+	//   - When DRADeviceBindingConditions is disabled, setting this field is considered an error.
+	//
+	// Valid values:
+	//   - >=1s (non-zero). No upper bound is enforced.
+	//
+	// Tuning guidance:
+	//   - Lower values reduce time-to-retry when devices aren’t ready but can
+	//     increase churn if drivers typically need longer to report readiness.
+	//   - Review scheduler latency metrics (e.g. PreBind duration in
+	//     `scheduler_framework_extension_point_duration_seconds`) and driver
+	//     readiness behavior before tightening this timeout.
+	BindingTimeout *metav1.Duration
 }
 
 const DynamicResourcesFilterTimeoutDefault = 10 * time.Second
+const DynamicResourcesBindingTimeoutDefault = 600 * time.Second

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -248,4 +248,10 @@ func SetDefaults_DynamicResourcesArgs(obj *configv1.DynamicResourcesArgs) {
 	if obj.FilterTimeout == nil && feature.DefaultFeatureGate.Enabled(features.DRASchedulerFilterTimeout) {
 		obj.FilterTimeout = &metav1.Duration{Duration: configv1.DynamicResourcesFilterTimeoutDefault}
 	}
+
+	if obj.BindingTimeout == nil &&
+		feature.DefaultFeatureGate.Enabled(features.DRADeviceBindingConditions) &&
+		feature.DefaultFeatureGate.Enabled(features.DRAResourceClaimDeviceStatus) {
+		obj.BindingTimeout = &metav1.Duration{Duration: configv1.DynamicResourcesBindingTimeoutDefault}
+	}
 }

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -892,6 +892,18 @@ func TestPluginArgsDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "DynamicResourcesArgs defaults, DRADeviceBindingConditions enabled",
+			features: map[featuregate.Feature]bool{
+				features.DRADeviceBindingConditions:   true,
+				features.DRAResourceClaimDeviceStatus: true,
+			},
+			in: &configv1.DynamicResourcesArgs{},
+			want: &configv1.DynamicResourcesArgs{
+				FilterTimeout:  &metav1.Duration{Duration: 10 * time.Second},
+				BindingTimeout: &metav1.Duration{Duration: 600 * time.Second},
+			},
+		},
 	}
 	for _, tc := range tests {
 		scheme := runtime.NewScheme()

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -285,6 +285,7 @@ func Convert_config_DefaultPreemptionArgs_To_v1_DefaultPreemptionArgs(in *config
 
 func autoConvert_v1_DynamicResourcesArgs_To_config_DynamicResourcesArgs(in *configv1.DynamicResourcesArgs, out *config.DynamicResourcesArgs, s conversion.Scope) error {
 	out.FilterTimeout = (*metav1.Duration)(unsafe.Pointer(in.FilterTimeout))
+	out.BindingTimeout = (*metav1.Duration)(unsafe.Pointer(in.BindingTimeout))
 	return nil
 }
 
@@ -295,6 +296,7 @@ func Convert_v1_DynamicResourcesArgs_To_config_DynamicResourcesArgs(in *configv1
 
 func autoConvert_config_DynamicResourcesArgs_To_v1_DynamicResourcesArgs(in *config.DynamicResourcesArgs, out *configv1.DynamicResourcesArgs, s conversion.Scope) error {
 	out.FilterTimeout = (*metav1.Duration)(unsafe.Pointer(in.FilterTimeout))
+	out.BindingTimeout = (*metav1.Duration)(unsafe.Pointer(in.BindingTimeout))
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -61,6 +61,11 @@ func (in *DynamicResourcesArgs) DeepCopyInto(out *DynamicResourcesArgs) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.BindingTimeout != nil {
+		in, out := &in.BindingTimeout, &out.BindingTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1797,7 +1797,10 @@ func TestPlugin(t *testing.T) {
 		"prebind-fail-with-binding-timeout": {
 			enableDRADeviceBindingConditions:   true,
 			enableDRAResourceClaimDeviceStatus: true,
-			pod:                                podWithClaimName,
+			args: &config.DynamicResourcesArgs{
+				BindingTimeout: &metav1.Duration{Duration: 600 * time.Second},
+			},
+			pod: podWithClaimName,
 			claims: func() []*resourceapi.ResourceClaim {
 				claim := allocatedClaim.DeepCopy()
 				claim.Status.Allocation = allocationResultWithBindingConditions.DeepCopy()

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -432,6 +432,33 @@ type DynamicResourcesArgs struct {
 	//
 	// Setting it to zero completely disables the timeout.
 	FilterTimeout *metav1.Duration `json:"filterTimeout"`
+
+	// BindingTimeout limits how long the PreBind extension point may wait for
+	// ResourceClaim device BindingConditions to become satisfied when such
+	// conditions are present. While waiting, the scheduler periodically checks
+	// device status. If the timeout elapses before all required conditions are
+	// true (or any bindingFailureConditions become true), the allocation is
+	// cleared and the Pod re-enters scheduling queue. Note that the same or other node may be
+	// chosen if feasible; otherwise the Pod is placed in the unschedulable queue and
+	// retried based on cluster changes and backoff.
+	//
+	// Defaults & feature gates:
+	//   - Defaults to 10 minutes when the DRADeviceBindingConditions feature gate is enabled.
+	//   - Has effect only when BOTH DRADeviceBindingConditions and
+	//     DRAResourceClaimDeviceStatus are enabled; otherwise omit this field.
+	//   - When DRADeviceBindingConditions is disabled, setting this field is considered an error.
+	//
+	// Valid values:
+	//   - >=1s (non-zero). No upper bound is enforced.
+	//
+	// Tuning guidance:
+	//   - Lower values reduce time-to-retry when devices aren’t ready but can
+	//     increase churn if drivers typically need longer to report readiness.
+	//   - Review scheduler latency metrics (e.g. PreBind duration in
+	//     `scheduler_framework_extension_point_duration_seconds`) and driver
+	//     readiness behavior before tightening this timeout.
+	BindingTimeout *metav1.Duration `json:"bindingTimeout,omitempty"`
 }
 
 const DynamicResourcesFilterTimeoutDefault = 10 * time.Second
+const DynamicResourcesBindingTimeoutDefault = 600 * time.Second

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -71,6 +71,11 @@ func (in *DynamicResourcesArgs) DeepCopyInto(out *DynamicResourcesArgs) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.BindingTimeout != nil {
+		in, out := &in.BindingTimeout, &out.BindingTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature 
/sig scheduling
 
 
**What this PR does / why we need it:**
 
This PR adds a new `bindingTimeout` field to the **DynamicResources** scheduler plugin arguments.
It enables users to configure how long the scheduler waits in the `PreBind` phase for device binding conditions before timing out.
 
Previously, the wait duration was hardcoded. This change makes it configurable through the scheduler configuration API, improving flexibility for environments using the Dynamic Resource Allocation (DRA) framework.
 
**Which issue(s) this PR fixes:**
 
Part of [KEP-5007: DRA Device Binding Conditions](https://github.com/kubernetes/enhancements/issues/5007)
 

**Special notes for your reviewer:**
 
* The new field `bindingTimeout` is only valid when both feature gates
  `DRADeviceBindingConditions` **and** `DRAResourceClaimDeviceStatus` are enabled.
* Default value: **600 seconds (10 minutes)** when both feature gates are active.
* Validation ensures a minimum of 1 second and forbids configuration if either gate is disabled.
* Legacy `BindingTimeoutDefaultSeconds` constant has been removed.
 
 
**Does this PR introduce a user-facing change?**
 
```release-note
Scheduler: added a new `bindingTimeout` argument to the DynamicResources plugin configuration.
This allows customizing the wait duration in PreBind for device binding conditions.
Defaults to 10 minutes when DRADeviceBindingConditions and DRAResourceClaimDeviceStatus are both enabled.
```
 

**Additional documentation (e.g., KEPs, usage docs, etc.):**
 
* **KEP:** [KEP-5007: DRA Device Binding Conditions](https://github.com/kubernetes/enhancements/issues/5007)
* **Example config:**
 
```yaml
apiVersion: kubescheduler.config.k8s.io/v1
kind: KubeSchedulerConfiguration
profiles:
  - pluginConfig:
      - name: DynamicResources
        args:
          filterTimeout: 10s
          bindingTimeout: 30s
```