### PR TITLE
Fix pod resize validation when adding non-resizable resources

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6222,11 +6222,11 @@ func validatePodResizeContainerOrdering(newPod, oldPod *core.Pod, specPath *fiel
 // dropCPUMemoryResourcesFromContainer deletes the cpu and memory resources from the container, and copies them from the old pod container resources if present.
 func dropCPUMemoryResourcesFromContainer(container *core.Container, oldPodSpecContainer *core.Container) {
 	dropCPUMemoryUpdates := func(resourceList, oldResourceList core.ResourceList) core.ResourceList {
-		if oldResourceList == nil {
-			return nil
-		}
 		var mungedResourceList core.ResourceList
 		if resourceList == nil {
+			if oldResourceList == nil {
+				return nil
+			}
 			mungedResourceList = make(core.ResourceList)
 		} else {
 			mungedResourceList = resourceList.DeepCopy()

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -28309,6 +28309,21 @@ func TestValidatePodResize(t *testing.T) {
 			old:  mkPodWithInitContainers(getResources("100m", "0", "1Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.RestartContainer)),
 			new:  mkPodWithInitContainers(getResources("100m", "0", "2Gi", ""), core.ResourceList{}, core.ContainerRestartPolicyAlways, resizePolicy(core.ResourceMemory, core.NotRequired)),
 			err:  "spec: Forbidden: only cpu and memory resources are mutable",
+		}, {
+			test: "invalid: adding non-resizable resources to a container without resources",
+			old: podtest.MakePod("pod", podtest.SetContainers(
+				podtest.MakeContainer("c1"),
+			)),
+			new: podtest.MakePod("pod", podtest.SetContainers(
+				podtest.MakeContainer("c1",
+					podtest.SetContainerResources(core.ResourceRequirements{
+						Requests: core.ResourceList{
+							core.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+						},
+					}),
+				),
+			)),
+			err: "spec: Forbidden: only cpu and memory resources are mutable",
 		},
 	}
 

--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -869,6 +869,11 @@ func TestPodResizeRBAC(t *testing.T) {
 					{
 						Name:  "fake-name",
 						Image: "fakeimage",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU: resource.MustParse("100m"),
+							},
+						},
 					},
 				},
 			},
@@ -929,7 +934,7 @@ func TestPodResizeRBAC(t *testing.T) {
 			}
 			resp.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Requests: v1.ResourceList{
-					v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+					v1.ResourceCPU: resource.MustParse("200m"),
 				},
 			}
 			_, err = saClient.CoreV1().Pods(ns.Name).UpdateResize(context.TODO(), resp.Name, resp, metav1.UpdateOptions{})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it:

While reviewing https://github.com/kubernetes/kubernetes/pull/132919 I noticed a bug in ValidatePodResize: if a container doesn't have any resources, you can add any resources other than CPU & memory.

#### Special notes for your reviewer:

This change is a candidate for backport.

This method could use some more cleanup, but I'm trying to keep the diff minimal.

#### Does this PR introduce a user-facing change?
```release-note
Forbid adding resources other than CPU & memory on pod resize.
```

/sig node
/priority important-soon

/assign @natasha41575