### PR TITLE
Add origins for the union validations errors

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -925,11 +925,11 @@ func validateDeviceAttribute(attribute resource.DeviceAttribute, fldPath *field.
 
 	switch numFields {
 	case 0:
-		allErrs = append(allErrs, field.Invalid(fldPath, "", "exactly one value must be specified").MarkCoveredByDeclarative())
+		allErrs = append(allErrs, field.Invalid(fldPath, "", "exactly one value must be specified").WithOrigin("union").MarkCoveredByDeclarative())
 	case 1:
 		// Okay.
 	default:
-		allErrs = append(allErrs, field.Invalid(fldPath, attribute, "exactly one value must be specified").MarkCoveredByDeclarative())
+		allErrs = append(allErrs, field.Invalid(fldPath, attribute, "exactly one value must be specified").WithOrigin("union").MarkCoveredByDeclarative())
 	}
 	return allErrs
 }

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -113,13 +113,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				"invalid: device attribute with multiple values": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", ""),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union"),
 					},
 				},
 				"invalid: device attribute no value": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", ""),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union"),
 					},
 				},
 				// spec.sharedCounters
@@ -281,7 +281,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					old:    mkResourceSliceWithDevices(),
 					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/multiple", resource.DeviceAttribute{IntValue: ptr.To[int64](123), BoolValue: ptr.To(true)})),
 					expectedErrs: field.ErrorList{
-						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "may have only one of the following fields set: bool, int, string, version"),
+						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/multiple"), "", "").WithOrigin("union"),
 					},
 				},
 				// spec.sharedCounters

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
@@ -72,7 +72,7 @@ func Union[T any](_ context.Context, op operation.Operation, fldPath *field.Path
 		},
 	}
 
-	return unionValidate(op, fldPath, obj, oldObj, union, options, isSetFns...)
+	return unionValidate(op, fldPath, obj, oldObj, union, options, isSetFns...).WithOrigin("union")
 }
 
 // DiscriminatedUnion verifies specified union member matches the discriminator.
@@ -134,7 +134,7 @@ func DiscriminatedUnion[T any, D ~string](_ context.Context, op operation.Operat
 	if op.Type == operation.Update && !changed {
 		return nil
 	}
-	return errs
+	return errs.WithOrigin("union")
 }
 
 // UnionMember represents a member of a union.

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
@@ -44,19 +44,19 @@ func TestUnion(t *testing.T) {
 			name:        "two members set",
 			fields:      []string{"a", "b", "c", "d"},
 			fieldValues: []bool{false, true, false, true},
-			expected:    field.ErrorList{field.Invalid(nil, "{b, d}", "must specify exactly one of: `a`, `b`, `c`, `d`")},
+			expected:    field.ErrorList{field.Invalid(nil, "{b, d}", "must specify exactly one of: `a`, `b`, `c`, `d`")}.WithOrigin("union"),
 		},
 		{
 			name:        "all members set",
 			fields:      []string{"a", "b", "c", "d"},
 			fieldValues: []bool{true, true, true, true},
-			expected:    field.ErrorList{field.Invalid(nil, "{a, b, c, d}", "must specify exactly one of: `a`, `b`, `c`, `d`")},
+			expected:    field.ErrorList{field.Invalid(nil, "{a, b, c, d}", "must specify exactly one of: `a`, `b`, `c`, `d`")}.WithOrigin("union"),
 		},
 		{
 			name:        "no member set",
 			fields:      []string{"a", "b", "c", "d"},
 			fieldValues: []bool{false, false, false, false},
-			expected:    field.ErrorList{field.Invalid(nil, "", "must specify one of: `a`, `b`, `c`, `d`")},
+			expected:    field.ErrorList{field.Invalid(nil, "", "must specify one of: `a`, `b`, `c`, `d`")}.WithOrigin("union"),
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestDiscriminatedUnion(t *testing.T) {
 			expected: field.ErrorList{
 				field.Invalid(field.NewPath("b"), "", "may only be specified when `type` is \"B\""),
 				field.Invalid(field.NewPath("c"), "", "must be specified when `type` is \"C\""),
-			},
+			}.WithOrigin("union"),
 		},
 		{
 			name:               "invalid, discriminator correct, multiple members set",
@@ -126,7 +126,7 @@ func TestDiscriminatedUnion(t *testing.T) {
 			expected: field.ErrorList{
 				field.Invalid(field.NewPath("b"), "", "may only be specified when `type` is \"B\""),
 				field.Invalid(field.NewPath("d"), "", "may only be specified when `type` is \"D\""),
-			},
+			}.WithOrigin("union"),
 		},
 	}
 
@@ -217,7 +217,7 @@ func TestUnionRatcheting(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Invalid(nil, "{m1, m2}", "must specify exactly one of: `m1`, `m2`"),
-			},
+			}.WithOrigin("union"),
 		},
 	}
 
