### PR TITLE
[DRA] Fix unexpected errors on ResourceClaim strategy update

### DIFF
--- a/pkg/api/resourceclaimspec/util.go
+++ b/pkg/api/resourceclaimspec/util.go
@@ -135,8 +135,8 @@ func dropDisabledDRAResourceClaimConsumableCapacityFields(new, old *resource.Res
 		return
 	}
 
-	for _, constaint := range new.Devices.Constraints {
-		constaint.DistinctAttribute = nil
+	for i := range new.Devices.Constraints {
+		new.Devices.Constraints[i].DistinctAttribute = nil
 	}
 
 	for i := range new.Devices.Requests {

--- a/pkg/registry/resource/resourceclaim/strategy_test.go
+++ b/pkg/registry/resource/resourceclaim/strategy_test.go
@@ -152,39 +152,6 @@ var objWithAdminAccessInNonAdminNamespace = &resource.ResourceClaim{
 	},
 }
 
-var objStatusInNonAdminNamespace = &resource.ResourceClaim{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "valid-claim",
-		Namespace: "default",
-	},
-	Spec: resource.ResourceClaimSpec{
-		Devices: resource.DeviceClaim{
-			Requests: []resource.DeviceRequest{
-				{
-					Name: "req-0",
-					Exactly: &resource.ExactDeviceRequest{
-						DeviceClassName: "class",
-						AllocationMode:  resource.DeviceAllocationModeAll,
-					},
-				},
-			},
-		},
-	},
-	Status: resource.ResourceClaimStatus{
-		Allocation: &resource.AllocationResult{
-			Devices: resource.DeviceAllocationResult{
-				Results: []resource.DeviceRequestAllocationResult{
-					{
-						Request: "req-0",
-						Driver:  "dra.example.com",
-						Pool:    "pool-0",
-						Device:  "device-0",
-					},
-				},
-			},
-		},
-	},
-}
 var objWithAdminAccessStatusInNonAdminNamespace = &resource.ResourceClaim{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "valid-claim",
@@ -245,7 +212,7 @@ var objWithDeviceTaints = &resource.ResourceClaim{
 var objWithPrioritizedList = &resource.ResourceClaim{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "valid-claim",
-		Namespace: "default",
+		Namespace: "kube-system",
 	},
 	Spec: resource.ResourceClaimSpec{
 		Devices: resource.DeviceClaim{
@@ -269,7 +236,7 @@ var objWithPrioritizedList = &resource.ResourceClaim{
 var objWithDeviceTaintsInPrioritizedList = &resource.ResourceClaim{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "valid-claim",
-		Namespace: "default",
+		Namespace: "kube-system",
 	},
 	Spec: resource.ResourceClaimSpec{
 		Devices: resource.DeviceClaim{
@@ -363,6 +330,31 @@ var objWithDeviceBindingConditions = &resource.ResourceClaim{
 	},
 }
 
+var objWithCapacityRequests = &resource.ResourceClaim{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "valid-claim",
+		Namespace: "kube-system",
+	},
+	Spec: resource.ResourceClaimSpec{
+		Devices: resource.DeviceClaim{
+			Requests: []resource.DeviceRequest{
+				{
+					Name: "req-0",
+					Exactly: &resource.ExactDeviceRequest{
+						DeviceClassName: "class",
+						AllocationMode:  resource.DeviceAllocationModeAll,
+						Capacity: &resource.CapacityRequirements{
+							Requests: map[resource.QualifiedName]apiresource.Quantity{
+								resource.QualifiedName("test-capacity"): apiresource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
 var ns1 = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:   "default",
@@ -380,13 +372,17 @@ var adminAccessError = "Forbidden: admin access to devices requires the `resourc
 var fieldImmutableError = "field is immutable"
 var metadataError = "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
 var deviceRequestError = "exactly one of `exactly` or `firstAvailable` is required"
+var constraintError = "matchAttribute: Required value"
 
 const (
+	req0        = "req-0"
+	subReq0     = "subreq-0"
+	req0SubReq0 = "req-0/subreq-0"
+
 	testRequest = "test-request"
 	testDriver  = "test-driver"
 	testPool    = "test-pool"
 	testDevice  = "test-device"
-	testClass   = "test-class"
 )
 
 var (
@@ -396,12 +392,6 @@ var (
 var testCapacity = map[resource.QualifiedName]apiresource.Quantity{
 	resource.QualifiedName("test-capacity"): apiresource.MustParse("1"),
 }
-
-var objWithCapacityRequests = func() *resource.ResourceClaim {
-	obj := obj.DeepCopy()
-	addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-	return obj
-}()
 
 func TestStrategy(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()
@@ -582,11 +572,22 @@ func TestStrategyCreate(t *testing.T) {
 		"drop-fields-consumable-capacity-disabled-feature": {
 			obj:                objWithCapacityRequests,
 			consumableCapacity: false,
-			expectObj: func() *resource.ResourceClaim {
+			expectObj:          obj,
+			verify: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 0 {
+					t.Errorf("expected no action to be taken")
+				}
+			},
+		},
+		"drop-fields-consumable-capacity-disabled-feature-with-distinct-attribute": {
+			obj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, nil, false)
+				modifySpecDeviceRequestWithCapacityRequests(obj, nil, false)
+				addDistinctAttribute(obj)
 				return obj
 			}(),
+			consumableCapacity:    false,
+			expectValidationError: constraintError,
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -595,15 +596,15 @@ func TestStrategyCreate(t *testing.T) {
 		},
 		"drop-fields-consumable-capacity-disabled-feature-with-prioritized-list": {
 			obj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, true)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, true)
 				return obj
 			}(),
 			consumableCapacity: false,
 			prioritizedList:    true,
 			expectObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, nil, true)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, nil, true)
 				return obj
 			}(),
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -629,6 +630,10 @@ func TestStrategyCreate(t *testing.T) {
 			obj := tc.obj.DeepCopy()
 			strategy.PrepareForCreate(ctx, obj)
 			if errs := strategy.Validate(ctx, obj); len(errs) != 0 {
+				if tc.expectValidationError == "" {
+					t.Fatalf("unexpected error(s): %v", errs)
+				}
+				assert.Len(t, errs, 1, "exactly one error expected")
 				assert.ErrorContains(t, errs[0], tc.expectValidationError, "the error message should have contained the expected error message")
 				return
 			}
@@ -782,7 +787,7 @@ func TestStrategyUpdate(t *testing.T) {
 			},
 		},
 		"keep-existing-fields-consumable-capacity": {
-			oldObj:             obj,
+			oldObj:             objWithCapacityRequests,
 			newObj:             objWithCapacityRequests,
 			consumableCapacity: true,
 			expectObj:          objWithCapacityRequests,
@@ -809,7 +814,7 @@ func TestStrategyUpdate(t *testing.T) {
 			consumableCapacity: false,
 			expectObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, nil, false)
+				modifySpecDeviceRequestWithCapacityRequests(obj, nil, false)
 				return obj
 			}(),
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -820,16 +825,20 @@ func TestStrategyUpdate(t *testing.T) {
 		},
 		"drop-fields-consumable-capacity-disabled-feature-with-prioritized-list": {
 			oldObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, nil, true)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, nil, true)
 				return obj
 			}(),
-			newObj:             objWithCapacityRequests,
+			newObj: func() *resource.ResourceClaim {
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, true)
+				return obj
+			}(),
 			consumableCapacity: false,
 			prioritizedList:    true,
 			expectObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, nil, true)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, nil, true)
 				return obj
 			}(),
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -956,6 +965,10 @@ func TestStrategyUpdate(t *testing.T) {
 
 			strategy.PrepareForUpdate(ctx, newObj, oldObj)
 			if errs := strategy.ValidateUpdate(ctx, newObj, oldObj); len(errs) != 0 {
+				if tc.expectValidationError == "" {
+					t.Fatalf("unexpected error(s): %v", errs)
+				}
+				assert.Len(t, errs, 1, "exactly one error expected")
 				assert.ErrorContains(t, errs[0], tc.expectValidationError, "the error message should have contained the expected error message")
 				return
 			}
@@ -1062,7 +1075,7 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			},
 		},
 		"keep-fields-admin-access-NonAdminNamespace": {
-			oldObj:                objStatusInNonAdminNamespace,
+			oldObj:                objInNonAdminNamespace,
 			newObj:                objWithAdminAccessStatusInNonAdminNamespace,
 			adminAccess:           true,
 			expectValidationError: adminAccessError,
@@ -1264,13 +1277,8 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			deviceStatusFeatureGate: true,
 		},
 		"keep-exist-fields-disable-bindingconditions-feature-gate": {
-			oldObj: objWithDeviceBindingConditions,
-			newObj: func() *resource.ResourceClaim {
-				obj := objWithDeviceBindingConditions.DeepCopy()
-				obj.Status.Allocation.Devices.Results[0].BindingConditions = nil
-				obj.Status.Allocation.Devices.Results[0].BindingFailureConditions = nil
-				return obj
-			}(),
+			oldObj:    objWithDeviceBindingConditions,
+			newObj:    objWithDeviceBindingConditions,
 			expectObj: objWithDeviceBindingConditions,
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
@@ -1319,14 +1327,16 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		"keep-fields-consumable-capacity-with-device-status": {
 			oldObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				return obj
 			}(),
 			newObj: func() *resource.ResourceClaim { // Status is added with share id and consumed capacities
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1335,8 +1345,9 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			prioritizedListFeatureGate:    false,
 			expectObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1349,14 +1360,16 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		"keep-fields-consumable-capacity-disabled-feature-gate-with-device-status": {
 			oldObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				return obj
 			}(),
 			newObj: func() *resource.ResourceClaim { // Status is added with share id and consumed capacities
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1364,8 +1377,9 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			consumableCapacityFeatureGate: false,
 			expectObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1378,14 +1392,16 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		"keep-fields-consumable-capacity-with-device-status-disabled-feature-gate": {
 			oldObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				return obj
 			}(),
 			newObj: func() *resource.ResourceClaim { // Status should not be added
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1393,8 +1409,9 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			consumableCapacityFeatureGate: true,
 			expectObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				return obj
 			}(),
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -1405,14 +1422,16 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		},
 		"keep-fields-consumable-capacity-with-device-status-with-prioritized-list-disabled-feature-gate": {
 			oldObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, true)
+				addDistinctAttribute(obj)
 				return obj
 			}(),
 			newObj: func() *resource.ResourceClaim { // Status is added with share id and consumed capacities but FirstAvailable should not be set
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, true)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, true)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0SubReq0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1420,9 +1439,10 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			consumableCapacityFeatureGate: true,
 			prioritizedListFeatureGate:    false,
 			expectObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, true)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0SubReq0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1435,18 +1455,18 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		"drop-fields-consumable-capacity-disabled-feature-gate": {
 			oldObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
+				addSpecDevicesRequest(obj, req0)
 				return obj
 			}(),
 			newObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
 				return obj
 			}(),
 			consumableCapacityFeatureGate: false,
 			expectObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
+				addSpecDevicesRequest(obj, req0)
 				return obj
 			}(),
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -1456,23 +1476,16 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			},
 		},
 		"drop-fields-consumable-capacity-disabled-feature-gate-with-prioritized-list": {
-			oldObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
-				return obj
-			}(),
+			oldObj: objWithPrioritizedList,
 			newObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, true)
