### PR TITLE
Fixing unit test flakes in pkg/kubelet/winstats TestCollectMetricsData

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats_test.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats_test.go
@@ -143,8 +143,9 @@ func TestCollectMetricsData(t *testing.T) {
 		memoryPrivWorkingSetBytes: 2,
 		memoryCommittedBytes:      3,
 		interfaceStats:            networkAdapterCounter.listInterfaceStats(),
-		timeStamp:                 time.Now(),
 	}
+	assert.WithinDuration(t, time.Now(), metrics.timeStamp, 20*time.Millisecond)
+	expectedMetrics.timeStamp = metrics.timeStamp
 	assert.Equal(t, expectedMetrics, metrics)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind regression
-->

#### What this PR does / why we need it:

The `TestCollectMetricsData` unit test in the winstats package occasionally fails because of very slight differences (usually ~6ms) between metrics are collected and validated.

ex:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-windows-master/1981737563995508736

```bash
        	            	  timeStamp: (time.Time) {
        	            	-  wall: (uint64) 13994658928772509516,
        	            	-  ext: (int64) 428034001,
        	            	+  wall: (uint64) 13994658928771942816,
        	            	+  ext: (int64) 427467301,
        	            	   loc: (*time.Location)({
  	            	   
```

and 
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-windows-master/1981464758213152768


```bash
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -6,4 +6,4 @@
        	            	  timeStamp: (time.Time) {
        	            	-  wall: (uint64) 13994589069317929728,
        	            	-  ext: (int64) 422052101,
        	            	+  wall: (uint64) 13994589069317418428,
        	            	+  ext: (int64) 421540801,
        	            	   loc: (*time.Location)({
```

This PR fixes the issue by using `assert.WithDuration` with a 20 ms buffer

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows
/area kubelet testing
