### PR TITLE
Fix potential dryrun failure when NodeLocalCRISocket reaches GA

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrun.go
@@ -567,9 +567,6 @@ func getNode(name string) *corev1.Node {
 			Labels: map[string]string{
 				"kubernetes.io/hostname": name,
 			},
-			Annotations: map[string]string{
-				constants.AnnotationKubeadmCRISocket: "dry-run-cri-socket",
-			},
 		},
 	}
 }

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
+	kubeadmruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 )
 
 // FetchInitConfigurationFromCluster fetches configuration from a ConfigMap in the cluster
@@ -115,7 +116,7 @@ func getInitConfigurationFromCluster(kubeconfigDir string, client clientset.Inte
 	if getNodeRegistration {
 		// gets the nodeRegistration for the current from the node object
 		kubeconfigFile := filepath.Join(kubeconfigDir, constants.KubeletKubeConfigFileName)
-		if err := GetNodeRegistration(kubeconfigFile, client, &initcfg.NodeRegistration, &initcfg.ClusterConfiguration); err != nil {
+		if err := GetNodeRegistration(kubeconfigFile, client, &initcfg.NodeRegistration); err != nil {
 			return nil, errors.Wrap(err, "failed to get node registration")
 		}
 	}
@@ -162,7 +163,7 @@ func GetNodeName(kubeconfigFile string) (string, error) {
 }
 
 // GetNodeRegistration returns the nodeRegistration for the current node
-func GetNodeRegistration(kubeconfigFile string, client clientset.Interface, nodeRegistration *kubeadmapi.NodeRegistrationOptions, clusterCfg *kubeadmapi.ClusterConfiguration) error {
+func GetNodeRegistration(kubeconfigFile string, client clientset.Interface, nodeRegistration *kubeadmapi.NodeRegistrationOptions) error {
 	// gets the name of the current node
 	nodeName, err := GetNodeName(kubeconfigFile)
 	if err != nil {
@@ -180,13 +181,21 @@ func GetNodeRegistration(kubeconfigFile string, client clientset.Interface, node
 		configFilePath := filepath.Join(constants.KubeletRunDirectory, constants.KubeletInstanceConfigurationFileName)
 		_, err := os.Stat(configFilePath)
 		if os.IsNotExist(err) {
-			return errors.Errorf("node %s doesn't have %s annotation, or kubelet instance config %s", nodeName, constants.AnnotationKubeadmCRISocket, configFilePath)
+			klog.Warningf("node %q lacks annotation %q and kubelet config file %q; attempting auto-detection", nodeName, constants.AnnotationKubeadmCRISocket, configFilePath)
+			criSocket, err = kubeadmruntime.DetectCRISocket()
+			if err != nil {
+				klog.Warningf("auto-detection of CRI socket failed for node %q: %v; falling back to default %q", nodeName, err, constants.DefaultCRISocket)
+				criSocket = constants.DefaultCRISocket
+			}
+		} else if err != nil {
+			return err
+		} else {
+			kubeletConfig, err := readKubeletConfig(constants.KubeletRunDirectory, constants.KubeletInstanceConfigurationFileName)
+			if err != nil {
+				return errors.Wrapf(err, "could not read kubelet instance configuration on node %q", nodeName)
+			}
+			criSocket = kubeletConfig.ContainerRuntimeEndpoint
 		}
-		kubeletConfig, err := readKubeletConfig(constants.KubeletRunDirectory, constants.KubeletInstanceConfigurationFileName)
-		if err != nil {
-			return errors.Wrapf(err, "could not read kubelet instance configuration on node %q", nodeName)
-		}
-		criSocket = kubeletConfig.ContainerRuntimeEndpoint
 	}
 
 	// returns the nodeRegistration attributes

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -330,7 +330,7 @@ func TestGetNodeRegistration(t *testing.T) {
 			}
 
 			cfg := &kubeadmapi.InitConfiguration{}
-			err = GetNodeRegistration(cfgPath, client, &cfg.NodeRegistration, &cfg.ClusterConfiguration)
+			err = GetNodeRegistration(cfgPath, client, &cfg.NodeRegistration)
 			if rt.expectedError != (err != nil) {
 				t.Errorf("unexpected return err from getNodeRegistration: %v", err)
 				return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The dryrun will fail once NodeLocalCRISocket reaches GA.

Specifically, if we remove the `kubeadm.alpha.kubernetes.io/cri-socket` annotation upon GA, the dryrun will fail in the `GetNodeRegistration` function. This occurs because the dryrun process cannot access the `instance-config.yaml` file, and we will have also removed the annotation as planned.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3257
Fixes #135086

#### Special notes for your reviewer:
I was contemplating a minimal solution by using the following approach before calling FetchInitConfigurationFromCluster:
```
getNodeRegistration := true
getAPIEndpoint := isControlPlaneNode
getComponentConfigs := true
if *dryRun {
	getNodeRegistration = false
}
initCfg, err := configutil.FetchInitConfigurationFromCluster(client, nil, "upgrade", getNodeRegistration, getAPIEndpoint, getComponentConfigs, *dryRun)
```
However, after implementing the change, I found it made the code more cumbersome. So I rolled it back and ended up using a more straightforward approach to implement it. :)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
