### PR TITLE
Revert "E2E framework: start slow tests first"

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -221,14 +221,8 @@ func registerInSuite(ginkgoCall func(string, ...interface{}) bool, args []interf
 					ginkgoArgs = append(ginkgoArgs, ginkgo.Label("BetaOffByDefault"))
 				}
 			}
-			switch fullLabel {
-			case "Serial":
+			if fullLabel == "Serial" {
 				ginkgoArgs = append(ginkgoArgs, ginkgo.Serial)
-			case "Slow":
-				// Start slow tests first. This avoids the risk
-				// that they get started towards the end of a
-				// run and then make the run longer overall.
-				ginkgoArgs = append(ginkgoArgs, ginkgo.SpecPriority(1))
 			}
 		case ginkgo.Offset:
 			offset = arg


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This reverts commit cff07e75519cbf09e3499976adb1d90b2f890db7 from https://github.com/kubernetes/kubernetes/pull/13488.

The commit caused several kubeadm jobs to fail while executing all conformance tests (including slow ones) in parallel. Sometimes execution took longer and ran into the overall timeout, sometimes there was:

    [FAILED] Expected
        <int>: 440
    to be ==
        <int>: 400
    In [It] at: k8s.io/kubernetes/test/e2e/apimachinery/chunking.go:202

It looks like the tests are flaky and/or reveal a real bug when slow tests run all in parallel at the same time.

This should work, but doesn't right now, so let's revert until that problem is fixed.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/135040
https://github.com/kubernetes/kubernetes/issues/135039

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assigng @neolit123 