### PR TITLE
Clean up Node Validation

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6923,15 +6923,12 @@ func ValidateNode(node *core.Node) field.ErrorList {
 		allErrs = append(allErrs, validateNodeTaints(node.Spec.Taints, fldPath.Child("taints"))...)
 	}
 
-	// Only validate spec.
-	// All status fields are optional and can be updated later.
-	// That said, if specified, we need to ensure they are valid.
-	allErrs = append(allErrs, ValidateNodeResources(node)...)
-	allErrs = append(allErrs, validateNodeSwapStatus(node.Status.NodeInfo.Swap, fldPath.Child("nodeSwapStatus"))...)
+	// Validate NodeSpec
+	specPath := field.NewPath("spec")
 
 	// validate PodCIDRS only if we need to
 	if len(node.Spec.PodCIDRs) > 0 {
-		podCIDRsField := field.NewPath("spec", "podCIDRs")
+		podCIDRsField := specPath.Child("podCIDRs")
 
 		// all PodCIDRs should be valid ones
 		for idx, value := range node.Spec.PodCIDRs {
@@ -6950,39 +6947,77 @@ func ValidateNode(node *core.Node) field.ErrorList {
 		}
 	}
 
+	// Validate NodeStatus
+	statusPath := field.NewPath("status")
+	allErrs = append(allErrs, validateNodeResources(&node.Status, statusPath)...)
+	allErrs = append(allErrs, validateNodeSwapStatus(node.Status.NodeInfo.Swap, statusPath.Child("nodeInfo", "swap"))...)
+
 	return allErrs
 }
 