+				obj := objWithPrioritizedList.DeepCopy()
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, true)
+				addDistinctAttribute(obj)
 				return obj
 			}(),
 			prioritizedListFeatureGate:    true,
 			consumableCapacityFeatureGate: false,
-			expectObj: func() *resource.ResourceClaim {
-				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
-				return obj
-			}(),
+			expectObj:                     objWithPrioritizedList,
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -1482,13 +1495,14 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		"drop-fields-consumable-capacity-disabled-feature-gate-with-device-status": {
 			oldObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
+				addSpecDevicesRequest(obj, req0)
 				return obj
 			}(),
 			newObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDeviceRequestWithCapacityRequests(obj, testRequest, testClass, testCapacity, false)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, testShareID, testCapacity)
+				modifySpecDeviceRequestWithCapacityRequests(obj, testCapacity, false)
+				addDistinctAttribute(obj)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, testShareID, testCapacity)
 				addStatusDevices(obj, testDriver, testPool, testDevice, testShareID)
 				return obj
 			}(),
@@ -1496,8 +1510,8 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			consumableCapacityFeatureGate: false,
 			expectObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, nil, nil)
+				addSpecDevicesRequest(obj, req0)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, nil, nil)
 				addStatusDevices(obj, testDriver, testPool, testDevice, nil)
 				return obj
 			}(),
