### PR TITLE
Automated cherry pick of #134740: remove taint values from unschedulable messages in pod status

### DIFF
--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -116,8 +116,8 @@ func (pl *TaintToleration) Filter(ctx context.Context, state fwk.CycleState, pod
 		return nil
 	}
 
-	errReason := fmt.Sprintf("node(s) had untolerated taint {%s: %s}", taint.Key, taint.Value)
-	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, errReason)
+	klog.FromContext(ctx).V(4).Info("node had untolerated taints", "node", klog.KObj(node), "pod", klog.KObj(pod), "untoleratedTaint", taint)
+	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node(s) had untolerated taint(s)")
 }
 
 // preScoreState computed at PreScore and used at Score.

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -283,7 +283,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 			pod:  podWithTolerations("pod1", []v1.Toleration{}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
 			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
-				"node(s) had untolerated taint {dedicated: user1}"),
+				"node(s) had untolerated taint(s)"),
 		},
 		{
 			name: "A pod which can be scheduled on a dedicated node assigned to user1 with effect NoSchedule",
@@ -295,7 +295,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "dedicated", Operator: "Equal", Value: "user2", Effect: "NoSchedule"}}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
 			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
-				"node(s) had untolerated taint {dedicated: user1}"),
+				"node(s) had untolerated taint(s)"),
 		},
 		{
 			name: "A pod can be scheduled onto the node, with a toleration uses operator Exists that tolerates the taints on the node",
@@ -319,7 +319,7 @@ func TestTaintTolerationFilter(t *testing.T) {
 			pod:  podWithTolerations("pod1", []v1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "PreferNoSchedule"}}),
 			node: nodeWithTaints("nodeA", []v1.Taint{{Key: "foo", Value: "bar", Effect: "NoSchedule"}}),
 			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
-				"node(s) had untolerated taint {foo: bar}"),
+				"node(s) had untolerated taint(s)"),
 		},
 		{
 			name: "The pod has a toleration that keys and values match the taint on the node, the effect of toleration is empty, " +


### PR DESCRIPTION
Cherry pick of #134740 on release-1.34.

#134740: Do not log untolerated taint in pod status updates.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-scheduler: Pod statuses no longer include specific taint keys or values when scheduling fails because of untolerated taints
```