### PR TITLE
KEP-4680: apply Health status to pods that have already terminated

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -42,9 +42,14 @@ import (
 // +k8s:deepcopy-gen=true
 type ClaimInfo struct {
 	state.ClaimInfoState
-	prepared      bool
-	tombstoned    bool        // Whether this claim has been unprepared but kept for health updates
-	tombstoneTime metav1.Time // When the claim was tombstoned
+	prepared bool
+	// tombstoned indicates whether this claim has been unprepared but is being
+	// kept in the cache temporarily to allow health status updates for terminated
+	// pods. This is part of the fix for issue #132978.
+	tombstoned bool
+	// tombstoneTime records when the claim was tombstoned. Used to determine
+	// when the tombstone should expire and be removed from the cache.
+	tombstoneTime metav1.Time
 }
 
 // claimInfoCache is a cache of processed resource claims keyed by namespace/claimname.

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -347,7 +347,13 @@ func (m *Manager) reconcileLoop(ctx context.Context) {
 	}
 
 	// Remove expired and LRU-evicted tombstones
-	tombstonesToRemove := append(expiredTombstones, lruEvictions...)
+	// Combine expired tombstones and LRU evictions into a single slice
+	tombstonesToRemove := make([]struct {
+		namespace string
+		claimName string
+	}, 0, len(expiredTombstones)+len(lruEvictions))
+	tombstonesToRemove = append(tombstonesToRemove, expiredTombstones...)
+	tombstonesToRemove = append(tombstonesToRemove, lruEvictions...)
 	if len(tombstonesToRemove) > 0 {
 		removedCount := 0
 		err := m.cache.withLock(func() error {

--- a/pkg/kubelet/cm/dra/state/checkpointer_test.go
+++ b/pkg/kubelet/cm/dra/state/checkpointer_test.go
@@ -300,7 +300,7 @@ func TestCheckpointStateStore(t *testing.T) {
 					PodUIDs:   sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
 				},
 			},
-			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}}}]}","Checksum":2570581864}`,
+			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}},\"Tombstoned\":false,\"TombstoneTime\":null}]}","Checksum":3693944325}`,
 		},
 		{
 			description: "single-claim-info-state-with-share-id",
@@ -325,7 +325,7 @@ func TestCheckpointStateStore(t *testing.T) {
 					PodUIDs:   sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
 				},
 			},
-			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\",\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}}}]}","Checksum":736302156}`,
+			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\",\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}},\"Tombstoned\":false,\"TombstoneTime\":null}]}","Checksum":565492021}`,
 		},
 		{
 			description: "claim-info-state-with-multiple-devices",
@@ -355,7 +355,7 @@ func TestCheckpointStateStore(t *testing.T) {
 					PodUIDs:   sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
 				},
 			},
-			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]},{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-2\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}}}]}","Checksum":1223221469}`,
+			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]},{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-2\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}},\"Tombstoned\":false,\"TombstoneTime\":null}]}","Checksum":3127590224}`,
 		},
 		{
 			description: "two-claim-info-states",
@@ -395,7 +395,7 @@ func TestCheckpointStateStore(t *testing.T) {
 					PodUIDs:   sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
 				},
 			},
-			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example-1\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}}},{\"ClaimUID\":\"4cf8db2d-06c0-7d70-1a51-e59b25b2c16c\",\"ClaimName\":\"example-2\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-2\",\"ShareID\":null,\"RequestNames\":null,\"CDIDeviceIDs\":null}]}}}]}","Checksum":2820117767}`,
+			expectedCheckpointContent: `{"Data":"{\"kind\":\"DRACheckpoint\",\"apiVersion\":\"checkpoint.dra.kubelet.k8s.io/v1\",\"ClaimInfoStateList\":[{\"ClaimUID\":\"067798be-454e-4be4-9047-1aa06aea63f7\",\"ClaimName\":\"example-1\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-1\",\"ShareID\":null,\"RequestNames\":[\"test request\"],\"CDIDeviceIDs\":[\"example.com/example=cdi-example\"]}]}},\"Tombstoned\":false,\"TombstoneTime\":null},{\"ClaimUID\":\"4cf8db2d-06c0-7d70-1a51-e59b25b2c16c\",\"ClaimName\":\"example-2\",\"Namespace\":\"default\",\"PodUIDs\":{\"139cdb46-f989-4f17-9561-ca10cfb509a6\":{}},\"DriverState\":{\"test-driver.cdi.k8s.io\":{\"Devices\":[{\"PoolName\":\"worker-1\",\"DeviceName\":\"dev-2\",\"ShareID\":null,\"RequestNames\":null,\"CDIDeviceIDs\":null}]}},\"Tombstoned\":false,\"TombstoneTime\":null}]}","Checksum":3737100187}`,
 		},
 	}
 

--- a/pkg/kubelet/cm/dra/state/state.go
+++ b/pkg/kubelet/cm/dra/state/state.go
@@ -19,6 +19,7 @@ package state
 import (
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -42,6 +43,12 @@ type ClaimInfoState struct {
 	// DriverState contains information about all drivers which have allocation
 	// results in the claim, even if they don't provide devices for their results.
 	DriverState map[string]DriverState
+
+	// Tombstoned indicates if this claim has been unprepared but kept for health updates
+	Tombstoned bool
+
+	// TombstoneTime records when the claim was tombstoned
+	TombstoneTime metav1.Time
 }
 
 // DriverState is used to store per-device claim info state in a checkpoint

--- a/pkg/kubelet/cm/dra/state/zz_generated.deepcopy.go
+++ b/pkg/kubelet/cm/dra/state/zz_generated.deepcopy.go
@@ -43,6 +43,7 @@ func (in *ClaimInfoState) DeepCopyInto(out *ClaimInfoState) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	in.TombstoneTime.DeepCopyInto(&out.TombstoneTime)
 	return
 }
 

--- a/pkg/kubelet/cm/dra/zz_generated.deepcopy.go
+++ b/pkg/kubelet/cm/dra/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ package dra
 func (in *ClaimInfo) DeepCopyInto(out *ClaimInfo) {
 	*out = *in
 	in.ClaimInfoState.DeepCopyInto(&out.ClaimInfoState)
+	in.tombstoneTime.DeepCopyInto(&out.tombstoneTime)
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 Currently, when a pod using DRA resources terminates, the kubelet immediately calls
  `NodeUnprepareResources` and deletes the `ClaimInfo` from its cache. If a health update from the DRA
  plugin arrives after this cleanup, the kubelet cannot determine which pod was using the device, so
  the health update is discarded and the pod's status is never updated.

This PR is clone of https://github.com/kubernetes/kubernetes/pull/134851 after rebaing with master. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes : https://github.com/kubernetes/kubernetes/issues/132978 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DRA: apply Health status to pods that have already terminated
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