@@ -1510,13 +1524,13 @@ func TestStatusStrategyUpdate(t *testing.T) {
 		"drop-fields-consumable-capacity-disabled-feature-gate-with-device-status-default-shareid": {
 			oldObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
+				addSpecDevicesRequest(obj, req0)
 				return obj
 			}(),
 			newObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, nil, nil)
+				addSpecDevicesRequest(obj, req0)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, nil, nil)
 				addStatusDevices(obj, testDriver, testPool, testDevice, nil)
 				return obj
 			}(),
@@ -1524,8 +1538,8 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			consumableCapacityFeatureGate: false,
 			expectObj: func() *resource.ResourceClaim {
 				obj := obj.DeepCopy()
-				addSpecDevicesRequest(obj, testRequest)
-				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, testRequest, nil, nil)
+				addSpecDevicesRequest(obj, req0)
+				addStatusAllocationDevicesResults(obj, testDriver, testPool, testDevice, req0, nil, nil)
 				addStatusDevices(obj, testDriver, testPool, testDevice, nil)
 				return obj
 			}(),
@@ -1562,6 +1576,10 @@ func TestStatusStrategyUpdate(t *testing.T) {
 
 			statusStrategy.PrepareForUpdate(ctx, newObj, oldObj)
 			if errs := statusStrategy.ValidateUpdate(ctx, newObj, oldObj); len(errs) != 0 {
+				if tc.expectValidationError == "" {
+					t.Fatalf("unexpected error(s): %v", errs)
+				}
+				assert.Len(t, errs, 1, "exactly one error expected")
 				assert.ErrorContains(t, errs[0], tc.expectValidationError, "the error message should have contained the expected error message")
 				return
 			}
@@ -1587,40 +1605,26 @@ func addSpecDevicesRequest(resourceClaim *resource.ResourceClaim, request string
 	})
 }
 
