### PR TITLE
pick one device class deterministically for extended resource

### DIFF
--- a/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
@@ -145,6 +145,6 @@ func (s *sharedDRAManagerContract) DeviceClassResolver() fwk.DeviceClassResolver
 
 type deviceClassResolverContract struct{}
 
-func (d *deviceClassResolverContract) GetDeviceClass(_ v1.ResourceName) string {
-	return ""
+func (d *deviceClassResolverContract) GetDeviceClass(_ v1.ResourceName) *resourceapi.DeviceClass {
+	return nil
 }

--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -90,7 +90,7 @@ func (s *DefaultDRAManager) DeviceClasses() fwk.DeviceClassLister {
 // disabled.
 //
 // That's okay, extendedresourcecache.ExtendedResourceCache.GetDeviceClass
-// returns the empty string if called for nil.
+// returns nil if called for nil.
 func (s *DefaultDRAManager) DeviceClassResolver() fwk.DeviceClassResolver {
 	return s.extendedResourceCache
 }

--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -51,7 +51,7 @@ type DefaultDRAManager struct {
 
 func NewDRAManager(ctx context.Context, claimsCache *assumecache.AssumeCache, resourceSliceTracker *resourceslicetracker.Tracker, informerFactory informers.SharedInformerFactory) *DefaultDRAManager {
 	logger := klog.FromContext(ctx)
-
+	dcLister := informerFactory.Resource().V1().DeviceClasses().Lister()
 	manager := &DefaultDRAManager{
 		resourceClaimTracker: &claimTracker{
 			cache:               claimsCache,
@@ -60,11 +60,11 @@ func NewDRAManager(ctx context.Context, claimsCache *assumecache.AssumeCache, re
 			logger:              logger,
 		},
 		resourceSliceLister: &resourceSliceLister{tracker: resourceSliceTracker},
-		deviceClassLister:   &deviceClassLister{classLister: informerFactory.Resource().V1().DeviceClasses().Lister()},
+		deviceClassLister:   &deviceClassLister{classLister: dcLister},
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.DRAExtendedResource) {
-		manager.extendedResourceCache = extendedresourcecache.NewExtendedResourceCache(logger)
+		manager.extendedResourceCache = extendedresourcecache.NewExtendedResourceCache(dcLister, logger)
 	}
 
 	// Reacting to events is more efficient than iterating over the list

--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager.go
@@ -51,7 +51,6 @@ type DefaultDRAManager struct {
 
 func NewDRAManager(ctx context.Context, claimsCache *assumecache.AssumeCache, resourceSliceTracker *resourceslicetracker.Tracker, informerFactory informers.SharedInformerFactory) *DefaultDRAManager {
 	logger := klog.FromContext(ctx)
-	dcLister := informerFactory.Resource().V1().DeviceClasses().Lister()
 	manager := &DefaultDRAManager{
 		resourceClaimTracker: &claimTracker{
 			cache:               claimsCache,
@@ -60,11 +59,11 @@ func NewDRAManager(ctx context.Context, claimsCache *assumecache.AssumeCache, re
 			logger:              logger,
 		},
 		resourceSliceLister: &resourceSliceLister{tracker: resourceSliceTracker},
-		deviceClassLister:   &deviceClassLister{classLister: dcLister},
+		deviceClassLister:   &deviceClassLister{classLister: informerFactory.Resource().V1().DeviceClasses().Lister()},
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.DRAExtendedResource) {
-		manager.extendedResourceCache = extendedresourcecache.NewExtendedResourceCache(dcLister, logger)
+		manager.extendedResourceCache = extendedresourcecache.NewExtendedResourceCache(logger)
 	}
 
 	// Reacting to events is more efficient than iterating over the list

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -414,7 +414,7 @@ func hasDeviceClassMappedExtendedResource(reqs v1.ResourceList, cache fwk.Device
 			continue
 		}
 		if schedutil.IsDRAExtendedResourceName(rName) {
-			if cache.GetDeviceClass(rName) != "" {
+			if cache.GetDeviceClass(rName) != nil {
 				return true
 			}
 		}
@@ -750,7 +750,7 @@ func (pl *DynamicResources) filterExtendedResources(state *stateData, pod *v1.Po
 			continue
 		}
 		allocatable, okScalar := nodeInfo.GetAllocatable().GetScalarResources()[rName]
-		isBackedByDRA := cache.GetDeviceClass(rName) != ""
+		isBackedByDRA := cache.GetDeviceClass(rName) != nil
 		if isBackedByDRA {
 			if allocatable > 0 {
 				// node provides the resource via device plugin
@@ -825,9 +825,9 @@ func createDeviceRequests(pod *v1.Pod, extendedResources map[v1.ResourceName]int
 			if !ok || crq == 0 {
 				continue
 			}
-			className := cache.GetDeviceClass(r)
+			class := cache.GetDeviceClass(r)
 			// skip if the request does not map to a device class
-			if className == "" {
+			if class == nil {
 				continue
 			}
 			keys := make([]string, 0, len(creqs))
@@ -851,7 +851,7 @@ func createDeviceRequests(pod *v1.Pod, extendedResources map[v1.ResourceName]int
 				resourceapi.DeviceRequest{
 					Name: fmt.Sprintf("container-%d-request-%d", i, ridx), // need to be container name index - extended resource name index
 					Exactly: &resourceapi.ExactDeviceRequest{
-						DeviceClassName: className, // map external resource name -> device class name
+						DeviceClassName: class.Name, // map external resource name -> device class name
 						AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
 						Count:           crq,
 					},

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -2708,10 +2708,10 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 
 // mockDeviceClassResolver is a simple mock implementation of fwk.DeviceClassResolver for testing
 type mockDeviceClassResolver struct {
-	mapping map[v1.ResourceName]string
+	mapping map[v1.ResourceName]*resourceapi.DeviceClass
 }
 
-func (m *mockDeviceClassResolver) GetDeviceClass(resourceName v1.ResourceName) string {
+func (m *mockDeviceClassResolver) GetDeviceClass(resourceName v1.ResourceName) *resourceapi.DeviceClass {
 	return m.mapping[resourceName]
 }
 
@@ -2754,16 +2754,36 @@ func Test_createDeviceRequests(t *testing.T) {
 		v1.ResourceName(extendedResourceName):          1,
 		v1.ResourceName(extendedResourceName + "init"): 2,
 	}
-	devMap := map[v1.ResourceName]string{
-		v1.ResourceName(extendedResourceName): "class",
+	devMap := map[v1.ResourceName]*resourceapi.DeviceClass{
+		v1.ResourceName(extendedResourceName): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class",
+			},
+		},
 	}
-	devMap2 := map[v1.ResourceName]string{
-		v1.ResourceName(extendedResourceName):       "class",
-		v1.ResourceName(extendedResourceName + "1"): "class1",
+	devMap2 := map[v1.ResourceName]*resourceapi.DeviceClass{
+		v1.ResourceName(extendedResourceName): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class",
+			},
+		},
+		v1.ResourceName(extendedResourceName + "1"): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class1",
+			},
+		},
 	}
-	devMapInit := map[v1.ResourceName]string{
-		v1.ResourceName(extendedResourceName):          "class",
-		v1.ResourceName(extendedResourceName + "init"): "classInit",
+	devMapInit := map[v1.ResourceName]*resourceapi.DeviceClass{
+		v1.ResourceName(extendedResourceName): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "class",
+			},
+		},
+		v1.ResourceName(extendedResourceName + "init"): {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "classInit",
+			},
+		},
 	}
 	devReq := resourceapi.DeviceRequest{
 		Name: "container-0-request-0",

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -208,7 +208,7 @@ func shouldDelegateResourceToDRA(rName v1.ResourceName, nodeInfo fwk.NodeInfo, d
 	// If draManager is available, check the cache for a mapping
 	if draManager != nil {
 		cache := draManager.DeviceClassResolver()
-		return cache.GetDeviceClass(rName) != ""
+		return cache.GetDeviceClass(rName) != nil
 	}
 
 	// If draManager is nil (e.g., kubelet admission check), delegate resources that are not in

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
@@ -35,7 +35,7 @@ type ExtendedResourceCache struct {
 	handlers []cache.ResourceEventHandler
 
 	mutex sync.RWMutex
-	// mapping maps extended resource name to device class name
+	// mapping maps extended resource name to device class
 	mapping map[v1.ResourceName]*resourceapi.DeviceClass
 }
 
@@ -66,11 +66,11 @@ func (c *ExtendedResourceCache) AddEventHandler(handler cache.ResourceEventHandl
 	c.handlers = append(c.handlers, handler)
 }
 
-// GetDeviceClass returns the device class name for the given extended resource name.
-// Returns empty string if the resource name is not found in the cache.
+// GetDeviceClass returns the device class for the given extended resource name.
+// Returns nil if the resource name is not found in the cache.
 //
 // This (and only this) method may be called on a nil ExtendedResourceCache. The nil
-// instance always returns the empty string.
+// instance always returns nil.
 func (c *ExtendedResourceCache) GetDeviceClass(resourceName v1.ResourceName) *resourceapi.DeviceClass {
 	if c == nil {
 		return nil

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -32,14 +32,14 @@ import (
 )
 
 type deviceClassResolver interface {
-	GetDeviceClass(resourceName v1.ResourceName) string
+	GetDeviceClass(resourceName v1.ResourceName) *resourceapi.DeviceClass
 }
 
 func TestNil(t *testing.T) {
 	var cache *ExtendedResourceCache
 	var resolver deviceClassResolver = cache
-	if className := resolver.GetDeviceClass("example.com/gpu"); className != "" {
-		t.Errorf("Expected the empty class name from a nil instance, got instead: %q", className)
+	if class := resolver.GetDeviceClass("example.com/gpu"); class != nil {
+		t.Errorf("Expected the nil class from a nil instance, got instead: %q", class.Name)
 	}
 }
 
@@ -91,7 +91,7 @@ func TestHandlers(t *testing.T) {
 			}
 		},
 	}
-	erCache := NewExtendedResourceCache(nil, logger, firstHandler)
+	erCache := NewExtendedResourceCache(logger, firstHandler)
 	secondHandler := &cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			if obj != class {
@@ -101,8 +101,8 @@ func TestHandlers(t *testing.T) {
 			if numAdd != 2 {
 				t.Errorf("second handler expected Add to be called last once, actual add #%d", numAdd)
 			}
-			if className := erCache.GetDeviceClass(resourceName); className != class.Name {
-				t.Errorf("expected %q, got %q", class.Name, className)
+			if deviceClass := erCache.GetDeviceClass(resourceName); deviceClass == nil || deviceClass.Name != class.Name {
+				t.Errorf("expected %q, got %q", class.Name, deviceClass)
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -116,8 +116,8 @@ func TestHandlers(t *testing.T) {
 			if numUpdate != 2 {
 				t.Errorf("second handler expected Update to be called last once, actual update #%d", numUpdate)
 			}
-			if className := erCache.GetDeviceClass(resourceName); className != "" {
-				t.Errorf("expected %q, got %q", "", className)
+			if class := erCache.GetDeviceClass(resourceName); class != nil {
+				t.Errorf("expected %q, got %v", "", class)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -128,8 +128,8 @@ func TestHandlers(t *testing.T) {
 			if numDelete != 2 {
 				t.Errorf("second handler expected Delete to be called last once, actual delete #%d", numDelete)
 			}
-			if className := erCache.GetDeviceClass(resourceName); className != "" {
-				t.Errorf("expected %q, got %q", "", className)
+			if class := erCache.GetDeviceClass(resourceName); class != nil {
+				t.Errorf("expected %q, got %q", "", class)
 			}
 		},
 	}
@@ -147,7 +147,7 @@ func TestExtendedResourceCache(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 	deviceClassInformer := informerFactory.Resource().V1().DeviceClasses()
-	cache := NewExtendedResourceCache(deviceClassInformer.Lister(), logger)
+	cache := NewExtendedResourceCache(logger)
 	if _, err := deviceClassInformer.Informer().AddEventHandler(cache); err != nil {
 		logger.Error(err, "Failed to add event handler for device classes")
 	}
@@ -229,20 +229,21 @@ func TestExtendedResourceCache(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Verify explicit mapping
-	deviceClassName := cache.GetDeviceClass("example.com/gpu")
-	if deviceClassName != "gpu-class" {
-		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %s", deviceClassName)
+	deviceClass := cache.GetDeviceClass("example.com/gpu")
+	if deviceClass == nil || deviceClass.Name != "gpu-class" {
+		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %v", deviceClass)
 	}
 
 	// Verify default mapping
 	defaultResourceName := v1.ResourceName("deviceclass.resource.kubernetes.io/fpga-class")
-	deviceClassName = cache.GetDeviceClass(defaultResourceName)
-	if deviceClassName != "fpga-class" {
-		t.Errorf("Expected to find device class 'fpga-class' for '%s', got %s", defaultResourceName, deviceClassName)
+	deviceClass = cache.GetDeviceClass(defaultResourceName)
+	if deviceClass == nil || deviceClass.Name != "fpga-class" {
+		t.Errorf("Expected to find device class 'fpga-class' for '%s', got %v", defaultResourceName, deviceClass)
 	}
 
 	// Verify both device classes have default mappings
-	if cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class") != "gpu-class" {
+	deviceClass = cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class")
+	if deviceClass == nil || deviceClass.Name != "gpu-class" {
 		t.Error("Expected default mapping for gpu-class")
 	}
 
@@ -254,9 +255,9 @@ func TestExtendedResourceCache(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// should keep deviceClass1, since it is newer than deviceClass3
-	deviceClassName = cache.GetDeviceClass("example.com/gpu")
-	if deviceClassName != "gpu-class" {
-		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %s", deviceClassName)
+	deviceClass = cache.GetDeviceClass("example.com/gpu")
+	if deviceClass == nil || deviceClass.Name != "gpu-class" {
+		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %v", deviceClass)
 	}
 
 	// deviceClass4 is newer than deviceClass1, hence it will replace deviceClass1
@@ -267,9 +268,9 @@ func TestExtendedResourceCache(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// deviceClass4 replaces deviceClass1, since it is newer with the same example.com/gpu extended resource name
-	deviceClassName = cache.GetDeviceClass("example.com/gpu")
-	if deviceClassName != "gpu-class-4" {
-		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %s", deviceClassName)
+	deviceClass = cache.GetDeviceClass("example.com/gpu")
+	if deviceClass == nil || deviceClass.Name != "gpu-class-4" {
+		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %v", deviceClass)
 	}
 
 	// deviceClass0 is created at the same time as deviceClass4, but its name is alphabetically ordered earlier,
@@ -282,9 +283,9 @@ func TestExtendedResourceCache(t *testing.T) {
 
 	// deviceClass0 replaces deviceClass4, it is created at the same time as deviceClass4, but its name is
 	// alphabetically ordered earlier
-	deviceClassName = cache.GetDeviceClass("example.com/gpu")
-	if deviceClassName != "gpu-class-0" {
-		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %s", deviceClassName)
+	deviceClass = cache.GetDeviceClass("example.com/gpu")
+	if deviceClass == nil || deviceClass.Name != "gpu-class-0" {
+		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %v", deviceClass)
 	}
 
 	// Test modifying a device class
@@ -297,11 +298,12 @@ func TestExtendedResourceCache(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Should have the new mapping
-	if cache.GetDeviceClass("test.com/gpu") != "gpu-class-0" {
-		t.Errorf("Expected to find device class 'gpu-class-0' for 'test.com/gpu' after modification, got %s", deviceClassName)
+	deviceClass = cache.GetDeviceClass("test.com/gpu")
+	if deviceClass == nil || deviceClass.Name != "gpu-class-0" {
+		t.Errorf("Expected to find device class 'gpu-class-0' for 'test.com/gpu' after modification, got %v", deviceClass)
 	}
 	// Should not have the old mapping for example.com/gpu
-	if cache.GetDeviceClass("example.com/gpu") != "" {
+	if cache.GetDeviceClass("example.com/gpu") != nil {
 		t.Errorf("Expected 'example.com/gpu' to be removed after modification, got %s", cache.GetDeviceClass("example.com/gpu"))
 	}
 
@@ -312,12 +314,12 @@ func TestExtendedResourceCache(t *testing.T) {
 	}
 	time.Sleep(1 * time.Second)
 
-	deviceClassName = cache.GetDeviceClass("test.com/gpu")
-	if deviceClassName != "" {
-		t.Errorf("Expected 'test.com/gpu' to be removed after deleting device class, got %s", deviceClassName)
+	deviceClass = cache.GetDeviceClass("test.com/gpu")
+	if deviceClass != nil {
+		t.Errorf("Expected 'test.com/gpu' to be removed after deleting device class, got %s", deviceClass)
 	}
 	// Verify the default mapping is removed
-	if cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class-0") != "" {
+	if cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class-0") != nil {
 		t.Errorf("Expected 'deviceclass.resource.kubernetes.io/gpu-class-0' to be removed after deleting device class, got %s", cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class"))
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package extendedresourcecache
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
@@ -87,7 +91,7 @@ func TestHandlers(t *testing.T) {
 			}
 		},
 	}
-	erCache := NewExtendedResourceCache(logger, firstHandler)
+	erCache := NewExtendedResourceCache(nil, logger, firstHandler)
 	secondHandler := &cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			if obj != class {
@@ -137,13 +141,33 @@ func TestHandlers(t *testing.T) {
 }
 
 func TestExtendedResourceCache(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
-	cache := NewExtendedResourceCache(logger)
+	logger, ctx := ktesting.NewTestContext(t)
+	tCtx, tCancel := context.WithCancel(ctx)
+	client := fake.NewClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	deviceClassInformer := informerFactory.Resource().V1().DeviceClasses()
+	cache := NewExtendedResourceCache(deviceClassInformer.Lister(), logger)
+	if _, err := deviceClassInformer.Informer().AddEventHandler(cache); err != nil {
+		logger.Error(err, "Failed to add event handler for device classes")
+	}
+	informerFactory.Start(tCtx.Done())
+	t.Cleanup(func() {
+		// Need to cancel before waiting for the shutdown.
+		tCancel()
+		// Now we can wait for all goroutines to stop.
+		informerFactory.Shutdown()
+	})
+	informerFactory.WaitForCacheSync(tCtx.Done())
 
 	// Test with a device class that has an explicit extended resource name
+	now := time.Now()
 	deviceClass1 := &resourceapi.DeviceClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "gpu-class",
+			CreationTimestamp: metav1.Time{
+				Time: now,
+			},
 		},
 		Spec: resourceapi.DeviceClassSpec{
 			ExtendedResourceName: ptr.To("example.com/gpu"),
@@ -159,10 +183,50 @@ func TestExtendedResourceCache(t *testing.T) {
 			// No explicit extended resource name
 		},
 	}
+	deviceClass3 := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-class-3",
+			CreationTimestamp: metav1.Time{
+				Time: now.Add(-24 * time.Hour),
+			},
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: ptr.To("example.com/gpu"),
+		},
+	}
+	deviceClass4 := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-class-4",
+			CreationTimestamp: metav1.Time{
+				Time: now.Add(time.Hour),
+			},
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: ptr.To("example.com/gpu"),
+		},
+	}
+	deviceClass0 := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-class-0",
+			CreationTimestamp: metav1.Time{
+				Time: now.Add(time.Hour),
+			},
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: ptr.To("example.com/gpu"),
+		},
+	}
 
 	// Test adding device classes
-	cache.OnAdd(deviceClass1, false)
-	cache.OnAdd(deviceClass2, false)
+	_, err := client.ResourceV1().DeviceClasses().Create(tCtx, deviceClass1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create device class: %v", err)
+	}
+	_, err = client.ResourceV1().DeviceClasses().Create(tCtx, deviceClass2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create device class: %v", err)
+	}
+	time.Sleep(1 * time.Second)
 
 	// Verify explicit mapping
 	deviceClassName := cache.GetDeviceClass("example.com/gpu")
@@ -182,14 +246,59 @@ func TestExtendedResourceCache(t *testing.T) {
 		t.Error("Expected default mapping for gpu-class")
 	}
 
+	// deviceClass3 is older than deviceClass1, hence it won't replace deviceClass1
+	_, err = client.ResourceV1().DeviceClasses().Create(tCtx, deviceClass3, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create device class: %v", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	// should keep deviceClass1, since it is newer than deviceClass3
+	deviceClassName = cache.GetDeviceClass("example.com/gpu")
+	if deviceClassName != "gpu-class" {
+		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %s", deviceClassName)
+	}
+
+	// deviceClass4 is newer than deviceClass1, hence it will replace deviceClass1
+	_, err = client.ResourceV1().DeviceClasses().Create(tCtx, deviceClass4, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create device class: %v", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	// deviceClass4 replaces deviceClass1, since it is newer with the same example.com/gpu extended resource name
+	deviceClassName = cache.GetDeviceClass("example.com/gpu")
+	if deviceClassName != "gpu-class-4" {
+		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %s", deviceClassName)
+	}
+
+	// deviceClass0 is created at the same time as deviceClass4, but its name is alphabetically ordered earlier,
+	//  hence it will replace deviceClass4
+	_, err = client.ResourceV1().DeviceClasses().Create(tCtx, deviceClass0, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create device class: %v", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	// deviceClass0 replaces deviceClass4, it is created at the same time as deviceClass4, but its name is
+	// alphabetically ordered earlier
+	deviceClassName = cache.GetDeviceClass("example.com/gpu")
+	if deviceClassName != "gpu-class-0" {
+		t.Errorf("Expected to find device class 'gpu-class' for 'example.com/gpu', got %s", deviceClassName)
+	}
+
 	// Test modifying a device class
-	deviceClass1Modified := deviceClass1.DeepCopy()
-	deviceClass1Modified.Spec.ExtendedResourceName = ptr.To("test.com/gpu")
-	cache.OnUpdate(deviceClass1, deviceClass1Modified)
+	deviceClass0Modified := deviceClass0.DeepCopy()
+	deviceClass0Modified.Spec.ExtendedResourceName = ptr.To("test.com/gpu")
+	_, err = client.ResourceV1().DeviceClasses().Update(tCtx, deviceClass0Modified, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update device class: %v", err)
+	}
+	time.Sleep(1 * time.Second)
 
 	// Should have the new mapping
-	if cache.GetDeviceClass("test.com/gpu") != "gpu-class" {
-		t.Errorf("Expected to find device class 'gpu-class' for 'test.com/gpu' after modification, got %s", deviceClassName)
+	if cache.GetDeviceClass("test.com/gpu") != "gpu-class-0" {
+		t.Errorf("Expected to find device class 'gpu-class-0' for 'test.com/gpu' after modification, got %s", deviceClassName)
 	}
 	// Should not have the old mapping for example.com/gpu
 	if cache.GetDeviceClass("example.com/gpu") != "" {
@@ -197,13 +306,18 @@ func TestExtendedResourceCache(t *testing.T) {
 	}
 
 	// Test deleting a device class
-	cache.OnDelete(deviceClass1Modified)
+	err = client.ResourceV1().DeviceClasses().Delete(tCtx, deviceClass0.Name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete device class: %v", err)
+	}
+	time.Sleep(1 * time.Second)
+
 	deviceClassName = cache.GetDeviceClass("test.com/gpu")
 	if deviceClassName != "" {
 		t.Errorf("Expected 'test.com/gpu' to be removed after deleting device class, got %s", deviceClassName)
 	}
 	// Verify the default mapping is removed
-	if cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class") != "" {
-		t.Errorf("Expected 'deviceclass.resource.kubernetes.io/gpu-class' to be removed after deleting device class, got %s", cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class"))
+	if cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class-0") != "" {
+		t.Errorf("Expected 'deviceclass.resource.kubernetes.io/gpu-class-0' to be removed after deleting device class, got %s", cache.GetDeviceClass("deviceclass.resource.kubernetes.io/gpu-class"))
 	}
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -114,7 +114,7 @@ type DeviceClassResolver interface {
 	// GetDeviceClass returns the device class name for the given extended resource name.
 	// Returns empty string if no mapping exists for the resource name or
 	// the DRAExtendedResource feature is disabled.
-	GetDeviceClass(resourceName v1.ResourceName) string
+	GetDeviceClass(resourceName v1.ResourceName) *resourceapi.DeviceClass
 }
 
 // SharedDRAManager can be used to obtain DRA objects, and track modifications to them in-memory - mainly by the DRA plugin.

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -111,8 +111,8 @@ type ResourceClaimTracker interface {
 
 // DeviceClassResolver resolves device class names from extended resource names.
 type DeviceClassResolver interface {
-	// GetDeviceClass returns the device class name for the given extended resource name.
-	// Returns empty string if no mapping exists for the resource name or
+	// GetDeviceClass returns the device class for the given extended resource name.
+	// Returns nil if no mapping exists for the resource name or
 	// the DRAExtendedResource feature is disabled.
 	GetDeviceClass(resourceName v1.ResourceName) *resourceapi.DeviceClass
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
pick one device class deterministically for extended resource when there are more than one


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/133693

#### Special notes for your reviewer:
Please focus on the last commit, the other commits are for the global cache from @sairameshv


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
pick one device class deterministically for extended resource when there are more than one
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
