### PR TITLE
kube-controller-manager/nodelifecyclecontroller: fix pod ready condition abnormal settings due to time race issues between goroutines

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -1130,7 +1130,8 @@ func (nc *Controller) processPod(ctx context.Context, podItem podUpdateItem) {
 
 	nodeHealth := nc.nodeHealthMap.getDeepCopy(nodeName)
 	if nodeHealth == nil {
-		// Node data is not gathered yet or node has been removed in the meantime.
+		// Node data is not gathered yet, requeue this pod until the data is gathered or the pod is deleted.
+		nc.podUpdateQueue.AddRateLimited(podItem)
 		return
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

This PR fixes a bug that if the kube-controller-manager process unexpectedly exits during the batch marking of pods as NotReady, it cannot continue to mark the remaining unprocessed pods as NotReady even if it automatically restarts.

In the code of kube-controller-manager, there are two places where MarkPodsNotReady is used to mark pods as NotReady. One place is when the node heartbeat is lost, and kube-controller-manager determines that the node has transitioned from the Ready state to the NotReady state. The other place is when PodProcessingWorker checks whether a node is NotReady based on the nodeStatus stored in nodeHealth; if it is, the worker marks the pod as NotReady.

However, when kube-controller-manager first starts up, the speed at which PodProcessingWorker processes pods is faster than the speed at which monitorNodeHealth collects nodeHealth data. This can cause the pods being processed by PodProcessingWorker to do nothing because the nodeHealth data has not yet gathered.

Therefore, for pods being processed by PodProcessingWorker, if it is detected that nodeHealth has not yet gathered, the pods are re-enqueued until the nodeHealth data is gathered or the pods are deleted.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
