### PR TITLE
revert of 8f0a6583ca81a64475e69a8b6b4d06bbe0c2ac67

### DIFF
--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -193,34 +193,6 @@ func Validate_AllocationResult(ctx context.Context, op operation.Operation, fldP
 	return errs
 }
 
-// Validate_CounterSet validates an instance of CounterSet according
-// to declarative validation rules in the API schema.
-func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.CounterSet) (errs field.ErrorList) {
-	// field resourcev1.CounterSet.Name has no validation
-
-	// field resourcev1.CounterSet.Counters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj map[string]resourcev1.Counter) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
-			return
-		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1.CounterSet) map[string]resourcev1.Counter { return oldObj.Counters }))...)
-
-	return errs
-}
-
 // Validate_Device validates an instance of Device according
 // to declarative validation rules in the API schema.
 func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.Device) (errs field.ErrorList) {
@@ -241,19 +213,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 		}))...)
 
 	// field resourcev1.Device.Capacity has no validation
-
-	// field resourcev1.Device.ConsumesCounters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []resourcev1.DeviceCounterConsumption) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceCounterConsumption)...)
-			return
-		}(fldPath.Child("consumesCounters"), obj.ConsumesCounters, safe.Field(oldObj, func(oldObj *resourcev1.Device) []resourcev1.DeviceCounterConsumption { return oldObj.ConsumesCounters }))...)
-
+	// field resourcev1.Device.ConsumesCounters has no validation
 	// field resourcev1.Device.NodeName has no validation
 	// field resourcev1.Device.NodeSelector has no validation
 	// field resourcev1.Device.AllNodes has no validation
@@ -909,36 +869,6 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 		}(fldPath.Child("matchAttribute"), obj.MatchAttribute, safe.Field(oldObj, func(oldObj *resourcev1.DeviceConstraint) *resourcev1.FullyQualifiedName { return oldObj.MatchAttribute }))...)
 
 	// field resourcev1.DeviceConstraint.DistinctAttribute has no validation
-	return errs
-}
-
-// Validate_DeviceCounterConsumption validates an instance of DeviceCounterConsumption according
-// to declarative validation rules in the API schema.
-func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1.DeviceCounterConsumption) (errs field.ErrorList) {
-	// field resourcev1.DeviceCounterConsumption.CounterSet has no validation
-
-	// field resourcev1.DeviceCounterConsumption.Counters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj map[string]resourcev1.Counter) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
-			return
-		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1.DeviceCounterConsumption) map[string]resourcev1.Counter {
-			return oldObj.Counters
-		}))...)
-
 	return errs
 }
 
@@ -1777,18 +1707,6 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1.ResourceSliceSpec) []resourcev1.Device { return oldObj.Devices }))...)
 
 	// field resourcev1.ResourceSliceSpec.PerDeviceNodeSelection has no validation
-
-	// field resourcev1.ResourceSliceSpec.SharedCounters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []resourcev1.CounterSet) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CounterSet)...)
-			return
-		}(fldPath.Child("sharedCounters"), obj.SharedCounters, safe.Field(oldObj, func(oldObj *resourcev1.ResourceSliceSpec) []resourcev1.CounterSet { return oldObj.SharedCounters }))...)
-
+	// field resourcev1.ResourceSliceSpec.SharedCounters has no validation
 	return errs
 }

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -213,21 +213,7 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 		}))...)
 
 	// field resourcev1beta1.BasicDevice.Capacity has no validation
-
-	// field resourcev1beta1.BasicDevice.ConsumesCounters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.DeviceCounterConsumption) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceCounterConsumption)...)
-			return
-		}(fldPath.Child("consumesCounters"), obj.ConsumesCounters, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []resourcev1beta1.DeviceCounterConsumption {
-			return oldObj.ConsumesCounters
-		}))...)
-
+	// field resourcev1beta1.BasicDevice.ConsumesCounters has no validation
 	// field resourcev1beta1.BasicDevice.NodeName has no validation
 	// field resourcev1beta1.BasicDevice.NodeSelector has no validation
 	// field resourcev1beta1.BasicDevice.AllNodes has no validation
