### PR TITLE
test(kubectl): migrate from deprecated NewSimpleClientset to NewClientset

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
@@ -38,7 +38,7 @@ func TestRunCordonOrUncordon(t *testing.T) {
 		{
 			description: "nil context object",
 			drainer: &Helper{
-				Client: fake.NewSimpleClientset(),
+				Client: fake.NewClientset(),
 			},
 			desired:       true,
 			expectedError: &nilContextError,

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -293,7 +293,7 @@ func TestCheckEvictionSupport(t *testing.T) {
 	for _, evictionVersion := range []string{"", "v1", "v1beta1"} {
 		t.Run(fmt.Sprintf("evictionVersion=%v", evictionVersion),
 			func(t *testing.T) {
-				k := fake.NewSimpleClientset()
+				k := fake.NewClientset()
 				if len(evictionVersion) > 0 {
 					addEvictionSupport(t, k, evictionVersion)
 				} else {
@@ -411,7 +411,7 @@ func TestDeleteOrEvict(t *testing.T) {
 			}
 
 			// Build the fake client
-			k := fake.NewSimpleClientset(create...)
+			k := fake.NewClientset(create...)
 			if tc.evictionSupported {
 				addEvictionSupport(t, k, "v1")
 			} else {

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers_test.go
@@ -91,7 +91,7 @@ func TestGetPodList(t *testing.T) {
 
 	for i := range tests {
 		test := tests[i]
-		fake := fakeexternal.NewSimpleClientset(test.podList)
+		fake := fakeexternal.NewClientset(test.podList)
 		if len(test.watching) > 0 {
 			watcher := watch.NewFake()
 			for _, event := range test.watching {
@@ -251,7 +251,7 @@ func TestGetFirstPod(t *testing.T) {
 
 	for i := range tests {
 		test := tests[i]
-		fake := fakeexternal.NewSimpleClientset(test.podList)
+		fake := fakeexternal.NewClientset(test.podList)
 		if len(test.watching) > 0 {
 			watcher := watch.NewFake()
 			for _, event := range test.watching {

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -387,7 +387,7 @@ func TestLogsForObject(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		fakeClientset := fakeexternal.NewSimpleClientset(test.clientsetPods...)
+		fakeClientset := fakeexternal.NewClientset(test.clientsetPods...)
 		responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), test.obj, test.opts, 20*time.Second, test.allContainers, test.allPods)
 		if test.expectedErr == "" && err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
@@ -565,7 +565,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			pod := tc.podFn()
-			fakeClientset := fakeexternal.NewSimpleClientset(pod)
+			fakeClientset := fakeexternal.NewClientset(pod)
 			responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), pod, tc.podLogOptions, 20*time.Second, tc.allContainers, tc.allPods)
 			if err != nil {
 				if len(tc.expectedError) > 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates 4 kubectl test files from deprecated `NewSimpleClientset` to `NewClientset`. 

Files migrated:
- `staging/src/k8s.io/kubectl/pkg/drain/default_test.go`
- `staging/src/k8s.io/kubectl/pkg/drain/drain_test.go`
- `staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers_test.go`
- `staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go`

`NewSimpleClientset` was marked deprecated in #125560. The new function provides field management support for better Server-Side Apply testing.

Reference: https://github.com/kubernetes/kubernetes/blob/afb2b97425317948e9e59b2a7871fca5bbb2ab08/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go#L147-L149

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

First contribution! I'm following the pattern of https://github.com/kubernetes/kubernetes/pull/134818

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
