### PR TITLE
feat: wire cisinode group for declarative validation

### DIFF
--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type CSINode
+	scheme.AddValidationFunc((*storagev1.CSINode)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_CSINode(ctx, op, nil /* fldPath */, obj.(*storagev1.CSINode), safe.Cast[*storagev1.CSINode](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type StorageClass
 	scheme.AddValidationFunc((*storagev1.StorageClass)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -56,6 +64,74 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_CSINode validates an instance of CSINode according
+// to declarative validation rules in the API schema.
+func Validate_CSINode(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.CSINode) (errs field.ErrorList) {
+	// field storagev1.CSINode.TypeMeta has no validation
+	// field storagev1.CSINode.ObjectMeta has no validation
+
+	// field storagev1.CSINode.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1.CSINodeSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CSINodeSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1.CSINode) *storagev1.CSINodeSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_CSINodeDriver validates an instance of CSINodeDriver according
+// to declarative validation rules in the API schema.
+func Validate_CSINodeDriver(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.CSINodeDriver) (errs field.ErrorList) {
+	// field storagev1.CSINodeDriver.Name has no validation
+
+	// field storagev1.CSINodeDriver.NodeID
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("nodeID"), &obj.NodeID, safe.Field(oldObj, func(oldObj *storagev1.CSINodeDriver) *string { return &oldObj.NodeID }), oldObj != nil)...)
+
+	// field storagev1.CSINodeDriver.TopologyKeys has no validation
+	// field storagev1.CSINodeDriver.Allocatable has no validation
+	return errs
+}
+
+// Validate_CSINodeSpec validates an instance of CSINodeSpec according
+// to declarative validation rules in the API schema.
+func Validate_CSINodeSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.CSINodeSpec) (errs field.ErrorList) {
+	// field storagev1.CSINodeSpec.Drivers
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []storagev1.CSINodeDriver, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CSINodeDriver)...)
+			return
+		}(fldPath.Child("drivers"), obj.Drivers, safe.Field(oldObj, func(oldObj *storagev1.CSINodeSpec) []storagev1.CSINodeDriver { return oldObj.Drivers }), oldObj != nil)...)
+
+	return errs
 }
 
 // Validate_StorageClass validates an instance of StorageClass according

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type CSINode
+	scheme.AddValidationFunc((*storagev1beta1.CSINode)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_CSINode(ctx, op, nil /* fldPath */, obj.(*storagev1beta1.CSINode), safe.Cast[*storagev1beta1.CSINode](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type StorageClass
 	scheme.AddValidationFunc((*storagev1beta1.StorageClass)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -56,6 +64,74 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_CSINode validates an instance of CSINode according
+// to declarative validation rules in the API schema.
+func Validate_CSINode(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.CSINode) (errs field.ErrorList) {
+	// field storagev1beta1.CSINode.TypeMeta has no validation
+	// field storagev1beta1.CSINode.ObjectMeta has no validation
+
+	// field storagev1beta1.CSINode.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1beta1.CSINodeSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_CSINodeSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1beta1.CSINode) *storagev1beta1.CSINodeSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_CSINodeDriver validates an instance of CSINodeDriver according
+// to declarative validation rules in the API schema.
+func Validate_CSINodeDriver(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.CSINodeDriver) (errs field.ErrorList) {
+	// field storagev1beta1.CSINodeDriver.Name has no validation
+
+	// field storagev1beta1.CSINodeDriver.NodeID
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("nodeID"), &obj.NodeID, safe.Field(oldObj, func(oldObj *storagev1beta1.CSINodeDriver) *string { return &oldObj.NodeID }), oldObj != nil)...)
+
+	// field storagev1beta1.CSINodeDriver.TopologyKeys has no validation
+	// field storagev1beta1.CSINodeDriver.Allocatable has no validation
+	return errs
+}
+
+// Validate_CSINodeSpec validates an instance of CSINodeSpec according
+// to declarative validation rules in the API schema.
+func Validate_CSINodeSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1beta1.CSINodeSpec) (errs field.ErrorList) {
+	// field storagev1beta1.CSINodeSpec.Drivers
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []storagev1beta1.CSINodeDriver, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CSINodeDriver)...)
+			return
+		}(fldPath.Child("drivers"), obj.Drivers, safe.Field(oldObj, func(oldObj *storagev1beta1.CSINodeSpec) []storagev1beta1.CSINodeDriver { return oldObj.Drivers }), oldObj != nil)...)
+
+	return errs
 }
 
 // Validate_StorageClass validates an instance of StorageClass according

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -334,7 +334,7 @@ func validateCSINodeDriverNodeID(nodeID string, fldPath *field.Path) field.Error
 
 	// nodeID is always required
 	if len(nodeID) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath, nodeID))
