### PR TITLE
DRA scheduler_perf: benchmark baseline test cases with different allocators

### DIFF
--- a/test/integration/scheduler_perf/dra/dra_test.go
+++ b/test/integration/scheduler_perf/dra/dra_test.go
@@ -69,10 +69,25 @@ func TestSchedulerPerf(t *testing.T) {
 	}
 }
 
+// These benchmarks have to contain the word BenchmarkPerfScheduling to be picked up
+// by benchmark jobs.
+//
+// Sub-tests should have worked, too, but gotestsum was unhappy.
+
 func BenchmarkPerfScheduling(b *testing.B) {
 	// Restrict benchmarking to the default allocator.
 	structured.EnableAllocators("incubating")
 	defer structured.EnableAllocators()
 
+	// "dra" is how this was called traditionally.
+	// It's kept to avoid changing perf-dash results.
 	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra", nil)
+}
+
+func BenchmarkPerfSchedulingExperimental(b *testing.B) {
+	// And now the experimental allocator.
+	structured.EnableAllocators("experimental")
+	defer structured.EnableAllocators()
+
+	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra_experimental", nil)
 }

--- a/test/integration/scheduler_perf/dra/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/performance-config.yaml
@@ -130,8 +130,9 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 40 # typically above 51
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 40 # typically above 51
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -142,8 +143,9 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 56 # typically above 70
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 56 # typically above 70
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -208,8 +210,9 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fempty_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 64 # typically above 81
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fempty_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 64 # typically above 81
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -220,8 +223,9 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fempty_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 64 # typically above 81
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fempty_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 64 # typically above 81
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -247,8 +251,9 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fhalf_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 70 # typically over 78
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fhalf_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 70 # typically over 78
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -259,8 +264,9 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fhalf_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 60 # typically over 75
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fhalf_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 60 # typically over 75
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -286,8 +292,9 @@
     featureGates:
       SchedulerQueueingHints: false
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Ffull_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 60 # typically over 75
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Ffull_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 60 # typically over 75
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0
@@ -298,8 +305,9 @@
     featureGates:
       SchedulerQueueingHints: true
     labels: [performance]
-    # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Ffull_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
-    threshold: 60 # typically over 75
+    threshold:
+      # https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Ffull_500nodes_QueueingHintsEnabled%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable
+      dra: 60 # typically over 75
     params:
       nodesWithDRA: 500
       nodesWithoutDRA: 0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When adding new features to the "experimental" allocator we are not directly breaking "normal" usage of DRA because that uses the "incubating" allocator. But we still want to know about potential performance problems also for those test cases. If there is one, we might not be able to implement an experimental feature in a way that allows promoting it later.

This is achieved by running the benchmarks twice as sub-tests, with different topic names. The topic names then can be used to select different thresholds, using a new extension of the scheduler_pref JSON config format.

#### Which issue(s) this PR is related to:

First TODO in https://github.com/kubernetes/kubernetes/issues/135058.

#### Special notes for your reviewer:

I verified locally that only the "incubating" test case fails because of the [current performance regression](https://github.com/kubernetes/kubernetes/issues/135032). The new "experimental" test case passes because it has no threshold.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @macsko 
/hold

Let's wait for a verified fix of https://github.com/kubernetes/kubernetes/issues/135032 before we merge this, it'll change the benchmark names.