### PR TITLE
docs: fix grammatical error in SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ The Kubernetes Community is active on Stack Overflow, you can post your question
 
 * [Kubernetes on Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes)
 
-  * Here are some tips for [about how to ask good questions](https://stackoverflow.com/help/how-to-ask).
+  * Here are some tips for [how to ask good questions](https://stackoverflow.com/help/how-to-ask).
   * Don't forget to check to see [what's on topic](https://stackoverflow.com/help/on-topic).
 
 ### Documentation


### PR DESCRIPTION
Fix grammatical error in Stack Overflow tips section

Removed redundant "about" from the sentence "Here are some tips for about how to ask good questions" to correct the grammar.

Changes:
- Fixed: "for about how to" → "for how to"