+		allErrs = append(allErrs, field.Required(fldPath, nodeID).MarkCoveredByDeclarative())
 	}
 
 	if len(nodeID) > csiNodeIDMaxLength {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -54397,7 +54397,7 @@ func schema_k8sio_api_storage_v1_StorageClass(ref common.ReferenceCallback) comm
 					},
 					"volumeBindingMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "volumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.\n\nPossible enum values:\n - `\"Immediate\"` indicates that PersistentVolumeClaims should be immediately provisioned and bound. This is the default mode.\n - `\"WaitForFirstConsumer\"` indicates that PersistentVolumeClaims should not be provisioned and bound until the first Pod is created that references the PeristentVolumeClaim. The volume provisioning and binding will occur during Pod scheduing.",
+							Description: "volumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.\n\nPossible enum values:\n - `\"Immediate\"` indicates that PersistentVolumeClaims should be immediately provisioned and bound. This is the default mode.\n - `\"WaitForFirstConsumer\"` indicates that PersistentVolumeClaims should not be provisioned and bound until the first Pod is created that references the PersistentVolumeClaim. The volume provisioning and binding will occur during Pod scheduling.",
 							Type:        []string{"string"},
 							Format:      "",
 							Enum:        []interface{}{"Immediate", "WaitForFirstConsumer"},

--- a/pkg/registry/storage/csinode/declarative_validation_test.go
+++ b/pkg/registry/storage/csinode/declarative_validation_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csinode
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/storage"
+)
+
+var apiVersions = []string{"v1beta1", "v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(
+		genericapirequest.NewDefaultContext(),
+		&genericapirequest.RequestInfo{
+			APIPrefix:         "apis",
+			APIGroup:          "storage.k8s.io",
+			APIVersion:        apiVersion,
+			Resource:          "csinodes",
+			IsResourceRequest: true,
+			Verb:              "create",
+		},
+	)
+
+	testCases := map[string]struct {
+		input        storage.CSINode
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidCSINodeDriverNode(),
+		},
+		"missing nodeID": {
+			input: mkValidCSINodeDriverNode(func(d *storage.CSINodeDriver) {
+				d.NodeID = ""
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(
+					field.NewPath("spec").Child("drivers").Index(0).Child("nodeID"),
+					"",
+				),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(
+				t,
+				ctx,
+				&tc.input,
+				Strategy.Validate,
+				tc.expectedErrs,
+			)
+		})
+	}
+}
+
+func mkValidCSINodeDriverNode(tweaks ...func(*storage.CSINodeDriver)) storage.CSINode {
+	driver := storage.CSINodeDriver{
+		Name:   "io.kubernetes.storage.csi.driver-1",
+		NodeID: "node-1",
+	}
+	for _, tweak := range tweaks {
+		tweak(&driver)
+	}
+
+	return storage.CSINode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+		Spec: storage.CSINodeSpec{
+			Drivers: []storage.CSINodeDriver{driver},
+		},
+	}
+}

