### PR TITLE
Fix NPE in CEL schema wrappers of additionalProperties=true objects

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/adaptor.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/adaptor.go
@@ -36,6 +36,9 @@ type SchemaOrBool struct {
 }
 
 func (sb *SchemaOrBool) Schema() common.Schema {
+	if sb.SchemaOrBool.Schema == nil {
+		return nil
+	}
 	return &Schema{Schema: sb.SchemaOrBool.Schema}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/schemas_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/schemas_test.go
@@ -30,6 +30,33 @@ import (
 )
 
 func TestSchemaDeclType(t *testing.T) {
+	t.Run("a schema with additionalProperties: true should be an valid object type", func(t *testing.T) {
+		schema := &spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"foo": {
+						SchemaProps: spec.SchemaProps{
+							Type:                 []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{Allows: true},
+						},
+					},
+				},
+			},
+		}
+		declType := SchemaDeclType(schema, false)
+		if declType == nil {
+			t.Fatal("SchemaDeclType returned nil")
+		}
+		fooField, found := declType.FindField("foo")
+		if !found {
+			t.Fatal("field 'foo' not found")
+		}
+		fooType := fooField.Type
+		if fooType.TypeName() != "object" {
+			t.Fatalf("expected foo to be a object, but got %s", fooType.TypeName())
+		}
+	})
 	ts := testSchema()
 	cust := SchemaDeclType(ts, false)
 	if cust.TypeName() != "object" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes an kube-controller-manager crash.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/135145

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix bug in ValidatingAdmissionPolicy where a object schema with additionalProperties:true would crash the kube-controller-manager with a nil pointer exception.
```
