### PR TITLE
Set microseconds eventTime in events

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -493,6 +493,7 @@ func (recorder *recorderImpl) makeEvent(ref *v1.ObjectReference, annotations map
 			Namespace:   namespace,
 			Annotations: annotations,
 		},
+		EventTime:      metav1.MicroTime{Time: time.Now()},
 		InvolvedObject: *ref,
 		Reason:         reason,
 		Message:        message,

--- a/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
@@ -115,6 +115,7 @@ func validateEvent(messagePrefix string, actualEvent *v1.Event, expectedEvent *v
 	// Temp clear time stamps for comparison because actual values don't matter for comparison
 	recvEvent.FirstTimestamp = expectedEvent.FirstTimestamp
 	recvEvent.LastTimestamp = expectedEvent.LastTimestamp
+	recvEvent.EventTime = expectedEvent.EventTime
 
 	recvEvent.ReportingController = expectedEvent.ReportingController
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

The record events API is used by many components and controllers, setting the event time can be useful for applications consuming events emitted by this package.
