### PR TITLE
Update CSI manifests from csi-driver-hostpath master

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -353,26 +353,27 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 
 // mockCSI
 type mockCSIDriver struct {
-	driverInfo                   storageframework.DriverInfo
-	manifests                    []string
-	podInfo                      *bool
-	storageCapacity              *bool
-	attachable                   bool
-	attachLimit                  int
-	enableTopology               bool
-	enableNodeExpansion          bool
-	hooks                        Hooks
-	tokenRequests                []storagev1.TokenRequest
-	requiresRepublish            *bool
-	serviceAccountTokenInSecrets *bool
-	fsGroupPolicy                *storagev1.FSGroupPolicy
-	enableVolumeMountGroup       bool
-	enableNodeVolumeCondition    bool
-	embedded                     bool
-	calls                        MockCSICalls
-	embeddedCSIDriver            *mockdriver.CSIDriver
-	enableSELinuxMount           *bool
-	disableControllerExpansion   bool
+	driverInfo                           storageframework.DriverInfo
+	manifests                            []string
+	podInfo                              *bool
+	storageCapacity                      *bool
+	attachable                           bool
+	attachLimit                          int
+	enableTopology                       bool
+	enableNodeExpansion                  bool
+	hooks                                Hooks
+	tokenRequests                        []storagev1.TokenRequest
+	requiresRepublish                    *bool
+	serviceAccountTokenInSecrets         *bool
+	fsGroupPolicy                        *storagev1.FSGroupPolicy
+	enableVolumeMountGroup               bool
+	enableNodeVolumeCondition            bool
+	embedded                             bool
+	calls                                MockCSICalls
+	embeddedCSIDriver                    *mockdriver.CSIDriver
+	enableSELinuxMount                   *bool
+	disableControllerExpansion           bool
+	enableMutableCSINodeAllocatableCount bool
 
 	// Additional values set during PrepareTest
 	clientSet       clientset.Interface
@@ -406,23 +407,24 @@ type MockCSITestDriver interface {
 
 // CSIMockDriverOpts defines options used for csi driver
 type CSIMockDriverOpts struct {
-	RegisterDriver               bool
-	DisableAttach                bool
-	PodInfo                      *bool
-	StorageCapacity              *bool
-	AttachLimit                  int
-	EnableTopology               bool
-	EnableResizing               bool
-	EnableNodeExpansion          bool
-	DisableControllerExpansion   bool
-	EnableSnapshot               bool
-	EnableVolumeMountGroup       bool
-	EnableNodeVolumeCondition    bool
-	TokenRequests                []storagev1.TokenRequest
-	ServiceAccountTokenInSecrets *bool
-	RequiresRepublish            *bool
-	FSGroupPolicy                *storagev1.FSGroupPolicy
-	EnableSELinuxMount           *bool
+	RegisterDriver                       bool
+	DisableAttach                        bool
+	PodInfo                              *bool
+	StorageCapacity                      *bool
+	AttachLimit                          int
+	EnableTopology                       bool
+	EnableResizing                       bool
+	EnableNodeExpansion                  bool
+	DisableControllerExpansion           bool
+	EnableSnapshot                       bool
+	EnableVolumeMountGroup               bool
+	EnableNodeVolumeCondition            bool
+	TokenRequests                        []storagev1.TokenRequest
+	ServiceAccountTokenInSecrets         *bool
+	RequiresRepublish                    *bool
+	FSGroupPolicy                        *storagev1.FSGroupPolicy
+	EnableSELinuxMount                   *bool
+	EnableMutableCSINodeAllocatableCount bool
 
 	// Embedded defines whether the CSI mock driver runs
 	// inside the cluster (false, the default) or just a proxy
@@ -564,23 +566,24 @@ func InitMockCSIDriver(driverOpts CSIMockDriverOpts) MockCSITestDriver {
 				storageframework.CapMultiplePVsSameID: true,
 			},
 		},
-		manifests:                    driverManifests,
-		podInfo:                      driverOpts.PodInfo,
-		storageCapacity:              driverOpts.StorageCapacity,
-		enableTopology:               driverOpts.EnableTopology,
-		attachable:                   !driverOpts.DisableAttach,
-		attachLimit:                  driverOpts.AttachLimit,
-		enableNodeExpansion:          driverOpts.EnableNodeExpansion,
-		enableNodeVolumeCondition:    driverOpts.EnableNodeVolumeCondition,
-		disableControllerExpansion:   driverOpts.DisableControllerExpansion,
-		tokenRequests:                driverOpts.TokenRequests,
-		requiresRepublish:            driverOpts.RequiresRepublish,
-		serviceAccountTokenInSecrets: driverOpts.ServiceAccountTokenInSecrets,
-		fsGroupPolicy:                driverOpts.FSGroupPolicy,
-		enableVolumeMountGroup:       driverOpts.EnableVolumeMountGroup,
-		enableSELinuxMount:           driverOpts.EnableSELinuxMount,
-		embedded:                     driverOpts.Embedded,
-		hooks:                        driverOpts.Hooks,
+		manifests:                            driverManifests,
+		podInfo:                              driverOpts.PodInfo,
+		storageCapacity:                      driverOpts.StorageCapacity,
+		enableTopology:                       driverOpts.EnableTopology,
+		attachable:                           !driverOpts.DisableAttach,
+		attachLimit:                          driverOpts.AttachLimit,
+		enableNodeExpansion:                  driverOpts.EnableNodeExpansion,
+		enableNodeVolumeCondition:            driverOpts.EnableNodeVolumeCondition,
+		disableControllerExpansion:           driverOpts.DisableControllerExpansion,
+		tokenRequests:                        driverOpts.TokenRequests,
+		requiresRepublish:                    driverOpts.RequiresRepublish,
+		serviceAccountTokenInSecrets:         driverOpts.ServiceAccountTokenInSecrets,
+		fsGroupPolicy:                        driverOpts.FSGroupPolicy,
+		enableVolumeMountGroup:               driverOpts.EnableVolumeMountGroup,
+		enableSELinuxMount:                   driverOpts.EnableSELinuxMount,
+		enableMutableCSINodeAllocatableCount: driverOpts.EnableMutableCSINodeAllocatableCount,
+		embedded:                             driverOpts.Embedded,
+		hooks:                                driverOpts.Hooks,
 	}
 }
 
