### PR TITLE
Fix goroutine leak in TestNodeSyncResync

### DIFF
--- a/pkg/controller/nodeipam/ipam/sync/sync_test.go
+++ b/pkg/controller/nodeipam/ipam/sync/sync_test.go
@@ -238,12 +238,11 @@ func TestNodeSyncResync(t *testing.T) {
 	sync := New(fake, fake, fake, SyncFromCluster, "node1", cidr)
 	doneChan := make(chan struct{})
 	go sync.Loop(logger, doneChan)
+	// Wait for the first resync to complete
 	<-fake.reportChan
+	// Close the operation channel to stop the loop
 	close(sync.opChan)
-	// Unblock loop().
-	go func() {
-		<-fake.reportChan
-	}()
+	// Wait for the loop to complete
 	<-doneChan
 	fake.dumpTrace()
 }


### PR DESCRIPTION
The test was spawning a goroutine that would block forever waiting for a second report that never came. The Loop() would exit after detecting the closed opChan, leaving the goroutine hanging.

Fixed by removing the unnecessary blocking goroutine and properly waiting for the Loop to complete via the doneChan.


Fixes #134563

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/area test