@@ -312,7 +312,7 @@ func TestDiscriminatedUnionRatcheting(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Invalid(field.NewPath("m2"), "", "may only be specified when `d` is \"m2\""),
-			},
+			}.WithOrigin("union"),
 		},
 		{
 			name: "fail on changing the discriminator",
@@ -327,7 +327,7 @@ func TestDiscriminatedUnionRatcheting(t *testing.T) {
 			expected: field.ErrorList{
 				field.Invalid(field.NewPath("m1"), "", "may only be specified when `d` is \"m1\""),
 				field.Invalid(field.NewPath("m2"), "", "must be specified when `d` is \"m2\""),
-			},
+			}.WithOrigin("union"),
 		},
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/custom_members/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/custom_members/doc_test.go
@@ -30,11 +30,11 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("m1"), nil, "may only be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	st.Value(&Struct{D: DM1}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("m1"), nil, "must be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	// Test validation ratcheting
 	st.Value(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).OldValue(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/multiple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/multiple/doc_test.go
@@ -43,7 +43,7 @@ func Test(t *testing.T) {
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("u1m1"), nil, "may only be specified when"),
 		field.Invalid(field.NewPath("u2m2"), nil, "must be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	st.Value(&Struct{
 		D1: U1M2, // no value
@@ -51,7 +51,7 @@ func Test(t *testing.T) {
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("u1m2"), nil, "must be specified when"),
 		field.Invalid(field.NewPath("u2m1"), nil, "may only be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	st.Value(&Struct{
 		D1: U1M2, // no value
@@ -59,7 +59,7 @@ func Test(t *testing.T) {
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("u1m2"), nil, "must be specified when"),
 		field.Invalid(field.NewPath("u2m2"), nil, "must be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	// Test validation ratcheting
 	st.Value(&Struct{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/simple/doc_test.go
@@ -32,11 +32,11 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("m1"), nil, "may only be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	st.Value(&Struct{D: DM1}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("m1"), nil, "must be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	// Test validation ratcheting
 	st.Value(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).OldValue(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/sparse/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/sparse/doc_test.go
@@ -32,11 +32,11 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{D: DM2, M1: &M1{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("m1"), nil, "may only be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	st.Value(&Struct{D: DM1}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("m1"), nil, "must be specified when"),
-	})
+	}.WithOrigin("union"))
 
 	// Test validation ratcheting
 	st.Value(&Struct{D: DM2, M1: &M1{}}).OldValue(&Struct{D: DM2, M1: &M1{}}).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/custom_members/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/custom_members/doc_test.go
@@ -30,10 +30,10 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify exactly one of"),
-	})
+	}.WithOrigin("union"))
 	st.Value(&Struct{}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify one of"),
-	})
+	}.WithOrigin("union"))
 
 	// Test validation ratcheting
 	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).OldValue(&Struct{M1: &M1{}, M2: &M2{}}).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/multiple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/multiple/doc_test.go
@@ -26,29 +26,29 @@ func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify one of"),
-		field.Invalid(nil, nil, "must specify one of"),
+		field.Invalid(nil, nil, "must specify one of: `u1m1`, `u1m2`").WithOrigin("union"),
+		field.Invalid(nil, nil, "must specify one of: `u2m1`, `u2m2`").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{U1M1: &M1{}, U2M1: &M1{}}).ExpectValid()
 	st.Value(&Struct{U1M2: &M2{}, U2M2: &M2{}}).ExpectValid()
 
 	st.Value(&Struct{U1M1: &M1{}, U1M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
-		field.Invalid(nil, nil, "must specify one of"),
+		field.Invalid(nil, nil, "must specify exactly one of: `u1m1`, `u1m2`").WithOrigin("union"),
+		field.Invalid(nil, nil, "must specify one of: `u2m1`, `u2m2`").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{U2M1: &M1{}, U2M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify one of"),
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify one of: `u1m1`, `u1m2`").WithOrigin("union"),
+		field.Invalid(nil, nil, "must specify exactly one of: `u2m1`, `u2m2`").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{
 		U1M1: &M1{}, U1M2: &M2{},
 		U2M1: &M1{}, U2M2: &M2{},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify exactly one of: `u1m1`, `u1m2`").WithOrigin("union"),
+		field.Invalid(nil, nil, "must specify exactly one of: `u2m1`, `u2m2`").WithOrigin("union"),
 	})
 
 	// Test validation ratcheting

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/doc_test.go
@@ -28,7 +28,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify one of"),
-	})
+	}.WithOrigin("union"))
 
 	st.Value(&Struct{M1: &M1{}}).ExpectValid()
 	st.Value(&Struct{M2: &M2{}}).ExpectValid()
@@ -37,13 +37,13 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify exactly one of"),
-	})
+	}.WithOrigin("union"))
 	st.Value(&Struct{M1: &M1{}, M3: "a string"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify exactly one of"),
-	})
+	}.WithOrigin("union"))
 	st.Value(&Struct{M1: &M1{}, M4: ptr.To("a string")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify exactly one of"),
-	})
+	}.WithOrigin("union"))
 
 	// Update only considers whether a field was set, not the value.
 	st.Value(&Struct{M3: "a string"}).OldValue(&Struct{M3: "different string"}).ExpectValid()


### PR DESCRIPTION

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR enhances the validation logic for union types in the Kubernetes API machinery. By adding `.WithOrigin("union")` to the validation error returns, it provides more specific and actionable error messages. When a union validation fails (e.g., because multiple fields are set where only one is allowed), the error message will now clearly indicate that the "union" validation was the source of the failure. This makes it easier for developers to debug issues related to union type validation.

The changes are applied consistently across various union validation scenarios, including discriminated and undiscriminated unions, as shown by the updates to the validation logic and the corresponding test files.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The core of this change is the addition of `.WithOrigin("union")` to the error construction in `pkg/apis/resource/validation/validation.go` and `staging/src/k8s.io/apimachinery/pkg/api/validate/union.go`. The majority of the file changes are in the test files to update the expected error matchers to include this new origin.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

