### PR TITLE
Enforce Golang a, b = b, a swaps

### DIFF
--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -432,7 +432,6 @@ linters:
         - typeSwitchVar
         - underef
         - unslice
-        - valSwap
     revive:
       # Only these rules are enabled.
       rules:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -253,7 +253,6 @@ linters:
         - typeSwitchVar
         - underef
         - unslice
-        - valSwap
     {{- end}}
     revive:
       # Only these rules are enabled.

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1827,9 +1827,7 @@ func (ss SortableSliceOfMaps) Less(i, j int) bool {
 }
 
 func (ss SortableSliceOfMaps) Swap(i, j int) {
-	tmp := ss.s[i]
-	ss.s[i] = ss.s[j]
-	ss.s[j] = tmp
+	ss.s[i], ss.s[j] = ss.s[j], ss.s[i]
 }
 
 func deduplicateAndSortScalars(s []interface{}) []interface{} {
@@ -1875,9 +1873,7 @@ func (ss SortableSliceOfScalars) Less(i, j int) bool {
 }
 
 func (ss SortableSliceOfScalars) Swap(i, j int) {
-	tmp := ss.s[i]
-	ss.s[i] = ss.s[j]
-	ss.s[j] = tmp
+	ss.s[i], ss.s[j] = ss.s[j], ss.s[i]
 }
 
 // Returns the type of the elements of N slice(s). If the type is different,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This eliminates the last two remaining three-step value swaps (t = a; a = b; b = t instead of a, b = b, a) and enables linting to prevent new ones being added in future.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
