### PR TITLE
Automated cherry pick of #135146: kube-proxy/winkernel: fix stale RemoteEndpoints due to premature clearing of terminatedEndpoints map

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -405,7 +405,7 @@ func (proxier *Proxier) updateTerminatedEndpoints(eps []proxy.Endpoint, isOldEnd
 func (proxier *Proxier) endpointsMapChange(oldEndpointsMap, newEndpointsMap proxy.EndpointsMap) {
 	// This will optimize remote endpoint and loadbalancer deletion based on the annotation
 	var svcPortMap = make(map[proxy.ServicePortName]bool)
-	clear(proxier.terminatedEndpoints)
+
 	var logLevel klog.Level = 5
 	for svcPortName, eps := range oldEndpointsMap {
 		logFormattedEndpoints("endpointsMapChange oldEndpointsMap", logLevel, svcPortName, eps)
@@ -1233,6 +1233,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		return
 	}
 
+	// Clear terminated endpoints map
+	clear(proxier.terminatedEndpoints)
+
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
@@ -1784,10 +1787,11 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		klog.V(5).InfoS("Terminated endpoints ready for deletion", "epIP", epIP)
 		if epToDelete := queriedEndpoints[epIP]; epToDelete != nil && epToDelete.hnsID != "" && !epToDelete.IsLocal() {
 			if refCount := proxier.endPointsRefCount.getRefCount(epToDelete.hnsID); refCount == nil || *refCount == 0 {
-				klog.V(3).InfoS("Deleting unreferenced remote endpoint", "hnsID", epToDelete.hnsID, "IP", epToDelete.ip)
 				err := proxier.hns.deleteEndpoint(epToDelete.hnsID)
 				if err != nil {
 					klog.ErrorS(err, "Deleting unreferenced remote endpoint failed", "hnsID", epToDelete.hnsID)
+				} else {
+					klog.V(3).InfoS("Deleting unreferenced remote endpoint succeeded", "hnsID", epToDelete.hnsID, "IP", epToDelete.ip)
 				}
 			}
 		}


### PR DESCRIPTION
Cherry pick of #135146 on release-1.34.

/kind bug

#135146: kube-proxy/winkernel: fix stale RemoteEndpoints due to premature clearing of terminatedEndpoints map

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix Windows kube-proxy (winkernel) issue where stale RemoteEndpoints remained
when a Deployment was referenced by multiple Services due to premature clearing
of the terminatedEndpoints map.
```