### PR TITLE
Informer batch

### DIFF
--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -84,7 +84,7 @@ var defaultKubernetesFeatureGates = map[Feature]FeatureSpec{
 	ClientsAllowCBOR:             {Default: false, PreRelease: Alpha},
 	ClientsPreferCBOR:            {Default: false, PreRelease: Alpha},
 	InOrderInformers:             {Default: true, PreRelease: Beta},
-	InOrderInformersBatchProcess: {Default: false, PreRelease: Alpha},
+	InOrderInformersBatchProcess: {Default: true, PreRelease: Beta},
 	InformerResourceVersion:      {Default: false, PreRelease: Alpha},
 	WatchListClient:              {Default: false, PreRelease: Beta},
 }

--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -54,6 +54,12 @@ const (
 	// Refactor informers to deliver watch stream events in order instead of out of order.
 	InOrderInformers Feature = "InOrderInformers"
 
+	// owner: @yue9944882
+	// alpha: v1.34
+	//
+	// Allow InOrderInformer to process incoming events in batches to expedite the process rate.
+	InOrderInformersBatchProcess Feature = "InOrderInformersBatchProcess"
+
 	// owner: @nilekhc
 	// alpha: v1.30
 	InformerResourceVersion Feature = "InformerResourceVersion"
@@ -75,9 +81,10 @@ const (
 // After registering with the binary, the features are, by default, controllable using environment variables.
 // For more details, please see envVarFeatureGates implementation.
 var defaultKubernetesFeatureGates = map[Feature]FeatureSpec{
-	ClientsAllowCBOR:        {Default: false, PreRelease: Alpha},
-	ClientsPreferCBOR:       {Default: false, PreRelease: Alpha},
-	InOrderInformers:        {Default: true, PreRelease: Beta},
-	InformerResourceVersion: {Default: false, PreRelease: Alpha},
-	WatchListClient:         {Default: false, PreRelease: Beta},
+	ClientsAllowCBOR:             {Default: false, PreRelease: Alpha},
+	ClientsPreferCBOR:            {Default: false, PreRelease: Alpha},
+	InOrderInformers:             {Default: true, PreRelease: Beta},
+	InOrderInformersBatchProcess: {Default: false, PreRelease: Alpha},
+	InformerResourceVersion:      {Default: false, PreRelease: Alpha},
+	WatchListClient:              {Default: false, PreRelease: Beta},
 }

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -644,10 +644,15 @@ func processDeltasInBatch(
 			}
 		}
 	}
+
+	err := txnStore.Transaction(txns...)
+	if err != nil {
+		return err
+	}
 	for _, callback := range callbacks {
 		callback()
 	}
-	return txnStore.Transaction(txns...)
+	return nil
 }
 
 // newInformer returns a controller for populating the store while also

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -312,6 +312,7 @@ func NewSharedIndexInformerWithOptions(lw ListerWatcher, exampleObject runtime.O
 		defaultEventHandlerResyncPeriod: options.ResyncPeriod,
 		clock:                           realClock,
 		cacheMutationDetector:           NewCacheMutationDetector(fmt.Sprintf("%T", exampleObject)),
+		batchSize:                       options.BatchSize,
 	}
 }
 
@@ -327,6 +328,8 @@ type SharedIndexInformerOptions struct {
 	// ObjectDescription is the sharedIndexInformer's object description. This is passed through to the
 	// underlying Reflector's type description.
 	ObjectDescription string
+
+	BatchSize int
 }
 
 // InformerSynced is a function that can be used to determine if an informer has synced.  This is useful for determining if caches have synced.
@@ -449,6 +452,7 @@ type sharedIndexInformer struct {
 	watchErrorHandler WatchErrorHandlerWithContext
 
 	transform TransformFunc
+	batchSize int
 }
 
 // dummyController hides the fact that a SharedInformer is different from a dedicated one
@@ -545,6 +549,7 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 				KeyFunction:  MetaNamespaceKeyFunc,
 				KnownObjects: s.indexer,
 				Transformer:  s.transform,
