### PR TITLE
E2E framework: start slow tests first

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -221,8 +221,14 @@ func registerInSuite(ginkgoCall func(string, ...interface{}) bool, args []interf
 					ginkgoArgs = append(ginkgoArgs, ginkgo.Label("BetaOffByDefault"))
 				}
 			}
-			if fullLabel == "Serial" {
+			switch fullLabel {
+			case "Serial":
 				ginkgoArgs = append(ginkgoArgs, ginkgo.Serial)
+			case "Slow":
+				// Start slow tests first. This avoids the risk
+				// that they get started towards the end of a
+				// run and then make the run longer overall.
+				ginkgoArgs = append(ginkgoArgs, ginkgo.SpecPriority(1))
 			}
 		case ginkgo.Offset:
 			offset = arg


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This avoids the risk of having a slow test started towards the end of a run, which then would cause the run to take longer. When started early they can run in parallel to other tests. In serial runs it doesn't matter.

The implementation maps the Slow label to the new ginkgo.SpecPriority. The default is 0. Tests with priority 1 run first.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/135045
https://github.com/kubernetes/kubernetes/pull/134881

#### Special notes for your reviewer:

This was previously merged in https://github.com/kubernetes/kubernetes/pull/134881, then reverted unnecessarily in https://github.com/kubernetes/kubernetes/pull/135045. As it then turned out, the Ginkgo update itself caused job failures, not this commit. Let's add it back because:

https://kubernetes.slack.com/archives/C09QZ4DQB/p1762101364877089?thread_ts=1762101357.443349&cid=C09QZ4DQB

> Since then, total runtime is consistently 38 to 40 minutes. I think that confirms that starting slow jobs first indeed works as expected.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @dims @BenTheElder 