### PR TITLE
new: add kuberc aliases in kubectl help

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -86,10 +86,6 @@ func (p *Preferences) AddFlags(flags *pflag.FlagSet) {
 // Apply firstly applies the aliases in the preferences file and secondly overrides
 // the default values of flags.
 func (p *Preferences) Apply(rootCmd *cobra.Command, args []string, errOut io.Writer) ([]string, error) {
-	if len(args) <= 1 {
-		return args, nil
-	}
-
 	kubercPath, err := getExplicitKuberc(args)
 	if err != nil {
 		return args, err
@@ -184,10 +180,42 @@ func (p *Preferences) applyOverrides(rootCmd *cobra.Command, kuberc *config.Pref
 // of the command. Lastly, others parameters (e.g. resources, etc.) that are passed as arguments in kuberc
 // is appended into the command args.
 func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Preference, args []string, errOut io.Writer) ([]string, error) {
-	_, _, err := rootCmd.Find(args[1:])
+	// First, always register all aliases as commands for help display
+	for _, alias := range kuberc.Aliases {
+		p.aliases[alias.Name] = struct{}{}
+
+		// Check if alias already exists or conflicts with built-in command
+		if _, _, err := rootCmd.Find([]string{alias.Name}); err == nil {
+			continue
+		}
+
+		// Find the target command to ensure it exists
+		commands := strings.Fields(alias.Command)
+		existingCmd, _, err := rootCmd.Find(commands)
+		if err != nil {
+			continue
+		}
+
+		aliasCmd := &cobra.Command{
+			Use:    alias.Name,
+			Short:  buildFullAliasDescription(alias),
+			Run:    existingCmd.Run,
+			RunE:   existingCmd.RunE,
+			Hidden: false,
+		}
+
+		aliasCmd.Flags().AddFlagSet(existingCmd.Flags())
+		aliasCmd.PersistentFlags().AddFlagSet(existingCmd.PersistentFlags())
+		rootCmd.AddCommand(aliasCmd)
+	}
+
+	// Now handle the original aliasing logic for command execution
+	foundCmd, _, err := rootCmd.Find(args[1:])
 	if err == nil {
-		// Command is found, no need to continue for aliasing
-		return args, nil
+		// If found command is not an alias we created, no need to continue for aliasing
+		if _, isAlias := p.aliases[foundCmd.Use]; !isAlias {
+			return args, nil
+		}
 	}
 
 	var aliasArgs *aliasing
@@ -203,25 +231,32 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 
 	for _, alias := range kuberc.Aliases {
 		p.aliases[alias.Name] = struct{}{}
-		if alias.Name != commandName {
-			continue
+		// Check for conflicts with existing commands
+		foundCmd, _, err := rootCmd.Find([]string{alias.Name})
+		if err == nil {
+			if alias.Name != commandName {
+				continue
+			}
+			if foundCmd.Use != alias.Name {
+				fmt.Fprintf(errOut, "Warning: Setting alias %q to a built-in command is not supported\n", alias.Name) //nolint:errcheck
+				continue
+			}
 		}
 
-		// do not allow shadowing built-ins
-		if _, _, err := rootCmd.Find([]string{alias.Name}); err == nil {
-			fmt.Fprintf(errOut, "Warning: Setting alias %q to a built-in command is not supported\n", alias.Name)
-			break
-		}
-
+		// Find the target command to ensure it exists
 		commands := strings.Fields(alias.Command)
 		existingCmd, flags, err := rootCmd.Find(commands)
 		if err != nil {
-			return args, fmt.Errorf("command %q not found to set alias %q: %v", alias.Command, alias.Name, flags)
+			if alias.Name == commandName {
+				return args, fmt.Errorf("command %q not found to set alias %q: %v", alias.Command, alias.Name, flags)
+			}
+			continue
 		}
 
 		newCmd := *existingCmd
 		newCmd.Use = alias.Name
 		newCmd.Aliases = []string{}
+		newCmd.Short = buildFullAliasDescription(alias)
 		aliasCmd := &newCmd
 
 		if alias.Name == commandName {
@@ -239,6 +274,11 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 			// pursue with the current behavior.
 			// This might be a built-in command, external plugin, etc.
 			return args, nil
+		}
+		aliasCmd.Flags().AddFlagSet(existingCmd.Flags())
+		aliasCmd.PersistentFlags().AddFlagSet(existingCmd.PersistentFlags())
+		if _, _, err := rootCmd.Find([]string{alias.Name}); err != nil {
+			rootCmd.AddCommand(aliasCmd)
 		}
 
 		rootCmd.AddCommand(aliasArgs.command)
@@ -303,7 +343,6 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 		aliasArgs.command.Annotations[KubeRCOriginalCommandAnnotation] = aliasArgs.originalCommand.String()
 		aliasArgs.originalCommand.Reset()
 	}
-
 	return args, nil
 }
 
@@ -437,6 +476,25 @@ func searchInArgs(flagName string, shorthand string, allShorthands map[string]st
 		}
 	}
 	return false
+}
+
+// buildFullAliasDescription creates a description showing the full expanded command
+// including prependArgs, appendArgs, and default flag values
+func buildFullAliasDescription(alias config.AliasOverride) string {
+	parts := []string{alias.Command}
+
+	if len(alias.PrependArgs) > 0 {
+		parts = append(parts, alias.PrependArgs...)
+	}
+	for _, option := range alias.Options {
+		parts = append(parts, fmt.Sprintf("--%s=%s", option.Name, option.Default))
+	}
+	if len(alias.AppendArgs) > 0 {
+		parts = append(parts, alias.AppendArgs...)
+	}
+	fullCommand := strings.Join(parts, " ")
+	description := fmt.Sprintf("Alias for '%s'", fullCommand)
+	return description
 }
 
 func validate(plugin *config.Preference) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig cli

#### What this PR does / why we need it:

Kuberc aliases now appear in kubectl help, making them discoverable. The tool processes aliases even for help commands, registers them for display, and shows full command expansions (e.g., "Alias for 'get namespace --output=json'").

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1740

#### Special notes for your reviewer:

With the following kuberc

```yaml
apiVersion: kubectl.config.k8s.io/v1alpha1
kind: Preference
aliases:
  - name: getdbprod
    command: get
    prependArgs:
      - pods
    flags:
      - name: selector
        default: tier=control-plane
      - name: namespace
        default: kube-system
      - name: output
        default: wide
  - name: cr
    command: create role
    prependArgs:
      - hello
    appendArgs:
      - -oyaml
    flags:
      - name: verb
        default: get
      - name: resource
        default: pods
      - name: dry-run
        default: client
```

When running `kubectl --help` we now obtain

```bash
$ kubectl --help
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/

...
Subcommands provided by plugins:

Other Commands:
  api-resources   Print the supported API resources on the server
  api-versions    Print the supported API versions on the server, in the form of "group/version"
  config          Modify kubeconfig files
  cr              Alias for 'create role hello --verb=get --resource=pods --dry-run=client -oyaml'
  getdbprod       Alias for 'get pods --selector=tier=control-plane --namespace=kube-system
--output=wide'
  plugin          Provides utilities for interacting with plugins
  version         Print the client and server version information

Usage:
  kubectl [flags] [options]

Use "kubectl <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).
```

and when using `--help` with an alias, we get:

```bash
$ kubectl cr --help
Alias for 'create role hello --verb=get --resource=pods --dry-run=client -oyaml'

Options:
    --allow-missing-template-keys=true:
        If true, ignore any errors in templates when a field or map key is missing in the
        template. Only applies to golang and jsonpath output formats.

    --dry-run='none':
        Must be "none", "server", or "client". If client strategy, only print the object that
        would be sent, without sending it. If server strategy, submit server-side request without
        persisting the resource.

    --field-manager='kubectl-create':
        Name of the manager used to track field ownership.

    -o, --output='':
        Output format. One of: (json, yaml, kyaml, name, go-template, go-template-file, template,
        templatefile, jsonpath, jsonpath-as-json, jsonpath-file).

    --resource=[]:
        Resource that the rule applies to

    --resource-name=[]:
        Resource in the white list that the rule applies to, repeat this flag for multiple items

    --save-config=false:
        If true, the configuration of current object will be saved in its annotation. Otherwise,
        the annotation will be unchanged. This flag is useful when you want to perform kubectl
        apply on this object in the future.

    --show-managed-fields=false:
        If true, keep the managedFields when printing objects in JSON or YAML format.

    --template='':
        Template string or path to template file to use when -o=go-template, -o=go-template-file.
        The template format is golang templates
        [http://golang.org/pkg/text/template/#pkg-overview].

    --validate='strict':
        Must be one of: strict (or true), warn, ignore (or false). "true" or "strict" will use a
        schema to validate the input and fail the request if invalid. It will perform server side
        validation if ServerSideFieldValidation is enabled on the api-server, but will fall back
        to less reliable client-side validation if not. "warn" will warn about unknown or
        duplicate fields without blocking the request if server-side field validation is enabled
        on the API server, and behave as "ignore" otherwise. "false" or "ignore" will not perform
        any schema validation, silently dropping any unknown or duplicate fields.

    --verb=[]:
        Verb that applies to the resources contained in the rule

Usage:
  kubectl cr [flags] [options]
```

#### Does this PR introduce a user-facing change?

```release-note
With kuberc enabled, kubectl help now shows kuberc aliases alongside plugins, making configured aliases easier to discover.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

