### PR TITLE
Fix failing test for pod group scheduling timeout on Windows

### DIFF
--- a/pkg/scheduler/backend/workloadmanager/podgroupinfo_test.go
+++ b/pkg/scheduler/backend/workloadmanager/podgroupinfo_test.go
@@ -66,6 +66,10 @@ func TestPodGroupInfo_SchedulingTimeout(t *testing.T) {
 		t.Errorf("Expected positive timeout duration, got %v", timeout)
 	}
 
+	// Sleep for a while to ensure that the time has increased,
+	// especially when testing on Windows machines with lower resolution.
+	time.Sleep(10 * time.Millisecond)
+
 	deadline := *pgi.schedulingDeadline
 	newTimeout := pgi.SchedulingTimeout()
 	if !deadline.Equal(*pgi.schedulingDeadline) {
@@ -74,6 +78,10 @@ func TestPodGroupInfo_SchedulingTimeout(t *testing.T) {
 	if newTimeout >= timeout {
 		t.Errorf("Expected lower timeout duration: previous: %v, current: %v", timeout, newTimeout)
 	}
+
+	// Sleep for a while to ensure that the time has increased,
+	// especially when testing on Windows machines with lower resolution.
+	time.Sleep(10 * time.Millisecond)
 
 	pgi.schedulingDeadline = ptr.To(time.Now().Add(-1 * time.Second))
 	newTimeout = pgi.SchedulingTimeout()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Due to a worse time resolution on Windows machines, the `TestPodGroupInfo_SchedulingTimeout` test is failing on `pull-kubernetes-unit-windows-master`. This PR adds two `time.Sleep` steps to ensure the time has incremented.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