-// ValidateNodeResources is used to make sure a node has valid capacity and allocatable values.
-func ValidateNodeResources(node *core.Node) field.ErrorList {
+// validateNodeResources is used to make sure a node has valid capacity and allocatable values.
+func validateNodeResources(nodeStatus *core.NodeStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Validate resource quantities in capacity.
-	for k, v := range node.Status.Capacity {
-		resPath := field.NewPath("status", "capacity", string(k))
-		allErrs = append(allErrs, ValidateResourceQuantityValue(k, v, resPath)...)
+	capacityPath := fldPath.Child("capacity")
+	for k, v := range nodeStatus.Capacity {
+		allErrs = append(allErrs, ValidateResourceQuantityValue(k, v, capacityPath.Key(k.String()))...)
 	}
 
 	// Validate resource quantities in allocatable.
-	for k, v := range node.Status.Allocatable {
-		resPath := field.NewPath("status", "allocatable", string(k))
-		allErrs = append(allErrs, ValidateResourceQuantityValue(k, v, resPath)...)
+	allocatablePath := fldPath.Child("allocatable")
+	for k, v := range nodeStatus.Allocatable {
+		allErrs = append(allErrs, ValidateResourceQuantityValue(k, v, allocatablePath.Key(k.String()))...)
 	}
 	return allErrs
 }
 
 // ValidateNodeUpdate tests to make sure a node update can be applied.
+// This validation is applied to regular node updates and also to status updates.
 func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
 	allErrs := ValidateNode(node)
 
-	fldPath := field.NewPath("metadata")
-	allErrs = append(allErrs, ValidateObjectMetaUpdate(&node.ObjectMeta, &oldNode.ObjectMeta, fldPath)...)
+	allErrs = append(allErrs, ValidateObjectMetaUpdate(&node.ObjectMeta, &oldNode.ObjectMeta, field.NewPath("metadata"))...)
 
-	// TODO: Enable the code once we have better core object.status update model. Currently,
-	// anyone can update node status.
-	// if !apiequality.Semantic.DeepEqual(node.Status, core.NodeStatus{}) {
-	// 	allErrs = append(allErrs, field.Invalid("status", node.Status, "must be empty"))
-	// }
+	// Validate Spec Updates:
+	// spec only has a few fields, so check the ones we don't allow changing
+	//  1. PodCIDRs - immutable after first set - checked
+	//  2. ProviderID - immutable after first set - checked
+	//  3. Unschedulable - allowed to change
+	//  4. Taints - allowed to change
+	//  5. ConfigSource - allowed to change (and checked)
+	//  6. DoNotUseExternalID - immutable - checked
+	specPath := field.NewPath("spec")
+
+	// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
+	if len(oldNode.Spec.PodCIDRs) > 0 {
+		// compare the entire slice
+		if len(oldNode.Spec.PodCIDRs) != len(node.Spec.PodCIDRs) {
+			allErrs = append(allErrs, field.Forbidden(specPath.Child("podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
+		} else {
+			for idx, value := range oldNode.Spec.PodCIDRs {
+				if value != node.Spec.PodCIDRs[idx] {
+					allErrs = append(allErrs, field.Forbidden(specPath.Child("podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
+				}
+			}
+		}
+	}
+
+	// Allow controller manager updating provider ID when not set
+	if len(oldNode.Spec.ProviderID) > 0 && oldNode.Spec.ProviderID != node.Spec.ProviderID {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("providerID"), "node updates may not change providerID except from \"\" to valid"))
+	}
+
+	if node.Spec.ConfigSource != nil {
+		allErrs = append(allErrs, validateNodeConfigSourceSpec(node.Spec.ConfigSource, specPath.Child("configSource"))...)
+	}
+
+	if node.Spec.DoNotUseExternalID != oldNode.Spec.DoNotUseExternalID {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("externalID"), "may not be updated"))
+	}
+
+	// Validate Status Updates
 
 	// Validate no duplicate addresses in node status.
 	addresses := make(map[core.NodeAddress]bool)
@@ -6993,44 +7028,9 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
 		addresses[address] = true
 	}
 
-	// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
-	if len(oldNode.Spec.PodCIDRs) > 0 {
-		// compare the entire slice
-		if len(oldNode.Spec.PodCIDRs) != len(node.Spec.PodCIDRs) {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
-		} else {
-			for idx, value := range oldNode.Spec.PodCIDRs {
-				if value != node.Spec.PodCIDRs[idx] {
-					allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
-				}
-			}
-		}
-	}
-
-	// Allow controller manager updating provider ID when not set
-	if len(oldNode.Spec.ProviderID) > 0 && oldNode.Spec.ProviderID != node.Spec.ProviderID {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "providerID"), "node updates may not change providerID except from \"\" to valid"))
-	}
-
-	if node.Spec.ConfigSource != nil {
-		allErrs = append(allErrs, validateNodeConfigSourceSpec(node.Spec.ConfigSource, field.NewPath("spec", "configSource"))...)
-	}
 	if node.Status.Config != nil {
 		allErrs = append(allErrs, validateNodeConfigStatus(node.Status.Config, field.NewPath("status", "config"))...)
 	}
-
-	if node.Spec.DoNotUseExternalID != oldNode.Spec.DoNotUseExternalID {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "externalID"), "may not be updated"))
-	}
-
-	// status and metadata are allowed change (barring restrictions above), so separately test spec field.
-	// spec only has a few fields, so check the ones we don't allow changing
-	//  1. PodCIDRs - immutable after first set - checked above
-	//  2. ProviderID - immutable after first set - checked above
-	//  3. Unschedulable - allowed to change
-	//  4. Taints - allowed to change
-	//  5. ConfigSource - allowed to change (and checked above)
-	//  6. DoNotUseExternalID - immutable - checked above
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6916,12 +6916,9 @@ func ValidateNodeSpecificAnnotations(annotations map[string]string, fldPath *fie
 
 // ValidateNode tests if required fields in the node are set.
 func ValidateNode(node *core.Node) field.ErrorList {
-	fldPath := field.NewPath("metadata")
-	allErrs := ValidateObjectMeta(&node.ObjectMeta, false, ValidateNodeName, fldPath)
-	allErrs = append(allErrs, ValidateNodeSpecificAnnotations(node.ObjectMeta.Annotations, fldPath.Child("annotations"))...)
-	if len(node.Spec.Taints) > 0 {
-		allErrs = append(allErrs, validateNodeTaints(node.Spec.Taints, fldPath.Child("taints"))...)
-	}
+	metadataPath := field.NewPath("metadata")
+	allErrs := ValidateObjectMeta(&node.ObjectMeta, false, ValidateNodeName, metadataPath)
+	allErrs = append(allErrs, ValidateNodeSpecificAnnotations(node.ObjectMeta.Annotations, metadataPath.Child("annotations"))...)
 
 	// Validate NodeSpec
 	specPath := field.NewPath("spec")
@@ -6945,6 +6942,10 @@ func ValidateNode(node *core.Node) field.ErrorList {
 				allErrs = append(allErrs, field.Invalid(podCIDRsField, node.Spec.PodCIDRs, "may specify no more than one CIDR for each IP family"))
 			}
 		}
+	}
+
+	if len(node.Spec.Taints) > 0 {
+		allErrs = append(allErrs, validateNodeTaints(node.Spec.Taints, specPath.Child("taints"))...)
 	}
 
 	// Validate NodeStatus

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -18587,7 +18587,13 @@ func TestValidateNodeUpdate(t *testing.T) {
 		node    core.Node
 		valid   bool
 	}{
-		{"empty-node", core.Node{}, core.Node{}, true},
+		{"no-change", core.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo"},
+		}, core.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo"},
+		}, true},
 		{"rename-node", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo"}},

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -18321,6 +18321,17 @@ func TestValidateNode(t *testing.T) {
 				PodCIDRs: []string{"192.168.000.000/16"},
 			},
 		},
