### PR TITLE
prepare kind configs for kubeadm v1beta4

### DIFF
--- a/test/e2e/dra/kind.yaml
+++ b/test/e2e/dra/kind.yaml
@@ -8,9 +8,48 @@ containerdConfigPatches:
     enable_cdi = true
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
+- role: worker
+- role: worker
+- role: worker
+kubeadmConfigPatches:
+  # v1beta4 for the future (v1.35.0+ ?)
+  # https://github.com/kubernetes-sigs/kind/issues/3847
+  # TODO: drop v1beta3 when kind makes the switch
   - |
     kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
+    scheduler:
+        extraArgs:
+          - name: "v"
+            value: "5"
+          - name: "vmodule"
+            value: "allocator=6,dynamicresources=6" # structured/allocator.go, DRA scheduler plugin
+    controllerManager:
+        extraArgs:
+          - name: "v"
+            value: "5"
+          - name: "vmodule"
+            value: "controller=6" # resourceclaim/controller.go - should have renamed it when copying the controller it was based on!
+    apiServer:
+        extraArgs:
+          runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true"
+  - |
+    kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
+    nodeRegistration:
+      kubeletExtraArgs:
+        - name: "v"
+          value: "5"
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        - name: "v"
+          value: "5"
+  # v1beta3 for v1.23.0 ... ?
+  - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
     scheduler:
         extraArgs:
           v: "5"
@@ -24,25 +63,10 @@ nodes:
           runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
     nodeRegistration:
       kubeletExtraArgs:
         v: "5"
-- role: worker
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        v: "5"
-- role: worker
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        v: "5"
-- role: worker
-  kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
     nodeRegistration:

--- a/test/e2e/testing-manifests/auth/encrypt/kind.yaml
+++ b/test/e2e/testing-manifests/auth/encrypt/kind.yaml
@@ -21,8 +21,39 @@ nodes:
     readOnly: true
     propagation: None
   kubeadmConfigPatches:
+    # v1beta4 for the future (v1.35.0+ ?)
+    # https://github.com/kubernetes-sigs/kind/issues/3847
+    # TODO: drop v1beta3 when kind makes the switch
     - |
       kind: ClusterConfiguration
+      apiVersion: kubeadm.k8s.io/v1beta4
+      apiServer:
+        extraArgs:
+          - name: "encryption-provider-config"
+            value: "/etc/kubernetes/encryption-config.yaml"
+          - name: "v"
+            value: "5"
+        extraVolumes:
+        - name: encryption-config
+          hostPath: "/etc/kubernetes/encryption-config.yaml"
+          mountPath: "/etc/kubernetes/encryption-config.yaml"
+          readOnly: true
+          pathType: File
+        - name: sock-path
+          hostPath: "/tmp"
+          mountPath: "/tmp"
+      scheduler:
+        extraArgs:
+          - name: "v"
+            value: "5"
+      controllerManager:
+        extraArgs:
+          - name: "v"
+            value: "5"
+    # v1beta3 for v1.23.0 ... ?
+    - |
+      kind: ClusterConfiguration
+      apiVersion: kubeadm.k8s.io/v1beta3
       apiServer:
         extraArgs:
           encryption-provider-config: "/etc/kubernetes/encryption-config.yaml"

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/run_group_snapshot_e2e.sh
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/run_group_snapshot_e2e.sh
@@ -28,8 +28,6 @@ set -o errexit -o nounset -o xtrace
 # parallel testing is enabled. Using LABEL_FILTER instead of combining SKIP and
 # FOCUS is recommended (more expressive, easier to read than regexp).
 #
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
@@ -84,73 +82,15 @@ build() {
   export PATH="${PWD}/_output/bin:$PATH"
 }
 
