### PR TITLE
DRA: revert "added WithFlaky() to the device plugin test case: supports extended resources together with ResourceClaim"

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1072,14 +1072,9 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			}).WithTimeout(f.Timeouts.PodDelete).Should(gomega.HaveField("Status.Allocation", (*resourceapi.AllocationResult)(nil)))
 		})
 
-		// https://github.com/kubernetes/kubernetes/issues/133488
-		// It conflicts with "must run pods with extended resource on dra nodes and device plugin nodes" test case,
-		// because device plugin does not clean up the extended resource "example.com/resource", and kubelet still
-		// keeps "example.com/resource" : 0 in node.status.Capacity.
-		// add WithFlaky to filter out the following test until we can clean up the leaked "example.com/resource" in node.status.
 		if withKubelet {
 			// Serial because the example device plugin can only be deployed with one instance at a time.
-			f.It("supports extended resources together with ResourceClaim", f.WithSerial(), f.WithFlaky(), func(ctx context.Context) {
+			f.It("supports extended resources together with ResourceClaim", f.WithSerial(), func(ctx context.Context) {
 				extendedResourceName := deployDevicePlugin(ctx, f, nodes.NodeNames[0:1])
 
 				pod := b.PodExternal()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This reverts temporary workaround commit edfa9a5bd28876c860d5a16edf5cbc1c8b1cf817 as https://github.com/kubernetes/kubernetes/issues/133488 has been resolved.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/133488

#### Does this PR introduce a user-facing change?

```release-note
NONE
```