### PR TITLE
pkg/controller: Improve goroutine management (part 2)

### DIFF
--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -85,6 +85,7 @@ type GraphBuilder struct {
 	// dependencyGraphBuilder
 	monitors    monitors
 	monitorLock sync.RWMutex
+	monitorWG   sync.WaitGroup
 	// informersStarted is closed after all of the controllers have been initialized and are running.
 	// After that it is safe to start them here, before that it is not.
 	informersStarted <-chan struct{}
@@ -307,11 +308,42 @@ func (gb *GraphBuilder) startMonitors(logger klog.Logger) {
 		if monitor.stopCh == nil {
 			monitor.stopCh = make(chan struct{})
 			gb.sharedInformers.Start(gb.stopCh)
-			go monitor.Run()
+			gb.monitorWG.Go(monitor.Run)
 			started++
 		}
 	}
 	logger.V(4).Info("started new monitors", "new", started, "current", len(monitors))
+}
+
+// stopMonitors terminates all running monitors.
+// stopMonitors should be called after startMonitors to do cleanup.
+//
+// This function panics unless the running flag is set to false.
+func (gb *GraphBuilder) stopMonitors(logger klog.Logger) {
+	var total, stopped int
+
+	func() {
+		gb.monitorLock.Lock()
+		defer gb.monitorLock.Unlock()
+
+		if gb.running {
+			panic("must not call stopMonitors while still marked as running")
+		}
+
+		total = len(gb.monitors)
+		for _, monitor := range gb.monitors {
+			if monitor.stopCh != nil {
+				stopped++
+				close(monitor.stopCh)
+			}
+		}
+
+		// reset monitors so that the graph builder can be safely re-run/synced.
+		gb.monitors = nil
+	}()
+
+	gb.monitorWG.Wait()
+	logger.Info("stopped monitors", "stopped", stopped, "total", total)
 }
 
 // IsResourceSynced returns true if a monitor exists for the given resource and has synced
@@ -347,6 +379,8 @@ func (gb *GraphBuilder) IsSynced(logger klog.Logger) bool {
 // Run sets the stop channel and starts monitor execution until stopCh is
 // closed. Any running monitors will be stopped before Run returns.
 func (gb *GraphBuilder) Run(ctx context.Context) {
+	defer utilruntime.HandleCrashWithContext(ctx)
+
 	logger := klog.FromContext(ctx)
 	logger.Info("Running", "component", "GraphBuilder")
 	defer logger.Info("Stopping", "component", "GraphBuilder")
@@ -357,26 +391,19 @@ func (gb *GraphBuilder) Run(ctx context.Context) {
 	gb.running = true
 	gb.monitorLock.Unlock()
 
-	// Start monitors and begin change processing until the stop channel is
-	// closed.
+	// Start monitors and begin change processing until the stop channel is closed.
 	gb.startMonitors(logger)
 	wait.Until(func() { gb.runProcessGraphChanges(logger) }, 1*time.Second, ctx.Done())
 
-	// Stop any running monitors.
+	// Mark as not running so that no new monitors can be started.
+	// Not doing this here could cause goroutine leaks and deadlocks since it would make it possible for startMonitors
+	// to proceed and start new monitors after stopMonitors has been called.
 	gb.monitorLock.Lock()
-	defer gb.monitorLock.Unlock()
-	monitors := gb.monitors
-	stopped := 0
-	for _, monitor := range monitors {
-		if monitor.stopCh != nil {
-			stopped++
-			close(monitor.stopCh)
-		}
-	}
+	gb.running = false
+	gb.monitorLock.Unlock()
 
-	// reset monitors so that the graph builder can be safely re-run/synced.
-	gb.monitors = nil
-	logger.Info("stopped monitors", "stopped", stopped, "total", len(monitors))
+	// Stop the currently running monitors.
+	gb.stopMonitors(logger)
 }
 
 var ignoredResources = map[schema.GroupResource]struct{}{

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -69,6 +69,7 @@ type event struct {
 type QuotaMonitor struct {
 	// each monitor list/watches a resource and determines if we should replenish quota
 	monitors    monitors
+	monitorWG   sync.WaitGroup
 	monitorLock sync.RWMutex
 	// informersStarted is closed after all the controllers have been initialized and are running.
 	// After that it is safe to start them here, before that it is not.
@@ -267,7 +268,7 @@ func (qm *QuotaMonitor) StartMonitors(ctx context.Context) {
 		if monitor.stopCh == nil {
 			monitor.stopCh = make(chan struct{})
 			qm.informerFactory.Start(qm.stopCh)
-			go monitor.Run()
+			qm.monitorWG.Go(monitor.Run)
 			started++
 		}
 	}
@@ -304,9 +305,7 @@ func (qm *QuotaMonitor) Run(ctx context.Context) {
 	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
-
 	logger.Info("QuotaMonitor running")
-	defer logger.Info("QuotaMonitor stopping")
 
 	// Set up the stop channel.
 	qm.monitorLock.Lock()
@@ -314,19 +313,22 @@ func (qm *QuotaMonitor) Run(ctx context.Context) {
 	qm.running = true
 	qm.monitorLock.Unlock()
 
-	// Start monitors and begin change processing until the stop channel is
-	// closed.
+	// Start monitors and begin change processing until the stop channel is closed.
 	qm.StartMonitors(ctx)
 
-	// The following workers are hanging forever until the queue is
-	// shutted down, so we need to shut it down in a separate goroutine.
-	go func() {
-		defer utilruntime.HandleCrashWithContext(ctx)
-		defer qm.resourceChanges.ShutDown()
-
-		<-ctx.Done()
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("QuotaMonitor stopping")
+		qm.resourceChanges.ShutDown()
+		wg.Wait()
 	}()
-	wait.UntilWithContext(ctx, qm.runProcessResourceChanges, 1*time.Second)
+
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, qm.runProcessResourceChanges, 1*time.Second)
+	})
+
+	// Keep running until cancelled.
+	<-ctx.Done()
 
 	// Stop any running monitors.
 	qm.monitorLock.Lock()
@@ -339,6 +341,7 @@ func (qm *QuotaMonitor) Run(ctx context.Context) {
 			close(monitor.stopCh)
 		}
 	}
+	qm.monitorWG.Wait()
 	logger.Info("QuotaMonitor stopped monitors", "stopped", stopped, "total", len(monitors))
 }
 

--- a/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner.go
+++ b/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner.go
@@ -107,9 +107,7 @@ func (tc *LegacySATokenCleaner) Run(ctx context.Context) {
 		return
 	}
 
-	go wait.UntilWithContext(ctx, tc.evaluateSATokens, tc.syncInterval)
-
-	<-ctx.Done()
+	wait.UntilWithContext(ctx, tc.evaluateSATokens, tc.syncInterval)
 }
 
 func (tc *LegacySATokenCleaner) evaluateSATokens(ctx context.Context) {

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -278,22 +278,24 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 // Run starts the controller which will run in loop until `stopCh` is closed.
 func (tc *Controller) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
+
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name)
-	defer logger.Info("Shutting down controller", "controller", tc.name)
 
 	// Start events processing pipeline.
 	tc.broadcaster.StartStructuredLogging(3)
-	if tc.client != nil {
-		logger.Info("Sending events to api server")
-		tc.broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: tc.client.CoreV1().Events("")})
-	} else {
-		logger.Error(nil, "kubeClient is nil", "controller", tc.name)
-		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
-	}
+	tc.broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: tc.client.CoreV1().Events("")})
+	logger.Info("Sending events to API server")
 	defer tc.broadcaster.Shutdown()
