### PR TITLE
kubelet: migrate allocation to contextual logging

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -54,6 +54,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	_ "k8s.io/kubernetes/pkg/volume/hostpath"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -2345,6 +2346,7 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
 			original := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					UID:       "1111",
@@ -2387,7 +2389,7 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 				return resizedPod, true
 			}
 			am.PushPendingResize(original.UID)
-			resizedPods := am.(*manager).retryPendingResizes(tc.trigger)
+			resizedPods := am.(*manager).retryPendingResizes(logger, tc.trigger)
 
 			require.Len(t, resizedPods, 1)
 			require.Equal(t, original.UID, resizedPods[0].UID)

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 )
 
 // PodResourceInfo stores resource requirements for containers within a pod.
@@ -58,7 +59,7 @@ type Reader interface {
 
 type writer interface {
 	SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error
-	SetPodResourceInfo(podUID types.UID, resourceInfo PodResourceInfo) error
+	SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error
 	SetPodLevelResources(podUID types.UID, alloc *v1.ResourceRequirements) error
 	RemovePod(podUID types.UID) error
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -34,10 +34,13 @@ var _ State = &stateMemory{}
 
 // NewStateMemory creates new State to track resources resourcesated to pods
 func NewStateMemory(resources PodResourceInfoMap) State {
+	// Use klog.TODO() because we currently do not have a proper logger to pass in.
+	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
+	logger := klog.TODO()
 	if resources == nil {
 		resources = PodResourceInfoMap{}
 	}
-	klog.V(2).InfoS("Initialized new in-memory state store for pod resource information tracking")
+	logger.V(2).Info("Initialized new in-memory state store for pod resource information tracking")
 	return &stateMemory{
 		podResources: resources,
 	}
@@ -87,6 +90,10 @@ func (s *stateMemory) GetPodResourceInfo(podUID types.UID) (PodResourceInfo, boo
 }
 
 func (s *stateMemory) SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
+	// Use klog.TODO() because we currently do not have a proper logger to pass in.
+	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
+	logger := klog.TODO()
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -104,11 +111,14 @@ func (s *stateMemory) SetContainerResources(podUID types.UID, containerName stri
 	podInfo.ContainerResources[containerName] = resources
 	s.podResources[podUID] = podInfo
 
-	klog.V(3).InfoS("Updated container resource information", "podUID", podUID, "containerName", containerName, "resources", resources)
+	logger.V(3).Info("Updated container resource information", "podUID", podUID, "containerName", containerName, "resources", resources)
 	return nil
 }
 
 func (s *stateMemory) SetPodLevelResources(podUID types.UID, resources *v1.ResourceRequirements) error {
+	// Use klog.TODO() because we currently do not have a proper logger to pass in.
+	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
+	logger := klog.TODO()
 	s.Lock()
 	defer s.Unlock()
 
@@ -121,24 +131,27 @@ func (s *stateMemory) SetPodLevelResources(podUID types.UID, resources *v1.Resou
 
 	s.podResources[podUID] = podInfo
 
-	klog.V(3).InfoS("Updated pod-level resource info", "podUID", podUID, "resources", resources)
+	logger.V(3).Info("Updated pod-level resource info", "podUID", podUID, "resources", resources)
 	return nil
 }
 
-func (s *stateMemory) SetPodResourceInfo(podUID types.UID, resourceInfo PodResourceInfo) error {
+func (s *stateMemory) SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error {
 	s.Lock()
 	defer s.Unlock()
 
 	s.podResources[podUID] = resourceInfo
-	klog.V(3).InfoS("Updated pod resource information", "podUID", podUID, "information", resourceInfo)
+	logger.V(3).Info("Updated pod resource information", "podUID", podUID, "information", resourceInfo)
 	return nil
 }
 
 func (s *stateMemory) RemovePod(podUID types.UID) error {
+	// Use klog.TODO() because we currently do not have a proper logger to pass in.
+	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
+	logger := klog.TODO()
 	s.Lock()
 	defer s.Unlock()
 	delete(s.podResources, podUID)
-	klog.V(3).InfoS("Deleted pod resource information", "podUID", podUID)
+	logger.V(3).Info("Deleted pod resource information", "podUID", podUID)
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates `pkg/kubelet/allocation` to contextual logging.

#### Which issue(s) this PR is related to:

Ref: https://github.com/kubernetes/kubernetes/issues/130069

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/wg structured-logging
/area logging