### PR TITLE
Fix failures in node-e2e image pull tests

### DIFF
--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -263,7 +263,7 @@ while true; do sleep 1; done
 			ginkgo.BeforeEach(func(ctx context.Context) {
 				var err error
 
-				registryAddress, _, err = e2eregistry.SetupRegistry(ctx, f, false)
+				registryAddress, _, err = e2eregistry.SetupRegistry(ctx, f, true)
 				framework.ExpectNoError(err)
 				// we need to wait for the registry to be removed and so we need to delete the whole NS ourselves
 				ginkgo.DeferCleanup(func(ctx context.Context) {

--- a/test/e2e/framework/registry/registry.go
+++ b/test/e2e/framework/registry/registry.go
@@ -137,7 +137,7 @@ func User1DockerSecret(registryAddress string) *v1.Secret {
 	return &v1.Secret{
 		Type: v1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
-			v1.DockerConfigJsonKey: fmt.Appendf(nil, dockerCredsFmt, "http://"+registryAddress, user1creds),
+			v1.DockerConfigJsonKey: fmt.Appendf(nil, dockerCredsFmt, registryAddress, user1creds),
 		},
 	}
 }

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -147,7 +147,7 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 
 					ginkgo.By("check the container status")
 					var latestErr error
-					err = wait.PollUntilContextCancel(ctx, node.ContainerStatusPollInterval, true, func(ctx context.Context) (bool, error) {
+					err = wait.PollUntilContextTimeout(ctx, node.ContainerStatusPollInterval, node.ContainerStatusRetryTimeout, true, func(ctx context.Context) (bool, error) {
 						if latestErr = checkContainerStatus(ctx); latestErr != nil {
 							return false, nil
 						}

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -154,6 +154,8 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 						return true, nil
 					})
 					if err != nil {
+						credsContent, readErr := os.ReadFile(configFile)
+						framework.Logf("credentials read error: %v; credentials used:\n%v", readErr, credsContent)
 						framework.Failf("Failed to read container status: %v; last observed error from wait loop: %v", err, latestErr)
 					}
 				})


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
fixes issues in serial node e2e conformance test suites

#### Which issue(s) this PR is related to:
Fixes #https://github.com/kubernetes/kubernetes/issues/134998

#### Special notes for your reviewer:
The node-e2e conformance test suite is not runnable locally and so it's easy to make a mistake in it.
It looks like it did not run in tests in the original PR, we need to make sure that the test is run here.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