+		"no-duplicate-node-address": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "abc",
+			},
+			Status: core.NodeStatus{
+				Addresses: []core.NodeAddress{
+					{Type: core.NodeHostName, Address: "cluster-foo.region-a.node-bar"},
+					{Type: core.NodeInternalDNS, Address: "cluster-foo.region-a.node-bar"},
+				},
+			},
+		},
 	}
 	for name, legacyCase := range legacyValidationCases {
 		t.Run(name, func(t *testing.T) {
@@ -18545,6 +18556,30 @@ func TestValidateNode(t *testing.T) {
 			},
 			Spec: core.NodeSpec{
 				PodCIDRs: []string{"10.0.0.1/16", "10.0.0.1/16"},
+			},
+		},
+		"duplicate-node-address": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "abc",
+			},
+			Status: core.NodeStatus{
+				Addresses: []core.NodeAddress{
+					{Type: core.NodeExternalIP, Address: "1.1.1.1"},
+					{Type: core.NodeHostName, Address: "cluster-foo.region-a.node-bar"},
+					{Type: core.NodeExternalIP, Address: "1.1.1.1"},
+				},
+			},
+		},
+		"invalid-node-config-status": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "abc",
+			},
+			Status: core.NodeStatus{
+				Config: &core.NodeConfigStatus{
+					Active: &core.NodeConfigSource{
+						ConfigMap: &core.ConfigMapNodeConfigSource{},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -18582,19 +18582,20 @@ func TestValidateNode(t *testing.T) {
 
 func TestValidateNodeUpdate(t *testing.T) {
 	tests := []struct {
+		name    string
 		oldNode core.Node
 		node    core.Node
 		valid   bool
 	}{
-		{core.Node{}, core.Node{}, true},
-		{core.Node{
+		{"empty-node", core.Node{}, core.Node{}, true},
+		{"rename-node", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo"}},
 			core.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bar"},
 			}, false},
-		{core.Node{
+		{"update-labels", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "foo",
 				Labels: map[string]string{"foo": "bar"},
@@ -18605,7 +18606,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Labels: map[string]string{"foo": "baz"},
 			},
 		}, true},
-		{core.Node{
+		{"add-labels", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18615,7 +18616,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Labels: map[string]string{"foo": "baz"},
 			},
 		}, true},
-		{core.Node{
+		{"replace-labels", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "foo",
 				Labels: map[string]string{"bar": "foo"},
@@ -18626,7 +18627,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Labels: map[string]string{"foo": "baz"},
 			},
 		}, true},
-		{core.Node{
+		{"set-pod-cidr", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18641,7 +18642,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				PodCIDRs: []string{"192.168.0.0/16"},
 			},
 		}, true},
-		{core.Node{
+		{"change-pod-cidr", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18656,7 +18657,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				PodCIDRs: []string{"192.168.0.0/16"},
 			},
 		}, false},
-		{core.Node{
+		{"update-capacity", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18677,7 +18678,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				},
 			},
 		}, true},
-		{core.Node{
+		{"update-labels-and-capacity", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "foo",
 				Labels: map[string]string{"bar": "foo"},
@@ -18700,7 +18701,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				},
 			},
 		}, true},
-		{core.Node{
+		{"update-labels-remove-addresses", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "foo",
 				Labels: map[string]string{"bar": "foo"},
@@ -18716,7 +18717,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Labels: map[string]string{"bar": "fooobaz"},
 			},
 		}, true},
-		{core.Node{
+		{"update-label-key-case", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "foo",
 				Labels: map[string]string{"foo": "baz"},
@@ -18727,7 +18728,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Labels: map[string]string{"Foo": "baz"},
 			},
 		}, true},
-		{core.Node{
+		{"update-unschedulable-true", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18742,7 +18743,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Unschedulable: true,
 			},
 		}, true},
-		{core.Node{
+		{"invalid-duplicate-node-addresses", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18760,7 +18761,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				},
 			},
 		}, false},
-		{core.Node{
+		{"add-valid-node-addresses", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18778,7 +18779,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				},
 			},
 		}, true},
-		{core.Node{
+		{"add-valid-prefer-avoid-pods-annotation", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18787,30 +18788,30 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Name: "foo",
 				Annotations: map[string]string{
 					core.PreferAvoidPodsAnnotationKey: `
-							{
-							    "preferAvoidPods": [
-							        {
-							            "podSignature": {
-							                "podController": {
-							                    "apiVersion": "v1",
-							                    "kind": "ReplicationController",
-							                    "name": "foo",
+                            {
+                                "preferAvoidPods": [
+                                    {
+                                        "podSignature": {
+                                            "podController": {
+                                                "apiVersion": "v1",
+                                                "kind": "ReplicationController",
+                                                "name": "foo",
                                                                            "uid": "abcdef123456",
                                                                            "controller": true
-							                }
-							            },
-							            "reason": "some reason",
-							            "message": "some message"
-							        }
-							    ]
-							}`,
+                                            }
+                                        },
+                                        "reason": "some reason",
+                                        "message": "some message"
+                                    }
+                                ]
+                            }`,
 				},
 			},
 			Spec: core.NodeSpec{
 				Unschedulable: false,
 			},
 		}, true},
-		{core.Node{
+		{"invalid-prefer-avoid-pods-no-signature", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18819,18 +18820,18 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Name: "foo",
 				Annotations: map[string]string{
 					core.PreferAvoidPodsAnnotationKey: `
-							{
-							    "preferAvoidPods": [
-							        {
-							            "reason": "some reason",
-							            "message": "some message"
-							        }
-							    ]
-							}`,
+                            {
+                                "preferAvoidPods": [
+                                    {
+                                        "reason": "some reason",
+                                        "message": "some message"
+                                    }
+                                ]
+                            }`,
 				},
 			},
 		}, false},