-func addSpecDeviceRequestWithCapacityRequests(resourceClaim *resource.ResourceClaim,
-	request, class string, capacity map[resource.QualifiedName]apiresource.Quantity, prioritizedListFeature bool) {
-	r := resource.DeviceRequest{
-		Name: request,
-		Exactly: &resource.ExactDeviceRequest{
-			DeviceClassName: class,
-			AllocationMode:  resource.DeviceAllocationModeAll,
-		},
-	}
-	distinctConstraint := resource.DeviceConstraint{
-		Requests:          []string{request},
-		DistinctAttribute: ptr.To(resource.FullyQualifiedName("")),
-	}
-	if prioritizedListFeature {
-		r.FirstAvailable = []resource.DeviceSubRequest{
-			{
-				Name:            testRequest,
-				DeviceClassName: class,
-				AllocationMode:  resource.DeviceAllocationModeExactCount,
-				Count:           1,
-			},
-		}
-	}
+func modifySpecDeviceRequestWithCapacityRequests(resourceClaim *resource.ResourceClaim,
+	capacity map[resource.QualifiedName]apiresource.Quantity, prioritizedListFeature bool) {
 	if capacity != nil {
-		r.Exactly.Capacity = &resource.CapacityRequirements{
-			Requests: capacity,
-		}
 		if prioritizedListFeature {
-			r.FirstAvailable[0].Capacity = &resource.CapacityRequirements{
+			resourceClaim.Spec.Devices.Requests[0].FirstAvailable[0].Capacity = &resource.CapacityRequirements{
+				Requests: capacity,
+			}
+		} else {
+			resourceClaim.Spec.Devices.Requests[0].Exactly.Capacity = &resource.CapacityRequirements{
 				Requests: capacity,
 			}
 		}
 	}
-	resourceClaim.Spec.Devices.Requests = append(resourceClaim.Spec.Devices.Requests, r)
+}
+
+func addDistinctAttribute(resourceClaim *resource.ResourceClaim) {
+	distinctConstraint := resource.DeviceConstraint{
+		Requests:          []string{req0},
+		DistinctAttribute: ptr.To(resource.FullyQualifiedName("driver-a/attr")),
+	}
 	resourceClaim.Spec.Devices.Constraints = append(resourceClaim.Spec.Devices.Constraints, distinctConstraint)
 }
 

--- a/pkg/registry/resource/resourceclaimtemplate/strategy_test.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy_test.go
@@ -150,7 +150,7 @@ var objWithDeviceTaints = &resource.ResourceClaimTemplate{
 var objWithPrioritizedList = &resource.ResourceClaimTemplate{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "valid-claim-template",
-		Namespace: "default",
+		Namespace: "kube-system",
 	},
 	Spec: resource.ResourceClaimTemplateSpec{
 		Spec: resource.ResourceClaimSpec{
@@ -186,11 +186,7 @@ var objWithCapacityRequests = func() *resource.ResourceClaimTemplate {
 func addSpecDeviceRequestWithCapacityRequests(resourceClaimTemplate *resource.ResourceClaimTemplate,
 	capacity map[resource.QualifiedName]apiresource.Quantity, prioritizedListFeature bool) {
 	r := resource.DeviceRequest{
-		Name: "req-0",
-		Exactly: &resource.ExactDeviceRequest{
-			DeviceClassName: "class",
-			AllocationMode:  resource.DeviceAllocationModeAll,
-		},
+		Name: "cap-req-0",
 	}
 	if prioritizedListFeature {
 		r.FirstAvailable = []resource.DeviceSubRequest{
@@ -201,13 +197,19 @@ func addSpecDeviceRequestWithCapacityRequests(resourceClaimTemplate *resource.Re
 				Count:           1,
 			},
 		}
+	} else {
+		r.Exactly = &resource.ExactDeviceRequest{
+			DeviceClassName: "class",
+			AllocationMode:  resource.DeviceAllocationModeAll,
+		}
 	}
 	if capacity != nil {
-		r.Exactly.Capacity = &resource.CapacityRequirements{
-			Requests: capacity,
-		}
 		if prioritizedListFeature {
 			r.FirstAvailable[0].Capacity = &resource.CapacityRequirements{
+				Requests: capacity,
+			}
+		} else {
+			r.Exactly.Capacity = &resource.CapacityRequirements{
 				Requests: capacity,
 			}
 		}
@@ -218,7 +220,7 @@ func addSpecDeviceRequestWithCapacityRequests(resourceClaimTemplate *resource.Re
 var objWithDeviceTaintsInPrioritizedList = &resource.ResourceClaimTemplate{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "valid-claim-template",
-		Namespace: "default",
+		Namespace: "kube-system",
 	},
 	Spec: resource.ResourceClaimTemplateSpec{
 		Spec: resource.ResourceClaimSpec{
@@ -475,15 +477,20 @@ func TestClaimTemplateStrategyCreate(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(ns1, ns2)
 			mockNSClient := fakeClient.CoreV1().Namespaces()
 			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-				features.DRAAdminAccess:     tc.adminAccess,
-				features.DRADeviceTaints:    tc.deviceTaints,
-				features.DRAPrioritizedList: tc.prioritizedList,
+				features.DRAAdminAccess:        tc.adminAccess,
+				features.DRADeviceTaints:       tc.deviceTaints,
+				features.DRAPrioritizedList:    tc.prioritizedList,
+				features.DRAConsumableCapacity: tc.consumableCapacity,
 			})
 			strategy := NewStrategy(mockNSClient)
 
 			obj := tc.obj.DeepCopy()
 			strategy.PrepareForCreate(ctx, obj)
 			if errs := strategy.Validate(ctx, obj); len(errs) != 0 {
+				if tc.expectValidationError == "" {
+					t.Fatalf("unexpected error(s): %v", errs)
+				}
+				assert.Len(t, errs, 1, "exactly one error expected")
 				assert.ErrorContains(t, errs[0], tc.expectValidationError, "the error message should have contained the expected error message")
 				return
 			}
@@ -555,6 +562,9 @@ func TestClaimTemplateStrategyUpdate(t *testing.T) {
 		strategy.PrepareForUpdate(ctx, newClaimTemplate, resourceClaimTemplate)
 		errs := strategy.ValidateUpdate(ctx, newClaimTemplate, resourceClaimTemplate)
 		if len(errs) != 0 {
+			if fieldImmutableError == "" {
+				t.Fatalf("unexpected error(s): %v", errs)
+			}
 			assert.ErrorContains(t, errs[0], fieldImmutableError, "the error message should have contained the expected error message")
 			return
 		}
@@ -570,14 +580,14 @@ func TestClaimTemplateStrategyUpdate(t *testing.T) {
 func TestStrategyUpdate(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	testcases := map[string]struct {
-		oldObj                *resource.ResourceClaimTemplate
-		newObj                *resource.ResourceClaimTemplate
-		adminAccess           bool
-		deviceTaints          bool
-		prioritizedList       bool
-		expectValidationError string
-		expectObj             *resource.ResourceClaimTemplate
-		verify                func(*testing.T, []testclient.Action)
+		oldObj                 *resource.ResourceClaimTemplate
+		newObj                 *resource.ResourceClaimTemplate
+		adminAccess            bool
+		deviceTaints           bool
+		prioritizedList        bool
+		expectValidationErrors []string
+		expectObj              *resource.ResourceClaimTemplate
+		verify                 func(*testing.T, []testclient.Action)
 	}{
 		"no-changes-okay": {
 			oldObj:    obj,
@@ -596,7 +606,7 @@ func TestStrategyUpdate(t *testing.T) {
 				obj.Name += "-2"
 				return obj
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -615,10 +625,10 @@ func TestStrategyUpdate(t *testing.T) {
 			},
 		},
 		"keep-fields-admin-access": {
-			oldObj:                obj,
-			newObj:                objWithAdminAccess,
-			adminAccess:           true,
-			expectValidationError: fieldImmutableError, // Spec is immutable.
+			oldObj:                 obj,
+			newObj:                 objWithAdminAccess,
+			adminAccess:            true,
+			expectValidationErrors: []string{fieldImmutableError}, // Spec is immutable.
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -648,10 +658,10 @@ func TestStrategyUpdate(t *testing.T) {
 			},
 		},
 		"admin-access-non-admin-namespace": {
-			oldObj:                objInNonAdminNamespace,
-			newObj:                objWithAdminAccessInNonAdminNamespace,
-			adminAccess:           true,
-			expectValidationError: fieldImmutableError,
+			oldObj:                 objInNonAdminNamespace,
+			newObj:                 objWithAdminAccessInNonAdminNamespace,
+			adminAccess:            true,
+			expectValidationErrors: []string{fieldImmutableError},
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -659,10 +669,10 @@ func TestStrategyUpdate(t *testing.T) {
 			},
 		},
 		"drop-fields-prioritized-list": {
-			oldObj:                obj,
-			newObj:                objWithPrioritizedList,
-			prioritizedList:       false,
-			expectValidationError: deviceRequestError,
+			oldObj:                 obj,
+			newObj:                 objWithPrioritizedList,
+			prioritizedList:        false,
+			expectValidationErrors: []string{deviceRequestError, fieldImmutableError},
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -670,10 +680,10 @@ func TestStrategyUpdate(t *testing.T) {
 			},
 		},
 		"keep-fields-prioritized-list": {
-			oldObj:                obj,
-			newObj:                objWithPrioritizedList,
-			prioritizedList:       true,
-			expectValidationError: fieldImmutableError, // Spec is immutable.
+			oldObj:                 obj,
+			newObj:                 objWithPrioritizedList,
+			prioritizedList:        true,
+			expectValidationErrors: []string{fieldImmutableError}, // Spec is immutable.
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -715,11 +725,11 @@ func TestStrategyUpdate(t *testing.T) {
 			},
 		},
 		"keep-fields-device-taints": {
-			oldObj:                obj,
-			newObj:                objWithDeviceTaints,
-			deviceTaints:          true,
-			prioritizedList:       true,
-			expectValidationError: fieldImmutableError, // Spec is immutable, cannot add tolerations.
+			oldObj:                 obj,
+			newObj:                 objWithDeviceTaints,
+			deviceTaints:           true,
+			prioritizedList:        true,
+			expectValidationErrors: []string{fieldImmutableError}, // Spec is immutable, cannot add tolerations.
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -763,11 +773,11 @@ func TestStrategyUpdate(t *testing.T) {
 			},
 		},
 		"keep-fields-device-taints-in-prioritized-list": {
-			oldObj:                objWithPrioritizedList,
-			newObj:                objWithDeviceTaintsInPrioritizedList,
-			deviceTaints:          true,
-			prioritizedList:       true,
-			expectValidationError: fieldImmutableError, // Spec is immutable, cannot add tolerations.
+			oldObj:                 objWithPrioritizedList,
+			newObj:                 objWithDeviceTaintsInPrioritizedList,
+			deviceTaints:           true,
+			prioritizedList:        true,
+			expectValidationErrors: []string{fieldImmutableError}, // Spec is immutable, cannot add tolerations.
 			verify: func(t *testing.T, as []testclient.Action) {
 				if len(as) != 0 {
 					t.Errorf("expected no action to be taken")
@@ -815,11 +825,16 @@ func TestStrategyUpdate(t *testing.T) {
 			newObj.ResourceVersion = "4"
 
 			strategy.PrepareForUpdate(ctx, newObj, oldObj)
+			expectedErrLen := len(tc.expectValidationErrors)
 			if errs := strategy.ValidateUpdate(ctx, newObj, oldObj); len(errs) != 0 {
-				assert.ErrorContains(t, errs[0], tc.expectValidationError, "the error message should have contained the expected error message")
-				return
+				if assert.Len(t, errs, expectedErrLen, "exact number of errors expected") {
+					for i, expectErr := range tc.expectValidationErrors {
+						assert.ErrorContains(t, errs[i], expectErr, "the error message should have contained the expected error message")
+					}
+					return
+				}
 			}
-			if tc.expectValidationError != "" {
+			if expectedErrLen > 0 {
 				t.Fatal("expected validation error(s), got none")
 			}
 			if warnings := strategy.WarningsOnUpdate(ctx, newObj, oldObj); len(warnings) != 0 {


### PR DESCRIPTION
- Fix unexpected error (immutable field, constraint validation)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

    - Fix setting distinctAttribute=nil when DRAConsumableCapacity is disabled
    - Add must have no error check when no error expected in strategy test
    - Update test case that causes unexpected errors


~~This PR corrects the matchesAttribute of distinctAttributeConstraint to use value instead of pointer and remove the following missing drop field implementation test in ResourceClaim strategy on DeviceBindingConditions: drop-fields-binding-conditions, drop-fields-binding-conditions-disable-feature-gate, drop-fields-binding-conditions-disable-binding-conditions-feature-gate~~ -> No longer valid, rebased.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/134961

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Fix setting distinctAttribute=nil when DRAConsumableCapacity is disabled
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
