### PR TITLE
DRA: Improve gather pools performance

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5124,6 +5124,29 @@ func TestAllocator(t *testing.T,
 				),
 			},
 		},
+		"multi-host-resource-pool-with-stale-slice-for-current-node": {
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrap(
+				func() wrapResourceSlice {
+					s := slice(slice1, node1, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice2, node2, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+			),
+			node: node(node1, region1),
+		},
 	}
 
 	for name, tc := range testcases {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -45,10 +45,6 @@ func nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 	return false, nil
 }
 
-type poolIdentifier struct {
-	driver, pool string
-}
-
 // GatherPools collects information about all resource pools which provide
 // devices that are accessible from the given node.
 //
@@ -56,44 +52,6 @@ type poolIdentifier struct {
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
-	slicesByPool := make(map[poolIdentifier][]*resourceapi.ResourceSlice)
-	for _, slice := range slices {
-		poolID := poolIdentifier{
-			driver: slice.Spec.Driver,
-			pool:   slice.Spec.Pool.Name,
-		}
-		slicesByPool[poolID] = append(slicesByPool[poolID], slice)
-	}
-
-	// We need to check whether a pool is complete while we have all
-	// the slices. Once we discard slices that don't target the node, we
-	// no longer have the information needed to find out.
-	incompletePools := sets.New[poolIdentifier]()
-	for poolID, slices := range slicesByPool {
-		complete := true
-		sliceCount := len(slices)
-		generation := slices[0].Spec.Pool.Generation
-		for _, slice := range slices {
-			// If the number of slices in the pool specified in any of the slices
-			// doesn't match what we found, the pool is most likely being updated
-			// by the controller.
-			if slice.Spec.Pool.ResourceSliceCount != int64(sliceCount) {
-				complete = false
-			}
-			// If the generation of the pool isn't the same across all slices,
-			// the pool is most likely being updated by the controller. We can't
-			// allocate devices from it.
-			if slice.Spec.Pool.Generation != generation {
-				complete = false
-			}
-		}
-		// We still need to keep incomplete pools, since we need to make sure
-		// all devices available on a node is considered for allocationMode All.
-		if !complete {
-			incompletePools.Insert(poolID)
-		}
-	}
-
 	pools := make(map[PoolID]*Pool)
 	var slicesWithBindingConditions []*resourceapi.ResourceSlice
 	for _, slice := range slices {
@@ -161,8 +119,17 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	// Find incomplete pools and flatten into a single slice.
 	result := make([]*Pool, 0, len(pools))
 	var resultWithBindingConditions []*Pool
-	for _, pool := range pools {
-		pool.IsIncomplete = incompletePools.Has(poolIdentifier{driver: pool.Driver.String(), pool: pool.Pool.String()})
+	for poolID, pool := range pools {
+		isIncomplete := int64(len(pool.Slices)) != pool.Slices[0].Spec.Pool.ResourceSliceCount
+		// If we have all slices, we are done. If not, then we need to start looking for slices
+		// which were filtered out above because their node selection made them look irrelevant
+		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
+		// pools).
+		if isIncomplete {
+			slicesForPool := findSlicesForPool(slices, poolID)
+			isIncomplete = poolIsIncomplete(slicesForPool)
+		}
+		pool.IsIncomplete = isIncomplete
 		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
 		// if pool has binding conditions, add the pool to the end of the result
 		if poolHasBindingConditions(*pool) {
@@ -209,6 +176,43 @@ func addSlice(pools map[PoolID]*Pool, s *resourceapi.ResourceSlice) error {
 	// Add to pool.
 	pool.Slices = append(pool.Slices, &slice)
 	return nil
+}
+
+// findSlicesForPool returns all ResourceSlices that belong to the provided pool.
+func findSlicesForPool(slices []*resourceapi.ResourceSlice, poolID PoolID) []*resourceapi.ResourceSlice {
+	driver := poolID.Driver.String()
+	pool := poolID.Pool.String()
+
+	var slicesForPool []*resourceapi.ResourceSlice
+	for i := range slices {
+		slice := slices[i]
+		if slice.Spec.Driver == driver && slice.Spec.Pool.Name == pool {
+			slicesForPool = append(slicesForPool, slice)
+		}
+	}
+	return slicesForPool
+}
+
+// poolIsIncomplete checks if the provided ResourceSlices belong to a
+// complete pool. All provided ResourceSlices must belong to the same pool.
+func poolIsIncomplete(slices []*resourceapi.ResourceSlice) bool {
+	if len(slices) == 0 {
+		return false
+	}
+	sliceCount := slices[0].Spec.Pool.ResourceSliceCount
+	if int64(len(slices)) != sliceCount {
+		return true
+	}
+	gen := slices[0].Spec.Pool.Generation
+	for _, slice := range slices {
+		if slice.Spec.Pool.Generation != gen {
+			return true
+		}
+		if slice.Spec.Pool.ResourceSliceCount != sliceCount {
+			return true
+		}
+	}
+	return false
 }
 
 func poolIsInvalid(pool *Pool) (bool, string) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -104,8 +104,24 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
 		// pools).
 		if isIncomplete {
+			// Find all the slices that belongs to the current pool. Doing this for each pool
+			// separately could be a big inefficient if there are multiple incomplete pools. But
+			// that is probably a rare situation.
 			slicesForPool := findSlicesForPool(slices, poolID)
+			// This allows to check ALL slices in the pool to make sure whether the pool is
+			// complete or not.
 			isIncomplete = poolIsIncomplete(slicesForPool)
+			// If the pool is truly incomplete after this check, then we need to find out if
+			// the slices we have in the pool object really is on the latest generation. If one of
+			// the slices that was filtered out earlier are on a newer generation, it is not.
+			if isIncomplete {
+				latestGeneration := findLatestGenerationInPool(slices)
+				// All slices in the pool are on the same generation, so if the first one is on an
+				// older generation, then they are all stale and must be removed from the pool.
+				if len(pool.Slices) > 0 && pool.Slices[0].Spec.Pool.Generation != latestGeneration {
+					pool.Slices = nil
+				}
+			}
 		}
 		pool.IsIncomplete = isIncomplete
 		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
@@ -165,14 +181,27 @@ func findSlicesForPool(slices []*resourceapi.ResourceSlice, poolID PoolID) []*re
 
 // poolIsIncomplete checks if the provided ResourceSlices belong to a
 // complete pool. All provided ResourceSlices must belong to the same pool.
+//
+// For a pool to be complete, the following must be true:
+//   - All slices have the same generation
+//   - All slices agree on the number of ResourceSlices in the pool
+//   - The number of actual slices found must equal the expected number of
+//     slices in the pool.
 func poolIsIncomplete(slices []*resourceapi.ResourceSlice) bool {
 	if len(slices) == 0 {
 		return false
 	}
+	// Just take the resourceSliceCount from the first slice as the
+	// point of comparison. If this doesn't equal the count in all
+	// other ResourceSlices and the total number of slices in the pool,
+	// then the pool is not complete.
 	sliceCount := slices[0].Spec.Pool.ResourceSliceCount
 	if int64(len(slices)) != sliceCount {
 		return true
 	}
+	// Just take the generation of the first slice as the point of
+	// comparison. If this value is not the latest version, then
+	// the pool can't be complete.
 	gen := slices[0].Spec.Pool.Generation
 	for _, slice := range slices {
 		if slice.Spec.Pool.Generation != gen {
@@ -183,6 +212,16 @@ func poolIsIncomplete(slices []*resourceapi.ResourceSlice) bool {
 		}
 	}
 	return false
+}
+
+func findLatestGenerationInPool(slices []*resourceapi.ResourceSlice) int64 {
+	var latestGeneration int64
+	for _, slice := range slices {
+		if slice.Spec.Pool.Generation > latestGeneration {
+			latestGeneration = slice.Spec.Pool.Generation
+		}
+	}
+	return latestGeneration
 }
 
 func poolIsInvalid(pool *Pool) (bool, string) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
@@ -104,8 +104,24 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
 		// pools).
 		if isIncomplete {
+			// Find all the slices that belongs to the current pool. Doing this for each pool
+			// separately could be a big inefficient if there are multiple incomplete pools. But
+			// that is probably a rare situation.
 			slicesForPool := findSlicesForPool(slices, poolID)
+			// This allows to check ALL slices in the pool to make sure whether the pool is
+			// complete or not.
 			isIncomplete = poolIsIncomplete(slicesForPool)
+			// If the pool is truly incomplete after this check, then we need to find out if
+			// the slices we have in the pool object really is on the latest generation. If one of
+			// the slices that was filtered out earlier are on a newer generation, it is not.
+			if isIncomplete {
+				latestGeneration := findLatestGenerationInPool(slices)
+				// All slices in the pool are on the same generation, so if the first one is on an
+				// older generation, then they are all stale and must be removed from the pool.
+				if len(pool.Slices) > 0 && pool.Slices[0].Spec.Pool.Generation != latestGeneration {
+					pool.Slices = nil
+				}
+			}
 		}
 		pool.IsIncomplete = isIncomplete
 		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
@@ -165,14 +181,27 @@ func findSlicesForPool(slices []*resourceapi.ResourceSlice, poolID PoolID) []*re
 
 // poolIsIncomplete checks if the provided ResourceSlices belong to a
 // complete pool. All provided ResourceSlices must belong to the same pool.
+//
+// For a pool to be complete, the following must be true:
+//   - All slices have the same generation
+//   - All slices agree on the number of ResourceSlices in the pool
+//   - The number of actual slices found must equal the expected number of
+//     slices in the pool.
 func poolIsIncomplete(slices []*resourceapi.ResourceSlice) bool {
 	if len(slices) == 0 {
 		return false
 	}
+	// Just take the resourceSliceCount from the first slice as the
+	// point of comparison. If this doesn't equal the count in all
+	// other ResourceSlices and the total number of slices in the pool,
+	// then the pool is not complete.
 	sliceCount := slices[0].Spec.Pool.ResourceSliceCount
 	if int64(len(slices)) != sliceCount {
 		return true
 	}
+	// Just take the generation of the first slice as the point of
+	// comparison. If this value is not the latest version, then
+	// the pool can't be complete.
 	gen := slices[0].Spec.Pool.Generation
 	for _, slice := range slices {
 		if slice.Spec.Pool.Generation != gen {
@@ -183,6 +212,16 @@ func poolIsIncomplete(slices []*resourceapi.ResourceSlice) bool {
 		}
 	}
 	return false
+}
+
+func findLatestGenerationInPool(slices []*resourceapi.ResourceSlice) int64 {
+	var latestGeneration int64
+	for _, slice := range slices {
+		if slice.Spec.Pool.Generation > latestGeneration {
+			latestGeneration = slice.Spec.Pool.Generation
+		}
+	}
+	return latestGeneration
 }
 
 func poolIsInvalid(pool *Pool) (bool, string) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This fixes the performance regression caused by https://github.com/kubernetes/kubernetes/pull/134466. Rather than detecting the incomplete resource pools up front, it does a more thorough check only for resource pools that looks incomplete.

#### Which issue(s) this PR is related to:

Related-to: https://github.com/kubernetes/kubernetes/issues/135032

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

