### PR TITLE
DRA device taint eviction: several improvements

### DIFF
--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -551,8 +551,7 @@ func (tc *Controller) maybeUpdateRuleStatus(ctx context.Context, ruleRef taintev
 			allocatedClaims: maps.Clone(tc.allocatedClaims),
 			pools:           tc.pools,
 			simulateRule:    ruleEvict,
-			// TODO: stub implementation
-			workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[workItem](), workqueue.TypedRateLimitingQueueConfig[workItem]{}),
+			workqueue:       &NOPQueue[workItem]{},
 		}
 		defer tc.workqueue.ShutDown()
 

--- a/pkg/controller/devicetainteviction/nopqueue.go
+++ b/pkg/controller/devicetainteviction/nopqueue.go
@@ -1,0 +1,79 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devicetainteviction
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// NOPQueue is an implementation of [TypedRateLimitingInterface] which
+// doesn't do anything.
+type NOPQueue[T comparable] struct {
+}
+
+var _ workqueue.TypedRateLimitingInterface[int] = &NOPQueue[int]{}
+
+// Add implements [TypedInterface].
+func (m *NOPQueue[T]) Add(item T) {
+}
+
+// Len implements [TypedInterface].
+func (m *NOPQueue[T]) Len() int {
+	return 0
+}
+
+// Get implements [TypedInterface].
+func (m *NOPQueue[T]) Get() (item T, shutdown bool) {
+	shutdown = true
+	return
+}
+
+// Done implements [TypedInterface].
+func (m *NOPQueue[T]) Done(item T) {
+}
+
+// ShutDown implements [TypedInterface].
+func (m *NOPQueue[T]) ShutDown() {
+}
+
+// ShutDownWithDrain implements [TypedInterface].
+func (m *NOPQueue[T]) ShutDownWithDrain() {
+}
+
+// ShuttingDown implements [TypedInterface].
+func (m *NOPQueue[T]) ShuttingDown() bool {
+	return true
+}
+
+// AddAfter implements [TypedDelayingInterface.AddAfter]
+func (m *NOPQueue[T]) AddAfter(item T, duration time.Duration) {
+}
+
+// AddRateLimited implements [TypedRateLimitingInterface.AddRateLimited].
+func (m *NOPQueue[T]) AddRateLimited(item T) {
+}
+
+// Forget implements [TypedRateLimitingInterface.Forget].
+func (m *NOPQueue[T]) Forget(item T) {
+}
+
+// NumRequeues implements [TypedRateLimitingInterface.NumRequeues].
+func (m *NOPQueue[T]) NumRequeues(item T) int {
+	return 0
+}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -203,6 +203,12 @@ const (
 	// owner: @pohly
 	// kep: http://kep.k8s.io/5055
 	//
+	// DeviceTaintRules allow administrators to add taints to devices.
+	DRADeviceTaintRules featuregate.Feature = "DRADeviceTaintRules"
+
+	// owner: @pohly
+	// kep: http://kep.k8s.io/5055
+	//
 	// Marking devices as tainted can prevent using them for new pods and/or
 	// cause pods using them to stop. Users can decide to tolerate taints.
 	DRADeviceTaints featuregate.Feature = "DRADeviceTaints"
@@ -1152,6 +1158,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	DRADeviceTaintRules: {
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	DRADeviceTaints: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 	},
@@ -2063,6 +2073,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	DRAConsumableCapacity: {DynamicResourceAllocation},
 
 	DRADeviceBindingConditions: {DynamicResourceAllocation, DRAResourceClaimDeviceStatus},
+
+	DRADeviceTaintRules: {DRADeviceTaints}, // DynamicResourceAllocation is indirect.
 
 	DRADeviceTaints: {DynamicResourceAllocation},
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -2314,11 +2314,11 @@ func setup(t *testing.T, args *config.DynamicResourcesArgs, nodes []*v1.Node, cl
 
 	tc.informerFactory = informers.NewSharedInformerFactory(tc.client, 0)
 	resourceSliceTrackerOpts := resourceslicetracker.Options{
-		EnableDeviceTaints: true,
-		SliceInformer:      tc.informerFactory.Resource().V1().ResourceSlices(),
-		TaintInformer:      tc.informerFactory.Resource().V1alpha3().DeviceTaintRules(),
-		ClassInformer:      tc.informerFactory.Resource().V1().DeviceClasses(),
-		KubeClient:         tc.client,
+		EnableDeviceTaintRules: true,
+		SliceInformer:          tc.informerFactory.Resource().V1().ResourceSlices(),
+		TaintInformer:          tc.informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+		ClassInformer:          tc.informerFactory.Resource().V1().DeviceClasses(),
+		KubeClient:             tc.client,
 	}
 	resourceSliceTracker, err := resourceslicetracker.StartTracker(tCtx, resourceSliceTrackerOpts)
 	require.NoError(t, err, "couldn't start resource slice tracker")

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -326,14 +326,14 @@ func New(ctx context.Context,
 		resourceClaimInformer := informerFactory.Resource().V1().ResourceClaims().Informer()
 		resourceClaimCache = assumecache.NewAssumeCache(logger, resourceClaimInformer, "ResourceClaim", "", nil)
 		resourceSliceTrackerOpts := resourceslicetracker.Options{
-			EnableDeviceTaints:       feature.DefaultFeatureGate.Enabled(features.DRADeviceTaints),
+			EnableDeviceTaintRules:   feature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules),
 			EnableConsumableCapacity: feature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity),
 			SliceInformer:            informerFactory.Resource().V1().ResourceSlices(),
 			KubeClient:               client,
 		}
-		// If device taints are disabled, the additional informers are not needed and
+		// If device taint rules are disabled, the additional informers are not needed and
 		// the tracker turns into a simple wrapper around the slice informer.
-		if resourceSliceTrackerOpts.EnableDeviceTaints {
+		if resourceSliceTrackerOpts.EnableDeviceTaintRules {
 			resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1alpha3().DeviceTaintRules()
 			resourceSliceTrackerOpts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 		}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -645,7 +645,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("create", "delete").Groups(resourceGroup).Resources("resourceclaims").RuleOrDie(),
 			)
 		}
