### PR TITLE
pkg/controller: Improve goroutine management

### DIFF
--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -155,19 +156,26 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 
 // Run runs controller loops and returns when they are done
 func (e *Signer) Run(ctx context.Context) {
-	// Shut down queues
 	defer utilruntime.HandleCrash()
-	defer e.syncQueue.ShutDown()
+
+	logger := klog.FromContext(ctx)
+	logger.V(5).Info("Starting")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.V(1).Info("Shutting down")
+		e.syncQueue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, e.configMapSynced, e.secretSynced) {
 		return
 	}
 
-	logger := klog.FromContext(ctx)
-	logger.V(5).Info("Starting workers")
-	go wait.UntilWithContext(ctx, e.serviceConfigMapQueue, 0)
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, e.serviceConfigMapQueue, 0)
+	})
 	<-ctx.Done()
-	logger.V(1).Info("Shutting down")
 }
 
 func (e *Signer) pokeConfigMapSync() {

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -111,18 +112,24 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 // Run runs controller loops and returns when they are done
 func (tc *TokenCleaner) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
-	defer tc.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting token cleaner controller")
-	defer logger.Info("Shutting down token cleaner controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down token cleaner controller")
+		tc.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, tc.secretSynced) {
 		return
 	}
 
-	go wait.UntilWithContext(ctx, tc.worker, 10*time.Second)
-
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, tc.worker, 10*time.Second)
+	})
 	<-ctx.Done()
 }
 

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -21,6 +21,7 @@ package certificates
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -114,20 +115,26 @@ func NewCertificateController(
 // Run the main goroutine responsible for watching and syncing jobs.
 func (cc *CertificateController) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	defer cc.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting certificate controller", "name", cc.name)
-	defer logger.Info("Shutting down certificate controller", "name", cc.name)
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down certificate controller", "name", cc.name)
+		cc.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, cc.csrsSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, cc.worker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, cc.worker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 

--- a/pkg/controller/certificates/cleaner/pcrcleaner.go
+++ b/pkg/controller/certificates/cleaner/pcrcleaner.go
@@ -69,9 +69,7 @@ func (c *PCRCleanerController) Run(ctx context.Context, workers int) {
 	logger.Info("Starting PodCertificateRequest cleaner controller")
 	defer logger.Info("Shutting down PodCertificateRequest cleaner controller")
 
-	go wait.UntilWithContext(ctx, c.worker, c.pollingInterval)
-
-	<-ctx.Done()
+	wait.UntilWithContext(ctx, c.worker, c.pollingInterval)
 }
 
 func (c *PCRCleanerController) worker(ctx context.Context) {

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -101,20 +102,26 @@ type Publisher struct {
 // Run starts process
 func (c *Publisher) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting root CA cert publisher controller")
-	defer logger.Info("Shutting down root CA cert publisher controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down root CA cert publisher controller")
+		c.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.cmListerSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	rbacv1ac "k8s.io/client-go/applyconfigurations/rbac/v1"
@@ -188,20 +189,26 @@ func ruleExists(haystack []rbacv1.PolicyRule, needle rbacv1.PolicyRule) bool {
 // Run starts the controller and blocks until stopCh is closed.
 func (c *ClusterRoleAggregationController) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ClusterRoleAggregator controller")
-	defer logger.Info("Shutting down ClusterRoleAggregator controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down ClusterRoleAggregator controller")
+		c.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.clusterRolesSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -303,24 +303,32 @@ func (dsc *DaemonSetsController) Run(ctx context.Context, workers int) {
 	dsc.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: dsc.kubeClient.CoreV1().Events("")})
 	defer dsc.eventBroadcaster.Shutdown()
 
-	defer dsc.queue.ShutDown()
-	defer dsc.nodeUpdateQueue.ShutDown()
-
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting daemon sets controller")
-	defer logger.Info("Shutting down daemon sets controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down daemon sets controller")
+		dsc.queue.ShutDown()
+		dsc.nodeUpdateQueue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, dsc.podStoreSynced, dsc.nodeStoreSynced, dsc.historyStoreSynced, dsc.dsStoreSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, dsc.runWorker, time.Second)
-		go wait.UntilWithContext(ctx, dsc.runNodeUpdateWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, dsc.runWorker, time.Second)
+		})
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, dsc.runNodeUpdateWorker, time.Second)
+		})
 	}
