### PR TITLE
kube-proxy/winkernel: fix stale RemoteEndpoints due to premature clearing of terminatedEndpoints map

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -405,7 +405,7 @@ func (proxier *Proxier) updateTerminatedEndpoints(eps []proxy.Endpoint, isOldEnd
 func (proxier *Proxier) endpointsMapChange(oldEndpointsMap, newEndpointsMap proxy.EndpointsMap) {
 	// This will optimize remote endpoint and loadbalancer deletion based on the annotation
 	var svcPortMap = make(map[proxy.ServicePortName]bool)
-	clear(proxier.terminatedEndpoints)
+
 	var logLevel klog.Level = 5
 	for svcPortName, eps := range oldEndpointsMap {
 		logFormattedEndpoints("endpointsMapChange oldEndpointsMap", logLevel, svcPortName, eps)
@@ -1233,6 +1233,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		return
 	}
 
+	// Clear terminated endpoints map
+	clear(proxier.terminatedEndpoints)
+
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
@@ -1784,10 +1787,11 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		klog.V(5).InfoS("Terminated endpoints ready for deletion", "epIP", epIP)
 		if epToDelete := queriedEndpoints[epIP]; epToDelete != nil && epToDelete.hnsID != "" && !epToDelete.IsLocal() {
 			if refCount := proxier.endPointsRefCount.getRefCount(epToDelete.hnsID); refCount == nil || *refCount == 0 {
-				klog.V(3).InfoS("Deleting unreferenced remote endpoint", "hnsID", epToDelete.hnsID, "IP", epToDelete.ip)
 				err := proxier.hns.deleteEndpoint(epToDelete.hnsID)
 				if err != nil {
 					klog.ErrorS(err, "Deleting unreferenced remote endpoint failed", "hnsID", epToDelete.hnsID)
+				} else {
+					klog.V(3).InfoS("Deleting unreferenced remote endpoint succeeded", "hnsID", epToDelete.hnsID, "IP", epToDelete.ip)
 				}
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The winkernel proxier maintains a map of terminated endpoints that is updated
in `endpointsMapChange()`. This information is used to delete the remote endpoints after the required loadbalancers are updated/deleted. When multiple Services are updated in batch during a
single `syncProxyRules()` call, `endpointsMapChange()` is invoked multiple times.
Each invocation currently clears the `terminatedEndpoints `map, causing data from
previous updates to be lost.

This results in incomplete cleanup and stale RemoteEndpoints when Deployments
are referenced by multiple Services at large scale.

**Fix**
Move the `clearTerminatedEndpointsMap()` invocation to occur before:

```
_ = proxier.svcPortMap.Update(proxier.serviceChanges)
_ = proxier.endpointsMap.Update(proxier.endpointsChanges)
```

This ensures the map is cleared only once at the beginning of `syncProxyRules()`
and remains valid throughout the update process.

#### Which issue(s) this PR is related to:
Fixes #135144

#### Special notes for your reviewer:
- Reproducible on large AKS clusters using Windows kube-proxy.
- Tested with multiple Services referencing the same Deployment.
- Verified that stale RemoteEndpoints no longer persist after Deployment deletion.

#### Does this PR introduce a user-facing change?
```release-note
Fix Windows kube-proxy (winkernel) issue where stale RemoteEndpoints remained
when a Deployment was referenced by multiple Services due to premature clearing
of the terminatedEndpoints map.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
