### PR TITLE
scheduler: add metric for pods scheduled after flush

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -323,11 +323,13 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo
 	}
 	aq.schedCycle++
 
-	// Update metrics and reset the set of unschedulable plugins for the next attempt.
+	// Update metrics and reset the set of pending plugins for the next attempt.
+	// Note: We don't clear UnschedulablePlugins here because:
+	// 1. If the pod schedules successfully, we need UnschedulablePlugins for logging/debugging
+	// 2. If the pod fails to schedule again, UnschedulablePlugins will be overwritten anyway
 	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 	}
-	pInfo.UnschedulablePlugins.Clear()
 	pInfo.PendingPlugins.Clear()
 	pInfo.GatingPlugin = ""
 	pInfo.GatingPluginEvents = nil

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -324,14 +324,9 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo
 	aq.schedCycle++
 
 	// Update metrics for unschedulable plugins.
-	// Note: We don't clear UnschedulablePlugins and PendingPlugins here because:
-	// 1. If the pod schedules successfully, we need them for logging/debugging
-	// 2. If the pod fails to schedule, they will be cleared and repopulated in handleSchedulingFailure
 	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 	}
-	pInfo.GatingPlugin = ""
-	pInfo.GatingPluginEvents = nil
 
 	return pInfo, nil
 }

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -323,14 +323,13 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo
 	}
 	aq.schedCycle++
 
-	// Update metrics and reset the set of pending plugins for the next attempt.
-	// Note: We don't clear UnschedulablePlugins here because:
-	// 1. If the pod schedules successfully, we need UnschedulablePlugins for logging/debugging
-	// 2. If the pod fails to schedule again, UnschedulablePlugins will be overwritten anyway
+	// Update metrics for unschedulable plugins.
+	// Note: We don't clear UnschedulablePlugins and PendingPlugins here because:
+	// 1. If the pod schedules successfully, we need them for logging/debugging
+	// 2. If the pod fails to schedule, they will be cleared and repopulated in handleSchedulingFailure
 	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 	}