@@ -736,6 +739,9 @@ func (m *mockCSIDriver) PrepareTest(ctx context.Context, f *framework.Framework)
 		FSGroupPolicy:                m.fsGroupPolicy,
 		SELinuxMount:                 m.enableSELinuxMount,
 		Features:                     map[string][]string{},
+	}
+	if m.enableMutableCSINodeAllocatableCount {
+		o.Features["csi-attacher"] = []string{"MutableCSINodeAllocatableCount=true"}
 	}
 
 	err = utils.CreateFromManifests(ctx, f, m.driverNamespace, func(item interface{}) error {

--- a/test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-attacher/raw/v4.6.1/deploy/kubernetes//rbac.yaml
-# for csi-driver-host-path release-1.14
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-attacher/raw/v4.10.0/deploy/kubernetes//rbac.yaml
+# for csi-driver-host-path master
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external

--- a/test/e2e/testing-manifests/storage-csi/external-health-monitor/external-health-monitor-controller/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-health-monitor/external-health-monitor-controller/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-health-monitor/raw/v0.12.1/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
-# for csi-driver-host-path release-1.14
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-health-monitor/raw/v0.16.0/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
+# for csi-driver-host-path master
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external

--- a/test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-provisioner/raw/v5.0.1/deploy/kubernetes//rbac.yaml
-# for csi-driver-host-path release-1.14
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-provisioner/raw/v6.0.0/deploy/kubernetes//rbac.yaml
+# for csi-driver-host-path master
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external

--- a/test/e2e/testing-manifests/storage-csi/external-resizer/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-resizer/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-resizer/raw/v1.11.1/deploy/kubernetes//rbac.yaml
-# for csi-driver-host-path release-1.14
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-resizer/raw/v2.0.0/deploy/kubernetes//rbac.yaml
+# for csi-driver-host-path master
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external
@@ -46,7 +46,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  # only required if enabling the alpha volume modify feature
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattributesclasses"]
     verbs: ["get", "list", "watch"]

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/csi-snapshotter/rbac-csi-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-snapshotter/raw/v8.0.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
-# for csi-driver-host-path release-1.14
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-snapshotter/raw/v8.4.0/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+# for csi-driver-host-path master
 # by ./update-hostpath.sh
 #
 # Together with the RBAC file for external-provisioner, this YAML file
@@ -39,11 +39,8 @@ rules:
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update", "patch", "create"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list", "watch", "update", "patch", "create"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]

--- a/test/e2e/testing-manifests/storage-csi/hostpath/README.md
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/README.md
@@ -1,4 +1,4 @@
 The files in this directory are exact copies of "kubernetes-latest" in
-https://github.com/kubernetes-csi/csi-driver-host-path/tree/release-1.14/deploy/
+https://github.com/kubernetes-csi/csi-driver-host-path/tree/master/deploy/
 
 Do not edit manually. Run ./update-hostpath.sh to refresh the content.

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -1,4 +1,4 @@
-# All of the individual sidecar RBAC roles get bound
+  # All of the individual sidecar RBAC roles get bound
 # to this account.
 kind: ServiceAccount
 apiVersion: v1
@@ -96,6 +96,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: external-snapshotter-runner
+subjects:
+- kind: ServiceAccount
+  name: csi-hostpathplugin-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: hostpath.csi.k8s.io
+    app.kubernetes.io/part-of: csi-driver-host-path
+    app.kubernetes.io/name: csi-hostpathplugin
+    app.kubernetes.io/component: snapshot-metadata-cluster-role
+  name: csi-hostpathplugin-snapshot-metadata-cluster-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-snapshot-metadata-runner
 subjects:
 - kind: ServiceAccount
   name: csi-hostpathplugin-sa
@@ -219,12 +237,13 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
+            # end hostpath args
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -262,7 +281,7 @@ spec:
               name: dev-dir
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.16.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -324,7 +343,7 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -340,7 +359,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.0.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -354,7 +373,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
@@ -366,6 +385,8 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+
+        # end csi containers
 
       volumes:
         - hostPath:
@@ -394,3 +415,4 @@ spec:
             path: /dev
             type: Directory
           name: dev-dir
+        # end csi volumes

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-testing.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-testing.yaml
@@ -66,7 +66,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.15.0
           command:
           - socat
           args:

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.0.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             # Topology support is needed for the pod rescheduling test
@@ -34,7 +34,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -53,7 +53,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.0
           args:
             - "--drivername=mock.storage.k8s.io"
             - "--nodeid=$(KUBE_NODE_NAME)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             # Topology support is needed for the pod rescheduling test
@@ -35,7 +35,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -53,7 +53,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.0
           args:
             - -v=5
             - -nodeid=$(KUBE_NODE_NAME)

--- a/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
+++ b/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
@@ -37,7 +37,7 @@ set -xe
 cd "$(dirname "$0")"
 
 # Remove stale files.
-rm -rf external-attacher external-provisioner external-resizer external-snapshotter external-health-monitor hostpath csi-driver-host-path
+rm -rf external-attacher external-provisioner external-resizer external-snapshotter/csi-snapshotter external-health-monitor hostpath csi-driver-host-path
 
 # Check out desired release.
 git clone https://github.com/kubernetes-csi/csi-driver-host-path.git

--- a/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
+++ b/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
@@ -127,6 +127,10 @@ for image in $images; do
                     path="csi-snapshotter"
                     rbac="rbac-csi-snapshotter.yaml"
                     ;;
+                external-snapshot-metadata)
+                    # Another special case. There is no e2e test that needs the RBAC manifest + it's on an unusual place.
+                    continue
+                    ;;
             esac
             ;;
     esac

--- a/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
+++ b/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
@@ -141,5 +141,12 @@ done
 grep -r image: hostpath/hostpath/csi-hostpath-plugin.yaml | while read -r image; do
     version=$(echo "$image" | sed -e 's/.*:\(.*\)/\1/')
     image=$(echo "$image" | sed -e 's/.*image: \([^:]*\).*/\1/')
-    sed -i '' -e "s;$image:.*;$image:$version;" mock/*.yaml
+
+    if sed --version >/dev/null 2>&1; then
+        # GNU sed, `-i ''` fails
+        sed -i -e "s;$image:.*;$image:$version;" mock/*.yaml
+    else
+        # BSD sed (macOS)
+        sed -i '' -e "s;$image:.*;$image:$version;" mock/*.yaml
+    fi
 done


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Update CSI manifests used in e2e tests from today's https://github.com/kubernetes-csi/csi-driver-host-path.

I had to update update-hostpath.sh quite a bit, see the individual commits. We haven't run it for a while.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
