### PR TITLE
mark device manager as haelthy before it started for the first time

### DIFF
--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
@@ -57,8 +57,8 @@ type server struct {
 	chandler   ClientHandler
 	clients    map[string]Client
 
-	// isStarted indicates whether the service has started successfully.
-	isStarted bool
+	// lastError records the last runtime error. A server is considered healthy till an actual error occurs.
+	lastError error
 
 	api.UnsafeRegistrationServer
 }
@@ -119,7 +119,7 @@ func (s *server) Start(logger klog.Logger) error {
 		defer s.wg.Done()
 		s.setHealthy()
 		if err = s.grpc.Serve(ln); err != nil {
-			s.setUnhealthy()
+			s.setUnhealthy(err)
 			logger.Error(err, "Error while serving device plugin registration grpc server")
 		}
 	}()
@@ -211,18 +211,19 @@ func (s *server) Name() string {
 }
 
 func (s *server) Check(_ *http.Request) error {
-	if s.isStarted {
-		return nil
-	}
-	return fmt.Errorf("device plugin registration gRPC server failed and no device plugins can register")
+	return s.lastError
 }
 
 // setHealthy sets the health status of the gRPC server.
 func (s *server) setHealthy() {
-	s.isStarted = true
+	s.lastError = nil
 }
 
 // setUnhealthy sets the health status of the gRPC server to unhealthy.
-func (s *server) setUnhealthy() {
-	s.isStarted = false
+func (s *server) setUnhealthy(err error) {
+	if err == nil {
+		s.lastError = fmt.Errorf("device registration error: device plugin registration gRPC server failed and no device plugins can register")
+		return
+	}
+	s.lastError = fmt.Errorf("device registration error: device plugin registration gRPC server failed and no device plugins can register: %w", err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Device manger health checking should not fail before it fully started.

Related to #135113

This PR doesn't have tests to discuss the fix. Also it may be simpler to cherry-pick when it is smaller

#### Does this PR introduce a user-facing change?
```release-note
The slow initialization of container runtime will not cause System WatchDog to kill kubelet. Device Manager is not considered healthy before it attempted to start listening on the port. 
```
