### PR TITLE
DRA: fix "all" allocation with incomplete pools differently

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5240,40 +5240,6 @@ func TestAllocator(t *testing.T,
 				),
 			},
 		},
-		"allocation-mode-all-with-multi-host-resource-pool": {
-			claimsToAllocate: objects(claimWithRequests(claim0, nil, resourceapi.DeviceRequest{
-				Name: req0,
-				Exactly: &resourceapi.ExactDeviceRequest{
-					AllocationMode:  resourceapi.DeviceAllocationModeAll,
-					DeviceClassName: classA,
-				},
-			})),
-			classes: objects(class(classA, driverA)),
-			slices: unwrap(
-				func() wrapResourceSlice {
-					s := slice(slice1, node1, pool1, driverA,
-						device(device1, nil, nil),
-					)
-					s.Spec.Pool.ResourceSliceCount = 2
-					return s
-				}(),
-				func() wrapResourceSlice {
-					s := slice(slice2, node2, pool1, driverA,
-						device(device2, nil, nil),
-					)
-					s.Spec.Pool.ResourceSliceCount = 2
-					return s
-				}(),
-			),
-			node: node(node1, region1),
-
-			expectResults: []any{
-				allocationResult(
-					localNodeSelector(node1),
-					deviceAllocationResult(req0, driverA, pool1, device1, false),
-				),
-			},
-		},
 	}
 
 	for name, tc := range testcases {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5240,6 +5240,267 @@ func TestAllocator(t *testing.T,
 				),
 			},
 		},
