### PR TITLE
[WIP] Fix scheduler crash when DRAExtendedResource is enabled without DRA

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -234,6 +234,13 @@ func computePodResourceRequest(pod *v1.Pod, opts ResourceRequestsOptions) *preFi
 
 // withDeviceClass adds resource to device class mapping to preFilterState.
 func withDeviceClass(result *preFilterState, draManager fwk.SharedDRAManager) *fwk.Status {
+	// If draManager is nil, DynamicResourceAllocation is not enabled.
+	// This can happen if DRAExtendedResource is enabled but DynamicResourceAllocation is not,
+	// which violates the feature gate dependency. Return early to avoid nil pointer dereference.
+	if draManager == nil {
+		return nil
+	}
+
 	hasExtendedResource := false
 	for rName, rQuant := range result.ScalarResources {
 		// Skip in case request quantity is zero

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -1997,4 +1997,21 @@ func TestWithDeviceClass(t *testing.T) {
 			}
 		})
 	}
+
+	// Test nil draManager (when DynamicResourceAllocation is disabled)
+	t.Run("nil draManager", func(t *testing.T) {
+		state := &preFilterState{
+			Resource: framework.Resource{
+				ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1},
+			},
+		}
+		// Should not panic and should return nil
+		status := withDeviceClass(state, nil)
+		if status != nil {
+			t.Errorf("expected nil status, got %v", status)
+		}
+		if state.resourceToDeviceClass != nil {
+			t.Errorf("expected nil resourceToDeviceClass, got %v", state.resourceToDeviceClass)
+		}
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fix
```
"Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address
or nil pointer dereference\"" stacktrace=<
    goroutine 692 [running]:
    k8s.io/apimachinery/pkg/util/runtime.logPanic({0x35583b8, 0x400bc8eb40}, {0x2d7da20, 0x4cf6f90})
        /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xe4
    k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x35583b8, 0x400bc8eb40}, {0x2d7da20, 0x4cf6f90}, {0x0, 0x0, 0x0})
        /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x104
    k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x35583f0, 0x400a013900}, {0x0, 0x0, 0x0})
        /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:78 +0x70
    panic({0x2d7da20?, 0x4cf6f90?})
        /usr/local/go/src/runtime/panic.go:792 +0xf0
    k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/extended.DeviceClassMapping({0x0, 0x0})
        /go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/extended/util.go:26 +0x34
    k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.withDeviceClass(0x400bc8eae0, {0x0, 0x0})
        /go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/fit.go:250 +0x104
    k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*Fit).PreFilter(0x40009a74a0, {0x35583f0, 0x400bb13d10},
{0x356a450, 0x400bb13cc0}, 0x400a719688, {0x400b8da408, 0x8b, 0x8b})
        /go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/fit.go:275 +0x194
    k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*instrumentedPreFilterPlugin).PreFilter(0x40007de720, {0x35583f0,
0x400bb13d10}, {0x356a450, 0x400bb13cc0}, 0x400a719688, {0x400b8da408, 0x8b, 0x8b})
        /go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/instrumented_plugins.go:50 +0x8c
    k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).runPreFilterPlugin(0x4000c1c008, {0x35583f0, 0x400bb13d10},
{0x3540720, 0x40007de720}, {0x356a450, 0x400bb13cc0}, 0x400a719688, {0x400b8da408, 0x8b, ...})
        /go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/framework.go:791 +0x1d0
    k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).RunPreFilterPlugins(0x4000c1c008, {0x35583f0, 0x400bb13d10},
{0x356a450, 0x400bb13cc0}, 0x400a719688)
        /go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/framework.go:751 +0x5a0
    k8s.io/kubernetes/pkg/scheduler.(*Scheduler).findNodesThatFitPod(0x4000c3a1a0, {0x35583f0, 0x400bb13d10}, {0x3587b38,
0x4000c1c008}, {0x356a450, 0x400bb13cc0}, 0x400a719688)
        /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:493 +0x214
    k8s.io/kubernetes/pkg/scheduler.(*Scheduler).schedulePod(0x4000c3a1a0, {0x35583f0, 0x400bb13d10}, {0x3587b38, 0x4000c1c008},
{0x356a450, 0x400bb13cc0}, 0x400a719688)
        /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:442 +0x3b4
    k8s.io/kubernetes/pkg/scheduler.(*Scheduler).schedulingCycle(0x4000c3a1a0, {0x35583f0, 0x400bb13d10}, {0x356a450, 0x400bb13cc0},
 {0x3587b38, 0x4000c1c008}, 0x400ae36510, {0xc236a4d3d9a26414, 0x3cf2bb50f, ...}, ...)
        /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:160 +0xf0
    k8s.io/kubernetes/pkg/scheduler.(*Scheduler).ScheduleOne(0x4000c3a1a0, {0x35583b8, 0x400bc8e720})
        /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:117 +0x7e0
    k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x35583f0, 0x400a013900}, 0x400b9a2000)
        /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:255 +0xb4
    k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x35583f0, 0x400a013900}, 0x400b9a2000, {0x3524360, 0x400b8f9950},
0x1)
        /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:256 +0xc0
    k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x35583f0, 0x400a013900}, 0x400b9a2000, 0x0, 0x0, 0x1)
        /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:223 +0x88
    k8s.io/apimachinery/pkg/util/wait.UntilWithContext({0x35583f0, 0x400a013900}, 0x400b9a2000, 0x0)
        /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:172 +0x34
    created by k8s.io/kubernetes/pkg/scheduler.(*Scheduler).Run in goroutine 685
        /go/src/k8s.io/kubernetes/pkg/scheduler/scheduler.go:538 +0x1bc
 >
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x27f5884]
goroutine 692 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x35583b8, 0x400bc8eb40}, {0x2d7da20, 0x4cf6f90}, {0x0, 0x0, 0x0})
    /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:114 +0x1b4
k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x35583f0, 0x400a013900}, {0x0, 0x0, 0x0})
    /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:78 +0x70
panic({0x2d7da20?, 0x4cf6f90?})
    /usr/local/go/src/runtime/panic.go:792 +0xf0
k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/extended.DeviceClassMapping({0x0, 0x0})
    /go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/extended/util.go:26 +0x34
k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.withDeviceClass(0x400bc8eae0, {0x0, 0x0})
    /go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/fit.go:250 +0x104
k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources.(*Fit).PreFilter(0x40009a74a0, {0x35583f0, 0x400bb13d10},
{0x356a450, 0x400bb13cc0}, 0x400a719688, {0x400b8da408, 0x8b, 0x8b})
    /go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources/fit.go:275 +0x194
k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*instrumentedPreFilterPlugin).PreFilter(0x40007de720, {0x35583f0, 0x400bb13d10},
{0x356a450, 0x400bb13cc0}, 0x400a719688, {0x400b8da408, 0x8b, 0x8b})
    /go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/instrumented_plugins.go:50 +0x8c
k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).runPreFilterPlugin(0x4000c1c008, {0x35583f0, 0x400bb13d10},
{0x3540720, 0x40007de720}, {0x356a450, 0x400bb13cc0}, 0x400a719688, {0x400b8da408, 0x8b, ...})
    /go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/framework.go:791 +0x1d0
k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).RunPreFilterPlugins(0x4000c1c008, {0x35583f0, 0x400bb13d10},
{0x356a450, 0x400bb13cc0}, 0x400a719688)
    /go/src/k8s.io/kubernetes/pkg/scheduler/framework/runtime/framework.go:751 +0x5a0
k8s.io/kubernetes/pkg/scheduler.(*Scheduler).findNodesThatFitPod(0x4000c3a1a0, {0x35583f0, 0x400bb13d10}, {0x3587b38, 0x4000c1c008},
 {0x356a450, 0x400bb13cc0}, 0x400a719688)
    /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:493 +0x214
k8s.io/kubernetes/pkg/scheduler.(*Scheduler).schedulePod(0x4000c3a1a0, {0x35583f0, 0x400bb13d10}, {0x3587b38, 0x4000c1c008},
{0x356a450, 0x400bb13cc0}, 0x400a719688)
    /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:442 +0x3b4
k8s.io/kubernetes/pkg/scheduler.(*Scheduler).schedulingCycle(0x4000c3a1a0, {0x35583f0, 0x400bb13d10}, {0x356a450, 0x400bb13cc0},
{0x3587b38, 0x4000c1c008}, 0x400ae36510, {0xc236a4d3d9a26414, 0x3cf2bb50f, ...}, ...)
    /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:160 +0xf0
k8s.io/kubernetes/pkg/scheduler.(*Scheduler).ScheduleOne(0x4000c3a1a0, {0x35583b8, 0x400bc8e720})
    /go/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:117 +0x7e0
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext.func1({0x35583f0, 0x400a013900}, 0x400b9a2000)
    /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:255 +0xb4
k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext({0x35583f0, 0x400a013900}, 0x400b9a2000, {0x3524360, 0x400b8f9950}, 0x1)
    /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:256 +0xc0
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x35583f0, 0x400a013900}, 0x400b9a2000, 0x0, 0x0, 0x1)
    /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:223 +0x88
k8s.io/apimachinery/pkg/util/wait.UntilWithContext({0x35583f0, 0x400a013900}, 0x400b9a2000, 0x0)
    /go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:172 +0x34
created by k8s.io/kubernetes/pkg/scheduler.(*Scheduler).Run in goroutine 685
    /go/src/k8s.io/kubernetes/pkg/scheduler/scheduler.go:538 +0x1bc
```

Add nil check in withDeviceClass to prevent panic when SharedDRAManager returns nil. This can occur if DRAExtendedResource feature gate is enabled but DynamicResourceAllocation is disabled, which violates the declared feature gate dependency.

The crash occurred in the scheduler's PreFilter phase:
- noderesources.Fit.PreFilter calls withDeviceClass with SharedDRAManager()
- When DynamicResourceAllocation is disabled, SharedDRAManager() returns nil
- withDeviceClass then calls extended.DeviceClassMapping(nil)
- This causes a nil pointer dereference at draManager.DeviceClasses().List()

Also added a test case to verify the fix handles nil draManager correctly.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:
Nothing to report

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
