### PR TITLE
provision 10G disks for testing pvc instead of 1 byte or 1GB

### DIFF
--- a/test/e2e/framework/statefulset/fixtures.go
+++ b/test/e2e/framework/statefulset/fixtures.go
@@ -108,7 +108,7 @@ func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 			},
 			Resources: v1.VolumeResourceRequirements{
 				Requests: v1.ResourceList{
-					v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+					v1.ResourceStorage: resource.MustParse("10Gi"),
 				},
 			},
 		},

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -82,7 +82,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		e2epv.SkipIfNoDefaultStorageClass(ctx, client)
 		t := testsuites.StorageClassTest{
 			Timeouts:  f.Timeouts,
-			ClaimSize: "1Gi",
+			ClaimSize: "10Gi",
 		}
 		pvc = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 			NamePrefix: prefix,

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -345,8 +345,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				Client:       c,
 				Name:         "default",
 				Timeouts:     f.Timeouts,
-				ClaimSize:    "2Gi",
-				ExpectedSize: "2Gi",
+				ClaimSize:    "10Gi",
+				ExpectedSize: "10Gi",
 			}
 
 			test.Claim = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
@@ -370,7 +370,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			test := testsuites.StorageClassTest{
 				Name:      "default",
 				Timeouts:  f.Timeouts,
-				ClaimSize: "2Gi",
+				ClaimSize: "10Gi",
 			}
 
 			ginkgo.By("setting the is-default StorageClass annotation to false")
@@ -407,7 +407,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			test := testsuites.StorageClassTest{
 				Name:      "default",
 				Timeouts:  f.Timeouts,
-				ClaimSize: "2Gi",
+				ClaimSize: "10Gi",
 			}
 
 			ginkgo.By("removing the is-default StorageClass annotation")
@@ -444,7 +444,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				Name:        "AWS EBS with invalid KMS key",
 				Provisioner: "kubernetes.io/aws-ebs",
 				Timeouts:    f.Timeouts,
-				ClaimSize:   "2Gi",
+				ClaimSize:   "10Gi",
 				Parameters:  map[string]string{"kmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/55555555-5555-5555-5555-555555555555"},
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

GCP hyperdisks don't allow disks to be smaller than 4GB so I'm bumping the PVC created by various tests to 10GB.

Logs: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/17712/pull-kops-e2e-k8s-gce-cilium-hyperdisk/1985815843962884096

The Statefulset tests are all creating PVCs that are 1 bytes and PVC protection is creating disks that are 1GB big which fail with the following error:

```
641088d29358 } ProvisioningFailed: Volume provisioning failed with infeasible error. Retries will be delayed. rpc error: code = InvalidArgument desc = CreateVolume failed: rpc error: code = InvalidArgument desc = CreateVolume failed to create single zonal disk pvc-8a4f4179-ff57-4942-9fb8-f210455315d7: failed to insert zonal disk: unknown Insert disk error: googleapi: Error 400: Disk size cannot be smaller than 4 GB for disk type hyperdisk-balanced., badRequest%!v(MISSING)
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
