### PR TITLE
feat: Migrate mount-utils to use native Windows API calls

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_helper_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_windows.go
@@ -19,12 +19,14 @@ limitations under the License.
 package mount
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
 
+	"golang.org/x/sys/windows"
 	"k8s.io/klog/v2"
 )
 
@@ -107,4 +109,57 @@ func PathExists(path string) (bool, error) {
 		return true, err
 	}
 	return false, err
+}
+
+func IsPathValid(path string) (bool, error) {
+	pathString, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false, fmt.Errorf("invalid path: %w", err)
+	}
+
+	attrs, err := windows.GetFileAttributes(pathString)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_PATH_NOT_FOUND) || errors.Is(err, windows.ERROR_FILE_NOT_FOUND) || errors.Is(err, windows.ERROR_INVALID_NAME) {
+			return false, nil
+		}
+
+		// GetFileAttribute returns user or password incorrect for a disconnected SMB connection after the password is changed
+		return false, fmt.Errorf("failed to get path %s attribute: %w", path, err)
+	}
+
+	klog.V(6).Infof("Path %s attribute: %O", path, attrs)
+	return attrs != windows.INVALID_FILE_ATTRIBUTES, nil
+}
+
+// IsMountedFolder checks whether the `path` is a mounted folder.
+func IsMountedFolder(path string) (bool, error) {
+	// https://learn.microsoft.com/en-us/windows/win32/fileio/determining-whether-a-directory-is-a-volume-mount-point
+	utf16Path, _ := windows.UTF16PtrFromString(path)
+	attrs, err := windows.GetFileAttributes(utf16Path)
+	if err != nil {
+		return false, err
+	}
+
+	if (attrs & windows.FILE_ATTRIBUTE_REPARSE_POINT) == 0 {
+		return false, nil
+	}
+
+	var findData windows.Win32finddata
+	findHandle, err := windows.FindFirstFile(utf16Path, &findData)
+	if err != nil && !errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+		return false, err
+	}
+
+	for err == nil {
+		if findData.Reserved0&windows.IO_REPARSE_TAG_MOUNT_POINT != 0 {
+			return true, nil
+		}
+
+		err = windows.FindNextFile(findHandle, &findData)
+		if err != nil && !errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			return false, err
+		}
+	}
+
+	return false, nil
 }

--- a/staging/src/k8s.io/mount-utils/mount_helper_windows_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_windows_test.go
@@ -19,7 +19,16 @@ limitations under the License.
 package mount
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeWindowsPath(t *testing.T) {
@@ -75,4 +84,251 @@ func TestValidateDiskNumber(t *testing.T) {
 			t.Errorf("TestValidateDiskNumber test failed, disk number: %s, error: %v", test.diskNum, err)
 		}
 	}
