### PR TITLE
Clean up ComputePodQOS functions

### DIFF
--- a/pkg/apis/core/helper/qos/qos.go
+++ b/pkg/apis/core/helper/qos/qos.go
@@ -19,18 +19,13 @@ limitations under the License.
 package qos
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
 )
 
-var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
-
-func isSupportedQoSComputeResource(name core.ResourceName) bool {
-	return supportedQoSComputeResources.Has(string(name))
-}
+var supportedQoSComputeResources = sets.New(core.ResourceCPU, core.ResourceMemory)
 
 // GetPodQOS returns the QoS class of a pod persisted in the PodStatus.QOSClass field.
 // If PodStatus.QOSClass is empty, it returns value of ComputePodQOS() which evaluates pod's QoS class.
@@ -41,131 +36,79 @@ func GetPodQOS(pod *core.Pod) core.PodQOSClass {
 	return ComputePodQOS(pod)
 }
 
-// zeroQuantity represents a resource.Quantity with value "0", used as a baseline
-// for resource comparisons.
-var zeroQuantity = resource.MustParse("0")
-
-// processResourceList adds non-zero quantities for supported QoS compute resources
-// quantities from newList to list.
-func processResourceList(list, newList core.ResourceList) {
-	for name, quantity := range newList {
-		if !isSupportedQoSComputeResource(name) {
-			continue
-		}
-		if quantity.Cmp(zeroQuantity) == 1 {
-			delta := quantity.DeepCopy()
-			if _, exists := list[name]; !exists {
-				list[name] = delta
-			} else {
-				delta.Add(list[name])
-				list[name] = delta
-			}
-		}
-	}
-}
-
-// getQOSResources returns a set of resource names from the provided resource list that:
-// 1. Are supported QoS compute resources
-// 2. Have quantities greater than zero
-func getQOSResources(list core.ResourceList) sets.Set[string] {
-	qosResources := sets.New[string]()
-	for name, quantity := range list {
-		if !isSupportedQoSComputeResource(name) {
-			continue
-		}
-		if quantity.Cmp(zeroQuantity) == 1 {
-			qosResources.Insert(string(name))
-		}
-	}
-	return qosResources
-}
-
 // ComputePodQOS evaluates the list of containers to determine a pod's QoS class. This function is more
 // expensive than GetPodQOS which should be used for pods having a non-empty .Status.QOSClass.
-// A pod is besteffort if none of its containers have specified any requests or limits.
-// A pod is guaranteed only when requests and limits are specified for all the containers and they are equal.
-// A pod is burstable if limits and requests do not match across all containers.
-// When this function is updated please also update staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
+// A pod is besteffort if none of its containers have specified any cpu or memory requests or limits.
+// A pod is guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
+// A pod is burstable if cpu & memory limits and requests do not match across all containers.
+// NOTE: This is tested in pkg/apis/core/v1/helper/qos/qos_test.go
 func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
-	requests := core.ResourceList{}
-	limits := core.ResourceList{}
-	isGuaranteed := true
 	// When pod-level resources are specified, we use them to determine QoS class.
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) &&
 		pod.Spec.Resources != nil {
-		if len(pod.Spec.Resources.Requests) > 0 {
-			// process requests
-			processResourceList(requests, pod.Spec.Resources.Requests)
-		}
+		return resourceQOS(pod.Spec.Resources)
+	}
 