-check_structured_log_support() {
-	case "${KUBE_VERSION}" in
-		v1.1[0-8].*)
-			echo "$1 is only supported on versions >= v1.19, got ${KUBE_VERSION}"
-			exit 1
-			;;
-	esac
-}
-
 # up a cluster with kind
 create_cluster() {
-  # Grab the version of the cluster we're about to start
-  KUBE_VERSION="$(docker run --rm --entrypoint=cat "kindest/node:latest" /kind/version)"
-
   # Default Log level for all components in test clusters
   KIND_CLUSTER_LOG_LEVEL=${KIND_CLUSTER_LOG_LEVEL:-4}
-
-  # potentially enable --logging-format
-  CLUSTER_LOG_FORMAT=${CLUSTER_LOG_FORMAT:-}
-  scheduler_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  controllerManager_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  apiServer_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  if [ -n "$CLUSTER_LOG_FORMAT" ]; then
-      check_structured_log_support "CLUSTER_LOG_FORMAT"
-      scheduler_extra_args="${scheduler_extra_args}
-      \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
-      controllerManager_extra_args="${controllerManager_extra_args}
-      \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
-      apiServer_extra_args="${apiServer_extra_args}
-      \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
-  fi
-  kubelet_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
-  KUBELET_LOG_FORMAT=${KUBELET_LOG_FORMAT:-$CLUSTER_LOG_FORMAT}
-  if [ -n "$KUBELET_LOG_FORMAT" ]; then
-      check_structured_log_support "KUBECTL_LOG_FORMAT"
-      kubelet_extra_args="${kubelet_extra_args}
-      \"logging-format\": \"${KUBELET_LOG_FORMAT}\""
-  fi
 
   # JSON or YAML map injected into featureGates config
   feature_gates="${FEATURE_GATES:-{\}}"
   # --runtime-config argument value passed to the API server, again as a map
   runtime_config="${RUNTIME_CONFIG:-{\}}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    :
-    ;;
-  true)
-    if [ "${feature_gates}" != "{}" ]; then
-      echo "GA_ONLY=true and FEATURE_GATES=${feature_gates} are mutually exclusive."
-      exit 1
-    fi
-    if [ "${runtime_config}" != "{}" ]; then
-      echo "GA_ONLY=true and RUNTIME_CONFIG=${runtime_config} are mutually exclusive."
-      exit 1
-    fi
-
-    echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
-    feature_gates='{"AllAlpha":false,"AllBeta":false}'
-    runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    exit 1
-    ;;
-  esac
 
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"
@@ -170,29 +110,63 @@ nodes:
 featureGates: ${feature_gates}
 runtimeConfig: ${runtime_config}
 kubeadmConfigPatches:
+# v1beta4 for the future (v1.35.0+ ?)
+# https://github.com/kubernetes-sigs/kind/issues/3847
+# TODO: drop v1beta3 when kind makes the switch
 - |
   kind: ClusterConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta4
   metadata:
     name: config
   apiServer:
     extraArgs:
-${apiServer_extra_args}
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
   controllerManager:
     extraArgs:
-${controllerManager_extra_args}
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
   scheduler:
     extraArgs:
-${scheduler_extra_args}
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
   ---
   kind: InitConfiguration
   nodeRegistration:
     kubeletExtraArgs:
-${kubelet_extra_args}
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
   ---
   kind: JoinConfiguration
   nodeRegistration:
     kubeletExtraArgs:
-${kubelet_extra_args}
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
+# v1beta3 for v1.23.0 ... ?
+- |
+  kind: ClusterConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta3
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+  controllerManager:
+    extraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+  scheduler:
+    extraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+  ---
+  kind: InitConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+     "v": "${KIND_CLUSTER_LOG_LEVEL}"
+  ---
+  kind: JoinConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes-sigs/kind/issues/3847

kubeadm v1beta4 contains breaking changes, previously some of these configurations were using unversioned paches to target extraArgs in kubeadm config, which now needs to target v1beta3 (used in kind for Kubernetes v1.23+) and v1beta4 (to be used in perhaps 1.35.0+)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

I intend to use this as an example when PSA-ing the dev@ mailinglist for other CI jobs.

This patch will work regardless of if / when kind adopts kubeadm v1beta4.

However, one downside is it will stop working when some new kubeadm version is used.

In the future we may move back to a verisonless patch that only works for the version that uses v1beta4 and up.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig testing storage node auth