### PR TITLE
Mark spec.selector as required in ReplicationController and add tests

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -159,7 +159,25 @@ func Validate_ReplicationControllerSpec(ctx context.Context, op operation.Operat
 			return
 		}(fldPath.Child("minReadySeconds"), &obj.MinReadySeconds, safe.Field(oldObj, func(oldObj *corev1.ReplicationControllerSpec) *int32 { return &oldObj.MinReadySeconds }))...)
 
-	// field corev1.ReplicationControllerSpec.Selector has no validation
+	// field corev1.ReplicationControllerSpec.Selector
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("selector"), obj.Selector, safe.Field(oldObj, func(oldObj *corev1.ReplicationControllerSpec) map[string]string { return oldObj.Selector }))...)
+
 	// field corev1.ReplicationControllerSpec.Template has no validation
 	return errs
 }

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -178,6 +178,24 @@ func Validate_ReplicationControllerSpec(ctx context.Context, op operation.Operat
 			return
 		}(fldPath.Child("selector"), obj.Selector, safe.Field(oldObj, func(oldObj *corev1.ReplicationControllerSpec) map[string]string { return oldObj.Selector }))...)
 
-	// field corev1.ReplicationControllerSpec.Template has no validation
+	// field corev1.ReplicationControllerSpec.Template
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *corev1.PodTemplateSpec) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("template"), obj.Template, safe.Field(oldObj, func(oldObj *corev1.ReplicationControllerSpec) *corev1.PodTemplateSpec { return oldObj.Template }))...)
+
 	return errs
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6788,7 +6788,7 @@ func ValidateNonEmptySelector(selectorMap map[string]string, fldPath *field.Path
 	allErrs := field.ErrorList{}
 	selector := labels.Set(selectorMap).AsSelector()
 	if selector.Empty() {
-		allErrs = append(allErrs, field.Required(fldPath, ""))
+		allErrs = append(allErrs, field.Required(fldPath, "")).MarkCoveredByDeclarative()
 	}
 	return allErrs
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6797,7 +6797,7 @@ func ValidateNonEmptySelector(selectorMap map[string]string, fldPath *field.Path
 func ValidatePodTemplateSpecForRC(template *core.PodTemplateSpec, selectorMap map[string]string, fldPath *field.Path, opts PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if template == nil {
-		allErrs = append(allErrs, field.Required(fldPath, ""))
+		allErrs = append(allErrs, field.Required(fldPath, "")).MarkCoveredByDeclarative()
 	} else {
 		selector := labels.Set(selectorMap).AsSelector()
 		if !selector.Empty() {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6788,7 +6788,7 @@ func ValidateNonEmptySelector(selectorMap map[string]string, fldPath *field.Path
 	allErrs := field.ErrorList{}
 	selector := labels.Set(selectorMap).AsSelector()
 	if selector.Empty() {
-		allErrs = append(allErrs, field.Required(fldPath, "")).MarkCoveredByDeclarative()
+		allErrs = append(allErrs, field.Required(fldPath, "").MarkCoveredByDeclarative())
 	}
 	return allErrs
 }

--- a/pkg/registry/core/replicationcontroller/declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/declarative_validation_test.go
@@ -186,6 +186,20 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum"),
 			},
 		},
+		// spec.selector
+		"selector: empty": {
+			input: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Selector = map[string]string{}
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec.selector"), ""),
+			},
+		},
+		"selector: valid": {
+			input: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Selector = map[string]string{"foo": "bar"}
+			}),
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -269,6 +283,22 @@ func TestValidateUpdateForDeclarative(t *testing.T) {
 				field.Invalid(field.NewPath("spec.minReadySeconds"), nil, "").WithOrigin("minimum"),
 			},
 		},
+		// spec.selector
+		"selector: empty": {
+			old: mkValidReplicationController(),
+			update: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Selector = map[string]string{}
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec.selector"), ""),
+			},
+		},
+		"selector: valid": {
+			old: mkValidReplicationController(),
+			update: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Selector = map[string]string{"foo": "bar"}
+			}),
+},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {

--- a/pkg/registry/core/replicationcontroller/declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/declarative_validation_test.go
@@ -197,7 +197,26 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 		},
 		"selector: valid": {
 			input: mkValidReplicationController(func(rc *api.ReplicationController) {
-				rc.Spec.Selector = map[string]string{"foo": "bar"}
+				rc.Spec.Selector = map[string]string{"a": "b"}
+			}),
+		},
+		// spec.template
+		"template: nil": {
+			input: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Template = nil
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec.template"), ""),
+			},
+		},
+		"template : valid": {
+			input: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Template = &api.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"a": "b"},
+					},
+					Spec: podtest.MakePodSpec(),
+				}
 			}),
 		},
 	}
@@ -296,9 +315,30 @@ func TestValidateUpdateForDeclarative(t *testing.T) {
 		"selector: valid": {
 			old: mkValidReplicationController(),
 			update: mkValidReplicationController(func(rc *api.ReplicationController) {
-				rc.Spec.Selector = map[string]string{"foo": "bar"}
+				rc.Spec.Selector = map[string]string{"a": "b"}
 			}),
-},
+		},
+		// spec.template
+		"template: nil": {
+			old: mkValidReplicationController(),
+			update: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Template = nil
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec.template"), ""),
+			},
+		},
+		"template: valid": {
+			old: mkValidReplicationController(),
+			update: mkValidReplicationController(func(rc *api.ReplicationController) {
+				rc.Spec.Template = &api.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"a": "b"},
+					},
+					Spec: podtest.MakePodSpec(),
+				}
+			}),
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5337,7 +5337,7 @@ message ReplicationControllerSpec {
   // insufficient replicas are detected. This takes precedence over a TemplateRef.
   // The only allowed template.spec.restartPolicy value is "Always".
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-  // +optional
+  // +k8s:required
   optional PodTemplateSpec template = 3;
 }
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5329,7 +5329,7 @@ message ReplicationControllerSpec {
   // Label keys and values that must match in order to be controlled by this replication
   // controller, if empty defaulted to labels on Pod template.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  // +optional
+  // +k8s:required
   // +mapType=atomic
   map<string, string> selector = 2;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5489,7 +5489,7 @@ type ReplicationControllerSpec struct {
 	// insufficient replicas are detected. This takes precedence over a TemplateRef.
 	// The only allowed template.spec.restartPolicy value is "Always".
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-	// +optional
+	// +k8s:required
 	Template *PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,3,opt,name=template"`
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -5475,7 +5475,7 @@ type ReplicationControllerSpec struct {
 	// Label keys and values that must match in order to be controlled by this replication
 	// controller, if empty defaulted to labels on Pod template.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	// +optional
+	// +k8s:required
 	// +mapType=atomic
 	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,2,rep,name=selector"`
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**

1.This change adds the +k8s:required tag to the spec.selector field in ReplicationController and includes validation tests to ensure an empty selector fails and a valid selector passes.
2. This change adds the +k8s:required tag to the template field in ReplicationControllerSpec to enforce its mandatory status in the API schema and includes corresponding validation tests for both nil (failure) and valid (success) scenarios.


**Which issue(s) this PR is related to:**
part of https://github.com/kubernetes/kubernetes/issues/134280

**Special notes for your reviewer:**
Code generation , Declarative Validation and fuzz testing are already enabled for ReplicationController as it is part of the core API group (group="", version="v1"), which is already registered

**Does this PR introduce a user-facing change?**
No

**Additional documentation, e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
[KEP]:**

https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md