### PR TITLE
Signature code for KEP 5598

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -167,6 +167,13 @@ type Framework interface {
 	// QueueSortFunc returns the function to sort pods in scheduling queue
 	QueueSortFunc() fwk.LessFunc
 
+	// Create a scheduling signature for a given pod, if possible. Two pods with the same signature
+	// should get the same feasibility and scores for any given set of nodes even after one of them gets assigned. If some plugins
+	// are unable to create a signature, the pod may be "unsignable" which disables results caching
+	// and gang scheduling optimizations.
+	// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5598-opportunistic-batching
+	SignPod(ctx context.Context, pod *v1.Pod) (string, *fwk.Status)
+
 	// RunPreFilterPlugins runs the set of configured PreFilter plugins. It returns
 	// *fwk.Status and its code is set to non-success if any of the plugins returns
 	// anything but Success. If a non-success status is returned, then the scheduling

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -189,10 +189,21 @@ var _ fwk.ScorePlugin = &DynamicResources{}
 var _ fwk.ReservePlugin = &DynamicResources{}
 var _ fwk.EnqueueExtensions = &DynamicResources{}
 var _ fwk.PreBindPlugin = &DynamicResources{}
+var _ fwk.SignPlugin = &DynamicResources{}
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *DynamicResources) Name() string {
 	return Name
+}
+
+// Because it isn't simple to determine if DRA claims are single host or more complex,
+// we exclude any pod with a DRA claim from signatures. We should improve this.
+// See https://github.com/kubernetes/kubernetes/issues/134986
+func (pl *DynamicResources) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	if len(pod.Spec.ResourceClaims) > 0 {
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+	return nil, fwk.NewStatus(fwk.Success)
 }
 
 // EventsToRegister returns the possible events that may make a Pod

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
@@ -18,10 +18,12 @@ package imagelocality
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 )
@@ -40,6 +42,7 @@ type ImageLocality struct {
 }
 
 var _ fwk.ScorePlugin = &ImageLocality{}
+var _ fwk.SignPlugin = &ImageLocality{}
 
 // Name is the name of the plugin used in the plugin registry and configurations.
 const Name = names.ImageLocality
@@ -47,6 +50,24 @@ const Name = names.ImageLocality
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *ImageLocality) Name() string {
 	return Name
+}
+
+// Filtering and scoring based on container image names.
+func (pl *ImageLocality) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	nameSet := sets.New[string]()
+
+	containers := []v1.Container{}
+	containers = append(containers, pod.Spec.Containers...)
+	containers = append(containers, pod.Spec.InitContainers...)
+
+	for _, container := range containers {
+		nameSet.Insert(normalizedImageName(container.Image))
+	}
+	names := nameSet.UnsortedList()
+	sort.Slice(names, func(i, j int) bool {
+		return names[i] < names[j]
+	})
+	return []fwk.SignFragment{{Key: fwk.ImageNamesSignerName, Value: names}}, fwk.NewStatus(fwk.Success)
 }
 
 // Score invoked at the score extension point.

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -41,6 +41,7 @@ var _ fwk.FilterPlugin = &InterPodAffinity{}
 var _ fwk.PreScorePlugin = &InterPodAffinity{}
 var _ fwk.ScorePlugin = &InterPodAffinity{}
 var _ fwk.EnqueueExtensions = &InterPodAffinity{}