-		if len(pod.Spec.Resources.Limits) > 0 {
-			// process limits
-			processResourceList(limits, pod.Spec.Resources.Limits)
-			qosLimitResources := getQOSResources(pod.Spec.Resources.Limits)
-			if !qosLimitResources.HasAll(string(core.ResourceMemory), string(core.ResourceCPU)) {
-				isGuaranteed = false
+	// Iterator for Init & main Containers.
+	// Cannot use podutil.ContainerIter due to import cycle.
+	containerIter := func(yield func(*core.Container) bool) {
+		for _, c := range pod.Spec.InitContainers {
+			if !yield(&c) {
+				return
 			}
 		}
-	} else {
-		// note, ephemeral containers are not considered for QoS as they cannot define resources
-		allContainers := []core.Container{}
-		allContainers = append(allContainers, pod.Spec.Containers...)
-		allContainers = append(allContainers, pod.Spec.InitContainers...)
-		for _, container := range allContainers {
-			// process requests
-			for name, quantity := range container.Resources.Requests {
-				if !isSupportedQoSComputeResource(name) {
-					continue
-				}
-				if quantity.Cmp(zeroQuantity) == 1 {
-					delta := quantity.DeepCopy()
-					if _, exists := requests[name]; !exists {
-						requests[name] = delta
-					} else {
-						delta.Add(requests[name])
-						requests[name] = delta
-					}
-				}
-			}
-			// process limits
-			qosLimitsFound := sets.NewString()
-			for name, quantity := range container.Resources.Limits {
-				if !isSupportedQoSComputeResource(name) {
-					continue
-				}
-				if quantity.Cmp(zeroQuantity) == 1 {
-					qosLimitsFound.Insert(string(name))
-					delta := quantity.DeepCopy()
-					if _, exists := limits[name]; !exists {
-						limits[name] = delta
-					} else {
-						delta.Add(limits[name])
-						limits[name] = delta
-					}
-				}
-			}
-
-			if !qosLimitsFound.HasAll(string(core.ResourceMemory), string(core.ResourceCPU)) {
-				isGuaranteed = false
+		for _, c := range pod.Spec.Containers {
+			if !yield(&c) {
+				return
 			}
 		}
 	}
 
-	if len(requests) == 0 && len(limits) == 0 {
+	var podQOS core.PodQOSClass
+	for container := range containerIter {
+		qos := resourceQOS(&container.Resources)
+		if qos == core.PodQOSBurstable {
+			return qos // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
+		} else if podQOS == "" {
+			podQOS = qos
+		} else {
+			if podQOS != qos {
+				return core.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
+			}
+		}
+	}
+	if podQOS == "" { // This should only happen in tests
+		podQOS = core.PodQOSBestEffort
+	}
+	return podQOS
+}
+
+// resourceQOS gets the QOSClass based on a single set of resource requirements. This may need to be aggregated to determine pod QOS.
+func resourceQOS(resources *core.ResourceRequirements) core.PodQOSClass {
+	if len(resources.Requests) == 0 && len(resources.Limits) == 0 {
 		return core.PodQOSBestEffort
 	}
-	// Check if requests match limits for all resources.
-	if isGuaranteed {
-		for name, req := range requests {
-			if lim, exists := limits[name]; !exists || lim.Cmp(req) != 0 {
-				isGuaranteed = false
-				break
+
+	var qos core.PodQOSClass
+	for res := range supportedQoSComputeResources {
+		req := resources.Requests[res]
+		lim := resources.Limits[res]
+		if !req.Equal(lim) {
+			// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+			return core.PodQOSBurstable
+		}
+		bestEffort := req.IsZero() && lim.IsZero()
+		if qos == "" {
+			if bestEffort {
+				qos = core.PodQOSBestEffort
+			} else {
+				qos = core.PodQOSGuaranteed
+			}
+		} else {
+			if bestEffort != (qos == core.PodQOSBestEffort) {
+				return core.PodQOSBurstable
 			}
 		}
 	}
-	if isGuaranteed &&
-		len(requests) == len(limits) {
-		return core.PodQOSGuaranteed
-	}
-	return core.PodQOSBurstable
+	return qos
 }

--- a/pkg/apis/core/helper/qos/qos.go
+++ b/pkg/apis/core/helper/qos/qos.go
@@ -38,15 +38,15 @@ func GetPodQOS(pod *core.Pod) core.PodQOSClass {
 
 // ComputePodQOS evaluates the list of containers to determine a pod's QoS class. This function is more
 // expensive than GetPodQOS which should be used for pods having a non-empty .Status.QOSClass.
-// A pod is besteffort if none of its containers have specified any cpu or memory requests or limits.
-// A pod is guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
-// A pod is burstable if cpu & memory limits and requests do not match across all containers.
+// A pod is BestEffort if none of its containers have specified any cpu or memory requests or limits.
+// A pod is Guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
+// A pod is Burstable if cpu & memory limits and requests do not match across all containers.
 // NOTE: This is tested in pkg/apis/core/v1/helper/qos/qos_test.go
 func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
 	// When pod-level resources are specified, we use them to determine QoS class.
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) &&
 		pod.Spec.Resources != nil {
-		return resourceQOS(pod.Spec.Resources)
+		return requirementsQOS(pod.Spec.Resources)
 	}
 
 	// Iterator for Init & main Containers.
@@ -66,49 +66,60 @@ func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
 
 	var podQOS core.PodQOSClass
 	for container := range containerIter {
-		qos := resourceQOS(&container.Resources)
-		if qos == core.PodQOSBurstable {
-			return qos // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
+		containerQOS := requirementsQOS(&container.Resources)
+		if containerQOS == core.PodQOSBurstable {
+			return containerQOS // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
 		} else if podQOS == "" {
-			podQOS = qos
-		} else {
-			if podQOS != qos {
-				return core.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
-			}
+			podQOS = containerQOS
+		} else if podQOS != containerQOS {
+			return core.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
 		}
 	}
-	if podQOS == "" { // This should only happen in tests
+	if podQOS == "" { // This can only happen if there aren't any containers (not possible in production).
 		podQOS = core.PodQOSBestEffort
 	}
 	return podQOS
 }
 
-// resourceQOS gets the QOSClass based on a single set of resource requirements. This may need to be aggregated to determine pod QOS.
-func resourceQOS(resources *core.ResourceRequirements) core.PodQOSClass {
+// requirementsQOS gets the QOSClass based on a single set of resource requirements. This may need
+// to be aggregated to determine pod QOS.
+func requirementsQOS(resources *core.ResourceRequirements) core.PodQOSClass {
 	if len(resources.Requests) == 0 && len(resources.Limits) == 0 {
 		return core.PodQOSBestEffort
 	}
 
 	var qos core.PodQOSClass
 	for res := range supportedQoSComputeResources {
-		req := resources.Requests[res]
-		lim := resources.Limits[res]
-		if !req.Equal(lim) {
-			// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+		resQOS := resourceQOS(resources, res)
+		if resQOS == core.PodQOSBurstable {
+			return resQOS // If any resource is Burstable, we know the pod isn't BestEffort or Guaranteed
+		} else if qos == "" {
+			qos = resQOS
+		} else if qos != resQOS {
+			// A mismatch indicates some but not all QOS resources are specified, so the pod must be
+			// burstable.
 			return core.PodQOSBurstable
-		}
-		bestEffort := req.IsZero() && lim.IsZero()
-		if qos == "" {
-			if bestEffort {
-				qos = core.PodQOSBestEffort
-			} else {
-				qos = core.PodQOSGuaranteed
-			}
-		} else {
-			if bestEffort != (qos == core.PodQOSBestEffort) {
-				return core.PodQOSBurstable
-			}
 		}
 	}
 	return qos
+}
+
+// resourceQOS determines the QOS "shape" of the given resource in the requirements:
+// - BestEffort: Request and Limit are both zero
+// - Burstable: Request != Limit
+// - Guaranteed: Request and Limit are equal and non-zero
+func resourceQOS(resources *core.ResourceRequirements, res core.ResourceName) core.PodQOSClass {
+	req := resources.Requests[res]
+	lim := resources.Limits[res]
+
+	if !req.Equal(lim) {
+		// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+		return core.PodQOSBurstable
+	} else if req.IsZero() {
+		// req == lim, so no need to check lim.IsZero()
+		return core.PodQOSBestEffort
+	} else {
+		// req == lim != 0
+		return core.PodQOSGuaranteed
+	}
 }

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -20,7 +20,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 )
 
@@ -47,8 +46,23 @@ func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 		return requirementsQOS(pod.Spec.Resources)
 	}
 
+	// Iterator for Init & main Containers.
+	// Cannot use podutil.ContainerIter due to forbidden import.
+	containerIter := func(yield func(*v1.Container) bool) {
+		for _, c := range pod.Spec.InitContainers {
+			if !yield(&c) {
+				return
+			}
+		}
+		for _, c := range pod.Spec.Containers {
+			if !yield(&c) {
+				return
+			}
+		}
+	}
+
 	var podQOS v1.PodQOSClass
-	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+	for container := range containerIter {
 		containerQOS := requirementsQOS(&container.Resources)
 		if containerQOS == v1.PodQOSBurstable {
 			return containerQOS // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -26,9 +26,6 @@ import (
 
 var supportedQoSComputeResources = sets.New(v1.ResourceCPU, v1.ResourceMemory)
 
-// QOSList is a set of (resource name, QoS class) pairs.
-type QOSList map[v1.ResourceName]v1.PodQOSClass
-
 // GetPodQOS returns the QoS class of a pod persisted in the PodStatus.QOSClass field.
 // If PodStatus.QOSClass is empty, it returns value of ComputePodQOS() which evaluates pod's QoS class.
 func GetPodQOS(pod *v1.Pod) v1.PodQOSClass {
@@ -40,61 +37,72 @@ func GetPodQOS(pod *v1.Pod) v1.PodQOSClass {
 
 // ComputePodQOS evaluates the list of containers to determine a pod's QoS class. This function is more
 // expensive than GetPodQOS which should be used for pods having a non-empty .Status.QOSClass.
-// A pod is besteffort if none of its containers have specified any cpu or memory requests or limits.
-// A pod is guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
-// A pod is burstable if cpu & memory limits and requests do not match across all containers.
+// A pod is BestEffort if none of its containers have specified any cpu or memory requests or limits.
+// A pod is Guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
+// A pod is Burstable if cpu & memory limits and requests do not match across all containers.
 func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 	// When pod-level resources are specified, we use them to determine QoS class.
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) &&
 		pod.Spec.Resources != nil {
-		return resourceQOS(pod.Spec.Resources)
+		return requirementsQOS(pod.Spec.Resources)
 	}
 
 	var podQOS v1.PodQOSClass
 	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
-		qos := resourceQOS(&container.Resources)
-		if qos == v1.PodQOSBurstable {
-			return qos // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
+		containerQOS := requirementsQOS(&container.Resources)
+		if containerQOS == v1.PodQOSBurstable {
+			return containerQOS // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
 		} else if podQOS == "" {
-			podQOS = qos
-		} else {
-			if podQOS != qos {
-				return v1.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
-			}
+			podQOS = containerQOS
+		} else if podQOS != containerQOS {
+			return v1.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
 		}
 	}
-	if podQOS == "" { // This should only happen in tests
+	if podQOS == "" { // This can only happen if there aren't any containers (not possible in production).
 		podQOS = v1.PodQOSBestEffort
 	}
 	return podQOS
 }
 
-// resourceQOS gets the QOSClass based on a single set of resource requirements. This may need to be aggregated to determine pod QOS.
-func resourceQOS(resources *v1.ResourceRequirements) v1.PodQOSClass {
+// requirementsQOS gets the QOSClass based on a single set of resource requirements. This may need
+// to be aggregated to determine pod QOS.
+func requirementsQOS(resources *v1.ResourceRequirements) v1.PodQOSClass {
 	if len(resources.Requests) == 0 && len(resources.Limits) == 0 {
 		return v1.PodQOSBestEffort
 	}
 
 	var qos v1.PodQOSClass
 	for res := range supportedQoSComputeResources {
-		req := resources.Requests[res]
-		lim := resources.Limits[res]
-		if !req.Equal(lim) {
-			// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+		resQOS := resourceQOS(resources, res)
+		if resQOS == v1.PodQOSBurstable {
+			return resQOS // If any resource is Burstable, we know the pod isn't BestEffort or Guaranteed
+		} else if qos == "" {
+			qos = resQOS
+		} else if qos != resQOS {
+			// A mismatch indicates some but not all QOS resources are specified, so the pod must be
+			// burstable.
 			return v1.PodQOSBurstable
-		}
-		bestEffort := req.IsZero() && lim.IsZero()
-		if qos == "" {
-			if bestEffort {
-				qos = v1.PodQOSBestEffort
-			} else {
-				qos = v1.PodQOSGuaranteed
-			}
-		} else {
-			if bestEffort != (qos == v1.PodQOSBestEffort) {
-				return v1.PodQOSBurstable
-			}
 		}
 	}
 	return qos
+}
+
+// resourceQOS determines the QOS "shape" of the given resource in the requirements:
+// - BestEffort: Request and Limit are both zero
+// - Burstable: Request != Limit
+// - Guaranteed: Request and Limit are equal and non-zero
+func resourceQOS(resources *v1.ResourceRequirements, res v1.ResourceName) v1.PodQOSClass {
+	req := resources.Requests[res]
+	lim := resources.Limits[res]
+
+	if !req.Equal(lim) {
+		// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+		return v1.PodQOSBurstable
+	} else if req.IsZero() {
+		// req == lim, so no need to check lim.IsZero()
+		return v1.PodQOSBestEffort
+	} else {
+		// req == lim != 0
+		return v1.PodQOSGuaranteed
+	}
 }

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -20,18 +20,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/apis/core"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 )
 
-var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+var supportedQoSComputeResources = sets.New(v1.ResourceCPU, v1.ResourceMemory)
 
 // QOSList is a set of (resource name, QoS class) pairs.
 type QOSList map[v1.ResourceName]v1.PodQOSClass
-
-func isSupportedQoSComputeResource(name v1.ResourceName) bool {
-	return supportedQoSComputeResources.Has(string(name))
-}
 
 // GetPodQOS returns the QoS class of a pod persisted in the PodStatus.QOSClass field.
 // If PodStatus.QOSClass is empty, it returns value of ComputePodQOS() which evaluates pod's QoS class.
@@ -42,128 +38,63 @@ func GetPodQOS(pod *v1.Pod) v1.PodQOSClass {
 	return ComputePodQOS(pod)
 }
 
-// processResourceList adds non-zero quantities for supported QoS compute resources
-// quantities from newList to list.
-func processResourceList(list, newList v1.ResourceList) {
-	for name, quantity := range newList {
-		if !isSupportedQoSComputeResource(name) {
-			continue
-		}
-		if quantity.Sign() == 1 {
-			delta := quantity.DeepCopy()
-			if _, exists := list[name]; !exists {
-				list[name] = delta
-			} else {
-				delta.Add(list[name])
-				list[name] = delta
-			}
-		}
-	}
-}
-
-// getQOSResources returns a set of resource names from the provided resource list that:
-// 1. Are supported QoS compute resources
-// 2. Have quantities greater than zero
-func getQOSResources(list v1.ResourceList) sets.Set[string] {
-	qosResources := sets.New[string]()
-	for name, quantity := range list {
-		if !isSupportedQoSComputeResource(name) {
-			continue
-		}
-		if quantity.Sign() == 1 {
-			qosResources.Insert(string(name))
-		}
-	}
-	return qosResources
-}
-
 // ComputePodQOS evaluates the list of containers to determine a pod's QoS class. This function is more
 // expensive than GetPodQOS which should be used for pods having a non-empty .Status.QOSClass.
-// A pod is besteffort if none of its containers have specified any requests or limits.
-// A pod is guaranteed only when requests and limits are specified for all the containers and they are equal.
-// A pod is burstable if limits and requests do not match across all containers.
-// TODO(ndixita): Refactor ComputePodQOS into smaller functions to make it more
-// readable and maintainable.
+// A pod is besteffort if none of its containers have specified any cpu or memory requests or limits.
+// A pod is guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
+// A pod is burstable if cpu & memory limits and requests do not match across all containers.
 func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
-	requests := v1.ResourceList{}
-	limits := v1.ResourceList{}
-	isGuaranteed := true
 	// When pod-level resources are specified, we use them to determine QoS class.
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) &&
 		pod.Spec.Resources != nil {
-		if len(pod.Spec.Resources.Requests) > 0 {
-			// process requests
-			processResourceList(requests, pod.Spec.Resources.Requests)
-		}
+		return resourceQOS(pod.Spec.Resources)
+	}
 
-		if len(pod.Spec.Resources.Limits) > 0 {
-			// process limits
-			processResourceList(limits, pod.Spec.Resources.Limits)
-			qosLimitResources := getQOSResources(pod.Spec.Resources.Limits)
-			if !qosLimitResources.HasAll(string(v1.ResourceMemory), string(v1.ResourceCPU)) {
-				isGuaranteed = false
-			}
-		}
-	} else {
-		// note, ephemeral containers are not considered for QoS as they cannot define resources
-		allContainers := []v1.Container{}
-		allContainers = append(allContainers, pod.Spec.Containers...)
-		allContainers = append(allContainers, pod.Spec.InitContainers...)
-		for _, container := range allContainers {
-			// process requests
-			for name, quantity := range container.Resources.Requests {
-				if !isSupportedQoSComputeResource(name) {
-					continue
-				}
-				if quantity.Sign() == 1 {
-					delta := quantity.DeepCopy()
-					if _, exists := requests[name]; !exists {
-						requests[name] = delta
-					} else {
-						delta.Add(requests[name])
-						requests[name] = delta
-					}
-				}
-			}
-			// process limits
-			qosLimitsFound := sets.NewString()
-			for name, quantity := range container.Resources.Limits {
-				if !isSupportedQoSComputeResource(name) {
-					continue
-				}
-				if quantity.Sign() == 1 {
-					qosLimitsFound.Insert(string(name))
-					delta := quantity.DeepCopy()
-					if _, exists := limits[name]; !exists {
-						limits[name] = delta
-					} else {
-						delta.Add(limits[name])
-						limits[name] = delta
-					}
-				}
-			}
-
-			if !qosLimitsFound.HasAll(string(v1.ResourceMemory), string(v1.ResourceCPU)) {
-				isGuaranteed = false
+	var podQOS v1.PodQOSClass
+	for container := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		qos := resourceQOS(&container.Resources)
+		if qos == v1.PodQOSBurstable {
+			return qos // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
+		} else if podQOS == "" {
+			podQOS = qos
+		} else {
+			if podQOS != qos {
+				return v1.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
 			}
 		}
 	}
+	if podQOS == "" { // This should only happen in tests
+		podQOS = v1.PodQOSBestEffort
+	}
+	return podQOS
+}
 
-	if len(requests) == 0 && len(limits) == 0 {
+// resourceQOS gets the QOSClass based on a single set of resource requirements. This may need to be aggregated to determine pod QOS.
+func resourceQOS(resources *v1.ResourceRequirements) v1.PodQOSClass {
+	if len(resources.Requests) == 0 && len(resources.Limits) == 0 {
 		return v1.PodQOSBestEffort
 	}
-	// Check is requests match limits for all resources.
-	if isGuaranteed {
-		for name, req := range requests {
-			if lim, exists := limits[name]; !exists || lim.Cmp(req) != 0 {
-				isGuaranteed = false
-				break
+
+	var qos v1.PodQOSClass
+	for res := range supportedQoSComputeResources {
+		req := resources.Requests[res]
+		lim := resources.Limits[res]
+		if !req.Equal(lim) {
+			// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+			return v1.PodQOSBurstable
+		}
+		bestEffort := req.IsZero() && lim.IsZero()
+		if qos == "" {
+			if bestEffort {
+				qos = v1.PodQOSBestEffort
+			} else {
+				qos = v1.PodQOSGuaranteed
+			}
+		} else {
+			if bestEffort != (qos == v1.PodQOSBestEffort) {
+				return v1.PodQOSBurstable
 			}
 		}
 	}
-	if isGuaranteed &&
-		len(requests) == len(limits) {
-		return v1.PodQOSGuaranteed
-	}
-	return v1.PodQOSBurstable
+	return qos
 }

--- a/pkg/apis/core/v1/helper/qos/qos_test.go
+++ b/pkg/apis/core/v1/helper/qos/qos_test.go
@@ -214,7 +214,9 @@ func TestComputePodQOS(t *testing.T) {
 
 			// Convert v1.Pod to core.Pod, and then check against the internal version of `ComputePodQOS`.
 			pod := core.Pod{}
-			corev1.Convert_v1_Pod_To_core_Pod(testCase.pod, &pod, nil)
+			if err := corev1.Convert_v1_Pod_To_core_Pod(testCase.pod, &pod, nil); err != nil {
+				t.Fatal(err)
+			}
 
 			if actual := v1.PodQOSClass(qos.ComputePodQOS(&pod)); testCase.expected != actual {
 				t.Errorf("internal ComputePodQOS error: expected: %s, actual: %s;\npod = %s", testCase.expected, actual, prettyPrintPod(testCase.pod))

--- a/pkg/apis/core/v1/helper/qos/qos_test.go
+++ b/pkg/apis/core/v1/helper/qos/qos_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package qos
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"slices"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -31,186 +35,191 @@ import (
 )
 
 func TestComputePodQOS(t *testing.T) {
-	testCases := []struct {
+	guaranteedResources := v1.ResourceRequirements{
+		// Ephemeral storage request should not affect QOS.
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:              resource.MustParse("100m"),
+			v1.ResourceMemory:           resource.MustParse("100Mi"),
+			v1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+		},
+		Limits: getResourceList("100m", "100Mi"),
+	}
+	bestEffortResources := []v1.ResourceRequirements{
+		{},
+		{
+			Requests: getResourceList("0", "0"),
+		}, {
+			Requests: getResourceList("0", "0"),
+			Limits:   getResourceList("0", "0"),
+		}, {
+			Requests: v1.ResourceList{v1.ResourceCPU: resource.Quantity{}, v1.ResourceMemory: resource.Quantity{}},
+		}, {
+			Requests: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("10Gi")},
+		}, {
+			Requests: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("10Gi")},
+			Limits:   v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("10Gi")},
+		},
+	}
+	burstableResources := []v1.ResourceRequirements{
+		{
+			Requests: getResourceList("100m", "100Mi"),
+			Limits:   getResourceList("200m", "200Mi"),
+		}, {
+			Requests: getResourceList("100m", "100Mi"),
+			Limits:   getResourceList("100m", "200Mi"),
+		}, {
+			Requests: getResourceList("100m", "100Mi"),
+			Limits:   getResourceList("200m", "100Mi"),
+		}, {
+			Requests: getResourceList("100m", "100Mi"),
+		}, {
+			Requests: getResourceList("100m", "100Mi"),
+			Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m")},
+		},
+	}
+
+	type testCase struct {
 		pod                      *v1.Pod
 		expected                 v1.PodQOSClass
 		podLevelResourcesEnabled bool
-	}{
-		{
-			pod: newPod("guaranteed", []v1.Container{
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-			}),
-			expected: v1.PodQOSGuaranteed,
-		},
-		{
-			pod: newPod("guaranteed-guaranteed", []v1.Container{
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-			}),
-			expected: v1.PodQOSGuaranteed,
-		},
-		{
-			pod: newPod("best-effort-best-effort", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBestEffort,
-		},
-		{
-			pod: newPod("best-effort", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBestEffort,
-		},
-		{
-			pod: newPod("best-effort-burstable", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				newContainer("burstable", getResourceList("1", ""), getResourceList("2", "")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("best-effort-guaranteed", []v1.Container{
-				newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				newContainer("guaranteed", getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-cpu-guaranteed-memory", []v1.Container{
-				newContainer("burstable", getResourceList("", "100Mi"), getResourceList("", "100Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-no-limits", []v1.Container{
-				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-guaranteed", []v1.Container{
-				newContainer("burstable", getResourceList("1", "100Mi"), getResourceList("2", "100Mi")),
-				newContainer("guaranteed", getResourceList("100m", "100Mi"), getResourceList("100m", "100Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-unbounded-but-requests-match-limits", []v1.Container{
-				newContainer("burstable", getResourceList("100m", "100Mi"), getResourceList("200m", "200Mi")),
-				newContainer("burstable-unbounded", getResourceList("100m", "100Mi"), getResourceList("", "")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-1", []v1.Container{
-				newContainer("burstable", getResourceList("10m", "100Mi"), getResourceList("100m", "200Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("burstable-2", []v1.Container{
-				newContainer("burstable", getResourceList("0", "0"), getResourceList("100m", "200Mi")),
-			}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPod("best-effort-hugepages", []v1.Container{
-				newContainer("best-effort", addResource("hugepages-2Mi", "1Gi", getResourceList("0", "0")), addResource("hugepages-2Mi", "1Gi", getResourceList("0", "0"))),
-			}),
-			expected: v1.PodQOSBestEffort,
-		},
-		{
-			pod: newPodWithInitContainers("init-container",
-				[]v1.Container{
-					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				},
-				[]v1.Container{
-					newContainer("burstable", getResourceList("10m", "100Mi"), getResourceList("100m", "200Mi")),
-				}),
-			expected: v1.PodQOSBurstable,
-		},
-		{
-			pod: newPodWithResources(
-				"guaranteed-with-pod-level-resources",
-				[]v1.Container{
-					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				},
-				getResourceRequirements(getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
-			),
-			expected:                 v1.PodQOSGuaranteed,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"guaranteed-with-pod-and-container-level-resources",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("3m", "10Mi"), getResourceList("5m", "20Mi")),
-				},
-				getResourceRequirements(getResourceList("10m", "100Mi"), getResourceList("10m", "100Mi")),
-			),
-			expected:                 v1.PodQOSGuaranteed,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-level-resources",
-				[]v1.Container{
-					newContainer("best-effort", getResourceList("", ""), getResourceList("", "")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("20m", "50Mi")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-and-container-level-resources",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("5m", "10Mi")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("20m", "50Mi")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-and-container-level-requests",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("", "")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("", "")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
-		{
-			pod: newPodWithResources(
-				"burstable-with-pod-and-container-level-resources-2",
-				[]v1.Container{
-					newContainer("burstable", getResourceList("5m", "10Mi"), getResourceList("", "")),
-					newContainer("guaranteed", getResourceList("5m", "10Mi"), getResourceList("5m", "10Mi")),
-				},
-				getResourceRequirements(getResourceList("10m", "10Mi"), getResourceList("5m", "")),
-			),
-			expected:                 v1.PodQOSBurstable,
-			podLevelResourcesEnabled: true,
-		},
 	}
-	for id, testCase := range testCases {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, testCase.podLevelResourcesEnabled)
-		if actual := ComputePodQOS(testCase.pod); testCase.expected != actual {
-			t.Errorf("[%d]: invalid qos pod %s, expected: %s, actual: %s", id, testCase.pod.Name, testCase.expected, actual)
-		}
 
-		// Convert v1.Pod to core.Pod, and then check against `core.helper.ComputePodQOS`.
-		pod := core.Pod{}
-		corev1.Convert_v1_Pod_To_core_Pod(testCase.pod, &pod, nil)
+	// Container level test cases
+	singleContainerTests := []testCase{{
+		pod: newPod("guaranteed", []v1.Container{
+			{Resources: guaranteedResources},
+		}),
+		expected: v1.PodQOSGuaranteed,
+	}}
+	for i, res := range bestEffortResources {
+		singleContainerTests = append(singleContainerTests, testCase{
+			pod: newPod(fmt.Sprintf("best-effort-%d", i), []v1.Container{
+				{Resources: res},
+			}),
+			expected: v1.PodQOSBestEffort,
+		})
+	}
+	for i, res := range burstableResources {
+		singleContainerTests = append(singleContainerTests, testCase{
+			pod: newPod(fmt.Sprintf("burstable-%d", i), []v1.Container{
+				{Resources: res},
+			}),
+			expected: v1.PodQOSBurstable,
+		})
+	}
+	containerTests := slices.Clone(singleContainerTests)
 
-		if actual := qos.ComputePodQOS(&pod); core.PodQOSClass(testCase.expected) != actual {
-			t.Errorf("[%d]: conversion invalid qos pod %s, expected: %s, actual: %s", id, testCase.pod.Name, testCase.expected, actual)
+	// 2 Container cases
+	secondContainerTests := []testCase{{
+		pod: newPod("2c-guaranteed", []v1.Container{
+			{Resources: guaranteedResources},
+			{Resources: guaranteedResources},
+		}),
+		expected: v1.PodQOSGuaranteed,
+	}, {
+		pod: newPod("2c-best-effort", []v1.Container{
+			{Resources: bestEffortResources[0]},
+			{Resources: bestEffortResources[1]},
+		}),
+		expected: v1.PodQOSBestEffort,
+	}, {
+		pod: newPod("2c-burstable", []v1.Container{
+			{Resources: burstableResources[0]},
+			{Resources: burstableResources[1]},
+		}),
+		expected: v1.PodQOSBurstable,
+	}}
+	// Mixed cases (all burstable)
+	for i, res1 := range []v1.ResourceRequirements{guaranteedResources, bestEffortResources[0], burstableResources[0]} {
+		for j, res2 := range []v1.ResourceRequirements{guaranteedResources, bestEffortResources[1], burstableResources[1]} {
+			if i == j {
+				continue
+			}
+			secondContainerTests = append(secondContainerTests, testCase{
+				pod: newPod(fmt.Sprintf("2c-mixed-burstable-%d-%d", i, j), []v1.Container{
+					{Resources: res1},
+					{Resources: res2},
+				}),
+				expected: v1.PodQOSBurstable,
+			})
 		}
+	}
+	containerTests = append(containerTests, secondContainerTests...)
+
+	// Add initContainer variant: doesn't matter if second container is an init container or not.
+	for _, tc := range secondContainerTests {
+		pod := tc.pod.DeepCopy()
+		pod.Name += "-init"
+		pod.Spec.InitContainers = pod.Spec.Containers[1:]
+		pod.Spec.Containers = pod.Spec.Containers[:1]
+		initTC := tc
+		initTC.pod = pod
+		containerTests = append(containerTests, initTC)
+	}
+
+	// A pod with an ephemeral container
+	guaranteedECPod := newPod("guaranteed-ephemeral", []v1.Container{
+		{Resources: guaranteedResources},
+	})
+	guaranteedECPod.Spec.EphemeralContainers = []v1.EphemeralContainer{{
+		EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "ec"},
+	}}
+	containerTests = append(containerTests, testCase{
+		pod:      guaranteedECPod,
+		expected: v1.PodQOSGuaranteed,
+	})
+
+	tests := slices.Clone(containerTests)
+
+	// Enabling pod-level-resources without setting pod.spec.resources
+	for _, tc := range containerTests {
+		pod := tc.pod.DeepCopy()
+		pod.Name += "-plr"
+		plrTest := tc
+		plrTest.pod = pod
+		plrTest.podLevelResourcesEnabled = true
+		tests = append(tests, plrTest)
+	}
+
+	// Pod level resources test cases
+	for _, tc := range singleContainerTests {
+		// variant 1: PLR enabled, guaranteed container with pod-level resources
+		pod := tc.pod.DeepCopy()
+		pod.Name = "pod-" + pod.Name + "-plr"
+		pod.Spec.Resources = pod.Spec.Containers[0].Resources.DeepCopy()
+		pod.Spec.Containers[0].Resources = guaranteedResources
+		tests = append(tests, testCase{
+			pod:                      pod,
+			expected:                 tc.expected,
+			podLevelResourcesEnabled: true,
+		})
+
+		// variant 2: PLR disabled, guaranteed pod
+		pod = tc.pod.DeepCopy()
+		pod.Name += "-pod-no-plr"
+		pod.Spec.Resources = &guaranteedResources
+		tests = append(tests, testCase{
+			pod:                      pod,
+			expected:                 tc.expected,
+			podLevelResourcesEnabled: false,
+		})
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.pod.Name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, testCase.podLevelResourcesEnabled)
+			if actual := ComputePodQOS(testCase.pod); testCase.expected != actual {
+				t.Errorf("ComputePodQOS error: expected: %s, actual: %s;\npod = %s", testCase.expected, actual, prettyPrintPod(testCase.pod))
+			}
+
+			// Convert v1.Pod to core.Pod, and then check against the internal version of `ComputePodQOS`.
+			pod := core.Pod{}
+			corev1.Convert_v1_Pod_To_core_Pod(testCase.pod, &pod, nil)
+
+			if actual := v1.PodQOSClass(qos.ComputePodQOS(&pod)); testCase.expected != actual {
+				t.Errorf("internal ComputePodQOS error: expected: %s, actual: %s;\npod = %s", testCase.expected, actual, prettyPrintPod(testCase.pod))
+			}
+		})
 	}
 }
 
@@ -225,25 +234,6 @@ func getResourceList(cpu, memory string) v1.ResourceList {
 	return res
 }
 
-func addResource(rName, value string, rl v1.ResourceList) v1.ResourceList {
-	rl[v1.ResourceName(rName)] = resource.MustParse(value)
-	return rl
-}
-
-func getResourceRequirements(requests, limits v1.ResourceList) *v1.ResourceRequirements {
-	res := v1.ResourceRequirements{}
-	res.Requests = requests
-	res.Limits = limits
-	return &res
-}
-
-func newContainer(name string, requests v1.ResourceList, limits v1.ResourceList) v1.Container {
-	return v1.Container{
-		Name:      name,
-		Resources: *(getResourceRequirements(requests, limits)),
-	}
-}
-
 func newPod(name string, containers []v1.Container) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -255,22 +245,14 @@ func newPod(name string, containers []v1.Container) *v1.Pod {
 	}
 }
 
-func newPodWithResources(name string, containers []v1.Container, podResources *v1.ResourceRequirements) *v1.Pod {
-	pod := newPod(name, containers)
-	if podResources != nil {
-		pod.Spec.Resources = podResources
+func prettyPrintPod(pod *v1.Pod) string {
+	output, err := json.Marshal(pod)
+	if err != nil {
+		panic(err)
 	}
-	return pod
-}
-
-func newPodWithInitContainers(name string, containers []v1.Container, initContainers []v1.Container) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.PodSpec{
-			Containers:     containers,
-			InitContainers: initContainers,
-		},
+	formatted := &bytes.Buffer{}
+	if err := json.Indent(formatted, output, "", "  "); err != nil {
+		panic(err)
 	}
+	return formatted.String()
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
@@ -21,11 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-var supportedQoSComputeResources = sets.New[string](string(core.ResourceCPU), string(core.ResourceMemory))
-
-func isSupportedQoSComputeResource(name core.ResourceName) bool {
-	return supportedQoSComputeResources.Has(string(name))
-}
+var supportedQoSComputeResources = sets.New(core.ResourceCPU, core.ResourceMemory)
 
 // GetPodQOS returns the QoS class of a pod persisted in the PodStatus.QOSClass field.
 // If PodStatus.QOSClass is empty, it returns value of ComputePodQOS() which evaluates pod's QoS class.
@@ -36,96 +32,76 @@ func GetPodQOS(pod *core.Pod) core.PodQOSClass {
 	return ComputePodQOS(pod)
 }
 
-// processResourceList adds non-zero quantities for supported QoS compute resources
-// quantities from newList to list.
-func processResourceList(list, newList core.ResourceList) {
-	for name, quantity := range newList {
-		if !isSupportedQoSComputeResource(name) {
-			continue
-		}
-		if quantity.Sign() == 1 {
-			delta := quantity.DeepCopy()
-			if _, exists := list[name]; !exists {
-				list[name] = delta
-			} else {
-				delta.Add(list[name])
-				list[name] = delta
-			}
-		}
-	}
-}
-
-// getQOSResources returns a set of resource names from the provided resource list that:
-// 1. Are supported QoS compute resources
-// 2. Have quantities greater than zero
-func getQOSResources(list core.ResourceList) sets.Set[string] {
-	qosResources := sets.New[string]()
-	for name, quantity := range list {
-		if !isSupportedQoSComputeResource(name) {
-			continue
-		}
-		if quantity.Sign() == 1 {
-			qosResources.Insert(string(name))
-		}
-	}
-	return qosResources
-}
-
 // ComputePodQOS evaluates the list of containers to determine a pod's QoS class. This function is more
 // expensive than GetPodQOS which should be used for pods having a non-empty .Status.QOSClass.
-// A pod is besteffort if none of its containers have specified any requests or limits.
-// A pod is guaranteed only when requests and limits are specified for all the containers and they are equal.
-// A pod is burstable if limits and requests do not match across all containers.
+// A pod is besteffort if none of its containers have specified any cpu or memory requests or limits.
+// A pod is guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
+// A pod is burstable if cpu & memory limits and requests do not match across all containers.
 func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
-	requests := core.ResourceList{}
-	limits := core.ResourceList{}
-	isGuaranteed := true
+	// When pod-level resources are specified, we use them to determine QoS class.
 	if pod.Spec.Resources != nil {
-		if pod.Spec.Resources.Requests != nil {
-			// process requests
-			processResourceList(requests, pod.Spec.Resources.Requests)
-		}
+		return resourceQOS(pod.Spec.Resources)
+	}
 
-		if pod.Spec.Resources.Limits != nil {
-			// process limits
-			processResourceList(limits, pod.Spec.Resources.Limits)
-			qosLimitResources := getQOSResources(pod.Spec.Resources.Limits)
-			if !qosLimitResources.HasAll(string(core.ResourceMemory), string(core.ResourceCPU)) {
-				isGuaranteed = false
+	// Iterator for Init & main Containers.
+	containerIter := func(yield func(*core.Container) bool) {
+		for _, c := range pod.Spec.InitContainers {
+			if !yield(&c) {
+				return
 			}
 		}
-	} else {
-		// note, ephemeral containers are not considered for QoS as they cannot define resources
-		allContainers := []core.Container{}
-		allContainers = append(allContainers, pod.Spec.Containers...)
-		allContainers = append(allContainers, pod.Spec.InitContainers...)
-		for _, container := range allContainers {
-			// process requests
-			processResourceList(requests, container.Resources.Requests)
-			// process limits
-			processResourceList(limits, container.Resources.Limits)
-			qosLimitResources := getQOSResources(container.Resources.Limits)
-			if !qosLimitResources.HasAll(string(core.ResourceMemory), string(core.ResourceCPU)) {
-				isGuaranteed = false
+		for _, c := range pod.Spec.Containers {
+			if !yield(&c) {
+				return
 			}
 		}
 	}
 
-	if len(requests) == 0 && len(limits) == 0 {
+	var podQOS core.PodQOSClass
+	for container := range containerIter {
+		qos := resourceQOS(&container.Resources)
+		if qos == core.PodQOSBurstable {
+			return qos // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
+		} else if podQOS == "" {
+			podQOS = qos
+		} else {
+			if podQOS != qos {
+				return core.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
+			}
+		}
+	}
+	if podQOS == "" { // This should only happen in tests
+		podQOS = core.PodQOSBestEffort
+	}
+	return podQOS
+}
+
+// resourceQOS gets the QOSClass based on a single set of resource requirements. This may need to be aggregated to determine pod QOS.
+func resourceQOS(resources *core.ResourceRequirements) core.PodQOSClass {
+	if len(resources.Requests) == 0 && len(resources.Limits) == 0 {
 		return core.PodQOSBestEffort
 	}
-	// Check is requests match limits for all resources.
-	if isGuaranteed {
-		for name, req := range requests {
-			if lim, exists := limits[name]; !exists || lim.Cmp(req) != 0 {
-				isGuaranteed = false
-				break
+
+	var qos core.PodQOSClass
+	for res := range supportedQoSComputeResources {
+		req := resources.Requests[res]
+		lim := resources.Limits[res]
+		if !req.Equal(lim) {
+			// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+			return core.PodQOSBurstable
+		}
+		bestEffort := req.IsZero() && lim.IsZero()
+		if qos == "" {
+			if bestEffort {
+				qos = core.PodQOSBestEffort
+			} else {
+				qos = core.PodQOSGuaranteed
+			}
+		} else {
+			if bestEffort != (qos == core.PodQOSBestEffort) {
+				return core.PodQOSBurstable
 			}
 		}
 	}
-	if isGuaranteed &&
-		len(requests) == len(limits) {
-		return core.PodQOSGuaranteed
-	}
-	return core.PodQOSBurstable
+	return qos
 }

--- a/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/qos/qos.go
@@ -34,13 +34,13 @@ func GetPodQOS(pod *core.Pod) core.PodQOSClass {
 
 // ComputePodQOS evaluates the list of containers to determine a pod's QoS class. This function is more
 // expensive than GetPodQOS which should be used for pods having a non-empty .Status.QOSClass.
-// A pod is besteffort if none of its containers have specified any cpu or memory requests or limits.
-// A pod is guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
-// A pod is burstable if cpu & memory limits and requests do not match across all containers.
+// A pod is BestEffort if none of its containers have specified any cpu or memory requests or limits.
+// A pod is Guaranteed only when cpu & memory requests and limits are specified for all the containers and they are equal.
+// A pod is Burstable if cpu & memory limits and requests do not match across all containers.
 func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
 	// When pod-level resources are specified, we use them to determine QoS class.
 	if pod.Spec.Resources != nil {
-		return resourceQOS(pod.Spec.Resources)
+		return requirementsQOS(pod.Spec.Resources)
 	}
 
 	// Iterator for Init & main Containers.
@@ -59,49 +59,60 @@ func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
 
 	var podQOS core.PodQOSClass
 	for container := range containerIter {
-		qos := resourceQOS(&container.Resources)
-		if qos == core.PodQOSBurstable {
-			return qos // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
+		containerQOS := requirementsQOS(&container.Resources)
+		if containerQOS == core.PodQOSBurstable {
+			return containerQOS // If any container is Burstable, we know the pod isn't BestEffort or Guaranteed
 		} else if podQOS == "" {
-			podQOS = qos
-		} else {
-			if podQOS != qos {
-				return core.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
-			}
+			podQOS = containerQOS
+		} else if podQOS != containerQOS {
+			return core.PodQOSBurstable // If one container is BestEffort and another is Guaranteed, the pod is Burstable
 		}
 	}
-	if podQOS == "" { // This should only happen in tests
+	if podQOS == "" { // This can only happen if there aren't any containers (not possible in production).
 		podQOS = core.PodQOSBestEffort
 	}
 	return podQOS
 }
 
-// resourceQOS gets the QOSClass based on a single set of resource requirements. This may need to be aggregated to determine pod QOS.
-func resourceQOS(resources *core.ResourceRequirements) core.PodQOSClass {
+// requirementsQOS gets the QOSClass based on a single set of resource requirements. This may need
+// to be aggregated to determine pod QOS.
+func requirementsQOS(resources *core.ResourceRequirements) core.PodQOSClass {
 	if len(resources.Requests) == 0 && len(resources.Limits) == 0 {
 		return core.PodQOSBestEffort
 	}
 
 	var qos core.PodQOSClass
 	for res := range supportedQoSComputeResources {
-		req := resources.Requests[res]
-		lim := resources.Limits[res]
-		if !req.Equal(lim) {
-			// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+		resQOS := resourceQOS(resources, res)
+		if resQOS == core.PodQOSBurstable {
+			return resQOS // If any resource is Burstable, we know the pod isn't BestEffort or Guaranteed
+		} else if qos == "" {
+			qos = resQOS
+		} else if qos != resQOS {
+			// A mismatch indicates some but not all QOS resources are specified, so the pod must be
+			// burstable.
 			return core.PodQOSBurstable
-		}
-		bestEffort := req.IsZero() && lim.IsZero()
-		if qos == "" {
-			if bestEffort {
-				qos = core.PodQOSBestEffort
-			} else {
-				qos = core.PodQOSGuaranteed
-			}
-		} else {
-			if bestEffort != (qos == core.PodQOSBestEffort) {
-				return core.PodQOSBurstable
-			}
 		}
 	}
 	return qos
+}
+
+// resourceQOS determines the QOS "shape" of the given resource in the requirements:
+// - BestEffort: Request and Limit are both zero
+// - Burstable: Request != Limit
+// - Guaranteed: Request and Limit are equal and non-zero
+func resourceQOS(resources *core.ResourceRequirements, res core.ResourceName) core.PodQOSClass {
+	req := resources.Requests[res]
+	lim := resources.Limits[res]
+
+	if !req.Equal(lim) {
+		// If they're not equal we know at least one is non-zero, so we know it's neither guaranteed nor best effort.
+		return core.PodQOSBurstable
+	} else if req.IsZero() {
+		// req == lim, so no need to check lim.IsZero()
+		return core.PodQOSBestEffort
+	} else {
+		// req == lim != 0
+		return core.PodQOSGuaranteed
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The previous ComputePodQOS functions were doing a lot of unnecessary mutation. This PR takes a much more direct approach that simplifies and optimizes the function. I also greatly expanded the test coverage to ensure correctness.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/133685

#### Special notes for your reviewer:

We should move these to component-helpers so we can de-duplicate at least the kubectl copy.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/assign @ndixita @nimdrak