### PR TITLE
DRA: test improvements

### DIFF
--- a/test/integration/dra/helpers_test.go
+++ b/test/integration/dra/helpers_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/ptr"
+)
+
+// must can be wrapped around a Create/Update/Patch/Get/Delete call and handles the error checking:
+//
+//	pod = must(tCtx, tCtx.Client().CoreV1().Pods(namespace).Create, pod, metav1.CreateOptions{})
+func must[R, P, O any](tCtx ktesting.TContext, call func(context.Context, P, O) (*R, error), p P, o O) *R {
+	tCtx.Helper()
+	r, err := call(tCtx, p, o)
+	tCtx.ExpectNoError(err)
+	return r
+}
+
+// createTestNamespace creates a namespace with a name that is derived from the
+// current test name:
+// - Non-alpha-numeric characters replaced by hyphen.
+// - Truncated in the middle to make it short enough for GenerateName.
+// - Hyphen plus random suffix added by the apiserver.
+func createTestNamespace(tCtx ktesting.TContext, labels map[string]string) string {
+	tCtx.Helper()
+	name := regexp.MustCompile(`[^[:alnum:]_-]`).ReplaceAllString(tCtx.Name(), "-")
+	name = strings.ToLower(name)
+	if len(name) > 63 {
+		name = name[:30] + "--" + name[len(name)-30:]
+	}
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: name + "-"}}
+	ns.Labels = labels
+	ns, err := tCtx.Client().CoreV1().Namespaces().Create(tCtx, ns, metav1.CreateOptions{})
+	tCtx.ExpectNoError(err, "create test namespace")
+	tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+		tCtx.ExpectNoError(tCtx.Client().CoreV1().Namespaces().Delete(tCtx, ns.Name, metav1.DeleteOptions{}))
+		// *Not* waiting here. Deleting namespaces is slow.
+	})
+	return ns.Name
+}
+
+// createSlice creates the given ResourceSlice and removes it when the test is done.
+func createSlice(tCtx ktesting.TContext, slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+	tCtx.Helper()
+	slice, err := tCtx.Client().ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{})
+	tCtx.ExpectNoError(err, "create ResourceSlice")
+	tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+		tCtx.Log("Cleaning up ResourceSlice...")
+		deleteAndWait(tCtx, tCtx.Client().ResourceV1().ResourceSlices().Delete, tCtx.Client().ResourceV1().ResourceSlices().Get, slice.Name)
+	})
+	return slice
+}
+
+// createTestClass creates a DeviceClass with a driver name derived from the test namespace
+func createTestClass(tCtx ktesting.TContext, namespace string) (*resourceapi.DeviceClass, string) {
+	tCtx.Helper()
+	driverName := namespace + ".driver"
+	class := class.DeepCopy()
+	class.Name = namespace + ".class"
+	class.Spec.Selectors = []resourceapi.DeviceSelector{{
+		CEL: &resourceapi.CELDeviceSelector{
+			Expression: fmt.Sprintf("device.driver == %q", driverName),
+		},
+	}}
+	_, err := tCtx.Client().ResourceV1().DeviceClasses().Create(tCtx, class, metav1.CreateOptions{})
+	tCtx.ExpectNoError(err, "create class")
+	tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+		tCtx.Log("Cleaning up DeviceClass...")
+		deleteAndWait(tCtx, tCtx.Client().ResourceV1().DeviceClasses().Delete, tCtx.Client().ResourceV1().DeviceClasses().Get, class.Name)
+	})
+
+	return class, driverName
+}
+
+// createClaim creates a claim and in the namespace.
+// The class must already exist and is used for all requests.
+func createClaim(tCtx ktesting.TContext, namespace string, suffix string, class *resourceapi.DeviceClass, claim *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
+	tCtx.Helper()
+	claim = claim.DeepCopy()
+	claim.Namespace = namespace
+	claim.Name += suffix
+	claimName := claim.Name
+	for i := range claim.Spec.Devices.Requests {
+		request := &claim.Spec.Devices.Requests[i]
+		if request.Exactly != nil && request.Exactly.DeviceClassName != "" {
+			request.Exactly.DeviceClassName = class.Name
+			continue
+		}
+		for e := range request.FirstAvailable {
+			subRequest := &request.FirstAvailable[e]
+			subRequest.DeviceClassName = class.Name
+		}
+	}
+	claim, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Create(tCtx, claim, metav1.CreateOptions{})
+	tCtx.ExpectNoError(err, "create claim "+claimName)
+	// TODO: some tests leak claims. Probably they need to be fixed... later.
+	// tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+	//		// We want to know when tearing this down gets stuck.
+	//	deleteAndWait(tCtx, tCtx.Client().ResourceV1().ResourceClaims(namespace).Delete, tCtx.Client().ResourceV1().ResourceClaims(namespace).Get, claim.Name)
+	// })
+	return claim
+}
+
+// createPod create a pod in the namespace, referencing the given claim.
+func createPod(tCtx ktesting.TContext, namespace string, suffix string, claim *resourceapi.ResourceClaim, pod *v1.Pod) *v1.Pod {
+	tCtx.Helper()
+	pod = pod.DeepCopy()
+	pod.Name += suffix
+	podName := pod.Name
+	pod.Namespace = namespace
+	pod.Spec.ResourceClaims[0].ResourceClaimName = &claim.Name
+	pod, err := tCtx.Client().CoreV1().Pods(namespace).Create(tCtx, pod, metav1.CreateOptions{})
+	tCtx.ExpectNoError(err, "create pod "+podName)
+	tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+		tCtx.Log("Cleaning up Pod...")
+		// We must delete pods before uninstalling our driver.
+		// Also, we want to know when stopping it gets stuck.
+		deleteAndWait(tCtx, tCtx.Client().CoreV1().Pods(namespace).Delete, tCtx.Client().CoreV1().Pods(namespace).Get, pod.Name)
+	})
+	return pod
+}
+
+func waitForPodScheduled(tCtx ktesting.TContext, namespace, podName string) {
+	tCtx.Helper()
+
+	ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) *v1.Pod {
+		return must(tCtx, tCtx.Client().CoreV1().Pods(namespace).Get, podName, metav1.GetOptions{})
+	}).WithTimeout(60*time.Second).Should(
+		gomega.HaveField("Status.Conditions", gomega.ContainElement(
+			gomega.And(
+				gomega.HaveField("Type", gomega.Equal(v1.PodScheduled)),
+				gomega.HaveField("Status", gomega.Equal(v1.ConditionTrue)),
+			),
+		)),
+		"Pod %s should have been scheduled.", podName,
+	)
+}
+
+func deleteAndWait[T any](tCtx ktesting.TContext, del func(context.Context, string, metav1.DeleteOptions) error, get func(context.Context, string, metav1.GetOptions) (T, error), name string) {
+	tCtx.Helper()
+
+	var t T
+	var anyT any = t
+	var options metav1.DeleteOptions
+	if _, ok := anyT.(*v1.Pod); ok {
+		// Special case for pods: we don't have a kubelet which acknowledges
+		// shutdown of a scheduled pod, so we have to force-delete.
+		options.GracePeriodSeconds = ptr.To(int64(0))
+	}
+
+	tCtx.ExpectNoError(del(tCtx, name, options), fmt.Sprintf("delete %T %s", t, name))
+	waitForNotFound(tCtx, get, name)
+}
+
+func waitForNotFound[T any](tCtx ktesting.TContext, get func(context.Context, string, metav1.GetOptions) (T, error), name string) {
+	tCtx.Helper()
+
+	var t T
+	ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) error {
+		_, err := get(tCtx, name, metav1.GetOptions{})
+		return err
+	}).WithTimeout(60*time.Second).Should(gomega.MatchError(apierrors.IsNotFound, "IsNotFound"), "Object %T %s should have been removed.", t, name)
+}

