### PR TITLE
validation: Add minimum memory requirement (4Ki) to prevent tmpfs mount failures

### DIFF
--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -102,14 +102,14 @@ func ValidateResourceQuantityValue(resource core.ResourceName, value resource.Qu
 	// This prevents confusing runtime errors like "no space left on device" when mounting
 	// tmpfs volumes (e.g., projected service account tokens) with extremely small memory limits.
 	// Common mistake: using decimal CPU suffix "m" (milliunits) for memory, e.g., "512m" = 0.512 bytes.
-	// The minimum practical memory allocation is one page (typically 4096 bytes on Linux).
+	// The minimum practical memory allocation is 512 bytes.
 	if resource == core.ResourceMemory {
-		// Allow zero (for BestEffort pods) but reject positive values less than 4Ki (4096 bytes)
-		const minMemoryBytes = 4096
+		// Allow zero (for BestEffort pods) but reject positive values less than 512 bytes
+		const minMemoryBytes = 512
 		byteValue := value.Value()
 		if byteValue > 0 && byteValue < minMemoryBytes {
 			allErrs = append(allErrs, field.Invalid(fldPath, value.String(),
-				fmt.Sprintf("must be at least 4Ki. Memory was %s (%d bytes). Use Ki/Mi/Gi suffixes for memory, not 'm'",
+				fmt.Sprintf("must be at least 512 bytes. Memory was %s (%d bytes). Use Ki/Mi/Gi suffixes for memory, not 'm'",
 					value.String(), byteValue)))
 		}
 	}

--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -96,6 +96,24 @@ func ValidateResourceQuantityValue(resource core.ResourceName, value resource.Qu
 			allErrs = append(allErrs, field.Invalid(fldPath, value, isNotIntegerErrorMsg))
 		}
 	}
+
+	// Validate that memory resources are not too small.
+	// Memory should use binary SI suffixes (Ki, Mi, Gi, Ti, Pi, Ei).
+	// This prevents confusing runtime errors like "no space left on device" when mounting
+	// tmpfs volumes (e.g., projected service account tokens) with extremely small memory limits.
+	// Common mistake: using decimal CPU suffix "m" (milliunits) for memory, e.g., "512m" = 0.512 bytes.
+	// The minimum practical memory allocation is one page (typically 4096 bytes on Linux).
+	if resource == core.ResourceMemory {
+		// Allow zero (for BestEffort pods) but reject positive values less than 4Ki (4096 bytes)
+		const minMemoryBytes = 4096
+		byteValue := value.Value()
+		if byteValue > 0 && byteValue < minMemoryBytes {
+			allErrs = append(allErrs, field.Invalid(fldPath, value.String(),
+				fmt.Sprintf("must be at least 4Ki. Memory was %s (%d bytes). Use Ki/Mi/Gi suffixes for memory, not 'm'",
+					value.String(), byteValue)))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/core/v1/validation/validation_test.go
+++ b/pkg/apis/core/v1/validation/validation_test.go
@@ -177,7 +177,11 @@ func TestValidateResourceQuantityValue(t *testing.T) {
 	}, {
 		name:         "Memory with exact minimum bytes",
 		resourceName: core.ResourceMemory,
-		value:        "4096",
+		value:        "512",
+	}, {
+		name:         "Memory above minimum",
+		resourceName: core.ResourceMemory,
+		value:        "1024",
 	}, {
 		name:         "Memory zero value (BestEffort pods)",
 		resourceName: core.ResourceMemory,
@@ -211,7 +215,7 @@ func TestValidateResourceQuantityValue(t *testing.T) {
 		name:         "Memory with milli suffix (common mistake)",
 		resourceName: core.ResourceMemory,
 		value:        "512m",
-		expectedErr:  "must be at least 4Ki",
+		expectedErr:  "must be at least 512 bytes",
 	}, {
 		name:         "Memory with very small value (1 byte)",
 		resourceName: core.ResourceMemory,
@@ -221,17 +225,22 @@ func TestValidateResourceQuantityValue(t *testing.T) {
 		name:         "Memory with very small value (3 bytes)",
 		resourceName: core.ResourceMemory,
 		value:        "3",
-		expectedErr:  "must be at least 4Ki",
+		expectedErr:  "must be at least 512 bytes",
 	}, {
 		name:         "Memory with small milli value",
 		resourceName: core.ResourceMemory,
 		value:        "100m",
 		expectedErr:  "not 'm'",
 	}, {
-		name:         "Memory below 4096 bytes",
+		name:         "Memory below 512 bytes",
 		resourceName: core.ResourceMemory,
-		value:        "4095",
-		expectedErr:  "4095 bytes",
+		value:        "511",
+		expectedErr:  "511 bytes",
+	}, {
+		name:         "Memory with 100 bytes",
+		resourceName: core.ResourceMemory,
+		value:        "100",
+		expectedErr:  "must be at least 512 bytes",
 	}}
 
 	for _, tc := range errorCase {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7860,14 +7860,14 @@ func ValidateResourceQuantityValue(resource core.ResourceName, value resource.Qu
 	// This prevents confusing runtime errors like "no space left on device" when mounting
 	// tmpfs volumes (e.g., projected service account tokens) with extremely small memory limits.
 	// Common mistake: using decimal CPU suffix "m" (milliunits) for memory, e.g., "512m" = 0.512 bytes.
-	// The minimum practical memory allocation is one page (typically 4096 bytes on Linux).
+	// The minimum practical memory allocation is 512 bytes.
 	if resource == core.ResourceMemory {
-		// Allow zero (for BestEffort pods) but reject positive values less than 4Ki (4096 bytes)
-		const minMemoryBytes = 4096
+		// Allow zero (for BestEffort pods) but reject positive values less than 512 bytes
+		const minMemoryBytes = 512
 		byteValue := value.Value()
 		if byteValue > 0 && byteValue < minMemoryBytes {
 			allErrs = append(allErrs, field.Invalid(fldPath, value.String(),
-				fmt.Sprintf("must be at least 4Ki. Memory was %s (%d bytes). Use Ki/Mi/Gi suffixes for memory, not 'm'",
+				fmt.Sprintf("must be at least 512 bytes. Memory was %s (%d bytes). Use Ki/Mi/Gi suffixes for memory, not 'm'",
 					value.String(), byteValue)))
 		}
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -9257,8 +9257,8 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits:   getResources("5", "3", "", ""),
-				Requests: getResources("6", "3", "", ""),
+				Limits:   getResources("5", "1Gi", "", ""),
+				Requests: getResources("6", "1Gi", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -9289,8 +9289,8 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits:   getResources("5", "3", "", ""),
-				Requests: getResources("6", "3", "", ""),
+				Limits:   getResources("5", "1Gi", "", ""),
+				Requests: getResources("6", "1Gi", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",
@@ -9303,8 +9303,8 @@ func TestValidateContainers(t *testing.T) {
 			Name:  "abc-123",
 			Image: "image",
 			Resources: core.ResourceRequirements{
-				Limits:   getResources("5", "3", "", ""),
-				Requests: getResources("5", "4", "", ""),
+				Limits:   getResources("5", "1Gi", "", ""),
+				Requests: getResources("5", "2Gi", "", ""),
 			},
 			ImagePullPolicy:          "IfNotPresent",
 			TerminationMessagePolicy: "File",

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -169,7 +169,7 @@ func TestResourceAllocationScorerCalculateRequests(t *testing.T) {
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									v1.ResourceCPU:    resource.MustParse("1m"),
-									v1.ResourceMemory: resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("1Ki"),
 								},
 							},
 						},
@@ -179,7 +179,7 @@ func TestResourceAllocationScorerCalculateRequests(t *testing.T) {
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									v1.ResourceCPU:    resource.MustParse("3m"),
-									v1.ResourceMemory: resource.MustParse("3"),
+									v1.ResourceMemory: resource.MustParse("3Ki"),
 								},
 							},
 						},
@@ -201,7 +201,7 @@ func TestResourceAllocationScorerCalculateRequests(t *testing.T) {
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									v1.ResourceCPU:    resource.MustParse("1m"),
-									v1.ResourceMemory: resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("1Ki"),
 								},
 							},
 						},
@@ -211,7 +211,7 @@ func TestResourceAllocationScorerCalculateRequests(t *testing.T) {
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									v1.ResourceCPU:    resource.MustParse("3m"),
-									v1.ResourceMemory: resource.MustParse("3"),
+									v1.ResourceMemory: resource.MustParse("3Ki"),
 								},
 							},
 						},
@@ -221,7 +221,7 @@ func TestResourceAllocationScorerCalculateRequests(t *testing.T) {
 			},
 			expected: map[v1.ResourceName]int64{
 				v1.ResourceCPU:    3 + util.DefaultMilliCPURequest,
-				v1.ResourceMemory: 3 + util.DefaultMemoryRequest,
+				v1.ResourceMemory: 3*1024 + util.DefaultMemoryRequest,
 			},
 		},
 	}

--- a/test/integration/scheduler/eventhandler/eventhandler_test.go
+++ b/test/integration/scheduler/eventhandler/eventhandler_test.go
@@ -151,7 +151,7 @@ func TestUpdateNominatedNodeName(t *testing.T) {
 	testBackoff := time.Minute
 	testContext := testutils.InitTestAPIServer(t, "test-event", nil)
 	capacity := map[v1.ResourceName]string{
-		v1.ResourceMemory: "32",
+		v1.ResourceMemory: "32Ki",
 	}
 	var cleanupPods []*v1.Pod
 
@@ -162,7 +162,7 @@ func TestUpdateNominatedNodeName(t *testing.T) {
 		Namespace: testContext.NS.Name,
 		Priority:  &lowPriority,
 		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
-			v1.ResourceMemory: *resource.NewQuantity(20, resource.DecimalSI)},
+			v1.ResourceMemory: *resource.NewQuantity(20*1024, resource.DecimalSI)},
 		}})
 	cleanupPods = append(cleanupPods, podLow)
 	podMidNominated := testutils.InitPausePod(&testutils.PausePodConfig{
@@ -170,7 +170,7 @@ func TestUpdateNominatedNodeName(t *testing.T) {
 		Namespace: testContext.NS.Name,
 		Priority:  &mediumPriority,
 		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
-			v1.ResourceMemory: *resource.NewQuantity(25, resource.DecimalSI)},
+			v1.ResourceMemory: *resource.NewQuantity(25*1024, resource.DecimalSI)},
 		}})
 	cleanupPods = append(cleanupPods, podMidNominated)
 	podHigh := testutils.InitPausePod(&testutils.PausePodConfig{
@@ -178,7 +178,7 @@ func TestUpdateNominatedNodeName(t *testing.T) {
 		Namespace: testContext.NS.Name,
 		Priority:  &highPriority,
 		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
-			v1.ResourceMemory: *resource.NewQuantity(10, resource.DecimalSI)},
+			v1.ResourceMemory: *resource.NewQuantity(10*1024, resource.DecimalSI)},
 		}})
 	cleanupPods = append(cleanupPods, podHigh)
 

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -2438,17 +2438,17 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 	lowPriority, highPriority := int32(100), int32(300)
 	resReq := map[v1.ResourceName]string{
 		v1.ResourceCPU:    "200m",
-		v1.ResourceMemory: "200",
+		v1.ResourceMemory: "200Ki",
 	}
 	preemptorReq := map[v1.ResourceName]string{
 		v1.ResourceCPU:    "400m",
-		v1.ResourceMemory: "400",
+		v1.ResourceMemory: "400Ki",
 	}
 
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 
 	tests := []struct {

--- a/test/integration/scheduler/preemption/misc/miscpreemption_test.go
+++ b/test/integration/scheduler/preemption/misc/miscpreemption_test.go
@@ -92,7 +92,7 @@ func TestNonPreemption(t *testing.T) {
 		Priority:  &lowPriority,
 		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 			v1.ResourceCPU:    *resource.NewMilliQuantity(400, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+			v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 		},
 	})
 
