### PR TITLE
remove Pod Generation feature gate from field descriptions

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9773,7 +9773,7 @@
           "type": "string"
         },
         "observedGeneration": {
-          "description": "If set, this represents the .metadata.generation that the pod condition was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+          "description": "If set, this represents the .metadata.generation that the pod condition was set based upon.",
           "format": "int64",
           "type": "integer"
         },

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -5388,7 +5388,7 @@
             "type": "string"
           },
           "observedGeneration": {
-            "description": "If set, this represents the .metadata.generation that the pod condition was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+            "description": "If set, this represents the .metadata.generation that the pod condition was set based upon.",
             "format": "int64",
             "type": "integer"
           },

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3159,7 +3159,6 @@ const (
 // PodCondition represents pod's condition
 type PodCondition struct {
 	Type PodConditionType
-	// +featureGate=PodObservedGenerationTracking
 	// +optional
 	ObservedGeneration int64
 	Status             ConditionStatus
@@ -4537,8 +4536,6 @@ type EphemeralContainer struct {
 // state of a system.
 type PodStatus struct {
 	// If set, this represents the .metadata.generation that the pod status was set based upon.
-	// The PodObservedGenerationTracking feature gate must be enabled to use this field.
-	// +featureGate=PodObservedGenerationTracking
 	// +optional
 	ObservedGeneration int64
 	// +optional

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -27054,7 +27054,7 @@ func schema_k8sio_api_core_v1_PodCondition(ref common.ReferenceCallback) common.
 					},
 					"observedGeneration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "If set, this represents the .metadata.generation that the pod condition was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+							Description: "If set, this represents the .metadata.generation that the pod condition was set based upon.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3927,8 +3927,6 @@ message PodCondition {
   optional string type = 1;
 
   // If set, this represents the .metadata.generation that the pod condition was set based upon.
-  // The PodObservedGenerationTracking feature gate must be enabled to use this field.
-  // +featureGate=PodObservedGenerationTracking
   // +optional
   optional int64 observedGeneration = 7;
 
@@ -4763,7 +4761,6 @@ message PodSpec {
 message PodStatus {
   // If set, this represents the .metadata.generation that the pod status was set based upon.
   // The PodObservedGenerationTracking feature gate must be enabled to use this field.
-  // +featureGate=PodObservedGenerationTracking
   // +optional
   optional int64 observedGeneration = 17;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3573,8 +3573,6 @@ type PodCondition struct {
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
 	Type PodConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=PodConditionType"`
 	// If set, this represents the .metadata.generation that the pod condition was set based upon.
-	// The PodObservedGenerationTracking feature gate must be enabled to use this field.
-	// +featureGate=PodObservedGenerationTracking
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,7,opt,name=observedGeneration"`
 	// Status is the status of the condition.
@@ -5272,7 +5270,6 @@ type EphemeralContainer struct {
 type PodStatus struct {
 	// If set, this represents the .metadata.generation that the pod status was set based upon.
 	// The PodObservedGenerationTracking feature gate must be enabled to use this field.
-	// +featureGate=PodObservedGenerationTracking
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,17,opt,name=observedGeneration"`
 	// The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1700,7 +1700,7 @@ func (PodCertificateProjection) SwaggerDoc() map[string]string {
 var map_PodCondition = map[string]string{
 	"":                   "PodCondition contains details for the current condition of this pod.",
 	"type":               "Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
-	"observedGeneration": "If set, this represents the .metadata.generation that the pod condition was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+	"observedGeneration": "If set, this represents the .metadata.generation that the pod condition was set based upon.",
 	"status":             "Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
 	"lastProbeTime":      "Last time we probed the condition.",
 	"lastTransitionTime": "Last time the condition transitioned from one status to another.",

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podcondition.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podcondition.go
@@ -32,7 +32,6 @@ type PodConditionApplyConfiguration struct {
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
 	Type *corev1.PodConditionType `json:"type,omitempty"`
 	// If set, this represents the .metadata.generation that the pod condition was set based upon.
-	// The PodObservedGenerationTracking feature gate must be enabled to use this field.
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove the reference to the "PodObservedGenerationTracking" feature gate in the API field description, as it is now GA

#### Which issue(s) this PR is related to:

Requested in https://github.com/kubernetes/website/pull/52913#issuecomment-3513990947

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node
/assign @SergeyKanzhelev @liggitt 

