### PR TITLE
Fix extended resource toleration admission controller logic to skip zero extended resources requests when adding pod tolerations

### DIFF
--- a/plugin/pkg/admission/extendedresourcetoleration/admission.go
+++ b/plugin/pkg/admission/extendedresourcetoleration/admission.go
@@ -70,15 +70,15 @@ func (p *plugin) Admit(ctx context.Context, attributes admission.Attributes, o a
 
 	resources := sets.String{}
 	for _, container := range pod.Spec.Containers {
-		for resourceName := range container.Resources.Requests {
-			if helper.IsExtendedResourceName(resourceName) {
+		for resourceName, resourceQuantity := range container.Resources.Requests {
+			if helper.IsExtendedResourceName(resourceName) && resourceQuantity.Value() > 0 {
 				resources.Insert(string(resourceName))
 			}
 		}
 	}
 	for _, container := range pod.Spec.InitContainers {
-		for resourceName := range container.Resources.Requests {
-			if helper.IsExtendedResourceName(resourceName) {
+		for resourceName, resourceQuantity := range container.Resources.Requests {
+			if helper.IsExtendedResourceName(resourceName) && resourceQuantity.Value() > 0 {
 				resources.Insert(string(resourceName))
 			}
 		}

--- a/plugin/pkg/admission/extendedresourcetoleration/admission_test.go
+++ b/plugin/pkg/admission/extendedresourcetoleration/admission_test.go
@@ -50,6 +50,14 @@ func TestAdmit(t *testing.T) {
 	extendedResource1 := "example.com/device-ek"
 	extendedResource2 := "example.com/device-do"
 
+	containerRequestingZeroResource1 := core.Container{
+		Resources: core.ResourceRequirements{
+			Requests: core.ResourceList{
+				core.ResourceName(extendedResource1): *resource.NewQuantity(0, resource.DecimalSI),
+			},
+		},
+	}
+
 	containerRequestingExtendedResource1 := core.Container{
 		Resources: core.ResourceRequirements{
 			Requests: core.ResourceList{
@@ -133,6 +141,40 @@ func TestAdmit(t *testing.T) {
 							Operator: core.TolerationOpExists,
 							Effect:   core.TaintEffectNoSchedule,
 						},
+					},
+				},
+			},
+		},
+		{
+			description: "pod with container with zero extended resource, expect no change in tolerations",
+			requestedPod: core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						containerRequestingZeroResource1,
+					},
+				},
+			},
+			expectedPod: core.Pod{
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						containerRequestingZeroResource1,
+					},
+				},
+			},
+		},
+		{
+			description: "pod with  init container with zero extended resource, expect no change in tolerations",
+			requestedPod: core.Pod{
+				Spec: core.PodSpec{
+					InitContainers: []core.Container{
+						containerRequestingZeroResource1,
+					},
+				},
+			},
+			expectedPod: core.Pod{
+				Spec: core.PodSpec{
+					InitContainers: []core.Container{
+						containerRequestingZeroResource1,
 					},
 				},
 			},


### PR DESCRIPTION
/kind bug
/sig scheduling
/area hw-accelerators

Fixes #125426

Before this change the ExtendedResourceToleration admission controller added tolerations for extended resources that requested 0, which allowed pods to schedule on tainted nodes when no resource is needed. 

#### Special notes for your reviewer:
This is my first contribution, let me know if there is any bit I'm missing

```release-note
Fixed: ExtendedResourceToleration admission plugin no longer adds tolerations for extended resources when the requested quantity is zero
```