@@ -102,7 +102,7 @@ func TestNonPreemption(t *testing.T) {
 		Priority:  &highPriority,
 		Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 			v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+			v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 		},
 	})
 
@@ -110,7 +110,7 @@ func TestNonPreemption(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 	_, err := createNode(testCtx.ClientSet, st.MakeNode().Name("node1").Capacity(nodeRes).Obj())
 	if err != nil {
@@ -170,7 +170,7 @@ func TestDisablePreemption(t *testing.T) {
 					Priority:  &lowPriority,
 					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 						v1.ResourceCPU:    *resource.NewMilliQuantity(400, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+						v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 					},
 				}),
 			},
@@ -180,7 +180,7 @@ func TestDisablePreemption(t *testing.T) {
 				Priority:  &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 		},
@@ -190,7 +190,7 @@ func TestDisablePreemption(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 	_, err := createNode(testCtx.ClientSet, st.MakeNode().Name("node1").Capacity(nodeRes).Obj())
 	if err != nil {
@@ -299,7 +299,7 @@ func TestPodPriorityResolution(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 	_, err := createNode(testCtx.ClientSet, st.MakeNode().Name("node1").Capacity(nodeRes).Obj())
 	if err != nil {
@@ -340,7 +340,7 @@ func TestPodPriorityResolution(t *testing.T) {
 func mkPriorityPodWithGrace(tc *testutils.TestContext, name string, priority int32, grace int64) *v1.Pod {
 	defaultPodRes := &v1.ResourceRequirements{Requests: v1.ResourceList{
 		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI)},
+		v1.ResourceMemory: *resource.NewQuantity(100*1024, resource.DecimalSI)},
 	}
 	pod := initPausePod(&testutils.PausePodConfig{
 		Name:      name,
@@ -380,7 +380,7 @@ func TestPreemptionStarvation(t *testing.T) {
 				Priority:  &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 		},
@@ -390,7 +390,7 @@ func TestPreemptionStarvation(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 	_, err := createNode(testCtx.ClientSet, st.MakeNode().Name("node1").Capacity(nodeRes).Obj())
 	if err != nil {
@@ -628,12 +628,12 @@ func TestPDBInPreemption(t *testing.T) {
 
 	defaultPodRes := &v1.ResourceRequirements{Requests: v1.ResourceList{
 		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI)},
+		v1.ResourceMemory: *resource.NewQuantity(100*1024, resource.DecimalSI)},
 	}
 	defaultNodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 
 	tests := []struct {
@@ -680,7 +680,7 @@ func TestPDBInPreemption(t *testing.T) {
 				Priority:  &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			preemptedPodIndexes: map[int]struct{}{2: {}},
@@ -715,7 +715,7 @@ func TestPDBInPreemption(t *testing.T) {
 				Priority:  &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			preemptedPodIndexes: map[int]struct{}{1: {}},
@@ -791,7 +791,7 @@ func TestPDBInPreemption(t *testing.T) {
 				Priority:  &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(400, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(400*1024, resource.DecimalSI)},
 				},
 			}),
 			// The third node is chosen because PDB is not violated for node 3 and the victims have lower priority than node-2.
@@ -1179,7 +1179,7 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 	nodeObject := st.MakeNode().Name("node1").Capacity(nodeRes).Label("node", "node1").Obj()
 	if _, err := createNode(cs, nodeObject); err != nil {

--- a/test/integration/scheduler/preemption/misc/miscpreemption_test.go
+++ b/test/integration/scheduler/preemption/misc/miscpreemption_test.go
@@ -494,7 +494,7 @@ func TestPreemptionRaces(t *testing.T) {
 				Priority:  &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(4900, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(4900, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(4900*1024, resource.DecimalSI)},
 				},
 			}),
 		},
@@ -504,7 +504,7 @@ func TestPreemptionRaces(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "100",
 		v1.ResourceCPU:    "5000m",
-		v1.ResourceMemory: "5000",
+		v1.ResourceMemory: "5000Ki",
 	}
 	_, err := createNode(testCtx.ClientSet, st.MakeNode().Name("node1").Capacity(nodeRes).Obj())
 	if err != nil {

--- a/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
+++ b/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
@@ -358,11 +358,11 @@ func TestPreferNominatedNode(t *testing.T) {
 	defaultNodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 	defaultPodRes := &v1.ResourceRequirements{Requests: v1.ResourceList{
 		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI)},
+		v1.ResourceMemory: *resource.NewQuantity(100*1024, resource.DecimalSI)},
 	}
 	tests := []struct {
 		name         string
@@ -387,7 +387,7 @@ func TestPreferNominatedNode(t *testing.T) {
 				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			runningNode: "node-1",
@@ -408,7 +408,7 @@ func TestPreferNominatedNode(t *testing.T) {
 				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			runningNode: "node-2",

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -156,7 +156,7 @@ func TestPreemption(t *testing.T) {
 
 	defaultPodRes := &v1.ResourceRequirements{Requests: v1.ResourceList{
 		v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI)},
+		v1.ResourceMemory: *resource.NewQuantity(100*1024, resource.DecimalSI)},
 	}
 
 	maxTokens := 1000
@@ -178,7 +178,7 @@ func TestPreemption(t *testing.T) {
 					Priority: &lowPriority,
 					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 						v1.ResourceCPU:    *resource.NewMilliQuantity(400, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+						v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 					},
 				}),
 			},
@@ -187,7 +187,7 @@ func TestPreemption(t *testing.T) {
 				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			preemptedPodIndexes: map[int]struct{}{0: {}},
@@ -201,7 +201,7 @@ func TestPreemption(t *testing.T) {
 					Priority: &lowPriority,
 					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+						v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 					},
 				}),
 			},
@@ -210,7 +210,7 @@ func TestPreemption(t *testing.T) {
 				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			preemptedPodIndexes: map[int]struct{}{0: {}},
@@ -229,7 +229,7 @@ func TestPreemption(t *testing.T) {
 					Priority: &lowPriority,
 					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+						v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 					},
 				}),
 			},
@@ -238,7 +238,7 @@ func TestPreemption(t *testing.T) {
 				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			preemptedPodIndexes: map[int]struct{}{0: {}},
@@ -254,7 +254,7 @@ func TestPreemption(t *testing.T) {
 					Priority: &lowPriority,
 					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+						v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 					},
 				}),
 			},
@@ -263,7 +263,7 @@ func TestPreemption(t *testing.T) {
 				Priority: &highPriority,
 				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-					v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI)},
