### PR TITLE
Set KubeletCrashLoopBackOffMax feature gate to default enabled for beta.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -435,8 +435,8 @@ const (
 	// fallback to using it's cgroupDriver option.
 	KubeletCgroupDriverFromCRI featuregate.Feature = "KubeletCgroupDriverFromCRI"
 
-	// owner: @lauralorenz
-	// kep: https://kep.k8s.io/4603
+	// owner: @lauralorenz @hankfreund
+	// kep: https://kep.k8s.io/5593
 	//
 	// Enables support for configurable per-node backoff maximums for restarting
 	// containers (aka containers in CrashLoopBackOff)
@@ -1328,6 +1328,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	KubeletCrashLoopBackOffMax: {
 		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KubeletEnsureSecretPulledImages: {

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -126,6 +126,9 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 				"AllAlpha": false,
 				"AllBeta":  true,
 			}
+			obj.CrashLoopBackOff = kubeletconfig.CrashLoopBackOffConfig{
+				MaxContainerRestartPeriod: &metav1.Duration{Duration: 5 * time.Minute},
+			}
 		},
 
 		// tokenAttributes field is only supported in v1 CredentialProvider

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
@@ -25,7 +25,8 @@ cpuCFSQuota: true
 cpuCFSQuotaPeriod: 100ms
 cpuManagerPolicy: none
 cpuManagerReconcilePeriod: 10s
-crashLoopBackOff: {}
+crashLoopBackOff:
+  maxContainerRestartPeriod: 5m0s
 enableControllerAttachDetach: true
 enableDebugFlagsHandler: true
 enableDebuggingHandlers: true

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
@@ -25,7 +25,8 @@ cpuCFSQuota: true
 cpuCFSQuotaPeriod: 100ms
 cpuManagerPolicy: none
 cpuManagerReconcilePeriod: 10s
-crashLoopBackOff: {}
+crashLoopBackOff:
+  maxContainerRestartPeriod: 5m0s
 enableControllerAttachDetach: true
 enableDebugFlagsHandler: true
 enableDebuggingHandlers: true

--- a/pkg/kubelet/apis/config/v1beta1/defaults_test.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_test.go
@@ -132,7 +132,9 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				LocalStorageCapacityIsolation: ptr.To(true),
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          nil,
-				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
+					MaxContainerRestartPeriod: &metav1.Duration{Duration: MaxContainerBackOff},
+				},
 			},
 		},
 		{
@@ -372,7 +374,9 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				LocalStorageCapacityIsolation: ptr.To(false),
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          ptr.To(false),
-				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
+					MaxContainerRestartPeriod: &metav1.Duration{Duration: MaxContainerBackOff},
+				},
 			},
 		},
 		{
@@ -785,7 +789,9 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				LocalStorageCapacityIsolation: ptr.To(true),
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          nil,
-				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
+					MaxContainerRestartPeriod: &metav1.Duration{Duration: MaxContainerBackOff},
+				},
 			},
 		},
 		{
@@ -881,7 +887,9 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				LocalStorageCapacityIsolation: ptr.To(true),
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          nil,
-				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
+					MaxContainerRestartPeriod: &metav1.Duration{Duration: MaxContainerBackOff},
+				},
 			},
 		},
 		{
@@ -976,16 +984,18 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				RegisterNode:                  ptr.To(true),
 				LocalStorageCapacityIsolation: ptr.To(true),
 				PodLogsDir:                    DefaultPodLogsDir,
-				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
+					MaxContainerRestartPeriod: &metav1.Duration{Duration: MaxContainerBackOff},
+				},
 			},
 		},
 		{
-			"CrashLoopBackOff.MaxContainerRestartPeriod defaults to internal default when feature gate enabled",
+			"CrashLoopBackOff defaults empty when feature gate disabled",
 			&v1beta1.KubeletConfiguration{
-				FeatureGates: map[string]bool{"KubeletCrashLoopBackOffMax": true},
+				FeatureGates: map[string]bool{"KubeletCrashLoopBackOffMax": false},
 			},
 			&v1beta1.KubeletConfiguration{
-				FeatureGates:       map[string]bool{"KubeletCrashLoopBackOffMax": true},
+				FeatureGates:       map[string]bool{"KubeletCrashLoopBackOffMax": false},
 				EnableServer:       ptr.To(true),
 				SyncFrequency:      metav1.Duration{Duration: 1 * time.Minute},
 				FileCheckFrequency: metav1.Duration{Duration: 20 * time.Second},
@@ -1073,9 +1083,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				LocalStorageCapacityIsolation: ptr.To(true),
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          nil,
-				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
-					MaxContainerRestartPeriod: &metav1.Duration{Duration: MaxContainerBackOff},
-				},
+				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
 			},
 		},
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3264,6 +3264,9 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 		ContainerLogMaxSize:                       "10Mi",
 		ContainerLogMaxFiles:                      5,
 		MemoryThrottlingFactor:                    ptr.To[float64](0),
+		CrashLoopBackOff: kubeletconfiginternal.CrashLoopBackOffConfig{
+			MaxContainerRestartPeriod: &metav1.Duration{Duration: 5 * time.Minute},
+		},
 	}
 	var prober volume.DynamicPluginProber
 	tp := noopoteltrace.NewTracerProvider()
