### PR TITLE
test: refine vgs resources clean up

### DIFF
--- a/test/e2e/storage/testsuites/volume_group_snapshottable.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshottable.go
@@ -237,7 +237,7 @@ func (s *VolumeGroupSnapshottableTestSuite) DefineTests(driver storageframework.
 					e2estatefulset.DeleteAllStatefulSets(ctx, cs, groupTest.statefulSet.Namespace)
 				}
 
-				var cleanUpVGSErrs []error
+				var cleanupVGSErrs []error
 				for _, vgsr := range groupTest.snapshots {
 					if vgsr == nil || vgsr.VGS == nil {
 						framework.Logf("Skipping cleanup: VolumeGroupSnapshotResource or VGS is nil")
@@ -250,13 +250,13 @@ func (s *VolumeGroupSnapshottableTestSuite) DefineTests(driver storageframework.
 					framework.Logf("deleting VolumeGroupSnapshotResource %s/%s", vgsNamespace, vgsName)
 					err := vgsr.CleanupResource(ctx, f.Timeouts)
 					if err != nil {
-						cleanUpVGSErrs = append(cleanUpVGSErrs, err)
+						cleanupVGSErrs = append(cleanupVGSErrs, err)
 						framework.Logf("Warning: failed to delete VolumeGroupSnapshotResource %s/%s: %v", vgsNamespace, vgsName, err)
 					} else {
 						framework.Logf("deleted VolumeGroupSnapshotResource %s/%s", vgsNamespace, vgsName)
 					}
 				}
-				framework.ExpectNoError(utilerrors.NewAggregate(cleanUpVGSErrs), "failed to delete VGS resources")
+				framework.ExpectNoError(utilerrors.NewAggregate(cleanupVGSErrs), "failed to delete VGS resources")
 
 				var cleanupVolumeErrs []error
 				for _, volumeResource := range groupTest.volumeResources {

--- a/test/e2e/storage/testsuites/volume_group_snapshottable.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshottable.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -230,41 +231,59 @@ func (s *VolumeGroupSnapshottableTestSuite) DefineTests(driver storageframework.
 				return originalMntTestData
 			}
 
-			cleanup := func(ctx context.Context) {
+			cleanupResources := func(ctx context.Context) {
 				if groupTest.statefulSet != nil {
-					framework.Logf("Deleting StatefulSet %s", groupTest.statefulSet.Name)
+					framework.Logf("deleting StatefulSet %s", groupTest.statefulSet.Name)
 					e2estatefulset.DeleteAllStatefulSets(ctx, cs, groupTest.statefulSet.Namespace)
 				}
-				for _, volumeResource := range groupTest.volumeResources {
-					if volumeResource != nil {
-						framework.Logf("Deleting volume resource")
-						err := volumeResource.CleanupResource(ctx)
-						framework.ExpectNoError(err, "failed to delete volume resource")
+
+				var cleanUpVGSErrs []error
+				for _, vgsr := range groupTest.snapshots {
+					if vgsr == nil || vgsr.VGS == nil {
+						framework.Logf("Skipping cleanup: VolumeGroupSnapshotResource or VGS is nil")
+						continue
+					}
+
+					vgsName := vgsr.VGS.GetName()
+					vgsNamespace := vgsr.VGS.GetNamespace()
+
+					framework.Logf("deleting VolumeGroupSnapshotResource %s/%s", vgsNamespace, vgsName)
+					err := vgsr.CleanupResource(ctx, f.Timeouts)
+					if err != nil {
+						cleanUpVGSErrs = append(cleanUpVGSErrs, err)
+						framework.Logf("Warning: failed to delete VolumeGroupSnapshotResource %s/%s: %v", vgsNamespace, vgsName, err)
+					} else {
+						framework.Logf("deleted VolumeGroupSnapshotResource %s/%s", vgsNamespace, vgsName)
 					}
 				}
+				framework.ExpectNoError(utilerrors.NewAggregate(cleanUpVGSErrs), "failed to delete VGS resources")
+
+				var cleanupVolumeErrs []error
+				for _, volumeResource := range groupTest.volumeResources {
+					if volumeResource == nil || volumeResource.Pvc == nil {
+						continue
+					}
+
+					ns, name := volumeResource.Pvc.Namespace, volumeResource.Pvc.Name
+					framework.Logf("deleting volume resource %s/%s", ns, name)
+					if err := volumeResource.CleanupResource(ctx); err != nil {
+						cleanupVolumeErrs = append(cleanupVolumeErrs, fmt.Errorf("%s/%s: %w", ns, name, err))
+						framework.Logf("Warning: failed to delete volume resource %s/%s: %v", ns, name, err)
+					} else {
+						framework.Logf("deleted volume resource %s/%s", ns, name)
+					}
+				}
+				framework.ExpectNoError(utilerrors.NewAggregate(cleanupVolumeErrs), "failed to delete volume resources")
 			}
 
 			ginkgo.It("should create snapshots for StatefulSet volumes and verify data consistency after restore", func(ctx context.Context) {
 				init(ctx)
 				createStatefulSetAndVolumes(ctx)
-				ginkgo.DeferCleanup(cleanup)
+				ginkgo.DeferCleanup(cleanupResources)
 
 				originalMntTestData := writeTestDataToVolumes(ctx)
-
 				snapshot := storageframework.CreateVolumeGroupSnapshotResource(ctx, snapshottableDriver, groupTest.config, pattern, labelValue, f.Namespace.Name, f.Timeouts, map[string]string{"deletionPolicy": pattern.SnapshotDeletionPolicy.String()})
 				groupTest.snapshots = append(groupTest.snapshots, snapshot)
-				ginkgo.DeferCleanup(func(ctx context.Context) {
-					for _, volumeGroupSnapshotResource := range groupTest.snapshots {
-						vgsName := volumeGroupSnapshotResource.VGS.Object["metadata"].(map[string]interface{})["name"].(string)
-						framework.Logf("Deleting volumeGroupSnapshotResource %s", vgsName)
-						err := volumeGroupSnapshotResource.CleanupResource(ctx, f.Timeouts)
-						if err != nil {
-							framework.Logf("Warning: failed to delete volumeGroupSnapshotResource %s: %v", vgsName, err)
-						} else {
-							framework.Logf("Deleted volumeGroupSnapshotResource %s", vgsName)
-						}
-					}
-				})
 
 				ginkgo.By("verifying the snapshots in the group are ready to use")
 				status := snapshot.VGS.Object["status"]


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- Refine vgs resources clean up make sure all created resources cleaned up gracefully and fix previously test namespace stuck at `Terminating` status issue caused by the statefulset pvc does not delete in order.

#### Special notes for your reviewer:
- I tested on my local verified that all created resources cleaned up gracefully:

<details>
<summary>&nbsp;&nbsp;&nbsp;&nbsp;<b>Click to Expand/Collapse Test Logs</b></summary>

```console
$ ./_output/bin/e2e.test \
  --provider=skeleton \
  --ginkgo.focus="\[Feature:volumegroupsnapshot\]" \
  --ginkgo.skip="\[Serial\]" \
  --num-nodes=2 \
  --kubeconfig=$HOME/.kube/config-kind \
  --ginkgo.v \
  --ginkgo.timeout=30m
...
  I1111 18:14:07.286295 82232 delete.go:86] Wait up to 5m0s for pod "pod-8190ec37-652a-47b8-ba63-e0b71f0e63a6" to be fully deleted
  I1111 18:14:09.294797 82232 volume_group_snapshottable.go:332] Deleting restored PVC restored-data-statefulset-vgs-volumegroupsnapshottable-1544-0
  I1111 18:14:09.305479 82232 volume_group_snapshottable.go:332] Deleting restored PVC restored-data-statefulset-vgs-volumegroupsnapshottable-1544-1
  I1111 18:14:09.314590 82232 volume_group_snapshottable.go:332] Deleting restored PVC restored-data-statefulset-vgs-volumegroupsnapshottable-1544-2
  I1111 18:14:09.330095 82232 volume_group_snapshottable.go:259] Deleting volumeGroupSnapshotResource group-snapshot-7t5z7
  I1111 18:14:09.330214 82232 volume_group_snapshot_resource.go:123] deleting groupSnapshot "volumegroupsnapshottable-1544"/"group-snapshot-7t5z7"
  I1111 18:14:09.335014 82232 volume_group_snapshot_resource.go:130] received snapshotStatus map[boundVolumeGroupSnapshotContentName:groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906 creationTime:2025-11-11T10:13:54Z readyToUse:true]
  I1111 18:14:09.335083 82232 volume_group_snapshot_resource.go:131] groupSnapshotContentName groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906
  I1111 18:14:09.348241 82232 utils.go:612] Waiting up to 5m0s for volumegroupsnapshots groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906 to be deleted
  I1111 18:14:09.350067 82232 utils.go:617] volumegroupsnapshots groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906 is not found and has been deleted
  I1111 18:14:09.350127 82232 utils.go:695] WaitUntil finished successfully after 1.688792ms
  I1111 18:14:09.350163 82232 volume_group_snapshot_resource.go:174] deleting group snapshot content "groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906"
  I1111 18:14:09.366711 82232 utils.go:612] Waiting up to 5m0s for volumegroupsnapshotcontents groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906 to be deleted
  I1111 18:14:09.371160 82232 utils.go:622] volumegroupsnapshotcontents groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906 has been found and is not deleted
  I1111 18:14:11.376514 82232 utils.go:617] volumegroupsnapshotcontents groupsnapcontent-986411eb-0fcc-452d-9f85-0567539f8906 is not found and has been deleted
  I1111 18:14:11.376653 82232 utils.go:695] WaitUntil finished successfully after 2.009840542s
  I1111 18:14:11.376700 82232 volume_group_snapshot_resource.go:203] deleting group snapshot class "volumegroupsnapshottable-1544l6pz6"
  I1111 18:14:11.381537 82232 utils.go:612] Waiting up to 5m0s for volumegroupsnapshotclasses volumegroupsnapshottable-1544l6pz6 to be deleted
  I1111 18:14:11.384144 82232 utils.go:617] volumegroupsnapshotclasses volumegroupsnapshottable-1544l6pz6 is not found and has been deleted
  I1111 18:14:11.384250 82232 utils.go:695] WaitUntil finished successfully after 2.606417ms
  I1111 18:14:11.384295 82232 volume_group_snapshottable.go:264] Deleted volumeGroupSnapshotResource group-snapshot-7t5z7
  I1111 18:14:11.384442 82232 volume_group_snapshottable.go:235] Deleting StatefulSet statefulset-vgs-volumegroupsnapshottable-1544
  I1111 18:14:11.387719 82232 rest.go:153] Scaling statefulset statefulset-vgs-volumegroupsnapshottable-1544 to 0
  I1111 18:15:51.400341 82232 wait.go:160] Waiting for statefulset status.replicas updated to 0
  I1111 18:15:51.403740 82232 rest.go:91] Deleting statefulset statefulset-vgs-volumegroupsnapshottable-1544
  I1111 18:15:51.412575 82232 rest.go:111] Deleting pvc: csi-hostpathwzhn7 with volume pvc-8bc26d2f-2f07-4770-9934-b2d4bacbd372
  I1111 18:15:51.419405 82232 rest.go:137] Still waiting for pvs of statefulset to disappear:
  pvc-8bc26d2f-2f07-4770-9934-b2d4bacbd372: {Phase:Bound Message: Reason: LastPhaseTransitionTime:2025-11-11 18:13:12 +0800 CST}
  I1111 18:16:01.426062 82232 volume_group_snapshottable.go:240] Deleting volume resource
  STEP: Deleting pvc @ 11/11/25 18:16:01.426
  I1111 18:16:01.426266 82232 pv.go:205] Deleting PersistentVolumeClaim "csi-hostpathwzhn7"
  I1111 18:16:01.429945 82232 pv.go:863] Waiting up to 20m0s for PersistentVolume pvc-8bc26d2f-2f07-4770-9934-b2d4bacbd372 to get deleted
  I1111 18:16:01.432787 82232 pv.go:871] PersistentVolume pvc-8bc26d2f-2f07-4770-9934-b2d4bacbd372 was removed
  STEP: Deleting sc @ 11/11/25 18:16:01.432
  STEP: uninstalling csi csi-hostpath driver @ 11/11/25 18:16:01.438
  STEP: deleting the driver namespace: volumegroupsnapshottable-1544-9796 @ 11/11/25 18:16:01.438
  STEP: Waiting for namespaces [volumegroupsnapshottable-1544-9796] to vanish @ 11/11/25 18:16:01.444
  I1111 18:16:13.549708 82232 helper.go:125] Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "volumegroupsnapshottable-1544" for this suite. @ 11/11/25 18:16:13.552
• [183.765 seconds]
...
[SynchronizedAfterSuite] 
k8s.io/kubernetes/test/e2e/e2e.go:80
  I1111 18:16:13.567659 82232 suites.go:34] Running AfterSuite actions on node 1
[SynchronizedAfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Invariant Metrics
k8s.io/kubernetes/test/e2e/invariants/metrics.go:46
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Kubernetes e2e suite report
k8s.io/kubernetes/test/e2e/e2e_test.go:158
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 1 of 7218 Specs in 183.927 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 7217 Skipped
PASS

# No Terminating test namespaces after test finished
$ oc get ns
NAME                 STATUS   AGE
default              Active   47d
kube-node-lease      Active   47d
kube-public          Active   47d
kube-system          Active   47d
local-path-storage   Active   47d

```
</details>

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/3476-volume-group-snapshot/

```
