### PR TITLE
feat: introduce DefaultContext(ctx) and deprecate NewDefaultContext() and NewContext()

### DIFF
--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -223,11 +223,11 @@ func TestCreateSetsFields(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
 	pod := validNewPod()
-	_, err := storage.Create(genericapirequest.NewDefaultContext(), pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	_, err := storage.Create(genericapirequest.DefaultContext(context.Background()), pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 	object, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -379,7 +379,7 @@ func TestResourceLocation(t *testing.T) {
 	defer server.Terminate(t)
 	for i, tc := range testCases {
 		// unique namespace/storage location per test
-		ctx := genericapirequest.WithNamespace(genericapirequest.NewDefaultContext(), fmt.Sprintf("namespace-%d", i))
+		ctx := genericapirequest.WithNamespace(genericapirequest.DefaultContext(context.Background()), fmt.Sprintf("namespace-%d", i))
 		key, _ := storage.KeyFunc(ctx, tc.pod.Name)
 		if err := storage.Storage.Create(ctx, key, &tc.pod, nil, 0, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -451,7 +451,7 @@ func TestConvertToTableList(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 
 	columns := []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -603,7 +603,7 @@ func TestEtcdCreate(t *testing.T) {
 	storage, bindingStorage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 	_, err := storage.Create(ctx, validNewPod(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -633,7 +633,7 @@ func TestEtcdCreateClearsNominatedNodeName(t *testing.T) {
 			storage, bindingStorage, statusStorage, server := newStorage(t)
 			defer server.Terminate(t)
 			defer storage.DestroyFunc()
-			ctx := genericapirequest.NewDefaultContext()
+			ctx := genericapirequest.DefaultContext(context.Background())
 
 			pod := validNewPod()
 			created, err := storage.Create(ctx, pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
@@ -687,7 +687,7 @@ func TestEtcdCreateBindingNoPod(t *testing.T) {
 	storage, bindingStorage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 
 	// Assume that a pod has undergone the following:
 	// - Create (apiserver)
@@ -730,7 +730,7 @@ func TestEtcdCreateWithContainersNotFound(t *testing.T) {
 	storage, bindingStorage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 	_, err := storage.Create(ctx, validNewPod(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -769,7 +769,7 @@ func TestEtcdCreateWithConflict(t *testing.T) {
 	storage, bindingStorage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 
 	_, err := storage.Create(ctx, validNewPod(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
@@ -822,7 +822,7 @@ func TestEtcdCreateWithSchedulingGates(t *testing.T) {
 			storage, bindingStorage, _, server := newStorage(t)
 			defer server.Terminate(t)
 			defer storage.Store.DestroyFunc()
-			ctx := genericapirequest.NewDefaultContext()
+			ctx := genericapirequest.DefaultContext(context.Background())
 
 			pod := validNewPod()
 			pod.Spec.SchedulingGates = tt.schedulingGates
@@ -952,7 +952,7 @@ func TestEtcdCreateBindingWithUIDAndResourceVersion(t *testing.T) {
 	for k, testCase := range testCases {
 		pod := validNewPod()
 		pod.Namespace = fmt.Sprintf("namespace-%s", strings.ToLower(k))
-		ctx := genericapirequest.WithNamespace(genericapirequest.NewDefaultContext(), pod.Namespace)
+		ctx := genericapirequest.WithNamespace(genericapirequest.DefaultContext(context.Background()), pod.Namespace)
 
 		podCreated, err := storage.Create(ctx, pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 		if err != nil {
@@ -1050,7 +1050,7 @@ func TestEtcdCreateBinding(t *testing.T) {
 	for k, test := range testCases {
 		pod := validNewPod()
 		pod.Namespace = fmt.Sprintf("namespace-%s", strings.ToLower(k))
-		ctx := genericapirequest.WithNamespace(genericapirequest.NewDefaultContext(), pod.Namespace)
+		ctx := genericapirequest.WithNamespace(genericapirequest.DefaultContext(context.Background()), pod.Namespace)
 		if _, err := storage.Create(ctx, pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{}); err != nil {
 			t.Fatalf("%s: unexpected error: %v", k, err)
 		}
@@ -1076,7 +1076,7 @@ func TestEtcdUpdateNotScheduled(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 
 	if _, err := storage.Create(ctx, validNewPod(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1102,7 +1102,7 @@ func TestEtcdUpdateScheduled(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 
 	key, _ := storage.KeyFunc(ctx, "foo")
 	err := storage.Storage.Create(ctx, key, &api.Pod{
@@ -1176,7 +1176,7 @@ func TestEtcdUpdateStatus(t *testing.T) {
 	storage, _, statusStorage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericapirequest.DefaultContext(context.Background())
 
 	key, _ := storage.KeyFunc(ctx, "foo")
 	podStart := api.Pod{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
@@ -34,14 +34,22 @@ const (
 	userKey
 )
 
+// Deprecated: callers should pass a context obtained from their caller
 // NewContext instantiates a base context object for request flows.
 func NewContext() context.Context {
 	return context.TODO()
 }
 
+// Deprecated: use DefaultContext instead.
 // NewDefaultContext instantiates a base context object for request flows in the default namespace
 func NewDefaultContext() context.Context {
 	return WithNamespace(NewContext(), metav1.NamespaceDefault)
+}
+
+// DefaultContext returns a context that includes the default namespace,
+// derived from the provided parent context.
+func DefaultContext(parent context.Context) context.Context {
+    return WithNamespace(parent, metav1.NamespaceDefault)
 }
 
 // WithValue returns a copy of parent in which the value associated with key is val.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new helper,
`DefaultContext(ctx context.Context)`, in
`staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go`

The new function returns a context derived from the provided parent and sets the default namespace.

Previously, the existing helpers NewContext() and NewDefaultContext() both relied on context.TODO(),
which produced non-cancelable contexts and broke upstream request propagation chains.
This PR also deprecates both of these older functions and updates a representative usage site in
pkg/registry/core/pod/storage/storage_test.go to demonstrate migration to the new API.

#### Which issue(s) this PR is related to:

Fixes #134940 

#### Special notes for your reviewer:
- This change is backward compatible — existing code using NewContext() or NewDefaultContext() continues to compile and function as before.


```release-note
NONE
```