### PR TITLE
added wildcard * for GroupResources to allow filtering of noisy subgr…

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -64867,7 +64867,7 @@ func schema_pkg_apis_audit_v1_GroupResources(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Group is the name of the API group that contains the resources. The empty string represents the core API group.",
+							Description: "Group is the name of the API group that contains the resources. The empty string represents the core API group. `*` matches all groups",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -275,6 +275,7 @@ type PolicyRule struct {
 type GroupResources struct {
 	// Group is the name of the API group that contains the resources.
 	// The empty string represents the core API group.
+	// `*` matches all groups
 	// +optional
 	Group string
 	// Resources is a list of resources this rule applies to.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
@@ -135,6 +135,7 @@ message EventList {
 message GroupResources {
   // Group is the name of the API group that contains the resources.
   // The empty string represents the core API group.
+  // `*` matches all groups
   // +optional
   optional string group = 1;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
@@ -278,6 +278,7 @@ type PolicyRule struct {
 type GroupResources struct {
 	// Group is the name of the API group that contains the resources.
 	// The empty string represents the core API group.
+	// `*` matches all groups
 	// +optional
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resources is a list of resources this rule applies to.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation.go
@@ -98,7 +98,7 @@ func validateResources(groupResources []audit.GroupResources, fldPath *field.Pat
 	var allErrs field.ErrorList
 	for _, groupResource := range groupResources {
 		// The empty string represents the core API group.
-		if len(groupResource.Group) != 0 {
+		if len(groupResource.Group) != 0 && groupResource.Group != "*" {
 			// Group names must be lower case and be valid DNS subdomains.
 			// reference: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
 			// an error is returned for group name like rbac.authorization.k8s.io/v1beta1

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
@@ -191,7 +191,7 @@ func ruleMatchesResource(r *audit.PolicyRule, attrs authorizer.Attributes) bool 
 	name := attrs.GetName()
 
 	for _, gr := range r.Resources {
-		if gr.Group == apiGroup {
+		if gr.Group == apiGroup || gr.Group == "*" {
 			if len(gr.Resources) == 0 {
 				return true
 			}

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
@@ -84,6 +84,17 @@ var (
 			ResourceRequest: true,
 			Path:            "/api/v1/namespaces/default/pods/busybox",
 		},
+		"ClusterRoleUpdate": &authorizer.AttributesRecord{
+			User:            tim,
+			Verb:            "update",
+			APIGroup:        "rbac.authorization.k8s.io",
+			APIVersion:      "v1beta1",
+			Resource:        "clusterroles",
+			Subresource:     "status",
+			Name:            "somerole",
+			ResourceRequest: true,
+			Path:            "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/somerole",
+		},
 	}
 
 	rules = map[string]audit.PolicyRule{
@@ -139,6 +150,14 @@ var (
 				Resources: []string{"clusterroles"},
 			}},
 			Namespaces: []string{""},
+		},
+		"getGroupWildCardMatchingWithSubresourceWildcardMatching": {
+			Level: audit.LevelRequestResponse,
+			Verbs: []string{"update"},
+			Resources: []audit.GroupResources{{
+				Group:     "*",
+				Resources: []string{"*/status"},
+			}},
 		},
 		"getLogs": {
 			Level: audit.LevelRequestResponse,
@@ -242,6 +261,7 @@ func testAuditLevel(t *testing.T, stages []audit.Stage) {
 	test(t, "Unauthorized", audit.LevelMetadata, stages, stages, "tims", "default")
 	test(t, "Unauthorized", audit.LevelNone, stages, stages, "humans")
 	test(t, "Unauthorized", audit.LevelMetadata, stages, stages, "humans", "default")
+	test(t, "ClusterRoleUpdate", audit.LevelRequestResponse, stages, stages, "getGroupWildCardMatchingWithSubresourceWildcardMatching")
 }
 
 func TestChecker(t *testing.T) {

--- a/test/integration/controlplane/audit/audit_test.go
+++ b/test/integration/controlplane/audit/audit_test.go
@@ -99,6 +99,11 @@ rules:
     resources:
       - group: "apps"
         resources: ["deployments/scale"]
+  - level: Request
+    namespaces: ["wildcard-group-audit-request"]
+    resources:
+      - group: "*"
+        resources: ["deployments"]
 
 `
 	nonAdmissionWebhookNamespace       = "no-webhook-namespace"
@@ -371,6 +376,25 @@ func runTestWithVersion(t *testing.T, version string) {
 					Namespace:         "update-audit-response",
 					RequestObject:     true,
 					ResponseObject:    true,
+					AuthorizeDecision: "allow",
+				},
+			},
+		},
+		{
+			auditLevel: auditinternal.LevelRequest,
+			namespace:  "wildcard-group-audit-request",
+			expEvents: []utils.AuditEvent{
+				{
+					Level:             auditinternal.LevelRequest,
+					Stage:             auditinternal.StageResponseComplete,
+					RequestURI:        fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments", "wildcard-group-audit-request"),
+					Verb:              "create",
+					Code:              201,
+					User:              auditTestUser,
+					Resource:          "deployments",
+					Namespace:         "wildcard-group-audit-request",
+					RequestObject:     true,
+					ResponseObject:    false,
 					AuthorizeDecision: "allow",
 				},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds the possibility to configure a https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go#L275  GroupResources to use a wildcard for groups. This enables a user to configure a PolicyRule to apply to wildcard subresources. We need this feature to disable audit logging for writes to */status to reduce noise. 

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: the `--audit-policy-file` config file now supports specifying `group: "*"` in resources rules to match all API groups
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

changes for the docs are prepared at  https://github.com/cmuuss/website/tree/auditrulegroupwildcards