-		{core.Node{
+		{"invalid-prefer-avoid-pods-controller-false", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -18839,27 +18840,27 @@ func TestValidateNodeUpdate(t *testing.T) {
 				Name: "foo",
 				Annotations: map[string]string{
 					core.PreferAvoidPodsAnnotationKey: `
-							{
-							    "preferAvoidPods": [
-							        {
-							            "podSignature": {
-							                "podController": {
-							                    "apiVersion": "v1",
-							                    "kind": "ReplicationController",
-							                    "name": "foo",
-							                    "uid": "abcdef123456",
-							                    "controller": false
-							                }
-							            },
-							            "reason": "some reason",
-							            "message": "some message"
-							        }
-							    ]
-							}`,
+                            {
+                                "preferAvoidPods": [
+                                    {
+                                        "podSignature": {
+                                            "podController": {
+                                                "apiVersion": "v1",
+                                                "kind": "ReplicationController",
+                                                "name": "foo",
+                                                "uid": "abcdef123456",
+                                                "controller": false
+                                            }
+                                        },
+                                        "reason": "some reason",
+                                        "message": "some message"
+                                    }
+                                ]
+                            }`,
 				},
 			},
 		}, false},
-		{core.Node{
+		{"valid-extended-resources", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid-extended-resources",
 			},
@@ -18876,7 +18877,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				},
 			},
 		}, true},
-		{core.Node{
+		{"invalid-fractional-extended-capacity", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "invalid-fractional-extended-capacity",
 			},
@@ -18892,7 +18893,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				},
 			},
 		}, false},
-		{core.Node{
+		{"invalid-fractional-extended-allocatable", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "invalid-fractional-extended-allocatable",
 			},
@@ -18913,7 +18914,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				},
 			},
 		}, false},
-		{core.Node{
+		{"update-provider-id-when-not-set", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "update-provider-id-when-not-set",
 			},
@@ -18925,7 +18926,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				ProviderID: "provider:///new",
 			},
 		}, true},
-		{core.Node{
+		{"update-provider-id-when-set", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "update-provider-id-when-set",
 			},
@@ -18940,7 +18941,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				ProviderID: "provider:///new",
 			},
 		}, false},
-		{core.Node{
+		{"pod-cidrs-as-is", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod-cidrs-as-is",
 			},
@@ -18955,7 +18956,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				PodCIDRs: []string{"192.168.0.0/16"},
 			},
 		}, true},
-		{core.Node{
+		{"pod-cidrs-as-is-dual-stack", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod-cidrs-as-is-2",
 			},
@@ -18970,7 +18971,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				PodCIDRs: []string{"192.168.0.0/16", "2000::/10"},
 			},
 		}, true},
-		{core.Node{
+		{"pod-cidrs-not-same-length", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod-cidrs-not-same-length",
 			},
@@ -18985,7 +18986,7 @@ func TestValidateNodeUpdate(t *testing.T) {
 				PodCIDRs: []string{"192.168.0.0/16", "2000::/10"},
 			},
 		}, false},
-		{core.Node{
+		{"pod-cidrs-not-same-order", core.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod-cidrs-not-same",
 			},
@@ -19001,17 +19002,19 @@ func TestValidateNodeUpdate(t *testing.T) {
 			},
 		}, false},
 	}
-	for i, test := range tests {
-		test.oldNode.ObjectMeta.ResourceVersion = "1"
-		test.node.ObjectMeta.ResourceVersion = "1"
-		errs := ValidateNodeUpdate(&test.node, &test.oldNode)
-		if test.valid && len(errs) > 0 {
-			t.Errorf("%d: Unexpected error: %v", i, errs)
-			t.Logf("%#v vs %#v", test.oldNode.ObjectMeta, test.node.ObjectMeta)
-		}
-		if !test.valid && len(errs) == 0 {
-			t.Errorf("%d: Unexpected non-error", i)
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.oldNode.ObjectMeta.ResourceVersion = "1"
+			test.node.ObjectMeta.ResourceVersion = "1"
+			errs := ValidateNodeUpdate(&test.node, &test.oldNode)
+			if test.valid && len(errs) > 0 {
+				t.Errorf("Unexpected error: %v", errs)
+				t.Logf("%#v vs %#v", test.oldNode.ObjectMeta, test.node.ObjectMeta)
+			}
+			if !test.valid && len(errs) == 0 {
+				t.Errorf("Expected error but got none")
+			}
+		})
 	}
 }
 

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -141,8 +141,7 @@ func (nodeStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an end user.
 func (nodeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	errorList := validation.ValidateNode(obj.(*api.Node))
-	return append(errorList, validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node))...)
+	return validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node))
 }
 
 // WarningsOnUpdate returns warnings for the given update.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Node validation was a bit of a mess. This PR fixes:
1. ValidateNode and ValidateNodeUpdate were both called on node update, but some checks were duplicated between them. Node status updates only called ValidateNodeUpdate.
2. Some fields were only validated in ValidateNodeUpdate, even though they weren't checking the old node value. In other words, you could create a node that wouldn't be valid on update.
3. Cleaned up comments and validation check ordering
4. Fix up some field paths

#### Special notes for your reviewer:

This PR makes some requests invalid that were previously valid:
- Creating a node with invalid address or config status fields
- Setting invalid swap status in a status update

I think these changes are safe?

Note: this PR doesn't add or modify any individual field validation checks. It just moves them around (and in one case fixes the field path).

#### Does this PR introduce a user-facing change?
```release-note
It is no longer possible to create nodes with invalid `.status.adresses` or `.status.config` fields. It is no longer possible to set an invalid swap capacity on status update.
```

/sig node
/label api-review
/assign @liggitt 
/cc @pravk03 