### PR TITLE
Job: clear status.startTime on suspend

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -660,7 +660,40 @@ func validatePodTemplateUpdate(spec, oldSpec batch.JobSpec, fldPath *field.Path,
 		oldTemplate.Labels = template.Labels                             // +k8s:verify-mutation:reason=clone
 		oldTemplate.Spec.SchedulingGates = template.Spec.SchedulingGates // +k8s:verify-mutation:reason=clone
 	}
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(template, oldTemplate, fldPath.Child("template"))...)
+	if !opts.AllowMutablePodResources {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(template, oldTemplate, fldPath.Child("template"))...)
+	} else {
+		// Only allow container resource updates when AllowMutablePodResources is true
+		allErrs = append(allErrs, validatePodResourceUpdatesOnly(template.Spec, oldTemplate.Spec, fldPath.Child("template.spec"))...)
+	}
+	return allErrs
+}
+
+// validatePodResourceUpdatesOnly will validate that only container resources are updated.
+func validatePodResourceUpdatesOnly(newPod api.PodSpec, oldPod api.PodSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Create a deep copy of the old pod spec to modify
+	oldPodCopy := oldPod.DeepCopy()
+
+	// Update container resources in the copy to match the new pod spec
+	if len(newPod.Containers) == len(oldPodCopy.Containers) {
+		for i := range newPod.Containers {
+			oldPodCopy.Containers[i].Resources = newPod.Containers[i].Resources // +k8s:verify-mutation:reason=clone
+		}
+	}
+
+	// Update init container resources in the copy to match the new pod spec
+	if len(newPod.InitContainers) == len(oldPodCopy.InitContainers) {
+		for i := range newPod.InitContainers {
+			oldPodCopy.InitContainers[i].Resources = newPod.InitContainers[i].Resources // +k8s:verify-mutation:reason=clone
+		}
+	}
+
+	// Validate that the modified copy is identical to the new pod spec
+	// This ensures only container resources were changed
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newPod, *oldPodCopy, fldPath)...)
+
 	return allErrs
 }
 