--- a/test/utils/ktesting/clientcontext.go
+++ b/test/utils/ktesting/clientcontext.go
@@ -87,7 +87,11 @@ func (cCtx clientContext) ExpectNoError(err error, explain ...interface{}) {
 }
 
 func (cCtx clientContext) Run(name string, cb func(tCtx TContext)) bool {
-	return run(cCtx, name, cb)
+	return run(cCtx, name, false, cb)
+}
+
+func (cCtx clientContext) SyncTest(name string, cb func(tCtx TContext)) bool {
+	return run(cCtx, name, true, cb)
 }
 
 func (cCtx clientContext) Logger() klog.Logger {

--- a/test/utils/ktesting/errorcontext.go
+++ b/test/utils/ktesting/errorcontext.go
@@ -173,7 +173,11 @@ func (eCtx *errorContext) ExpectNoError(err error, explain ...interface{}) {
 }
 
 func (cCtx *errorContext) Run(name string, cb func(tCtx TContext)) bool {
-	return run(cCtx, name, cb)
+	return run(cCtx, name, false, cb)
+}
+
+func (cCtx *errorContext) SyncTest(name string, cb func(tCtx TContext)) bool {
+	return run(cCtx, name, true, cb)
 }
 
 func (eCtx *errorContext) Logger() klog.Logger {

--- a/test/utils/ktesting/withcontext.go
+++ b/test/utils/ktesting/withcontext.go
@@ -107,7 +107,11 @@ func (wCtx withContext) ExpectNoError(err error, explain ...interface{}) {
 }
 
 func (cCtx withContext) Run(name string, cb func(tCtx TContext)) bool {
-	return run(cCtx, name, cb)
+	return run(cCtx, name, false, cb)
+}
+
+func (cCtx withContext) SyncTest(name string, cb func(tCtx TContext)) bool {
+	return run(cCtx, name, true, cb)
 }
 
 func (wCtx withContext) Logger() klog.Logger {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- synctest support in ktesting is going to be used in https://github.com/kubernetes/kubernetes/pull/134152
- refactoring test/integration/dra makes it cleaner

See commit messages for further details.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/134152/files#r2476223752

#### Special notes for your reviewer:

This is a blocker for device taints in 1.35. Could also be merged through that other PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @nojnhuh 