### PR TITLE
[FG:PodObservedGenerationTracking] Promote Pod Generation e2e tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2458,6 +2458,27 @@
     The PodTemplate must be deleted.
   release: v1.19
   file: test/e2e/common/node/podtemplates.go
+- testname: Pods Generation, graceful delete
+  codename: '[sig-node] Pods Extended (pod generation) Pod Generation custom-set generation
+    on new pods and graceful delete [Conformance]'
+  description: Create a Pod, ensure that triggering a graceful delete causes the generation
+    to be updated.
+  release: v1.35
+  file: test/e2e/node/pods.go
+- testname: Pods Generation, 500 updates
+  codename: '[sig-node] Pods Extended (pod generation) Pod Generation issue 500 podspec
+    updates and verify generation and observedGeneration eventually converge [Conformance]'
+  description: Create a Pod, issue 499 podSpec updates and verify generation and observedGeneration
+    eventually converge to 500.
+  release: v1.35
+  file: test/e2e/node/pods.go
+- testname: Pods Generation, updates
+  codename: '[sig-node] Pods Extended (pod generation) Pod Generation pod generation
+    should start at 1 and increment per update [Conformance]'
+  description: Create a Pod, and perform a few updates, ensuring that the pod's metadata.generation
+    and status.observedGeneration are updated as expected.
+  release: v1.35
+  file: test/e2e/node/pods.go
 - testname: Pods, QOS
   codename: '[sig-node] Pods Extended Pods Set QOS Class should be set on Pods with
     matching resource requests and limits for memory and cpu [Conformance]'

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -419,7 +419,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 	})
 })
 
-var _ = SIGDescribe("Pods Extended (pod generation)", framework.WithFeatureGate(features.PodObservedGenerationTracking), func() {
+var _ = SIGDescribe("Pods Extended (pod generation)", func() {
 	f := framework.NewDefaultFramework("pods")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
@@ -429,7 +429,12 @@ var _ = SIGDescribe("Pods Extended (pod generation)", framework.WithFeatureGate(
 			podClient = e2epod.NewPodClient(f)
 		})
 
-		ginkgo.It("pod generation should start at 1 and increment per update", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: Pods Generation, updates
+			Description: Create a Pod, and perform a few updates, ensuring that the pod's metadata.generation and status.observedGeneration are updated as expected.
+		*/
+		framework.ConformanceIt("pod generation should start at 1 and increment per update", func(ctx context.Context) {
 			ginkgo.By("creating the pod")
 			podName := "pod-generation-" + string(uuid.NewUUID())
 			pod := e2epod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, nil)
@@ -529,7 +534,12 @@ var _ = SIGDescribe("Pods Extended (pod generation)", framework.WithFeatureGate(
 			}
 		})
 
-		ginkgo.It("custom-set generation on new pods and graceful delete", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: Pods Generation, graceful delete
+			Description: Create a Pod, ensure that triggering a graceful delete causes the generation to be updated.
+		*/
+		framework.ConformanceIt("custom-set generation on new pods and graceful delete", func(ctx context.Context) {
 			ginkgo.By("creating the pod")
 			name := "pod-generation-" + string(uuid.NewUUID())
 			value := strconv.Itoa(time.Now().Nanosecond())
@@ -565,7 +575,12 @@ var _ = SIGDescribe("Pods Extended (pod generation)", framework.WithFeatureGate(
 			gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(2))
 		})
 
-		ginkgo.It("issue 500 podspec updates and verify generation and observedGeneration eventually converge", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: Pods Generation, 500 updates
+			Description: Create a Pod, issue 499 podSpec updates and verify generation and observedGeneration eventually converge to 500.
+		*/
+		framework.ConformanceIt("issue 500 podspec updates and verify generation and observedGeneration eventually converge", func(ctx context.Context) {
 			ginkgo.By("creating the pod")
 			name := "pod-generation-" + string(uuid.NewUUID())
 			value := strconv.Itoa(time.Now().Nanosecond())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area test

#### What this PR does / why we need it:

Promote pod generation tests to conformance.
- The feature is now GA: https://github.com/kubernetes/kubernetes/pull/134948
- No flakes in the last 2 weeks: https://storage.googleapis.com/k8s-triage/index.html?test=Pods%20Extended%20(pod%20generation) (or ever, I think)
- Follows https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#promoting-tests-to-conformance

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/priority important-soon
