### PR TITLE
Fix minor grammar in staging/README.md

### DIFF
--- a/staging/README.md
+++ b/staging/README.md
@@ -78,8 +78,8 @@ import (
 5. Make sure that the `.github/PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING.md`
    files mention that PRs are not directly accepted to the repo.
 
-6. Ensure that `docs.go` file is added. Refer to
-   [#kubernetes/kubernetes#91354](https://github.com/kubernetes/kubernetes/blob/release-1.24/staging/src/k8s.io/client-go/doc.go)
+6. Ensure that the `docs.go` file is added. Refer to
+   [kubernetes/kubernetes#91354](https://github.com/kubernetes/kubernetes/blob/release-1.24/staging/src/k8s.io/client-go/doc.go)
    for reference.
 
 7. NOTE: Do not edit go.mod or go.sum in the new repo (staging/src/k8s.io/<newrepo>/) manually. Run the following instead:


### PR DESCRIPTION
Added "the" before `docs.go` for smoother grammar and removed unnecessary "#" in reference link.

#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Fixes a minor typo in the staging README for clarity.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
NONE
