### PR TITLE
kubelet: delay looking up pod image pull credentials until necessary

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -199,48 +199,14 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 		return "", message, err
 	}
 
-	if imageRef != "" && !utilfeature.DefaultFeatureGate.Enabled(features.KubeletEnsureSecretPulledImages) {
-		imagePullRequired = ptr.To(false)
-		msg := fmt.Sprintf("Container image %q already present on machine", requestedImage)
-		m.logIt(objRef, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
+	// wrap the lookup in a function to ensure that we only look up credentials once and no earlier than needed
+	lookupPullCredentials := m.makeLookupPullCredentialsFunc(spec.Image, pod, pullSecrets, podSandboxConfig)
 
-		// we need to stop recording if it is still in progress, as the image
-		// has already been pulled by another pod.
-		m.podPullingTimeRecorder.RecordImageFinishedPulling(pod.UID)
-
-		return imageRef, msg, nil
-	}
-
-	repoToPull, _, _, err := parsers.ParseImageName(spec.Image)
-	if err != nil {
-		return "", err.Error(), err
-	}
-
-	// construct the dynamic keyring using the providers we have in the kubelet
-	var podName, podNamespace, podUID string
-	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletServiceAccountTokenForCredentialProviders) {
-		sandboxMetadata := podSandboxConfig.GetMetadata()
-
-		podName = sandboxMetadata.Name
-		podNamespace = sandboxMetadata.Namespace
-		podUID = sandboxMetadata.Uid
-	}
-
-	externalCredentialProviderKeyring := credentialproviderplugin.NewExternalCredentialProviderDockerKeyring(
-		podNamespace,
-		podName,
-		podUID,
-		pod.Spec.ServiceAccountName)
-
-	keyring, err := credentialprovidersecrets.MakeDockerKeyring(pullSecrets, credentialprovider.UnionDockerKeyring{m.nodeKeyring, externalCredentialProviderKeyring})
-	if err != nil {
-		return "", err.Error(), err
-	}
-
-	pullCredentials, _ := keyring.Lookup(repoToPull)
-
-	if imageRef != "" {
-		imagePullRequired = ptr.To(false) // should be overridden right after this if-block in case pull was required
+	getPodCredentials := func() ([]kubeletconfiginternal.ImagePullSecret, *kubeletconfiginternal.ImagePullServiceAccount, error) {
+		pullCredentials, err := lookupPullCredentials()
+		if err != nil {
+			return nil, nil, err
+		}
 
 		var imagePullSecrets []kubeletconfiginternal.ImagePullSecret
 		// we don't take the audience of the service account into account, so there can only
@@ -268,8 +234,25 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 			}
 		}
 
