### PR TITLE
change client go default features to versioned

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -2406,6 +2406,6 @@ func init() {
 	// are. Further, client-go features automatically support the existing mechanisms for
 	// feature enablement metrics and test overrides.
 	ca := &clientAdapter{utilfeature.DefaultMutableFeatureGate}
-	runtime.Must(clientfeatures.AddFeaturesToExistingFeatureGates(ca))
+	runtime.Must(clientfeatures.AddVersionedFeaturesToExistingFeatureGates(ca))
 	clientfeatures.ReplaceFeatureGates(ca)
 }

--- a/staging/src/k8s.io/client-go/features/features_test.go
+++ b/staging/src/k8s.io/client-go/features/features_test.go
@@ -17,17 +17,67 @@ limitations under the License.
 package features
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // TestAddFeaturesToExistingFeatureGates ensures that
-// the defaultKubernetesFeatureGates are added to a test feature gates registry.
+// the defaultVersionedKubernetesFeatureGates are added to a test feature gates registry.
 func TestAddFeaturesToExistingFeatureGates(t *testing.T) {
 	fakeFeatureGates := &fakeRegistry{}
 	require.NoError(t, AddFeaturesToExistingFeatureGates(fakeFeatureGates))
-	require.Equal(t, defaultKubernetesFeatureGates, fakeFeatureGates.specs)
+	require.Equal(t, unversionedFeatureGates(defaultVersionedKubernetesFeatureGates), fakeFeatureGates.specs)
+}
+
+// TestAddVersionedFeaturesToExistingFeatureGates ensures that
+// the defaultVersionedKubernetesFeatureGates are added to a versioned test feature gates registry.
+func TestAddVersionedFeaturesToExistingFeatureGates(t *testing.T) {
+	fakeFeatureGates := &fakeVersionedRegistry{}
+	require.NoError(t, AddVersionedFeaturesToExistingFeatureGates(fakeFeatureGates))
+	require.Equal(t, defaultVersionedKubernetesFeatureGates, fakeFeatureGates.specs)
+}
+
+func TestUnversionedFeatureGates(t *testing.T) {
+	testCases := []struct {
+		name         string
+		featureGates map[Feature]VersionedSpecs
+		expected     map[Feature]FeatureSpec
+	}{
+		{
+			name: "multiple features",
+			featureGates: map[Feature]VersionedSpecs{
+				"AlphaFeature": {
+					{Version: version.MustParse("1.30"), Default: false, PreRelease: Alpha},
+				},
+				"BetaFeature": {
+					{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.30"), Default: true, PreRelease: Beta},
+				},
+				"GAFeature": {
+					{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+					{Version: version.MustParse("1.27"), Default: true, PreRelease: Beta},
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: GA, LockToDefault: true},
+				},
+			},
+			expected: map[Feature]FeatureSpec{
+				"AlphaFeature": {Default: false, PreRelease: Alpha},
+				"BetaFeature":  {Default: true, PreRelease: Beta},
+				"GAFeature":    {Default: true, PreRelease: GA, LockToDefault: true},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := unversionedFeatureGates(tc.featureGates)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("unversionedFeatureGates() = %v, want %v", actual, tc.expected)
+			}
+		})
+	}
 }
 
 func TestReplaceFeatureGatesWithWarningIndicator(t *testing.T) {
@@ -44,6 +94,15 @@ type fakeRegistry struct {
 }
 
 func (f *fakeRegistry) Add(specs map[Feature]FeatureSpec) error {
+	f.specs = specs
+	return nil
+}
+
+type fakeVersionedRegistry struct {
+	specs map[Feature]VersionedSpecs
+}
+
+func (f *fakeVersionedRegistry) AddVersioned(specs map[Feature]VersionedSpecs) error {
 	f.specs = specs
 	return nil
 }

--- a/staging/src/k8s.io/client-go/features/known_features.go
+++ b/staging/src/k8s.io/client-go/features/known_features.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package features
 
+import (
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
 // Every feature gate should have an entry here following this template:
 //
 // // owner: @username
@@ -70,15 +74,26 @@ const (
 	WatchListClient Feature = "WatchListClient"
 )
 
-// defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
+// defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
 //
 // To add a new feature, define a key for it above and add it here.
 // After registering with the binary, the features are, by default, controllable using environment variables.
 // For more details, please see envVarFeatureGates implementation.
-var defaultKubernetesFeatureGates = map[Feature]FeatureSpec{
-	ClientsAllowCBOR:        {Default: false, PreRelease: Alpha},
-	ClientsPreferCBOR:       {Default: false, PreRelease: Alpha},
-	InOrderInformers:        {Default: true, PreRelease: Beta},
-	InformerResourceVersion: {Default: true, PreRelease: GA},
-	WatchListClient:         {Default: false, PreRelease: Beta},
+var defaultVersionedKubernetesFeatureGates = map[Feature]VersionedSpecs{
+	ClientsAllowCBOR: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: Alpha},
+	},
+	ClientsPreferCBOR: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: Alpha},
+	},
+	InOrderInformers: {
+		{Version: version.MustParse("1.33"), Default: true, PreRelease: Beta},
+	},
+	InformerResourceVersion: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: Alpha},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: GA},
+	},
+	WatchListClient: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: Beta},
+	},
 }

--- a/staging/src/k8s.io/client-go/features/testing/features.go
+++ b/staging/src/k8s.io/client-go/features/testing/features.go
@@ -77,6 +77,7 @@ func setFeatureDuringTestInternal(tb testing.TB, feature clientfeatures.Feature,
 		overriddenFeaturesLock.Lock()
 		defer overriddenFeaturesLock.Unlock()
 		delete(overriddenFeatures, feature)
+		// if default is not set
 		if err := featureGates.Set(feature, originalFeatureValue); err != nil {
 			tb.Errorf("failed restoring client-go feature: %v to its original value: %v, err: %v", feature, originalFeatureValue, err)
 		}


### PR DESCRIPTION
so that their enablement can be consistent with emulated version.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://github.com/kubernetes/enhancements/issues/4330 introduced emulation version into kube control plane components.
Some CP components use client-go. In order for the client-go features to work properly with emulation version inside CP, we need to add version information to the default features. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/enhancements/issues/4330

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