@@ -1014,6 +1047,8 @@ type JobValidationOptions struct {
 	AllowMutableSchedulingDirectives bool
 	// Require Job to have the label on batch.kubernetes.io/job-name and batch.kubernetes.io/controller-uid
 	RequirePrefixedLabels bool
+	// Allow mutable pod resources
+	AllowMutablePodResources bool
 }
 
 type JobStatusValidationOptions struct {

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -2240,6 +2241,191 @@ func TestValidateJobUpdate(t *testing.T) {
 			update: func(job *batch.Job) {
 				job.Spec.Completions = ptr.To[int32](2)
 				job.Spec.Parallelism = ptr.To[int32](3)
+			},
+		},
+		"allow container resource updates only": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: validPodTemplateSpecForGenerated,
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Template.Spec.Containers[0].Resources = api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("200m"),
+						api.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("500m"),
+						api.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				}
+			},
+			opts: JobValidationOptions{
+				AllowMutablePodResources: true,
+			},
+		},
+		"allow init container resource updates only": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: func() api.PodTemplateSpec {
+						template := getValidPodTemplateSpecForGenerated(validGeneratedSelector)
+						template.Spec.InitContainers = []api.Container{
+							podtest.MakeContainer("init-container", podtest.SetContainerResources(api.ResourceRequirements{
+								Requests: api.ResourceList{
+									api.ResourceCPU:    resource.MustParse("100m"),
+									api.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							})),
+						}
+						return template
+					}(),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Template.Spec.InitContainers[0].Resources = api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("200m"),
+						api.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Limits: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("400m"),
+						api.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}
+			},
+			opts: JobValidationOptions{
+				AllowMutablePodResources: true,
+			},
+		},
+		"allow both container and init container resource updates": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: func() api.PodTemplateSpec {
+						template := getValidPodTemplateSpecForGenerated(validGeneratedSelector)
+						template.Spec.InitContainers = []api.Container{
+							podtest.MakeContainer("init-container", podtest.SetContainerResources(api.ResourceRequirements{
+								Requests: api.ResourceList{
+									api.ResourceCPU:    resource.MustParse("100m"),
+									api.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							})),
+						}
+						return template
+					}(),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Template.Spec.Containers[0].Resources = api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("200m"),
+						api.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}
+				job.Spec.Template.Spec.InitContainers[0].Resources = api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("150m"),
+						api.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				}
+			},
+			opts: JobValidationOptions{
+				AllowMutablePodResources: true,
+			},
+		},
+		"reject container resource update with other field changes": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: validPodTemplateSpecForGenerated,
+				},
+			},
+			update: func(job *batch.Job) {
+				// Update container resources
+				job.Spec.Template.Spec.Containers[0].Resources = api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("200m"),
+						api.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}
+				// Also update another field (should cause validation failure)
+				job.Spec.Template.Spec.Containers[0].Image = "nginx:latest"
+			},
+			opts: JobValidationOptions{
+				AllowMutablePodResources: true,
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.template.spec",
+			},
+		},
+		"reject non-resource field updates when AllowMutablePodResources is true": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: validPodTemplateSpecForGenerated,
+				},
+			},
+			update: func(job *batch.Job) {
+				// Update only a non-resource field
+				job.Spec.Template.Spec.Containers[0].Image = "nginx:latest"
+			},
+			opts: JobValidationOptions{
+				AllowMutablePodResources: true,
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.template.spec",
+			},
+		},
+		"reject pod spec changes when container count differs": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: validPodTemplateSpecForGenerated,
+				},
+			},
+			update: func(job *batch.Job) {
+				// Add a new container (changes container count)
+				job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, podtest.MakeContainer("sidecar"))
+			},
+			opts: JobValidationOptions{
+				AllowMutablePodResources: true,
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.template.spec",
+			},
+		},
+		"reject pod spec changes when init container count differs": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: validPodTemplateSpecForGenerated,
+				},
+			},
+			update: func(job *batch.Job) {
+				// Add an init container (changes init container count)
+				job.Spec.Template.Spec.InitContainers = []api.Container{
+					podtest.MakeContainer("init-container"),
+				}
+			},
+			opts: JobValidationOptions{
+				AllowMutablePodResources: true,
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.template.spec",
 			},
 		},
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1040,6 +1040,9 @@ func (jm *Controller) syncJob(ctx context.Context, key string) (rErr error) {
 				if isUpdated {
 					suspendCondChanged = true
 					jm.recorder.Event(&job, v1.EventTypeNormal, "Suspended", "Job suspended")
+					if feature.DefaultFeatureGate.Enabled(features.MutablePodResourcesForSuspendedJobs) {
+						job.Status.StartTime = nil
+					}
 				}
 			} else {
 				// Job not suspended.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -2183,6 +2183,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 
 	MutableCSINodeAllocatableCount: {},
 
+	MutablePodResourcesForSuspendedJobs: {},
+
 	NFTablesProxyMode: {},
 
 	NodeInclusionPolicyInPodTopologySpread: {},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -585,6 +585,12 @@ const (
 	// update the number of volumes that can be allocated on a node
 	MutableCSINodeAllocatableCount featuregate.Feature = "MutableCSINodeAllocatableCount"
 
+	// owner: @kannon92
+	// kep: https://kep.k8s.io/5440
+	//
+	// Enables mutable pod resources for suspended Jobs, regardless of whether they have started before.
+	MutablePodResourcesForSuspendedJobs featuregate.Feature = "MutablePodResourcesForSuspendedJobs"
+
 	// owner: @danwinship
 	// kep: https://kep.k8s.io/3866
 	//
@@ -1435,6 +1441,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	MutablePodResourcesForSuspendedJobs: {
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	NFTablesProxyMode: {

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -192,6 +192,9 @@ func validationOptionsForJob(newJob, oldJob *batch.Job) batchvalidation.JobValid
 		suspended := oldJob.Spec.Suspend != nil && *oldJob.Spec.Suspend
 		notStarted := oldJob.Status.StartTime == nil
 		opts.AllowMutableSchedulingDirectives = suspended && notStarted
+		// Updating pod resources is allowed only for suspended jobs that never started before.
+		// This requires the MutableJobPodResourcesForSuspendedJobs feature gate to be enabled.
+		opts.AllowMutablePodResources = utilfeature.DefaultFeatureGate.Enabled(features.MutableJobPodResourcesForSuspendedJobs) && suspended && notStarted
 
 		// Validation should not fail jobs if they don't have the new labels.
 		// This can be removed once we have high confidence that both labels exist (1.30 at least)

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -192,9 +192,9 @@ func validationOptionsForJob(newJob, oldJob *batch.Job) batchvalidation.JobValid
 		suspended := oldJob.Spec.Suspend != nil && *oldJob.Spec.Suspend
 		notStarted := oldJob.Status.StartTime == nil
 		opts.AllowMutableSchedulingDirectives = suspended && notStarted
-		// Updating pod resources is allowed only for suspended jobs that never started before.
-		// This requires the MutableJobPodResourcesForSuspendedJobs feature gate to be enabled.
-		opts.AllowMutablePodResources = utilfeature.DefaultFeatureGate.Enabled(features.MutableJobPodResourcesForSuspendedJobs) && suspended && notStarted
+		// Updating pod resources is allowed for suspended jobs.
+		// This requires the MutablePodResourcesForSuspendedJobs feature gate to be enabled.
+		opts.AllowMutablePodResources = utilfeature.DefaultFeatureGate.Enabled(features.MutablePodResourcesForSuspendedJobs) && suspended
 
 		// Validation should not fail jobs if they don't have the new labels.
 		// This can be removed once we have high confidence that both labels exist (1.30 at least)

--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -1266,7 +1266,7 @@ func TestJobStrategy_ValidateUpdate_MutablePodResources(t *testing.T) {
 				{Type: field.ErrorTypeInvalid, Field: "spec.template"},
 			},
 		},
-		"feature gate enabled - suspended but started job resource updates rejected": {
+		"feature gate enabled - suspended but started job resource updates allowed": {
 			enableFeatureGate: true,
 			job: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1289,9 +1289,6 @@ func TestJobStrategy_ValidateUpdate_MutablePodResources(t *testing.T) {
 				job.Spec.Template.Spec.Containers[0].Resources.Requests = api.ResourceList{
 					api.ResourceCPU: resource.MustParse("200m"),
 				}
-			},
-			wantErrs: field.ErrorList{
-				{Type: field.ErrorTypeInvalid, Field: "spec.template"},
 			},
 		},
 		"feature gate enabled - suspended and not started job resource updates allowed": {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1021,6 +1021,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.35"
+- name: MutablePodResourcesForSuspendedJobs
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.35"
 - name: MutatingAdmissionPolicy
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

To avoid overriding status.startTime on Job resume, except for rare cases when the user resumes the job almost immediately after suspend.

#### Which issue(s) this PR is related to:

It was discussed on https://github.com/kubernetes/kubernetes/pull/134769
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 Job resets the  status.startTime immediately after suspend.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
