### PR TITLE
[FG:PodObservedGenerationTracking] Promote Pod Generation to GA

### DIFF
--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -1234,97 +1234,47 @@ func TestDropDisabledPodStatusFields_ObservedGeneration(t *testing.T) {
 		name          string
 		podStatus     *api.PodStatus
 		oldPodStatus  *api.PodStatus
-		featureGateOn bool
 		wantPodStatus *api.PodStatus
 	}{
-		{
-			name:          "old=without, new=without / feature gate off",
-			oldPodStatus:  podWithoutObservedGen(),
-			podStatus:     podWithoutObservedGen(),
-			featureGateOn: false,
-			wantPodStatus: podWithoutObservedGen(),
-		},
 		{
 			name:          "old=without, new=without / feature gate on",
 			oldPodStatus:  podWithoutObservedGen(),
 			podStatus:     podWithoutObservedGen(),
-			featureGateOn: true,
-			wantPodStatus: podWithoutObservedGen(),
-		},
-		{
-			name:          "old=without, new=with / feature gate off",
-			oldPodStatus:  podWithoutObservedGen(),
-			podStatus:     podWithObservedGen(),
-			featureGateOn: false,
 			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
 			name:          "old=with, new=without / feature gate on",
 			oldPodStatus:  podWithObservedGen(),
 			podStatus:     podWithoutObservedGen(),
-			featureGateOn: true,
 			wantPodStatus: podWithoutObservedGen(),
-		},
-		{
-			name:          "old=with, new=with / feature gate off",
-			oldPodStatus:  podWithObservedGen(),
-			podStatus:     podWithObservedGen(),
-			featureGateOn: false,
-			wantPodStatus: podWithObservedGen(),
 		},
 		{
 			name:          "old=with, new=with / feature gate on",
 			oldPodStatus:  podWithObservedGen(),
 			podStatus:     podWithObservedGen(),
-			featureGateOn: true,
 			wantPodStatus: podWithObservedGen(),
-		},
-		{
-			name:          "old=without, new=withInConditions / feature gate off",
-			oldPodStatus:  podWithoutObservedGen(),
-			podStatus:     podWithObservedGenInConditions(),
-			featureGateOn: false,
-			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
 			name:          "old=without, new=withInConditions / feature gate on",
 			oldPodStatus:  podWithoutObservedGen(),
 			podStatus:     podWithObservedGenInConditions(),
-			featureGateOn: true,
 			wantPodStatus: podWithObservedGenInConditions(),
-		},
-		{
-			name:          "old=withInConditions, new=without / feature gate off",
-			oldPodStatus:  podWithObservedGenInConditions(),
-			podStatus:     podWithoutObservedGen(),
-			featureGateOn: false,
-			wantPodStatus: podWithoutObservedGen(),
 		},
 		{
 			name:          "old=withInConditions, new=without / feature gate on",
 			oldPodStatus:  podWithObservedGenInConditions(),
 			podStatus:     podWithoutObservedGen(),
-			featureGateOn: true,
 			wantPodStatus: podWithoutObservedGen(),
-		},
-		{
-			name:          "old=withInConditions, new=withInCondtions / feature gate off",
-			oldPodStatus:  podWithObservedGenInConditions(),
-			podStatus:     podWithObservedGenInConditions(),
-			featureGateOn: false,
-			wantPodStatus: podWithObservedGenInConditions(),
 		},
 		{
 			name:          "old=withInConditions, new=withInCondtions / feature gate on",
 			oldPodStatus:  podWithObservedGenInConditions(),
 			podStatus:     podWithObservedGenInConditions(),
-			featureGateOn: true,
 			wantPodStatus: podWithObservedGenInConditions(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodObservedGenerationTracking, tt.featureGateOn)
 			dropDisabledPodStatusFields(tt.podStatus, tt.oldPodStatus, &api.PodSpec{}, &api.PodSpec{})
 			if !reflect.DeepEqual(tt.podStatus, tt.wantPodStatus) {
 				t.Errorf("dropDisabledStatusFields() = %v, want %v", tt.podStatus, tt.wantPodStatus)

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -28,10 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/component-base/featuregate"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestVisitContainers(t *testing.T) {
@@ -1015,45 +1011,14 @@ func TestCalculatePodStatusObservedGeneration(t *testing.T) {
 	tests := []struct {
 		name     string
 		pod      *v1.Pod
-		features map[featuregate.Feature]bool
 		expected int64
 	}{
-		{
-			name: "pod with no observedGeneration/PodObservedGenerationTracking=false",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 5,
-				},
-			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: false,
-			},
-			expected: 0,
-		},
 		{
 			name: "pod with no observedGeneration/PodObservedGenerationTracking=true",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: 5,
 				},
-			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: true,
-			},
-			expected: 5,
-		},
-		{
-			name: "pod with observedGeneration/PodObservedGenerationTracking=false",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 5,
-				},
-				Status: v1.PodStatus{
-					ObservedGeneration: 5,
-				},
-			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: false,
 			},
 			expected: 5,
 		},