-		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaints) {
+		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules) {
 			kubeSchedulerRules = append(kubeSchedulerRules, rbacv1helpers.NewRule(Read...).Groups(resourceGroup).Resources("devicetaintrules").RuleOrDie())
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -551,11 +551,11 @@ func TestListPatchedResourceSlices(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute)
 
 		opts := Options{
-			EnableDeviceTaints: true,
-			SliceInformer:      informerFactory.Resource().V1().ResourceSlices(),
-			TaintInformer:      informerFactory.Resource().V1alpha3().DeviceTaintRules(),
-			ClassInformer:      informerFactory.Resource().V1().DeviceClasses(),
-			KubeClient:         kubeClient,
+			EnableDeviceTaintRules: true,
+			SliceInformer:          informerFactory.Resource().V1().ResourceSlices(),
+			TaintInformer:          informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+			ClassInformer:          informerFactory.Resource().V1().DeviceClasses(),
+			KubeClient:             kubeClient,
 		}
 		tracker, err := newTracker(ctx, opts)
 		require.NoError(t, err)
@@ -959,11 +959,11 @@ func BenchmarkEventHandlers(b *testing.B) {
 		kubeClient := fake.NewSimpleClientset()
 		informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute)
 		opts := Options{
-			EnableDeviceTaints: true,
-			SliceInformer:      informerFactory.Resource().V1().ResourceSlices(),
-			TaintInformer:      informerFactory.Resource().V1alpha3().DeviceTaintRules(),
-			ClassInformer:      informerFactory.Resource().V1().DeviceClasses(),
-			KubeClient:         kubeClient,
+			EnableDeviceTaintRules: true,
+			SliceInformer:          informerFactory.Resource().V1().ResourceSlices(),
+			TaintInformer:          informerFactory.Resource().V1alpha3().DeviceTaintRules(),
+			ClassInformer:          informerFactory.Resource().V1().DeviceClasses(),
+			KubeClient:             kubeClient,
 		}
 		tracker, err := newTracker(ctx, opts)
 		require.NoError(b, err)

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -481,6 +481,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.34"
+- name: DRADeviceTaintRules
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.35"
 - name: DRADeviceTaints
   versionedSpecs:
   - default: false

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -1991,7 +1991,7 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			b.TestPod(ctx, f, pod)
 		})
 