@@ -291,34 +277,6 @@ func Validate_BasicDevice(ctx context.Context, op operation.Operation, fldPath *
 		}(fldPath.Child("bindingFailureConditions"), obj.BindingFailureConditions, safe.Field(oldObj, func(oldObj *resourcev1beta1.BasicDevice) []string { return oldObj.BindingFailureConditions }))...)
 
 	// field resourcev1beta1.BasicDevice.AllowMultipleAllocations has no validation
-	return errs
-}
-
-// Validate_CounterSet validates an instance of CounterSet according
-// to declarative validation rules in the API schema.
-func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.CounterSet) (errs field.ErrorList) {
-	// field resourcev1beta1.CounterSet.Name has no validation
-
-	// field resourcev1beta1.CounterSet.Counters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj map[string]resourcev1beta1.Counter) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
-			return
-		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta1.CounterSet) map[string]resourcev1beta1.Counter { return oldObj.Counters }))...)
-
 	return errs
 }
 
@@ -941,36 +899,6 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 		}))...)
 
 	// field resourcev1beta1.DeviceConstraint.DistinctAttribute has no validation
-	return errs
-}
-
-// Validate_DeviceCounterConsumption validates an instance of DeviceCounterConsumption according
-// to declarative validation rules in the API schema.
-func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta1.DeviceCounterConsumption) (errs field.ErrorList) {
-	// field resourcev1beta1.DeviceCounterConsumption.CounterSet has no validation
-
-	// field resourcev1beta1.DeviceCounterConsumption.Counters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj map[string]resourcev1beta1.Counter) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
-			return
-		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta1.DeviceCounterConsumption) map[string]resourcev1beta1.Counter {
-			return oldObj.Counters
-		}))...)
-
 	return errs
 }
 
@@ -1813,20 +1741,6 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceSliceSpec) []resourcev1beta1.Device { return oldObj.Devices }))...)
 
 	// field resourcev1beta1.ResourceSliceSpec.PerDeviceNodeSelection has no validation
-
-	// field resourcev1beta1.ResourceSliceSpec.SharedCounters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []resourcev1beta1.CounterSet) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CounterSet)...)
-			return
-		}(fldPath.Child("sharedCounters"), obj.SharedCounters, safe.Field(oldObj, func(oldObj *resourcev1beta1.ResourceSliceSpec) []resourcev1beta1.CounterSet {
-			return oldObj.SharedCounters
-		}))...)
-
+	// field resourcev1beta1.ResourceSliceSpec.SharedCounters has no validation
 	return errs
 }

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -195,34 +195,6 @@ func Validate_AllocationResult(ctx context.Context, op operation.Operation, fldP
 	return errs
 }
 
-// Validate_CounterSet validates an instance of CounterSet according
-// to declarative validation rules in the API schema.
-func Validate_CounterSet(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.CounterSet) (errs field.ErrorList) {
-	// field resourcev1beta2.CounterSet.Name has no validation
-
-	// field resourcev1beta2.CounterSet.Counters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj map[string]resourcev1beta2.Counter) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
-			return
-		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta2.CounterSet) map[string]resourcev1beta2.Counter { return oldObj.Counters }))...)
-
-	return errs
-}
-
 // Validate_Device validates an instance of Device according
 // to declarative validation rules in the API schema.
 func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.Device) (errs field.ErrorList) {
@@ -243,21 +215,7 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 		}))...)
 
 	// field resourcev1beta2.Device.Capacity has no validation
-
-	// field resourcev1beta2.Device.ConsumesCounters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.DeviceCounterConsumption) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceCounterConsumption)...)
-			return
-		}(fldPath.Child("consumesCounters"), obj.ConsumesCounters, safe.Field(oldObj, func(oldObj *resourcev1beta2.Device) []resourcev1beta2.DeviceCounterConsumption {
-			return oldObj.ConsumesCounters
-		}))...)
-
+	// field resourcev1beta2.Device.ConsumesCounters has no validation
 	// field resourcev1beta2.Device.NodeName has no validation
 	// field resourcev1beta2.Device.NodeSelector has no validation
 	// field resourcev1beta2.Device.AllNodes has no validation
