### PR TITLE
kubelet: delay looking up pod image pull credentials until necessary

### DIFF
--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -734,9 +734,14 @@ type mockImagePullManager struct {
 	config *mockImagePullManagerConfig
 }
 
-func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, _ string, podSecrets []kubeletconfiginternal.ImagePullSecret, podServiceAccount *kubeletconfiginternal.ImagePullServiceAccount) bool {
+func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, _ string, getPodCredentials pullmanager.GetPodCredentials) (bool, error) {
 	if m.config == nil || m.config.allowAll {
-		return false
+		return false, nil
+	}
+
+	podSecrets, podServiceAccount, err := getPodCredentials()
+	if err != nil {
+		return true, err
 	}
 
 	// Check secrets
@@ -744,7 +749,7 @@ func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, 
 		for _, s := range podSecrets {
 			for _, allowed := range allowedSecrets {
 				if s.Namespace == allowed.Namespace && s.Name == allowed.Name && s.UID == allowed.UID {
-					return false
+					return false, nil
 				}
 			}
 		}
@@ -754,12 +759,12 @@ func (m *mockImagePullManager) MustAttemptImagePull(ctx context.Context, image, 
 	if podServiceAccount != nil {
 		if allowedServiceAccounts, ok := m.config.allowedServiceAccounts[image]; ok {
 			if slices.Contains(allowedServiceAccounts, *podServiceAccount) {
-				return false
+				return false, nil
 			}
 		}
 	}
 
-	return true
+	return true, nil
 }
 
 // mockImagePullManagerWithTracking tracks calls to MustAttemptImagePull for service account testing
@@ -776,19 +781,25 @@ type mockImagePullManagerWithTracking struct {
 	recordedCredentials *kubeletconfiginternal.ImagePullCredentials
 }
 
-func (m *mockImagePullManagerWithTracking) MustAttemptImagePull(ctx context.Context, image, imageRef string, podSecrets []kubeletconfiginternal.ImagePullSecret, podServiceAccount *kubeletconfiginternal.ImagePullServiceAccount) bool {
+func (m *mockImagePullManagerWithTracking) MustAttemptImagePull(ctx context.Context, image, imageRef string, getPodCredentials pullmanager.GetPodCredentials) (bool, error) {
 	m.mustAttemptCalled = true
 	m.lastImage = image
 	m.lastImageRef = imageRef
+
+	podSecrets, podServiceAccount, err := getPodCredentials()
+	if err != nil {
+		return true, err
+	}
+
 	m.lastSecrets = podSecrets
 	if podServiceAccount != nil {
 		m.lastServiceAccounts = []kubeletconfiginternal.ImagePullServiceAccount{*podServiceAccount}
 	}
 
 	if m.allowAll {
-		return false
+		return false, nil
 	}
-	return m.mustAttemptReturn
+	return m.mustAttemptReturn, nil
 }
 
 func (m *mockImagePullManagerWithTracking) RecordImagePulled(ctx context.Context, image, imageRef string, credentials *kubeletconfiginternal.ImagePullCredentials) {

--- a/pkg/kubelet/images/pullmanager/benchmarks_test.go
+++ b/pkg/kubelet/images/pullmanager/benchmarks_test.go
@@ -74,9 +74,11 @@ func directRecordReadFunc(expectHit bool) benchmarkedCheckFunc {
 func mustAttemptPullReadFunc(expectHit bool) benchmarkedCheckFunc {
 	return func(b *testing.B, pullManager PullManager, imgRef string) {
 		tCtx := ktesting.Init(b)
-		mustPull := pullManager.MustAttemptImagePull(tCtx, "test.repo/org/"+imgRef, imgRef, nil, nil)
-		if mustPull != !expectHit {
-			b.Fatalf("MustAttemptImagePull() expected %t, got %t", !expectHit, mustPull)
+		mustPull, err := pullManager.MustAttemptImagePull(tCtx, "test.repo/org/"+imgRef, imgRef, func() ([]kubeletconfig.ImagePullSecret, *kubeletconfig.ImagePullServiceAccount, error) {
+			return nil, nil, nil
+		})
+		if mustPull != !expectHit || err != nil {
+			b.Fatalf("no error expected (got %v); MustAttemptImagePull() expected %t, got %t", err, !expectHit, mustPull)
 		}
 	}
 }

--- a/pkg/kubelet/images/pullmanager/image_pull_manager.go
+++ b/pkg/kubelet/images/pullmanager/image_pull_manager.go
@@ -182,9 +182,9 @@ func (f *PullManager) decrementImagePullIntent(ctx context.Context, image string
 	f.decrementIntentCounterForImage(image)
 }
 
-func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef string, podSecrets []kubeletconfiginternal.ImagePullSecret, podServiceAccount *kubeletconfiginternal.ImagePullServiceAccount) bool {
+func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef string, getPodCredentials GetPodCredentials) (bool, error) {
 	if len(imageRef) == 0 {
-		return true
+		return true, nil
 	}
 	logger := klog.FromContext(ctx)
 
@@ -238,42 +238,49 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 	if err != nil {
 		resultForMetrics = checkResultError
 		logger.Error(err, "Unable to access cache records about image pulls")
-		return true
+		return true, nil
 	}
 
 	if !f.imagePolicyEnforcer.RequireCredentialVerificationForImage(image, imagePulledByKubelet) {
 		resultForMetrics = checkResultCredentialPolicyAllowed
-		return false
+		return false, nil
 	}
 
 	if pulledRecord == nil {
 		// we have no proper records of the image being pulled in the past, we can short-circuit here
 		resultForMetrics = checkResultMustAuthenticate
-		return true
+		return true, nil
 	}
 
 	sanitizedImage, err := trimImageTagDigest(image)
 	if err != nil {
 		resultForMetrics = checkResultError
 		logger.Error(err, "failed to parse image name, forcing image credentials reverification", "image", sanitizedImage)
-		return true
+		return true, nil
 	}
 
 	cachedCreds, ok := pulledRecord.CredentialMapping[sanitizedImage]
 	if !ok {
 		resultForMetrics = checkResultMustAuthenticate
-		return true
+		return true, nil
 	}
 
 	if cachedCreds.NodePodsAccessible {
 		// anyone on this node can access the image
 		resultForMetrics = checkResultCredentialRecordFound
-		return false
+		return false, nil
 	}
 
 	if len(cachedCreds.KubernetesSecrets) == 0 && len(cachedCreds.KubernetesServiceAccounts) == 0 {
 		resultForMetrics = checkResultMustAuthenticate
-		return true
+		return true, nil
+	}
+
+	podSecrets, podServiceAccount, err := getPodCredentials()
+	if err != nil {
+		resultForMetrics = checkResultError
+		logger.Error(err, "failed to retrieve credentials for the image pull")
+		return true, err
 	}
 
 	for _, podSecret := range podSecrets {
@@ -295,7 +302,7 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 					}
 				}
 				resultForMetrics = checkResultCredentialRecordFound
-				return false
+				return false, nil
 			}
 
 			if secretCoordinatesMatch {
@@ -307,7 +314,7 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 						logger.Error(err, "failed to write an image pulled record", "image", image, "imageRef", imageRef)
 					}
 					resultForMetrics = checkResultCredentialRecordFound
-					return false
+					return false, nil
 				}
 			}
 		}
