### PR TITLE
Enable gRPC health checking and round-robin load balancing for etcd client

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,6 +1,0 @@
----
-schema-version: v1
-kind: mergegate
-rules:
-  - require: commit-signatures
-    allow_unsigned_external: true

--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,6 @@
+---
+schema-version: v1
+kind: mergegate
+rules:
+  - require: commit-signatures
+    allow_unsigned_external: true


### PR DESCRIPTION
Enable gRPC health checking and round-robin load balancing for etcd client

Configure gRPC client to use round-robin load balancing with health checking across all etcd endpoints. This enables proactive detection of soft failures (slow responses, high error rates) in addition to hard failures detected by TCP keepalives, improving etcd client connection reliability.

## Testing
Performed tests are described in the doc: https://docs.google.com/document/d/1VsHGjmEQyn1dpWIBB23iXLyVy-EYvG_ZWLK6yDyVxA0/edit?pli=1&tab=t.0