### PR TITLE
Update OWNERS to sig-apps owned registry packages (batch & policy)

### DIFF
--- a/pkg/registry/batch/OWNERS
+++ b/pkg/registry/batch/OWNERS
@@ -1,4 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+  - sig-apps-approvers
 reviewers:
-  - deads2k
+  - sig-apps-reviewers
+labels:
+  - sig/apps

--- a/pkg/registry/policy/OWNERS
+++ b/pkg/registry/policy/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-auth-policy-approvers
+  - sig-apps-approvers
 reviewers:
-  - sig-auth-policy-reviewers
+  - sig-apps-reviewers
 labels:
-  - sig/auth
+  - sig/apps


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
This is followup to #121210 updating the registry packages owned by sig-apps.

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:
/assign @msau42 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