@@ -316,11 +323,11 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 	if podServiceAccount != nil && slices.Contains(cachedCreds.KubernetesServiceAccounts, *podServiceAccount) {
 		// we found a matching service account, no need to pull the image
 		resultForMetrics = checkResultCredentialRecordFound
-		return false
+		return false, nil
 	}
 
 	resultForMetrics = checkResultMustAuthenticate
-	return true
+	return true, nil
 }
 
 func (f *PullManager) PruneUnknownRecords(ctx context.Context, imageList []string, until time.Time) {

--- a/pkg/kubelet/images/pullmanager/metrics_test.go
+++ b/pkg/kubelet/images/pullmanager/metrics_test.go
@@ -200,39 +200,64 @@ func TestMustAttemptPullMetrics(t *testing.T) {
 	})
 
 	expectedMetrics := make(map[string]int)
-	require.True(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/broken", "testbrokenrecord", nil, nil))
+	mustPull, err := imageManager.MustAttemptImagePull(ctx, "docker.io/testing/broken", "testbrokenrecord", nil)
+	require.NoError(t, err)
+	require.True(t, mustPull)
 	expectedMetrics[string(checkResultError)]++
 	cmpMustAttemptPullMetrics(t, expectedMetrics)
 
-	require.True(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/broken", "testbrokenrecord", nil, nil))
-	require.True(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/broken", "testbrokenrecord", nil, nil))
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/broken", "testbrokenrecord", nil)
+	require.NoError(t, err)
+	require.True(t, mustPull)
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/broken", "testbrokenrecord", nil)
+	require.NoError(t, err)
+	require.True(t, mustPull)
 	expectedMetrics[string(checkResultError)] += 2
 
-	require.False(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil, nil))
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil)
+	require.NoError(t, err)
+	require.False(t, mustPull)
 	expectedMetrics[string(checkResultCredentialRecordFound)]++
 	cmpMustAttemptPullMetrics(t, expectedMetrics)
 
-	require.False(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil, nil))
-	require.False(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil, nil))
-	require.False(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil, nil))
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil)
+	require.NoError(t, err)
+	require.False(t, mustPull)
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil)
+	require.NoError(t, err)
+	require.False(t, mustPull)
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimage-anonpull", nil)
+	require.NoError(t, err)
+	require.False(t, mustPull)
 	expectedMetrics[string(checkResultCredentialRecordFound)] += 3
 	cmpMustAttemptPullMetrics(t, expectedMetrics)
 
