### PR TITLE
FIFO queued size metric

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/fifo_metrics.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo_metrics.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+)
+
+// FIFOMetricsProvider defines an interface for creating metrics that track FIFO queue operations.
+type FIFOMetricsProvider interface {
+	// NewQueuedItemMetric returns a gauge metric for tracking the total number of items
+	// currently queued and waiting to be processed.
+	NewQueuedItemMetric(*Identifier) GaugeMetric
+}
+
+// SetFIFOMetricsProvider sets the global metrics provider for FIFO queues.
+func SetFIFOMetricsProvider(metricsProvider FIFOMetricsProvider) {
+	setFIFOMetricsOnce.Do(func() {
+		fifoMetricsProvider = metricsProvider
+	})
+}
+
+var (
+	fifoMetricsProvider FIFOMetricsProvider = noopFIFOMetricsProvider{}
+	setFIFOMetricsOnce  sync.Once
+)
+
+// newFIFOMetrics creates a new fifoMetrics instance for tracking metrics related to FIFO queues.
+func newFIFOMetrics(id *Identifier, metricsProvider FIFOMetricsProvider) *fifoMetrics {
+	if metricsProvider == nil {
+		metricsProvider = fifoMetricsProvider
+	}
+	metrics := &fifoMetrics{
+		numberOfQueuedItem: noopMetric{},
+	}
+
+	if id.IsUnique() {
+		metrics.numberOfQueuedItem = metricsProvider.NewQueuedItemMetric(id)
+	}
+	return metrics
+}
+
+// fifoMetrics tracks metrics for a FIFO queue, including the number of stored and queued items.
+type fifoMetrics struct {
+	numberOfQueuedItem GaugeMetric
+}
+
+type noopFIFOMetricsProvider struct{}
+
+func (noopFIFOMetricsProvider) NewQueuedItemMetric(*Identifier) GaugeMetric {
+	return noopMetric{}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/identity.go
+++ b/staging/src/k8s.io/client-go/tools/cache/identity.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func NewIdentifier(name string, exampleObject runtime.Object) *Identifier {
+	id := &Identifier{name: name, itemType: itemType(exampleObject)}
+	id.tryMakeUnique()
+	return id
+}
+
+// Identifier is used to identify of informers and FIFO for metrics and logging purposes.
+type Identifier struct {
+	// Name is the name of proposed name to reference.
+	name string
+	// ItemType is the type of item type like "v1.Pod".
+	itemType string
+}
+
+func (id *Identifier) Name() string {
+	if id == nil {
+		return ""
+	}
+	return id.name
+}
+
+func (id *Identifier) ItemType() string {
+	if id == nil {
+		return ""
+	}
+	return id.itemType
+}
+
+func (id *Identifier) WithObjectType(exampleObject runtime.Object) *Identifier {
+	if id == nil {
+		return nil
+	}
+	itemType := itemType(exampleObject)
+	if id.itemType == itemType {
+		return id
+	}
+	newId := *id
+	newId.itemType = itemType
+	newId.tryMakeUnique()
+	return &newId
+}
+
+func itemType(exampleObject runtime.Object) string {
+	return reflect.TypeOf(exampleObject).Elem().String()
+}
+
+func (id *Identifier) IsUnique() bool {
+	if id == nil {
+		return false
+	}
+	if id.name == "" || id.itemType == "" {
+		return false
+	}
+	identityLock.RLock()
+	defer identityLock.RUnlock()
+	return identityRepresentative[*id] == id
+}
+
+func (id *Identifier) tryMakeUnique() {
+	if id.name == "" || id.itemType == "" {
+		return
+	}
+	if id.IsUnique() {
+		return
+	}
+	identityLock.Lock()
+	defer identityLock.Unlock()
+	if identityCounter[*id] > 0 {
+		identityCounter[*id]++
+		// Try to give suffix to make it unique.
+		id.name = fmt.Sprintf("%s-%d", id.name, identityCounter[*id]-1)
+		if identityCounter[*id] > 0 {
+			// Prevent case where user provided name with the name suffix pattern.
+			return
+		}
+	}
+	identityCounter[*id]++
+	identityRepresentative[*id] = id
+}
+
+var identityLock sync.RWMutex
+var identityCounter map[Identifier]int
+var identityRepresentative map[Identifier]*Identifier
+
+func init() {
+	resetIdentity()
+}
+
+func resetIdentity() {
+	identityLock.Lock()
+	identityCounter = make(map[Identifier]int)
+	identityRepresentative = make(map[Identifier]*Identifier)
+	identityLock.Unlock()
+}

--- a/staging/src/k8s.io/client-go/tools/cache/identity_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/identity_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestNewIdentifierDuplicate(t *testing.T) {
+	resetIdentity()
+	aPod := NewIdentifier("a", &v1.Pod{})
+	aPod1 := NewIdentifier("a", &v1.Pod{})
+	aPod2 := NewIdentifier("a", &v1.Pod{})
+	aNode := NewIdentifier("a", &v1.Node{})
+
+	assert.Equal(t, "a", aPod.Name())
+	assert.Equal(t, "v1.Pod", aPod.ItemType())
+	assert.True(t, aPod.IsUnique())
+
+	assert.Equal(t, "a-1", aPod1.Name())
+	assert.Equal(t, "v1.Pod", aPod1.ItemType())
+	assert.True(t, aPod1.IsUnique())
+
+	assert.Equal(t, "a-2", aPod2.Name())
+	assert.Equal(t, "v1.Pod", aPod2.ItemType())
+	assert.True(t, aPod2.IsUnique())
+
+	assert.Equal(t, "a", aNode.Name())
+	assert.Equal(t, "v1.Node", aNode.ItemType())
+	assert.True(t, aNode.IsUnique())
+}
+
+func TestNewIdentifierEMpty(t *testing.T) {
+	resetIdentity()
+	empty := NewIdentifier("", &v1.Pod{})
+	assert.Equal(t, "", empty.Name())
+	assert.Equal(t, "v1.Pod", empty.ItemType())
+	assert.False(t, empty.IsUnique())
+}
+
+func TestNewIdentifierDash(t *testing.T) {
+	resetIdentity()
+	a := NewIdentifier("a", &v1.Pod{})
+	aDashOne := NewIdentifier("a-1", &v1.Pod{})
+	aDuplicate := NewIdentifier("a", &v1.Pod{})
+
+	assert.Equal(t, "a", a.Name())
+	assert.Equal(t, "v1.Pod", a.ItemType())
+	assert.True(t, a.IsUnique())
+
+	assert.Equal(t, "a-1", aDashOne.Name())
+	assert.Equal(t, "v1.Pod", aDashOne.ItemType())
+	assert.True(t, aDashOne.IsUnique())
+
+	assert.Equal(t, "a-1", aDuplicate.Name())
+	assert.Equal(t, "v1.Pod", aDuplicate.ItemType())
+	assert.False(t, aDuplicate.IsUnique())
+}
+
+func TestNewIdentifierWithItemType(t *testing.T) {
+	resetIdentity()
+	aPod := NewIdentifier("a", &v1.Pod{})
+
+	assert.Equal(t, "a", aPod.Name())
+	assert.Equal(t, "v1.Pod", aPod.ItemType())
+	assert.True(t, aPod.IsUnique())
+
+	assert.Equal(t, aPod, aPod.WithObjectType(&v1.Pod{}))
+	aNode := aPod.WithObjectType(&v1.Node{})
+
+	assert.Equal(t, "a", aNode.Name())
+	assert.Equal(t, "v1.Node", aNode.ItemType())
+	assert.True(t, aNode.IsUnique())
+
+	assert.Equal(t, "a", aPod.Name())
+	assert.Equal(t, "v1.Pod", aPod.ItemType())
+	assert.True(t, aPod.IsUnique())
+}

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	clientfeatures "k8s.io/client-go/features"
 	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/component-base/metrics/prometheus/fifo"
 )
 
 func (f *RealFIFO) getItems() []Delta {
@@ -1288,4 +1290,16 @@ func TestRealFIFO_PopBrokenItemsInBatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRealFIFO_metrics(t *testing.T) {
+	f := NewRealFIFOWithOptions(RealFIFOOptions{
+		KeyFunction:     testFifoObjectKeyFunc,
+		KnownObjects:    emptyKnownObjects(),
+		Transformer:     nil,
+		Identifier:      NewIdentifier("shared-informer", &v1.Pod{}),
+		MetricsProvider: provider,
+	})
+	f.Add(mkFifoObj("a", nil))
+	fifo.Register()
 }

--- a/staging/src/k8s.io/component-base/metrics/prometheus/fifo/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/fifo/metrics.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fifo
+
+import (
+	"k8s.io/client-go/tools/cache"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	queuedItems = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
+		Name:           "fifo_queue_length",
+		Help:           "Length of FIFO quque",
+		StabilityLevel: k8smetrics.ALPHA,
+	}, []string{"name", "item_type"})
+
+	metrics = []k8smetrics.Registerable{queuedItems}
+)
+
+type fifoMetricsProvider struct{}
+
+// Register registers FIFO metrics.
+func Register() {
+	for _, m := range metrics {
+		legacyregistry.MustRegister(m)
+	}
+	cache.SetFIFOMetricsProvider(fifoMetricsProvider{})
+}
+
+func (fifoMetricsProvider) NewQueuedItemMetric(id *cache.Identifier) cache.GaugeMetric {
+	return queuedItems.WithLabelValues(id.Name(), id.ItemType())
+}