+var _ fwk.SignPlugin = &InterPodAffinity{}
 
 // InterPodAffinity is a plugin that checks inter pod affinity
 type InterPodAffinity struct {
@@ -54,6 +55,29 @@ type InterPodAffinity struct {
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *InterPodAffinity) Name() string {
 	return Name
+}
+
+// Inter pod affinity make feasibility and scoring dependent on the placement of other
+// pods in addition the current pod and node, so we cannot sign pods with these
+// constraints.
+func (pl *InterPodAffinity) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	if pod.Spec.Affinity != nil && (pod.Spec.Affinity.PodAffinity != nil || pod.Spec.Affinity.PodAntiAffinity != nil) {
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+
+	ret := []fwk.SignFragment{
+		{Key: fwk.InterPodAffinitySignerName, Value: nil},
+	}
+
+	// If this option is set then we only consider affinity between pods that have affinity configured,
+	// so we can ignore the pods labels if it doesn't have rules set.
+	// Otherwise we need to include the pod's labels to ensure we catch affinity between the pod
+	// and other pods which may have affinity rules set.
+	if !pl.args.IgnorePreferredTermsOfExistingPods {
+		ret = append(ret, fwk.SignFragment{Key: fwk.LabelsSignerName, Value: pod.Labels})
+	}
+
+	return ret, fwk.NewStatus(fwk.Success)
 }
 
 // EventsToRegister returns the possible events that may make a failed Pod

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
@@ -48,6 +48,7 @@ var _ fwk.FilterPlugin = &NodeAffinity{}
 var _ fwk.PreScorePlugin = &NodeAffinity{}
 var _ fwk.ScorePlugin = &NodeAffinity{}
 var _ fwk.EnqueueExtensions = &NodeAffinity{}
+var _ fwk.SignPlugin = &NodeAffinity{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -72,6 +73,14 @@ const (
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *NodeAffinity) Name() string {
 	return Name
+}
+
+// Node affinity filtering and scoring depend on NodeAffinity and NodeSelectors.
+func (pl *NodeAffinity) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.NodeAffinitySignerName, Value: fwk.NodeAffinitySigner(pod)},
+		{Key: fwk.NodeSelectorSignerName, Value: pod.Spec.NodeSelector},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 type preFilterState struct {

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -33,6 +33,7 @@ type NodeName struct {
 
 var _ fwk.FilterPlugin = &NodeName{}
 var _ fwk.EnqueueExtensions = &NodeName{}
+var _ fwk.SignPlugin = &NodeName{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -65,6 +66,13 @@ func (pl *NodeName) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithH
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *NodeName) Name() string {
 	return Name
+}
+
+// NodeName scoring and feasibility are dependent on the NodeName field.
+func (pl *NodeName) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.NodeNameSignerName, Value: pod.Spec.NodeName},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 // Filter invoked at the filter extension point.

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -37,6 +37,7 @@ type NodePorts struct {
 var _ fwk.PreFilterPlugin = &NodePorts{}
 var _ fwk.FilterPlugin = &NodePorts{}
 var _ fwk.EnqueueExtensions = &NodePorts{}
+var _ fwk.SignPlugin = &NodePorts{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -61,6 +62,13 @@ func (s preFilterState) Clone() fwk.StateData {
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *NodePorts) Name() string {
 	return Name
+}
+
+// NodePort feasibility and scheduling is based on the host ports for the containers.
+func (pl *NodePorts) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.HostPortsSignerName, Value: fwk.HostPortsSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 // PreFilter invoked at the prefilter extension point.

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -41,6 +41,7 @@ type BalancedAllocation struct {
 
 var _ fwk.PreScorePlugin = &BalancedAllocation{}
 var _ fwk.ScorePlugin = &BalancedAllocation{}
+var _ fwk.SignPlugin = &BalancedAllocation{}
 
 // BalancedAllocationName is the name of the plugin used in the plugin registry and configurations.
 const (
@@ -114,6 +115,13 @@ func getBalancedAllocationPreScoreState(cycleState fwk.CycleState) (*balancedAll
 // Name returns name of the plugin. It is used in logs, etc.
 func (ba *BalancedAllocation) Name() string {
 	return BalancedAllocationName
+}
+
+// Filtering and scoring based on the container resources and overheads.
+func (pl *BalancedAllocation) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.ResourcesSignerName, Value: resourcesSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 // Score invoked at the score extension point.

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -37,6 +37,7 @@ type NodeUnschedulable struct {
 
 var _ fwk.FilterPlugin = &NodeUnschedulable{}
 var _ fwk.EnqueueExtensions = &NodeUnschedulable{}
+var _ fwk.SignPlugin = &NodeUnschedulable{}
 
 // Name is the name of the plugin used in the plugin registry and configurations.
 const Name = names.NodeUnschedulable
@@ -126,6 +127,13 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *NodeUnschedulable) Name() string {
 	return Name
+}
+
+// Feasibility and scoring based on the pod's tolerations.
+func (pl *NodeUnschedulable) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.TolerationsSignerName, Value: fwk.TolerationsSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 // Filter invoked at the filter extension point.

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -73,6 +73,7 @@ type CSILimits struct {
 var _ fwk.PreFilterPlugin = &CSILimits{}
 var _ fwk.FilterPlugin = &CSILimits{}
 var _ fwk.EnqueueExtensions = &CSILimits{}
+var _ fwk.SignPlugin = &CSILimits{}
 
 // CSIName is the name of the plugin used in the plugin registry and configurations.
 const CSIName = names.NodeVolumeLimits
@@ -657,4 +658,11 @@ func (pl *CSILimits) getNodeVolumeAttachmentInfo(logger klog.Logger, nodeName st
 
 func getVolumeUniqueName(driverName, volumeHandle string) string {
 	return fmt.Sprintf("%s/%s", driverName, volumeHandle)
+}
+
+// Feasibility and scoring based on the non-synthetic volume sources.
+func (pl *CSILimits) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.VolumesSignerName, Value: fwk.VolumesSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -76,6 +76,7 @@ var _ fwk.FilterPlugin = &PodTopologySpread{}
 var _ fwk.PreScorePlugin = &PodTopologySpread{}
 var _ fwk.ScorePlugin = &PodTopologySpread{}
 var _ fwk.EnqueueExtensions = &PodTopologySpread{}
+var _ fwk.SignPlugin = &PodTopologySpread{}
 
 // Name is the name of the plugin used in the plugin registry and configurations.
 const Name = names.PodTopologySpread
@@ -83,6 +84,16 @@ const Name = names.PodTopologySpread
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *PodTopologySpread) Name() string {
 	return Name
+}
+
+// Pod topology spread is not localized to a pod and node, so we cannot
+// sign pods that have topology spread constraints, either explicit or
+// defaulted.
+func (pl *PodTopologySpread) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	if len(pl.defaultConstraints) > 0 || len(pod.Spec.TopologySpreadConstraints) > 0 {
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+	return nil, fwk.NewStatus(fwk.Success)
 }
 
 // New initializes a new plugin and returns it.

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -41,6 +41,7 @@ var _ fwk.FilterPlugin = &TaintToleration{}
 var _ fwk.PreScorePlugin = &TaintToleration{}
 var _ fwk.ScorePlugin = &TaintToleration{}
 var _ fwk.EnqueueExtensions = &TaintToleration{}
+var _ fwk.SignPlugin = &TaintToleration{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -54,6 +55,13 @@ const (
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *TaintToleration) Name() string {
 	return Name
+}
+
+// Feasibility and scoring based on the pod's tolerations.
+func (pl *TaintToleration) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.TolerationsSignerName, Value: fwk.TolerationsSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 // EventsToRegister returns the possible events that may make a Pod

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -85,6 +85,7 @@ var _ fwk.PreBindPlugin = &VolumeBinding{}
 var _ fwk.PreScorePlugin = &VolumeBinding{}
 var _ fwk.ScorePlugin = &VolumeBinding{}
 var _ fwk.EnqueueExtensions = &VolumeBinding{}
+var _ fwk.SignPlugin = &VolumeBinding{}
 
 // Name is the name of the plugin used in Registry and configurations.
 const Name = names.VolumeBinding
@@ -92,6 +93,13 @@ const Name = names.VolumeBinding
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *VolumeBinding) Name() string {
 	return Name
+}
+
+// Feasibility and scoring based on the non-synthetic volume sources.
+func (pl *VolumeBinding) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.VolumesSignerName, Value: fwk.VolumesSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 // EventsToRegister returns the possible events that may make a Pod

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -45,6 +45,7 @@ var _ fwk.PreFilterPlugin = &VolumeRestrictions{}
 var _ fwk.FilterPlugin = &VolumeRestrictions{}
 var _ fwk.EnqueueExtensions = &VolumeRestrictions{}
 var _ fwk.StateData = &preFilterState{}
+var _ fwk.SignPlugin = &VolumeRestrictions{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -98,6 +99,13 @@ func (s *preFilterState) Clone() fwk.StateData {
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *VolumeRestrictions) Name() string {
 	return Name
+}
+
+// Feasibility and scoring based on the non-synthetic volume sources.
+func (pl *VolumeRestrictions) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.VolumesSignerName, Value: fwk.VolumesSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 func isVolumeConflict(volume *v1.Volume, pod *v1.Pod) bool {

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -49,6 +49,7 @@ type VolumeZone struct {
 var _ fwk.FilterPlugin = &VolumeZone{}
 var _ fwk.PreFilterPlugin = &VolumeZone{}
 var _ fwk.EnqueueExtensions = &VolumeZone{}
+var _ fwk.SignPlugin = &VolumeZone{}
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -100,6 +101,13 @@ func translateToGALabel(label string) string {
 // Name returns name of the plugin. It is used in logs, etc.
 func (pl *VolumeZone) Name() string {
 	return Name
+}
+
+// Feasibility and scoring based on the non-synthetic volume sources.
+func (pl *VolumeZone) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return []fwk.SignFragment{
+		{Key: fwk.VolumesSignerName, Value: fwk.VolumesSigner(pod)},
+	}, fwk.NewStatus(fwk.Success)
 }
 
 // PreFilter invoked at the prefilter extension point

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -80,6 +80,7 @@ const (
 	Reserve                     = "Reserve"
 	Unreserve                   = "Unreserve"
 	Permit                      = "Permit"
+	Sign                        = "Sign"
 )
 
 const (

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1173,6 +1173,236 @@ func TestSchedulerScheduleOne(t *testing.T) {
 	}
 }
 
+type constSigPluginConfig struct {
+	name       string
+	signature  []fwk.SignFragment
+	status     *fwk.Status
+	pluginType string
+}
+
+type constantSigPlugin struct {
+	config *constSigPluginConfig
+}
+
+var _ fwk.FilterPlugin = &constantSigPlugin{}
+var _ fwk.PreFilterPlugin = &constantSigPlugin{}
+var _ fwk.ScorePlugin = &constantSigPlugin{}
+var _ fwk.PreScorePlugin = &constantSigPlugin{}
+
+func (pl *constantSigPlugin) Name() string {
+	return pl.config.name
+}
+
+func (pl *constantSigPlugin) Filter(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ fwk.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Success)
+}
+
+func (pl *constantSigPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodes []fwk.NodeInfo) (*fwk.PreFilterResult, *fwk.Status) {
+	return nil, fwk.NewStatus(fwk.Success)
+}
+
+func (pl *constantSigPlugin) PreFilterExtensions() fwk.PreFilterExtensions {
+	return nil
+}
+
+func (pl *constantSigPlugin) PreScore(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Success)
+}
+
+func (pl *constantSigPlugin) Score(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
+	return 1, fwk.NewStatus(fwk.Success)
+}
+
+func (pl *constantSigPlugin) ScoreExtensions() fwk.ScoreExtensions {
+	return nil
+}
+
+func (pl *constantSigPlugin) SignPod(_ context.Context, pod *v1.Pod) ([]fwk.SignFragment, *fwk.Status) {
+	return pl.config.signature, pl.config.status
+}
+
+func newConstSigFactory(config *constSigPluginConfig) frameworkruntime.PluginFactory {
+	return func(_ context.Context, _ runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+		return &constantSigPlugin{config: config}, nil
+	}
+}
+
+func TestSignatures(t *testing.T) {
+	table := []struct {
+		name                 string
+		plugins              []*constSigPluginConfig
+		expectedSignature    string
+		expectUnscheduleable bool
+	}{
+		{
+			name:              "no plugins",
+			expectedSignature: `{"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "single filter",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "filter",
+				},
+			},
+			expectedSignature: `{"test":16,"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "single prefilter",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "prefilter",
+				},
+			},
+			expectedSignature: `{"test":16,"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "single score",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "score",
+				},
+			},
+			expectedSignature: `{"test":16,"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "single prescore",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "prescore",
+				},
+			},
+			expectedSignature: `{"test":16,"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "two plugins",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "filter",
+				},
+				{
+					name:       "ConstSig2",
+					signature:  []fwk.SignFragment{{Key: "test2", Value: 17}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "score",
+				},
+			},
+			expectedSignature: `{"test":16,"test2":17,"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "plugin with multiple fragments",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}, {Key: "test2", Value: 17}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "filter",
+				},
+			},
+			expectedSignature: `{"test":16,"test2":17,"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "overlapping fragments",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "filter",
+				},
+				{
+					name:       "ConstSig2",
+					signature:  []fwk.SignFragment{{Key: "test", Value: 16}},
+					status:     fwk.NewStatus(fwk.Success),
+					pluginType: "score",
+				},
+			},
+			expectedSignature: `{"test":16,"v1.Pod.Spec.SchedulerName":"test-scheduler"}`,
+		},
+		{
+			name: "unsignable plugin",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					status:     fwk.NewStatus(fwk.Unschedulable),
+					pluginType: "filter",
+				},
+			},
+			expectUnscheduleable: true,
+		},
+		{
+			name: "error plugin",
+			plugins: []*constSigPluginConfig{
+				{
+					name:       "ConstSig",
+					status:     fwk.NewStatus(fwk.Error),
+					pluginType: "filter",
+				},
+			},
+			expectUnscheduleable: true,
+		},
+	}
+	for _, item := range table {
+		t.Run(item.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			snapshot := internalcache.NewSnapshot([]*v1.Pod{}, []*v1.Node{})
+			informerFactory := informers.NewSharedInformerFactory(nil, 0)
+
+			plugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+
+			for _, pl := range item.plugins {
+				switch pl.pluginType {
+				case "filter":
+					plugins = append(plugins, tf.RegisterFilterPlugin(pl.name, newConstSigFactory(pl)))
+				case "prefilter":
+					plugins = append(plugins, tf.RegisterPreFilterPlugin(pl.name, newConstSigFactory(pl)))
+				case "score":
+					plugins = append(plugins, tf.RegisterScorePlugin(pl.name, newConstSigFactory(pl), 1))
+				case "prescore":
+					plugins = append(plugins, tf.RegisterPreScorePlugin(pl.name, newConstSigFactory(pl)))
+				}
+			}
+
+			schedFramework, err := tf.NewFramework(ctx,
+				plugins,
+				testSchedulerName,
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			signature, status := schedFramework.SignPod(ctx, podWithID("foo", ""))
+			if !status.IsSuccess() {
+				if !item.expectUnscheduleable || status.Code() != fwk.Unschedulable {
+					t.Fatalf("Unexpected status %v on %s", status, item.name)
+				}
+			}
+			if signature != item.expectedSignature {
+				t.Fatal(fmt.Errorf("Test %s got signature %s, expected %s", item.name, signature, item.expectedSignature))
+			}
+		})
+	}
+}
+
 // Tests the logic removing pods from inFlightPods after Permit (needed to fix issue https://github.com/kubernetes/kubernetes/issues/129967).
 // This needs to be a separate test case, because it mocks the waitOnPermit and runPrebindPlugins functions.
 func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
@@ -4446,6 +4676,20 @@ func podWithResources(id, desiredHost string, limits v1.ResourceList, requests v
 	pod := podWithID(id, desiredHost)
 	pod.Spec.Containers = []v1.Container{
 		{Name: "ctr", Resources: v1.ResourceRequirements{Limits: limits, Requests: requests}},
+	}
+	return pod
+}
+
+func podWithAffinity(id, desiredHost, label string) *v1.Pod {
+	pod := podWithID(id, desiredHost)
+	pod.Spec.Affinity = &v1.Affinity{
+		PodAffinity: &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					TopologyKey: label,
+				},
+			},
+		},
 	}
 	return pod
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -435,7 +435,8 @@ type PreFilterExtensions interface {
 }
 
 // PreFilterPlugin is an interface that must be implemented by "PreFilter" plugins.
-// These plugins are called at the beginning of the scheduling cycle.
+// These plugins are called at the beginning of the scheduling cycle. Plugins that implement PreFilterPlugin should
+// also implement SignPlugin to enable batching optimizations.
 type PreFilterPlugin interface {
 	Plugin
 	// PreFilter is called at the beginning of the scheduling cycle. All PreFilter
@@ -463,7 +464,8 @@ type PreFilterPlugin interface {
 // These plugins should return "Success", "Unschedulable" or "Error" in Status.code.
 // However, the scheduler accepts other valid codes as well.
 // Anything other than "Success" will lead to exclusion of the given host from
-// running the pod.
+// running the pod. Plugins that implement FilterPlugin should
+// also implement SignPlugin to enable batching optimizations.
 type FilterPlugin interface {
 	Plugin
 	// Filter is called by the scheduling framework.
@@ -518,7 +520,8 @@ type PostFilterPlugin interface {
 // PreScorePlugin is an interface for "PreScore" plugin. PreScore is an
 // informational extension point. Plugins will be called with a list of nodes
 // that passed the filtering phase. A plugin may use this data to update internal
-// state or to generate logs/metrics.
+// state or to generate logs/metrics. Plugins that implement PreScorePlugin should
+// also implement SignPlugin to enable batching optimizations.
 type PreScorePlugin interface {
 	Plugin
 	// PreScore is called by the scheduling framework after a list of nodes
@@ -538,7 +541,8 @@ type ScoreExtensions interface {
 }
 
 // ScorePlugin is an interface that must be implemented by "Score" plugins to rank
-// nodes that passed the filtering phase.
+// nodes that passed the filtering phase. Plugins that implement ScorePlugin should
+// also implement SignPlugin to enable batching optimizations.
 type ScorePlugin interface {
 	Plugin
 	// Score is called on each filtered node. It must return success and an integer
@@ -620,6 +624,55 @@ type BindPlugin interface {
 	// it must return Skip in its Status code. If a bind plugin returns an Error, the
 	// pod is rejected and will not be bound.
 	Bind(ctx context.Context, state CycleState, p *v1.Pod, nodeName string) *Status
+}
+
+type SignFragment struct {
+	// Pod signature fragments are identified by a key, i.e., fragments with the same key
+	// should contain the same value for the same pod. Plugin authors can return the same SignFragment
+	// from multiple plugins, the framework just ignores duplicates. This allows plugins to share signers easily.
+	//
+	// Fragment names can be found in k8s.io/kube-scheduler/framework/signers.go. New fragment names for
+	// in-tree plugins should be added there, and custom plugins can also use them.
+	// Simple SignFragments which return a field should have names that follow the field name they return.
+	// So a SignFragment that returns NodeName would have the key:
+	//
+	//	"v1.Pod.Spec.NodeName"
+	//
+	// If a SignFragment does some processing on the resource, its name should include the path to the base of the state it uses,
+	// and then suffix this with a descriptive function name followed by (). So, for example, a SignFragment that only returns
+	// Ephemeral volumes might use the key:
+	//
+	//	"v1.Pod.Volumes.EphemeralVolumes()"
+	Key string
+
+	// The value of a SignFragment must be a json-marshallable object.
+	Value any
+}
+
+const Unsignable = ""
+
+// SignPlugin is an interface that should be implemented by plugins that either filter or score
+// pods to enable batching and gang scheduling optimizations.
+// Each plugin returns SignFragments used to build a single signature per pod entering the scheduling cycle,
+// and the scheduler uses signatures to determine whether it can use a cached scheduling result, or needs to
+// recompute the prioritized nodes.
+//
+// If an enabled plugin that does Scoring, Prescoring, Filtering or Prefiltering does not implement this interface we will turn off batching for all pods.
+type SignPlugin interface {
+	Plugin
+	// SignPod returns SignFragments for use in batching. This is called at every scheduling cycle
+	// and is used to construct a signature builder used for pods. (KEP-5598).
+	//
+	// The sign fragments from all the plugins are combined to create a single signature. Only one fragment
+	// with a given key will be included.
+	//
+	// Status means:
+	//   - Success: the signer can sign the pod, accompanied by a set of signature fragments to be included.
+	//   - Unschedulable: the signer refuses to sign the pod, meaning the pod is not eligible for opportunistic batching optimization.
+	//   - Error: the signer hits something _unexpected_ and cannot build sign(s). A framework runtime just
+	//     proceeds with scheduling this pod without opportunistic batching optimization like Unschedulable,
+	//     but just report errors to logs.
+	SignPod(ctx context.Context, pod *v1.Pod) ([]SignFragment, *Status)
 }
 
 // Handle provides data and some tools that plugins can use. It is

--- a/staging/src/k8s.io/kube-scheduler/framework/signers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/signers.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"sort"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// This file contains the names and implementations of various functions used
+// to compute pod signatures for use in batching and other scheduling optimizations.
+// See the definition of BatchablePlugin for more details.
+
+// Signer names
+const (
+	DynamicResourcesSignerName = "v1.Pod.Spec.DynamicResources"
+	ImageNamesSignerName       = "v1.Pod.Spec.CanonicalImageNames()"
+	LabelsSignerName           = "v1.Pod.Labels"
+	NodeNameSignerName         = "v1.Pod.Spec.NodeName"
+	NodeAffinitySignerName     = "v1.Pod.Spec.Affinity.NodeAffinity"
+	NodeSelectorSignerName     = "v1.Pod.Spec.Affinity.NodeSelector"
+	InterPodAffinitySignerName = "v1.Pod.Spec.Affinity.InterPodAffinity"
+	HostPortsSignerName        = "v1.Pod.Spec.HostPorts()"
+	ResourcesSignerName        = "v1.Pod.Spec.ContainerResourcesAndOverheads()"
+	SchedulerNameSignerName    = "v1.Pod.Spec.SchedulerName"
+	TolerationsSignerName      = "v1.Pod.Spec.Tolerations"
+	PodToplogySpreadSignerName = "v1.Pod.Spec.PodTopologySpread"
+	VolumesSignerName          = "v1.Pod.Spec.Volumes.NonSyntheticSources()"
+)
+
+// Common signers. These are either generic or shared across plugins.
+
+func HostPortsSigner(pod *v1.Pod) any {
+	portSet := sets.New[int32]()
+	containers := []v1.Container{}
+	containers = append(containers, pod.Spec.Containers...)
+	containers = append(containers, pod.Spec.InitContainers...)
+	for _, container := range containers {
+		for _, port := range container.Ports {
+			if port.HostPort != 0 {
+				portSet.Insert(port.HostPort)
+			}
+		}
+	}
+	ports := portSet.UnsortedList()
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i] < ports[j]
+	})
+	return ports
+}
+
+func NodeAffinitySigner(pod *v1.Pod) any {
+	if pod.Spec.Affinity != nil {
+		return pod.Spec.Affinity.NodeAffinity
+	}
+	return nil
+}
+
+func TolerationsSigner(pod *v1.Pod) any {
+	ret := []v1.Toleration{}
+	ret = append(ret, pod.Spec.Tolerations...)
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Key < ret[j].Key || (ret[i].Key == ret[j].Key && ret[i].Value < ret[j].Value)
+	})
+	return ret
+}
+
+// We special case volumes because config and secret volumes don't
+// impact scheduling but are very specific to individual pods. If we
+// don't exclude them no pods will have matching signatures.
+func VolumesSigner(pod *v1.Pod) any {
+	ret := []v1.VolumeSource{}
+	for _, vol := range pod.Spec.Volumes {
+		if vol.VolumeSource.ConfigMap == nil && vol.VolumeSource.Secret == nil {
+			ret = append(ret, vol.VolumeSource)
+		}
+	}
+	return ret
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This introduces signature code to identify pods that are "identical" from a scheduling perspective.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5598

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No. Future PR will expose.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
