### PR TITLE
rbac: migrate PolicyRule.verbs to Declarative Validation

### DIFF
--- a/pkg/apis/rbac/v1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1/zz_generated.validations.go
@@ -39,11 +39,27 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type ClusterRole
+	scheme.AddValidationFunc((*rbacv1.ClusterRole)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ClusterRole(ctx, op, nil /* fldPath */, obj.(*rbacv1.ClusterRole), safe.Cast[*rbacv1.ClusterRole](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type ClusterRoleBinding
 	scheme.AddValidationFunc((*rbacv1.ClusterRoleBinding)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
 		case "/":
 			return Validate_ClusterRoleBinding(ctx, op, nil /* fldPath */, obj.(*rbacv1.ClusterRoleBinding), safe.Cast[*rbacv1.ClusterRoleBinding](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type Role
+	scheme.AddValidationFunc((*rbacv1.Role)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_Role(ctx, op, nil /* fldPath */, obj.(*rbacv1.Role), safe.Cast[*rbacv1.Role](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
@@ -56,6 +72,28 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_ClusterRole validates an instance of ClusterRole according
+// to declarative validation rules in the API schema.
+func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1.ClusterRole) (errs field.ErrorList) {
+	// field rbacv1.ClusterRole.TypeMeta has no validation
+	// field rbacv1.ClusterRole.ObjectMeta has no validation
+
+	// field rbacv1.ClusterRole.Rules
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []rbacv1.PolicyRule, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
+			return
+		}(fldPath.Child("rules"), obj.Rules, safe.Field(oldObj, func(oldObj *rbacv1.ClusterRole) []rbacv1.PolicyRule { return oldObj.Rules }), oldObj != nil)...)
+
+	// field rbacv1.ClusterRole.AggregationRule has no validation
+	return errs
 }
 
 // Validate_ClusterRoleBinding validates an instance of ClusterRoleBinding according
@@ -87,6 +125,56 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			errs = append(errs, Validate_RoleRef(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("roleRef"), &obj.RoleRef, safe.Field(oldObj, func(oldObj *rbacv1.ClusterRoleBinding) *rbacv1.RoleRef { return &oldObj.RoleRef }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_PolicyRule validates an instance of PolicyRule according
+// to declarative validation rules in the API schema.
+func Validate_PolicyRule(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1.PolicyRule) (errs field.ErrorList) {
+	// field rbacv1.PolicyRule.Verbs
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("verbs"), obj.Verbs, safe.Field(oldObj, func(oldObj *rbacv1.PolicyRule) []string { return oldObj.Verbs }), oldObj != nil)...)
+
+	// field rbacv1.PolicyRule.APIGroups has no validation
+	// field rbacv1.PolicyRule.Resources has no validation
+	// field rbacv1.PolicyRule.ResourceNames has no validation
+	// field rbacv1.PolicyRule.NonResourceURLs has no validation
+	return errs
+}
+
+// Validate_Role validates an instance of Role according
+// to declarative validation rules in the API schema.
+func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1.Role) (errs field.ErrorList) {
+	// field rbacv1.Role.TypeMeta has no validation
+	// field rbacv1.Role.ObjectMeta has no validation
+
+	// field rbacv1.Role.Rules
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []rbacv1.PolicyRule, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
+			return
+		}(fldPath.Child("rules"), obj.Rules, safe.Field(oldObj, func(oldObj *rbacv1.Role) []rbacv1.PolicyRule { return oldObj.Rules }), oldObj != nil)...)
 
 	return errs
 }

--- a/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
@@ -39,11 +39,27 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type ClusterRole
+	scheme.AddValidationFunc((*rbacv1alpha1.ClusterRole)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ClusterRole(ctx, op, nil /* fldPath */, obj.(*rbacv1alpha1.ClusterRole), safe.Cast[*rbacv1alpha1.ClusterRole](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type ClusterRoleBinding
 	scheme.AddValidationFunc((*rbacv1alpha1.ClusterRoleBinding)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
 		case "/":
 			return Validate_ClusterRoleBinding(ctx, op, nil /* fldPath */, obj.(*rbacv1alpha1.ClusterRoleBinding), safe.Cast[*rbacv1alpha1.ClusterRoleBinding](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type Role
+	scheme.AddValidationFunc((*rbacv1alpha1.Role)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_Role(ctx, op, nil /* fldPath */, obj.(*rbacv1alpha1.Role), safe.Cast[*rbacv1alpha1.Role](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
@@ -56,6 +72,28 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_ClusterRole validates an instance of ClusterRole according
+// to declarative validation rules in the API schema.
+func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1alpha1.ClusterRole) (errs field.ErrorList) {
+	// field rbacv1alpha1.ClusterRole.TypeMeta has no validation
+	// field rbacv1alpha1.ClusterRole.ObjectMeta has no validation
+
+	// field rbacv1alpha1.ClusterRole.Rules
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []rbacv1alpha1.PolicyRule, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
+			return
+		}(fldPath.Child("rules"), obj.Rules, safe.Field(oldObj, func(oldObj *rbacv1alpha1.ClusterRole) []rbacv1alpha1.PolicyRule { return oldObj.Rules }), oldObj != nil)...)
+
+	// field rbacv1alpha1.ClusterRole.AggregationRule has no validation
+	return errs
 }
 
 // Validate_ClusterRoleBinding validates an instance of ClusterRoleBinding according
@@ -87,6 +125,56 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			errs = append(errs, Validate_RoleRef(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("roleRef"), &obj.RoleRef, safe.Field(oldObj, func(oldObj *rbacv1alpha1.ClusterRoleBinding) *rbacv1alpha1.RoleRef { return &oldObj.RoleRef }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_PolicyRule validates an instance of PolicyRule according
+// to declarative validation rules in the API schema.
+func Validate_PolicyRule(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1alpha1.PolicyRule) (errs field.ErrorList) {
+	// field rbacv1alpha1.PolicyRule.Verbs
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("verbs"), obj.Verbs, safe.Field(oldObj, func(oldObj *rbacv1alpha1.PolicyRule) []string { return oldObj.Verbs }), oldObj != nil)...)
+
+	// field rbacv1alpha1.PolicyRule.APIGroups has no validation
+	// field rbacv1alpha1.PolicyRule.Resources has no validation
+	// field rbacv1alpha1.PolicyRule.ResourceNames has no validation
+	// field rbacv1alpha1.PolicyRule.NonResourceURLs has no validation
+	return errs
+}
+
+// Validate_Role validates an instance of Role according
+// to declarative validation rules in the API schema.
+func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1alpha1.Role) (errs field.ErrorList) {
+	// field rbacv1alpha1.Role.TypeMeta has no validation
+	// field rbacv1alpha1.Role.ObjectMeta has no validation
+
+	// field rbacv1alpha1.Role.Rules
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []rbacv1alpha1.PolicyRule, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
+			return
+		}(fldPath.Child("rules"), obj.Rules, safe.Field(oldObj, func(oldObj *rbacv1alpha1.Role) []rbacv1alpha1.PolicyRule { return oldObj.Rules }), oldObj != nil)...)
 
 	return errs
 }

--- a/pkg/apis/rbac/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.validations.go
@@ -39,11 +39,27 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type ClusterRole
+	scheme.AddValidationFunc((*rbacv1beta1.ClusterRole)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_ClusterRole(ctx, op, nil /* fldPath */, obj.(*rbacv1beta1.ClusterRole), safe.Cast[*rbacv1beta1.ClusterRole](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type ClusterRoleBinding
 	scheme.AddValidationFunc((*rbacv1beta1.ClusterRoleBinding)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
 		case "/":
 			return Validate_ClusterRoleBinding(ctx, op, nil /* fldPath */, obj.(*rbacv1beta1.ClusterRoleBinding), safe.Cast[*rbacv1beta1.ClusterRoleBinding](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type Role
+	scheme.AddValidationFunc((*rbacv1beta1.Role)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_Role(ctx, op, nil /* fldPath */, obj.(*rbacv1beta1.Role), safe.Cast[*rbacv1beta1.Role](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
@@ -56,6 +72,28 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_ClusterRole validates an instance of ClusterRole according
+// to declarative validation rules in the API schema.
+func Validate_ClusterRole(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1beta1.ClusterRole) (errs field.ErrorList) {
+	// field rbacv1beta1.ClusterRole.TypeMeta has no validation
+	// field rbacv1beta1.ClusterRole.ObjectMeta has no validation
+
+	// field rbacv1beta1.ClusterRole.Rules
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []rbacv1beta1.PolicyRule, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
+			return
+		}(fldPath.Child("rules"), obj.Rules, safe.Field(oldObj, func(oldObj *rbacv1beta1.ClusterRole) []rbacv1beta1.PolicyRule { return oldObj.Rules }), oldObj != nil)...)
+
+	// field rbacv1beta1.ClusterRole.AggregationRule has no validation
+	return errs
 }
 
 // Validate_ClusterRoleBinding validates an instance of ClusterRoleBinding according
@@ -87,6 +125,56 @@ func Validate_ClusterRoleBinding(ctx context.Context, op operation.Operation, fl
 			errs = append(errs, Validate_RoleRef(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("roleRef"), &obj.RoleRef, safe.Field(oldObj, func(oldObj *rbacv1beta1.ClusterRoleBinding) *rbacv1beta1.RoleRef { return &oldObj.RoleRef }), oldObj != nil)...)
+
+	return errs
+}
+
+// Validate_PolicyRule validates an instance of PolicyRule according
+// to declarative validation rules in the API schema.
+func Validate_PolicyRule(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1beta1.PolicyRule) (errs field.ErrorList) {
+	// field rbacv1beta1.PolicyRule.Verbs
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("verbs"), obj.Verbs, safe.Field(oldObj, func(oldObj *rbacv1beta1.PolicyRule) []string { return oldObj.Verbs }), oldObj != nil)...)
+
+	// field rbacv1beta1.PolicyRule.APIGroups has no validation
+	// field rbacv1beta1.PolicyRule.Resources has no validation
+	// field rbacv1beta1.PolicyRule.ResourceNames has no validation
+	// field rbacv1beta1.PolicyRule.NonResourceURLs has no validation
+	return errs
+}
+
+// Validate_Role validates an instance of Role according
+// to declarative validation rules in the API schema.
+func Validate_Role(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *rbacv1beta1.Role) (errs field.ErrorList) {
+	// field rbacv1beta1.Role.TypeMeta has no validation
+	// field rbacv1beta1.Role.ObjectMeta has no validation
+
+	// field rbacv1beta1.Role.Rules
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []rbacv1beta1.PolicyRule, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule)...)
+			return
+		}(fldPath.Child("rules"), obj.Rules, safe.Field(oldObj, func(oldObj *rbacv1beta1.Role) []rbacv1beta1.PolicyRule { return oldObj.Rules }), oldObj != nil)...)
 
 	return errs
 }

--- a/pkg/apis/rbac/validation/validation.go
+++ b/pkg/apis/rbac/validation/validation.go
@@ -103,7 +103,7 @@ func ValidateClusterRoleUpdate(role *rbac.ClusterRole, oldRole *rbac.ClusterRole
 func ValidatePolicyRule(rule rbac.PolicyRule, isNamespaced bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(rule.Verbs) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("verbs"), "verbs must contain at least one value"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("verbs"), "verbs must contain at least one value").MarkCoveredByDeclarative())
 	}
 
 	if len(rule.NonResourceURLs) > 0 {

--- a/pkg/registry/rbac/role/declarative_validation_test.go
+++ b/pkg/registry/rbac/role/declarative_validation_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package role
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+var apiVersions = []string{"v1", "v1alpha1", "v1beta1"}
+
+func TestDeclarativeValidateForDeclarative(t *testing.T) {
+	for _, v := range apiVersions {
+		t.Run("version="+v, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(
+				genericapirequest.NewDefaultContext(),
+				&genericapirequest.RequestInfo{
+					APIGroup:   "rbac.authorization.k8s.io",
+					APIVersion: v,
+				},
+			)
+
+			testCases := map[string]struct {
+				input        rbac.Role
+				expectedErrs field.ErrorList
+			}{
+				"valid: minimal resource rule": {
+					input: newRoleDeclarative("ns", "role-valid",
+						[]rbac.PolicyRule{{
+							Verbs:     []string{"get"},
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+						}},
+					),
+				},
+				"invalid: verbs empty (required)": {
+					input: newRoleDeclarative("ns", "role-no-verbs",
+						[]rbac.PolicyRule{{
+							Verbs:     []string{}, 
+							APIGroups: []string{""},
+							Resources: []string{"pods"},
+						}},
+					),
+					expectedErrs: field.ErrorList{
+						field.Required(
+							field.NewPath("rules").Index(0).Child("verbs"),
+							"verbs must contain at least one value",
+						),
+					},
+				},
+				"invalid: namespaced rule has nonResourceURLs": {
+					input: newRoleDeclarative("ns", "role-nonresource",
+						[]rbac.PolicyRule{{
+							Verbs:           []string{"get"},
+							NonResourceURLs: []string{"/healthz"},
+						}},
+					),
+					expectedErrs: field.ErrorList{
+						field.Invalid(
+							field.NewPath("rules").Index(0).Child("nonResourceURLs"),
+							[]string{"/healthz"},
+							"namespaced rules cannot apply to non-resource URLs",
+						),
+					},
+				},
+				// TODO: Add more test cases
+			}
+
+			for name, tc := range testCases {
+				t.Run(name, func(t *testing.T) {
+					apitesting.VerifyValidationEquivalence(
+						t,
+						ctx,
+						&tc.input,
+						Strategy.Validate,
+						tc.expectedErrs,
+					)
+				})
+			}
+		})
+	}
+}
+
+func TestValidateUpdateForDeclarative(t *testing.T) {
+	for _, v := range apiVersions {
+		t.Run("version="+v, func(t *testing.T) {
+			ctx := genericapirequest.WithRequestInfo(
+				genericapirequest.NewDefaultContext(),
+				&genericapirequest.RequestInfo{
+					APIGroup:   "rbac.authorization.k8s.io",
+					APIVersion: v,
+				},
+			)
+
+			testCases := map[string]struct {
+				old, update  rbac.Role
+				expectedErrs field.ErrorList
+			}{
+				// TODO: Add more test cases
+			}
+
+			for name, tc := range testCases {
+				t.Run(name, func(t *testing.T) {
+					apitesting.VerifyUpdateValidationEquivalence(
+						t,
+						ctx,
+						&tc.update,
+						&tc.old,
+						Strategy.ValidateUpdate,
+						tc.expectedErrs,
+					)
+				})
+			}
+		})
+	}
+}
+
+// Helper to create a base Role for declarative tests.
+func newRoleDeclarative(ns, name string, rules []rbac.PolicyRule) rbac.Role {
+	return rbac.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       ns,
+			Name:            name,
+			ResourceVersion: "1",
+		},
+		Rules: rules,
+	}
+}

--- a/pkg/registry/rbac/role/strategy.go
+++ b/pkg/registry/rbac/role/strategy.go
@@ -19,6 +19,7 @@ package role
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -71,7 +72,8 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 // Validate validates a new Role. Validation must check for a correct signature.
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	role := obj.(*rbac.Role)
-	return validation.ValidateRole(role)
+	allErrs := validation.ValidateRole(role)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, role, nil, allErrs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -84,7 +86,10 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an end user.
 func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateRoleUpdate(obj.(*rbac.Role), old.(*rbac.Role))
+	newObj := obj.(*rbac.Role)
+	oldObj := old.(*rbac.Role)
+	errs := validation.ValidateRoleUpdate(newObj, oldObj)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newObj, oldObj, errs, operation.Update)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -98,6 +98,8 @@ message ClusterRoleList {
 message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
+  // +required
+  // +k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -49,6 +49,8 @@ const (
 type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
+	// +required
+	// +k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -101,6 +101,8 @@ message ClusterRoleList {
 message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
+  // +required
+  // +k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -49,6 +49,8 @@ const (
 type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
+	// +required
+	// +k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -101,6 +101,8 @@ message ClusterRoleList {
 message PolicyRule {
   // Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
+  // +required
+  // +k8s:required
   repeated string verbs = 1;
 
   // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -49,6 +49,8 @@ const (
 type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
+	// +required
+	// +k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Enables the Declarative validation for role 
- Migrated PolicyRule.verbs field to Declarative Validation and marked with +k8s: required.

#### Which issue(s) this PR is related to:

part of #134280 

#### Special notes for your reviewer:


```release-note
NONE
```