+
+		"allocation-mode-all-with-multi-host-resource-pool": {
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, resourceapi.DeviceRequest{
+				Name: req0,
+				Exactly: &resourceapi.ExactDeviceRequest{
+					AllocationMode:  resourceapi.DeviceAllocationModeAll,
+					DeviceClassName: classA,
+				},
+			})),
+			classes: objects(class(classA, driverA)),
+			slices: unwrap(
+				func() wrapResourceSlice {
+					s := slice(slice1, node1, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice2, node2, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, false),
+				),
+			},
+		},
+
+		"multi-host-resource-pool-with-stale-slice-for-current-node": {
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrap(
+				func() wrapResourceSlice {
+					s := slice(slice1, node1, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice2, node2, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+			),
+			node: node(node1, region1),
+		},
+
+		// update-from-node-1-to-node-2 and vice-versa is dangerous,
+		// DRA drivers should not do this: there is no guarantee that
+		// the scheduler sees the change and then might allocate a
+		// device for a node where it is no longer available.
+		//
+		// We do not have to support such a change exactly as expected
+		// by these test cases if it makes the implementation too
+		// expensive because of additional checks.
+		//
+		// The support for allocation from incomplete pools is also under
+		// debate. It's currently done because without scoring it makes
+		// no difference how many slices are available, as long as one
+		// device can be found.
+
+		"multi-host-resource-pool-complete-update-from-node-1-to-node-2": {
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrap(
+				// Node 1, generation 1.
+				func() wrapResourceSlice {
+					s := slice(slice1, node1, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice1, node1, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				// Node 2, generation 2.
+				func() wrapResourceSlice {
+					s := slice(slice2, node2, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice2, node2, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+			),
+			node: node(node1, region1),
+
+			// We'd like this to *not* be allocated, but the current implementation ignores
+			// the updated slices. Allocating from the old pool is also what would happen
+			// if the scheduler hadn't received the update yet, so DRA drivers shouldn't
+			// depend on better handling of this situation.
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, false),
+				),
+			},
+		},
+
+		"multi-host-resource-pool-complete-update-from-node-2-to-node-1": {
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrap(
+				// Node 2, generation 1.
+				func() wrapResourceSlice {
+					s := slice(slice1, node2, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice1, node2, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				// Node 1, generation 2.
+				func() wrapResourceSlice {
+					s := slice(slice2, node1, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice2, node1, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, false),
+				),
+			},
+		},
+
+		"multi-host-resource-pool-incomplete-update-from-node-1-to-node-2": {
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrap(
+				// Node 1, generation 1.
+				func() wrapResourceSlice {
+					s := slice(slice1, node1, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice1, node1, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				// Node 2, generation 2.
+				func() wrapResourceSlice {
+					s := slice(slice2, node2, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+			),
+			node: node(node1, region1),
+
+			// We'd like this to *not* be allocated, but the current implementation ignores
+			// the updated slices. Allocating from the old pool is also what would happen
+			// if the scheduler hadn't received the update yet, so DRA drivers shouldn't
+			// depend on better handling of this situation.
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, false),
+				),
+			},
+		},
+
+		"multi-host-resource-pool-incomplete-update-from-node-2-to-node-1": {
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrap(
+				// Node 2, generation 1.
+				func() wrapResourceSlice {
+					s := slice(slice1, node2, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				func() wrapResourceSlice {
+					s := slice(slice1, node2, pool1, driverA,
+						device(device2, nil, nil),
+					)
+					s.Spec.Pool.Generation = 1
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+				// Node 1, generation 2.
+				func() wrapResourceSlice {
+					s := slice(slice2, node1, pool1, driverA,
+						device(device1, nil, nil),
+					)
+					s.Spec.Pool.Generation = 2
+					s.Spec.Pool.ResourceSliceCount = 2
+					return s
+				}(),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{
+				allocationResult(
+					localNodeSelector(node1),
+					deviceAllocationResult(req0, driverA, pool1, device1, false),
+				),
+			},
+		},
 	}
 
 	for name, tc := range testcases {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -45,10 +45,6 @@ func nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 	return false, nil
 }
 
-type poolIdentifier struct {
-	driver, pool string
-}
-
 // GatherPools collects information about all resource pools which provide
 // devices that are accessible from the given node.
 //
@@ -56,46 +52,9 @@ type poolIdentifier struct {
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
-	slicesByPool := make(map[poolIdentifier][]*resourceapi.ResourceSlice)
-	for _, slice := range slices {
-		poolID := poolIdentifier{
-			driver: slice.Spec.Driver,
-			pool:   slice.Spec.Pool.Name,
-		}
-		slicesByPool[poolID] = append(slicesByPool[poolID], slice)
-	}
-
-	// We need to check whether a pool is complete while we have all
-	// the slices. Once we discard slices that don't target the node, we
-	// no longer have the information needed to find out.
-	incompletePools := sets.New[poolIdentifier]()
-	for poolID, slices := range slicesByPool {
-		complete := true
-		sliceCount := len(slices)
-		generation := slices[0].Spec.Pool.Generation
-		for _, slice := range slices {
-			// If the number of slices in the pool specified in any of the slices
-			// doesn't match what we found, the pool is most likely being updated
-			// by the controller.
-			if slice.Spec.Pool.ResourceSliceCount != int64(sliceCount) {
-				complete = false
-			}
-			// If the generation of the pool isn't the same across all slices,
-			// the pool is most likely being updated by the controller. We can't
-			// allocate devices from it.
-			if slice.Spec.Pool.Generation != generation {
-				complete = false
-			}
-		}
-		// We still need to keep incomplete pools, since we need to make sure
-		// all devices available on a node is considered for allocationMode All.
-		if !complete {
-			incompletePools.Insert(poolID)
-		}
-	}
-
 	pools := make(map[PoolID]*Pool)
 	var slicesWithBindingConditions []*resourceapi.ResourceSlice
+
 	for _, slice := range slices {
 		if !features.PartitionableDevices && slice.Spec.PerDeviceNodeSelection != nil {
 			continue
@@ -162,7 +121,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	result := make([]*Pool, 0, len(pools))
 	var resultWithBindingConditions []*Pool
 	for _, pool := range pools {
-		pool.IsIncomplete = incompletePools.Has(poolIdentifier{driver: pool.Driver.String(), pool: pool.Pool.String()})
+		pool.IsIncomplete = int64(len(pool.Slices)) != pool.Slices[0].Spec.Pool.ResourceSliceCount
 		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
 		// if pool has binding conditions, add the pool to the end of the result
 		if poolHasBindingConditions(*pool) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -120,8 +120,30 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	// Find incomplete pools and flatten into a single slice.
 	result := make([]*Pool, 0, len(pools))
 	var resultWithBindingConditions []*Pool
-	for _, pool := range pools {
-		pool.IsIncomplete = int64(len(pool.Slices)) != pool.Slices[0].Spec.Pool.ResourceSliceCount
+	for poolID, pool := range pools {
+		// If we have all slices, we are done. If not, then we need to start looking for slices
+		// which were filtered out above because their node selection made them look irrelevant
+		// for the current node. This is necessary for "allocate all" mode (it rejects incomplete
+		// pools).
+		isComplete := int64(len(pool.Slices)) == pool.Slices[0].Spec.Pool.ResourceSliceCount
+		if !isComplete {
+			isObsolete, numSlices := checkSlicesInPool(slices, poolID, pool.Slices[0].Spec.Pool.Generation)
+			if isObsolete {
+				// A more thorough check determined that the DRA driver is in the process
+				// of replacing the current generation. The newer one didn't have any slice
+				// which devices for the node, or we would have noticed sooner.
+				//
+				// Let's ignore the old device information by ignoring the pool.
+				continue
+			}
+			// Use the more complete number of slices to check for "incomplete pool".
+			//
+			// The slices that we return to the caller still don't represent the whole
+			// pool, but that's okay: we *want* to limit the result to relevant devices
+			// so the caller doesn't need to check node selectors unnecessarily.
+			isComplete = numSlices == pool.Slices[0].Spec.Pool.ResourceSliceCount
+		}
+		pool.IsIncomplete = !isComplete
 		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
 		// if pool has binding conditions, add the pool to the end of the result
 		if poolHasBindingConditions(*pool) {
@@ -201,6 +223,37 @@ func poolHasBindingConditions(pool Pool) bool {
 		}
 	}
 	return false
+}
+
+// checkSlicesInPool is an expensive check of all slices in the pool.
+// The generation is what the caller wants to move ahead with.
+//
+// It returns:
+// - current generation is obsolete -> no further checking
+// - total number of slices with the generation
+//
+// Future TODO: detect inconsistent ResourceSliceCount, also in poolIsInvalid.
+func checkSlicesInPool(slices []*resourceapi.ResourceSlice, poolID PoolID, generation int64) (isObsolete bool, numSlices int64) {
+	// A cached index by pool ID would make this more efficient.
+	// It may be needed long-term to support features which always have to consider all slices.
+	for _, slice := range slices {
+		if slice.Spec.Driver != poolID.Driver.String() ||
+			slice.Spec.Pool.Name != poolID.Pool.String() {
+			// Different pool.
+			continue
+		}
+		switch {
+		case slice.Spec.Pool.Generation == generation:
+			numSlices++
+		case slice.Spec.Pool.Generation > generation:
+			// The caller must have missed some other slice in the pool.
+			// Abort!
+			return true, 0
+		default:
+			// Older generation, ignore.
+		}
+	}
+	return false, numSlices
 }
 
 type Pool struct {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -45,10 +45,6 @@ func nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 	return false, nil
 }
 
-type poolIdentifier struct {
-	driver, pool string
-}
-
 // GatherPools collects information about all resource pools which provide
 // devices that are accessible from the given node.
 //
@@ -56,45 +52,8 @@ type poolIdentifier struct {
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
-	slicesByPool := make(map[poolIdentifier][]*resourceapi.ResourceSlice)
-	for _, slice := range slices {
-		poolID := poolIdentifier{
-			driver: slice.Spec.Driver,
-			pool:   slice.Spec.Pool.Name,
-		}
-		slicesByPool[poolID] = append(slicesByPool[poolID], slice)
-	}
-
-	// We need to check whether a pool is complete while we have all
-	// the slices. Once we discard slices that don't target the node, we
-	// no longer have the information needed to find out.
-	incompletePools := sets.New[poolIdentifier]()
-	for poolID, slices := range slicesByPool {
-		complete := true
-		sliceCount := len(slices)
-		generation := slices[0].Spec.Pool.Generation
-		for _, slice := range slices {
-			// If the number of slices in the pool specified in any of the slices
-			// doesn't match what we found, the pool is most likely being updated
-			// by the controller.
-			if slice.Spec.Pool.ResourceSliceCount != int64(sliceCount) {
-				complete = false
-			}
-			// If the generation of the pool isn't the same across all slices,
-			// the pool is most likely being updated by the controller. We can't
-			// allocate devices from it.
-			if slice.Spec.Pool.Generation != generation {
-				complete = false
-			}
-		}
-		// We still need to keep incomplete pools, since we need to make sure
-		// all devices available on a node is considered for allocationMode All.
-		if !complete {
-			incompletePools.Insert(poolID)
-		}
-	}
-
 	pools := make(map[PoolID]*Pool)
+
 	for _, slice := range slices {
 		if !features.PartitionableDevices && slice.Spec.PerDeviceNodeSelection != nil {
 			continue
@@ -140,7 +99,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	// Find incomplete pools and flatten into a single slice.
 	result := make([]*Pool, 0, len(pools))
 	for _, pool := range pools {
-		pool.IsIncomplete = incompletePools.Has(poolIdentifier{driver: pool.Driver.String(), pool: pool.Pool.String()})
+		pool.IsIncomplete = int64(len(pool.Slices)) != pool.Slices[0].Spec.Pool.ResourceSliceCount
 		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
 		result = append(result, pool)
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
@@ -45,10 +45,6 @@ func nodeMatches(node *v1.Node, nodeNameToMatch string, allNodesMatch bool, node
 	return false, nil
 }
 
-type poolIdentifier struct {
-	driver, pool string
-}
-
 // GatherPools collects information about all resource pools which provide
 // devices that are accessible from the given node.
 //
@@ -56,45 +52,8 @@ type poolIdentifier struct {
 // required slices available) or invalid (for example, device names not unique).
 // Both is recorded in the result.
 func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node *v1.Node, features Features) ([]*Pool, error) {
-	slicesByPool := make(map[poolIdentifier][]*resourceapi.ResourceSlice)
-	for _, slice := range slices {
-		poolID := poolIdentifier{
-			driver: slice.Spec.Driver,
-			pool:   slice.Spec.Pool.Name,
-		}
-		slicesByPool[poolID] = append(slicesByPool[poolID], slice)
-	}
-
-	// We need to check whether a pool is complete while we have all
-	// the slices. Once we discard slices that don't target the node, we
-	// no longer have the information needed to find out.
-	incompletePools := sets.New[poolIdentifier]()
-	for poolID, slices := range slicesByPool {
-		complete := true
-		sliceCount := len(slices)
-		generation := slices[0].Spec.Pool.Generation
-		for _, slice := range slices {
-			// If the number of slices in the pool specified in any of the slices
-			// doesn't match what we found, the pool is most likely being updated
-			// by the controller.
-			if slice.Spec.Pool.ResourceSliceCount != int64(sliceCount) {
-				complete = false
-			}
-			// If the generation of the pool isn't the same across all slices,
-			// the pool is most likely being updated by the controller. We can't
-			// allocate devices from it.
-			if slice.Spec.Pool.Generation != generation {
-				complete = false
-			}
-		}
-		// We still need to keep incomplete pools, since we need to make sure
-		// all devices available on a node is considered for allocationMode All.
-		if !complete {
-			incompletePools.Insert(poolID)
-		}
-	}
-
 	pools := make(map[PoolID]*Pool)
+
 	for _, slice := range slices {
 		if !features.PartitionableDevices && slice.Spec.PerDeviceNodeSelection != nil {
 			continue
@@ -140,7 +99,7 @@ func GatherPools(ctx context.Context, slices []*resourceapi.ResourceSlice, node 
 	// Find incomplete pools and flatten into a single slice.
 	result := make([]*Pool, 0, len(pools))
 	for _, pool := range pools {
-		pool.IsIncomplete = incompletePools.Has(poolIdentifier{driver: pool.Driver.String(), pool: pool.Pool.String()})
+		pool.IsIncomplete = int64(len(pool.Slices)) != pool.Slices[0].Spec.Pool.ResourceSliceCount
 		pool.IsInvalid, pool.InvalidReason = poolIsInvalid(pool)
 		result = append(result, pool)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/commit/2e534d6da100ef20a048ed44f9ec9997f64676a7 caused a performance regression. This PR reverts it and solves the problem differently in the second commit.

In contrast to the previous attempt to fix this, now additional work only gets done when the current pool is not already known to be complete. In other words, most of the time no additional work is needed.
    
When doing the additional checking, then some cases of "updated devices no longer available for now" can be detected. This is not a full solution, but because DRA drivers doing this will have problems with race conditions anyway, this is not something that needs to be supported better. DRA drivers simply shouldn't be doing this.
    
This adds back the test case from the original fix and a few more.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/135032

#### Special notes for your reviewer:

This is an (IMHO) simpler alternative to https://github.com/kubernetes/kubernetes/pull/135036

I verified locally that performance for SteadyStateClusterResourceClaimTemplate with the last commit is the same as after the revert.

#### Does this PR introduce a user-facing change?

NONE because the performance regression never reached users.

```release-note
NONE
```

/assign @mortent