-	defer tc.nodeUpdateQueue.ShutDown()
-	defer tc.podUpdateQueue.ShutDown()
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down controller", "controller", tc.name)
+		tc.nodeUpdateQueue.ShutDown()
+		tc.podUpdateQueue.ShutDown()
+		tc.taintEvictionQueue.CancelAndWait()
+		wg.Wait()
+	}()
 
 	// wait for the cache to be synced
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, tc.podListerSynced, tc.nodeListerSynced) {
@@ -305,9 +307,8 @@ func (tc *Controller) Run(ctx context.Context) {
 		tc.podUpdateChannels = append(tc.podUpdateChannels, make(chan podUpdateItem, podUpdateChannelSize))
 	}
 
-	// Functions that are responsible for taking work items out of the workqueues and putting them
-	// into channels.
-	go func(stopCh <-chan struct{}) {
+	// Functions that are responsible for taking work items out of the workqueues and putting them into channels.
+	wg.Go(func() {
 		for {
 			nodeUpdate, shutdown := tc.nodeUpdateQueue.Get()
 			if shutdown {
@@ -315,16 +316,16 @@ func (tc *Controller) Run(ctx context.Context) {
 			}
 			hash := hash(nodeUpdate.nodeName, UpdateWorkerSize)
 			select {
-			case <-stopCh:
+			case <-ctx.Done():
 				tc.nodeUpdateQueue.Done(nodeUpdate)
 				return
 			case tc.nodeUpdateChannels[hash] <- nodeUpdate:
 				// tc.nodeUpdateQueue.Done is called by the nodeUpdateChannels worker
 			}
 		}
-	}(ctx.Done())
+	})
 
-	go func(stopCh <-chan struct{}) {
+	wg.Go(func() {
 		for {
 			podUpdate, shutdown := tc.podUpdateQueue.Get()
 			if shutdown {
@@ -336,33 +337,31 @@ func (tc *Controller) Run(ctx context.Context) {
 			// It's possible that even without this assumption this code is still correct.
 			hash := hash(podUpdate.nodeName, UpdateWorkerSize)
 			select {
-			case <-stopCh:
+			case <-ctx.Done():
 				tc.podUpdateQueue.Done(podUpdate)
 				return
 			case tc.podUpdateChannels[hash] <- podUpdate:
 				// tc.podUpdateQueue.Done is called by the podUpdateChannels worker
 			}
 		}
-	}(ctx.Done())
+	})
 
-	wg := sync.WaitGroup{}
-	wg.Add(UpdateWorkerSize)
 	for i := 0; i < UpdateWorkerSize; i++ {
-		go tc.worker(ctx, i, wg.Done, ctx.Done())
+		wg.Go(func() {
+			tc.worker(ctx, i)
+		})
 	}
-	wg.Wait()
+	<-ctx.Done()
 }
 
-func (tc *Controller) worker(ctx context.Context, worker int, done func(), stopCh <-chan struct{}) {
-	defer done()
-
+func (tc *Controller) worker(ctx context.Context, worker int) {
 	// When processing events we want to prioritize Node updates over Pod updates,
 	// as NodeUpdates that interest the controller should be handled as soon as possible -
 	// we don't want user (or system) to wait until PodUpdate queue is drained before it can
 	// start evicting Pods from tainted Nodes.
 	for {
 		select {
-		case <-stopCh:
+		case <-ctx.Done():
 			return
 		case nodeUpdate := <-tc.nodeUpdateChannels[worker]:
 			tc.handleNodeUpdate(ctx, nodeUpdate)

--- a/pkg/controller/tainteviction/timed_workers_test.go
+++ b/pkg/controller/tainteviction/timed_workers_test.go
@@ -116,7 +116,7 @@ func TestCancel(t *testing.T) {
 	}
 }
 
-func TestCancelAndReadd(t *testing.T) {
+func TestCancelAndRead(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	testVal := int32(0)
 	wg := sync.WaitGroup{}

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -21,10 +21,8 @@ package attachdetach
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
-
-	"k8s.io/klog/v2"
-	"k8s.io/mount-utils"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
@@ -45,6 +43,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	csitrans "k8s.io/csi-translation-lib"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/metrics"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/populator"
@@ -59,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
+	"k8s.io/mount-utils"
 )
 
 // TimerConfig contains configuration of internal attach/detach timers and
@@ -325,7 +325,6 @@ type attachDetachController struct {
 
 func (adc *attachDetachController) Run(ctx context.Context) {
 	defer runtime.HandleCrash()
-	defer adc.pvcQueue.ShutDown()
 
 	// Start events processing pipeline.
 	adc.broadcaster.StartStructuredLogging(3)
@@ -334,7 +333,13 @@ func (adc *attachDetachController) Run(ctx context.Context) {
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting attach detach controller")
-	defer logger.Info("Shutting down attach detach controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down attach detach controller")
+		adc.pvcQueue.ShutDown()
+		wg.Wait()
+	}()
 
 	synced := []kcache.InformerSynced{adc.podsSynced, adc.nodesSynced, adc.pvcsSynced, adc.pvsSynced,
 		adc.csiNodeSynced, adc.csiDriversSynced, adc.volumeAttachmentSynced}
@@ -350,18 +355,27 @@ func (adc *attachDetachController) Run(ctx context.Context) {
 	if err != nil {
 		logger.Error(err, "Error populating the desired state of world")
 	}
-	go adc.reconciler.Run(ctx)
-	go adc.desiredStateOfWorldPopulator.Run(ctx)
-	go wait.UntilWithContext(ctx, adc.pvcWorker, time.Second)
-	metrics.Register(adc.pvcLister,
+
+	metrics.Register(
+		adc.pvcLister,
 		adc.pvLister,
 		adc.podLister,
 		adc.actualStateOfWorld,
 		adc.desiredStateOfWorld,
 		&adc.volumePluginMgr,
 		adc.csiMigratedPluginManager,
-		adc.intreeToCSITranslator)
+		adc.intreeToCSITranslator,
+	)
 
+	wg.Go(func() {
+		adc.reconciler.Run(ctx)
+	})
+	wg.Go(func() {
+		adc.desiredStateOfWorldPopulator.Run(ctx)
+	})
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, adc.pvcWorker, time.Second)
+	})
 	<-ctx.Done()
 }
 

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -19,6 +19,7 @@ package pvprotection
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -75,20 +76,26 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PV protection controller")
-	defer logger.Info("Shutting down PV protection controller")
+
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down PV protection controller")
+		c.queue.ShutDown()
+		wg.Wait()
+	}()
 
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.pvListerSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		})
 	}
-
 	<-ctx.Done()
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Make sure all goroutines are terminated before returning from controller.Run function in various controller packages.

This is the second part of a larger change, see the linked issues. This particular PR contains changes for `volumes` and more complicated controllers.

#### Which issue(s) this PR is related to:

Required for https://github.com/kubernetes/kubernetes/issues/132599
Followup to https://github.com/kubernetes/kubernetes/pull/134910

#### Special notes for your reviewer:

See the notes in  https://github.com/kubernetes/kubernetes/pull/134910

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A