-
-	go wait.Until(dsc.failedPodsBackoff.GC, BackoffGCInterval, ctx.Done())
-
+	wg.Go(func() {
+		wait.Until(dsc.failedPodsBackoff.GC, BackoffGCInterval, ctx.Done())
+	})
 	<-ctx.Done()
 }
 

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -244,28 +244,35 @@ func newControllerWithClock(ctx context.Context, podInformer coreinformers.PodIn
 // Run the main goroutine responsible for watching and syncing jobs.
 func (jm *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	logger := klog.FromContext(ctx)
 
 	// Start events processing pipeline.
 	jm.broadcaster.StartStructuredLogging(3)
 	jm.broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: jm.kubeClient.CoreV1().Events("")})
 	defer jm.broadcaster.Shutdown()
 
-	defer jm.queue.ShutDown()
-	defer jm.orphanQueue.ShutDown()
-
+	logger := klog.FromContext(ctx)
 	logger.Info("Starting job controller")
-	defer logger.Info("Shutting down job controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down job controller")
+		jm.queue.ShutDown()
+		jm.orphanQueue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, jm.podStoreSynced, jm.jobStoreSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, jm.worker, time.Second)
-		go wait.UntilWithContext(ctx, jm.orphanWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, jm.worker, time.Second)
+		})
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, jm.orphanWorker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -19,6 +19,8 @@ package nodeipam
 import (
 	"context"
 	"fmt"
+	"net"
+
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -30,7 +32,6 @@ import (
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam"
-	"net"
 )
 
 // ipamController is an interface abstracting an interface for
@@ -146,12 +147,10 @@ func (nc *Controller) Run(ctx context.Context) {
 	}
 
 	if nc.allocatorType == ipam.IPAMFromClusterAllocatorType || nc.allocatorType == ipam.IPAMFromCloudAllocatorType {
-		go nc.legacyIPAM.Run(ctx)
+		nc.legacyIPAM.Run(ctx)
 	} else {
-		go nc.cidrAllocator.Run(ctx)
+		nc.cidrAllocator.Run(ctx)
 	}
-
-	<-ctx.Done()
 }
 
 // RunWithMetrics is a wrapper for Run that also tracks starting and stopping of the nodeipam controller with additional metric

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -457,12 +457,16 @@ func (nc *Controller) Run(ctx context.Context) {
 		})
 	defer nc.broadcaster.Shutdown()
 
-	// Close node update queue to cleanup go routine.
-	defer nc.nodeUpdateQueue.ShutDown()
-	defer nc.podUpdateQueue.ShutDown()
-
 	logger.Info("Starting node controller")
-	defer logger.Info("Shutting down node controller")
+
+	// Close node update queue to cleanup go routine.
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down node controller")
+		nc.nodeUpdateQueue.ShutDown()
+		nc.podUpdateQueue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, nc.leaseInformerSynced, nc.nodeInformerSynced, nc.podInformerSynced, nc.daemonSetInformerSynced) {
 		return
@@ -470,7 +474,9 @@ func (nc *Controller) Run(ctx context.Context) {
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SeparateTaintEvictionController) {
 		logger.Info("Starting", "controller", taintEvictionController)
-		go nc.taintManager.Run(ctx)
+		wg.Go(func() {
+			nc.taintManager.Run(ctx)
+		})
 	}
 
 	// Start workers to reconcile labels and/or update NoSchedule taint for nodes.
@@ -479,24 +485,31 @@ func (nc *Controller) Run(ctx context.Context) {
 		// the item is flagged when got from queue: if new event come, the new item will
 		// be re-queued until "Done", so no more than one worker handle the same item and
 		// no event missed.
-		go wait.UntilWithContext(ctx, nc.doNodeProcessingPassWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, nc.doNodeProcessingPassWorker, time.Second)
+		})
 	}
 
 	for i := 0; i < podUpdateWorkerSize; i++ {
-		go wait.UntilWithContext(ctx, nc.doPodProcessingWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, nc.doPodProcessingWorker, time.Second)
+		})
 	}
 
 	// Handling taint based evictions. Because we don't want a dedicated logic in TaintManager for NC-originated
 	// taints and we normally don't rate limit evictions caused by taints, we need to rate limit adding taints.
