### PR TITLE
[DRA] Add dropDeviceBindingConditionsFields and fix immutable field on DeviceBindingConditions strategy test

### DIFF
--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -237,6 +237,7 @@ func dropDisabledStatusFields(newClaim, oldClaim *resource.ResourceClaim) {
 	dropDisabledDRAResourceClaimDeviceStatusFields(newClaim, oldClaim)
 	dropDisabledDRAAdminAccessStatusFields(newClaim, oldClaim)
 	dropDisabledDRAResourceClaimConsumableCapacityStatusFields(newClaim, oldClaim)
+	dropDeviceBindingConditionsFields(newClaim, oldClaim)
 }
 
 func dropDisabledDRAAdminAccessStatusFields(newClaim, oldClaim *resource.ResourceClaim) {
@@ -373,6 +374,20 @@ func draConsumableCapacityFeatureInUse(claim *resource.ResourceClaim) bool {
 	return false
 }
 
+func draDeviceBindingConditionsInUse(claim *resource.ResourceClaim) bool {
+	if claim == nil {
+		return false
+	}
+	if allocation := claim.Status.Allocation; allocation != nil {
+		for _, result := range allocation.Devices.Results {
+			if result.BindingConditions != nil || result.BindingFailureConditions != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // dropDisabledDRAResourceClaimConsumableCapacityStatusFields drops any new feature fields
 // from the newClaim status if they were not used in the oldClaim.
 func dropDisabledDRAResourceClaimConsumableCapacityStatusFields(newClaim, oldClaim *resource.ResourceClaim) {
@@ -392,6 +407,23 @@ func dropDisabledDRAResourceClaimConsumableCapacityStatusFields(newClaim, oldCla
 	if devices := newClaim.Status.Devices; devices != nil {
 		for i := range devices {
 			newClaim.Status.Devices[i].ShareID = nil
+		}
+	}
+}
+
+// dropDeviceBindingConditionsFields drops any new feature fields
+// from the newClaim status if they were not used in the oldClaim.
+func dropDeviceBindingConditionsFields(newClaim, oldClaim *resource.ResourceClaim) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceBindingConditions) ||
+		draDeviceBindingConditionsInUse(oldClaim) {
+		// No need to drop anything.
+		return
+	}
+
+	if allocation := newClaim.Status.Allocation; allocation != nil {
+		for i := range allocation.Devices.Results {
+			newClaim.Status.Allocation.Devices.Results[i].BindingConditions = nil
+			newClaim.Status.Allocation.Devices.Results[i].BindingFailureConditions = nil
 		}
 	}
 }

--- a/pkg/registry/resource/resourceclaim/strategy_test.go
+++ b/pkg/registry/resource/resourceclaim/strategy_test.go
@@ -340,7 +340,6 @@ var objWithDeviceBindingConditions = &resource.ResourceClaim{
 					Exactly: &resource.ExactDeviceRequest{
 						DeviceClassName: "class",
 						AllocationMode:  resource.DeviceAllocationModeAll,
-						AdminAccess:     ptr.To(true),
 					},
 				},
 			},
@@ -1253,7 +1252,7 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			},
 		},
 		"keep-fields-binding-conditions": {
-			oldObj:    objWithStatus,
+			oldObj:    obj,
 			newObj:    objWithDeviceBindingConditions,
 			expectObj: objWithDeviceBindingConditions,
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -1282,7 +1281,7 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			deviceStatusFeatureGate: true,
 		},
 		"drop-fields-binding-conditions": {
-			oldObj:    objWithStatus,
+			oldObj:    obj,
 			newObj:    objWithDeviceBindingConditions,
 			expectObj: objWithStatus,
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -1294,7 +1293,7 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			deviceStatusFeatureGate: true,
 		},
 		"drop-fields-binding-conditions-disable-feature-gate": {
-			oldObj:    objWithStatus,
+			oldObj:    obj,
 			newObj:    objWithDeviceBindingConditions,
 			expectObj: objWithStatus,
 			verify: func(t *testing.T, as []testclient.Action) {
@@ -1306,7 +1305,7 @@ func TestStatusStrategyUpdate(t *testing.T) {
 			deviceStatusFeatureGate: false,
 		},
 		"drop-fields-binding-conditions-disable-binding-conditions-feature-gate": {
-			oldObj:    objWithStatus,
+			oldObj:    obj,
 			newObj:    objWithDeviceBindingConditions,
 			expectObj: objWithStatus,
 			verify: func(t *testing.T, as []testclient.Action) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Add the function to drop DeviceBindingConditionsFields when the previous one is not in-use and feature is disabled.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Contributes to https://github.com/kubernetes/kubernetes/issues/134961

#### Special notes for your reviewer:

Separated from the previously pushed PR https://github.com/kubernetes/kubernetes/issues/134961.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Drop DeviceBindingConditions fields if the DRADeviceBindingConditions is not enabled and not in-use
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc: @KobayashiD27  