### PR DESCRIPTION
/kind feature

Based on https://github.com/kubernetes/kubernetes/pull/129160

```release-note
Add fifo_queued_size metric
```

For now we will identify fifo by item_type and a uniquely assigned name. Leaving option to override name so in the future we could relate it to informers.
```
# HELP fifo_queue_length [ALPHA] Length of FIFO quque
# TYPE fifo_queue_length gauge
fifo_queue_length{item_type="v1.CSIDriver",name="shared-informers"} 0
fifo_queue_length{item_type="v1.CSINode",name="shared-informers"} 0
fifo_queue_length{item_type="v1.CSIStorageCapacity",name="shared-informers"} 0
fifo_queue_length{item_type="v1.CertificateSigningRequest",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ClusterRole",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ClusterRoleBinding",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ConfigMap",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ControllerRevision",name="shared-informers"} 0
fifo_queue_length{item_type="v1.CronJob",name="shared-informers"} 0
fifo_queue_length{item_type="v1.DaemonSet",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Deployment",name="shared-informers"} 0
fifo_queue_length{item_type="v1.DeviceClass",name="shared-informers"} 0
fifo_queue_length{item_type="v1.EndpointSlice",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Endpoints",name="shared-informers"} 0
fifo_queue_length{item_type="v1.FlowSchema",name="shared-informers"} 0
fifo_queue_length{item_type="v1.IPAddress",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Ingress",name="shared-informers"} 0
fifo_queue_length{item_type="v1.IngressClass",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Job",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Lease",name="shared-informers"} 0
fifo_queue_length{item_type="v1.LimitRange",name="shared-informers"} 0
fifo_queue_length{item_type="v1.MutatingWebhookConfiguration",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Namespace",name="shared-informers"} 0
fifo_queue_length{item_type="v1.NetworkPolicy",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Node",name="shared-informers"} 0
fifo_queue_length{item_type="v1.PartialObjectMetadata",name="metadata-informers"} 0
fifo_queue_length{item_type="v1.PartialObjectMetadata",name="metadata-informers-1"} 0
fifo_queue_length{item_type="v1.PersistentVolume",name="shared-informers"} 0
fifo_queue_length{item_type="v1.PersistentVolumeClaim",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Pod",name="shared-informers"} 0
fifo_queue_length{item_type="v1.PodDisruptionBudget",name="shared-informers"} 0
fifo_queue_length{item_type="v1.PodTemplate",name="shared-informers"} 0
fifo_queue_length{item_type="v1.PriorityClass",name="shared-informers"} 0
fifo_queue_length{item_type="v1.PriorityLevelConfiguration",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ReplicaSet",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ReplicationController",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ResourceClaim",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ResourceClaimTemplate",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ResourceQuota",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ResourceSlice",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Role",name="shared-informers"} 0
fifo_queue_length{item_type="v1.RoleBinding",name="shared-informers"} 0
fifo_queue_length{item_type="v1.RuntimeClass",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Secret",name="shared-informers"} 0
fifo_queue_length{item_type="v1.Service",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ServiceAccount",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ServiceCIDR",name="shared-informers"} 0
fifo_queue_length{item_type="v1.StatefulSet",name="shared-informers"} 0
fifo_queue_length{item_type="v1.StorageClass",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ValidatingAdmissionPolicy",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ValidatingAdmissionPolicyBinding",name="shared-informers"} 0
fifo_queue_length{item_type="v1.ValidatingWebhookConfiguration",name="shared-informers"} 0
fifo_queue_length{item_type="v1.VolumeAttachment",name="shared-informers"} 0
fifo_queue_length{item_type="v1.VolumeAttributesClass",name="shared-informers"} 0
fifo_queue_length{item_type="v2.HorizontalPodAutoscaler",name="shared-informers"} 0

```