### PR TITLE
Introduce kuberc view/set commands under kubectl alpha

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	cmdkuberc "k8s.io/kubectl/pkg/cmd/kuberc"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -32,6 +33,11 @@ func NewCmdAlpha(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.C
 		Use:   "alpha",
 		Short: i18n.T("Commands for features in alpha"),
 		Long:  templates.LongDesc(i18n.T("These commands correspond to alpha features that are not enabled in Kubernetes clusters by default.")),
+	}
+
+	// Add alpha commands
+	if !cmdutil.KubeRC.IsDisabled() {
+		cmd.AddCommand(cmdkuberc.NewCmdKubeRC(streams))
 	}
 
 	// NewKubeletCommand() will hide the alpha command if it has no subcommands. Overriding

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberc
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	kubercLong = templates.LongDesc(i18n.T(`
+		Manage kuberc configuration files.
+
+		The kuberc file allows you to define command aliases and default flag values
+		for kubectl commands, making it easier to customize your kubectl experience.`))
+
+	kubercExample = templates.Examples(i18n.T(`
+		# View the current kuberc configuration
+		kubectl alpha kuberc view
+
+		# Set a default value for a command flag
+		kubectl alpha kuberc set --section defaults --command get --option output=wide
+
+		# Create an alias for a command
+		kubectl alpha kuberc set --section aliases --name getn --command get --prependarg nodes --option output=wide`))
+)
+
+// NewCmdKubeRC creates a command object for the "kuberc" action, and adds all child commands to it.
+func NewCmdKubeRC(streams genericiooptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "kuberc SUBCOMMAND",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Manage kuberc configuration files"),
+		Long:                  kubercLong,
+		Example:               kubercExample,
+		Run:                   cmdutil.DefaultSubCommandRun(streams.ErrOut),
+	}
+
+	cmd.AddCommand(NewCmdKubeRCView(streams))
+	cmd.AddCommand(NewCmdKubeRCSet(streams))
+
+	return cmd
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/kuberc.go
@@ -17,15 +17,7 @@ limitations under the License.
 package kuberc
 
 import (
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/config/v1beta1"
-	"sigs.k8s.io/yaml"
-
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -64,24 +56,4 @@ func NewCmdKubeRC(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(NewCmdKubeRCSet(streams))
 
 	return cmd
-}
-
-// SavePreference saves the preference to the kuberc file
-func SavePreference(pref *v1beta1.Preference, file string, out io.Writer) error {
-	dir := filepath.Dir(file)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
-	}
-
-	data, err := yaml.Marshal(pref)
-	if err != nil {
-		return fmt.Errorf("failed to marshal preferences: %w", err)
-	}
-
-	if err := os.WriteFile(file, data, 0644); err != nil {
-		return fmt.Errorf("failed to write kuberc file: %w", err)
-	}
-
-	fmt.Fprintf(out, "Updated %s\n", file) // nolint:errcheck
-	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/kuberc"
+	"sigs.k8s.io/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/config/v1beta1"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+const (
+	sectionDefaults = "defaults"
+	sectionAliases  = "aliases"
+)
+
+var (
+	setLong = templates.LongDesc(i18n.T(`
+		Set values in the kuberc configuration file.
+
+		Use --section to specify whether to set defaults or aliases.
+
+		For defaults: Sets default flag values for kubectl commands. The --command flag
+		should specify only the command (e.g., "get", "create", "set env"), not resources.
+
+		For aliases: Creates command aliases with optional default flag values and arguments.
+		Use --prependarg and --appendarg to include resources or other arguments.`))
+
+	setExample = templates.Examples(i18n.T(`
+		# Set default output format for 'get' command
+		kubectl kuberc set --section defaults --command get --option output=wide
+
+		# Set default output format for a subcommand
+		kubectl kuberc set --section defaults --command "set env" --option output=yaml
+
+		# Create an alias 'getn' for 'get' command with prepended 'nodes' resource
+		kubectl kuberc set --section aliases --name getn --command get --prependarg nodes --option output=wide
+
+		# Create an alias 'runx' for 'run' command with appended arguments
+		kubectl kuberc set --section aliases --name runx --command run --option image=nginx --appendarg "--" --appendarg custom-arg1
+
+		# Overwrite an existing default
+		kubectl kuberc set --section defaults --command get --option output=json --overwrite`))
+)
+
+// SetOptions contains the options for setting kuberc configuration
+type SetOptions struct {
+	KubeRCFile  string
+	Section     string // "defaults" or "aliases"
+	Command     string
+	AliasName   string   // for aliases
+	Options     []string // flag=value pairs
+	PrependArgs []string
+	AppendArgs  []string
+	Overwrite   bool
+
+	genericiooptions.IOStreams
+}
+
+func NewSetOptions(ioStreams genericiooptions.IOStreams) *SetOptions {
+	return &SetOptions{
+		IOStreams:   ioStreams,
+		Options:     []string{},
+		PrependArgs: []string{},
+		AppendArgs:  []string{},
+	}
+}
+
+// NewCmdKubeRCSet returns a Command instance for 'kuberc set' sub command
+func NewCmdKubeRCSet(streams genericiooptions.IOStreams) *cobra.Command {
+	o := NewSetOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:                   "set --section (defaults|aliases) --command COMMAND",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Set values in the kuberc configuration"),
+		Long:                  setLong,
+		Example:               setExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(cmd))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	cmd.Flags().StringVar(&o.KubeRCFile, "file", o.KubeRCFile, "Path to the kuberc file to modify. If it is not specified, default kuberc location will be used.")
+	cmd.Flags().StringVar(&o.Section, "section", o.Section, "Section to modify: 'defaults' or 'aliases'")
+	cmd.MarkFlagRequired("section") // nolint:errcheck
+	cmd.Flags().StringVar(&o.Command, "command", o.Command, "Command to configure (e.g., 'get', 'create', 'set env')")
+	cmd.MarkFlagRequired("command") // nolint:errcheck
+	cmd.Flags().StringVar(&o.AliasName, "name", o.AliasName, "Alias name (required for --section=aliases)")
+	cmd.Flags().StringArrayVar(&o.Options, "option", o.Options, "Flag option in the form flag=value (can be specified multiple times)")
+	cmd.Flags().StringArrayVar(&o.PrependArgs, "prependarg", o.PrependArgs, "Argument to prepend to the command (can be specified multiple times, for aliases only)")
+	cmd.Flags().StringArrayVar(&o.AppendArgs, "appendarg", o.AppendArgs, "Argument to append to the command (can be specified multiple times, for aliases only)")
+	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", o.Overwrite, "Allow overwriting existing entries")
+
+	return cmd
+}
+
+// Complete sets default values for SetOptions
+func (o *SetOptions) Complete(cmd *cobra.Command) error {
+	if env := os.Getenv("KUBERC"); env != "off" {
+		if o.KubeRCFile == "" {
+			o.KubeRCFile = kuberc.RecommendedKubeRCFile
+		}
+	}
+
+	return nil
+}
+
+// Validate validates the SetOptions
+func (o *SetOptions) Validate() error {
+	if o.KubeRCFile == "" {
+		return fmt.Errorf("KUBERC is disabled via KUBERC=off environment variable")
+	}
+
+	if o.Section != sectionDefaults && o.Section != sectionAliases {
+		return fmt.Errorf("--section must be %q or %q, got: %s", sectionDefaults, sectionAliases, o.Section)
+	}
+
+	if o.Section == sectionAliases && o.AliasName == "" {
+		return fmt.Errorf("--name is required when --section=%s", sectionAliases)
+	}
+
+	if o.Section == sectionDefaults && o.AliasName != "" {
+		return fmt.Errorf("--name should not be specified when --section=%s", sectionDefaults)
+	}
+
+	if o.Section == sectionDefaults && (len(o.PrependArgs) > 0 || len(o.AppendArgs) > 0) {
+		return fmt.Errorf("--prependarg and --appendarg are only valid for --section=%s", sectionAliases)
+	}
+
+	return nil
+}
+
+// Run executes the set command
+func (o *SetOptions) Run() error {
+	pref, err := o.loadOrCreatePreference()
+	if err != nil {
+		return err
+	}
+
+	optionDefaults, err := o.parseOptions()
+	if err != nil {
+		return err
+	}
+
+	if o.Section == sectionDefaults {
+		if err := o.setDefaults(pref, optionDefaults); err != nil {
+			return err
+		}
+	} else {
+		if err := o.setAlias(pref, optionDefaults); err != nil {
+			return err
+		}
+	}
+
+	return o.savePreference(pref)
+}
+
+// loadOrCreatePreference loads existing preference or creates a new one
+func (o *SetOptions) loadOrCreatePreference() (*v1beta1.Preference, error) {
+	data, err := os.ReadFile(o.KubeRCFile)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("error reading kuberc file: %w", err)
+	}
+
+	if os.IsNotExist(err) || len(data) == 0 {
+		return &v1beta1.Preference{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "kubectl.config.k8s.io/v1beta1",
+				Kind:       "Preference",
+			},
+		}, nil
+	}
+
+	var pref v1beta1.Preference
+	if err := yaml.Unmarshal(data, &pref); err != nil {
+		return nil, fmt.Errorf("error parsing kuberc file: %w", err)
+	}
+
+	return &pref, nil
+}
+
+// parseOptions parses the --option flags into CommandOptionDefault structs
+func (o *SetOptions) parseOptions() ([]v1beta1.CommandOptionDefault, error) {
+	var options []v1beta1.CommandOptionDefault
+
+	for _, opt := range o.Options {
+		parts := strings.SplitN(opt, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid option format %q, expected flag=value", opt)
+		}
+
+		// Remove leading dashes from flag name if present
+		flagName := strings.TrimLeft(parts[0], "-")
+
+		options = append(options, v1beta1.CommandOptionDefault{
+			Name:    flagName,
+			Default: parts[1],
+		})
+	}
+
+	return options, nil
+}
+
+// setDefaults updates the defaults section of the preference
+func (o *SetOptions) setDefaults(pref *v1beta1.Preference, options []v1beta1.CommandOptionDefault) error {
+	for i, def := range pref.Defaults {
+		if def.Command == o.Command {
+			if !o.Overwrite {
+				return fmt.Errorf("defaults for command %q already exist, use --overwrite to replace", o.Command)
+			}
+
+			pref.Defaults[i].Options = options
+			return nil
+		}
+	}
+
+	pref.Defaults = append(pref.Defaults, v1beta1.CommandDefaults{
+		Command: o.Command,
+		Options: options,
+	})
+
+	return nil
+}
+
+// setAlias updates the aliases section of the preference
+func (o *SetOptions) setAlias(pref *v1beta1.Preference, options []v1beta1.CommandOptionDefault) error {
+	// Check if this alias already exists
+	for i, alias := range pref.Aliases {
+		if alias.Name == o.AliasName {
+			if !o.Overwrite {
+				return fmt.Errorf("alias %q already exists, use --overwrite to replace", o.AliasName)
+			}
+
+			pref.Aliases[i] = v1beta1.AliasOverride{
+				Name:        o.AliasName,
+				Command:     o.Command,
+				PrependArgs: o.PrependArgs,
+				AppendArgs:  o.AppendArgs,
+				Options:     options,
+			}
+			return nil
+		}
+	}
+
+	pref.Aliases = append(pref.Aliases, v1beta1.AliasOverride{
+		Name:        o.AliasName,
+		Command:     o.Command,
+		PrependArgs: o.PrependArgs,
+		AppendArgs:  o.AppendArgs,
+		Options:     options,
+	})
+
+	return nil
+}
+
+// savePreference saves the preference to the kuberc file
+func (o *SetOptions) savePreference(pref *v1beta1.Preference) error {
+	dir := filepath.Dir(o.KubeRCFile)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	data, err := yaml.Marshal(pref)
+	if err != nil {
+		return fmt.Errorf("failed to marshal preferences: %w", err)
+	}
+
+	if err := os.WriteFile(o.KubeRCFile, data, 0644); err != nil {
+		return fmt.Errorf("failed to write kuberc file: %w", err)
+	}
+
+	fmt.Fprintf(o.Out, "Updated %s\n", o.KubeRCFile) // nolint:errcheck
+	return nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/config/v1beta1"
+	"sigs.k8s.io/yaml"
 )
 
 func TestSetOptions_Run_Defaults(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set_test.go
@@ -1,0 +1,470 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/kubectl/pkg/config/v1beta1"
+)
+
+func TestSetOptions_Run_Defaults(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingKuberc string
+		options        SetOptions
+		expectedPref   *v1beta1.Preference
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:           "create new defaults",
+			existingKuberc: "",
+			options: SetOptions{
+				Section: sectionDefaults,
+				Command: "get",
+				Options: []string{"output=wide"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Defaults: []v1beta1.CommandDefaults{
+					{
+						Command: "get",
+						Options: []v1beta1.CommandOptionDefault{
+							{
+								Name:    "output",
+								Default: "wide",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "add defaults to existing file",
+			existingKuberc: `apiVersion: kubectl.config.k8s.io/v1beta1
+kind: Preference
+defaults:
+- command: get
+  options:
+  - name: output
+    default: wide
+`,
+			options: SetOptions{
+				Section: sectionDefaults,
+				Command: "create",
+				Options: []string{"output=yaml"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Defaults: []v1beta1.CommandDefaults{
+					{
+						Command: "get",
+						Options: []v1beta1.CommandOptionDefault{
+							{
+								Name:    "output",
+								Default: "wide",
+							},
+						},
+					},
+					{
+						Command: "create",
+						Options: []v1beta1.CommandOptionDefault{
+							{
+								Name:    "output",
+								Default: "yaml",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "overwrite existing defaults",
+			existingKuberc: `apiVersion: kubectl.config.k8s.io/v1beta1
+kind: Preference
+defaults:
+- command: get
+  options:
+  - name: output
+    default: wide
+`,
+			options: SetOptions{
+				Section:   sectionDefaults,
+				Command:   "get",
+				Options:   []string{"output=json"},
+				Overwrite: true,
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Defaults: []v1beta1.CommandDefaults{
+					{
+						Command: "get",
+						Options: []v1beta1.CommandOptionDefault{
+							{
+								Name:    "output",
+								Default: "json",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "error without overwrite",
+			existingKuberc: `apiVersion: kubectl.config.k8s.io/v1beta1
+kind: Preference
+defaults:
+- command: get
+  options:
+  - name: output
+    default: wide
+`,
+			options: SetOptions{
+				Section:   sectionDefaults,
+				Command:   "get",
+				Options:   []string{"output=json"},
+				Overwrite: false,
+			},
+			expectError:   true,
+			errorContains: "already exist",
+		},
+		{
+			name:           "subcommand with multiple options",
+			existingKuberc: "",
+			options: SetOptions{
+				Section: sectionDefaults,
+				Command: "set env",
+				Options: []string{"output=yaml", "local=true"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Defaults: []v1beta1.CommandDefaults{
+					{
+						Command: "set env",
+						Options: []v1beta1.CommandOptionDefault{
+							{
+								Name:    "output",
+								Default: "yaml",
+							},
+							{
+								Name:    "local",
+								Default: "true",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "kuberc-set-test-")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer func() {
+				os.RemoveAll(tmpDir) // nolint:errcheck
+			}()
+
+			kubercPath := filepath.Join(tmpDir, "kuberc")
+			if tt.existingKuberc != "" {
+				if err := os.WriteFile(kubercPath, []byte(tt.existingKuberc), 0644); err != nil {
+					t.Fatalf("failed to write existing kuberc file: %v", err)
+				}
+			}
+
+			streams, _, out, _ := genericiooptions.NewTestIOStreams()
+			tt.options.KubeRCFile = kubercPath
+			tt.options.IOStreams = streams
+
+			err = tt.options.Run()
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Run() unexpected error = %v", err)
+			}
+
+			// Verify the file was written
+			data, err := os.ReadFile(kubercPath)
+			if err != nil {
+				t.Fatalf("failed to read written kuberc file: %v", err)
+			}
+
+			var actualPref v1beta1.Preference
+			if err := yaml.Unmarshal(data, &actualPref); err != nil {
+				t.Fatalf("failed to unmarshal actual output: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.expectedPref, &actualPref); diff != "" {
+				t.Errorf("Run() output mismatch (-expected +got):\n%s", diff)
+			}
+
+			// Verify output message
+			if !strings.Contains(out.String(), "Updated") {
+				t.Errorf("expected output to contain 'Updated', got: %s", out.String())
+			}
+		})
+	}
+}
+
+func TestSetOptions_Run_Aliases(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingKuberc string
+		options        SetOptions
+		expectedPref   *v1beta1.Preference
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:           "create new alias",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:     sectionAliases,
+				AliasName:   "getn",
+				Command:     "get",
+				PrependArgs: []string{"nodes"},
+				Options:     []string{"output=wide"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Aliases: []v1beta1.AliasOverride{
+					{
+						Name:        "getn",
+						Command:     "get",
+						PrependArgs: []string{"nodes"},
+						Options: []v1beta1.CommandOptionDefault{
+							{
+								Name:    "output",
+								Default: "wide",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "add alias to existing file",
+			existingKuberc: `apiVersion: kubectl.config.k8s.io/v1beta1
+kind: Preference
+aliases:
+- name: getn
+  command: get
+  prependArgs:
+  - nodes
+`,
+			options: SetOptions{
+				Section:     sectionAliases,
+				AliasName:   "getp",
+				Command:     "get",
+				PrependArgs: []string{"pods"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Aliases: []v1beta1.AliasOverride{
+					{
+						Name:        "getn",
+						Command:     "get",
+						PrependArgs: []string{"nodes"},
+					},
+					{
+						Name:        "getp",
+						Command:     "get",
+						PrependArgs: []string{"pods"},
+					},
+				},
+			},
+		},
+		{
+			name: "overwrite existing alias",
+			existingKuberc: `apiVersion: kubectl.config.k8s.io/v1beta1
+kind: Preference
+aliases:
+- name: getn
+  command: get
+  prependArgs:
+  - nodes
+`,
+			options: SetOptions{
+				Section:     sectionAliases,
+				AliasName:   "getn",
+				Command:     "get",
+				PrependArgs: []string{"namespaces"},
+				Overwrite:   true,
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Aliases: []v1beta1.AliasOverride{
+					{
+						Name:        "getn",
+						Command:     "get",
+						PrependArgs: []string{"namespaces"},
+					},
+				},
+			},
+		},
+		{
+			name: "error without overwrite",
+			existingKuberc: `apiVersion: kubectl.config.k8s.io/v1beta1
+kind: Preference
+aliases:
+- name: getn
+  command: get
+  prependArgs:
+  - nodes
+`,
+			options: SetOptions{
+				Section:     sectionAliases,
+				AliasName:   "getn",
+				Command:     "get",
+				PrependArgs: []string{"namespaces"},
+				Overwrite:   false,
+			},
+			expectError:   true,
+			errorContains: "already exists",
+		},
+		{
+			name:           "alias with append args",
+			existingKuberc: "",
+			options: SetOptions{
+				Section:    sectionAliases,
+				AliasName:  "runx",
+				Command:    "run",
+				AppendArgs: []string{"--", "custom-arg1"},
+				Options:    []string{"image=nginx"},
+			},
+			expectedPref: &v1beta1.Preference{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubectl.config.k8s.io/v1beta1",
+					Kind:       "Preference",
+				},
+				Aliases: []v1beta1.AliasOverride{
+					{
+						Name:       "runx",
+						Command:    "run",
+						AppendArgs: []string{"--", "custom-arg1"},
+						Options: []v1beta1.CommandOptionDefault{
+							{
+								Name:    "image",
+								Default: "nginx",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "kuberc-set-test-")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer func() {
+				os.RemoveAll(tmpDir) // nolint:errcheck
+			}()
+
+			kubercPath := filepath.Join(tmpDir, "kuberc")
+			if tt.existingKuberc != "" {
+				if err := os.WriteFile(kubercPath, []byte(tt.existingKuberc), 0644); err != nil {
+					t.Fatalf("failed to write existing kuberc file: %v", err)
+				}
+			}
+
+			streams, _, out, _ := genericiooptions.NewTestIOStreams()
+			tt.options.KubeRCFile = kubercPath
+			tt.options.IOStreams = streams
+
+			err = tt.options.Run()
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Run() unexpected error = %v", err)
+			}
+
+			// Verify the file was written
+			data, err := os.ReadFile(kubercPath)
+			if err != nil {
+				t.Fatalf("failed to read written kuberc file: %v", err)
+			}
+
+			var actualPref v1beta1.Preference
+			if err := yaml.Unmarshal(data, &actualPref); err != nil {
+				t.Fatalf("failed to unmarshal actual output: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.expectedPref, &actualPref); diff != "" {
+				t.Errorf("Run() output mismatch (-expected +got):\n%s", diff)
+			}
+
+			// Verify output message
+			if !strings.Contains(out.String(), "Updated") {
+				t.Errorf("expected output to contain 'Updated', got: %s", out.String())
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberc
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/kuberc"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/config/v1beta1"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	viewLong = templates.LongDesc(i18n.T(`
+		Display the current kuberc configuration.
+
+		The kuberc file contains command aliases and default flag values
+		for kubectl commands. This command displays the contents of the
+		kuberc file in the specified output format.`))
+
+	viewExample = templates.Examples(i18n.T(`
+		# View kuberc configuration in YAML format (default)
+		kubectl kuberc view
+
+		# View kuberc configuration in JSON format
+		kubectl kuberc view --output json
+
+		# View a specific kuberc file
+		kubectl kuberc view --kuberc /path/to/kuberc`))
+)
+
+// ViewOptions contains the options for viewing kuberc configuration
+type ViewOptions struct {
+	KubeRCFile string
+	PrintFlags *genericclioptions.PrintFlags
+
+	genericiooptions.IOStreams
+}
+
+// NewCmdKubeRCView returns a Command instance for 'kuberc view' sub command
+func NewCmdKubeRCView(streams genericiooptions.IOStreams) *cobra.Command {
+	o := &ViewOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput("yaml"),
+		IOStreams:  streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "view",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Display the current kuberc configuration"),
+		Long:                  viewLong,
+		Example:               viewExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(cmd))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	cmd.Flags().StringVar(&o.KubeRCFile, "kuberc", o.KubeRCFile, "Path to the kuberc file to view")
+	o.PrintFlags.AddFlags(cmd)
+
+	return cmd
+}
+
+// Complete sets default values for ViewOptions
+func (o *ViewOptions) Complete(cmd *cobra.Command) error {
+	if env := os.Getenv("KUBERC"); env != "" && env != "off" {
+		o.KubeRCFile = env
+	} else if env != "off" {
+		if o.KubeRCFile == "" {
+			o.KubeRCFile = kuberc.RecommendedKubeRCFile
+		}
+	}
+	return nil
+}
+
+// Validate validates the ViewOptions
+func (o *ViewOptions) Validate() error {
+	return nil
+}
+
+// Run executes the view command
+func (o *ViewOptions) Run() error {
+	if o.KubeRCFile == "" {
+		return fmt.Errorf("KUBERC is disabled via KUBERC=off environment variable")
+	}
+
+	data, err := os.ReadFile(o.KubeRCFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("kuberc file not found at %s", o.KubeRCFile)
+		}
+		return fmt.Errorf("error reading kuberc file: %w", err)
+	}
+
+	var pref *v1beta1.Preference
+	if err := yaml.Unmarshal(data, &pref); err != nil {
+		return fmt.Errorf("error parsing kuberc file: %w", err)
+	}
+
+	if pref.Aliases == nil {
+		pref.Aliases = []v1beta1.AliasOverride{}
+	}
+	if pref.Defaults == nil {
+		pref.Defaults = []v1beta1.CommandDefaults{}
+	}
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	return printer.PrintObj(pref, o.Out)
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/config/v1beta1"
+	"sigs.k8s.io/yaml"
 )
 
 func TestViewOptions_Run(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/kubectl/pkg/config/v1beta1"
+)
+
+func TestViewOptions_Run(t *testing.T) {
+	kubercContent := `apiVersion: kubectl.config.k8s.io/v1beta1
+kind: Preference
+defaults:
+- command: get
+  options:
+  - name: output
+    default: wide
+aliases:
+- name: getn
+  command: get
+  prependArgs:
+  - nodes
+`
+
+	expectedPref := &v1beta1.Preference{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubectl.config.k8s.io/v1beta1",
+			Kind:       "Preference",
+		},
+		Defaults: []v1beta1.CommandDefaults{
+			{
+				Command: "get",
+				Options: []v1beta1.CommandOptionDefault{
+					{
+						Name:    "output",
+						Default: "wide",
+					},
+				},
+			},
+		},
+		Aliases: []v1beta1.AliasOverride{
+			{
+				Name:        "getn",
+				Command:     "get",
+				PrependArgs: []string{"nodes"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		outputFormat string
+	}{
+		{
+			name:         "yaml output",
+			outputFormat: "yaml",
+		},
+		{
+			name:         "json output",
+			outputFormat: "json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "kuberc-test-")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer func() {
+				os.RemoveAll(tmpDir) // nolint:errcheck
+			}()
+
+			kubercPath := filepath.Join(tmpDir, "kuberc")
+			if err := os.WriteFile(kubercPath, []byte(kubercContent), 0644); err != nil {
+				t.Fatalf("failed to write kuberc file: %v", err)
+			}
+
+			streams, _, out, _ := genericiooptions.NewTestIOStreams()
+			o := &ViewOptions{
+				KubeRCFile: kubercPath,
+				PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(tt.outputFormat),
+				IOStreams:  streams,
+			}
+
+			err = o.Run()
+			if err != nil {
+				t.Fatalf("Run() unexpected error = %v", err)
+			}
+
+			// Unmarshal actual output to v1beta1.Preference
+			var actualPref v1beta1.Preference
+			if err := yaml.Unmarshal(out.Bytes(), &actualPref); err != nil {
+				t.Fatalf("failed to unmarshal actual output: %v", err)
+			}
+
+			if diff := cmp.Diff(expectedPref, &actualPref); diff != "" {
+				t.Errorf("Run() output mismatch (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/cmd/kuberc.sh
+++ b/test/cmd/kuberc.sh
@@ -25,21 +25,23 @@ run_kuberc_tests() {
   create_and_use_new_namespace
   kube::log::status "Testing kubectl alpha kuberc set commands"
 
-  # Build up the kuberc file using kubectl alpha kuberc set commands
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=defaults --command=apply --option=server-side=true --option=dry-run=server --option=validate=strict
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=defaults --command=delete --option=interactive=true
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=defaults --command=get --option=namespace=test-kuberc-ns --option=output=json
+  KUBERC_FILE="${TMPDIR:-/tmp}"/kuberc_file
 
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=crns --command="create namespace" --appendarg=test-kuberc-ns
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=getn --command=get --prependarg=namespace --option=output=wide
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=crole --command="create role" --option=verb=get,watch
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=getrole --command=get --option=output=json
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=runx --command=run --option=image=nginx --option=labels=app=test,env=test --option=env=DNS_DOMAIN=test --option=namespace=test-kuberc-ns --appendarg=test-pod-2 --appendarg=-- --appendarg=custom-arg1 --appendarg=custom-arg2
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=setx --command="set image" --appendarg=pod/test-pod-2 --appendarg=test-pod-2=busybox
+  # Build up the kuberc file using kubectl alpha kuberc set commands
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=defaults --command=apply --option=server-side=true --option=dry-run=server --option=validate=strict
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=defaults --command=delete --option=interactive=true
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=defaults --command=get --option=namespace=test-kuberc-ns --option=output=json
+
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=crns --command="create namespace" --appendarg=test-kuberc-ns
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=getn --command=get --prependarg=namespace --option=output=wide
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=crole --command="create role" --option=verb=get,watch
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=getrole --command=get --option=output=json
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=runx --command=run --option=image=nginx --option=labels=app=test,env=test --option=env=DNS_DOMAIN=test --option=namespace=test-kuberc-ns --appendarg=test-pod-2 --appendarg=-- --appendarg=custom-arg1 --appendarg=custom-arg2
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=setx --command="set image" --appendarg=pod/test-pod-2 --appendarg=test-pod-2=busybox
 
   kube::log::status "Testing kubectl alpha kuberc view commands"
   # Test: kubectl alpha kuberc view
-  output_message=$(kubectl alpha kuberc view --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(kubectl alpha kuberc view --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" "apiVersion: kubectl.config.k8s.io/v1beta1"
   kube::test::if_has_string "${output_message}" "kind: Preference"
   kube::test::if_has_string "${output_message}" "command: apply"
@@ -48,30 +50,30 @@ run_kuberc_tests() {
   kube::test::if_has_string "${output_message}" "interactive"
 
   # Test: kubectl alpha kuberc view with json output
-  output_message=$(kubectl alpha kuberc view --kuberc="${TMPDIR:-/tmp}"/kuberc_file -o json)
+  output_message=$(kubectl alpha kuberc view --kuberc="$KUBERC_FILE" -o json)
   kube::test::if_has_string "${output_message}" "\"apiVersion\": \"kubectl.config.k8s.io/v1beta1\""
   kube::test::if_has_string "${output_message}" "\"kind\": \"Preference\""
 
   # Test: Attempt to set existing default without --overwrite flag should fail
-  output_message=$(! kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=defaults --command=get --option=output=yaml 2>&1)
+  output_message=$(! kubectl alpha kuberc set --file="$KUBERC_FILE" --section=defaults --command=get --option=output=yaml 2>&1)
   kube::test::if_has_string "${output_message}" "defaults for command \"get\" already exist, use --overwrite to replace"
 
   # Test: Now set with --overwrite flag should succeed and merge options
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=defaults --command=get --option=output=yaml --overwrite
-  output_message=$(kubectl alpha kuberc view --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=defaults --command=get --option=output=yaml --overwrite
+  output_message=$(kubectl alpha kuberc view --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" "default: yaml"
   # Should still have namespace option from before
   kube::test::if_has_string "${output_message}" "default: test-kuberc-ns"
 
   # Test: Attempt to set existing alias without --overwrite flag should fail
-  output_message=$(! kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=getn --command=get --prependarg=pods 2>&1)
+  output_message=$(! kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=getn --command=get --prependarg=pods 2>&1)
   kube::test::if_has_string "${output_message}" "alias \"getn\" already exists, use --overwrite to replace"
 
   # Test: Error cases - Missing required flags
-  output_message=$(! kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --command=get --option=output=wide 2>&1)
+  output_message=$(! kubectl alpha kuberc set --file="$KUBERC_FILE" --command=get --option=output=wide 2>&1)
   kube::test::if_has_string "${output_message}" "required flag(s) \"section\" not set"
 
-  output_message=$(! kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=defaults --option=output=wide 2>&1)
+  output_message=$(! kubectl alpha kuberc set --file="$KUBERC_FILE" --section=defaults --option=output=wide 2>&1)
   kube::test::if_has_string "${output_message}" "required flag(s) \"command\" not set"
 
   # Test: KUBERC=off with view command
@@ -83,77 +85,77 @@ run_kuberc_tests() {
   kube::test::if_has_string "${output_message}" "KUBERC is disabled via KUBERC=off environment variable"
 
   # Restore getn alias back to "namespace" for remaining tests
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=aliases --name=getn --command=get --prependarg=namespace --option=output=wide --overwrite
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=aliases --name=getn --command=get --prependarg=namespace --option=output=wide --overwrite
   # Restore get defaults back to namespace=test-kuberc-ns and output=json for remaining tests
-  kubectl alpha kuberc set --file="${TMPDIR:-/tmp}"/kuberc_file --section=defaults --command=get --option=namespace=test-kuberc-ns --option=output=json --overwrite
+  kubectl alpha kuberc set --file="$KUBERC_FILE" --section=defaults --command=get --option=namespace=test-kuberc-ns --option=output=json --overwrite
 
   kube::log::status "Testing kuberc aliases and defaults functionality"
 
   # Pre-condition: the test-kuberc-ns namespace does not exist
   kube::test::get_object_assert 'namespaces' "{{range.items}}{{ if eq ${id_field:?} \"test-kuberc-ns\" }}found{{end}}{{end}}:" ':'
   # Alias command crns successfully creates namespace
-  kubectl crns --kuberc="${TMPDIR:-/tmp}"/kuberc_file
+  kubectl crns --kuberc="$KUBERC_FILE"
   # Post-condition: namespace 'test-kuberc-ns' is created.
   kube::test::get_object_assert 'namespaces/test-kuberc-ns' "{{$id_field}}" 'test-kuberc-ns'
 
   # Alias command crns successfully creates namespace
-  kubectl getn --kuberc="${TMPDIR:-/tmp}"/kuberc_file test-kuberc-ns
+  kubectl getn --kuberc="$KUBERC_FILE" test-kuberc-ns
   # Post-condition: namespace 'test-kuberc-ns' is created.
   kube::test::get_object_assert 'namespaces/test-kuberc-ns' "{{$id_field}}" 'test-kuberc-ns'
 
   # Alias command crns successfully creates namespace
-  kubectl getn test-kuberc-ns --output=json --kuberc="${TMPDIR:-/tmp}"/kuberc_file
+  kubectl getn test-kuberc-ns --output=json --kuberc="$KUBERC_FILE"
   # Post-condition: namespace 'test-kuberc-ns' is created.
   kube::test::get_object_assert 'namespaces/test-kuberc-ns' "{{$id_field}}" 'test-kuberc-ns'
 
   # check array flags are appended after implicit defaults
-  kubectl crole testkubercrole --verb=list --namespace test-kuberc-ns --resource=pods --kuberc="${TMPDIR:-/tmp}"/kuberc_file
-  output_message=$(kubectl getrole role/testkubercrole -n test-kuberc-ns -oyaml --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  kubectl crole testkubercrole --verb=list --namespace test-kuberc-ns --resource=pods --kuberc="$KUBERC_FILE"
+  output_message=$(kubectl getrole role/testkubercrole -n test-kuberc-ns -oyaml --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" 'list'
   kube::test::if_has_not_string "${output_message}" 'watch' 'get'
   # Post-condition: remove role
   kubectl delete role testkubercrole --namespace=test-kuberc-ns
 
   # Alias run command creates a pod with the given configurations
-  kubectl runx --kuberc "${TMPDIR:-/tmp}"/kuberc_file
+  kubectl runx --kuberc "$KUBERC_FILE"
   # Post-Condition: assertion object exists
   kube::test::get_object_assert 'pod/test-pod-2 --namespace=test-kuberc-ns' "{{$id_field}}" 'test-pod-2'
   # Not explicitly pass namespace to assure that default flag value is used
-  output_message=$(kubectl get pod/test-pod-2 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(kubectl get pod/test-pod-2 2>&1 "${kube_flags[@]:?}" --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" 'nginx' 'app=test' 'env=test' 'DNS_DOMAIN=test' 'custom-arg1'
   # output flag is defaulted to json and assure that it is correct format
   kube::test::if_has_string "${output_message}" '{'
 
   # pass explicit invalid namespace to assure that it takes precedence over the value in kuberc
-  output_message=$(! kubectl get pod/test-pod-2 -n kube-system 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(! kubectl get pod/test-pod-2 -n kube-system 2>&1 "${kube_flags[@]:?}" --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" 'pods "test-pod-2" not found'
 
   # Alias set env command sets new env var
-  kubectl setx --kuberc="${TMPDIR:-/tmp}"/kuberc_file -n test-kuberc-ns
+  kubectl setx --kuberc="$KUBERC_FILE" -n test-kuberc-ns
   # explicitly pass same namespace also defined in kuberc
-  output_message=$(kubectl get pod/test-pod-2 -n test-kuberc-ns 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(kubectl get pod/test-pod-2 -n test-kuberc-ns 2>&1 "${kube_flags[@]:?}" --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" 'busybox'
   kube::test::if_has_not_string "${output_message}" 'nginx'
 
   # default overrides should prevent actual apply as they are all dry-run=server
   # also assure that explicit flags are also passed
-  output_message=$(kubectl apply -n test-kuberc-ns -f hack/testdata/pod.yaml --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(kubectl apply -n test-kuberc-ns -f hack/testdata/pod.yaml --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" 'serverside-applied (server dry run)'
 
   # interactive flag is defaulted to true and prompted as no
-  output_message=$(kubectl delete pod/test-pod-2 -n test-kuberc-ns <<< $'n\n' --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(kubectl delete pod/test-pod-2 -n test-kuberc-ns <<< $'n\n' --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" 'pod/test-pod-2'
   # assure that it is not deleted
-  output_message=$(kubectl get pod/test-pod-2 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(kubectl get pod/test-pod-2 2>&1 "${kube_flags[@]:?}" --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" "test-pod-2"
 
   # verify getn alias is working or not, depending if KUBECTL_KUBERC is on or off
-  output_message=$(! KUBECTL_KUBERC=false kubectl getn 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(! KUBECTL_KUBERC=false kubectl getn 2>&1 "${kube_flags[@]:?}" --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" "error: unknown command \"getn\" for \"kubectl\""
-  KUBECTL_KUBERC=true kubectl getn "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/kuberc_file
+  KUBECTL_KUBERC=true kubectl getn "${kube_flags[@]:?}" --kuberc="$KUBERC_FILE"
 
   # verify KUBERC=off is working as expected
-  output_message=$(! KUBERC=off kubectl getn 2>&1 "${kube_flags[@]:?}" --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(! KUBERC=off kubectl getn 2>&1 "${kube_flags[@]:?}" --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" "KUBERC=off and passing kuberc flag are mutually exclusive"
   output_message=$(! KUBERC=off kubectl getn 2>&1 "${kube_flags[@]:?}")
   kube::test::if_has_string "${output_message}" "error: unknown command \"getn\" for \"kubectl\""
@@ -203,7 +205,7 @@ EOF
 
   # explicitly overwriting the value that is also defaulted in kuberc and
   # assure that explicit value supersedes
-  output_message=$(kubectl delete namespace/test-kuberc-ns --interactive=false --kuberc="${TMPDIR:-/tmp}"/kuberc_file)
+  output_message=$(kubectl delete namespace/test-kuberc-ns --interactive=false --kuberc="$KUBERC_FILE")
   kube::test::if_has_string "${output_message}" 'namespace "test-kuberc-ns" deleted'
 
   rm "${TMPDIR:-/tmp}"/kuberc_file


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR introduces two commands under kubectl alpha for kuberc file operations. 

* kubectl alpha kuberc view: This command views the kuberc file (either explicitly defined via `--kuberc` or `KUBERC` env var or default location).
* kubectl alpha kuberc set: This command creates/updates kuberc file (either in default location or explicitly defined via `--file`).

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/3104

#### Does this PR introduce a user-facing change?

```release-note
Adding new kuberc view/set commands in kubectl to perform operations against kuberc file
```
#### Special notes for your reviewer:

Claude helped me preparation of this PR (but this is not a bulk generated PR).

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3104-introduce-kuberc
```
