### PR TITLE
Fix volume performance tests with performance constraints

### DIFF
--- a/test/e2e/storage/testsuites/volumeperf.go
+++ b/test/e2e/storage/testsuites/volumeperf.go
@@ -297,11 +297,11 @@ func newPVCWatch(ctx context.Context, f *framework.Framework, provisionCount int
 	_, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{})
+				obj, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).List(ctx, options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return f.ClientSet.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, metav1.ListOptions{})
+				return f.ClientSet.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, options)
 			},
 		},
 		&v1.PersistentVolumeClaim{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

volumeperf reports a timeout at 13:01 (`[FAILED] expected all PVCs to be in Bound state within 15m0s minutes`) even though the PVC create/bind events all finished successfully within the first minute: the log contains only ProvisioningSucceeded events for every PVC and no actual provisioning errors.

Log: blob:https://prow.k8s.io/7e4fbae7-b5cc-4658-99af-8a58479af2ee

```
STEP: Waiting for all PVCs to be Bound...
...
[FAILED] expected all PVCs to be in Bound state within 15m0s minutes
```

<img width="1008" height="309" alt="image" src="https://github.com/user-attachments/assets/5718d97a-6bba-4207-a622-cc1e5ca4a79f" />

While the test was waiting, the client-side reflector kept warning that the watch stream had gone quiet (“event bookmark expired”), indicating the informer never observed the remaining PVC transitions despite the cluster finishing the work.

<img width="1345" height="822" alt="image" src="https://github.com/user-attachments/assets/9794866d-5707-41b2-ba15-6f988b0c09e7" />

The informer used by the test starts its watch without honoring the ResourceVersion supplied by the list call. Because the watch begins “from now” (ListOptions{}), any PVCs that bound in the tiny gap between the initial LIST and the mis-specified WATCH are never seen as transitions, so the counter never reaches 300 and the timeout fires.

**Root cause:** the PVC informer in volumeperf.go discards the options.ResourceVersion provided by the shared informer, creating a LIST/WATCH gap that drops some Pending→Bound updates. The test therefore times out despite the driver provisioning all volumes successfully.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Ref: https://github.com/kubernetes/kubernetes/issues/135239

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
