### PR TITLE
kubeadm: add --allow-deprecated-api to 'config validate'

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -311,7 +311,7 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 // newCmdConfigValidate returns cobra.Command for the "kubeadm config validate" command
 func newCmdConfigValidate(out io.Writer) *cobra.Command {
 	var cfgPath string
-	var allowExperimental bool
+	var allowDeprecated, allowExperimental bool
 
 	cmd := &cobra.Command{
 		Use:   "validate",
@@ -336,7 +336,7 @@ func newCmdConfigValidate(out io.Writer) *cobra.Command {
 				return err
 			}
 
-			if err := configutil.ValidateConfig(cfgBytes, allowExperimental); err != nil {
+			if err := configutil.ValidateConfig(cfgBytes, allowDeprecated, allowExperimental); err != nil {
 				return err
 			}
 			fmt.Fprintln(out, "ok")
@@ -346,6 +346,7 @@ func newCmdConfigValidate(out io.Writer) *cobra.Command {
 		Args: cobra.NoArgs,
 	}
 	options.AddConfigFlag(cmd.Flags(), &cfgPath)
+	cmd.Flags().BoolVar(&allowDeprecated, options.AllowDeprecatedAPI, false, "Allow validation of deprecated APIs.")
 	cmd.Flags().BoolVar(&allowExperimental, options.AllowExperimentalAPI, false, "Allow validation of experimental, unreleased APIs.")
 	return cmd
 }

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -143,6 +143,9 @@ const (
 	// CleanupTmpDir flag indicates whether reset will cleanup the tmp dir
 	CleanupTmpDir = "cleanup-tmp-dir"
 
+	// AllowDeprecatedAPI flag can be used to allow deprecated APIs
+	AllowDeprecatedAPI = "allow-deprecated-api"
+
 	// AllowExperimentalAPI flag can be used to allow experimental / work in progress APIs
 	AllowExperimentalAPI = "allow-experimental-api"
 

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -726,7 +726,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ValidateConfig([]byte(test.cfg), test.allowExperimental)
+			err := ValidateConfig([]byte(test.cfg), true, test.allowExperimental)
 			if (err != nil) != test.expectedError {
 				t.Fatalf("expected error: %v, got: %v, error: %v", test.expectedError, (err != nil), err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug feature

#### What this PR does / why we need it:

The command can have this additional flag so that a warning is printed or not printed when a deprecated API is validated.

Additionally, this commit fixes missing UpgradeConfiguration validation and strict errors. By default we call:
  documentMapToUpgradeConfiguration(gvkmap, false, false, false)

so there is no change in behavior outside of
'config migrate/validate'.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: added the flag --allow-deprecated-api to 'kubeadm config validate'. By default the command will print a warning for a deprecated API unless the flag is passed. Additionally, added missing support for v1beta4 UpgradeConfiguration to 'kubeadm config migrate|validate' commands.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
