### PR TITLE
Enable optionalfields rule for Kube API linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -161,6 +161,10 @@ linters:
         path: "staging/src/k8s.io/api/events/(v1|v1beta1)/types.go"
       - text: 'notimestamp: naming convention "notimestamp": field AllocationResult.AllocationTimestamp: prefer use of the term ''time'' over ''timestamp'''
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+      # optionalfields - Ignore optionalfields issues for existing API group
+      # TODO: For each existing API group, we aim to remove it over time.
+      - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -164,7 +164,9 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+      - text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
       
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -167,7 +167,16 @@ linters:
         path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       - text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      
+      - text: "optionalfields: field StorageVersion.Spec should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersion.Status should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersionCondition.LastTransitionTime should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersion.Spec should have the omitempty tag."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersion.Status should have the omitempty tag."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.
       # This is incorrect, but cannot be changed without breaking changes.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -417,7 +417,7 @@ linters:
               - "nonullable" # Ensure fields are not marked as nullable.
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
-              # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
+              - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
               - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -430,7 +430,7 @@ linters:
               - "nonullable" # Ensure fields are not marked as nullable.
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
-              # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
+              - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
               - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -176,6 +176,10 @@ linters:
         path: "staging/src/k8s.io/api/events/(v1|v1beta1)/types.go"
       - text: 'notimestamp: naming convention "notimestamp": field AllocationResult.AllocationTimestamp: prefer use of the term ''time'' over ''timestamp'''
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+      # optionalfields - Ignore optionalfields issues for existing API group
+      # TODO: For each existing API group, we aim to remove it over time.
+      - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -179,7 +179,9 @@ linters:
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-        path: "staging/src/k8s.io/api/(admission|admissionregistration|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+      - text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
       
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -182,7 +182,16 @@ linters:
         path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
       - text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
         path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-      
+      - text: "optionalfields: field StorageVersion.Spec should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersion.Status should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersionCondition.LastTransitionTime should be a pointer."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersion.Spec should have the omitempty tag."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+      - text: "optionalfields: field StorageVersion.Status should have the omitempty tag."
+        path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
       # Pre-existing issues from the conflictmarkers linter
       # The Error field in some older API types is marked as both optional and required.
       # This is incorrect, but cannot be changed without breaking changes.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -37,6 +37,10 @@
   path: "staging/src/k8s.io/api/events/(v1|v1beta1)/types.go"
 - text: 'notimestamp: naming convention "notimestamp": field AllocationResult.AllocationTimestamp: prefer use of the term ''time'' over ''timestamp'''
   path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+# optionalfields - Ignore optionalfields issues for existing API group
+# TODO: For each existing API group, we aim to remove it over time.
+- text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
 
 # Pre-existing issues from the conflictmarkers linter
 # The Error field in some older API types is marked as both optional and required.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -40,7 +40,9 @@
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
-  path: "staging/src/k8s.io/api/(admission|admissionregistration|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
+- text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
+  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
 
 # Pre-existing issues from the conflictmarkers linter
 # The Error field in some older API types is marked as both optional and required.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -43,7 +43,16 @@
   path: "staging/src/k8s.io/api/(admission|admissionregistration|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|scheduling|storage|storagemigration)"
 - text: "optionalfields: field StorageVersionCondition.ObservedGeneration should be a pointer."
   path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
-
+- text: "optionalfields: field StorageVersion.Spec should be a pointer."
+  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+- text: "optionalfields: field StorageVersion.Status should be a pointer."
+  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+- text: "optionalfields: field StorageVersionCondition.LastTransitionTime should be a pointer."
+  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+- text: "optionalfields: field StorageVersion.Spec should have the omitempty tag."
+  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
+- text: "optionalfields: field StorageVersion.Status should have the omitempty tag."
+  path: "staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go"
 # Pre-existing issues from the conflictmarkers linter
 # The Error field in some older API types is marked as both optional and required.
 # This is incorrect, but cannot be changed without breaking changes.

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -16,7 +16,7 @@ linters:
     - "nonullable" # Ensure fields are not marked as nullable.
     # - "nophase" # Ensure field names do not have the word "phase" in them.
     - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
-    # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
+    - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
     - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
     # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
     - "ssatags" # Ensure lists have a listType tag.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This enables optionalfields rule for Kube API linter

#### Which issue(s) this PR is related to:

relates to #134671 

#### Special notes for your reviewer:
I had ran `hack/verify-golangci-lint.sh staging/src/k8s.io/api`   but there are no violations found on this linter.

```release-note
NONE
```