+					v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.DecimalSI)},
 				},
 			}),
 			preemptedPodIndexes: map[int]struct{}{},
@@ -399,7 +399,7 @@ func TestPreemption(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 	nodeObject := st.MakeNode().Name("node1").Capacity(nodeRes).Label("node", "node1").Obj()
 

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -352,7 +352,7 @@ func TestAllocatable(t *testing.T) {
 	nodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "30m",
-		v1.ResourceMemory: "30",
+		v1.ResourceMemory: "30Ki",
 	}
 	allocNode, err := testutils.CreateNode(testCtx.ClientSet, st.MakeNode().Name("node-allocatable-scheduler-test-node").Capacity(nodeRes).Obj())
 	if err != nil {
@@ -363,7 +363,7 @@ func TestAllocatable(t *testing.T) {
 	podName := "pod-test-allocatable"
 	podRes := &v1.ResourceList{
 		v1.ResourceCPU:    *resource.NewMilliQuantity(20, resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(20, resource.BinarySI),
+		v1.ResourceMemory: *resource.NewQuantity(20*1024, resource.BinarySI),
 	}
 	testAllocPod, err := testutils.CreatePausePodWithResource(testCtx.ClientSet, podName, testCtx.NS.Name, podRes)
 	if err != nil {
@@ -383,12 +383,12 @@ func TestAllocatable(t *testing.T) {
 		Capacity: v1.ResourceList{
 			v1.ResourcePods:   *resource.NewQuantity(32, resource.DecimalSI),
 			v1.ResourceCPU:    *resource.NewMilliQuantity(30, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(30, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(30*1024, resource.BinarySI),
 		},
 		Allocatable: v1.ResourceList{
 			v1.ResourcePods:   *resource.NewQuantity(32, resource.DecimalSI),
 			v1.ResourceCPU:    *resource.NewMilliQuantity(10, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(10, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(10*1024, resource.BinarySI),
 		},
 	}
 
@@ -424,12 +424,12 @@ func TestSchedulerInformers(t *testing.T) {
 
 	defaultPodRes := &v1.ResourceRequirements{Requests: v1.ResourceList{
 		v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(200, resource.BinarySI)},
+		v1.ResourceMemory: *resource.NewQuantity(200*1024, resource.BinarySI)},
 	}
 	defaultNodeRes := map[v1.ResourceName]string{
 		v1.ResourcePods:   "32",
 		v1.ResourceCPU:    "500m",
-		v1.ResourceMemory: "500",
+		v1.ResourceMemory: "500Ki",
 	}
 
 	type nodeConfig struct {
@@ -568,7 +568,7 @@ func TestNodeEvents(t *testing.T) {
 		Capacity(map[v1.ResourceName]string{
 			v1.ResourcePods:   "32",
 			v1.ResourceCPU:    "100m",
-			v1.ResourceMemory: "30",
+			v1.ResourceMemory: "30Ki",
 		}).Obj())
 	if err != nil {
 		t.Fatalf("Failed to create %s: %v", node1.Name, err)
@@ -598,7 +598,7 @@ func TestNodeEvents(t *testing.T) {
 		Capacity(map[v1.ResourceName]string{
 			v1.ResourcePods:   "32",
 			v1.ResourceCPU:    "100m",
-			v1.ResourceMemory: "30",
+			v1.ResourceMemory: "30Ki",
 		}).
 		Label("affinity-key", "affinity-value").
 		Taints([]v1.Taint{{Key: "taint-key", Effect: v1.TaintEffectNoSchedule}}).Obj()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area apiserver
/sig api-machinery
/priority important-soon

#### What this PR does / why we need it:

This PR adds validation to reject memory resources below 4Ki (4096 bytes).

Currently, when someone accidentally uses CPU suffixes for memory (like `memory: "512m"`), it parses as 0.512 bytes instead of 512 megabytes. This causes pods to fail at runtime with a confusing error:
```
MountVolume.SetUp failed for volume "kube-api-access-xxx" : no space left on device
```

This happens because tmpfs volumes (service account tokens, ConfigMaps, Secrets) try to mount with a memory limit smaller than a page size. The error message makes you think it's a disk space issue when it's actually just a wrong suffix.

The fix validates memory at the API level and rejects anything below 4Ki with a clear error message explaining to use Ki/Mi/Gi instead of 'm'.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Chose 4Ki (4096 bytes) because that's the standard page size on Linux
- Zero is still allowed for BestEffort pods
- This is technically a breaking change for specs with memory < 4Ki, but those values don't work in practice anyway
- I updated an existing test that was using 1-3 byte memory values (unrealistic) to use 1-3 Ki instead

#### Does this PR introduce a user-facing change?

```release-note
Memory resource requests and limits below 4Ki are now rejected during API validation with a clear error message. Use Ki/Mi/Gi suffixes for memory resources, not 'm'.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
