### PR TITLE
Automated cherry pick of #134861: [release-1.34] etcd: Bump supported etcd version to v3.5.24 for release v1.31, v1.32, and v1.33

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -64,7 +64,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.5.16
+    version: 3.5.24
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version
@@ -74,10 +74,6 @@ dependencies:
       match: DefaultEtcdVersion =
     - path: hack/lib/etcd.sh
       match: ETCD_VERSION=
-    - path: staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
-      match: gcr.io/etcd-development/etcd
-    - path: test/utils/image/manifest.go
-      match: configs\[Etcd\] = Config{list\.GcEtcdRegistry, "etcd", "\d+\.\d+.\d+(-(alpha|beta|rc).\d+)?(-\d+)?"}
 
   - name: "etcd-image"
     version: 3.5.16

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.16-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.24-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -43,7 +43,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.5.16') }}"
+        "value": "{{ pillar.get('etcd_version', '3.5.24') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.5.16-0
-export ETCD_VERSION=3.5.16
+export ETCD_IMAGE=3.5.24-0
+export ETCD_VERSION=3.5.24
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -323,7 +323,7 @@ const (
 	KubeletHealthzPort = 10248
 
 	// MinExternalEtcdVersion indicates minimum external etcd version which kubeadm supports
-	MinExternalEtcdVersion = "3.5.11-0"
+	MinExternalEtcdVersion = "3.5.24-0"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
 	DefaultEtcdVersion = "3.5.16-0"
@@ -495,10 +495,10 @@ var (
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
-		29: "3.5.16-0",
-		30: "3.5.16-0",
-		31: "3.5.16-0",
-		32: "3.5.16-0",
+		29: "3.5.24-0",
+		30: "3.5.24-0",
+		31: "3.5.24-0",
+		32: "3.5.24-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -326,7 +326,7 @@ const (
 	MinExternalEtcdVersion = "3.5.24-0"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.5.16-0"
+	DefaultEtcdVersion = "3.5.24-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.16}
+ETCD_VERSION=${ETCD_VERSION:-3.5.24}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:


### PR DESCRIPTION
Cherry pick of #134861 on release-1.32.

#134861: [release-1.34] etcd: Bump supported etcd version to v3.5.24 for release v1.31, v1.32, and v1.33

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: updated the supported etcd version to v3.5.24 for the skewed control plane version v1.33.
```