### PR TITLE
Switch kube-proxy/server.go to context-aware logging APIs (HandleErrorWithContext, UntilWithContext)

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -440,7 +440,7 @@ func serveHealthz(ctx context.Context, hz *healthcheck.ProxyHealthServer, errCh 
 		return
 	}
 
-	fn := func() {
+	fn := func(ctx context.Context) {
 		err := hz.Run(ctx)
 		if err != nil {
 			logger.Error(err, "Healthz server failed")
@@ -454,7 +454,7 @@ func serveHealthz(ctx context.Context, hz *healthcheck.ProxyHealthServer, errCh 
 			logger.Error(nil, "Healthz server returned without error")
 		}
 	}
-	go wait.Until(fn, 5*time.Second, ctx.Done())
+	go wait.UntilWithContext(ctx, fn, 5*time.Second)
 }
 
 func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyconfig.ProxyMode, enableProfiling bool, flagzReader flagz.Reader, errCh chan error) {
@@ -493,12 +493,11 @@ func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyco
 		statusz.Install(proxyMux, kubeProxy, reg)
 	}
 
-	fn := func() {
+	fn := func(ctx context.Context) {
 		var err error
 		defer func() {
 			if err != nil {
-				err = fmt.Errorf("starting metrics server failed: %w", err)
-				utilruntime.HandleError(err)
+				utilruntime.HandleErrorWithContext(ctx, err, "starting metrics server failed")
 				if errCh != nil {
 					errCh <- err
 					// if in hardfail mode, never retry again
@@ -520,7 +519,7 @@ func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyco
 		}
 
 	}
-	go wait.Until(fn, 5*time.Second, wait.NeverStop)
+	go wait.UntilWithContext(ctx, fn, 5*time.Second)
 }
 
 // Run runs the specified ProxyServer.  This should never exit (unless CleanupAndExit is set).


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR updates `cmd/kube-proxy/app/server.go` to use context-aware logging APIs (`HandleErrorWithContext`, `UntilWithContext`) instead of the deprecated non-contextual ones.  
This change is part of the ongoing migration to the contextual logging framework in Kubernetes components.

#### Which issue(s) this PR is related to:
Contributes to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:
This PR focuses only on replacing the legacy logging calls with contextual logging functions in kube-proxy.  
All verification scripts (`make verify`) and tests (`make test WHAT=cmd/kube-proxy`) have passed successfully to ensure no regressions.