@@ -1067,16 +1032,12 @@ func TestCalculatePodStatusObservedGeneration(t *testing.T) {
 					ObservedGeneration: 5,
 				},
 			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: true,
-			},
 			expected: 5,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, tc.features)
 			assert.Equal(t, tc.expected, CalculatePodStatusObservedGeneration(tc.pod))
 		})
 	}
@@ -1086,26 +1047,8 @@ func TestCalculatePodConditionObservedGeneration(t *testing.T) {
 	tests := []struct {
 		name     string
 		pod      *v1.Pod
-		features map[featuregate.Feature]bool
 		expected int64
 	}{
-		{
-			name: "pod with no observedGeneration/PodObservedGenerationTracking=false",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 5,
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{{
-						Type: v1.PodReady,
-					}},
-				},
-			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: false,
-			},
-			expected: 0,
-		},
 		{
 			name: "pod with no observedGeneration/PodObservedGenerationTracking=true",
 			pod: &v1.Pod{
@@ -1117,27 +1060,6 @@ func TestCalculatePodConditionObservedGeneration(t *testing.T) {
 						Type: v1.PodReady,
 					}},
 				},
-			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: true,
-			},
-			expected: 5,
-		},
-		{
-			name: "pod with observedGeneration/PodObservedGenerationTracking=false",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 5,
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{{
-						Type:               v1.PodReady,
-						ObservedGeneration: 5,
-					}},
-				},
-			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: false,
 			},
 			expected: 5,
 		},
@@ -1154,16 +1076,12 @@ func TestCalculatePodConditionObservedGeneration(t *testing.T) {
 					}},
 				},
 			},
-			features: map[featuregate.Feature]bool{
-				features.PodObservedGenerationTracking: true,
-			},
 			expected: 5,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, tc.features)
 			assert.Equal(t, tc.expected, CalculatePodConditionObservedGeneration(&tc.pod.Status, tc.pod.Generation, v1.PodReady))
 		})
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1507,6 +1507,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	PodObservedGenerationTracking: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.35, remove in 1.38
 	},
 
 	PodReadyToStartContainersCondition: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1189,6 +1189,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.34"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.35"
 - name: PodReadyToStartContainersCondition
   versionedSpecs:
   - default: false

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -333,10 +333,6 @@ var (
 	// (used for testing specific log stream <https://kep.k8s.io/3288>)
 	PodLogsQuerySplitStreams = framework.WithFeature(framework.ValidFeatures.Add("PodLogsQuerySplitStreams"))
 
-	// Owner: sig-node
-	// Marks tests that require a cluster with PodObservedGenerationTracking
-	PodObservedGenerationTracking = framework.WithFeature(framework.ValidFeatures.Add("PodObservedGenerationTracking"))
-
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	PodPriority = framework.WithFeature(framework.ValidFeatures.Add("PodPriority"))
 

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/events"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -420,7 +419,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 	})
 })
 
-var _ = SIGDescribe("Pods Extended (pod generation)", feature.PodObservedGenerationTracking, framework.WithFeatureGate(features.PodObservedGenerationTracking), func() {
+var _ = SIGDescribe("Pods Extended (pod generation)", framework.WithFeatureGate(features.PodObservedGenerationTracking), func() {
 	f := framework.NewDefaultFramework("pods")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Promote Pod Generation ([KEP 5067](https://github.com/kubernetes/enhancements/issues/5067)) to GA.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5067

#### Special notes for your reviewer:

I have an outstanding TODO item to promote the tests to conformance, but was advised that typically we first switch the feature to GA before promoting to conformance. I am planning to promote to conformance as a fast-follow. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote PodObservedGenerationTracking to GA. 
```

/sig node
/priority important-soon