@@ -3729,60 +3732,46 @@ func TestCrashLoopBackOffConfiguration(t *testing.T) {
 	testCases := []struct {
 		name            string
 		featureGates    []featuregate.Feature
-		nodeDecay       metav1.Duration
+		configuredMax   metav1.Duration
 		expectedInitial time.Duration
 		expectedMax     time.Duration
 	}{
 		{
-			name:            "Prior behavior",
-			expectedMax:     time.Duration(300 * time.Second),
-			expectedInitial: time.Duration(10 * time.Second),
-		},
-		{
-			name:            "New default only",
-			featureGates:    []featuregate.Feature{features.ReduceDefaultCrashLoopBackOffDecay},
-			expectedMax:     time.Duration(60 * time.Second),
-			expectedInitial: time.Duration(1 * time.Second),
-		},
-		{
 			name:            "Faster per node config; only node config configured",
-			featureGates:    []featuregate.Feature{features.KubeletCrashLoopBackOffMax},
-			nodeDecay:       metav1.Duration{Duration: 2 * time.Second},
+			configuredMax:   metav1.Duration{Duration: 2 * time.Second},
 			expectedMax:     time.Duration(2 * time.Second),
 			expectedInitial: time.Duration(2 * time.Second),
 		},
 		{
 			name:            "Faster per node config; new default and node config configured",
-			featureGates:    []featuregate.Feature{features.KubeletCrashLoopBackOffMax, features.ReduceDefaultCrashLoopBackOffDecay},
-			nodeDecay:       metav1.Duration{Duration: 2 * time.Second},
+			featureGates:    []featuregate.Feature{features.ReduceDefaultCrashLoopBackOffDecay},
+			configuredMax:   metav1.Duration{Duration: 2 * time.Second},
 			expectedMax:     time.Duration(2 * time.Second),
 			expectedInitial: time.Duration(1 * time.Second),
 		},
 		{
 			name:            "Slower per node config; new default and node config configured, set A",
-			featureGates:    []featuregate.Feature{features.KubeletCrashLoopBackOffMax, features.ReduceDefaultCrashLoopBackOffDecay},
-			nodeDecay:       metav1.Duration{Duration: 10 * time.Second},
+			featureGates:    []featuregate.Feature{features.ReduceDefaultCrashLoopBackOffDecay},
+			configuredMax:   metav1.Duration{Duration: 10 * time.Second},
 			expectedMax:     time.Duration(10 * time.Second),
 			expectedInitial: time.Duration(1 * time.Second),
 		},
 		{
 			name:            "Slower per node config; new default and node config configured, set B",
-			featureGates:    []featuregate.Feature{features.KubeletCrashLoopBackOffMax, features.ReduceDefaultCrashLoopBackOffDecay},
-			nodeDecay:       metav1.Duration{Duration: 300 * time.Second},
+			featureGates:    []featuregate.Feature{features.ReduceDefaultCrashLoopBackOffDecay},
+			configuredMax:   metav1.Duration{Duration: 300 * time.Second},
 			expectedMax:     time.Duration(300 * time.Second),
 			expectedInitial: time.Duration(1 * time.Second),
 		},
 		{
 			name:            "Slower per node config; only node config configured, set A",
-			featureGates:    []featuregate.Feature{features.KubeletCrashLoopBackOffMax},
-			nodeDecay:       metav1.Duration{Duration: 11 * time.Second},
+			configuredMax:   metav1.Duration{Duration: 11 * time.Second},
 			expectedMax:     time.Duration(11 * time.Second),
 			expectedInitial: time.Duration(10 * time.Second),
 		},
 		{
 			name:            "Slower per node config; only node config configured, set B",
-			featureGates:    []featuregate.Feature{features.KubeletCrashLoopBackOffMax},
-			nodeDecay:       metav1.Duration{Duration: 300 * time.Second},
+			configuredMax:   metav1.Duration{Duration: 300 * time.Second},
 			expectedMax:     time.Duration(300 * time.Second),
 			expectedInitial: time.Duration(10 * time.Second),
 		},
@@ -3795,8 +3784,8 @@ func TestCrashLoopBackOffConfiguration(t *testing.T) {
 			for _, f := range tc.featureGates {
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, f, true)
 			}
-			if tc.nodeDecay.Duration > 0 {
-				kubeCfg.CrashLoopBackOff.MaxContainerRestartPeriod = &tc.nodeDecay
+			if tc.configuredMax.Duration > 0 {
+				kubeCfg.CrashLoopBackOff.MaxContainerRestartPeriod = &tc.configuredMax
 			}
 
 			resultMax, resultInitial := newCrashLoopBackOff(kubeCfg)

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -787,6 +787,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.32"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.35"
 - name: KubeletEnsureSecretPulledImages
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update the KubeletCrashLoopBackOffMax feature gate to default enabled and mark it as beta.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/enhancements/issues/5593
KEP: https://github.com/kubernetes/enhancements/issues/5593
Docs update: https://github.com/kubernetes/website/pull/52816

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promoted the `KubeletCrashLoopBackOffMax` feature gate to beta, it is now enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/hankfreund/enhancements/tree/124ad4b69759c5a0347caf275a99cb0cc9e39a11/keps/sig-node/5593-configure-the-max-crashloopbackoff-delay
```
