### PR TITLE
KEP-5278 Bring back clearing NominatedNodeName after scheduling or binding failure

### DIFF
--- a/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
+++ b/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
@@ -94,15 +94,12 @@ func TestNominatedNode(t *testing.T) {
 		nodeCapacity map[v1.ResourceName]string
 		// A slice of pods to be created in batch.
 		podsToCreate [][]*v1.Pod
-		// Each postCheck function is run after each batch of pods' creation.
+		// Each postCheck function is run after creating the corresponding batch of pods. The check is run for each pod in the batch.
 		postChecks []func(ctx context.Context, cs clientset.Interface, pod *v1.Pod) error
 		// Delete the fake node or not. Optional.
 		deleteFakeNode bool
 		// Pods to be deleted. Optional.
 		podNamesToDelete []string
-		// Whether NominatedNodeName will be always nil at the end of the test,
-		// regardless of the NominatedNodeNameForExpectation feature gate state.
-		expectNilNominatedNodeName bool
 
 		// Register dummy plugin to simulate particular scheduling failures. Optional.
 		customPlugins     *configv1.Plugins
@@ -127,11 +124,12 @@ func TestNominatedNode(t *testing.T) {
 			},
 			postChecks: []func(ctx context.Context, cs clientset.Interface, pod *v1.Pod) error{
 				testutils.WaitForPodToSchedule,
+				// Expect NNN to be set on "medium" pod after starting preemption.
 				testutils.WaitForNominatedNodeName,
+				// Expect NNN to be set on "high" pod after starting preemption.
 				testutils.WaitForNominatedNodeName,
 			},
-			podNamesToDelete:           []string{"low-1", "low-2", "low-3", "low-4"},
-			expectNilNominatedNodeName: true,
+			podNamesToDelete: []string{"low-1", "low-2", "low-3", "low-4"},
 		},
 		{
 			name:         "mid-priority pod preempts low-priority pod, followed by a high-priority pod without additional preemption",
@@ -149,7 +147,9 @@ func TestNominatedNode(t *testing.T) {
 			},
 			postChecks: []func(ctx context.Context, cs clientset.Interface, pod *v1.Pod) error{
 				testutils.WaitForPodToSchedule,
+				// Expect NNN to be set on "medium" pod after starting preemption.
 				testutils.WaitForNominatedNodeName,
+				// Expect "high" pod to get scheduled before "medium" re-enters the scheduling cycle.
 				testutils.WaitForPodToSchedule,
 			},
 			podNamesToDelete: []string{"low"},
@@ -205,7 +205,7 @@ func TestNominatedNode(t *testing.T) {
 			podNamesToDelete: []string{"low"},
 		},
 		{
-			name:         "mid-priority pod preempts low-priority pod, but failed the scheduling unexpectedly",
+			name:         "mid-priority pod preempts low-priority pod, but failed on PreBind",
 			nodeCapacity: map[v1.ResourceName]string{v1.ResourceCPU: "1"},
 			podsToCreate: [][]*v1.Pod{
 				{
@@ -233,7 +233,7 @@ func TestNominatedNode(t *testing.T) {
 
 	for _, asyncPreemptionEnabled := range []bool{true, false} {
 		for _, asyncAPICallsEnabled := range []bool{true, false} {
-			for _, nominatedNodeNameForExpectationEnabled := range []bool{false} {
+			for _, nominatedNodeNameForExpectationEnabled := range []bool{true, false} {
 				for _, tt := range tests {
 					t.Run(fmt.Sprintf("%s (Async preemption: %v, Async API calls: %v, NNN for expectation: %v)", tt.name, asyncPreemptionEnabled, asyncAPICallsEnabled, nominatedNodeNameForExpectationEnabled), func(t *testing.T) {
 						featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
@@ -301,33 +301,18 @@ func TestNominatedNode(t *testing.T) {
 							}
 						}
 
-						if nominatedNodeNameForExpectationEnabled && !tt.expectNilNominatedNodeName {
-							// Verify if .status.nominatedNodeName is not cleared when NominatedNodeNameForExpectation is enabled.
-							// Wait for 1 second to make sure the pod is re-processed, what would potentially clear the NominatedNodeName (when the feature won't work).
-							select {
-							case <-time.After(time.Second):
-							case <-testCtx.Ctx.Done():
-							}
-							pod, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, "medium", metav1.GetOptions{})
+						// Verify if .status.nominatedNodeName is cleared.
+						if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+							pod, err := cs.CoreV1().Pods(ns).Get(ctx, "medium", metav1.GetOptions{})
 							if err != nil {
 								t.Errorf("Error getting the medium pod: %v", err)
-							} else if len(pod.Status.NominatedNodeName) == 0 {
-								t.Errorf(".status.nominatedNodeName of the medium pod was cleared: %v", err)
 							}
-						} else {
-							// Verify if .status.nominatedNodeName is cleared when NominatedNodeNameForExpectation is disabled.
-							if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-								pod, err := cs.CoreV1().Pods(ns).Get(ctx, "medium", metav1.GetOptions{})
-								if err != nil {
-									t.Errorf("Error getting the medium pod: %v", err)
-								}
-								if len(pod.Status.NominatedNodeName) == 0 {
-									return true, nil
-								}
-								return false, err
-							}); err != nil {
-								t.Errorf(".status.nominatedNodeName of the medium pod was not cleared: %v", err)
+							if len(pod.Status.NominatedNodeName) == 0 {
+								return true, nil
 							}
+							return false, err
+						}); err != nil {
+							t.Errorf(".status.nominatedNodeName of the medium pod was not cleared: %v", err)
 						}
 					})
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR updates NominatedNodeName clearing logic in case of scheduling or binding failure, to keep it in line with the updated KEP-5278.
PR also fixes the exisiting integration tests for NominatedNodeName clearing logic, to make them pass with the feature gate NominatedNodeNameForExpectation enabled and disabled.



#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5278
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Please note that this is not exactly reverting code in https://github.com/kubernetes/kubernetes/pull/133276
I changed this line as well:
pkg/scheduler/schedule_one.go:L175
I figured that if there are no PostFilter plugins registered, it means that no preemption could have happened previously for that pod, and it hasn't reached PreBind/WaitOnPermit yet, so there's no reason not to clear NNN.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The scheduler clears the `nominatedNodeName` field for Pods upon scheduling or binding failure. External components, such as Cluster Autoscaler and Karpenter, should not overwrite this field.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5278
```
