### PR TITLE
add integration tests for pod replacement during scaling and Recreate/RollingUpdate strategies

### DIFF
--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -19,6 +19,7 @@ package deployment
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -220,6 +221,37 @@ func (d *deploymentTester) markUpdatedPodsReady(wg *sync.WaitGroup) {
 	}
 }
 
+// removeTerminatedPods manually removes terminated Deployment pods,
+// until the deployment is complete
+func (d *deploymentTester) removeTerminatedPods(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		// We're done when the deployment is complete
+		if completed, err := d.deploymentComplete(); err != nil {
+			return false, err
+		} else if completed {
+			return true, nil
+		}
+		// Otherwise, mark remaining pods as ready
+		rsList, err := deploymentutil.ListReplicaSets(d.deployment, deploymentutil.RsListFromClient(d.c.AppsV1()))
+		if err != nil {
+			d.t.Log(err)
+			return false, nil
+		}
+		for _, rs := range rsList {
+			if err := d.removeRSPods(ctx, rs, math.MaxInt, true, 0); err != nil {
+				d.t.Log(err)
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		d.t.Errorf("failed to remove terminated Deployment pods: %v", err)
+	}
+}
+
 func (d *deploymentTester) deploymentComplete() (bool, error) {
 	latest, err := d.c.AppsV1().Deployments(d.deployment.Namespace).Get(context.TODO(), d.deployment.Name, metav1.GetOptions{})
 	if err != nil {
@@ -275,6 +307,30 @@ func (d *deploymentTester) waitForDeploymentCompleteAndMarkPodsReady() error {
 	err := d.waitForDeploymentComplete()
 	if err != nil {
 		return fmt.Errorf("failed to wait for Deployment status %s: %v", d.deployment.Name, err)
+	}
+
+	// Wait for goroutine to finish
+	wg.Wait()
+
+	return nil
+}
+
+// waitForDeploymentCompleteAndMarkPodsReadyAndRemoveTerminating waits for the Deployment to complete
+// while marking updated Deployment pods as ready and removes terminated pods at the same time.
+func (d *deploymentTester) waitForDeploymentCompleteAndMarkPodsReadyAndRemoveTerminated(ctx context.Context) error {
+	var wg sync.WaitGroup
+
+	// Manually mark updated Deployment pods as ready in a separate goroutine
+	wg.Add(1)
+	go d.markUpdatedPodsReady(&wg)
+
+	wg.Add(1)
+	go d.removeTerminatedPods(ctx, &wg)
+
+	// Wait for the Deployment status to complete using soft check, while Deployment pods are becoming ready
+	err := d.waitForDeploymentComplete()
+	if err != nil {
+		return fmt.Errorf("failed to wait for Deployment status %s: %w", d.deployment.Name, err)
 	}
 
 	// Wait for goroutine to finish
@@ -432,6 +488,20 @@ func (d *deploymentTester) markUpdatedPodsReadyWithoutComplete() error {
 	return nil
 }
 
+// waitForReadyReplicas waits for number of ready replicas to equal number of replicas.
+func (d *deploymentTester) waitForDeploymentStatusReplicasFields(ctx context.Context, replicas, updatedReplicas, readyReplicas, availableReplicas, unavailableReplicas int32, terminatingReplicas *int32) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(_ context.Context) (bool, error) {
+		// do not pass ctx to checkDeploymentStatusReplicasFields (Deployments().Get) so we always obtain the latest error and not the one from deadline exceeded
+		lastErr = d.checkDeploymentStatusReplicasFields(replicas, updatedReplicas, readyReplicas, availableReplicas, unavailableReplicas, terminatingReplicas)
+		return lastErr == nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", lastErr, err)
+	}
+	return nil
+}
+
 // Verify all replicas fields of DeploymentStatus have desired count.
 // Immediately return an error when found a non-matching replicas field.
 func (d *deploymentTester) checkDeploymentStatusReplicasFields(replicas, updatedReplicas, readyReplicas, availableReplicas, unavailableReplicas int32, terminatingReplicas *int32) error {
@@ -456,6 +526,33 @@ func (d *deploymentTester) checkDeploymentStatusReplicasFields(replicas, updated
 	}
 	if !ptr.Equal(deployment.Status.TerminatingReplicas, terminatingReplicas) {
 		return fmt.Errorf("unexpected .terminatingReplicas: expect %v, got %v", ptr.Deref(terminatingReplicas, -1), ptr.Deref(deployment.Status.TerminatingReplicas, -1))
+
 	}
+	return nil
+}
+
+func (d *deploymentTester) removeRSPods(ctx context.Context, replicaset *apps.ReplicaSet, count int, targetOnlyTerminating bool, gracePeriodSeconds int64) error {
+	selector, err := metav1.LabelSelectorAsSelector(replicaset.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("could not parse a selector for a replica set %q: %w", replicaset.Name, err)
+	}
+	pods, err := d.c.CoreV1().Pods(replicaset.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return fmt.Errorf("failed to get pods for a replica set %q: %w", replicaset.Name, err)
+	}
+
+	for i, pod := range pods.Items {
+		if i >= count {
+			break
+		}
+		if targetOnlyTerminating && pod.DeletionTimestamp == nil {
+			continue
+		}
+		err := d.c.CoreV1().Pods(replicaset.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To(gracePeriodSeconds)})
+		if err != nil {
+			return fmt.Errorf("failed to delete pod %q for a replica set %q: %w", pod.Name, replicaset.Name, err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds integration tests for Recreate and RollingUpdate strategies, and scaling to properly test pod replacement.

It uses DeploymentReplicaSetTerminatingReplicas feature to test the number of terminating replicas.

It increases ./pkg/controller/deployment integration test coverage

```
progress.go 79.1% -> 80.6%
recreate.go 54.2% -> 81.2%
```

I also ran `stress` on these new tests for couple of hours.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

tracking issue: https://github.com/kubernetes/enhancements/issues/3973

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
