### PR TITLE
apiserver/pkg/storage/cacher/lister_watcher: pass RV for request from the watchlist consistency checker

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/lister_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/lister_watcher.go
@@ -31,26 +31,30 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/consistencydetector"
 	"k8s.io/client-go/util/watchlist"
 )
 
 // listerWatcher opaques storage.Interface to expose cache.ListerWatcher.
 type listerWatcher struct {
-	storage                       storage.Interface
-	resourcePrefix                string
-	newListFunc                   func() runtime.Object
-	contextMetadata               metadata.MD
-	unsupportedWatchListSemantics bool
+	storage         storage.Interface
+	resourcePrefix  string
+	newListFunc     func() runtime.Object
+	contextMetadata metadata.MD
+
+	unsupportedWatchListSemantics    bool
+	watchListConsistencyCheckEnabled bool
 }
 
 // NewListerWatcher returns a storage.Interface backed ListerWatcher.
 func NewListerWatcher(storage storage.Interface, resourcePrefix string, newListFunc func() runtime.Object, contextMetadata metadata.MD) cache.ListerWatcher {
 	return &listerWatcher{
-		storage:                       storage,
-		resourcePrefix:                resourcePrefix,
-		newListFunc:                   newListFunc,
-		contextMetadata:               contextMetadata,
-		unsupportedWatchListSemantics: watchlist.DoesClientNotSupportWatchListSemantics(storage),
+		storage:                          storage,
+		resourcePrefix:                   resourcePrefix,
+		newListFunc:                      newListFunc,
+		contextMetadata:                  contextMetadata,
+		unsupportedWatchListSemantics:    watchlist.DoesClientNotSupportWatchListSemantics(storage),
+		watchListConsistencyCheckEnabled: consistencydetector.IsDataConsistencyDetectionForWatchListEnabled(),
 	}
 }
 
@@ -69,6 +73,27 @@ func (lw *listerWatcher) List(options metav1.ListOptions) (runtime.Object, error
 		Predicate:            pred,
 		Recursive:            true,
 	}
+
+	// The ConsistencyChecker built into reflectors for the WatchList feature is responsible
+	// for verifying that the data received from the server (potentially from the watch cache)
+	// is consistent with the data stored in etcd.
+	//
+	// To perform this verification, the checker uses the ResourceVersion obtained from the initial request
+	// and sets the ResourceVersionMatch so that it retrieves exactly the same data directly from etcd.
+	// This allows comparing both data sources and confirming their consistency.
+	//
+	// The code below checks whether the incoming request originates from the ConsistencyChecker.
+	// If so, it allows explicitly setting the ResourceVersion.
+	//
+	// As of Oct 2025, reflector on its own is not setting RVM=Exact.
+	// However, even if that changes in the meantime, we would have to propagate that
+	// down to storage to ensure the correct semantics of the request.
+	watchListEnabled := utilfeature.DefaultFeatureGate.Enabled(features.WatchList)
+	supportedRVM := options.ResourceVersionMatch == metav1.ResourceVersionMatchExact
+	if watchListEnabled && lw.watchListConsistencyCheckEnabled && supportedRVM {
+		storageOpts.ResourceVersion = options.ResourceVersion
+	}
+
 	ctx := context.Background()
 	if lw.contextMetadata != nil {
 		ctx = metadata.NewOutgoingContext(ctx, lw.contextMetadata)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Updates the ListWatcher used by the watch cache to allow it to pass the ResourceVersion when performing a List request originating from the ConsistencyChecker.

The ConsistencyChecker built into reflectors for the WatchList feature is responsible
for verifying that the data received from the server (potentially from the watch cache)
is consistent with the data stored in etcd.

To perform this verification, the checker uses the ResourceVersion obtained from the initial request
and sets the ResourceVersionMatch so that it retrieves exactly the same data directly from etcd.
This allows comparing both data sources and confirming their consistency.

xref: https://github.com/kubernetes/kubernetes/pull/134180


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
