### PR TITLE
DRA scheduler_perf: write JSON where perf-dash expects it

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1332,7 +1332,15 @@ func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName strin
 			}
 		})
 	}
-	if err := dataItems2JSONFile(dataItems, strings.ReplaceAll(b.Name(), "/", "_")+"_benchmark_"+topicName); err != nil {
+	// Different top-level BenchmarkPerfScheduling* tests are supported as long as they use unique topic names.
+	// The final JSON file then is always called BenchmarkPerfScheduling_benchmark_<topic name>_<date+time>.json
+	// because that is what perf-dash is configured to read:
+	// https://github.com/kubernetes/perf-tests/blob/581139e45e79cf04b9c2777b82677957f1e7f90b/perfdash/config.go#L520-L525
+	namePrefix := b.Name()
+	namePrefix = regexp.MustCompile(`^BenchmarkPerfScheduling[^/]*`).ReplaceAllString(namePrefix, "BenchmarkPerfScheduling")
+	namePrefix = strings.ReplaceAll(namePrefix, "/", "_")
+	namePrefix += "_benchmark_" + topicName
+	if err := dataItems2JSONFile(dataItems, namePrefix); err != nil {
 		b.Fatalf("unable to write measured data %+v: %v", dataItems, err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

BenchmarkPerfSchedulingExperimental_benchmark_dra_experimental_2025-11-05T07:10:33Z.json is ignored by perf-dash. It probably needs to be called BenchmarkPerfScheduling_benchmark_*.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/135058#issuecomment-3490595220
https://github.com/kubernetes/kubernetes/pull/135060

#### Special notes for your reviewer:

I've not found exactly where perf-dash is configured, but I remember that it had a file pattern somewhere. Following the current practice is easier than changing perf-dash configuration and more consistent.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