-		f.It("DeviceTaintRule evicts pod", func(ctx context.Context) {
+		f.It("DeviceTaintRule evicts pod", f.WithFeatureGate(features.DRADeviceTaintRules), func(ctx context.Context) {
 			pod, template := b.PodInline()
 			template.Spec.Spec.Devices.Requests[0].Exactly.Tolerations = []resourceapi.DeviceToleration{{
 				Effect:   resourceapi.DeviceTaintEffectNoSchedule,

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -192,6 +192,14 @@ func TestDRA(t *testing.T) {
 				})
 			},
 		},
+		"slice-taints": {
+			features: map[featuregate.Feature]bool{
+				features.DRADeviceTaints: true,
+			},
+			f: func(tCtx ktesting.TContext) {
+				tCtx.Run("EvictClusterWithSlices", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, false) })
+			},
+		},
 		"all": {
 			apis: map[schema.GroupVersion]bool{
 				resourcev1beta1.SchemeGroupVersion:  true,
@@ -206,6 +214,7 @@ func TestDRA(t *testing.T) {
 				features.DRADeviceBindingConditions:   true,
 				features.DRAConsumableCapacity:        true,
 				features.DRADeviceTaints:              true,
+				features.DRADeviceTaintRules:          true,
 				features.DRAPartitionableDevices:      true,
 				features.DRAPrioritizedList:           true,
 				features.DRAResourceClaimDeviceStatus: true,
@@ -222,7 +231,8 @@ func TestDRA(t *testing.T) {
 				tCtx.Run("ExtendedResource", func(tCtx ktesting.TContext) { testExtendedResource(tCtx, true) })
 				tCtx.Run("ResourceClaimDeviceStatus", func(tCtx ktesting.TContext) { testResourceClaimDeviceStatus(tCtx, true) })
 				tCtx.Run("MaxResourceSlice", testMaxResourceSlice)
-				tCtx.Run("EvictCluster", testEvictCluster)
+				tCtx.Run("EvictClusterWithRule", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, true) })
+				tCtx.Run("EvictClusterWithSlices", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, false) })
 			},
 		},
 	} {

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -286,12 +286,12 @@ func (op *allocResourceClaimsOp) run(tCtx ktesting.TContext) {
 	claimInformer := informerFactory.Resource().V1().ResourceClaims().Informer()
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	resourceSliceTrackerOpts := resourceslicetracker.Options{
-		EnableDeviceTaints:       utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaints),
+		EnableDeviceTaintRules:   utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules),
 		EnableConsumableCapacity: utilfeature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity),
 		SliceInformer:            informerFactory.Resource().V1().ResourceSlices(),
 		KubeClient:               tCtx.Client(),
 	}
-	if resourceSliceTrackerOpts.EnableDeviceTaints {
+	if resourceSliceTrackerOpts.EnableDeviceTaintRules {
 		resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1alpha3().DeviceTaintRules()
 		resourceSliceTrackerOpts.ClassInformer = informerFactory.Resource().V1().DeviceClasses()
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

This builds on top of the the already merged https://github.com/kubernetes/kubernetes/pull/134152 and adds things which weren't meant to block merging that PR. They would be nice to have in 1.35.

- add separate feature gate for rules

    Support for DeviceTaintRules depends on a significant amount of
    additional code:
    - ResourceSlice tracker is a NOP without it.
    - Additional informers and corresponding permissions in scheduler and controller.
    - Controller code for handling status.
    
    Not all users necessarily need DeviceTaintRules, so adding a second feature
    gate for that code makes it possible to limit the blast radius of bugs in that
    code without having to turn off device taints and tolerations entirely.

- use NOP queue during simulation
    
    It's slightly more efficient and a bit cleaner.

- track evicting rules
    
    This avoids having to call the rule lister (which theoretically, but not in
    practice) fail and having to iterate over rules which can be ignored (might be
    a small performance boost).

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

It was [suggested](https://github.com/kubernetes/kubernetes/pull/134152#discussion_r2492011181) by @soltysh to refactor the controller into fields+code for the logic (how many pods to evict, for example) and the actual controller itself. I tried that, but it turned into a pretty weird mixture of controller and logic code with not much left in the controller itself. I don't think this should be done.

#### Does this PR introduce a user-facing change?

```release-note
The DRA device taints and toleration feature now has a separate feature gate, DRADeviceTaintRules, which controls whether support for DeviceTaintRules is enabled. It is possible to disable that and keep DRADeviceTaints enabled, in which case tainting by DRA drivers through ResourceSlices continues to work.
```