-	pInfo.PendingPlugins.Clear()
 	pInfo.GatingPlugin = ""
 	pInfo.GatingPluginEvents = nil
 

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -948,6 +948,8 @@ func (p *PriorityQueue) flushUnschedulablePodsLeftover(logger klog.Logger) {
 	for _, pInfo := range p.unschedulablePods.podInfoMap {
 		lastScheduleTime := pInfo.Timestamp
 		if currentTime.Sub(lastScheduleTime) > p.podMaxInUnschedulablePodsDuration {
+			// Mark this pod as flushed so we can detect if it schedules soon after
+			pInfo.FlushedFromUnschedulableAt = &currentTime
 			podsToMove = append(podsToMove, pInfo)
 		}
 	}

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1239,13 +1239,6 @@ func (p *PriorityQueue) movePodsToActiveOrBackoffQueue(logger klog.Logger, podIn
 			continue
 		}
 
-		// Clear the flush flag if this pod is being moved by an event (not by timeout flush).
-		// EventUnschedulableTimeout is the event used by flushUnschedulablePodsLeftover,
-		// where the flag is set to true before calling this function.
-		if event != framework.EventUnschedulableTimeout {
-			pInfo.WasFlushedFromUnschedulable = false
-		}
-
 		p.unschedulablePods.delete(pInfo.Pod, pInfo.Gated())
 		queue := p.requeuePodWithQueueingStrategy(logger, pInfo, schedulingHint, event.Label())
 		if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -649,7 +649,7 @@ func Test_InFlightPods(t *testing.T) {
 			},
 		},
 		{
-			name:                         "popped pod must have empty UnschedulablePlugins and PendingPlugins",
+			name:                         "popped pod preserves UnschedulablePlugins but clears PendingPlugins",
 			isSchedulingQueueHintEnabled: true,
 			initialPods:                  []*v1.Pod{pod1},
 			actions: []action{
@@ -666,8 +666,13 @@ func Test_InFlightPods(t *testing.T) {
 				{eventHappens: &pvAdd}, // Active again.
 				{callback: func(t *testing.T, q *PriorityQueue) {
 					poppedPod = popPod(t, logger, q, pod1)
-					if len(poppedPod.UnschedulablePlugins) > 0 {
-						t.Errorf("QueuedPodInfo from Pop should have empty UnschedulablePlugins, got instead: %+v", poppedPod)
+					// UnschedulablePlugins should be preserved for logging/debugging
+					if !poppedPod.UnschedulablePlugins.Equal(sets.New("fooPlugin2")) {
+						t.Errorf("QueuedPodInfo from Pop should preserve UnschedulablePlugins, expected fooPlugin2, got: %+v", poppedPod.UnschedulablePlugins)
+					}
+					// PendingPlugins should still be cleared
+					if len(poppedPod.PendingPlugins) > 0 {
+						t.Errorf("QueuedPodInfo from Pop should have empty PendingPlugins, got instead: %+v", poppedPod.PendingPlugins)
 					}
 				}},
 				{callback: func(t *testing.T, q *PriorityQueue) {
@@ -3028,33 +3033,18 @@ func TestHighPriorityFlushUnschedulablePodsLeftover(t *testing.T) {
 func TestFlushUnschedulablePodsLeftoverSetsFlag(t *testing.T) {
 	c := testingclock.NewFakeClock(time.Now())
 	m := makeEmptyQueueingHintMapPerProfile()
-	m[""][nodeAdd] = []*QueueingHintFunction{
-		{
-			PluginName:     "fakePlugin",
-			QueueingHintFn: queueHintReturnQueue,
-		},
-	}
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m))
 
 	pod := st.MakePod().Name("test-pod").Namespace("ns1").UID("tp-1").Priority(midPriority).NominatedNodeName("node1").Obj()
-	podutil.UpdatePodCondition(&pod.Status, &v1.PodCondition{
-		Type:    v1.PodScheduled,
-		Status:  v1.ConditionFalse,
-		Reason:  v1.PodReasonUnschedulable,
-		Message: "fake scheduling failure",
-	})
 
 	// Add pod to activeQ and pop it to simulate a scheduling attempt
 	q.Add(logger, pod)
 	pInfo, err := q.Pop(logger)
 	if err != nil {
-		t.Fatalf("unexpected error from Pop: %v", err)
-	}
-	if pInfo.Pod != pod {
-		t.Errorf("Expected: %v after Pop, but got: %v", pod.Name, pInfo.Pod.Name)
+		t.Fatalf("Unexpected error from Pop: %v", err)
 	}
 
 	// Verify flag is initially false
@@ -3065,7 +3055,7 @@ func TestFlushUnschedulablePodsLeftoverSetsFlag(t *testing.T) {
 	// Add pod to unschedulablePods (simulating failed scheduling)
 	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(pod, "fakePlugin"), q.SchedulingCycle())
 	if err != nil {
-		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+		t.Fatalf("Unexpected error from AddUnschedulableIfNotPresent: %v", err)
 	}
 
 	// Advance time past the flush duration and flush
@@ -3075,37 +3065,25 @@ func TestFlushUnschedulablePodsLeftoverSetsFlag(t *testing.T) {
 	// Pop the pod and verify flag is now true
 	pInfo, err = q.Pop(logger)
 	if err != nil {
-		t.Fatalf("unexpected error from Pop after flush: %v", err)
-	}
-	if pInfo.Pod != pod {
-		t.Errorf("Expected: %v after Pop, but got: %v", pod.Name, pInfo.Pod.Name)
+		t.Fatalf("Unexpected error from Pop after flush: %v", err)
 	}
 	if !pInfo.WasFlushedFromUnschedulable {
 		t.Errorf("Expected WasFlushedFromUnschedulable to be true after flush, but got false")
 	}
 
 	// Simulate pod failing to schedule again and returning to queue
-	err = q.AddUnschedulableIfNotPresent(logger, pInfo, q.SchedulingCycle())
+	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(pInfo.Pod, "fakePlugin"), q.SchedulingCycle())
 	if err != nil {
-		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+		t.Fatalf("Unexpected error from AddUnschedulableIfNotPresent: %v", err)
 	}
 
 	// Verify flag is cleared when pod returns to queue
-	// Pod can be in either backoffQ or unschedulablePods depending on queueing hints
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	var internalPInfo *framework.QueuedPodInfo
-	// Check backoffQ first
-	if pInfoFromBackoff, exists := q.backoffQ.get(newQueuedPodInfoForLookup(pod)); exists {
-		internalPInfo = pInfoFromBackoff
-	} else {
-		// Check unschedulablePods
-		internalPInfo = q.unschedulablePods.get(pod)
-	}
-
+	internalPInfo := q.unschedulablePods.get(pod)
 	if internalPInfo == nil {
-		t.Fatalf("pod should be in either backoffQ or unschedulablePods")
+		t.Fatalf("pod should be in unschedulablePods")
 	}
 	if internalPInfo.WasFlushedFromUnschedulable {
 		t.Errorf("Expected WasFlushedFromUnschedulable to be cleared (false) after returning to queue, but got true")

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -942,7 +942,7 @@ func TestPop(t *testing.T) {
 			poppedPod = popPod(t, logger, q, pod)
 			// PendingPlugins are preserved after Pop() so they can be logged if scheduling
 			// succeeds, or cleared in handleSchedulingFailure() if it fails.
-			if len(poppedPod.PendingPlugins) != 1 || !poppedPod.PendingPlugins.Has("fooPlugin1") {
+			if !poppedPod.PendingPlugins.Equal(sets.New("fooPlugin1")) {
 				t.Errorf("QueuedPodInfo from Pop should preserve PendingPlugins, expected fooPlugin1, got instead: %+v", poppedPod)
 			}
 		})
@@ -3080,9 +3080,6 @@ func TestFlushUnschedulablePodsLeftoverSetsFlag(t *testing.T) {
 	}
 
 	// Verify flag is cleared when pod returns to queue
-	q.lock.Lock()
-	defer q.lock.Unlock()
-
 	internalPInfo := q.unschedulablePods.get(pod)
 	if internalPInfo == nil {
 		t.Fatalf("pod should be in unschedulablePods")

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -529,7 +529,7 @@ type QueuedPodInfo struct {
 	// WasFlushedFromUnschedulable tracks whether this pod was most recently moved to activeQ
 	// by the periodic flush from unschedulablePods due to timeout (rather than by an event).
 	// This is used to detect if the pod becomes schedulable soon after flush, which may
-	// indicate missing queue hint optimizations or event handling bugs.
+	// indicate queueing hint misconfigurations or event handling bugs.
 	// This flag is cleared when the pod returns to the queue for any reason.
 	WasFlushedFromUnschedulable bool
 	// The time when the pod is added to the queue for the first time. The pod may be added
@@ -620,8 +620,7 @@ func (pqi *QueuedPodInfo) DeepCopy() *QueuedPodInfo {
 }
 
 // ClearRejectorPlugins clears the plugin-related fields that track why a pod
-// was rejected in a previous scheduling attempt. This should be called at the
-// beginning of a new scheduling attempt to ensure stale data doesn't persist.
+// was rejected in a previous scheduling attempt.
 func (pqi *QueuedPodInfo) ClearRejectorPlugins() {
 	pqi.UnschedulablePlugins.Clear()
 	pqi.PendingPlugins.Clear()

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -526,6 +526,10 @@ type QueuedPodInfo struct {
 	// That's why we need to distinguish ConsecutiveErrorsCount for the error status and UnschedulableCount for the unschedulable status.
 	// See https://github.com/kubernetes/kubernetes/issues/128744 for the discussion.
 	ConsecutiveErrorsCount int
+	// FlushedFromUnschedulableAt tracks when this pod was last flushed from unschedulablePods
+	// due to timeout. This is used to detect if the pod becomes schedulable soon after flush,
+	// which may indicate missing queue hint optimizations or event handling bugs.
+	FlushedFromUnschedulableAt *time.Time
 	// The time when the pod is added to the queue for the first time. The pod may be added
 	// back to the queue multiple times before it's successfully scheduled.
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -526,10 +526,12 @@ type QueuedPodInfo struct {
 	// That's why we need to distinguish ConsecutiveErrorsCount for the error status and UnschedulableCount for the unschedulable status.
 	// See https://github.com/kubernetes/kubernetes/issues/128744 for the discussion.
 	ConsecutiveErrorsCount int
-	// FlushedFromUnschedulableAt tracks when this pod was last flushed from unschedulablePods
-	// due to timeout. This is used to detect if the pod becomes schedulable soon after flush,
-	// which may indicate missing queue hint optimizations or event handling bugs.
-	FlushedFromUnschedulableAt *time.Time
+	// WasFlushedFromUnschedulable tracks whether this pod was most recently moved to activeQ
+	// by the periodic flush from unschedulablePods due to timeout (rather than by an event).
+	// This is used to detect if the pod becomes schedulable soon after flush, which may
+	// indicate missing queue hint optimizations or event handling bugs.
+	// This flag is cleared when the pod returns to the queue for any reason.
+	WasFlushedFromUnschedulable bool
 	// The time when the pod is added to the queue for the first time. The pod may be added
 	// back to the queue multiple times before it's successfully scheduled.
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -619,6 +619,16 @@ func (pqi *QueuedPodInfo) DeepCopy() *QueuedPodInfo {
 	}
 }
 
+// ClearRejectorPlugins clears the plugin-related fields that track why a pod
+// was rejected in a previous scheduling attempt. This should be called at the
+// beginning of a new scheduling attempt to ensure stale data doesn't persist.
+func (pqi *QueuedPodInfo) ClearRejectorPlugins() {
+	pqi.UnschedulablePlugins.Clear()
+	pqi.PendingPlugins.Clear()
+	pqi.GatingPlugin = ""
+	pqi.GatingPluginEvents = nil
+}
+
 // PodInfo is a wrapper to a Pod with additional pre-computed information to
 // accelerate processing. This information is typically immutable (e.g., pre-processed
 // inter-pod affinity selectors).

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -131,6 +131,7 @@ var (
 
 	PodSchedulingSLIDuration        *metrics.HistogramVec
 	PodSchedulingAttempts           *metrics.Histogram
+	PodScheduledAfterFlush          *metrics.Counter
 	FrameworkExtensionPointDuration *metrics.HistogramVec
 	PluginExecutionDuration         *metrics.HistogramVec
 
@@ -294,6 +295,14 @@ func InitMetrics() {
 			Help:           "Number of attempts to successfully schedule a pod.",
 			Buckets:        metrics.ExponentialBuckets(1, 2, 5),
 			StabilityLevel: metrics.STABLE,
+		})
+
+	PodScheduledAfterFlush = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "pod_scheduled_after_flush_total",
+			Help:           "Number of pods that were successfully scheduled after being flushed from unschedulablePods due to timeout. This metric helps detect potential queue hint bugs or event handling issues.",
+			StabilityLevel: metrics.ALPHA,
 		})
 
 	FrameworkExtensionPointDuration = metrics.NewHistogramVec(
@@ -463,6 +472,7 @@ func InitMetrics() {
 		pendingPods,
 		PodSchedulingSLIDuration,
 		PodSchedulingAttempts,
+		PodScheduledAfterFlush,
 		FrameworkExtensionPointDuration,
 		PluginExecutionDuration,
 		SchedulerQueueIncomingPods,

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -301,7 +301,7 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "pod_scheduled_after_flush_total",
-			Help:           "Number of pods that were successfully scheduled after being flushed from unschedulablePods due to timeout. This metric helps detect potential queue hint bugs or event handling issues.",
+			Help:           "Number of pods that were successfully scheduled after being flushed from unschedulablePods due to timeout. This metric helps detect potential queueing hint misconfigurations or event handling issues.",
 			StabilityLevel: metrics.ALPHA,
 		})
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -342,6 +342,7 @@ func (sched *Scheduler) bindingCycle(
 	}
 	// Count pods scheduled after being flushed from unschedulablePods
 	if assumedPodInfo.WasFlushedFromUnschedulable {
+		logger.Info("Pod scheduled after flush from unschedulablePods", "pod", klog.KObj(assumedPodInfo.Pod), "unschedulablePlugins", assumedPodInfo.UnschedulablePlugins)
 		metrics.PodScheduledAfterFlush.Inc()
 	}
 	// Run "postbind" plugins.

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -342,7 +342,7 @@ func (sched *Scheduler) bindingCycle(
 	}
 	// Count pods scheduled after being flushed from unschedulablePods
 	if assumedPodInfo.WasFlushedFromUnschedulable {
-		logger.Info("Pod scheduled after flush from unschedulablePods", "pod", klog.KObj(assumedPodInfo.Pod), "unschedulablePlugins", assumedPodInfo.UnschedulablePlugins, "pendingPlugins", assumedPodInfo.PendingPlugins)
+		logger.V(4).Info("Pod scheduled after flush from unschedulablePods", "pod", klog.KObj(assumedPodInfo.Pod), "unschedulablePlugins", assumedPodInfo.UnschedulablePlugins, "pendingPlugins", assumedPodInfo.PendingPlugins)
 		metrics.PodScheduledAfterFlush.Inc()
 	}
 	// Run "postbind" plugins.

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -341,7 +341,7 @@ func (sched *Scheduler) bindingCycle(
 		metrics.PodSchedulingSLIDuration.WithLabelValues(getAttemptsLabel(assumedPodInfo)).Observe(metrics.SinceInSeconds(*assumedPodInfo.InitialAttemptTimestamp))
 	}
 	// Count pods scheduled after being flushed from unschedulablePods
-	if assumedPodInfo.FlushedFromUnschedulableAt != nil {
+	if assumedPodInfo.WasFlushedFromUnschedulable {
 		metrics.PodScheduledAfterFlush.Inc()
 	}
 	// Run "postbind" plugins.

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1063,10 +1063,11 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, fwk framewo
 	err := status.AsError()
 	errMsg := status.Message()
 
-	// Clear plugin sets to avoid stale data from previous scheduling attempts.
-	// They will be repopulated below for FitError cases.
-	podInfo.UnschedulablePlugins.Clear()
-	podInfo.PendingPlugins.Clear()
+	// Clear plugin-related fields to avoid stale data from previous scheduling attempts.
+	// These fields will be repopulated below for FitError cases.
+	// We clear them here (rather than at Pop) because we sometimes want to use them
+	// for logging when a pod schedules successfully (e.g., after being flushed).
+	podInfo.ClearRejectorPlugins()
 
 	if err == ErrNoNodesAvailable {
 		logger.V(2).Info("Unable to schedule pod; no nodes are registered to the cluster; waiting", "pod", klog.KObj(pod))

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -340,6 +340,10 @@ func (sched *Scheduler) bindingCycle(
 	if assumedPodInfo.InitialAttemptTimestamp != nil {
 		metrics.PodSchedulingSLIDuration.WithLabelValues(getAttemptsLabel(assumedPodInfo)).Observe(metrics.SinceInSeconds(*assumedPodInfo.InitialAttemptTimestamp))
 	}
+	// Count pods scheduled after being flushed from unschedulablePods
+	if assumedPodInfo.FlushedFromUnschedulableAt != nil {
+		metrics.PodScheduledAfterFlush.Inc()
+	}
 	// Run "postbind" plugins.
 	schedFramework.RunPostBindPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a counter metric to track pods that successfully schedule after being flushed from the unschedulablePods queue due to timeout. When pods sit in unschedulablePods for more than 5 minutes, they're automatically flushed back to activeQ. If these pods schedule shortly after, it may indicate missing queue hint optimizations or event handling bugs.

The metric `scheduler_pod_scheduled_after_flush_total` (ALPHA) increments whenever a pod that was flushed schedules successfully, helping maintainers detect and investigate potential queue hint issues.

#### Which issue(s) this PR is related to:

Fixes #134999

#### Special notes for your reviewer:

This is a minimal change (~17 lines across 3 files):
- Added `WasFlushedFromUnschedulable` boolean field to `QueuedPodInfo`
- Set to true when `flushUnschedulablePodsLeftover()` moves pods due to timeout
- Cleared when pod returns to queue after scheduling failure or when moved by events (not timeout)
- Created counter metric with ALPHA stability
- Increment metric when pods with flag set successfully schedule

The boolean flag approach ensures we only count pods that schedule immediately after timeout flush, avoiding false positives when pods are later moved by cluster events.

#### Does this PR introduce a user-facing change?

```release-note
Added ALPHA metric `scheduler_pod_scheduled_after_flush_total` to count pods scheduled after being flushed from unschedulablePods due to timeout
```