### PR TITLE
kubelet: fix concurrent map write error when creating a pod with empty volume

### DIFF
--- a/pkg/volume/util/fsquota/quota_linux.go
+++ b/pkg/volume/util/fsquota/quota_linux.go
@@ -158,6 +158,12 @@ func clearMountpoint(path string) {
 	delete(mountpointMap, path)
 }
 
+func clearSupportsQuotas(path string) {
+	supportsQuotasLock.Lock()
+	defer supportsQuotasLock.Unlock()
+	delete(supportsQuotasMap, path)
+}
+
 // getFSInfo Returns mountpoint and backing device
 // getFSInfo should cache the mountpoint and backing device for the
 // path.
@@ -430,7 +436,7 @@ func ClearQuota(m mount.Interface, path string, userNamespacesEnabled bool) erro
 		// stale directory, so if we find a quota, just remove it.
 		// The process of clearing the quota requires that an applier
 		// be found, which needs to be cleaned up.
-		defer delete(supportsQuotasMap, path)
+		defer clearSupportsQuotas(path)
 		defer clearApplier(path)
 		return clearQuotaOnDir(m, path, userNamespacesEnabled)
 	}
@@ -467,7 +473,7 @@ func ClearQuota(m mount.Interface, path string, userNamespacesEnabled bool) erro
 	}
 	delete(dirPodMap, path)
 	delete(dirQuotaMap, path)
-	delete(supportsQuotasMap, path)
+	clearSupportsQuotas(path)
 	clearApplier(path)
 	if err != nil {
 		return fmt.Errorf("unable to clear quota for %s: %v", path, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The supportsQuotasMap is being accessed with inconsistent locking:
Lines 68-69: The map and its lock are declared:

https://github.com/kubernetes/kubernetes/blob/b07d0f852df1d93251aa5450e4f9aafa5c3cb103/pkg/volume/util/fsquota/quota_linux.go#L68-L69

Lines 283-286, 303: In SupportsQuotas(), the map is accessed with supportsQuotasLock:

https://github.com/kubernetes/kubernetes/blob/b07d0f852df1d93251aa5450e4f9aafa5c3cb103/pkg/volume/util/fsquota/quota_linux.go#L283-L286

Lines 433, 470: In ClearQuota(), the map is modified without supportsQuotasLock (only quotaLock is held):

https://github.com/kubernetes/kubernetes/blob/b07d0f852df1d93251aa5450e4f9aafa5c3cb103/pkg/volume/util/fsquota/quota_linux.go#L433
https://github.com/kubernetes/kubernetes/blob/b07d0f852df1d93251aa5450e4f9aafa5c3cb103/pkg/volume/util/fsquota/quota_linux.go#L470

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #135089
KEP: https://github.com/kubernetes/enhancements/issues/1029

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: fix concurrent map write error when creating a pod with empty volume when the LocalStorageCapacityIsolationFSQuotaMonitoring feature-gate is enabled
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