-	go wait.UntilWithContext(ctx, nc.doNoExecuteTaintingPass, scheduler.NodeEvictionPeriod)
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, nc.doNoExecuteTaintingPass, scheduler.NodeEvictionPeriod)
+	})
 
 	// Incorporate the results of node health signal pushed from kubelet to master.
-	go wait.UntilWithContext(ctx, func(ctx context.Context) {
-		if err := nc.monitorNodeHealth(ctx); err != nil {
-			logger.Error(err, "Error monitoring node health")
-		}
-	}, nc.nodeMonitorPeriod)
-
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, func(ctx context.Context) {
+			if err := nc.monitorNodeHealth(ctx); err != nil {
+				logger.Error(err, "Error monitoring node health")
+			}
+		}, nc.nodeMonitorPeriod)
+	})
 	<-ctx.Done()
 }
 

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -199,20 +199,26 @@ func NewHorizontalController(
 // Run begins watching and syncing.
 func (a *HorizontalController) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	defer a.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting HPA controller")
-	defer logger.Info("Shutting down HPA controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down HPA controller")
+		a.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, a.hpaListerSynced, a.podListerSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, a.worker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, a.worker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -825,9 +825,14 @@ func coolCPUCreationTime() metav1.Time {
 
 func (tc *testCase) runTestWithController(t *testing.T, hpaController *HorizontalController, informerFactory informers.SharedInformerFactory) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	informerFactory.Start(ctx.Done())
-	go hpaController.Run(ctx, 5)
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		hpaController.Run(ctx, 5)
+	})
+	defer wg.Wait()
+	defer cancel()
 
 	tc.Lock()
 	shouldWait := tc.verifyEvents

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -19,6 +19,7 @@ package storageversionmigrator
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -123,18 +124,24 @@ func (rv *ResourceVersionController) enqueue(svm *svmv1alpha1.StorageVersionMigr
 
 func (rv *ResourceVersionController) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
-	defer rv.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", ResourceVersionControllerName)
-	defer logger.Info("Shutting down", "controller", ResourceVersionControllerName)
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down", "controller", ResourceVersionControllerName)
+		rv.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, rv.svmSynced) {
 		return
 	}
 
-	go wait.UntilWithContext(ctx, rv.worker, time.Second)
-
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, rv.worker, time.Second)
+	})
 	<-ctx.Done()
 }
 

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -136,20 +137,26 @@ func (svmc *SVMController) enqueue(svm *svmv1alpha1.StorageVersionMigration) {
 
 func (svmc *SVMController) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
-	defer svmc.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", svmc.controllerName)
-	defer logger.Info("Shutting down", "controller", svmc.controllerName)
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down", "controller", svmc.controllerName)
+		svmc.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, svmc.svmSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, svmc.worker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, svmc.worker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -122,19 +122,26 @@ var (
 // Run begins watching and syncing.
 func (ttlc *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	defer ttlc.queue.ShutDown()
+
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting TTL controller")
-	defer logger.Info("Shutting down TTL controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down TTL controller")
+		ttlc.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, ttlc.hasSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, ttlc.worker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, ttlc.worker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Make sure all goroutines are terminated before returning from `controller.Run` function in various controller packages.

This is the first part of the overall improvement, which contains all controllers where the change was trivial.

#### Which issue(s) this PR is related to:

Required for https://github.com/kubernetes/kubernetes/issues/132599 
Followup to https://github.com/kubernetes/kubernetes/pull/132703

#### Special notes for your reviewer:

The structure of every `Run` function is basically the same:

1. Init a WaitGroup.
2. defer queue shutdown, then WaitGroup.Wait
3. Add threads to the WaitGroup.
4. Wait for the context to be cancelled.

This enforces that once the context is cancelled, the queue is terminated, which unblocks the workers to return, which we await in WaitGroup.Wait.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A