@@ -923,36 +881,6 @@ func Validate_DeviceConstraint(ctx context.Context, op operation.Operation, fldP
 		}))...)
 
 	// field resourcev1beta2.DeviceConstraint.DistinctAttribute has no validation
-	return errs
-}
-
-// Validate_DeviceCounterConsumption validates an instance of DeviceCounterConsumption according
-// to declarative validation rules in the API schema.
-func Validate_DeviceCounterConsumption(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *resourcev1beta2.DeviceCounterConsumption) (errs field.ErrorList) {
-	// field resourcev1beta2.DeviceCounterConsumption.CounterSet has no validation
-
-	// field resourcev1beta2.DeviceCounterConsumption.Counters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj map[string]resourcev1beta2.Counter) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
-			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName)...)
-			return
-		}(fldPath.Child("counters"), obj.Counters, safe.Field(oldObj, func(oldObj *resourcev1beta2.DeviceCounterConsumption) map[string]resourcev1beta2.Counter {
-			return oldObj.Counters
-		}))...)
-
 	return errs
 }
 
@@ -1815,20 +1743,6 @@ func Validate_ResourceSliceSpec(ctx context.Context, op operation.Operation, fld
 		}(fldPath.Child("devices"), obj.Devices, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceSliceSpec) []resourcev1beta2.Device { return oldObj.Devices }))...)
 
 	// field resourcev1beta2.ResourceSliceSpec.PerDeviceNodeSelection has no validation
-
-	// field resourcev1beta2.ResourceSliceSpec.SharedCounters
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj []resourcev1beta2.CounterSet) (errs field.ErrorList) {
-			// don't revalidate unchanged data
-			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
-				return nil
-			}
-			// iterate the list and call the type's validation function
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_CounterSet)...)
-			return
-		}(fldPath.Child("sharedCounters"), obj.SharedCounters, safe.Field(oldObj, func(oldObj *resourcev1beta2.ResourceSliceSpec) []resourcev1beta2.CounterSet {
-			return oldObj.SharedCounters
-		}))...)
-
+	// field resourcev1beta2.ResourceSliceSpec.SharedCounters has no validation
 	return errs
 }

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -354,7 +354,7 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"bad-attribute": {
 			wantFailures: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes"), badName, "a valid C identifier must start with alphabetic character or '_', followed by a string of alphanumeric characters or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName', regex used for validation is '[A-Za-z_][A-Za-z0-9_]*')"),
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(badName), badName, "a valid C identifier must start with alphabetic character or '_', followed by a string of alphanumeric characters or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName', regex used for validation is '[A-Za-z_][A-Za-z0-9_]*')"),
 				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(badName), "", "exactly one value must be specified").MarkCoveredByDeclarative(),
 				field.Invalid(field.NewPath("spec", "devices").Index(2).Child("attributes").Key(goodName), resourceapi.DeviceAttribute{StringValue: ptr.To("x"), VersionValue: ptr.To("1.2.3")}, "exactly one value must be specified").MarkCoveredByDeclarative(),
 				field.Invalid(field.NewPath("spec", "devices").Index(3).Child("attributes").Key(goodName).Child("version"), strings.Repeat("x", resourceapi.DeviceAttributeMaxValueLength+1), "must be a string compatible with semver.org spec 2.0.0"),
@@ -390,8 +390,8 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"bad-attribute-c-identifier": {
 			wantFailures: field.ErrorList{
-				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(1).Child("attributes"), strings.Repeat(".", resourceapi.DeviceMaxIDLength+1), resourceapi.DeviceMaxIDLength),
-				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes"), strings.Repeat(".", resourceapi.DeviceMaxIDLength+1), "a valid C identifier must start with alphabetic character or '_', followed by a string of alphanumeric characters or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName', regex used for validation is '[A-Za-z_][A-Za-z0-9_]*')"),
+				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(strings.Repeat(".", resourceapi.DeviceMaxIDLength+1)), strings.Repeat(".", resourceapi.DeviceMaxIDLength+1), resourceapi.DeviceMaxIDLength),
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(strings.Repeat(".", resourceapi.DeviceMaxIDLength+1)), strings.Repeat(".", resourceapi.DeviceMaxIDLength+1), "a valid C identifier must start with alphabetic character or '_', followed by a string of alphanumeric characters or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName', regex used for validation is '[A-Za-z_][A-Za-z0-9_]*')"),
 			},
 			slice: func() *resourceapi.ResourceSlice {
 				slice := testResourceSlice(goodName, goodName, goodName, 2)
@@ -403,8 +403,8 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"bad-attribute-domain": {
 			wantFailures: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "devices").Index(1).Child("attributes"), strings.Repeat("_", resourceapi.DeviceMaxDomainLength+1), resourceapi.DeviceMaxDomainLength),