-	require.False(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/policyexempt", "policyallowed", nil, nil))
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/policyexempt", "policyallowed", nil)
+	require.NoError(t, err)
+	require.False(t, mustPull)
 	expectedMetrics[string(checkResultCredentialPolicyAllowed)]++
 	cmpMustAttemptPullMetrics(t, expectedMetrics)
 
-	require.False(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/policyexempt", "policyallowed", nil, nil))
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/policyexempt", "policyallowed", nil)
+	require.NoError(t, err)
+	require.False(t, mustPull)
 	expectedMetrics[string(checkResultCredentialPolicyAllowed)]++
 	cmpMustAttemptPullMetrics(t, expectedMetrics)
 
-	require.True(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/norecords", "somewhatunknown", nil, nil))
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/norecords", "somewhatunknown", nil)
+	require.NoError(t, err)
+	require.True(t, mustPull)
 	expectedMetrics[string(checkResultMustAuthenticate)]++
 	cmpMustAttemptPullMetrics(t, expectedMetrics)
 
-	require.False(t, imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimageref", []kubeletconfig.ImagePullSecret{
-		{UID: "testsecretuid", Namespace: "default", Name: "pull-secret", CredentialHash: "testsecrethash"},
-	}, nil))
+	mustPull, err = imageManager.MustAttemptImagePull(ctx, "docker.io/testing/test", "testimageref",
+		func() ([]kubeletconfig.ImagePullSecret, *kubeletconfig.ImagePullServiceAccount, error) {
+			return []kubeletconfig.ImagePullSecret{
+				{UID: "testsecretuid", Namespace: "default", Name: "pull-secret", CredentialHash: "testsecrethash"},
+			}, nil, nil
+		})
+	require.NoError(t, err)
+	require.False(t, mustPull)
 	expectedMetrics[string(checkResultCredentialRecordFound)]++
 	cmpMustAttemptPullMetrics(t, expectedMetrics)
 }

--- a/pkg/kubelet/images/pullmanager/noop_pull_manager.go
+++ b/pkg/kubelet/images/pullmanager/noop_pull_manager.go
@@ -31,7 +31,7 @@ func (m *NoopImagePullManager) RecordPullIntent(string) error { return nil }
 func (m *NoopImagePullManager) RecordImagePulled(context.Context, string, string, *kubeletconfiginternal.ImagePullCredentials) {
 }
 func (m *NoopImagePullManager) RecordImagePullFailed(context.Context, string) {}
-func (m *NoopImagePullManager) MustAttemptImagePull(context.Context, string, string, []kubeletconfiginternal.ImagePullSecret, *kubeletconfiginternal.ImagePullServiceAccount) bool {
-	return false
+func (m *NoopImagePullManager) MustAttemptImagePull(context.Context, string, string, GetPodCredentials) (bool, error) {
+	return false, nil
 }
 func (m *NoopImagePullManager) PruneUnknownRecords(context.Context, []string, time.Time) {}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This is a rebase of https://github.com/kubernetes/kubernetes/pull/133114 on current master after metrics were added to `EnsureImageExists()` in https://github.com/kubernetes/kubernetes/pull/132644.

Examples:
Related-to PR https://github.com/kubernetes/kubernetes/pull/133114

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet now performs image pull credentials lookups lazily with the `KubeletEnsureSecretPulledImages` featuregate enabled to prevent unnecessary credential lookups.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
