### PR TITLE
dynamic-resource-allocation/client: expose IsWatchListSemanticsUnSupported

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/client/client.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/client.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	cgoresource "k8s.io/client-go/kubernetes/typed/resource/v1"
 	rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/watchlist"
 )
 
 // Enumerate all supported APIs, most preferred first.
@@ -101,4 +102,15 @@ func (c *Client) ResourceSlices() cgoresource.ResourceSliceInterface {
 		c.clientSet.ResourceV1beta1().ResourceSlices(),
 		c.clientSet.ResourceV1beta2().ResourceSlices(),
 	)
+}
+
+// IsWatchListSemanticsSupported informs the reflector that this client
+// doesn't support WatchList semantics.
+//
+// This is a synthetic method whose sole purpose is to satisfy the optional
+// interface check performed by the reflector.
+// Returning true signals that WatchList can NOT be used.
+// No additional logic is implemented here.
+func (c *Client) IsWatchListSemanticsUnSupported() bool {
+	return watchlist.DoesClientNotSupportWatchListSemantics(c.clientSet)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/client_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/client_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/watchlist"
+)
+
+func TestDoesClientSupportWatchListSemantics(t *testing.T) {
+	scenarios := []struct {
+		name                                           string
+		clientSet                                      kubernetes.Interface
+		expectedDoesClientNotSupportWatchListSemantics bool
+	}{
+		{
+			name:      "DR with real kube client supports WatchList semantics",
+			clientSet: kubernetes.NewForConfigOrDie(&restclient.Config{}),
+			expectedDoesClientNotSupportWatchListSemantics: false,
+		},
+		{
+			name:      "DR with fake kube client does NOT support WatchList semantics",
+			clientSet: fake.NewClientset(),
+			expectedDoesClientNotSupportWatchListSemantics: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			target := New(scenario.clientSet)
+			actual := watchlist.DoesClientNotSupportWatchListSemantics(target)
+			if actual != scenario.expectedDoesClientNotSupportWatchListSemantics {
+				t.Fatalf("watchlist.DoesClientNotSupportWatchListSemantics, got: %v, want: %v", actual, scenario.expectedDoesClientNotSupportWatchListSemantics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
introduces the `IsWatchListSemanticsUnSupported()` on the DR client. The method allows the reflector to determine whether the underlying client supports WatchList semantics.
```
// IsWatchListSemanticsUnSupported informs the reflector that this client
// doesn't support WatchList semantics.
//
// This is a synthetic method whose sole purpose is to satisfy the optional
// interface check performed by the reflector.
// Returning true signals that WatchList can NOT be used.
// No additional logic is implemented here.
func (c *Client) IsWatchListSemanticsUnSupported() bool {
	return watchlist.DoesClientNotSupportWatchListSemantics(c.clientSet)
}
```

This change is especially useful in unit tests, where fake clients are used. Fake clients do not support WatchList semantics, and without this method, the reflector may attempt to use WatchList.

xref: https://github.com/kubernetes/kubernetes/pull/134180


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
