### PR TITLE
Automated cherry pick of #134833: Return error in case of discovery client failure

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -229,6 +229,9 @@ func (o *APIResourceOptions) RunAPIResources() error {
 		allResources = append(allResources, apiList)
 	}
 
+	if len(allResources) == 0 {
+		return utilerrors.NewAggregate(errs)
+	}
 	flatList := &metav1.APIResourceList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: allResources[0].APIVersion,


### PR DESCRIPTION
Cherry pick of #134833 on release-1.34.

#134833: Return error in case of discovery client failure

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix panic on kubectl api-resources
```