-				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes"), strings.Repeat("_", resourceapi.DeviceMaxDomainLength+1), "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				field.TooLong(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(strings.Repeat("_", resourceapi.DeviceMaxDomainLength+1)+"/y"), strings.Repeat("_", resourceapi.DeviceMaxDomainLength+1), resourceapi.DeviceMaxDomainLength),
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(strings.Repeat("_", resourceapi.DeviceMaxDomainLength+1)+"/y"), strings.Repeat("_", resourceapi.DeviceMaxDomainLength+1), "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
 			},
 			slice: func() *resourceapi.ResourceSlice {
 				slice := testResourceSlice(goodName, goodName, goodName, 2)
@@ -416,8 +416,8 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"bad-key-too-long": {
 			wantFailures: field.ErrorList{
-				field.TooLong(field.NewPath("spec", "devices").Index(1).Child("attributes"), strings.Repeat("x", resourceapi.DeviceMaxDomainLength+1), resourceapi.DeviceMaxDomainLength),
-				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(1).Child("attributes"), strings.Repeat("y", resourceapi.DeviceMaxIDLength+1), resourceapi.DeviceMaxIDLength),
+				field.TooLong(field.NewPath("spec", "devices").Index(1).Child("attributes").Key("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxx/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"), strings.Repeat("x", resourceapi.DeviceMaxDomainLength+1), resourceapi.DeviceMaxDomainLength),
+				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(1).Child("attributes").Key("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxx/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"), strings.Repeat("y", resourceapi.DeviceMaxIDLength+1), resourceapi.DeviceMaxIDLength),
 			},
 			slice: func() *resourceapi.ResourceSlice {
 				slice := testResourceSlice(goodName, goodName, goodName, 2)
@@ -429,8 +429,8 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"bad-attribute-empty-domain-and-c-identifier": {
 			wantFailures: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes"), "", "the domain must not be empty"),
-				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes"), "", "the name must not be empty"),
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key("/"), "", "the domain must not be empty"),
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key("/"), "", "the name must not be empty"),
 			},
 			slice: func() *resourceapi.ResourceSlice {
 				slice := testResourceSlice(goodName, goodName, goodName, 2)
@@ -682,7 +682,7 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"bad-countername-shared-counters": {
 			wantFailures: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), badName, "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')").MarkCoveredByDeclarative(),
+				field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters").Key(badName), badName, "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
 			},
 			slice: func() *resourceapi.ResourceSlice {
 				slice := testResourceSlice(goodName, goodName, driverName, 1)

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -122,27 +122,6 @@ func TestDeclarativeValidate(t *testing.T) {
 						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", ""),
 					},
 				},
-				// spec.sharedCounters.counters
-				"invalid: shared counter key with uppercase": {
-					input: mkResourceSlice(tweakSharedCounter("InvalidKey")),
-					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
-					},
-				},
-				"valid: shared counter key": {
-					input: mkResourceSlice(tweakSharedCounter("valid-key")),
-				},
-				// spec.devices.consumesCounters.counters
-				"invalid: device counter key with uppercase": {
-					input: mkResourceSlice(tweakSharedCounter("InvalidKey"), tweakDeviceCounter("InvalidKey")),
-					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
-					},
-				},
-				"valid: device counter key": {
-					input: mkResourceSlice(tweakSharedCounter("valid-key"), tweakDeviceCounter("valid-key")),
-				},
 				// TODO: Add more test cases
 			}
 