+}
+
+func TestIsPathValid(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "valid-file")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	tmpDir, err := os.MkdirTemp("", "valid-dir")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	nonexistent := filepath.Join(os.TempDir(), "does-not-exist-"+filepath.Base(tmpFile.Name()))
+
+	invalid := string([]byte{0x00}) // illegal null character
+
+	tests := []struct {
+		name             string
+		path             string
+		expectValid      bool
+		expectErrMessage string
+	}{
+		{
+			name:             "ValidFile",
+			path:             tmpFile.Name(),
+			expectValid:      true,
+			expectErrMessage: "",
+		},
+		{
+			name:             "ValidDirectory",
+			path:             tmpDir,
+			expectValid:      true,
+			expectErrMessage: "",
+		},
+		{
+			name:             "NonExistentPath",
+			path:             nonexistent,
+			expectValid:      false,
+			expectErrMessage: "",
+		},
+		{
+			name:             "InvalidPath",
+			path:             invalid,
+			expectValid:      false,
+			expectErrMessage: "invalid path: invalid argument",
+		},
+		{
+			name:             "Drive C",
+			path:             "c:",
+			expectValid:      true,
+			expectErrMessage: "",
+		},
+		{
+			name:             "InvalidRemotePath",
+			path:             "invalid-remote-path",
+			expectValid:      false,
+			expectErrMessage: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, err := IsPathValid(tt.path)
+			if valid != tt.expectValid {
+				t.Errorf("Expected valid = %v, got %v", tt.expectValid, valid)
+			}
+			if err == nil && tt.expectErrMessage != "" {
+				t.Errorf("Expected error message = %s, got no error", tt.expectErrMessage)
+			}
+			if err != nil {
+				if tt.expectErrMessage != "" && err.Error() != tt.expectErrMessage {
+					t.Errorf("Expected error message = %s, got error = %s", tt.expectErrMessage, err.Error())
+				} else if tt.expectErrMessage == "" {
+					t.Errorf("Expected no error, got error = %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func runPowershellCmd(t *testing.T, command string) (string, error) {
+	cmd := exec.Command("powershell", "/c", fmt.Sprintf("& { $global:ProgressPreference = 'SilentlyContinue'; %s }", command))
+	t.Logf("Executing command: %q", cmd.String())
+	result, err := cmd.CombinedOutput()
+	return string(result), err
+}
+
+func createMountedFolder(t *testing.T, vhdxPath, mountedPath string, initialSize int) {
+	cmd := fmt.Sprintf("New-VHD -Path %s -SizeBytes %d", vhdxPath, initialSize)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %q. Out: %s.", err, cmd, out)
+	}
+	cmd = fmt.Sprintf("Mount-VHD -Path %s", vhdxPath)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	cmd = fmt.Sprintf("Mount-VHD -Path %s", vhdxPath)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	cmd = fmt.Sprintf("(Get-VHD -Path %s).DiskNumber", vhdxPath)
+	diskNumUnparsed, err := runPowershellCmd(t, cmd)
+	if err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+	diskNumUnparsed = strings.TrimSpace(diskNumUnparsed)
+	cmd = fmt.Sprintf("Initialize-Disk -Number %s -PartitionStyle GPT", diskNumUnparsed)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error initializing disk: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	// Create a new partition using all available space
+	cmd = fmt.Sprintf("New-Partition -DiskNumber %s -UseMaximumSize", diskNumUnparsed)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error creating partition: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	// Format the partition with NTFS
+	cmd = fmt.Sprintf("(Get-Disk -Number %s | Get-Partition | Get-Volume) | Format-Volume -FileSystem NTFS -Confirm:$false", diskNumUnparsed)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error formatting volume: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+	cmd = fmt.Sprintf(`(Get-Disk -Number %s | Get-Partition ) | Add-PartitionAccessPath -AccessPath %s`, diskNumUnparsed, mountedPath)
+	if _, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+}
+
+func unmountFolder(t *testing.T, vhdxPath, mountedPath string) {
+	cmd := fmt.Sprintf("(Get-VHD -Path %s).DiskNumber", vhdxPath)
+	diskNumUnparsed, err := runPowershellCmd(t, cmd)
+	if err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+	diskNumUnparsed = strings.TrimSpace(diskNumUnparsed)
+	cmd = fmt.Sprintf(`Get-Disk -Number %s | Get-Partition | Remove-PartitionAccessPath -AccessPath %s`, diskNumUnparsed, mountedPath)
+	if _, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error: %v. Command: %s", err, cmd)
+	}
+	cmd = fmt.Sprintf("Dismount-VHD -Path %s", vhdxPath)
+	if out, err := runPowershellCmd(t, cmd); err != nil {
+		t.Fatalf("Error unmounting VHD: %v. Command: %q. Out: %s", err, cmd, out)
+	}
+}
+
+func TestIsMountedFolder(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test-dir")
+	require.NoError(t, err, "Failed to create temporary directory.")
+
+	tests := []struct {
+		name           string
+		path           string
+		setup          func()
+		cleanup        func()
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name:           "Non-existent path",
+			path:           filepath.Join(tempDir, "nonexistent"),
+			expectedResult: false,
+			expectedError:  errors.New("The system cannot find the file specified."),
+		},
+		{
+			name: "Regular directory",
+			path: filepath.Join(tempDir, "regular_dir"),
+			setup: func() {
+				err := os.MkdirAll(filepath.Join(tempDir, "regular_dir"), 0644)
+				require.NoError(t, err, "Failed to create regular_dir directory.")
+			},
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			name: "Mounted folder",
+			path: filepath.Join(tempDir, "mounted_folder"),
+			setup: func() {
+				err := os.MkdirAll(filepath.Join(tempDir, "mounted_folder"), 0644)
+				require.NoError(t, err, "Failed to create regular_dir directory.")
+
+				createMountedFolder(t, filepath.Join(tempDir, "test.vhdx"), filepath.Join(tempDir, "mounted_folder"), 1024*1024*1024)
+			},
+			cleanup: func() {
+				unmountFolder(t, filepath.Join(tempDir, "test.vhdx"), filepath.Join(tempDir, "mounted_folder"))
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+		{
+			name: "Regular file",
+			path: filepath.Join(tempDir, "regular_file"),
+			setup: func() {
+				err := os.WriteFile(filepath.Join(tempDir, "regular_file"), []byte("just_a_test"), 0644)
+				require.NoError(t, err, "Failed to create regular_file.")
+			},
+			expectedResult: false,
+			expectedError:  nil,
+		},
+		{
+			name: "Regular symlink",
+			path: filepath.Join(tempDir, "regular_symlink"),
+			setup: func() {
+				err := os.WriteFile(filepath.Join(tempDir, "regular_file"), []byte("just_a_test"), 0644)
+				require.NoError(t, err, "Failed to create regular_file.")
+
+				err = os.Symlink(filepath.Join(tempDir, "regular_file"), filepath.Join(tempDir, "regular_symlink"))
+				require.NoError(t, err, "Failed to create regular_file.")
+			},
+			cleanup: func() {
+				err := os.RemoveAll(filepath.Join(tempDir, "regular_file"))
+				require.NoError(t, err, "Failed to delete regular_file.")
+
+				err = os.RemoveAll(filepath.Join(tempDir, "regular_symlink"))
+				require.NoError(t, err, "Failed to delete regular_symlink.")
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			// Run test
+			result, err := IsMountedFolder(tt.path)
+
+			if tt.cleanup != nil {
+				tt.cleanup()
+			}
+
+			// Assert results
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+
+	err = os.RemoveAll(tempDir)
+	require.NoError(t, err, "Failed to remove directory.")
 }

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -19,12 +19,14 @@ limitations under the License.
 package mount
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/sys/windows"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/keymutex"
 )
@@ -118,7 +120,7 @@ func (mounter *Mounter) MountSensitive(source string, target string, fstype stri
 		if output, err := newSMBMapping(username, password, source); err != nil {
 			klog.Warningf("SMB Mapping(%s) returned with error(%v), output(%s)", source, err, string(output))
 			if isSMBMappingExist(source) {
-				valid, err := isValidPath(source)
+				valid, err := IsPathValid(source)
 				if !valid {
 					if err == nil || isAccessDeniedError(err) {
 						klog.V(2).Infof("SMB Mapping(%s) already exists while it's not valid, return error: %v, now begin to remove and remount", source, err)
@@ -189,19 +191,6 @@ func isSMBMappingExist(remotepath string) bool {
 	return err == nil
 }
 
-// check whether remotepath is valid
-// return (true, nil) if remotepath is valid
-func isValidPath(remotepath string) (bool, error) {
-	cmd := exec.Command("powershell", "/c", `Test-Path $Env:remotepath`)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("remotepath=%s", remotepath))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false, fmt.Errorf("returned output: %s, error: %v", string(output), err)
-	}
-
-	return strings.HasPrefix(strings.ToLower(string(output)), "true"), nil
-}
-
 func isAccessDeniedError(err error) bool {
 	return err != nil && strings.Contains(strings.ToLower(err.Error()), accessDenied)
 }
@@ -231,21 +220,16 @@ func (mounter *Mounter) List() ([]MountPoint, error) {
 	return []MountPoint{}, nil
 }
 
-// IsLikelyNotMountPoint determines if a directory is not a mountpoint.
+// IsLikelyNotMountPoint determines if a directory is not a mount point.
 func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
-	stat, err := os.Lstat(file)
+	isMnt, err := mounter.IsMountPoint(file)
 	if err != nil {
-		return true, err
-	}
-
-	if stat.Mode()&os.ModeSymlink != 0 {
+		if errors.Is(err, windows.ERROR_PATH_NOT_FOUND) || errors.Is(err, windows.ERROR_FILE_NOT_FOUND) || errors.Is(err, windows.ERROR_INVALID_NAME) {
+			return true, err
+		}
 		return false, err
 	}
-	// go1.23 behavior change: https://github.com/golang/go/issues/63703#issuecomment-2535941458
-	if stat.Mode()&os.ModeIrregular != 0 {
-		return false, err
-	}
-	return true, nil
+	return !isMnt, nil
 }
 
 // CanSafelySkipMountPointCheck always returns false on Windows
@@ -253,13 +237,9 @@ func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
 	return false
 }
 
-// IsMountPoint: determines if a directory is a mountpoint.
-func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
-	isNotMnt, err := mounter.IsLikelyNotMountPoint(file)
-	if err != nil {
-		return false, err
-	}
-	return !isNotMnt, nil
+// IsMountPoint determines if a directory is a mount point.
+func (mounter *Mounter) IsMountPoint(path string) (bool, error) {
+	return IsMountedFolder(path)
 }
 
 // GetMountRefs : empty implementation here since there is no place to query all mount points on Windows

--- a/staging/src/k8s.io/mount-utils/mount_windows_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows_test.go
@@ -339,36 +339,6 @@ func TestNewSMBMapping(t *testing.T) {
 	}
 }
 
-func TestIsValidPath(t *testing.T) {
-	tests := []struct {
-		remotepath     string
-		expectedResult bool
-		expectError    bool
-	}{
-		{
-			"c:",
-			true,
-			false,
-		},
-		{
-			"invalid-path",
-			false,
-			false,
-		},
-	}
-
-	for _, test := range tests {
-		result, err := isValidPath(test.remotepath)
-		assert.Equal(t, result, test.expectedResult, "Expect result not equal with isValidPath(%s) return: %q, expected: %q, error: %v",
-			test.remotepath, result, test.expectedResult, err)
-		if test.expectError {
-			assert.NotNil(t, err, "Expect error during isValidPath(%s)", test.remotepath)
-		} else {
-			assert.Nil(t, err, "Expect error is nil during isValidPath(%s)", test.remotepath)
-		}
-	}
-}
-
 func TestIsAccessDeniedError(t *testing.T) {
 	tests := []struct {
 		err            error


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Migrate Windows related volume operations to use native Windows API and WMI calls than PowerShell for performance boost and more reliable result across Go version.
This feature has been delivered in [kubernetes-csi/csi-proxy@v1.3.0 (release)](https://github.com/kubernetes-csi/csi-proxy/releases/tag/v1.3.0)
The same change in mount-utils is needed to allow more CSI driver to adopt the same performance improvement.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

Refer to https://github.com/kubernetes-csi/csi-proxy/pull/399/files

WMI related changes will be in a follow-up PR as they may need to introduce a new staging repository.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
