### PR TITLE
Add basic test for KCM controller goroutine leakage

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -128,12 +128,12 @@ func TestGracefulControllers(t *testing.T) {
 		// relies on discovery that isn't properly set up in fakes
 		names.NamespaceController,
 		names.GarbageCollectorController,
-		// fsnotify is not graceful
-		names.PersistentVolumeBinderController,
-		names.PersistentVolumeAttachDetachController,
-		names.PersistentVolumeExpanderController,
-		names.PersistentVolumeClaimProtectionController,
-		names.PersistentVolumeProtectionController,
+		// fsnotify is not graceful. Will be fixed in corresponding PR
+		// names.PersistentVolumeBinderController,
+		// names.PersistentVolumeAttachDetachController,
+		// names.PersistentVolumeExpanderController,
+		// names.PersistentVolumeClaimProtectionController,
+		// names.PersistentVolumeProtectionController,
 	)
 
 	for controllerName, controllerDesc := range controllerDescriptorMap {
@@ -143,7 +143,6 @@ func TestGracefulControllers(t *testing.T) {
 				return
 			}
 
-			// Start with a single controller as test
 			if skippedControllers.Has(controllerName) {
 				t.Skipf("Controller %s is not yet marked as graceful", controllerName)
 			}

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	rbacv1ac "k8s.io/client-go/applyconfigurations/rbac/v1"
@@ -194,12 +195,21 @@ func (c *ClusterRoleAggregationController) Run(ctx context.Context, workers int)
 	logger.Info("Starting ClusterRoleAggregator controller")
 	defer logger.Info("Shutting down ClusterRoleAggregator controller")
 
+	var wg sync.WaitGroup
+	defer func() {
+		logger.Info("Shutting down ClusterRoleAggregator controller")
+		c.queue.ShutDown()
+		wg.Wait()
+	}()
+
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.clusterRolesSynced) {
 		return
 	}
 
 	for i := 0; i < workers; i++ {
-		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		wg.Go(func() {
+			wait.UntilWithContext(ctx, c.runWorker, time.Second)
+		})
 	}
 
 	<-ctx.Done()

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -326,6 +326,7 @@ type attachDetachController struct {
 func (adc *attachDetachController) Run(ctx context.Context) {
 	defer runtime.HandleCrash()
 	defer adc.pvcQueue.ShutDown()
+	defer adc.volumePluginMgr.Shutdown()
 
 	// Start events processing pipeline.
 	adc.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -344,6 +344,7 @@ func (c *Controller) enqueueAllPodsForCSIDriver(csiDriverName string) {
 func (c *Controller) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
+	defer c.vpm.Shutdown()
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting SELinux warning controller")
 	defer logger.Info("Shutting down SELinux warning controller")

--- a/pkg/volume/flexvolume/fake_watcher.go
+++ b/pkg/volume/flexvolume/fake_watcher.go
@@ -51,3 +51,5 @@ func (w *fakeWatcher) AddWatch(path string) error {
 func (w *fakeWatcher) TriggerEvent(op fsnotify.Op, filename string) {
 	w.eventHandler(fsnotify.Event{Op: op, Name: filename})
 }
+
+func (f *fakeWatcher) Close() {}

--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -68,6 +68,10 @@ func (prober *flexVolumeProber) Init() error {
 	return nil
 }
 
+func (prober *flexVolumeProber) Shutdown() {
+	prober.watcher.Close()
+}
+
 // If probeAllNeeded is true, probe all pluginDir
 // else probe events in eventsMap
 func (prober *flexVolumeProber) Probe() (events []volume.ProbeEvent, err error) {

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -230,3 +230,5 @@ func (prober *fakeProber) Probe() (events []ProbeEvent, err error) {
 	}
 	return []ProbeEvent{}, nil
 }
+
+func (f *fakeProber) Shutdown() {}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Tests for goroutine leakage when controller's Run function returns.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
