### PR TITLE
[InPlacePodVerticalScaling] Promote IPPR e2e tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2436,6 +2436,62 @@
     its new label found. Deleting the Node MUST succeed and its deletion MUST be confirmed.
   release: v1.32
   file: test/e2e/node/node_lifecycle.go
+- testname: In-place Pod Resize, burtable pod with multiple containers and various
+    operations
+  codename: '[sig-node] Pod InPlace Resize Container burstable pods - extended 6 containers
+    - various operations performed (including adding limits and requests) [Conformance]'
+  description: Issuing a Pod Resize request via the Pod Resize subresource patch endpoint
+    to modify CPU and memory requests and limits on a 6-container pod with various
+    operations MUST result in the Pod resources being updated as expected.
+  release: v1.35
+  file: test/e2e/common/node/pod_resize.go
+- testname: In-place Pod Resize, burstable pod resized with equivalents
+  codename: '[sig-node] Pod InPlace Resize Container burstable pods - extended resize
+    with equivalents [Conformance]'
+  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
+    patch endpoint to modify CPU requests and limits using equivalent values (e.g.
+    2m -> 1m) MUST result in the updated Pod resources displayed correctly in the
+    status.
+  release: v1.35
+  file: test/e2e/common/node/pod_resize.go
+- testname: In-place Pod Resize, guaranteed pods with multiple containers, net increase
+  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
+    containers 3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on
+    c3 - net increase [Conformance]'
+  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
+    patch endpoint to modify CPU and memory requests and limits for a guaranteed pod
+    with 3 containers with a net increase MUST result in the Pod resources being updated
+    as expected.
+  release: v1.35
+  file: test/e2e/common/node/pod_resize.go
+- testname: In-place Pod Resize, guaranteed pods with multiple containers, net decrease
+  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
+    containers 3 containers - increase cpu & mem on c1, decrease cpu & mem on c2,
+    c3 - net decrease [Conformance]'
+  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
+    patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers
+    with a net decrease MUST result in the Pod resources being updated as expected.
+  release: v1.35
+  file: test/e2e/common/node/pod_resize.go
+- testname: In-place Pod Resize, guaranteed pods with multiple containers, various
+    operations
+  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
+    containers 3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU
+    (c2) [Conformance]'
+  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
+    patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers
+    with various operations MUST result in the Pod resources being updated as expected.
+  release: v1.35
+  file: test/e2e/common/node/pod_resize.go
+- testname: In-place Pod Resize, read and replace endpoints
+  codename: '[sig-node] Pod InPlace Resize Container resize pod via the replace endpoint
+    [Conformance]'
+  description: Issuing a Pod Resize request via the Pod Resize subresource replace
+    endpoint MUST result in the Pod resources being updated as expected. The Pod object
+    fetched from the Pod Resize subresource MUST be equivalent to the Pod object fetched
+    from the main Pod endpoint after the resize is completed.
+  release: v1.35
+  file: test/e2e/common/node/pod_resize.go
 - testname: PodTemplate, delete a collection
   codename: '[sig-node] PodTemplates should delete a collection of pod templates [Conformance]'
   description: A set of Pod Templates is created with a label selector which MUST

--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -1,4 +1,1 @@
 ---
