### PR TITLE
Reapply "prepare DRA kind config for kubeadm v1beta4"

### DIFF
--- a/test/e2e/dra/kind.yaml
+++ b/test/e2e/dra/kind.yaml
@@ -8,9 +8,48 @@ containerdConfigPatches:
     enable_cdi = true
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
+- role: worker
+- role: worker
+- role: worker
+kubeadmConfigPatches:
+  # v1beta4 for the future (v1.35.0+ ?)
+  # https://github.com/kubernetes-sigs/kind/issues/3847
+  # TODO: drop v1beta3 when kind makes the switch
   - |
     kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
+    scheduler:
+        extraArgs:
+          - name: "v"
+            value: "5"
+          - name: "vmodule"
+            value: "allocator=6,dynamicresources=6" # structured/allocator.go, DRA scheduler plugin
+    controllerManager:
+        extraArgs:
+          - name: "v"
+            value: "5"
+          - name: "vmodule"
+            value: "controller=6" # resourceclaim/controller.go - should have renamed it when copying the controller it was based on!
+    apiServer:
+        extraArgs:
+          runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true"
+  - |
+    kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta4
+    nodeRegistration:
+      kubeletExtraArgs:
+        - name: "v"
+          value: "5"
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        - name: "v"
+          value: "5"
+  # v1beta3 for v1.23.0 ... ?
+  - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
     scheduler:
         extraArgs:
           v: "5"
@@ -24,25 +63,10 @@ nodes:
           runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true"
   - |
     kind: InitConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
     nodeRegistration:
       kubeletExtraArgs:
         v: "5"
-- role: worker
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        v: "5"
-- role: worker
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        v: "5"
-- role: worker
-  kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
     nodeRegistration:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This reverts commit 1fc389c43f875d00be9ca9432ed9b10fe01cde39. https://github.com/kubernetes/kubernetes/pull/135093

Which re-applies https://github.com/kubernetes/kubernetes/commit/d17ed9be174ef8a6f0971196530f785fd1ab759f from https://github.com/kubernetes/kubernetes/pull/135016

We have since merged https://github.com/kubernetes/test-infra/pull/35853, which should fix the issues, and make sure the jobs trigger on dra config changes.

This change is necessary to enable kind to use v1beta4 kubeadm config so kubeadm can drop v1beta3 config support in the future. v1beta3 => v1beta4 is breaking and we are overdue to get ahead of that project-wide.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
