### PR TITLE
support multi conditions in apicall

### DIFF
--- a/pkg/scheduler/backend/api_cache/api_cache.go
+++ b/pkg/scheduler/backend/api_cache/api_cache.go
@@ -41,8 +41,8 @@ func New(schedulingQueue internalqueue.SchedulingQueue, cache internalcache.Cach
 // PatchPodStatus sends a patch request for a Pod's status through a scheduling queue.
 // The patch could be first applied to the cached Pod object and then the API call is executed asynchronously.
 // It returns a channel that can be used to wait for the call's completion.
-func (c *APICache) PatchPodStatus(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error) {
-	return c.schedulingQueue.PatchPodStatus(pod, condition, nominatingInfo)
+func (c *APICache) PatchPodStatus(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error) {
+	return c.schedulingQueue.PatchPodStatus(pod, conditions, nominatingInfo)
 }
 
 // BindPod sends a binding request through a cache. The binding could be first applied to the cached Pod object

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -131,7 +131,7 @@ type SchedulingQueue interface {
 
 	// PatchPodStatus handles the pod status update by sending an update API call through API dispatcher.
 	// This method should be used only if the SchedulerAsyncAPICalls feature gate is enabled.
-	PatchPodStatus(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error)
+	PatchPodStatus(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error)
 
 	// The following functions are supposed to be used only for testing or debugging.
 	GetPod(name, namespace string) (*framework.QueuedPodInfo, bool)
@@ -1360,10 +1360,10 @@ func (p *PriorityQueue) PendingPods() ([]*v1.Pod, string) {
 
 // PatchPodStatus handles the pod status update by sending an update API call through API dispatcher.
 // This method should be used only if the SchedulerAsyncAPICalls feature gate is enabled.
-func (p *PriorityQueue) PatchPodStatus(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error) {
+func (p *PriorityQueue) PatchPodStatus(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error) {
 	// Don't store anything in the cache. This might be extended in the next releases.
 	onFinish := make(chan error, 1)
-	err := p.apiDispatcher.Add(apicalls.Implementations.PodStatusPatch(pod, condition, nominatingInfo), fwk.APICallOptions{
+	err := p.apiDispatcher.Add(apicalls.Implementations.PodStatusPatch(pod, conditions, nominatingInfo), fwk.APICallOptions{
 		OnFinish: onFinish,
 	})
 	if fwk.IsUnexpectedError(err) {

--- a/pkg/scheduler/framework/api_calls/pod_status_patch.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch.go
@@ -130,7 +130,7 @@ func (psuc *PodStatusPatchCall) Sync(obj metav1.Object) (metav1.Object, error) {
 		return obj, fmt.Errorf("unexpected error: object of type %T is not of type *v1.Pod", obj)
 	}
 
-	newConditions := []*v1.PodCondition{}
+	var newConditions []*v1.PodCondition
 	psuc.lock.Lock()
 	if !psuc.executed {
 		// Set podStatus only if the call execution haven't started yet,

--- a/pkg/scheduler/framework/api_calls/pod_status_patch.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch.go
@@ -68,7 +68,7 @@ func (psuc *PodStatusPatchCall) UID() types.UID {
 	return psuc.podUID
 }
 
-// syncStatus syncs the given status with condition and nominatingInfo. It returns true if anything was actually updated.
+// syncStatus syncs the given status with conditions and nominatingInfo. It returns true if anything was actually updated.
 func syncStatus(status *v1.PodStatus, condition []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) bool {
 	nnnNeedsUpdate := nominatingInfo.Mode() == fwk.ModeOverride && status.NominatedNodeName != nominatingInfo.NominatedNodeName
 	if len(condition) > 0 {

--- a/pkg/scheduler/framework/api_calls/pod_status_patch.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch.go
@@ -71,18 +71,14 @@ func (psuc *PodStatusPatchCall) UID() types.UID {
 // syncStatus syncs the given status with conditions and nominatingInfo. It returns true if anything was actually updated.
 func syncStatus(status *v1.PodStatus, condition []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) bool {
 	nnnNeedsUpdate := nominatingInfo.Mode() == fwk.ModeOverride && status.NominatedNodeName != nominatingInfo.NominatedNodeName
-	if len(condition) > 0 {
-		anyUpdated := false
-		for _, cond := range condition {
-			updated := podutil.UpdatePodCondition(status, cond)
-			if updated {
-				anyUpdated = true
-			}
+	anyUpdated := false
+	for _, cond := range condition {
+		updated := podutil.UpdatePodCondition(status, cond)
+		if updated {
+			anyUpdated = true
 		}
-		if !anyUpdated && !nnnNeedsUpdate {
-			return false
-		}
-	} else if !nnnNeedsUpdate {
+	}
+	if !anyUpdated && !nnnNeedsUpdate {
 		return false
 	}
 	if nnnNeedsUpdate {
@@ -162,10 +158,9 @@ func (psuc *PodStatusPatchCall) Merge(oldCall fwk.APICall) error {
 	}
 	for _, cond := range oldPsuc.newConditions {
 		found := false
-		for i, newCond := range psuc.newConditions {
+		for _, newCond := range psuc.newConditions {
 			if newCond.Type == cond.Type {
 				found = true
-				psuc.newConditions[i] = cond
 				break
 			}
 		}

--- a/pkg/scheduler/framework/api_calls/pod_status_patch.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch.go
@@ -126,20 +126,20 @@ func (psuc *PodStatusPatchCall) Sync(obj metav1.Object) (metav1.Object, error) {
 		return obj, fmt.Errorf("unexpected error: object of type %T is not of type *v1.Pod", obj)
 	}
 
-	var newConditions []*v1.PodCondition
 	psuc.lock.Lock()
 	if !psuc.executed {
 		// Set podStatus only if the call execution haven't started yet,
 		// because otherwise it's irrelevant and might race.
 		psuc.podStatus = pod.Status.DeepCopy()
 	}
+	newConditions := make([]*v1.PodCondition, 0, len(psuc.newConditions))
 	for _, condition := range psuc.newConditions {
 		newConditions = append(newConditions, condition.DeepCopy())
 	}
 	psuc.lock.Unlock()
 
 	podCopy := pod.DeepCopy()
-	// Sync status to have the condition and nominatingInfo applied on a podStatusCopy.
+	// Sync status to have the condition and nominatingInfo applied on a podCopy.
 	anySynced := syncStatus(&podCopy.Status, newConditions, psuc.nominatingInfo)
 	if !anySynced {
 		return pod, nil

--- a/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
@@ -47,49 +47,49 @@ func TestPodStatusPatchCall_IsNoOp(t *testing.T) {
 	tests := []struct {
 		name           string
 		pod            *v1.Pod
-		condition      *v1.PodCondition
+		conditions     []*v1.PodCondition
 		nominatingInfo *fwk.NominatingInfo
 		want           bool
 	}{
 		{
 			name:           "No-op when condition and node name match",
 			pod:            podWithNode,
-			condition:      &v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionFalse},
+			conditions:     []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
 			want:           true,
 		},
 		{
 			name:           "Not no-op when condition is different",
 			pod:            podWithNode,
-			condition:      &v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionTrue},
+			conditions:     []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
 			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
 			want:           false,
 		},
 		{
 			name:           "Not no-op when nominated node name is different",
 			pod:            podWithNode,
-			condition:      &v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionFalse},
+			conditions:     []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride},
 			want:           false,
 		},
 		{
 			name:           "No-op when condition is nil and node name matches",
 			pod:            podWithNode,
-			condition:      nil,
+			conditions:     nil,
 			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
 			want:           true,
 		},
 		{
 			name:           "Not no-op when condition is nil but node name differs",
 			pod:            podWithNode,
-			condition:      nil,
+			conditions:     nil,
 			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride},
 			want:           false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			call := NewPodStatusPatchCall(test.pod, test.condition, test.nominatingInfo)
+			call := NewPodStatusPatchCall(test.pod, test.conditions, test.nominatingInfo)
 			if got := call.IsNoOp(); got != test.want {
 				t.Errorf("Expected IsNoOp() to return %v, but got %v", test.want, got)
 			}
@@ -105,7 +105,7 @@ func TestPodStatusPatchCall_Merge(t *testing.T) {
 	}
 
 	t.Run("Merges nominating info and condition from the old call", func(t *testing.T) {
-		oldCall := NewPodStatusPatchCall(pod, &v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionFalse},
+		oldCall := NewPodStatusPatchCall(pod, []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 			&fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
 		)
 		newCall := NewPodStatusPatchCall(pod, nil, &fwk.NominatingInfo{NominatingMode: fwk.ModeNoop})
@@ -116,14 +116,14 @@ func TestPodStatusPatchCall_Merge(t *testing.T) {
 		if newCall.nominatingInfo.NominatedNodeName != "node-a" {
 			t.Errorf("Expected NominatedNodeName to be node-a, but got: %v", newCall.nominatingInfo.NominatedNodeName)
 		}
-		if newCall.newCondition == nil || newCall.newCondition.Type != v1.PodScheduled {
-			t.Errorf("Expected PodScheduled condition, but got: %v", newCall.newCondition)
+		if len(newCall.newConditions) == 0 || newCall.newConditions[0].Type != v1.PodScheduled {
+			t.Errorf("Expected PodScheduled condition, but got: %v", newCall.newConditions)
 		}
 	})
 
 	t.Run("Doesn't overwrite nominating info and condition of a new call", func(t *testing.T) {
 		oldCall := NewPodStatusPatchCall(pod, nil, &fwk.NominatingInfo{NominatingMode: fwk.ModeNoop})
-		newCall := NewPodStatusPatchCall(pod, &v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionFalse},
+		newCall := NewPodStatusPatchCall(pod, []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 			&fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride})
 
 		if err := newCall.Merge(oldCall); err != nil {
@@ -132,8 +132,8 @@ func TestPodStatusPatchCall_Merge(t *testing.T) {
 		if newCall.nominatingInfo.NominatedNodeName != "node-b" {
 			t.Errorf("Expected NominatedNodeName to be node-b, but got: %v", newCall.nominatingInfo.NominatedNodeName)
 		}
-		if newCall.newCondition == nil || newCall.newCondition.Type != v1.PodScheduled {
-			t.Errorf("Expected PodScheduled condition, but got: %v", newCall.newCondition)
+		if len(newCall.newConditions) == 0 || newCall.newConditions[0].Type != v1.PodScheduled {
+			t.Errorf("Expected PodScheduled condition, but got: %v", newCall.newConditions)
 		}
 	})
 }
@@ -217,7 +217,7 @@ func TestPodStatusPatchCall_Execute(t *testing.T) {
 			return true, nil, nil
 		})
 
-		call := NewPodStatusPatchCall(pod, &v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionFalse},
+		call := NewPodStatusPatchCall(pod, []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 			&fwk.NominatingInfo{NominatingMode: fwk.ModeNoop})
 		if err := call.Execute(ctx, client); err != nil {
 			t.Fatalf("Unexpected error returned by Execute(): %v", err)

--- a/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
@@ -137,14 +137,14 @@ func TestPodStatusPatchCall_Merge(t *testing.T) {
 		}
 	})
 
-	t.Run("Doesn't overwrite nominating info and condition of a old call", func(t *testing.T) {
+	t.Run("Overwrite nominating info and condition of a old call", func(t *testing.T) {
 		oldCall := NewPodStatusPatchCall(pod, []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}}, nil)
 		newCall := NewPodStatusPatchCall(pod, []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}, {Type: v1.PodInitialized, Status: v1.ConditionTrue}}, nil)
 
 		if err := newCall.Merge(oldCall); err != nil {
 			t.Fatalf("Unexpected error returned by Merge(): %v", err)
 		}
-		if newCall.newConditions[0].Type != v1.PodScheduled || newCall.newConditions[0].Status != v1.ConditionFalse {
+		if newCall.newConditions[0].Type != v1.PodScheduled || newCall.newConditions[0].Status != v1.ConditionTrue {
 			t.Errorf("Expected PodScheduled condition, but got: %v", newCall.newConditions)
 		}
 		if newCall.newConditions[1].Type != v1.PodInitialized || newCall.newConditions[1].Status != v1.ConditionTrue {

--- a/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
@@ -19,6 +19,8 @@ package apicalls
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,6 +88,29 @@ func TestPodStatusPatchCall_IsNoOp(t *testing.T) {
 			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride},
 			want:           false,
 		},
+		{
+			name:           "Not no-op when any of multiple conditions differ",
+			pod:            podWithNode,
+			conditions:     []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}, {Type: v1.PodInitialized, Status: v1.ConditionTrue}},
+			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
+			want:           false,
+		},
+		{
+			name: "No-op when multiple conditions all match",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{UID: "uid"},
+				Status: v1.PodStatus{
+					NominatedNodeName: "node-a",
+					Conditions: []v1.PodCondition{
+						{Type: v1.PodScheduled, Status: v1.ConditionFalse},
+						{Type: v1.PodInitialized, Status: v1.ConditionTrue},
+					},
+				},
+			},
+			conditions:     []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}, {Type: v1.PodInitialized, Status: v1.ConditionTrue}},
+			nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
+			want:           true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -144,11 +169,31 @@ func TestPodStatusPatchCall_Merge(t *testing.T) {
 		if err := newCall.Merge(oldCall); err != nil {
 			t.Fatalf("Unexpected error returned by Merge(): %v", err)
 		}
-		if newCall.newConditions[0].Type != v1.PodScheduled || newCall.newConditions[0].Status != v1.ConditionTrue {
-			t.Errorf("Expected PodScheduled condition, but got: %v", newCall.newConditions)
+		expectedConditions := []*v1.PodCondition{
+			{Type: v1.PodScheduled, Status: v1.ConditionTrue},
+			{Type: v1.PodInitialized, Status: v1.ConditionTrue},
 		}
-		if newCall.newConditions[1].Type != v1.PodInitialized || newCall.newConditions[1].Status != v1.ConditionTrue {
-			t.Errorf("Expected PodScheduled condition, but got: %v", newCall.newConditions)
+		if diff := cmp.Diff(expectedConditions, newCall.newConditions); diff != "" {
+			t.Errorf("Unexpected conditions after merging (-want,+got):\n%s", diff)
+		}
+	})
+
+	t.Run("Merges condition from old call that new call doesn't have", func(t *testing.T) {
+		oldCall := NewPodStatusPatchCall(pod, []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
+			&fwk.NominatingInfo{NominatingMode: fwk.ModeNoop},
+		)
+		newCall := NewPodStatusPatchCall(pod, []*v1.PodCondition{{Type: v1.PodInitialized, Status: v1.ConditionTrue}},
+			&fwk.NominatingInfo{NominatingMode: fwk.ModeNoop})
+
+		if err := newCall.Merge(oldCall); err != nil {
+			t.Fatalf("Unexpected error returned by Merge(): %v", err)
+		}
+		expectedConditions := []*v1.PodCondition{
+			{Type: v1.PodInitialized, Status: v1.ConditionTrue},
+			{Type: v1.PodScheduled, Status: v1.ConditionFalse},
+		}
+		if diff := cmp.Diff(expectedConditions, newCall.newConditions); diff != "" {
+			t.Errorf("Unexpected conditions after merging (-want,+got):\n%s", diff)
 		}
 	})
 }
@@ -213,17 +258,17 @@ func TestPodStatusPatchCall_Sync(t *testing.T) {
 
 func TestSyncStatus(t *testing.T) {
 	tests := []struct {
-		name                    string
-		podStatusBefore         *v1.PodStatus
-		conditions              []*v1.PodCondition
-		nominatingInfo          *fwk.NominatingInfo
-		expectedResult          bool
-		expectedNominatedNode   string
-		expectedConditionStatus map[v1.PodConditionType]v1.ConditionStatus
+		name                  string
+		oldPodStatus          *v1.PodStatus
+		conditions            []*v1.PodCondition
+		nominatingInfo        *fwk.NominatingInfo
+		expectUpdated         bool
+		expectedNominatedNode string
+		expectedConditions    []v1.PodCondition
 	}{
 		{
 			name: "No changes needed - empty conditions and same node name",
-			podStatusBefore: &v1.PodStatus{
+			oldPodStatus: &v1.PodStatus{
 				NominatedNodeName: "node-a",
 				Conditions: []v1.PodCondition{
 					{
@@ -232,15 +277,15 @@ func TestSyncStatus(t *testing.T) {
 					},
 				},
 			},
-			conditions:              nil,
-			nominatingInfo:          &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
-			expectedResult:          false,
-			expectedNominatedNode:   "node-a",                                                                       // should remain unchanged
-			expectedConditionStatus: map[v1.PodConditionType]v1.ConditionStatus{v1.PodScheduled: v1.ConditionFalse}, // should remain unchanged
+			conditions:            nil,
+			nominatingInfo:        &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeOverride},
+			expectUpdated:         false,
+			expectedNominatedNode: "node-a",
+			expectedConditions:    []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 		},
 		{
 			name: "Condition needs update",
-			podStatusBefore: &v1.PodStatus{
+			oldPodStatus: &v1.PodStatus{
 				NominatedNodeName: "node-a",
 				Conditions: []v1.PodCondition{
 					{
@@ -249,15 +294,15 @@ func TestSyncStatus(t *testing.T) {
 					},
 				},
 			},
-			conditions:              []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
-			nominatingInfo:          &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeNoop},
-			expectedResult:          true,
-			expectedNominatedNode:   "node-a",                                                                      // should remain unchanged
-			expectedConditionStatus: map[v1.PodConditionType]v1.ConditionStatus{v1.PodScheduled: v1.ConditionTrue}, // should be updated
+			conditions:            []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
+			nominatingInfo:        &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeNoop},
+			expectUpdated:         true,
+			expectedNominatedNode: "node-a",
+			expectedConditions:    []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
 		},
 		{
 			name: "Nominated node name needs update",
-			podStatusBefore: &v1.PodStatus{
+			oldPodStatus: &v1.PodStatus{
 				NominatedNodeName: "node-a",
 				Conditions: []v1.PodCondition{
 					{
@@ -266,15 +311,15 @@ func TestSyncStatus(t *testing.T) {
 					},
 				},
 			},
-			conditions:              nil,
-			nominatingInfo:          &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride},
-			expectedResult:          true,
-			expectedNominatedNode:   "node-b",                                                                       // should be updated
-			expectedConditionStatus: map[v1.PodConditionType]v1.ConditionStatus{v1.PodScheduled: v1.ConditionFalse}, // should remain unchanged
+			conditions:            nil,
+			nominatingInfo:        &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride},
+			expectUpdated:         true,
+			expectedNominatedNode: "node-b",
+			expectedConditions:    []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 		},
 		{
 			name: "Both condition and node name need update",
-			podStatusBefore: &v1.PodStatus{
+			oldPodStatus: &v1.PodStatus{
 				NominatedNodeName: "node-a",
 				Conditions: []v1.PodCondition{
 					{
@@ -283,29 +328,29 @@ func TestSyncStatus(t *testing.T) {
 					},
 				},
 			},
-			conditions:              []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
-			nominatingInfo:          &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride},
-			expectedResult:          true,
-			expectedNominatedNode:   "node-b",                                                                      // should be updated
-			expectedConditionStatus: map[v1.PodConditionType]v1.ConditionStatus{v1.PodScheduled: v1.ConditionTrue}, // should be updated
+			conditions:            []*v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
+			nominatingInfo:        &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeOverride},
+			expectUpdated:         true,
+			expectedNominatedNode: "node-b",
+			expectedConditions:    []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
 		},
 		{
 			name: "Multiple conditions need update",
-			podStatusBefore: &v1.PodStatus{
+			oldPodStatus: &v1.PodStatus{
 				NominatedNodeName: "node-original",
 			},
 			conditions: []*v1.PodCondition{
 				{Type: v1.PodScheduled, Status: v1.ConditionTrue},
 				{Type: v1.ContainersReady, Status: v1.ConditionFalse},
 			},
-			nominatingInfo:          &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeNoop},
-			expectedResult:          true,
-			expectedNominatedNode:   "node-original",                                                                                                      // should remain unchanged because ModeNoop
-			expectedConditionStatus: map[v1.PodConditionType]v1.ConditionStatus{v1.PodScheduled: v1.ConditionTrue, v1.ContainersReady: v1.ConditionFalse}, // should be updated
+			nominatingInfo:        &fwk.NominatingInfo{NominatedNodeName: "node-a", NominatingMode: fwk.ModeNoop},
+			expectUpdated:         true,
+			expectedNominatedNode: "node-original",
+			expectedConditions:    []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}, {Type: v1.ContainersReady, Status: v1.ConditionFalse}},
 		},
 		{
 			name: "No-op nominating mode with different node name",
-			podStatusBefore: &v1.PodStatus{
+			oldPodStatus: &v1.PodStatus{
 				NominatedNodeName: "node-a",
 				Conditions: []v1.PodCondition{
 					{
@@ -314,40 +359,26 @@ func TestSyncStatus(t *testing.T) {
 					},
 				},
 			},
-			conditions:              nil,
-			nominatingInfo:          &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeNoop},
-			expectedResult:          false,
-			expectedNominatedNode:   "node-a",                                                                       // should remain unchanged
-			expectedConditionStatus: map[v1.PodConditionType]v1.ConditionStatus{v1.PodScheduled: v1.ConditionFalse}, // should remain unchanged
+			conditions:            nil,
+			nominatingInfo:        &fwk.NominatingInfo{NominatedNodeName: "node-b", NominatingMode: fwk.ModeNoop},
+			expectUpdated:         false,
+			expectedNominatedNode: "node-a",
+			expectedConditions:    []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			podStatus := test.podStatusBefore.DeepCopy()
+			podStatus := test.oldPodStatus.DeepCopy()
 			result := syncStatus(podStatus, test.conditions, test.nominatingInfo)
-			if result != test.expectedResult {
-				t.Errorf("Expected syncStatus to return %v, but got %v", test.expectedResult, result)
+			if result != test.expectUpdated {
+				t.Errorf("Expected syncStatus to return %v, but got %v", test.expectUpdated, result)
 			}
-			// Check if the nominated node name was updated correctly
 			if podStatus.NominatedNodeName != test.expectedNominatedNode {
 				t.Errorf("Expected NominatedNodeName to be %s, but got %s", test.expectedNominatedNode, podStatus.NominatedNodeName)
 			}
-			// Check if the conditions were updated correctly
-			for expectedType, expectedStatus := range test.expectedConditionStatus {
-				found := false
-				for _, condition := range podStatus.Conditions {
-					if condition.Type == expectedType {
-						found = true
-						if condition.Status != expectedStatus {
-							t.Errorf("Expected condition %s to have status %s, but got %s", expectedType, expectedStatus, condition.Status)
-						}
-						break
-					}
-				}
-				if !found {
-					t.Errorf("Expected condition %s not found in pod status", expectedType)
-				}
+			if diff := cmp.Diff(test.expectedConditions, podStatus.Conditions, cmpopts.IgnoreFields(v1.PodCondition{}, "LastTransitionTime", "LastProbeTime")); diff != "" {
+				t.Errorf("Unexpected conditions (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1142,7 +1142,11 @@ func truncateMessage(message string) string {
 func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.APICacher, pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) error {
 	if apiCacher != nil {
 		// When API cacher is available, use it to patch the status.
-		_, err := apiCacher.PatchPodStatus(pod, []*v1.PodCondition{condition}, nominatingInfo)
+		conditions := make([]*v1.PodCondition, 0)
+		if condition != nil {
+			conditions = append(conditions, condition)
+		}
+		_, err := apiCacher.PatchPodStatus(pod, conditions, nominatingInfo)
 		return err
 	}
 	logger := klog.FromContext(ctx)

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1142,9 +1142,9 @@ func truncateMessage(message string) string {
 func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.APICacher, pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) error {
 	if apiCacher != nil {
 		// When API cacher is available, use it to patch the status.
-		conditions := make([]*v1.PodCondition, 0)
+		var conditions []*v1.PodCondition
 		if condition != nil {
-			conditions = append(conditions, condition)
+			conditions = []*v1.PodCondition{condition}
 		}
 		_, err := apiCacher.PatchPodStatus(pod, conditions, nominatingInfo)
 		return err

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1142,7 +1142,7 @@ func truncateMessage(message string) string {
 func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.APICacher, pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) error {
 	if apiCacher != nil {
 		// When API cacher is available, use it to patch the status.
-		_, err := apiCacher.PatchPodStatus(pod, condition, nominatingInfo)
+		_, err := apiCacher.PatchPodStatus(pod, []*v1.PodCondition{condition}, nominatingInfo)
 		return err
 	}
 	logger := klog.FromContext(ctx)

--- a/staging/src/k8s.io/kube-scheduler/framework/api_calls.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/api_calls.go
@@ -31,7 +31,7 @@ type APICacher interface {
 	// PatchPodStatus sends a patch request for a Pod's status.
 	// The patch could be first applied to the cached Pod object and then the API call is executed asynchronously.
 	// It returns a channel that can be used to wait for the call's completion.
-	PatchPodStatus(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *NominatingInfo) (<-chan error, error)
+	PatchPodStatus(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *NominatingInfo) (<-chan error, error)
 
 	// BindPod sends a binding request. The binding could be first applied to the cached Pod object
 	// and then the API call is executed asynchronously.
@@ -51,7 +51,7 @@ type APICacher interface {
 // APICallImplementations define constructors for each APICall that is used by the scheduler internally.
 type APICallImplementations[T, K APICall] struct {
 	// PodStatusPatch is a constructor used to create APICall object for pod status patch.
-	PodStatusPatch func(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *NominatingInfo) T
+	PodStatusPatch func(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *NominatingInfo) T
 	// PodBinding is a constructor used to create APICall object for pod binding.
 	PodBinding func(binding *v1.Binding) K
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

As a kube-scheduler plugin developer, I have to update Pod conditions in my plugin. When multi conditions have to be updated, old api calls will be overwritten by the new api calls, so I want to update multi conditions in one API call.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#135159

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed the `PatchPodStatus` API in the scheduler framework to accept a slice of Pod conditions (`[]*v1.PodCondition`) instead of a single condition (`*v1.PodCondition`). This allows scheduler plugins to update multiple Pod conditions in a single API call, preventing newer calls from overwriting older ones when multiple conditions need to be updated concurrently.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