@@ -233,23 +212,6 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "may have only one of the following fields set: bool, int, string, version"),
 					},
 				},
-				// spec.sharedCounters.counters
-				"invalid update: shared counter key with uppercase": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakSharedCounter("InvalidKey")),
-					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
-					},
-				},
-				// spec.devices.consumesCounters.counters
-				"invalid update: device counter key with uppercase": {
-					old:    mkResourceSlice(),
-					update: mkResourceSlice(tweakSharedCounter("InvalidKey"), tweakDeviceCounter("InvalidKey")),
-					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "InvalidKey", "").WithOrigin("format=k8s-short-name"),
-					},
-				},
 			}
 			for k, tc := range testCases {
 				t.Run(k, func(t *testing.T) {
@@ -330,31 +292,5 @@ func tweakDeviceAttribute(name resource.QualifiedName, value resource.DeviceAttr
 			rs.Spec.Devices[0].Attributes = make(map[resource.QualifiedName]resource.DeviceAttribute)
 		}
 		rs.Spec.Devices[0].Attributes[name] = value
-	}
-}
-
-func tweakSharedCounter(key string) func(*resource.ResourceSlice) {
-	return func(rs *resource.ResourceSlice) {
-		rs.Spec.SharedCounters = []resource.CounterSet{
-			{
-				Name: "shared-counter-set",
-				Counters: map[string]resource.Counter{
-					key: {},
-				},
-			},
-		}
-	}
-}
-
-func tweakDeviceCounter(key string) func(*resource.ResourceSlice) {
-	return func(rs *resource.ResourceSlice) {
-		rs.Spec.Devices[0].ConsumesCounters = []resource.DeviceCounterConsumption{
-			{
-				CounterSet: "shared-counter-set",
-				Counters: map[string]resource.Counter{
-					key: {},
-				},
-			},
-		}
 	}
 }

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -315,8 +315,6 @@ message CounterSet {
   // The maximum number of counters in all sets is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -796,8 +794,6 @@ message DeviceCounterConsumption {
   // 16 counters each).
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -202,8 +202,6 @@ type CounterSet struct {
 	// The maximum number of counters in all sets is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -422,8 +420,6 @@ type DeviceCounterConsumption struct {
 	// 16 counters each).
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -453,8 +453,6 @@ message CounterSet {
   // The maximum number of counters is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -804,8 +802,6 @@ message DeviceCounterConsumption {
   // 16 counters each).
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -202,8 +202,6 @@ type CounterSet struct {
 	// The maximum number of counters is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -434,8 +432,6 @@ type DeviceCounterConsumption struct {
 	// 16 counters each).
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -315,8 +315,6 @@ message CounterSet {
   // The maximum number of counters in all sets is 32.
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 
@@ -796,8 +794,6 @@ message DeviceCounterConsumption {
   // 16 counters each).
   //
   // +required
-  // +k8s:required
-  // +k8s:eachKey=+k8s:format=k8s-short-name
   map<string, Counter> counters = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -202,8 +202,6 @@ type CounterSet struct {
 	// The maximum number of counters in all sets is 32.
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,name=counters"`
 }
 
@@ -422,8 +420,6 @@ type DeviceCounterConsumption struct {
 	// 16 counters each).
 	//
 	// +required
-	// +k8s:required
-	// +k8s:eachKey=+k8s:format=k8s-short-name
 	Counters map[string]Counter `json:"counters,omitempty" protobuf:"bytes,2,opt,name=counters"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -269,7 +269,7 @@ func (ektv eachKeyTagValidator) GetValidations(context Context, tag codetags.Tag
 
 	elemContext := Context{
 		Scope:      ScopeMapKey,
-		Type:       nt.Key,
+		Type:       nt.Elem,
 		Path:       context.Path.Key("(keys)"),
 		Member:     nil, // NA for map keys
 		ParentPath: context.Path,


### PR DESCRIPTION
Saw a test failure in #134189. Clean reverting for now, to prevent mismatches. 

reverts https://github.com/kubernetes/kubernetes/pull/134836

#### Does this PR introduce a user-facing change?
```release-note
NONE
```