### PR TITLE
Fix node-conformance failures

### DIFF
--- a/test/e2e/framework/registry/registry.go
+++ b/test/e2e/framework/registry/registry.go
@@ -102,7 +102,8 @@ func SetupRegistry(ctx context.Context, f *framework.Framework, podOnly bool) (s
 		podNodes = append(podNodes, pod.Spec.NodeName)
 	}
 
-	return "localhost:5000", podNodes, nil
+	// returning the IPv4 form here, IPv6 is causing issues in node-conformance on dual-stack
+	return "127.0.0.1:5000", podNodes, nil
 }
 
 func podManifest(podTestLabel string) (*v1.Pod, error) {

--- a/test/e2e/framework/registry/registry.go
+++ b/test/e2e/framework/registry/registry.go
@@ -102,8 +102,7 @@ func SetupRegistry(ctx context.Context, f *framework.Framework, podOnly bool) (s
 		podNodes = append(podNodes, pod.Spec.NodeName)
 	}
 
-	// returning the IPv4 form here, IPv6 is causing issues in node-conformance on dual-stack
-	return "127.0.0.1:5000", podNodes, nil
+	return "localhost:5000", podNodes, nil
 }
 
 func podManifest(podTestLabel string) (*v1.Pod, error) {
@@ -128,6 +127,9 @@ func podManifest(podTestLabel string) (*v1.Pod, error) {
 		},
 	}
 	pod.Spec.Containers[0].SecurityContext.RunAsUser = ptr.To[int64](5123)
+	// setting HostNetwork to true so that the registry is accessible on localhost:<hostport>
+	// and we don't have to deal with any CNI quirks.
+	pod.Spec.HostNetwork = true
 
 	return pod, nil
 }

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -76,7 +76,7 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 					})
 				})
 
-				f.It(testCase.description+"", f.WithNodeConformance(), f.WithFlaky() /* https://github.com/kubernetes/kubernetes/issues/134998 */, func(ctx context.Context) {
+				f.It(testCase.description+"", f.WithNodeConformance(), f.WithSerial(), func(ctx context.Context) {
 					name := "image-pull-test"
 					container := node.ConformanceContainer{
 						PodClient: e2epod.NewPodClient(f),
@@ -94,6 +94,10 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 
 					auth := e2eregistry.User1DockerSecret(registryAddress).Data[v1.DockerConfigJsonKey]
 					configFile := filepath.Join(services.KubeletRootDirectory, "config.json")
+
+					// the kubelet would cache the config for 5 minutes, let's restart instead
+					restartKubelet(context.Background(), true)
+
 					err := os.WriteFile(configFile, []byte(auth), 0644)
 					framework.ExpectNoError(err)
 					ginkgo.DeferCleanup(func() { framework.ExpectNoError(os.Remove(configFile)) })

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -76,7 +76,7 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 					})
 				})
 
-				f.It(testCase.description+"", f.WithNodeConformance(), f.WithSerial(), func(ctx context.Context) {
+				f.It(testCase.description+"", f.WithNodeConformance(), f.WithDisruptive(), f.WithSerial(), func(ctx context.Context) {
 					name := "image-pull-test"
 					container := node.ConformanceContainer{
 						PodClient: e2epod.NewPodClient(f),


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Fixes connectivity to e2e registry in node conformance tests.

#### Which issue(s) this PR is related to:
Related-to #https://github.com/kubernetes/kubernetes/issues/134998

#### Special notes for your reviewer:
This is based on @carlory's ideas and testing, only instead of waiting longer for the cached creds to expire, kubelet is restarted.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/cc @BenTheElder @SergeyKanzhelev @aramase @carlory 
