### PR TITLE
fix sorting logic after after normalizing errors

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -66,17 +66,17 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old runtime.Object,
 					break
 				}
 			}
-			// Re-sort the error list based primarily on the normalized field paths
-			// to ensure errors align correctly during index-by-index comparison,
-			// regardless of their original structure.
-			sort.Slice(errs, func(i, j int) bool {
-				if errs[i].Field != errs[j].Field {
-					return errs[i].Field < errs[j].Field
-				}
-				// Secondary sort by full error string for determinism when fields are equal
-				return errs[i].Error() < errs[j].Error()
-			})
 		}
+		// Re-sort the error list based primarily on the normalized field paths
+		// to ensure errors align correctly during index-by-index comparison,
+		// regardless of their original structure.
+		sort.Slice(errs, func(i, j int) bool {
+			if errs[i].Field != errs[j].Field {
+				return errs[i].Field < errs[j].Field
+			}
+			// Secondary sort by full error string for determinism when fields are equal
+			return errs[i].Error() < errs[j].Error()
+		})
 		all[gv] = errs
 	}
 	// Convert versioned object to internal format before validation.


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
This PR fixes an issue where validation errors were not being sorted deterministically. This could cause flaky tests and make it difficult to compare error outputs. The change ensures that errors are always sorted in the same order, first by field path and then by error message.

**Which issue(s) this PR is related to:**
N/A

**Special notes for your reviewer:**
NONE

**Does this PR introduce a user-facing change?**
```release-note
NONE
```