+				BatchSize:    s.batchSize,
 			})
 		} else {
 			fifo = NewDeltaFIFOWithOptions(DeltaFIFOOptions{

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -732,6 +732,9 @@ func (s *sharedIndexInformer) HandleDeltas(obj interface{}, isInInitialList bool
 	if deltas, ok := obj.(Deltas); ok {
 		return processDeltas(s, s.indexer, deltas, isInInitialList)
 	}
+	if deltaList, ok := obj.([]Deltas); ok {
+		return processDeltasInBatch(s, s.indexer, deltaList, isInInitialList)
+	}
 	return errors.New("object given as Process argument is not Deltas")
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/watch"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+)
+
+var benchmarkNamespace = "default"
+
+func BenchmarkSharedIndexInformer(b *testing.B) {
+	for _, podCount := range []int{10_000, 20_000, 40_000, 80_000, 160_000} {
+		b.Run(fmt.Sprintf("podCount=%d", podCount), func(b *testing.B) {
+			pods := createPods(podCount, benchmarkNamespace)
+			for _, batch := range []int{1, 10, 100, 1000, 10000} {
+				clientfeaturestesting.SetFeatureDuringTest(b, clientfeatures.InOrderInformersBatchProcess, batch > 1)
+				b.Run(fmt.Sprintf("batch=%d", batch), func(b *testing.B) {
+					for _, readers := range []int{0, 1, 10, 20, 40, 80} {
+						b.Run(fmt.Sprintf("readers=%d", readers), func(b *testing.B) {
+							watcher := watch.NewFakeWithChanSize(1, false)
+							informer, stop := setupSharedIndexInformer(b, watcher, batch, pods)
+							defer stop()
+							queuedEvents := batch * 2
+							benchmarkSharedIndexInformer(b, readers, watcher, informer, pods, queuedEvents)
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func createPods(count int, namespace string) []corev1.Pod {
+	pods := []corev1.Pod{}
+	for i := 0; i < count; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rand.String(20),
+				Namespace: namespace,
+			},
+		}
+		pods = append(pods, *pod)
+	}
+	return pods
+}
+
+func setupSharedIndexInformer(b *testing.B, watcher watch.Interface, batchSize int, pods []corev1.Pod) (SharedIndexInformer, func()) {
+	podInformer := NewSharedIndexInformerWithOptions(
+		&ListWatch{
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				return &corev1.PodList{
+					Items: pods,
+				}, nil
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				return watcher, nil
+			},
+		},
+		&corev1.Pod{},
+		SharedIndexInformerOptions{
+			ResyncPeriod: time.Second * 60,
+			Indexers:     Indexers{NamespaceIndex: MetaNamespaceIndexFunc},
+			BatchSize:    batchSize,
+		},
+	)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		podInformer.Run(stop)
+	}()
+	for !podInformer.HasSynced() {
+		time.Sleep(time.Millisecond)
+	}
+	return podInformer, func() {
+		close(stop)
+		wg.Wait()
+	}
+}
+
+func benchmarkSharedIndexInformer(b *testing.B, readers int, watcher *watch.FakeWatcher, podInformer SharedIndexInformer, pods []corev1.Pod, queuedEvents int) {
+	var writes atomic.Int64
+	got := make(chan struct{}, queuedEvents)
+
+	podInformer.AddEventHandler(ResourceEventHandlerDetailedFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			writes.Add(1)
+			select {
+			case <-got:
+			default:
+			}
+		},
+	})
+	pod := pods[rand.Intn(len(pods))]
+	watcher.Modify(&pod)
+	// Wait for modify to arrive to confirm initial pods where handled.
+	for writes.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	var reads atomic.Int64
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				err := ListAllByNamespace(podInformer.GetIndexer(), benchmarkNamespace, labels.Everything(), func(obj interface{}) {
+				})
+				if err != nil {
+					panic(err)
+				}
+				reads.Add(1)
+			}
+		}()
+	}
+
+	writes.Store(0)
+	reads.Store(0)
+	for b.Loop() {
+		pod := pods[rand.Intn(len(pods))]
+		watcher.Modify(&pod)
+		got <- struct{}{}
+	}
+	b.ReportMetric(float64(reads.Load())/b.Elapsed().Seconds(), "reads/s")
+	b.ReportMetric(float64(writes.Load())/b.Elapsed().Seconds(), "writes/s")
+	close(stop)
+	wg.Wait()
+}

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
@@ -44,6 +44,7 @@ type RealFIFOOptions struct {
 	// If set, will be called for objects before enqueueing them. Please
 	// see the comment on TransformFunc for details.
 	Transformer TransformFunc
+	BatchSize   int
 }
 
 const (
@@ -504,13 +505,16 @@ func NewRealFIFOWithOptions(opts RealFIFOOptions) *RealFIFO {
 	if opts.KnownObjects == nil {
 		panic("coding error: knownObjects must be provided")
 	}
+	if opts.BatchSize == 0 {
+		opts.BatchSize = defaultBatchSize
+	}
 
 	f := &RealFIFO{
 		items:        make([]Delta, 0, 10),
 		keyFunc:      opts.KeyFunction,
 		knownObjects: opts.KnownObjects,
 		transformer:  opts.Transformer,
-		batchSize:    defaultBatchSize,
+		batchSize:    opts.BatchSize,
 	}
 
 	f.cond.L = &f.lock


### PR DESCRIPTION
/kind feature

```release-note
Enables batching of watch events in the informer to improve performance, can be disabled via InOrderInformersBatchProcess feature gate.
```

Added some patches over https://github.com/kubernetes/kubernetes/pull/132240 mostly to cleanup the code. Created a PR to run tests in CI with feature enabled by default.