--- a/pkg/registry/storage/csinode/strategy.go
+++ b/pkg/registry/storage/csinode/strategy.go
@@ -18,6 +18,8 @@ package csinode
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/operation"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -47,7 +49,8 @@ func (csiNodeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object)
 
 func (csiNodeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	csiNode := obj.(*storage.CSINode)
-	return validation.ValidateCSINode(csiNode)
+	allErrs := validation.ValidateCSINode(csiNode)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -68,7 +71,8 @@ func (csiNodeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 func (csiNodeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newCSINodeObj := obj.(*storage.CSINode)
 	oldCSINodeObj := old.(*storage.CSINode)
-	return validation.ValidateCSINodeUpdate(newCSINodeObj, oldCSINodeObj)
+	errs := validation.ValidateCSINodeUpdate(newCSINodeObj, oldCSINodeObj)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newCSINodeObj, oldCSINodeObj, errs, operation.Update)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -284,6 +284,8 @@ message CSINodeDriver {
   // system to attach a volume to a specific node, it can use this field to
   // refer to the node name using the ID that the storage system will
   // understand, e.g. "nodeA" instead of "node1". This field is required.
+  // +required
+  // +k8s:required
   optional string nodeID = 2;
 
   // topologyKeys is the list of keys supported by the driver.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -108,8 +108,8 @@ const (
 
 	// VolumeBindingWaitForFirstConsumer indicates that PersistentVolumeClaims
 	// should not be provisioned and bound until the first Pod is created that
-	// references the PeristentVolumeClaim.  The volume provisioning and
-	// binding will occur during Pod scheduing.
+	// references the PersistentVolumeClaim.  The volume provisioning and
+	// binding will occur during Pod scheduling.
 	VolumeBindingWaitForFirstConsumer VolumeBindingMode = "WaitForFirstConsumer"
 )
 
@@ -599,6 +599,8 @@ type CSINodeDriver struct {
 	// system to attach a volume to a specific node, it can use this field to
 	// refer to the node name using the ID that the storage system will
 	// understand, e.g. "nodeA" instead of "node1". This field is required.
+	// +required
+	// +k8s:required
 	NodeID string `json:"nodeID" protobuf:"bytes,2,opt,name=nodeID"`
 
 	// topologyKeys is the list of keys supported by the driver.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -287,6 +287,8 @@ message CSINodeDriver {
   // system to attach a volume to a specific node, it can use this field to
   // refer to the node name using the ID that the storage system will
   // understand, e.g. "nodeA" instead of "node1". This field is required.
+  // +required
+  // +k8s:required
   optional string nodeID = 2;
 
   // topologyKeys is the list of keys supported by the driver.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -611,6 +611,8 @@ type CSINodeDriver struct {
 	// system to attach a volume to a specific node, it can use this field to
 	// refer to the node name using the ID that the storage system will
 	// understand, e.g. "nodeA" instead of "node1". This field is required.
+	// +required
+	// +k8s:required
 	NodeID string `json:"nodeID" protobuf:"bytes,2,opt,name=nodeID"`
 
 	// topologyKeys is the list of keys supported by the driver.


### PR DESCRIPTION
/kind feature
/sig api-machinery
/sig network

## What this PR does / why we need it

- Enables the **validation-gen** framework for the `storage.k8s.io` API group (`v1beta1`, `v1`).
- Adds **Declarative Validation (DV)** support for **CSINodeDriver**.
- Maintains parity with existing hand-written strategy validation as part of the migration.

## Which issue(s) this PR is related to

- Part of kubernetes/kubernetes#134280

## Special notes for your reviewer

- Scope is limited to enabling validation-gen and DV for `CSINodeDriver`; no user-visible behavior changes intended.
- Includes unit tests that verify parity between declarative and hand-written validations (create/update paths).
- Follow-ups will extend DV to additional types in `storage.k8s.io` as needed.

## Test plan

- Table-driven unit tests covering:
  - Create & update for `v1beta1` and `v1`
  - Required/immutable fields (e.g., `NodeID`)
- Parity checks via `VerifyValidationEquivalence` and `VerifyUpdateValidationEquivalence`.

## Does this PR introduce a user-facing change?

```release-note
NONE