-- patchCoreV1NamespacedPodResize
-- readCoreV1NamespacedPodResize
-- replaceCoreV1NamespacedPodResize

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/cgroups"
 	"k8s.io/kubernetes/test/e2e/common/node/framework/podresize"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -133,7 +132,12 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 	// All tests will perform the requested resize, and once completed, will roll back the change.
 	// This results in coverage of both the operation as described, and its reverse.
 	ginkgo.Describe("guaranteed pods with multiple containers", func() {
-		ginkgo.It("3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on c3 - net increase", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: In-place Pod Resize, guaranteed pods with multiple containers, net increase
+			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a guaranteed pod with 3 containers with a net increase MUST result in the Pod resources being updated as expected.
+		*/
+		framework.ConformanceIt("3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on c3 - net increase", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil
@@ -158,7 +162,12 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 			doPatchAndRollback(ctx, f, originalContainers, expectedContainers, true)
 		})
 
-		ginkgo.It("3 containers - increase cpu & mem on c1, decrease cpu & mem on c2, c3 - net decrease", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: In-place Pod Resize, guaranteed pods with multiple containers, net decrease
+			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers with a net decrease MUST result in the Pod resources being updated as expected.
+		*/
+		framework.ConformanceIt("3 containers - increase cpu & mem on c1, decrease cpu & mem on c2, c3 - net decrease", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil
@@ -183,7 +192,12 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 			doPatchAndRollback(ctx, f, originalContainers, expectedContainers, true)
 		})
 
-		ginkgo.It("3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2)", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: In-place Pod Resize, guaranteed pods with multiple containers, various operations
+			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers with various operations MUST result in the Pod resources being updated as expected.
+		*/
+		framework.ConformanceIt("3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2)", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil
@@ -253,7 +267,12 @@ func doBurstablePodResizeTests(f *framework.Framework) {
 	// - adding requests where none were previously set
 	// - resizing with equivalents (e.g. 2m -> 1m)
 	ginkgo.Describe("burstable pods - extended", func() {
-		ginkgo.It("6 containers - various operations performed (including adding limits and requests)", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: In-place Pod Resize, burtable pod with multiple containers and various operations
+			Description: Issuing a Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits on a 6-container pod with various operations MUST result in the Pod resources being updated as expected.
+		*/
+		framework.ConformanceIt("6 containers - various operations performed (including adding limits and requests)", func(ctx context.Context) {
 			originalContainers := []podresize.ResizableContainerInfo{
 				{
 					// c1 starts with CPU requests only; increase CPU requests + add CPU limits
@@ -311,7 +330,12 @@ func doBurstablePodResizeTests(f *framework.Framework) {
 			doPatchAndRollback(ctx, f, originalContainers, expectedContainers, false)
 		})
 
-		ginkgo.It("resize with equivalents", func(ctx context.Context) {
+		/*
+			Release: v1.35
+			Testname: In-place Pod Resize, burstable pod resized with equivalents
+			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU requests and limits using equivalent values (e.g. 2m -> 1m) MUST result in the updated Pod resources displayed correctly in the status.
+		*/
+		framework.ConformanceIt("resize with equivalents", func(ctx context.Context) {
 			originalContainers := []podresize.ResizableContainerInfo{
 				{
 					Name:      "c1",
@@ -682,9 +706,12 @@ func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
 }
 
 func doPodResizeReadAndReplaceTests(f *framework.Framework) {
-	// This test provides basic coverage for the `read` and `replace` endpoints.
-	// TODO: Promote to conformance prior to GA.
-	ginkgo.It("resize pod via the replace endpoint", func(ctx context.Context) {
+	/*
+		Release: v1.35
+		Testname: In-place Pod Resize, read and replace endpoints
+		Description: Issuing a Pod Resize request via the Pod Resize subresource replace endpoint MUST result in the Pod resources being updated as expected. The Pod object fetched from the Pod Resize subresource MUST be equivalent to the Pod object fetched from the main Pod endpoint after the resize is completed.
+	*/
+	framework.ConformanceIt("resize pod via the replace endpoint", func(ctx context.Context) {
 		podClient := e2epod.NewPodClient(f)
 		original := []podresize.ResizableContainerInfo{{
 			Name:      "c1",
@@ -768,7 +795,7 @@ func doPodResizeReadAndReplaceTests(f *framework.Framework) {
 //	   b) api-server in services doesn't start with --enable-admission-plugins=ResourceQuota
 //	      and is not possible to start it from TEST_ARGS
 //	Above tests in test/e2e/node/pod_resize.go
-var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithFeatureGate(features.InPlacePodVerticalScaling), func() {
+var _ = SIGDescribe("Pod InPlace Resize Container", func() {
 	f := framework.NewDefaultFramework("pod-resize-tests")
 
 	ginkgo.BeforeEach(func(ctx context.Context) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/area test
/area conformance
/sig node
/priority important-soon

#### What this PR does / why we need it:

Promote InPlacePodVerticalScaling e2e test to conformance

- The feature is now GA: https://github.com/kubernetes/kubernetes/pull/134949
- Minimal flakes in the last 2 weeks: 
  - Guaranteed pod tests (3 clusters of 6 failures out of 164348 builds): https://storage.googleapis.com/k8s-triage/index.html?test=guaranteed%20pods%20with%20multiple%20containers
  - Burstable pod tests (1 clusters of 2 failures out of 164348 builds): https://storage.googleapis.com/k8s-triage/index.html?test=burstable%20pods%20-%20extended
  - Read and replace endpoint test (1 clusters of 1 failures out of 164348 builds): https://storage.googleapis.com/k8s-triage/index.html?test=resize%20pod%20via%20the%20replace%20endpoint
- Follows https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#promoting-tests-to-conformance

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/133607

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


