### PR TITLE
Revert "prepare DRA kind config for kubeadm v1beta4"

### DIFF
--- a/test/e2e/dra/kind.yaml
+++ b/test/e2e/dra/kind.yaml
@@ -8,48 +8,9 @@ containerdConfigPatches:
     enable_cdi = true
 nodes:
 - role: control-plane
-- role: worker
-- role: worker
-- role: worker
-kubeadmConfigPatches:
-  # v1beta4 for the future (v1.35.0+ ?)
-  # https://github.com/kubernetes-sigs/kind/issues/3847
-  # TODO: drop v1beta3 when kind makes the switch
+  kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta4
-    scheduler:
-        extraArgs:
-          - name: "v"
-            value: "5"
-          - name: "vmodule"
-            value: "allocator=6,dynamicresources=6" # structured/allocator.go, DRA scheduler plugin
-    controllerManager:
-        extraArgs:
-          - name: "v"
-            value: "5"
-          - name: "vmodule"
-            value: "controller=6" # resourceclaim/controller.go - should have renamed it when copying the controller it was based on!
-    apiServer:
-        extraArgs:
-          runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true"
-  - |
-    kind: InitConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta4
-    nodeRegistration:
-      kubeletExtraArgs:
-        - name: "v"
-          value: "5"
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        - name: "v"
-          value: "5"
-  # v1beta3 for v1.23.0 ... ?
-  - |
-    kind: ClusterConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
     scheduler:
         extraArgs:
           v: "5"
@@ -63,10 +24,25 @@ kubeadmConfigPatches:
           runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true"
   - |
     kind: InitConfiguration
-    apiVersion: kubeadm.k8s.io/v1beta3
     nodeRegistration:
       kubeletExtraArgs:
         v: "5"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"
+- role: worker
+  kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
     nodeRegistration:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This reverts commit d17ed9be174ef8a6f0971196530f785fd1ab759f.

The CI jobs append

    kubeadmConfigPatches:
    - | kind: ClusterConfiguration etcd: local: dataDir: /tmp/etcd

With that commit also adding kubeadmConfigPatches, all jobs break with

     mapping key "kubeadmConfigPatches" already defined at line 14

We have to update jobs first, then add the change back.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/135016/files#r2489258642

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh