### PR TITLE
Add field selector support for status.replicas on ReplicaSet

### DIFF
--- a/pkg/apis/apps/v1/register.go
+++ b/pkg/apis/apps/v1/register.go
@@ -41,5 +41,5 @@ func init() {
 	// We only register manually written functions here. The registration of the
 	// generated functions takes place in the generated files. The separation
 	// makes the code compile even when the generated files are missing.
-	localSchemeBuilder.Register(addDefaultingFuncs)
+	localSchemeBuilder.Register(addDefaultingFuncs, addConversionFuncs)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR adds field label conversion registration for the `status.replicas` field on ReplicaSet resources, enabling users to filter ReplicaSets using kubectl field selectors.

**Problem:**
Currently, attempting to use `status.replicas` as a field selector fails with an error:
```
kubectl get rs --field-selector status.replicas=0
Error from server (BadRequest): Unable to find "apps/v1, Resource=replicasets" that match label selector "", field selector "status.replicas=0": "status.replicas" is not a known field selector: only "metadata.name", "metadata.namespace"
```

This occurs even though `status.replicas` is already defined in the `ToSelectableFields` function in the ReplicaSet storage layer.

**Solution:**
The fix registers the field label conversion function for ReplicaSet in `pkg/apis/apps/v1/conversion.go`, which maps the external API field name to the internal field name. This registration was previously missing, causing the API server to reject the field selector.

The changes include:
1. Added `addConversionFuncs()` function in `pkg/apis/apps/v1/conversion.go` to register field label conversions for ReplicaSet
2. Registered `status.replicas`, `metadata.name`, and `metadata.namespace` as valid field selectors
3. Updated `pkg/apis/apps/v1/register.go` to call `addConversionFuncs` during scheme initialization

**Example usage after this fix:**
```bash
# List ReplicaSets with 0 replicas
kubectl get rs --field-selector status.replicas=0

# List ReplicaSets with specific replica count in a namespace
kubectl get rs -n my-namespace --field-selector status.replicas=3

# Combine with other field selectors
kubectl get rs --field-selector metadata.namespace=default,status.replicas=0
```

#### Which issue(s) this PR is related to:
Fixes #135136

#### Notes for reviewer:

- Field selector tests already exist in `pkg/registry/apps/replicaset/storage/storage_test.go` (lines 237, 243, 247) which test `status.replicas` field selector functionality
- The `ToSelectableFields` function in `pkg/registry/apps/replicaset/strategy.go` already includes `status.replicas` (line 161)
- This PR only adds the missing field label conversion registration to wire everything together

#### Does this PR introduce a user-facing change?
```release-note
Field selector support for `status.replicas` on ReplicaSet is now enabled, allowing users to filter ReplicaSets using kubectl commands like `kubectl get rs --field-selector status.replicas=0`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```