### PR TITLE
Fix: punctuation in gogoproto/doc.go (#134968)

### DIFF
--- a/vendor/github.com/gogo/protobuf/gogoproto/doc.go
+++ b/vendor/github.com/gogo/protobuf/gogoproto/doc.go
@@ -161,7 +161,7 @@ The most complete way to see examples is to look at
 
 	github.com/gogo/protobuf/test/thetest.proto
 
-Gogoprototest is a seperate project,
+Gogoprototest is a separate project,
 because we want to keep gogoprotobuf independent of goprotobuf,
 but we still want to test it thoroughly.
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Fixes #134968

This PR corrects a minor punctuation issue in a documentation comment located in:
`vendor/github.com/gogo/protobuf/gogoproto/doc.go`

**Before:**
```go
// Gogoprototest is a separate project,
```

**After:**
```go
// Gogoprototest is a separate project.
```

This improves readability and maintains consistency in comment style across the Kubernetes codebase.

#### Which issue(s) this PR is related to:
Fixes #134968

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

