### PR TITLE
node: mm-mgr: Refactor to use logger parameter instead of context

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -344,7 +344,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	cm.topologyManager.AddHintProvider(logger, cm.cpuManager)
 
 	cm.memoryManager, err = memorymanager.NewManager(
-		context.TODO(),
+		logger,
 		nodeConfig.MemoryManagerPolicy,
 		machineInfo,
 		cm.GetNodeAllocatableReservation(),
@@ -997,7 +997,7 @@ func (cm *containerManagerImpl) GetMemory(podUID, containerName string) []*podre
 
 	// This is tempporary as part of migration of memory manager to Contextual logging.
 	// Direct context to be passed when container manager is migrated.
-	return containerMemoryFromBlock(cm.memoryManager.GetMemory(context.TODO(), podUID, containerName))
+	return containerMemoryFromBlock(cm.memoryManager.GetMemory(podUID, containerName))
 }
 
 func (cm *containerManagerImpl) GetAllocatableMemory() []*podresourcesapi.ContainerMemory {
@@ -1007,7 +1007,7 @@ func (cm *containerManagerImpl) GetAllocatableMemory() []*podresourcesapi.Contai
 
 	// This is tempporary as part of migration of memory manager to Contextual logging.
 	// Direct context to be passed when container manager is migrated.
-	return containerMemoryFromBlock(cm.memoryManager.GetAllocatableMemory(context.TODO()))
+	return containerMemoryFromBlock(cm.memoryManager.GetAllocatableMemory())
 }
 
 func (cm *containerManagerImpl) GetDynamicResources(pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -51,7 +51,7 @@ var _ ContainerManager = &containerManagerStub{}
 
 func (cm *containerManagerStub) Start(ctx context.Context, _ *v1.Node, _ ActivePodsFunc, _ GetNodeFunc, _ config.SourcesReady, _ status.PodStatusProvider, _ internalapi.RuntimeService, _ bool) error {
 	klog.V(2).InfoS("Starting stub container manager")
-	cm.memoryManager = memorymanager.NewFakeManager(ctx)
+	cm.memoryManager = memorymanager.NewFakeManager(klog.FromContext(ctx))
 	cm.cpuManager = cpumanager.NewFakeManager(klog.FromContext(ctx))
 	return nil
 }

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -141,7 +141,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 
 	cm.topologyManager = topologymanager.NewFakeManager()
 	cm.cpuManager = cpumanager.NewFakeManager(klog.TODO())
-	cm.memoryManager = memorymanager.NewFakeManager(context.TODO())
+	cm.memoryManager = memorymanager.NewFakeManager(klog.TODO())
 
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
 		klog.InfoS("Creating topology manager")
@@ -174,7 +174,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 
 		klog.InfoS("Creating memory manager")
 		cm.memoryManager, err = memorymanager.NewManager(
-			context.TODO(),
+			klog.TODO(),
 			nodeConfig.MemoryManagerPolicy,
 			machineInfo,
 			cm.GetNodeAllocatableReservation(),

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -56,7 +56,7 @@ func NewFakeContainerManager() *FakeContainerManager {
 	return &FakeContainerManager{
 		PodContainerManager: NewFakePodContainerManager(),
 		cpuManager:          cpumanager.NewFakeManager(klog.TODO()),
-		memoryManager:       memorymanager.NewFakeManager(context.TODO()),
+		memoryManager:       memorymanager.NewFakeManager(klog.TODO()),
 	}
 }
 

--- a/pkg/kubelet/cm/internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cm
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
@@ -46,7 +44,7 @@ func (i *internalContainerLifecycleImpl) PreStartContainer(pod *v1.Pod, containe
 	}
 
 	if i.memoryManager != nil {
-		i.memoryManager.AddContainer(context.TODO(), pod, container, containerID)
+		i.memoryManager.AddContainer(klog.TODO(), pod, container, containerID)
 	}
 
 	i.topologyManager.AddContainer(pod, container, containerID)

--- a/pkg/kubelet/cm/internal_container_lifecycle_linux.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_linux.go
@@ -20,13 +20,13 @@ limitations under the License.
 package cm
 
 import (
-	"context"
 	"strconv"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/klog/v2"
 )
 
 func (i *internalContainerLifecycleImpl) PreCreateContainer(pod *v1.Pod, container *v1.Container, containerConfig *runtimeapi.ContainerConfig) error {
@@ -38,7 +38,7 @@ func (i *internalContainerLifecycleImpl) PreCreateContainer(pod *v1.Pod, contain
 	}
 
 	if i.memoryManager != nil {
-		numaNodes := i.memoryManager.GetMemoryNUMANodes(context.TODO(), pod, container)
+		numaNodes := i.memoryManager.GetMemoryNUMANodes(klog.TODO(), pod, container)
 		if numaNodes.Len() > 0 {
 			var affinity []string
 			for _, numaNode := range sets.List(numaNodes) {

--- a/pkg/kubelet/cm/internal_container_lifecycle_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cm
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -42,7 +41,7 @@ type mockMemoryManager struct {
 	memorymanager.Manager
 }
 
-func (memoryManager *mockMemoryManager) AddContainer(context.Context, *v1.Pod, *v1.Container, string) {
+func (memoryManager *mockMemoryManager) AddContainer(logr.Logger, *v1.Pod, *v1.Container, string) {
 	memoryManager.called = true
 }
 

--- a/pkg/kubelet/cm/internal_container_lifecycle_windows.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_windows.go
@@ -20,7 +20,6 @@ limitations under the License.
 package cm
 
 import (
-	"context"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -48,7 +47,7 @@ func (i *internalContainerLifecycleImpl) PreCreateContainer(pod *v1.Pod, contain
 
 	var numaNodes sets.Set[int]
 	if i.memoryManager != nil {
-		numaNodes = i.memoryManager.GetMemoryNUMANodes(context.TODO(), pod, container)
+		numaNodes = i.memoryManager.GetMemoryNUMANodes(klog.TODO(), pod, container)
 	}
 
 	// Gather all CPUs associated with the selected NUMA nodes

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -39,46 +39,39 @@ func (m *fakeManager) Start(ctx context.Context, activePods ActivePodsFunc, sour
 	return nil
 }
 
-func (m *fakeManager) Policy(ctx context.Context) Policy {
-	logger := klog.FromContext(ctx)
+func (m *fakeManager) Policy(logger klog.Logger) Policy {
 	logger.Info("Policy()")
-	return NewPolicyNone(ctx)
+	return NewPolicyNone(logger)
 }
 
 func (m *fakeManager) Allocate(pod *v1.Pod, container *v1.Container) error {
-	ctx := context.TODO()
-	logger := klog.FromContext(ctx)
+	logger := klog.TODO()
 	logger.Info("Allocate", "pod", klog.KObj(pod), "containerName", container.Name)
 	return nil
 }
 
-func (m *fakeManager) AddContainer(ctx context.Context, pod *v1.Pod, container *v1.Container, containerID string) {
-	logger := klog.FromContext(ctx)
+func (m *fakeManager) AddContainer(logger klog.Logger, pod *v1.Pod, container *v1.Container, containerID string) {
 	logger.Info("Add container", "pod", klog.KObj(pod), "containerName", container.Name, "containerID", containerID)
 }
 
-func (m *fakeManager) GetMemoryNUMANodes(ctx context.Context, pod *v1.Pod, container *v1.Container) sets.Set[int] {
-	logger := klog.FromContext(ctx)
+func (m *fakeManager) GetMemoryNUMANodes(logger klog.Logger, pod *v1.Pod, container *v1.Container) sets.Set[int] {
 	logger.Info("Get MemoryNUMANodes", "pod", klog.KObj(pod), "containerName", container.Name)
 	return nil
 }
 
-func (m *fakeManager) RemoveContainer(ctx context.Context, containerID string) error {
-	logger := klog.FromContext(ctx)
+func (m *fakeManager) RemoveContainer(logger klog.Logger, containerID string) error {
 	logger.Info("RemoveContainer", "containerID", containerID)
 	return nil
 }
 
 func (m *fakeManager) GetTopologyHints(pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
-	ctx := context.TODO()
-	logger := klog.FromContext(ctx)
+	logger := klog.TODO()
 	logger.Info("Get Topology Hints", "pod", klog.KObj(pod), "containerName", container.Name)
 	return map[string][]topologymanager.TopologyHint{}
 }
 
 func (m *fakeManager) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymanager.TopologyHint {
-	ctx := context.TODO()
-	logger := klog.FromContext(ctx)
+	logger := klog.TODO()
 	logger.Info("Get Pod Topology Hints", "pod", klog.KObj(pod))
 	return map[string][]topologymanager.TopologyHint{}
 }
@@ -88,24 +81,23 @@ func (m *fakeManager) State() state.Reader {
 }
 
 // GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
-func (m *fakeManager) GetAllocatableMemory(ctx context.Context) []state.Block {
-	logger := klog.FromContext(ctx)
+func (m *fakeManager) GetAllocatableMemory() []state.Block {
+	logger := klog.TODO()
 	logger.Info("Get Allocatable Memory")
 	return []state.Block{}
 }
 
 // GetMemory returns the memory allocated by a container from NUMA nodes
-func (m *fakeManager) GetMemory(ctx context.Context, podUID, containerName string) []state.Block {
-	logger := klog.LoggerWithValues(klog.FromContext(ctx), "podUID", podUID, "containerName", containerName)
+func (m *fakeManager) GetMemory(podUID, containerName string) []state.Block {
+	logger := klog.LoggerWithValues(klog.TODO(), "podUID", podUID, "containerName", containerName)
 	logger.Info("Get Memory")
 	return []state.Block{}
 }
 
 // NewFakeManager creates empty/fake memory manager
-func NewFakeManager(ctx context.Context) Manager {
-	logger := klog.LoggerWithName(klog.FromContext(ctx), "memory-mgr.fake")
+func NewFakeManager(logger klog.Logger) Manager {
+	logger = klog.LoggerWithName(logger, "memory-mgr.fake")
 	return &fakeManager{
-		// logger: logger,
 		state: state.NewMemoryState(logger),
 	}
 }

--- a/pkg/kubelet/cm/memorymanager/policy.go
+++ b/pkg/kubelet/cm/memorymanager/policy.go
@@ -17,9 +17,8 @@ limitations under the License.
 package memorymanager
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 )
@@ -30,19 +29,19 @@ type policyType string
 // Policy implements logic for pod container to a memory assignment.
 type Policy interface {
 	Name() string
-	Start(ctx context.Context, s state.State) error
+	Start(logger klog.Logger, s state.State) error
 	// Allocate call is idempotent
-	Allocate(ctx context.Context, s state.State, pod *v1.Pod, container *v1.Container) error
+	Allocate(logger klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) error
 	// RemoveContainer call is idempotent
-	RemoveContainer(ctx context.Context, s state.State, podUID string, containerName string)
+	RemoveContainer(logger klog.Logger, s state.State, podUID string, containerName string)
 	// GetTopologyHints implements the topologymanager.HintProvider Interface
 	// and is consulted to achieve NUMA aware resource alignment among this
 	// and other resource controllers.
-	GetTopologyHints(ctx context.Context, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint
+	GetTopologyHints(logger klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint
 	// GetPodTopologyHints implements the topologymanager.HintProvider Interface
 	// and is consulted to achieve NUMA aware resource alignment among this
 	// and other resource controllers.
-	GetPodTopologyHints(ctx context.Context, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint
+	GetPodTopologyHints(logger klog.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint
 	// GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
-	GetAllocatableMemory(ctx context.Context, s state.State) []state.Block
+	GetAllocatableMemory(s state.State) []state.Block
 }

--- a/pkg/kubelet/cm/memorymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/memorymanager/policy_best_effort.go
@@ -17,8 +17,7 @@ limitations under the License.
 package memorymanager
 
 import (
-	"context"
-
+	"github.com/go-logr/logr"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 
 	v1 "k8s.io/api/core/v1"
@@ -41,8 +40,8 @@ type bestEffortPolicy struct {
 
 var _ Policy = &bestEffortPolicy{}
 
-func NewPolicyBestEffort(ctx context.Context, machineInfo *cadvisorapi.MachineInfo, reserved systemReservedMemory, affinity topologymanager.Store) (Policy, error) {
-	p, err := NewPolicyStatic(ctx, machineInfo, reserved, affinity)
+func NewPolicyBestEffort(logger logr.Logger, machineInfo *cadvisorapi.MachineInfo, reserved systemReservedMemory, affinity topologymanager.Store) (Policy, error) {
+	p, err := NewPolicyStatic(logger, machineInfo, reserved, affinity)
 
 	if err != nil {
 		return nil, err
@@ -57,26 +56,26 @@ func (p *bestEffortPolicy) Name() string {
 	return string(policyTypeBestEffort)
 }
 
-func (p *bestEffortPolicy) Start(ctx context.Context, s state.State) error {
-	return p.static.Start(ctx, s)
+func (p *bestEffortPolicy) Start(logger logr.Logger, s state.State) error {
+	return p.static.Start(logger, s)
 }
 
-func (p *bestEffortPolicy) Allocate(ctx context.Context, s state.State, pod *v1.Pod, container *v1.Container) (rerr error) {
-	return p.static.Allocate(ctx, s, pod, container)
+func (p *bestEffortPolicy) Allocate(logger logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) (rerr error) {
+	return p.static.Allocate(logger, s, pod, container)
 }
 
-func (p *bestEffortPolicy) RemoveContainer(ctx context.Context, s state.State, podUID string, containerName string) {
-	p.static.RemoveContainer(ctx, s, podUID, containerName)
+func (p *bestEffortPolicy) RemoveContainer(logger logr.Logger, s state.State, podUID string, containerName string) {
+	p.static.RemoveContainer(logger, s, podUID, containerName)
 }
 
-func (p *bestEffortPolicy) GetPodTopologyHints(ctx context.Context, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
-	return p.static.GetPodTopologyHints(ctx, s, pod)
+func (p *bestEffortPolicy) GetPodTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+	return p.static.GetPodTopologyHints(logger, s, pod)
 }
 
-func (p *bestEffortPolicy) GetTopologyHints(ctx context.Context, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
-	return p.static.GetTopologyHints(ctx, s, pod, container)
+func (p *bestEffortPolicy) GetTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+	return p.static.GetTopologyHints(logger, s, pod, container)
 }
 
-func (p *bestEffortPolicy) GetAllocatableMemory(ctx context.Context, s state.State) []state.Block {
-	return p.static.GetAllocatableMemory(ctx, s)
+func (p *bestEffortPolicy) GetAllocatableMemory(s state.State) []state.Block {
+	return p.static.GetAllocatableMemory(s)
 }

--- a/pkg/kubelet/cm/memorymanager/policy_none.go
+++ b/pkg/kubelet/cm/memorymanager/policy_none.go
@@ -17,8 +17,6 @@ limitations under the License.
 package memorymanager
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
@@ -34,7 +32,7 @@ type none struct{}
 var _ Policy = &none{}
 
 // NewPolicyNone returns new none policy instance
-func NewPolicyNone(ctx context.Context) Policy {
+func NewPolicyNone(logger klog.Logger) Policy {
 	return &none{}
 }
 
@@ -42,36 +40,35 @@ func (p *none) Name() string {
 	return string(policyTypeNone)
 }
 
-func (p *none) Start(ctx context.Context, s state.State) error {
-	logger := klog.FromContext(ctx)
+func (p *none) Start(logger klog.Logger, s state.State) error {
 	logger.Info("Start")
 	return nil
 }
 
 // Allocate call is idempotent
-func (p *none) Allocate(_ context.Context, s state.State, pod *v1.Pod, container *v1.Container) error {
+func (p *none) Allocate(_ klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) error {
 	return nil
 }
 
 // RemoveContainer call is idempotent
-func (p *none) RemoveContainer(_ context.Context, s state.State, podUID string, containerName string) {
+func (p *none) RemoveContainer(_ klog.Logger, s state.State, podUID string, containerName string) {
 }
 
 // GetTopologyHints implements the topologymanager.HintProvider Interface
 // and is consulted to achieve NUMA aware resource alignment among this
 // and other resource controllers.
-func (p *none) GetTopologyHints(_ context.Context, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+func (p *none) GetTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
 // GetPodTopologyHints implements the topologymanager.HintProvider Interface
 // and is consulted to achieve NUMA aware resource alignment among this
 // and other resource controllers.
-func (p *none) GetPodTopologyHints(_ context.Context, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+func (p *none) GetPodTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
 // GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
-func (p *none) GetAllocatableMemory(_ context.Context, s state.State) []state.Block {
+func (p *none) GetAllocatableMemory(s state.State) []state.Block {
 	return []state.Block{}
 }

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -149,13 +149,13 @@ type testStaticPolicy struct {
 }
 
 func initTests(t *testing.T, testCase *testStaticPolicy, hint *topologymanager.TopologyHint, initContainersReusableMemory reusableMemory) (Policy, state.State, error) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	logger, _ := ktesting.NewTestContext(t)
 	manager := topologymanager.NewFakeManager()
 	if hint != nil {
 		manager = topologymanager.NewFakeManagerWithHint(hint)
 	}
 
-	p, err := NewPolicyStatic(tCtx, testCase.machineInfo, testCase.systemReserved, manager)
+	p, err := NewPolicyStatic(logger, testCase.machineInfo, testCase.systemReserved, manager)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -228,7 +228,7 @@ func TestStaticPolicyName(t *testing.T) {
 }
 
 func TestStaticPolicyStart(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []testStaticPolicy{
 		{
 			description: "should fail, if machine state is empty, but it has memory assignments",
@@ -1169,7 +1169,7 @@ func TestStaticPolicyStart(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			err = p.Start(tCtx, s)
+			err = p.Start(logger, s)
 			if !reflect.DeepEqual(err, testCase.expectedError) {
 				t.Fatalf("The actual error: %v is different from the expected one: %v", err, testCase.expectedError)
 			}
@@ -1192,7 +1192,7 @@ func TestStaticPolicyStart(t *testing.T) {
 }
 
 func TestStaticPolicyAllocate(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []testStaticPolicy{
 		{
 			description:         "should do nothing for non-guaranteed pods",
@@ -2089,7 +2089,7 @@ func TestStaticPolicyAllocate(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			err = p.Allocate(tCtx, s, testCase.pod, &testCase.pod.Spec.Containers[0])
+			err = p.Allocate(logger, s, testCase.pod, &testCase.pod.Spec.Containers[0])
 			if (err == nil) != (testCase.expectedError == nil) || (err != nil && testCase.expectedError != nil && err.Error() != testCase.expectedError.Error()) {
 				t.Fatalf("The actual error %v is different from the expected one %v", err, testCase.expectedError)
 			}
@@ -2112,7 +2112,7 @@ func TestStaticPolicyAllocate(t *testing.T) {
 }
 
 func TestStaticPolicyAllocateWithInitContainers(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []testStaticPolicy{
 		{
 			description: "should re-use init containers memory, init containers requests 1Gi and 2Gi, apps containers 3Gi and 4Gi",
@@ -2814,14 +2814,14 @@ func TestStaticPolicyAllocateWithInitContainers(t *testing.T) {
 			}
 
 			for i := range testCase.pod.Spec.InitContainers {
-				err = p.Allocate(tCtx, s, testCase.pod, &testCase.pod.Spec.InitContainers[i])
+				err = p.Allocate(logger, s, testCase.pod, &testCase.pod.Spec.InitContainers[i])
 				if !reflect.DeepEqual(err, testCase.expectedError) {
 					t.Fatalf("The actual error %v is different from the expected one %v", err, testCase.expectedError)
 				}
 			}
 
 			for i := range testCase.pod.Spec.Containers {
-				err = p.Allocate(tCtx, s, testCase.pod, &testCase.pod.Spec.Containers[i])
+				err = p.Allocate(logger, s, testCase.pod, &testCase.pod.Spec.Containers[i])
 				if !reflect.DeepEqual(err, testCase.expectedError) {
 					t.Fatalf("The actual error %v is different from the expected one %v", err, testCase.expectedError)
 				}
@@ -2841,7 +2841,7 @@ func TestStaticPolicyAllocateWithInitContainers(t *testing.T) {
 }
 
 func TestStaticPolicyAllocateWithRestartableInitContainers(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []testStaticPolicy{
 		{
 			description: "should do nothing once containers already exist under the state file",
@@ -3148,7 +3148,7 @@ func TestStaticPolicyAllocateWithRestartableInitContainers(t *testing.T) {
 			}
 
 			for i := range testCase.pod.Spec.InitContainers {
-				err = p.Allocate(tCtx, s, testCase.pod, &testCase.pod.Spec.InitContainers[i])
+				err = p.Allocate(logger, s, testCase.pod, &testCase.pod.Spec.InitContainers[i])
 				if !reflect.DeepEqual(err, testCase.expectedError) {
 					t.Fatalf("The actual error %v is different from the expected one %v", err, testCase.expectedError)
 				}
@@ -3159,7 +3159,7 @@ func TestStaticPolicyAllocateWithRestartableInitContainers(t *testing.T) {
 			}
 
 			for i := range testCase.pod.Spec.Containers {
-				err = p.Allocate(tCtx, s, testCase.pod, &testCase.pod.Spec.Containers[i])
+				err = p.Allocate(logger, s, testCase.pod, &testCase.pod.Spec.Containers[i])
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -3179,7 +3179,7 @@ func TestStaticPolicyAllocateWithRestartableInitContainers(t *testing.T) {
 }
 
 func TestStaticPolicyRemoveContainer(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []testStaticPolicy{
 		{
 			description:         "should do nothing when the container does not exist under the state",
@@ -3422,7 +3422,7 @@ func TestStaticPolicyRemoveContainer(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			p.RemoveContainer(tCtx, s, "pod1", "container1")
+			p.RemoveContainer(logger, s, "pod1", "container1")
 			assignments := s.GetMemoryAssignments()
 			if !areContainerMemoryAssignmentsEqual(t, assignments, testCase.expectedAssignments) {
 				t.Fatalf("Actual assignments %v are different from the expected %v", assignments, testCase.expectedAssignments)
@@ -3437,7 +3437,7 @@ func TestStaticPolicyRemoveContainer(t *testing.T) {
 }
 
 func TestStaticPolicyGetTopologyHints(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []testStaticPolicy{
 		{
 			description: "should not provide topology hints for non-guaranteed pods",
@@ -3827,7 +3827,7 @@ func TestStaticPolicyGetTopologyHints(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			topologyHints := p.GetTopologyHints(tCtx, s, testCase.pod, &testCase.pod.Spec.Containers[0])
+			topologyHints := p.GetTopologyHints(logger, s, testCase.pod, &testCase.pod.Spec.Containers[0])
 			if !reflect.DeepEqual(topologyHints, testCase.expectedTopologyHints) {
 				t.Fatalf("The actual topology hints: '%+v' are different from the expected one: '%+v'", topologyHints, testCase.expectedTopologyHints)
 			}
@@ -3836,7 +3836,7 @@ func TestStaticPolicyGetTopologyHints(t *testing.T) {
 }
 
 func TestStaticPolicyGetPodTopologyHints(t *testing.T) {
-	_, tCtx := ktesting.NewTestContext(t)
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []testStaticPolicy{
 		{
 			description: "should not provide pod topology hints for guaranteed pod with pod level resources",
@@ -3860,7 +3860,7 @@ func TestStaticPolicyGetPodTopologyHints(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			topologyHints := p.GetPodTopologyHints(tCtx, s, testCase.pod)
+			topologyHints := p.GetPodTopologyHints(logger, s, testCase.pod)
 			if !reflect.DeepEqual(topologyHints, testCase.expectedTopologyHints) {
 				t.Fatalf("The actual topology hints: '%+v' are different from the expected one: '%+v'", topologyHints, testCase.expectedTopologyHints)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change completes the contextual logging migration for the memory manager by updating the Manager interface and all implementations to accept `logr.Logger` parameters instead of `context.Context`.

This aligns with the contextual logging migration pattern where:
- Functions that need a logger accept logr.Logger parameter directly
- Logger is passed from the boundary (e.g., Start()) down to implementation
- klog.TODO() is used temporarily in call sites where logger is not yet available
- Context is only used where truly needed (e.g., Start() method)

This follows the same pattern as recent migrations in:
- pkg/kubelet/cm/topologymanager (#134174)
- pkg/kubelet/cm/devicemanager (#134293)
- pkg/kubelet/cm/cpumanager (#125912)

Related to the initial memory manager contextual logging work in #130727.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/130069
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".


#### Special notes for your reviewer:
-->
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->