### PR TITLE
Drop support for networkingv1beta1.IngressClass in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -5470,57 +5470,29 @@ Parameters:
   Kind:      ConfigMap
   Name:      example-parameters` + "\n"
 
-	tests := map[string]struct {
-		input  *fake.Clientset
-		output string
-	}{
-		"basic IngressClass (v1beta1)": {
-			input: fake.NewClientset(&networkingv1beta1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-class",
-				},
-				Spec: networkingv1beta1.IngressClassSpec{
-					Controller: "example.com/controller",
-					Parameters: &networkingv1beta1.IngressClassParametersReference{
-						APIGroup: ptr.To("v1"),
-						Kind:     "ConfigMap",
-						Name:     "example-parameters",
-					},
-				},
-			}),
-			output: expectedOut,
+	input := fake.NewClientset(&networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "example-class",
 		},
-		"basic IngressClass (v1)": {
-			input: fake.NewClientset(&networkingv1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-class",
-				},
-				Spec: networkingv1.IngressClassSpec{
-					Controller: "example.com/controller",
-					Parameters: &networkingv1.IngressClassParametersReference{
-						APIGroup: ptr.To("v1"),
-						Kind:     "ConfigMap",
-						Name:     "example-parameters",
-					},
-				},
-			}),
-			output: expectedOut,
+		Spec: networkingv1.IngressClassSpec{
+			Controller: "example.com/controller",
+			Parameters: &networkingv1.IngressClassParametersReference{
+				APIGroup: ptr.To("v1"),
+				Kind:     "ConfigMap",
+				Name:     "example-parameters",
+			},
 		},
-	}
+	})
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			c := &describeClient{T: t, Namespace: "foo", Interface: test.input}
-			d := IngressClassDescriber{c}
-			out, err := d.Describe("", "example-class", DescriberSettings{})
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if out != expectedOut {
-				t.Log(out)
-				t.Errorf("expected : %q\n but got output:\n %q", test.output, out)
-			}
-		})
+	c := &describeClient{T: t, Namespace: "foo", Interface: input}
+	d := IngressClassDescriber{c}
+	out, err := d.Describe("", "example-class", DescriberSettings{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if out != expectedOut {
+		t.Log(out)
+		t.Errorf("expected : %q\n but got output:\n %q", expectedOut, out)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
It cleans up deprecated `networkingv1beta1.IngressClass` so we will not have to modify `ResourceDescriber` logic for it when implementing https://github.com/kubernetes/kubectl/issues/1769 and https://github.com/kubernetes/kubernetes/pull/133498.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubectl/issues/1769

#### Does this PR introduce a user-facing change?
```release-note
Dropped support for networking/v1beta1 IngressClass in kubectl
```
