### PR TITLE
fix instances of comments not matching unexported function names

### DIFF
--- a/cluster/gce/gci/mounter/mounter.go
+++ b/cluster/gce/gci/mounter/mounter.go
@@ -60,7 +60,7 @@ func main() {
 	}
 }
 
-// MountInChroot is to run mount within chroot with the passing root directory
+// mountInChroot is to run mount within chroot with the passing root directory
 func mountInChroot(rootfsPath string, args []string) error {
 	if _, err := os.Stat(rootfsPath); os.IsNotExist(err) {
 		return fmt.Errorf("path <%s> does not exist", rootfsPath)

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -961,7 +961,7 @@ func newLegacyServiceAccountTokenCleanerController(ctx context.Context, controll
 	return newControllerLoop(legacySATokenCleaner.Run, controllerName), nil
 }
 
-// processCIDRs is a helper function that works on a comma separated cidrs and returns
+// validateCIDRs is a helper function that works on a comma separated cidrs and returns
 // a list of typed cidrs
 // error if failed to parse any of the cidrs or invalid length of cidrs
 func validateCIDRs(cidrsList string) ([]*net.IPNet, error) {

--- a/cmd/kube-controller-manager/app/service_accounts.go
+++ b/cmd/kube-controller-manager/app/service_accounts.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
-// serviceAccountTokenController is special because it must run first to set up permissions for other controllers.
+// newServiceAccountTokenControllerDescriptor is special because it must run first to set up permissions for other controllers.
 // It cannot use the "normal" client builder, so it tracks its own.
 func newServiceAccountTokenControllerDescriptor(rootClientBuilder clientbuilder.ControllerClientBuilder) *ControllerDescriptor {
 	return &ControllerDescriptor{

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -274,7 +274,7 @@ func (printer *upgradePlanTextPrinter) PrintObj(obj runtime.Object, writer io.Wr
 	return nil
 }
 
-// printUpgradePlan prints a UX-friendly overview of what versions are available to upgrade to
+// printAvailableUpgrade prints a UX-friendly overview of what versions are available to upgrade to
 func (printer *upgradePlanTextPrinter) printAvailableUpgrade(writer io.Writer, au *outputapiv1alpha3.AvailableUpgrade) error {
 	var kubeVersion string
 	var beforeKubeadmVersion, afterKubeadmVersion string

--- a/cmd/kubeadm/app/util/apiclient/dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrun.go
@@ -165,7 +165,7 @@ func (d *DryRun) FakeClient() clientset.Interface {
 	return d.fakeClient
 }
 
-// addRectors is by default called by NewDryRun after creating the fake client.
+// addReactors is by default called by NewDryRun after creating the fake client.
 // It prepends a set of reactors before the default fake client reactor.
 func (d *DryRun) addReactors() {
 	reactors := []testing.Reactor{

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -443,7 +443,7 @@ func (mutators *migrateMutators) addEmpty(in []any) {
 	*mutators = append(*mutators, mutator)
 }
 
-// defaultMutators returns the default list of mutators for known configuration objects.
+// defaultMigrateMutators returns the default list of mutators for known configuration objects.
 // TODO: make this function return defaultEmptyMutators() when v1beta3 is removed.
 func defaultMigrateMutators() migrateMutators {
 	var (

--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -588,7 +588,7 @@ func validatingHasAcceptedAdmissionReviewVersions(webhooks []admissionregistrati
 	return true
 }
 
-// ignoreMatchConditions returns false if any change to match conditions
+// ignoreMutatingWebhookMatchConditions returns false if any change to match conditions
 func ignoreMutatingWebhookMatchConditions(new, old []admissionregistration.MutatingWebhook) bool {
 	if len(new) != len(old) {
 		return false
@@ -602,7 +602,7 @@ func ignoreMutatingWebhookMatchConditions(new, old []admissionregistration.Mutat
 	return true
 }
 
-// ignoreMatchConditions returns true if any new expressions are added
+// ignoreValidatingWebhookMatchConditions returns true if any new expressions are added
 func ignoreValidatingWebhookMatchConditions(new, old []admissionregistration.ValidatingWebhook) bool {
 	if len(new) != len(old) {
 		return false
@@ -682,7 +682,7 @@ func validatingHasNoSideEffects(webhooks []admissionregistration.ValidatingWebho
 	return true
 }
 
-// validatingWebhookAllowInvalidLabelValueInSelector returns true if all webhooksallow invalid label value in selector
+// validatingWebhookHasInvalidLabelValueInSelector returns true if all webhooksallow invalid label value in selector
 func validatingWebhookHasInvalidLabelValueInSelector(webhooks []admissionregistration.ValidatingWebhook) bool {
 	labelSelectorValidationOpts := metav1validation.LabelSelectorValidationOptions{
 		AllowInvalidLabelValueInSelector: false,
@@ -703,7 +703,7 @@ func validatingWebhookHasInvalidLabelValueInSelector(webhooks []admissionregistr
 	return false
 }
 
-// mutatingWebhookAllowInvalidLabelValueInSelector returns true if all webhooks allow invalid label value in selector
+// mutatingWebhookHasInvalidLabelValueInSelector returns true if all webhooks allow invalid label value in selector
 func mutatingWebhookHasInvalidLabelValueInSelector(webhooks []admissionregistration.MutatingWebhook) bool {
 	labelSelectorValidationOpts := metav1validation.LabelSelectorValidationOptions{
 		AllowInvalidLabelValueInSelector: false,

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -502,7 +502,7 @@ func IsMatchedVolume(name string, volumes map[string]core.VolumeSource) bool {
 	return false
 }
 
-// isMatched checks whether the volume with the given name is used by a
+// isMatchedDevice checks whether the volume with the given name is used by a
 // container and if so, if it involves a PVC.
 func isMatchedDevice(name string, volumes map[string]core.VolumeSource) (isMatched bool, isPVC bool) {
 	if source, ok := volumes[name]; ok {
@@ -3783,7 +3783,7 @@ func validateEphemeralContainers(ephemeralContainers []core.EphemeralContainer, 
 	return allErrs
 }
 
-// ValidateFieldAcceptList checks that only allowed fields are set.
+// validateFieldAllowList checks that only allowed fields are set.
 // The value must be a struct (not a pointer to a struct!).
 func validateFieldAllowList(value interface{}, allowedFields map[string]bool, errorText string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
@@ -5289,7 +5289,7 @@ func ValidateSeccompPodAnnotations(annotations map[string]string, fldPath *field
 	return allErrs
 }
 
-// ValidateSeccompProfileType tests that the argument is a valid SeccompProfileType.
+// validateSeccompProfileType tests that the argument is a valid SeccompProfileType.
 func validateSeccompProfileType(fldPath *field.Path, seccompProfileType core.SeccompProfileType) *field.Error {
 	switch seccompProfileType {
 	case core.SeccompProfileTypeLocalhost, core.SeccompProfileTypeRuntimeDefault, core.SeccompProfileTypeUnconfined:
@@ -6469,7 +6469,7 @@ var supportedServiceIPFamilyPolicy = sets.New(
 	core.IPFamilyPolicyPreferDualStack,
 	core.IPFamilyPolicyRequireDualStack)
 
-// ValidateService tests if required fields/annotations of a Service are valid.
+// validateService tests if required fields/annotations of a Service are valid.
 func validateService(service, oldService *core.Service) field.ErrorList {
 	metaPath := field.NewPath("metadata")
 

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -159,7 +159,7 @@ func ValidateVolumeAttachmentV1(volumeAttachment *storage.VolumeAttachment) fiel
 	return allErrs
 }
 
-// ValidateVolumeAttachmentSpec tests that the specified VolumeAttachmentSpec
+// validateVolumeAttachmentSpec tests that the specified VolumeAttachmentSpec
 // has valid data.
 func validateVolumeAttachmentSpec(
 	spec *storage.VolumeAttachmentSpec, fldPath *field.Path) field.ErrorList {
@@ -179,7 +179,7 @@ func validateAttacher(attacher string, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-// validateSource tests if the source is valid for VolumeAttachment.
+// validateVolumeAttachmentSource tests if the source is valid for VolumeAttachment.
 func validateVolumeAttachmentSource(source *storage.VolumeAttachmentSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	switch {
@@ -208,7 +208,7 @@ func validateNodeName(nodeName string, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-// validaVolumeAttachmentStatus tests if volumeAttachmentStatus is valid.
+// validateVolumeAttachmentStatus tests if volumeAttachmentStatus is valid.
 func validateVolumeAttachmentStatus(status *storage.VolumeAttachmentStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateAttachmentMetadata(status.AttachmentMetadata, fldPath.Child("attachmentMetadata"))...)
@@ -275,7 +275,7 @@ func validateVolumeBindingMode(mode *storage.VolumeBindingMode, fldPath *field.P
 	return allErrs
 }
 
-// validateAllowedTopology tests that AllowedTopologies specifies valid values.
+// validateAllowedTopologies tests that AllowedTopologies specifies valid values.
 func validateAllowedTopologies(topologies []api.TopologySelectorTerm, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -338,7 +338,7 @@ func ValidateCSINodeUpdate(new, old *storage.CSINode, validationOpts CSINodeVali
 	return allErrs
 }
 
-// ValidateCSINodeSpec tests that the specified CSINodeSpec has valid data.
+// validateCSINodeSpec tests that the specified CSINodeSpec has valid data.
 func validateCSINodeSpec(
 	spec *storage.CSINodeSpec, fldPath *field.Path, validationOpts CSINodeValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -443,7 +443,7 @@ func ValidateCSIDriverUpdate(new, old *storage.CSIDriver) field.ErrorList {
 	return allErrs
 }
 
-// ValidateCSIDriverSpec tests that the specified CSIDriverSpec
+// validateCSIDriverSpec tests that the specified CSIDriverSpec
 // has valid data.
 func validateCSIDriverSpec(
 	spec *storage.CSIDriverSpec, fldPath *field.Path) field.ErrorList {
@@ -573,7 +573,7 @@ func validateSELinuxMount(seLinuxMount *bool, fldPath *field.Path) field.ErrorLi
 	return allErrs
 }
 
-// validvalidateServiceAccountTokenInSecrets validates serviceAccountTokenInSecrets and its relation to tokenRequests.
+// validateServiceAccountTokenInSecrets validates serviceAccountTokenInSecrets and its relation to tokenRequests.
 func validateServiceAccountTokenInSecrets(serviceAccountTokenInSecrets *bool, tokenRequests []storage.TokenRequest, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if serviceAccountTokenInSecrets != nil && len(tokenRequests) == 0 {

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
@@ -212,7 +212,7 @@ func NewAlphaClusterTrustBundlePublisher(
 	)
 }
 
-// NewClusterTrustBundlePublisher creates and maintains a cluster trust bundle object
+// newClusterTrustBundlePublisher creates and maintains a cluster trust bundle object
 // for a signer named `signerName`. The cluster trust bundle object contains the
 // CA from the `caProvider` in its .spec.TrustBundle.
 func newClusterTrustBundlePublisher[T clusterTrustBundle](

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers.go
@@ -127,7 +127,7 @@ func removeSlice(slices []*discovery.EndpointSlice, sliceToRemove *discovery.End
 	return slices
 }
 
-// toSliceByAddrType returns lists of EndpointSlices grouped by address.
+// toSlicesByAddrType returns lists of EndpointSlices grouped by address.
 func toSlicesByAddrType(slices []*discovery.EndpointSlice) slicesByAddrType {
 	byAddrType := slicesByAddrType{}
 	for _, slice := range slices {

--- a/pkg/controller/job/indexed_job_utils.go
+++ b/pkg/controller/job/indexed_job_utils.go
@@ -355,7 +355,7 @@ func addIndexFailureCountAnnotation(logger klog.Logger, template *v1.PodTemplate
 	}
 }
 
-// getNewIndexFailureCount returns the value of the index-failure-count
+// getNewIndexFailureCounts returns the value of the index-failure-count
 // annotation for the new pod being created
 func getNewIndexFailureCounts(logger klog.Logger, job *batch.Job, podBeingReplaced *v1.Pod) (int32, int32) {
 	if podBeingReplaced != nil {

--- a/pkg/controller/job/tracking_utils.go
+++ b/pkg/controller/job/tracking_utils.go
@@ -51,7 +51,7 @@ type uidTrackingExpectations struct {
 	store cache.Store
 }
 
-// GetUIDs is a convenience method to avoid exposing the set of expected uids.
+// getSet is a convenience method to avoid exposing the set of expected uids.
 // The returned set is not thread safe, all modifications must be made holding
 // the uidStoreLock.
 func (u *uidTrackingExpectations) getSet(controllerKey string) *uidSet {
@@ -94,7 +94,7 @@ func (u *uidTrackingExpectations) expectFinalizersRemoved(logger klog.Logger, jo
 	return nil
 }
 
-// FinalizerRemovalObserved records the given deleteKey as a deletion, for the given job.
+// finalizerRemovalObserved records the given deleteKey as a deletion, for the given job.
 func (u *uidTrackingExpectations) finalizerRemovalObserved(logger klog.Logger, jobKey string, deleteKey types.UID) {
 	uids := u.getSet(jobKey)
 	if uids != nil {
@@ -117,7 +117,7 @@ func (u *uidTrackingExpectations) deleteExpectations(logger klog.Logger, jobKey 
 	}
 }
 
-// NewUIDTrackingControllerExpectations returns a wrapper around
+// newUIDTrackingExpectations returns a wrapper around
 // ControllerExpectations that is aware of deleteKeys.
 func newUIDTrackingExpectations() *uidTrackingExpectations {
 	return &uidTrackingExpectations{store: cache.NewStore(uidSetKeyFunc)}

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -316,7 +316,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 	}
 }
 
-// matchError returns true if errors match, false if they don't, compares by error message only for convenience which should be sufficient for these tests
+// matchErrors returns true if errors match, false if they don't, compares by error message only for convenience which should be sufficient for these tests
 func matchErrors(e1, e2 error) bool {
 	if e1 == nil && e2 == nil {
 		return true

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -207,7 +207,7 @@ func (r *rangeAllocator) runWorker(ctx context.Context) {
 	}
 }
 
-// processNextWorkItem will read a single work item off the queue and
+// processNextNodeWorkItem will read a single work item off the queue and
 // attempt to process it, by calling the syncHandler.
 func (r *rangeAllocator) processNextNodeWorkItem(ctx context.Context) bool {
 	obj, shutdown := r.queue.Get()

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -1353,7 +1353,7 @@ func calculateScaleUpLimitWithScalingRules(currentReplicas int32, scaleUpEvents,
 	return result
 }
 
-// calculateScaleDownLimitWithBehavior returns the maximum number of pods that could be deleted for the given HPAScalingRules
+// calculateScaleDownLimitWithBehaviors returns the maximum number of pods that could be deleted for the given HPAScalingRules
 func calculateScaleDownLimitWithBehaviors(currentReplicas int32, scaleUpEvents, scaleDownEvents []timestampedScaleEvent, scalingRules *autoscalingv2.HPAScalingRules) int32 {
 	var result int32
 	var proposed int32

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -428,7 +428,7 @@ func (ssc *StatefulSetController) enqueueStatefulSet(logger klog.Logger, obj int
 	ssc.queue.Add(key)
 }
 
-// enqueueStatefulSet enqueues the given statefulset in the work queue after given time
+// enqueueSSAfter enqueues the given statefulset in the work queue after given time
 func (ssc *StatefulSetController) enqueueSSAfter(logger klog.Logger, ss *apps.StatefulSet, duration time.Duration) {
 	key, err := controller.KeyFunc(ss)
 	if err != nil {

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -155,7 +155,7 @@ func storageMatches(set *apps.StatefulSet, pod *v1.Pod) bool {
 	return true
 }
 
-// getPersistentVolumeClaimPolicy returns the PVC policy for a StatefulSet, returning a retain policy if the set policy is nil.
+// getPersistentVolumeClaimRetentionPolicy returns the PVC policy for a StatefulSet, returning a retain policy if the set policy is nil.
 func getPersistentVolumeClaimRetentionPolicy(set *apps.StatefulSet) apps.StatefulSetPersistentVolumeClaimRetentionPolicy {
 	policy := apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
 		WhenDeleted: apps.RetainPersistentVolumeClaimRetentionPolicyType,

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -250,7 +250,7 @@ func (ec *ephemeralController) syncHandler(ctx context.Context, key string) erro
 	return nil
 }
 
-// handleEphemeralVolume is invoked for each volume of a pod.
+// handleVolume is invoked for each volume of a pod.
 func (ec *ephemeralController) handleVolume(ctx context.Context, pod *v1.Pod, vol v1.Volume) error {
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Ephemeral: checking volume", "volumeName", vol.Name)

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -356,7 +356,7 @@ func newExternalProvisionedVolume(name, capacity, boundToClaimUID, boundToClaimN
 	return &volume
 }
 
-// newVolume returns a new volume with given attributes
+// newVolumeWithFinalizers returns a new volume with given attributes
 func newVolumeWithFinalizers(name, capacity, boundToClaimUID, boundToClaimName string, phase v1.PersistentVolumePhase, reclaimPolicy v1.PersistentVolumeReclaimPolicy, class string, finalizers []string, annotations ...string) *v1.PersistentVolume {
 	retVolume := newVolume(name, capacity, boundToClaimUID, boundToClaimName, phase, reclaimPolicy, class, annotations...)
 	retVolume.SetFinalizers(finalizers)

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -471,7 +471,7 @@ func TestFindingVolumeWithDifferentAccessModes(t *testing.T) {
 	}
 }
 
-// createVolumeNodeAffinity returns a VolumeNodeAffinity for given key and value.
+// createNodeAffinity returns a VolumeNodeAffinity for given key and value.
 func createNodeAffinity(key string, value string) *v1.VolumeNodeAffinity {
 	return &v1.VolumeNodeAffinity{
 		Required: &v1.NodeSelector{

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -395,7 +395,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-// syncHandler is invoked for each pod which might need to be processed.
+// sync is invoked for each pod which might need to be processed.
 // If an error is returned from this function, the pod will be requeued.
 func (c *Controller) sync(ctx context.Context, podRef cache.ObjectName) error {
 	logger := klog.FromContext(ctx)

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -332,7 +332,7 @@ func (c *Controller) isBeingUsed(ctx context.Context, vac *storagev1.VolumeAttri
 	return false
 }
 
-// pvAddedUpdated reacts to vac added/updated events
+// vacAddedUpdated reacts to vac added/updated events
 func (c *Controller) vacAddedUpdated(logger klog.Logger, obj interface{}) {
 	vac, ok := obj.(*storagev1.VolumeAttributesClass)
 	if !ok {

--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -797,7 +797,7 @@ func parseRegistry(image string) string {
 	return imageParts[0]
 }
 
-// mergedEnvVars overlays system defined env vars with credential provider env vars,
+// mergeEnvVars overlays system defined env vars with credential provider env vars,
 // it gives priority to the credential provider vars allowing user to override system
 // env vars
 func mergeEnvVars(sysEnvVars, credProviderVars []string) []string {

--- a/pkg/kubelet/apis/config/validation/validation_reserved_memory.go
+++ b/pkg/kubelet/apis/config/validation/validation_reserved_memory.go
@@ -24,7 +24,7 @@ import (
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 )
 
-// validateReservedMemory validates the reserved memory configuration and returns an error if it is invalid.
+// validateReservedMemoryConfiguration validates the reserved memory configuration and returns an error if it is invalid.
 func validateReservedMemoryConfiguration(kc *kubeletconfig.KubeletConfiguration) []error {
 	if len(kc.ReservedMemory) == 0 {
 		return nil

--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -75,7 +75,7 @@ func newClaimInfoFromClaim(claim *resourceapi.ResourceClaim) (*ClaimInfo, error)
 	return info, nil
 }
 
-// newClaimInfoFromClaim creates a new claim info from a checkpointed claim info state object.
+// newClaimInfoFromState creates a new claim info from a checkpointed claim info state object.
 func newClaimInfoFromState(state *state.ClaimInfoState) *ClaimInfo {
 	info := &ClaimInfo{
 		ClaimInfoState: *state.DeepCopy(),

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -164,7 +164,7 @@ func (m *Manager) Start(ctx context.Context, activePods ActivePodsFunc, getNode 
 	return nil
 }
 
-// initPluginManager can be used instead of Start to make the manager useable
+// initDRAPluginManager can be used instead of Start to make the manager useable
 // for calls to prepare/unprepare. It exists primarily for testing purposes.
 func (m *Manager) initDRAPluginManager(ctx context.Context, getNode GetNodeFunc, wipingDelay time.Duration) {
 	m.draPlugins = draplugin.NewDRAPluginManager(ctx, m.kubeClient, getNode, m, wipingDelay)

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -638,7 +638,7 @@ func (ms *multiSorter) Sort(pods []*v1.Pod) {
 	sort.Sort(ms)
 }
 
-// OrderedBy returns a Sorter that sorts using the cmp functions, in order.
+// orderedBy returns a Sorter that sorts using the cmp functions, in order.
 // Call its Sort method to sort the data.
 func orderedBy(cmp ...cmpFunc) *multiSorter {
 	return &multiSorter{

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -144,7 +144,7 @@ func (m *imageManager) logIt(objRef *v1.ObjectReference, eventtype, event, prefi
 	}
 }
 
-// imageNotPresentOnNeverPolicy error is a utility function that emits an event about
+// imageNotPresentOnNeverPolicyError error is a utility function that emits an event about
 // an image not being present and returns the appropriate error to be passed on.
 //
 // Called in 2 scenarios:

--- a/pkg/kubelet/images/pullmanager/fs_pullrecords.go
+++ b/pkg/kubelet/images/pullmanager/fs_pullrecords.go
@@ -349,7 +349,7 @@ func processDirFiles(dirName string, fileAction func(filePath string, fileConten
 	return utilerrors.NewAggregate(walkErrors)
 }
 
-// createKubeletCOnfigSchemeEncoderDecoder creates strict-encoding encoder and
+// createKubeletConfigSchemeEncoderDecoder creates strict-encoding encoder and
 // decoder for the internal and alpha kubelet config APIs.
 func createKubeletConfigSchemeEncoderDecoder() (runtime.Encoder, runtime.Decoder, error) {
 	codecs, info, err := getKubeletConfigSerializerInfo()

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -161,7 +161,7 @@ func (kl *Kubelet) getPodDir(podUID types.UID) string {
 	return filepath.Join(kl.getPodsDir(), string(podUID))
 }
 
-// getPodVolumesSubpathsDir returns the full path to the per-pod subpaths directory under
+// getPodVolumeSubpathsDir returns the full path to the per-pod subpaths directory under
 // which subpath volumes are created for the specified pod.  This directory may not
 // exist if the pod does not exist or subpaths are not specified.
 func (kl *Kubelet) getPodVolumeSubpathsDir(podUID types.UID) string {
@@ -216,7 +216,7 @@ func (kl *Kubelet) getPodContainerDir(podUID types.UID, ctrName string) string {
 	return filepath.Join(kl.getPodDir(podUID), kubeletconfig.DefaultKubeletContainersDirName, ctrName)
 }
 
-// getPodResourcesSocket returns the full path to the directory containing the pod resources socket
+// getPodResourcesDir returns the full path to the directory containing the pod resources socket
 func (kl *Kubelet) getPodResourcesDir() string {
 	return filepath.Join(kl.getRootDir(), kubeletconfig.DefaultKubeletPodResourcesDirName)
 }
@@ -466,7 +466,7 @@ func (kl *Kubelet) setCachedMachineInfo(info *cadvisorapiv1.MachineInfo) {
 	kl.machineInfo = info
 }
 
-// getLastStableNodeAddresses returns the last observed node addresses.
+// getLastObservedNodeAddresses returns the last observed node addresses.
 func (kl *Kubelet) getLastObservedNodeAddresses() []v1.NodeAddress {
 	node, err := kl.GetNode()
 	if err != nil || node == nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -42,7 +42,7 @@ type containerGC struct {
 	tracer           trace.Tracer
 }
 
-// NewContainerGC creates a new containerGC.
+// newContainerGC creates a new containerGC.
 func newContainerGC(client internalapi.RuntimeService, podStateProvider podStateProvider, manager *kubeGenericRuntimeManager, tracer trace.Tracer) *containerGC {
 	return &containerGC{
 		client:           client,

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -301,7 +301,7 @@ func (m *kubeGenericRuntimeManager) getKubeletSandboxes(ctx context.Context, all
 	return resp, nil
 }
 
-// determinePodSandboxIP determines the IP addresses of the given pod sandbox.
+// determinePodSandboxIPs determines the IP addresses of the given pod sandbox.
 func (m *kubeGenericRuntimeManager) determinePodSandboxIPs(ctx context.Context, podNamespace, podName string, podSandbox *runtimeapi.PodSandboxStatus) []string {
 	logger := klog.FromContext(ctx)
 	podIPs := make([]string, 0)

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -406,7 +406,7 @@ func computeEvents(logger klog.Logger, oldPod, newPod *kubecontainer.Pod, cid *k
 	return generateEvents(logger, pid, cid.ID, oldState, newState)
 }
 
-// getPodIP preserves an older cached status' pod IP if the new status has no pod IPs
+// getPodIPs preserves an older cached status' pod IP if the new status has no pod IPs
 // and its sandboxes have exited
 func (g *GenericPLEG) getPodIPs(pid types.UID, status *kubecontainer.PodStatus) []string {
 	if len(status.IPs) != 0 {

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -185,7 +185,7 @@ func (og *operationGenerator) notifyPlugin(ctx context.Context, client registera
 	return nil
 }
 
-// Dial establishes the gRPC communication with the picked up plugin socket. https://godoc.org/google.golang.org/grpc#Dial
+// dial establishes the gRPC communication with the picked up plugin socket. https://godoc.org/google.golang.org/grpc#Dial
 func dial(ctx context.Context, unixSocketPath string, timeout time.Duration) (registerapi.RegistrationClient, *grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/pkg/kubelet/pluginmanager/pluginwatcher/example_handler.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/example_handler.go
@@ -135,7 +135,7 @@ func (p *exampleHandler) DecreasePluginCount(pluginName string) (old int, ok boo
 	return v, ok
 }
 
-// Dial establishes the gRPC communication with the picked up plugin socket. https://godoc.org/google.golang.org/grpc#Dial
+// dial establishes the gRPC communication with the picked up plugin socket. https://godoc.org/google.golang.org/grpc#Dial
 func dial(ctx context.Context, unixSocketPath string, timeout time.Duration) (registerapi.RegistrationClient, *grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -51,7 +51,7 @@ type prober struct {
 	recorder record.EventRecorder
 }
 
-// NewProber creates a Prober, it takes a command runner and
+// newProber creates a Prober, it takes a command runner and
 // several container info managers.
 func newProber(
 	runner kubecontainer.CommandRunner,

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -1361,7 +1361,7 @@ func (m *manager) recordPendingResizeCount() {
 	}
 }
 
-// recordInProgressResize sets the in-progress resize metric.
+// recordInProgressResizeCount sets the in-progress resize metric.
 func (m *manager) recordInProgressResizeCount() {
 	inProgressResizeCount := 0
 	for _, conditions := range m.podResizeConditions {

--- a/pkg/proxy/endpointschangetracker.go
+++ b/pkg/proxy/endpointschangetracker.go
@@ -234,21 +234,21 @@ func (em EndpointsMap) Update(ect *EndpointsChangeTracker) UpdateEndpointsMapRes
 	return result
 }
 
-// Merge ensures that the current EndpointsMap contains all <service, endpoints> pairs from the EndpointsMap passed in.
+// merge ensures that the current EndpointsMap contains all <service, endpoints> pairs from the EndpointsMap passed in.
 func (em EndpointsMap) merge(other EndpointsMap) {
 	for svcPortName := range other {
 		em[svcPortName] = other[svcPortName]
 	}
 }
 
-// Unmerge removes the <service, endpoints> pairs from the current EndpointsMap which are contained in the EndpointsMap passed in.
+// unmerge removes the <service, endpoints> pairs from the current EndpointsMap which are contained in the EndpointsMap passed in.
 func (em EndpointsMap) unmerge(other EndpointsMap) {
 	for svcPortName := range other {
 		delete(em, svcPortName)
 	}
 }
 
-// getLocalEndpointIPs returns endpoints IPs if given endpoint is local - local means the endpoint is running in same host as kube-proxy.
+// getLocalReadyEndpointIPs returns endpoints IPs if given endpoint is local - local means the endpoint is running in same host as kube-proxy.
 func (em EndpointsMap) getLocalReadyEndpointIPs() map[types.NamespacedName]sets.Set[string] {
 	localIPs := make(map[types.NamespacedName]sets.Set[string])
 	for svcPortName, epList := range em {

--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -159,7 +159,7 @@ type hcInstance struct {
 	endpoints int // number of local endpoints for a service
 }
 
-// listenAll opens health check port on all the addresses provided
+// listenAndServeAll opens health check port on all the addresses provided
 func (hcI *hcInstance) listenAndServeAll(hcs *server) error {
 	var err error
 	var listener net.Listener

--- a/pkg/registry/discovery/endpointslice/strategy.go
+++ b/pkg/registry/discovery/endpointslice/strategy.go
@@ -139,7 +139,7 @@ func (endpointSliceStrategy) AllowUnconditionalUpdate() bool {
 	return true
 }
 
-// dropDisabledConditionsOnCreate will drop any fields that are disabled.
+// dropDisabledFieldsOnCreate will drop any fields that are disabled.
 func dropDisabledFieldsOnCreate(endpointSlice *discovery.EndpointSlice) {
 	dropHints := !utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareHints)
 	dropNodeHints := !utilfeature.DefaultFeatureGate.Enabled(features.PreferSameTrafficDistribution)

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -249,7 +249,7 @@ func (aq *activeQueue) underLock(fn func(unlockedActiveQ unlockedActiveQueuer)) 
 	fn(aq.unlockedQueue)
 }
 
-// underLock runs the fn function under the lock.RLock.
+// underRLock runs the fn function under the lock.RLock.
 // fn can run unlockedActiveQueueReader methods but should NOT run any other activeQueue method,
 // as it would end up in deadlock.
 func (aq *activeQueue) underRLock(fn func(unlockedActiveQ unlockedActiveQueueReader)) {

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -479,7 +479,7 @@ func (f *Fit) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldO
 	return fwk.Queue, nil
 }
 
-// isSchedulableAfterDeviceClassChange is invoked whenever a device class added or changed. It checks whether
+// isSchedulableAfterDeviceClassEvent is invoked whenever a device class added or changed. It checks whether
 // that change could make a previously unschedulable pod schedulable.
 func (f *Fit) isSchedulableAfterDeviceClassEvent(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 	originalClass, modifiedClass, err := schedutil.As[*resourceapi.DeviceClass](oldObj, newObj)

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -134,7 +134,7 @@ func (s *preScoreState) Clone() fwk.StateData {
 	return s
 }
 
-// getAllTolerationEffectPreferNoSchedule gets the list of all Tolerations with Effect PreferNoSchedule or with no effect.
+// getAllTolerationPreferNoSchedule gets the list of all Tolerations with Effect PreferNoSchedule or with no effect.
 func getAllTolerationPreferNoSchedule(tolerations []v1.Toleration) (tolerationList []v1.Toleration) {
 	for _, toleration := range tolerations {
 		// Empty effect means all effects which includes PreferNoSchedule, so we need to collect it as well.
@@ -168,7 +168,7 @@ func getPreScoreState(cycleState fwk.CycleState) (*preScoreState, error) {
 	return s, nil
 }
 
-// CountIntolerableTaintsPreferNoSchedule gives the count of intolerable taints of a pod with effect PreferNoSchedule
+// countIntolerableTaintsPreferNoSchedule gives the count of intolerable taints of a pod with effect PreferNoSchedule
 func (pl *TaintToleration) countIntolerableTaintsPreferNoSchedule(logger klog.Logger, taints []v1.Taint, tolerations []v1.Toleration) (intolerableTaints int) {
 	for _, taint := range taints {
 		// check only on taints that have effect PreferNoSchedule

--- a/pkg/serviceaccount/externaljwt/plugin/keycache.go
+++ b/pkg/serviceaccount/externaljwt/plugin/keycache.go
@@ -53,7 +53,7 @@ func newKeyCache(client externaljwtv1.ExternalJWTSignerClient) *keyCache {
 	return cache
 }
 
-// InitialFill can be used to perform an initial fetch for keys get the
+// initialFill can be used to perform an initial fetch for keys get the
 // refresh interval as recommended by external signer.
 func (p *keyCache) initialFill(ctx context.Context) error {
 	if err := p.syncKeys(ctx); err != nil {

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -526,7 +526,7 @@ func (c *csiMountMgr) getFSGroupPolicy() (storage.FSGroupPolicy, error) {
 	return *csiDriver.Spec.FSGroupPolicy, nil
 }
 
-// supportsVolumeMode checks whether the CSI driver supports a volume in the given mode.
+// supportsVolumeLifecycleMode checks whether the CSI driver supports a volume in the given mode.
 // An error indicates that it isn't supported and explains why.
 func (c *csiMountMgr) supportsVolumeLifecycleMode() error {
 	// Retrieve CSIDriver. It's not an error if the driver isn't found

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -141,7 +141,7 @@ func inUseError(err error) bool {
 	return st.Code() == codes.FailedPrecondition
 }
 
-// IsInfeasibleError returns true for grpc errors that are considered terminal in a way
+// isInfeasibleError returns true for grpc errors that are considered terminal in a way
 // that they indicate CSI operation as infeasible.
 // This function returns a subset of final errors. All infeasible errors are also final errors.
 func isInfeasibleError(err error) bool {

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager.go
@@ -178,7 +178,7 @@ func (nim *nodeInfoManager) updateNode(updateFuncs ...nodeUpdateFunc) error {
 	return nil
 }
 
-// updateNode repeatedly attempts to update the corresponding node object
+// tryUpdateNode repeatedly attempts to update the corresponding node object
 // which is modified by applying the given update functions sequentially.
 // Because updateFuncs are applied sequentially, later updateFuncs should take into account
 // the effects of previous updateFuncs to avoid potential conflicts. For example, if multiple

--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -207,7 +207,7 @@ func (prober *flexVolumeProber) handleWatchEvent(event fsnotify.Event) error {
 	return nil
 }
 
-// getExecutableName returns the executableName of a flex plugin
+// getExecutablePathRel returns the executableName of a flex plugin
 func getExecutablePathRel(driverDirName string) string {
 	parts := strings.Split(driverDirName, "~")
 	return filepath.Join(driverDirName, parts[len(parts)-1])

--- a/plugin/pkg/admission/podtolerationrestriction/config.go
+++ b/plugin/pkg/admission/podtolerationrestriction/config.go
@@ -37,7 +37,7 @@ func init() {
 	install.Install(scheme)
 }
 
-// LoadConfiguration loads the provided configuration.
+// loadConfiguration loads the provided configuration.
 func loadConfiguration(config io.Reader) (*internalapi.Configuration, error) {
 	// if no config is provided, return a default configuration
 	if config == nil {

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -2237,7 +2237,7 @@ func newTestPodForQuotaWithPriority(f *framework.Framework, name string, request
 	}
 }
 
-// newTestPodForQuota returns a pod that has the specified requests and limits
+// newTestPodWithAffinityForQuota returns a pod that has the specified requests and limits
 func newTestPodWithAffinityForQuota(f *framework.Framework, name string, affinity *v1.Affinity) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -147,7 +147,7 @@ func (r *RestartDaemonConfig) kill(ctx context.Context) {
 	framework.ExpectNoError(err)
 }
 
-// Restart checks if the daemon is up, kills it, and waits till it comes back up
+// restart checks if the daemon is up, kills it, and waits till it comes back up
 func (r *RestartDaemonConfig) restart(ctx context.Context) {
 	r.waitUp(ctx)
 	r.kill(ctx)

--- a/test/e2e/cloud/nodes.go
+++ b/test/e2e/cloud/nodes.go
@@ -78,7 +78,7 @@ var _ = SIGDescribe(feature.CloudProvider, framework.WithDisruptive(), "Nodes", 
 	})
 })
 
-// DeleteNodeOnCloudProvider deletes the specified node.
+// deleteNodeOnCloudProvider deletes the specified node.
 func deleteNodeOnCloudProvider(node *v1.Node) error {
 	return framework.TestContext.CloudConfig.Provider.DeleteNode(node)
 }

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -1713,7 +1713,7 @@ func RunSidecarLivenessTest(ctx context.Context, f *framework.Framework, pod *v1
 	runLivenessTest(ctx, f, pod, expectNumRestarts, timeout, containerName)
 }
 
-// RunLivenessTest verifies the number of restarts for pod with given expected number of restarts
+// runLivenessTest verifies the number of restarts for pod with given expected number of restarts
 func runLivenessTest(ctx context.Context, f *framework.Framework, pod *v1.Pod, expectNumRestarts int, timeout time.Duration, containerName string) {
 	podClient := e2epod.NewPodClient(f)
 	ns := f.Namespace.Name

--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -308,7 +308,7 @@ func (ex *ExamplePlugin) getUnprepareResourcesFailure() error {
 	return ex.unprepareResourcesFailure
 }
 
-// NodePrepareResource ensures that the CDI file(s) (one per request) for the claim exists. It uses
+// nodePrepareResource ensures that the CDI file(s) (one per request) for the claim exists. It uses
 // a deterministic name to simplify NodeUnprepareResource (no need to remember
 // or discover the name) and idempotency (when called again, the file simply
 // gets written again).
@@ -453,7 +453,7 @@ func (ex *ExamplePlugin) PrepareResourceClaims(ctx context.Context, claims []*re
 	return result, nil
 }
 
-// NodeUnprepareResource removes the CDI file created by
+// nodeUnprepareResource removes the CDI file created by
 // NodePrepareResource. It's idempotent, therefore it is not an error when that
 // file is already gone.
 func (ex *ExamplePlugin) nodeUnprepareResource(ctx context.Context, claimRef kubeletplugin.NamespacedObject) error {

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -163,7 +163,7 @@ func getSidecarContainer(name string, cpuLimit, memLimit int64) v1.Container {
 }
 
 /*
-NewResourceConsumer creates new ResourceConsumer
+newResourceConsumer creates new ResourceConsumer
 initCPUTotal argument is in millicores
 initMemoryTotal argument is in megabytes
 memLimit argument is in megabytes, memLimit is a maximum amount of memory that can be consumed by a single pod

--- a/test/e2e/framework/debug/dump.go
+++ b/test/e2e/framework/debug/dump.go
@@ -168,7 +168,7 @@ func getKubeletPods(ctx context.Context, c clientset.Interface, node string) (*v
 	}
 }
 
-// logNodeEvents logs kubelet events from the given node. This includes kubelet
+// getNodeEvents logs kubelet events from the given node. This includes kubelet
 // restart and node unhealthy events. Note that listing events like this will mess
 // with latency metrics, beware of calling it during a test.
 func getNodeEvents(ctx context.Context, c clientset.Interface, nodeName string) []v1.Event {

--- a/test/e2e/framework/pod/pod_client.go
+++ b/test/e2e/framework/pod/pod_client.go
@@ -371,7 +371,7 @@ func (c *PodClient) PodIsReady(ctx context.Context, name string) bool {
 	return podutils.IsPodReady(pod)
 }
 
-// RemoveString returns a newly created []string that contains all items from slice
+// removeString returns a newly created []string that contains all items from slice
 // that are not equal to s.
 // This code is taken from k/k/pkg/util/slice/slice.go to remove
 // e2e/framework/pod -> k/k/pkg/util/slice dependency.

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -235,7 +235,7 @@ func SSH(ctx context.Context, cmd, host, provider string) (Result, error) {
 	return result, err
 }
 
-// runSSHCommandViaBastion returns the stdout, stderr, and exit code from running cmd on
+// runSSHCommand returns the stdout, stderr, and exit code from running cmd on
 // host as specific user, along with any SSH-level error.
 func runSSHCommand(ctx context.Context, cmd, user, host string, signer ssh.Signer) (string, string, int, error) {
 	if user == "" {

--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -75,7 +75,7 @@ func newKubeManager(framework *framework.Framework, dnsDomain string) *kubeManag
 	}
 }
 
-// initializeCluster initialized the cluster, creating namespaces pods and services as needed.
+// initializeClusterFromModel initialized the cluster, creating namespaces pods and services as needed.
 func (k *kubeManager) initializeClusterFromModel(ctx context.Context, model *Model) error {
 	var createdPods []*v1.Pod
 	for _, ns := range model.Namespaces {
@@ -338,12 +338,12 @@ func getWorkers() int {
 	return 3
 }
 
-// getPollInterval returns the value for which the Prober will wait before attempting next attempt.
+// getPollIntervalSeconds returns the value for which the Prober will wait before attempting next attempt.
 func getPollIntervalSeconds() int {
 	return defaultPollIntervalSeconds
 }
 
-// getPollTimeout returns the timeout for polling on probes, and takes windows heuristics into account, where requests can take longer sometimes.
+// getPollTimeoutSeconds returns the timeout for polling on probes, and takes windows heuristics into account, where requests can take longer sometimes.
 func getPollTimeoutSeconds() int {
 	if framework.NodeOSDistroIs("windows") {
 		return defaultPollTimeoutSeconds * 2

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -162,7 +162,7 @@ func affinityCheckFromTest(ctx context.Context, cs clientset.Interface, serviceI
 	return interval, timeout, getHosts
 }
 
-// CheckAffinity function tests whether the service affinity works as expected.
+// checkAffinity function tests whether the service affinity works as expected.
 // If affinity is expected, the test will return true once affinityConfirmCount
 // number of same response observed in a row. If affinity is not expected, the
 // test will keep observe until different responses observed. The function will

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -767,7 +767,7 @@ func cleanupStorageClass(ctx context.Context, config *localTestConfig) {
 	framework.ExpectNoError(config.client.StorageV1().StorageClasses().Delete(ctx, config.scName, metav1.DeleteOptions{}))
 }
 
-// podNode wraps RunKubectl to get node where pod is running
+// podNodeName wraps RunKubectl to get node where pod is running
 func podNodeName(ctx context.Context, config *localTestConfig, pod *v1.Pod) (string, error) {
 	runtimePod, runtimePodErr := config.client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	return runtimePod.Spec.NodeName, runtimePodErr
@@ -1055,7 +1055,7 @@ func setupLocalVolumesPVCsPVs(
 	return testVols
 }
 
-// newLocalClaim creates a new persistent volume claim.
+// newLocalClaimWithName creates a new persistent volume claim.
 func newLocalClaimWithName(config *localTestConfig, name string) *v1.PersistentVolumeClaim {
 	claim := v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -226,7 +226,7 @@ func isValidOutput(output string) bool {
 		!strings.Contains(output, "RPC_S_SERVER_UNAVAILABLE")
 }
 
-// findPreconfiguredGmsaNode finds node with the gmsaFullNodeLabel label on it.
+// findPreconfiguredGmsaNodes finds node with the gmsaFullNodeLabel label on it.
 func findPreconfiguredGmsaNodes(ctx context.Context, c clientset.Interface) []v1.Node {
 	nodeOpts := metav1.ListOptions{
 		LabelSelector: gmsaFullNodeLabel,

--- a/test/e2e/windows/memory_limits.go
+++ b/test/e2e/windows/memory_limits.go
@@ -216,7 +216,7 @@ func getNodeMemory(ctx context.Context, f *framework.Framework, node v1.Node) no
 	return nodeMem
 }
 
-// getNodeMemory populates a nodeMemory struct with information from the first Windows node
+// getFirstNodeMemory populates a nodeMemory struct with information from the first Windows node
 // that is found in the cluster.
 func getFirstNodeMemory(ctx context.Context, f *framework.Framework) nodeMemory {
 	selector := labels.Set{"kubernetes.io/os": "windows"}.AsSelector()

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -2671,7 +2671,7 @@ type ctnAttribute struct {
 	restartPolicy *v1.ContainerRestartPolicy
 }
 
-// makeCPUMangerPod returns a pod with the provided ctnAttributes.
+// makeCPUManagerPod returns a pod with the provided ctnAttributes.
 func makeCPUManagerPod(podName string, ctnAttributes []ctnAttribute) *v1.Pod {
 	var containers []v1.Container
 	for _, ctnAttr := range ctnAttributes {
@@ -2739,7 +2739,7 @@ func makeCPUManagerPod(podName string, ctnAttributes []ctnAttribute) *v1.Pod {
 	}
 }
 
-// makeCPUMangerInitContainersPod returns a pod with init containers with the
+// makeCPUManagerInitContainersPod returns a pod with init containers with the
 // provided ctnAttributes.
 func makeCPUManagerInitContainersPod(podName string, ctnAttributes []ctnAttribute) *v1.Pod {
 	var containers []v1.Container

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -98,7 +98,7 @@ func makeMemoryManagerContainers(ctnCmd string, ctnAttributes []memoryManagerCtn
 	return containers, hugepagesMount
 }
 
-// makeMemoryMangerPod returns a pod with the provided ctnAttributes.
+// makeMemoryManagerPod returns a pod with the provided ctnAttributes.
 func makeMemoryManagerPod(podName string, initCtnAttributes, ctnAttributes []memoryManagerCtnAttributes) *v1.Pod {
 	hugepagesMount := false
 	memsetCmd := "grep Mems_allowed_list /proc/self/status | cut -f2"

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -387,7 +387,7 @@ func validatePodAlignment(ctx context.Context, f *framework.Framework, pod *v1.P
 	}
 }
 
-// validatePodAligmentWithPodScope validates whether all pod's CPUs are affined to the same NUMA node.
+// validatePodAlignmentWithPodScope validates whether all pod's CPUs are affined to the same NUMA node.
 func validatePodAlignmentWithPodScope(ctx context.Context, f *framework.Framework, pod *v1.Pod, envInfo *testEnvInfo) error {
 	// Mapping between CPU IDs and NUMA node IDs.
 	podsNUMA := make(map[int]int)

--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -350,7 +350,7 @@ func hostnameHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, getHostName())
 }
 
-// healthHandler response with a 200 if the UDP server is ready. It also serves
+// healthzHandler response with a 200 if the UDP server is ready. It also serves
 // as a health check of the HTTP server by virtue of being a HTTP handler.
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("GET /healthz")

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -407,13 +407,13 @@ func podUnschedulable(c clientset.Interface, podNamespace, podName string) wait.
 	}
 }
 
-// waitForPodUnscheduleWithTimeout waits for a pod to fail scheduling and returns
+// waitForPodUnschedulableWithTimeout waits for a pod to fail scheduling and returns
 // an error if it does not become unschedulable within the given timeout.
 func waitForPodUnschedulableWithTimeout(cs clientset.Interface, pod *v1.Pod, timeout time.Duration) error {
 	return wait.Poll(100*time.Millisecond, timeout, podUnschedulable(cs, pod.Namespace, pod.Name))
 }
 
-// waitForPodUnschedule waits for a pod to fail scheduling and returns
+// waitForPodUnschedulable waits for a pod to fail scheduling and returns
 // an error if it does not become unschedulable within the timeout duration (30 seconds).
 func waitForPodUnschedulable(cs clientset.Interface, pod *v1.Pod) error {
 	return waitForPodUnschedulableWithTimeout(cs, pod, 10*time.Second)

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -315,7 +315,7 @@ func (d *deploymentTester) waitForDeploymentCompleteAndMarkPodsReady() error {
 	return nil
 }
 
-// waitForDeploymentCompleteAndMarkPodsReadyAndRemoveTerminating waits for the Deployment to complete
+// waitForDeploymentCompleteAndMarkPodsReadyAndRemoveTerminated waits for the Deployment to complete
 // while marking updated Deployment pods as ready and removes terminated pods at the same time.
 func (d *deploymentTester) waitForDeploymentCompleteAndMarkPodsReadyAndRemoveTerminated(ctx context.Context) error {
 	var wg sync.WaitGroup

--- a/test/integration/dra/binding_conditions_test.go
+++ b/test/integration/dra/binding_conditions_test.go
@@ -51,7 +51,7 @@ func testDeviceBindingConditions(tCtx ktesting.TContext, enabled bool) {
 	}
 }
 
-// testBindingConditionsBasicFlow tests scheduling with mixed devices: one with BindingConditions, one without.
+// testDeviceBindingConditionsBasicFlow tests scheduling with mixed devices: one with BindingConditions, one without.
 // It verifies that the scheduler prioritizes the device without BindingConditions for the first pod.
 // The second pod then uses the device with BindingConditions. The test checks that the scheduler retries
 // after an initial binding failure of the second pod, ensuring successful scheduling after rescheduling.
@@ -221,7 +221,7 @@ func testDeviceBindingConditionsBasicFlow(tCtx ktesting.TContext, enabled bool) 
 	waitForPodScheduled(tCtx, namespace, pod.Name)
 }
 
-// testBindingFailureReschedule verifies scheduling behavior when device preparation fails on a node.
+// testDeviceBindingFailureConditionsReschedule verifies scheduling behavior when device preparation fails on a node.
 // It tests that a BindingFailure is written, and the scheduler successfully reschedules the pod
 // to a different node where binding succeeds. This ensures that failure recovery via rescheduling works as expected.
 // Device preparation failure is simulated in two ways: by applying DeviceTaints or by removing the device from ResourceSlice.

--- a/test/integration/dra/dra_test.go
+++ b/test/integration/dra/dra_test.go
@@ -353,7 +353,7 @@ func startScheduler(tCtx ktesting.TContext) {
 	startSchedulerWithConfig(tCtx, "")
 }
 
-// startScheduler starts the scheduler with the given config.
+// startSchedulerWithConfig starts the scheduler with the given config.
 // This may be used only in tests which run sequentially if the config is non-empty.
 func startSchedulerWithConfig(tCtx ktesting.TContext, config string) {
 	tCtx.Helper()

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -270,7 +270,7 @@ func TestFrontProxyConfig(t *testing.T) {
 	})
 }
 
-// TestFrontProxyConfig tests that the RequestHeader configuration is consumed
+// testFrontProxyConfig tests that the RequestHeader configuration is consumed
 // correctly by the aggregated API servers.
 func testFrontProxyConfig(t *testing.T, withUID bool) {
 	const testNamespace = "integration-test-front-proxy-config"

--- a/test/integration/namespace/ns_conditions_test.go
+++ b/test/integration/namespace/ns_conditions_test.go
@@ -159,7 +159,7 @@ func TestNamespaceLabels(t *testing.T) {
 	}
 }
 
-// JSONToUnstructured converts a JSON stub to unstructured.Unstructured and
+// jsonToUnstructured converts a JSON stub to unstructured.Unstructured and
 // returns a dynamic resource client that can be used to interact with it
 func jsonToUnstructured(stub, version, kind string) (*unstructured.Unstructured, error) {
 	typeMetaAdder := map[string]interface{}{}

--- a/test/integration/scheduler/scoring/priorities_test.go
+++ b/test/integration/scheduler/scoring/priorities_test.go
@@ -926,7 +926,7 @@ func TestImageLocalityScoring(t *testing.T) {
 	}
 }
 
-// makeContainerWithImage returns a list of v1.Container objects for each given image. Duplicates of an image are ignored,
+// makeContainersWithImages returns a list of v1.Container objects for each given image. Duplicates of an image are ignored,
 // i.e., each image is used only once.
 func makeContainersWithImages(images []string) []v1.Container {
 	var containers []v1.Container

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -55,7 +55,7 @@ func labelMap() map[string]string {
 	return map[string]string{"foo": "bar"}
 }
 
-// newService returns a service with a fake name for StatefulSet to be created soon
+// newHeadlessService returns a service with a fake name for StatefulSet to be created soon
 func newHeadlessService(namespace string) *v1.Service {
 	return &v1.Service{
 		TypeMeta: metav1.TypeMeta{

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -39,13 +39,13 @@ func waitForPodToSchedule(cs clientset.Interface, pod *v1.Pod) error {
 	return waitForPodToScheduleWithTimeout(cs, pod, 30*time.Second)
 }
 
-// waitForPodUnscheduleWithTimeout waits for a pod to fail scheduling and returns
+// waitForPodUnschedulableWithTimeout waits for a pod to fail scheduling and returns
 // an error if it does not become unschedulable within the given timeout.
 func waitForPodUnschedulableWithTimeout(cs clientset.Interface, pod *v1.Pod, timeout time.Duration) error {
 	return wait.Poll(100*time.Millisecond, timeout, podUnschedulable(cs, pod.Namespace, pod.Name))
 }
 
-// waitForPodUnschedule waits for a pod to fail scheduling and returns
+// waitForPodUnschedulable waits for a pod to fail scheduling and returns
 // an error if it does not become unschedulable within the timeout duration (30 seconds).
 func waitForPodUnschedulable(cs clientset.Interface, pod *v1.Pod) error {
 	return waitForPodUnschedulableWithTimeout(cs, pod, 30*time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There are ~100 comments in this codebase on unexported functions where the comments use names that have changed and no longer match the associated function names. Linters will complain about this for exported functions, but not for unexported functions, where comment style enforcement is optional.

This fixes these cases of comment-vs-name drift so they match, using the auto-fix feature of a [new linter](https://github.com/cce/docnametypo) I'm working on (and to head off a flurry of smaller typo PRs in other OSS projects I work on). I used kubernetes as an example codebase while working on getting my linter to report zero false positives (related: https://github.com/golangci/golangci-lint/pull/6189) and figured I would open a PR with the fixes.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