-		pullRequired := m.imagePullManager.MustAttemptImagePull(ctx, requestedImage, imageRef, imagePullSecrets, imagePullServiceAccount)
-		if !pullRequired {
+		return imagePullSecrets, imagePullServiceAccount, nil
+	}
+
+	if imageRef != "" {
+		imagePullRequired = ptr.To(false) // should be overridden right after this if-block in case pull was required
+		if !utilfeature.DefaultFeatureGate.Enabled(features.KubeletEnsureSecretPulledImages) {
+			msg := fmt.Sprintf("Container image %q already present on machine", requestedImage)
+			m.logIt(objRef, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
+
+			// we need to stop recording if it is still in progress, as the image
+			// has already been pulled by another pod.
+			m.podPullingTimeRecorder.RecordImageFinishedPulling(pod.UID)
+
+			return imageRef, msg, nil
+		}
+		if pullRequired, err := m.imagePullManager.MustAttemptImagePull(ctx, requestedImage, imageRef, getPodCredentials); err != nil {
+			imagePullRequired = nil
+			return "", err.Error(), err
+		} else if !pullRequired {
 			msg := fmt.Sprintf("Container image %q already present on machine and can be accessed by the pod", requestedImage)
 			m.logIt(objRef, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
 
@@ -289,7 +272,45 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectR
 		return "", msg, err
 	}
 
+	pullCredentials, err := lookupPullCredentials()
+	if err != nil {
+		return "", err.Error(), err
+	}
+
 	return m.pullImage(ctx, logPrefix, objRef, pod.UID, requestedImage, spec, pullCredentials, podSandboxConfig)
+}
+
+func (m *imageManager) makeLookupPullCredentialsFunc(image string, pod *v1.Pod, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) func() ([]credentialprovider.TrackedAuthConfig, error) {
+	return sync.OnceValues(func() ([]credentialprovider.TrackedAuthConfig, error) {
+		repoToPull, _, _, err := parsers.ParseImageName(image)
+		if err != nil {
+			return nil, err
+		}
+
+		// construct the dynamic keyring using the providers we have in the kubelet
+		var podName, podNamespace, podUID string
+		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletServiceAccountTokenForCredentialProviders) {
+			sandboxMetadata := podSandboxConfig.GetMetadata()
+
+			podName = sandboxMetadata.Name
+			podNamespace = sandboxMetadata.Namespace
+			podUID = sandboxMetadata.Uid
+		}
+
+		externalCredentialProviderKeyring := credentialproviderplugin.NewExternalCredentialProviderDockerKeyring(
+			podNamespace,
+			podName,
+			podUID,
+			pod.Spec.ServiceAccountName)
+
+		keyring, err := credentialprovidersecrets.MakeDockerKeyring(pullSecrets, credentialprovider.UnionDockerKeyring{m.nodeKeyring, externalCredentialProviderKeyring})
+		if err != nil {
+			return nil, err
+		}
+
+		pullCredentials, _ := keyring.Lookup(repoToPull)
+		return pullCredentials, nil
+	})
 }
 
 func (m *imageManager) pullImage(ctx context.Context, logPrefix string, objRef *v1.ObjectReference, podUID types.UID, image string, imgSpec kubecontainer.ImageSpec, pullCredentials []credentialprovider.TrackedAuthConfig, podSandboxConfig *runtimeapi.PodSandboxConfig) (imageRef, message string, err error) {

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -734,9 +734,14 @@ type mockImagePullManager struct {
 	config *mockImagePullManagerConfig
 }
 
-func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, _ string, podSecrets []kubeletconfiginternal.ImagePullSecret, podServiceAccount *kubeletconfiginternal.ImagePullServiceAccount) bool {
+func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, _ string, getPodCredentials pullmanager.GetPodCredentials) (bool, error) {
 	if m.config == nil || m.config.allowAll {
-		return false
+		return false, nil
+	}
+
+	podSecrets, podServiceAccount, err := getPodCredentials()
+	if err != nil {
+		return true, err
 	}
 
 	// Check secrets
@@ -744,7 +749,7 @@ func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, 
 		for _, s := range podSecrets {
 			for _, allowed := range allowedSecrets {
 				if s.Namespace == allowed.Namespace && s.Name == allowed.Name && s.UID == allowed.UID {
-					return false
+					return false, nil
 				}
 			}
 		}
@@ -754,12 +759,12 @@ func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, 
 	if podServiceAccount != nil {
 		if allowedServiceAccounts, ok := m.config.allowedServiceAccounts[image]; ok {
 			if slices.Contains(allowedServiceAccounts, *podServiceAccount) {
-				return false
+				return false, nil
 			}
 		}
 	}
 
-	return true
+	return true, nil
 }
 
 // mockImagePullManagerWithTracking tracks calls to MustAttemptImagePull for service account testing
@@ -776,19 +781,25 @@ type mockImagePullManagerWithTracking struct {
 	recordedCredentials *kubeletconfiginternal.ImagePullCredentials
 }
 
-func (m *mockImagePullManagerWithTracking) MustAttemptImagePull(ctx context.Context, image, imageRef string, podSecrets []kubeletconfiginternal.ImagePullSecret, podServiceAccount *kubeletconfiginternal.ImagePullServiceAccount) bool {
+func (m *mockImagePullManagerWithTracking) MustAttemptImagePull(ctx context.Context, image, imageRef string, getPodCredentials pullmanager.GetPodCredentials) (bool, error) {
 	m.mustAttemptCalled = true
 	m.lastImage = image
 	m.lastImageRef = imageRef
+
+	podSecrets, podServiceAccount, err := getPodCredentials()
+	if err != nil {
+		return true, err
+	}
+
 	m.lastSecrets = podSecrets
 	if podServiceAccount != nil {
 		m.lastServiceAccounts = []kubeletconfiginternal.ImagePullServiceAccount{*podServiceAccount}
 	}
 
 	if m.allowAll {
-		return false
+		return false, nil
 	}
-	return m.mustAttemptReturn
+	return m.mustAttemptReturn, nil
 }
 
 func (m *mockImagePullManagerWithTracking) RecordImagePulled(ctx context.Context, image, imageRef string, credentials *kubeletconfiginternal.ImagePullCredentials) {

--- a/pkg/kubelet/images/pullmanager/benchmarks_test.go
+++ b/pkg/kubelet/images/pullmanager/benchmarks_test.go
@@ -74,9 +74,11 @@ func directRecordReadFunc(expectHit bool) benchmarkedCheckFunc {
 func mustAttemptPullReadFunc(expectHit bool) benchmarkedCheckFunc {
 	return func(b *testing.B, pullManager PullManager, imgRef string) {
 		tCtx := ktesting.Init(b)
-		mustPull := pullManager.MustAttemptImagePull(tCtx, "test.repo/org/"+imgRef, imgRef, nil, nil)
-		if mustPull != !expectHit {
-			b.Fatalf("MustAttemptImagePull() expected %t, got %t", !expectHit, mustPull)
+		mustPull, err := pullManager.MustAttemptImagePull(tCtx, "test.repo/org/"+imgRef, imgRef, func() ([]kubeletconfig.ImagePullSecret, *kubeletconfig.ImagePullServiceAccount, error) {
+			return nil, nil, nil
+		})
+		if mustPull != !expectHit || err != nil {
+			b.Fatalf("no error expected (got %v); MustAttemptImagePull() expected %t, got %t", err, !expectHit, mustPull)
 		}
 	}
 }

--- a/pkg/kubelet/images/pullmanager/image_pull_manager.go
+++ b/pkg/kubelet/images/pullmanager/image_pull_manager.go
@@ -182,9 +182,9 @@ func (f *PullManager) decrementImagePullIntent(ctx context.Context, image string
 	f.decrementIntentCounterForImage(image)
 }
 
-func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef string, podSecrets []kubeletconfiginternal.ImagePullSecret, podServiceAccount *kubeletconfiginternal.ImagePullServiceAccount) bool {
+func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef string, getPodCredentials GetPodCredentials) (bool, error) {
 	if len(imageRef) == 0 {
-		return true
+		return true, nil
 	}
 
 	logger := klog.FromContext(ctx)
@@ -229,36 +229,41 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 
 	if err != nil {
 		logger.Error(err, "Unable to access cache records about image pulls")
-		return true
+		return true, nil
 	}
 
 	if !f.imagePolicyEnforcer.RequireCredentialVerificationForImage(image, imagePulledByKubelet) {
-		return false
+		return false, nil
 	}
 
 	if pulledRecord == nil {
 		// we have no proper records of the image being pulled in the past, we can short-circuit here
-		return true
+		return true, nil
 	}
 
 	sanitizedImage, err := trimImageTagDigest(image)
 	if err != nil {
 		logger.Error(err, "failed to parse image name, forcing image credentials reverification", "image", sanitizedImage)
-		return true
+		return true, nil
 	}
 
 	cachedCreds, ok := pulledRecord.CredentialMapping[sanitizedImage]
 	if !ok {
-		return true
+		return true, nil
 	}
 
 	if cachedCreds.NodePodsAccessible {
 		// anyone on this node can access the image
-		return false
+		return false, nil
 	}
 
 	if len(cachedCreds.KubernetesSecrets) == 0 && len(cachedCreds.KubernetesServiceAccounts) == 0 {
-		return true
+		return true, nil
+	}
+
+	podSecrets, podServiceAccount, err := getPodCredentials()
+	if err != nil {
+		return true, err
 	}
 
 	for _, podSecret := range podSecrets {
@@ -279,7 +284,7 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 						logger.Error(err, "failed to write an image pulled record", "image", image, "imageRef", imageRef)
 					}
 				}
-				return false
+				return false, nil
 			}
 
 			if secretCoordinatesMatch {
@@ -290,7 +295,7 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 					if err := f.writePulledRecordIfChanged(ctx, image, imageRef, &kubeletconfiginternal.ImagePullCredentials{KubernetesSecrets: []kubeletconfiginternal.ImagePullSecret{podSecret}}); err != nil {
 						logger.Error(err, "failed to write an image pulled record", "image", image, "imageRef", imageRef)
 					}
-					return false
+					return false, nil
 				}
 			}
 		}
@@ -298,10 +303,10 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 
 	if podServiceAccount != nil && slices.Contains(cachedCreds.KubernetesServiceAccounts, *podServiceAccount) {
 		// we found a matching service account, no need to pull the image
-		return false
+		return false, nil
 	}
 
-	return true
+	return true, nil
 }
 
 func (f *PullManager) PruneUnknownRecords(ctx context.Context, imageList []string, until time.Time) {

--- a/pkg/kubelet/images/pullmanager/noop_pull_manager.go
+++ b/pkg/kubelet/images/pullmanager/noop_pull_manager.go
@@ -31,7 +31,7 @@ func (m *NoopImagePullManager) RecordPullIntent(string) error { return nil }
 func (m *NoopImagePullManager) RecordImagePulled(context.Context, string, string, *kubeletconfiginternal.ImagePullCredentials) {
 }
 func (m *NoopImagePullManager) RecordImagePullFailed(context.Context, string) {}
-func (m *NoopImagePullManager) MustAttemptImagePull(context.Context, string, string, []kubeletconfiginternal.ImagePullSecret, *kubeletconfiginternal.ImagePullServiceAccount) bool {
-	return false
+func (m *NoopImagePullManager) MustAttemptImagePull(context.Context, string, string, GetPodCredentials) (bool, error) {
+	return false, nil
 }
 func (m *NoopImagePullManager) PruneUnknownRecords(context.Context, []string, time.Time) {}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This is a rebase of https://github.com/kubernetes/kubernetes/pull/133114 on current master after metrics were added to `EnsureImageExists()` in https://github.com/kubernetes/kubernetes/pull/132644.

Examples:
Related-to PR https://github.com/kubernetes/kubernetes/pull/133114

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet now performs image pull credentials lookups lazily with the `KubeletEnsureSecretPulledImages` featuregate enabled to prevent unnecessary credential lookups.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
