### PR TITLE
[Flaking test] [InPlacePodVerticalScaling] Fix Pod Resize deferred tests

### DIFF
--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -690,10 +690,13 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 
 func doPodResizeRetryDeferredTests(f *framework.Framework) {
 	ginkgo.It("pod-resize-retry-deferred-test-1", func(ctx context.Context) {
-		// Deferred resize E2E test case #1:
-		// 	   1. Create pod1 and pod2 and pod3 on node.
-		// 	   2. Resize pod3 to request more cpu than available, verify the resize is deferred.
-		//	   3. Resize pod1 down to make space for pod3, verify pod3's resize has completed.
+		// Deferred resize E2E test case #1 (2-Pod Scenario):
+		//     1. Assume Node CPU is divided into 10 "parts".
+		//     2. Create Pod A (5 parts) and Pod B (3 parts).
+		//     3. Verify remaining free CPU is < 3 parts (cannot fit Pod B's requested increase).
+		//     4. Resize Pod B to 6 parts. Verify the resize is deferred.
+		//     5. Resize Pod A down to 2 parts (frees up exactly 3 parts).
+		//     6. Verify Pod B's deferred resize has now completed successfully.
 
 		podClient := e2epod.NewPodClient(f)
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
@@ -708,118 +711,105 @@ func doPodResizeRetryDeferredTests(f *framework.Framework) {
 		framework.Logf("Node '%s': NodeAllocatable MilliCPUs = %dm. MilliCPUs currently available to allocate = %dm.",
 			node.Name, nodeAllocatableCPU.MilliValue(), nodeAvailableCPU.MilliValue())
 
-		testPod1CPUQuantity := resource.NewMilliQuantity(nodeAvailableCPU.MilliValue()/2, resource.DecimalSI)  // 50% of available CPU
-		testPod2CPUQuantity := resource.NewMilliQuantity(nodeAvailableCPU.MilliValue()/4, resource.DecimalSI)  // 25% of available CPU
-		testPod3CPUQuantity := resource.NewMilliQuantity(nodeAvailableCPU.MilliValue()/16, resource.DecimalSI) // 6.25% of available CPU
+		// Conceptually divide the available CPU into 10 parts.
+		onePartCPU := nodeAvailableCPU.MilliValue() / 10
+		framework.Logf("Node '%s' currently available MilliCPUs = %dm (1 part = %dm)", node.Name, nodeAvailableCPU.MilliValue(), onePartCPU)
 
-		framework.Logf("testPod1 initial CPU request is '%dm'", testPod1CPUQuantity.MilliValue())
-		framework.Logf("testPod2 initial CPU request is '%dm'", testPod2CPUQuantity.MilliValue())
-		framework.Logf("testPod3 initial CPU request is '%dm'", testPod3CPUQuantity.MilliValue())
+		// Pod A: 5 parts, Pod B: 3 parts
+		podACPU := resource.NewMilliQuantity(onePartCPU*5, resource.DecimalSI)
+		podBCPU := resource.NewMilliQuantity(onePartCPU*3, resource.DecimalSI)
 
-		c1 := []podresize.ResizableContainerInfo{
-			{
-				Name:      "c1",
-				Resources: &cgroups.ContainerResources{CPUReq: testPod1CPUQuantity.String(), CPULim: testPod1CPUQuantity.String()},
-			},
+		framework.Logf("Pod A initial CPU request is '%dm'", podACPU.MilliValue())
+		framework.Logf("Pod B initial CPU request is '%dm'", podBCPU.MilliValue())
+
+		cA := []podresize.ResizableContainerInfo{
+			{Name: "ca", Resources: &cgroups.ContainerResources{CPUReq: podACPU.String(), CPULim: podACPU.String()}},
 		}
-		c2 := []podresize.ResizableContainerInfo{
-			{
-				Name:      "c2",
-				Resources: &cgroups.ContainerResources{CPUReq: testPod2CPUQuantity.String(), CPULim: testPod2CPUQuantity.String()},
-			},
+		cB := []podresize.ResizableContainerInfo{
+			{Name: "cb", Resources: &cgroups.ContainerResources{CPUReq: podBCPU.String(), CPULim: podBCPU.String()}},
 		}
-		c3 := []podresize.ResizableContainerInfo{
-			{
-				Name:      "c3",
-				Resources: &cgroups.ContainerResources{CPUReq: testPod3CPUQuantity.String(), CPULim: testPod3CPUQuantity.String()},
-			},
-		}
+
 		tStamp := strconv.Itoa(time.Now().Nanosecond())
-		testPod1 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod1", tStamp, c1, nil)
-		testPod1 = e2epod.MustMixinRestrictedPodSecurity(testPod1)
-		testPod2 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod2", tStamp, c2, nil)
-		testPod2 = e2epod.MustMixinRestrictedPodSecurity(testPod2)
-		testPod3 := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod3", tStamp, c3, nil)
-		testPod3 = e2epod.MustMixinRestrictedPodSecurity(testPod3)
-		e2epod.SetNodeAffinity(&testPod1.Spec, node.Name)
-		e2epod.SetNodeAffinity(&testPod2.Spec, node.Name)
-		e2epod.SetNodeAffinity(&testPod3.Spec, node.Name)
 
-		ginkgo.By(fmt.Sprintf("Create pod '%s' that fits the node '%s'", testPod1.Name, node.Name))
-		testPod1 = podClient.CreateSync(ctx, testPod1)
-		gomega.Expect(testPod1.Status.Phase).To(gomega.Equal(v1.PodRunning))
-		gomega.Expect(testPod1.Generation).To(gomega.BeEquivalentTo(1))
+		podA := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod-a", tStamp, cA, nil)
+		podA = e2epod.MustMixinRestrictedPodSecurity(podA)
+		e2epod.SetNodeAffinity(&podA.Spec, node.Name)
 
-		ginkgo.By(fmt.Sprintf("Create pod '%s' that fits the node '%s'", testPod2.Name, node.Name))
-		testPod2 = podClient.CreateSync(ctx, testPod2)
-		gomega.Expect(testPod2.Status.Phase).To(gomega.Equal(v1.PodRunning))
-		gomega.Expect(testPod2.Generation).To(gomega.BeEquivalentTo(1))
+		podB := podresize.MakePodWithResizableContainers(f.Namespace.Name, "testpod-b", tStamp, cB, nil)
+		podB = e2epod.MustMixinRestrictedPodSecurity(podB)
+		e2epod.SetNodeAffinity(&podB.Spec, node.Name)
 
-		ginkgo.By(fmt.Sprintf("Create pod '%s' that fits the node '%s'", testPod3.Name, node.Name))
-		testPod3 = podClient.CreateSync(ctx, testPod3)
-		gomega.Expect(testPod3.Status.Phase).To(gomega.Equal(v1.PodRunning))
-		gomega.Expect(testPod3.Generation).To(gomega.BeEquivalentTo(1))
+		ginkgo.By(fmt.Sprintf("Create Pod A '%s' and Pod B '%s'", podA.Name, podB.Name))
 
-		nodeAllocatableCPU2, nodeAvailableCPU2, err := e2enode.GetNodeAllocatableAndAvailableQuantities(ctx, f.ClientSet, &node, v1.ResourceCPU)
+		podA = podClient.CreateSync(ctx, podA)
+		gomega.Expect(podA.Status.Phase).To(gomega.Equal(v1.PodRunning))
+		gomega.Expect(podA.Generation).To(gomega.BeEquivalentTo(1))
+
+		podB = podClient.CreateSync(ctx, podB)
+		gomega.Expect(podB.Status.Phase).To(gomega.Equal(v1.PodRunning))
+		gomega.Expect(podB.Generation).To(gomega.BeEquivalentTo(1))
+
+		ginkgo.By("Verify remaining CPU is less than the 3 parts required for Pod B's resize")
+		_, nodeAvailableCPU2, err := e2enode.GetNodeAllocatableAndAvailableQuantities(ctx, f.ClientSet, &node, v1.ResourceCPU)
 		framework.ExpectNoError(err, "failed to get CPU resources available for allocation")
 
-		framework.Logf("Node '%s': NodeAllocatable MilliCPUs = %dm. MilliCPUs currently available to allocate = %dm.",
-			node.Name, nodeAllocatableCPU2.MilliValue(), nodeAvailableCPU2.MilliValue())
+		threePartsCPU := onePartCPU * 3
+		framework.Logf("Remaining CPU = %dm. Pod B needs %dm more to resize.", nodeAvailableCPU2.MilliValue(), threePartsCPU)
+		gomega.Expect(nodeAvailableCPU2.MilliValue()).To(gomega.BeNumerically("<", threePartsCPU),
+			"Available CPU should be strictly less than 3 parts to ensure Pod B's resize is deferred")
 
-		// Considering only these 3 pods consumed the resources, the nodeAvailableMilliCPU2 will be 18.75% (50%(testpod1)+25%(testpod2)+6.25%(testpod3))
-		// Resize the testpod3 to add current available resource + 75% of testpod1 resource, i.e 18.75% + 37.5%
-		testPod3CPUQuantityResized := resource.NewMilliQuantity(nodeAllocatableCPU2.MilliValue()+testPod1CPUQuantity.MilliValue()*3/4, resource.DecimalSI)
-		framework.Logf("testPod3 MilliCPUs after resize '%dm'", testPod3CPUQuantityResized.MilliValue())
+		// Calculations for Resizing
+		// Pod B: Resize to 6 parts (needs 3 more parts)
+		podBResizedCPU := resource.NewMilliQuantity(onePartCPU*6, resource.DecimalSI)
+		// Pod A: Resize to 2 parts (drops 3 parts, freeing them up)
+		podAResizedCPU := resource.NewMilliQuantity(onePartCPU*2, resource.DecimalSI)
 
-		// Resize the testpod1 to 25% from its initial value so its new resource will be 12.5%
-		testPod1CPUQuantityResizedCPU := resource.NewMilliQuantity(testPod1CPUQuantity.MilliValue()/4, resource.DecimalSI)
-		framework.Logf("testPod1 MilliCPUs after resize '%dm'", testPod1CPUQuantityResizedCPU.MilliValue())
+		patchPodBToDeferred := fmt.Sprintf(`{
+        	"spec": {
+            	"containers": [
+                	{
+                    	"name":      "cb",
+                    	"resources": {"requests": {"cpu": "%dm"},"limits": {"cpu": "%dm"}}
+                	}
+            	]
+        	}
+    	}`, podBResizedCPU.MilliValue(), podBResizedCPU.MilliValue())
 
-		patchTestpod3ToDeferred := fmt.Sprintf(`{
-			"spec": {
-				"containers": [
-					{
-						"name":      "c3",
-						"resources": {"requests": {"cpu": "%dm"},"limits": {"cpu": "%dm"}}
-					}
-				]
-			}
-		}`, testPod3CPUQuantityResized.MilliValue(), testPod3CPUQuantityResized.MilliValue())
-		patchTestpod1ToMakeSpaceForPod3 := fmt.Sprintf(`{
-				"spec": {
-					"containers": [
-						{
-							"name":      "c1",
-							"resources": {"requests": {"cpu": "%dm"},"limits": {"cpu": "%dm"}}
-						}
-					]
-				}
-			}`, testPod1CPUQuantityResizedCPU.MilliValue(), testPod1CPUQuantityResizedCPU.MilliValue())
+		patchPodAToMakeSpace := fmt.Sprintf(`{
+        	"spec": {
+           		"containers": [
+                	{
+                    	"name":      "ca",
+                    	"resources": {"requests": {"cpu": "%dm"},"limits": {"cpu": "%dm"}}
+                	}
+            	]
+        	}
+    	}`, podAResizedCPU.MilliValue(), podAResizedCPU.MilliValue())
 
-		ginkgo.By(fmt.Sprintf("Resize pod '%s' that cannot fit node due to insufficient CPU", testPod3.Name))
-		testPod3, p3Err := f.ClientSet.CoreV1().Pods(testPod3.Namespace).Patch(ctx,
-			testPod3.Name, types.StrategicMergePatchType, []byte(patchTestpod3ToDeferred), metav1.PatchOptions{}, "resize")
-		framework.ExpectNoError(p3Err, "failed to patch pod for resize")
-		waitForPodDeferred(ctx, f, testPod3)
+		ginkgo.By(fmt.Sprintf("Resize Pod B '%s' to 6 parts (will be deferred due to insufficient CPU)", podB.Name))
+		podB, err = f.ClientSet.CoreV1().Pods(podB.Namespace).Patch(ctx,
+			podB.Name, types.StrategicMergePatchType, []byte(patchPodBToDeferred), metav1.PatchOptions{}, "resize")
+		framework.ExpectNoError(err, "failed to patch Pod B for resize")
+		waitForPodDeferred(ctx, f, podB)
 
-		ginkgo.By(fmt.Sprintf("Resize pod '%s' to make enough space for pod '%s'", testPod1.Name, testPod3.Name))
-		testPod1, p1Err := f.ClientSet.CoreV1().Pods(testPod1.Namespace).Patch(ctx,
-			testPod1.Name, types.StrategicMergePatchType, []byte(patchTestpod1ToMakeSpaceForPod3), metav1.PatchOptions{}, "resize")
-		framework.ExpectNoError(p1Err, "failed to patch pod for resize")
-		gomega.Expect(testPod1.Generation).To(gomega.BeEquivalentTo(2))
+		ginkgo.By(fmt.Sprintf("Resize Pod A '%s' down to 2 parts, freeing up exactly 3 parts for Pod B", podA.Name))
+		podA, err = f.ClientSet.CoreV1().Pods(podA.Namespace).Patch(ctx,
+			podA.Name, types.StrategicMergePatchType, []byte(patchPodAToMakeSpace), metav1.PatchOptions{}, "resize")
+		framework.ExpectNoError(err, "failed to patch Pod A to free up space")
+		gomega.Expect(podA.Generation).To(gomega.BeEquivalentTo(2))
 
-		ginkgo.By(fmt.Sprintf("Verify pod '%s' is resized successfully after pod resize '%s'", testPod3.Name, testPod1.Name))
+		ginkgo.By("Verify Pod B successfully actuates the deferred resize after space is freed")
 		expected := []podresize.ResizableContainerInfo{
 			{
-				Name:      "c3",
-				Resources: &cgroups.ContainerResources{CPUReq: testPod3CPUQuantityResized.String(), CPULim: testPod3CPUQuantityResized.String()},
+				Name:      "cb",
+				Resources: &cgroups.ContainerResources{CPUReq: podBResizedCPU.String(), CPULim: podBResizedCPU.String()},
 			},
 		}
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod3, expected)
-		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
+		resizedPodB := podresize.WaitForPodResizeActuation(ctx, f, podClient, podB, expected)
+		podresize.ExpectPodResized(ctx, f, resizedPodB, expected)
 
-		ginkgo.By("deleting pods")
-		e2epod.DeletePodsWithWait(ctx, f.ClientSet, []*v1.Pod{testPod1, testPod2, testPod3})
+		ginkgo.By("Cleaning up test pods")
+		e2epod.DeletePodsWithWait(ctx, f.ClientSet, []*v1.Pod{podA, podB})
 	})
 
 	ginkgo.It("pod-resize-retry-deferred-test-2", func(ctx context.Context) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR tries to fix the flake for tests verifying the Differed state in InPlacePodVerticalScaling feature.

Test output
```
STEP: Creating a kubernetes client @ 10/29/25 16:35:07.97
  I1029 16:35:07.970529 917444 util.go:414] >>> kubeConfig: /root/kubernetes/kind.conf
  STEP: Building a namespace api object, basename pod-resize-deferred-resize-tests @ 10/29/25 16:35:07.971
  STEP: Waiting for a default service account to be provisioned in namespace @ 10/29/25 16:35:07.979
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 10/29/25 16:35:07.982
  I1029 16:35:07.987725 917444 pod_resize.go:701] Found 1 schedulable nodes
  STEP: Find node CPU resources available for allocation! @ 10/29/25 16:35:07.987
  I1029 16:35:07.990482 917444 pod_resize.go:1265] Found 9 pods on node 'kind-control-plane'
  I1029 16:35:07.990542 917444 pod_resize.go:706] Node 'kind-control-plane': NodeAllocatable MilliCPUs = 16000m. MilliCPUs currently available to allocate = 15050m.
  I1029 16:35:07.990555 917444 pod_resize.go:712] testPod1 initial CPU request is '7525m'
  I1029 16:35:07.990562 917444 pod_resize.go:713] testPod2 initial CPU request is '3762m'
  I1029 16:35:07.990567 917444 pod_resize.go:714] testPod3 initial CPU request is '940m'
  STEP: Create pod 'testpod1' that fits the node 'kind-control-plane' @ 10/29/25 16:35:07.99
  STEP: Create pod 'testpod2' that fits the node 'kind-control-plane' @ 10/29/25 16:35:10.004
  STEP: Create pod 'testpod3' that fits the node 'kind-control-plane' @ 10/29/25 16:35:12.015
  I1029 16:35:14.030184 917444 pod_resize.go:1265] Found 12 pods on node 'kind-control-plane'
  I1029 16:35:14.030248 917444 pod_resize.go:761] Node 'kind-control-plane': NodeAllocatable MilliCPUs = 16000m. MilliCPUs currently available to allocate = 2823m.
  I1029 16:35:14.030262 917444 pod_resize.go:767] testPod3 MilliCPUs after resize '8466m'
  I1029 16:35:14.030271 917444 pod_resize.go:771] testPod1 MilliCPUs after resize '1881m'
  STEP: Resize pod 'testpod3' that cannot fit node due to insufficient CPU @ 10/29/25 16:35:14.03
  STEP: Resize pod 'testpod1' to make enough space for pod 'testpod3' @ 10/29/25 16:35:16.043
  STEP: Verify pod 'testpod3' is resized successfully after pod resize 'testpod1' @ 10/29/25 16:35:16.049
```

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/134458
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:

<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
