### PR TITLE
Close the underlying connection to prevent fd leak

### DIFF
--- a/staging/src/k8s.io/streaming/pkg/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/spdy/roundtripper.go
@@ -413,7 +413,14 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 	connectionHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderConnection))
 	upgradeHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderUpgrade))
 	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+			// Close the underlying network connection to prevent fd leak when
+			// the upgrade is not successful (e.g. container not found).
+			if s.conn != nil {
+				_ = s.conn.Close()
+			}
+		}()
 		responseErrorBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("unable to upgrade connection: unable to read error from server response")

--- a/staging/src/k8s.io/streaming/pkg/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/spdy/roundtripper_test.go
@@ -940,6 +940,80 @@ func TestRoundTripSocks5AndNewConnection(t *testing.T) {
 	}
 }
 
+// TestNewConnectionClosesConnOnFailedUpgrade verifies that when NewConnection
+// receives a non-101 response (failed SPDY upgrade), the underlying network
+// connection (s.conn) is closed. This prevents file descriptor leaks in the
+// apiserver when kubectl exec targets a container that cannot be found.
+// Regression test for https://github.com/kubernetes/kubernetes/issues/135245
+func TestNewConnectionClosesConnOnFailedUpgrade(t *testing.T) {
+	testCases := map[string]struct {
+		statusCode       int
+		connectionHeader string
+		upgradeHeader    string
+	}{
+		"forbidden status": {
+			statusCode:       http.StatusForbidden,
+			connectionHeader: "Upgrade",
+			upgradeHeader:    "SPDY/3.1",
+		},
+		"missing connection header": {
+			statusCode:       http.StatusSwitchingProtocols,
+			connectionHeader: "",
+			upgradeHeader:    "SPDY/3.1",
+		},
+		"missing upgrade header": {
+			statusCode:       http.StatusSwitchingProtocols,
+			connectionHeader: "Upgrade",
+			upgradeHeader:    "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(serverHandler(t, serverHandlerConfig{
+				shouldError:      true,
+				statusCode:       tc.statusCode,
+				connectionHeader: tc.connectionHeader,
+				upgradeHeader:    tc.upgradeHeader,
+			}))
+			defer server.Close()
+
+			spdyTransport, err := NewRoundTripper(nil)
+			if err != nil {
+				t.Fatalf("error creating SpdyRoundTripper: %v", err)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			if err != nil {
+				t.Fatalf("error creating request: %v", err)
+			}
+
+			client := &http.Client{Transport: spdyTransport}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("error executing request: %v", err)
+			}
+
+			// NewConnection should fail because the upgrade was not successful.
+			_, err = spdyTransport.NewConnection(resp)
+			if err == nil {
+				t.Fatalf("expected NewConnection to fail, but it succeeded")
+			}
+
+			// The underlying connection must have been closed by NewConnection.
+			// Verify by attempting to read from it — a closed connection returns an error.
+			if spdyTransport.conn == nil {
+				t.Fatalf("conn should have been set by RoundTrip")
+			}
+			buf := make([]byte, 1)
+			_, readErr := spdyTransport.conn.Read(buf)
+			if readErr == nil {
+				t.Errorf("expected error reading from closed connection, indicating conn was properly closed")
+			}
+		})
+	}
+}
+
 func TestRoundTripPassesContextToDialer(t *testing.T) {
 	urls := []string{"http://127.0.0.1:1233/", "https://127.0.0.1:1233/"}
 	for _, u := range urls {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig api-machinery
/area apiserver
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Close the underlying connection to prevent fd leak
#### Which issue(s) this PR is related to:
Fixes #135245
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #135245
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
**I'll add the test cases after we first confirm that the fix is acceptable.**
bugfix before：
```
➜  test kubectl exec httpd -c httpd -- sh -c "ps -ef | grep java | grep -v grep";lsof -p 49320 |wc -l
error: Internal error occurred: unable to upgrade connection: container not found ("httpd")
100
➜  test kubectl exec httpd -c httpd -- sh -c "ps -ef | grep java | grep -v grep";lsof -p 49320 |wc -l
error: Internal error occurred: unable to upgrade connection: container not found ("httpd")
101
➜  test kubectl exec httpd -c httpd -- sh -c "ps -ef | grep java | grep -v grep";lsof -p 49320 |wc -l
error: Internal error occurred: unable to upgrade connection: container not found ("httpd")
102
```
bugfix after：
```
➜  test kubectl exec httpd -c httpd -- sh -c "ps -ef | grep java | grep -v grep";lsof -p 34233 |wc -l
error: Internal error occurred: unable to upgrade connection: container not found ("httpd")
86
➜  test kubectl exec httpd -c httpd -- sh -c "ps -ef | grep java | grep -v grep";lsof -p 34233 |wc -l
error: Internal error occurred: unable to upgrade connection: container not found ("httpd")
86
➜  test kubectl exec httpd -c httpd -- sh -c "ps -ef | grep java | grep -v grep";lsof -p 34233 |wc -l
error: Internal error occurred: unable to upgrade connection: container not found ("httpd")
86
```



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a fd leak in the SPDY round tripper by closing the underlying network connection when
  the protocol upgrade fails (e.g., container not found during kubectl exec).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
