### PR TITLE
kubelet: add diagnostic message to PodReadyToStartContainers condition

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -4597,8 +4597,10 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   v1.PodReadyToStartContainers,
-				Status: v1.ConditionFalse,
+				Type:    v1.PodReadyToStartContainers,
+				Status:  v1.ConditionFalse,
+				Reason:  kubetypes.PodSandboxNotReadyReason,
+				Message: kubetypes.PodSandboxNotReadyMsgNoPodSandbox,
 			},
 		},
 		{
@@ -4643,8 +4645,10 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				Message: "test",
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   v1.PodReadyToStartContainers,
-				Status: v1.ConditionFalse,
+				Type:    v1.PodReadyToStartContainers,
+				Status:  v1.ConditionFalse,
+				Reason:  kubetypes.PodSandboxNotReadyReason,
+				Message: kubetypes.PodSandboxNotReadyMsgNoPodSandbox,
 			},
 		},
 		{
@@ -4696,8 +4700,10 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				Message: "test",
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   v1.PodReadyToStartContainers,
-				Status: v1.ConditionFalse,
+				Type:    v1.PodReadyToStartContainers,
+				Status:  v1.ConditionFalse,
+				Reason:  kubetypes.PodSandboxNotReadyReason,
+				Message: kubetypes.PodSandboxNotReadyMsgNoPodSandbox,
 			},
 		},
 		{

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1121,7 +1121,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Syncing Pod", "pod", klog.KObj(pod))
 
-	createPodSandbox, attempt, sandboxID := runtimeutil.PodSandboxChanged(pod, podStatus)
+	createPodSandbox, attempt, sandboxID, _ := runtimeutil.PodSandboxChanged(pod, podStatus)
 	changes := podActions{
 		KillPod:           createPodSandbox,
 		CreateSandbox:     createPodSandbox,

--- a/pkg/kubelet/kuberuntime/util/util_test.go
+++ b/pkg/kubelet/kuberuntime/util/util_test.go
@@ -28,6 +28,7 @@ import (
 	pkgfeatures "k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -38,6 +39,7 @@ func TestPodSandboxChanged(t *testing.T) {
 		expectedChanged   bool
 		expectedAttempt   uint32
 		expectedSandboxID string
+		expectedReason    string
 	}{
 		"Pod with no existing sandboxes": {
 			pod:               &v1.Pod{},
@@ -45,6 +47,7 @@ func TestPodSandboxChanged(t *testing.T) {
 			expectedChanged:   true,
 			expectedAttempt:   0,
 			expectedSandboxID: "",
+			expectedReason:    kubetypes.PodSandboxNotReadyMsgNoPodSandbox,
 		},
 		"Pod with multiple ready sandbox statuses": {
 			pod: &v1.Pod{},
@@ -65,6 +68,7 @@ func TestPodSandboxChanged(t *testing.T) {
 			expectedChanged:   true,
 			expectedAttempt:   2,
 			expectedSandboxID: "sandboxID2",
+			expectedReason:    kubetypes.PodSandboxNotReadyMsgMultipleSandboxes,
 		},
 		"Pod with no ready sandbox statuses": {
 			pod: &v1.Pod{},
@@ -85,6 +89,7 @@ func TestPodSandboxChanged(t *testing.T) {
 			expectedChanged:   true,
 			expectedAttempt:   2,
 			expectedSandboxID: "sandboxID2",
+			expectedReason:    kubetypes.PodSandboxNotReadyMsgSandboxNotReady,
 		},
 		"Pod with ready sandbox status but network namespace mismatch": {
 			pod: &v1.Pod{
@@ -111,6 +116,7 @@ func TestPodSandboxChanged(t *testing.T) {
 			expectedChanged:   true,
 			expectedAttempt:   1,
 			expectedSandboxID: "",
+			expectedReason:    kubetypes.PodSandboxNotReadyMsgNetworkNamespaceMode,
 		},
 		"Pod with ready sandbox status but no IP": {
 			pod: &v1.Pod{
@@ -133,6 +139,7 @@ func TestPodSandboxChanged(t *testing.T) {
 			expectedChanged:   true,
 			expectedAttempt:   1,
 			expectedSandboxID: "sandboxID1",
+			expectedReason:    kubetypes.PodSandboxNotReadyMsgNoIPAddress,
 		},
 		"Pod with ready sandbox status with IP": {
 			pod: &v1.Pod{
@@ -155,13 +162,15 @@ func TestPodSandboxChanged(t *testing.T) {
 			expectedChanged:   false,
 			expectedAttempt:   0,
 			expectedSandboxID: "sandboxID1",
+			expectedReason:    "",
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			changed, attempt, id := PodSandboxChanged(test.pod, test.status)
+			changed, attempt, id, reason := PodSandboxChanged(test.pod, test.status)
 			require.Equal(t, test.expectedChanged, changed)
 			require.Equal(t, test.expectedAttempt, attempt)
 			require.Equal(t, test.expectedSandboxID, id)
+			require.Equal(t, test.expectedReason, reason)
 		})
 	}
 }

--- a/pkg/kubelet/status/generate.go
+++ b/pkg/kubelet/status/generate.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	runtimeutil "k8s.io/kubernetes/pkg/kubelet/kuberuntime/util"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -268,7 +269,7 @@ func GeneratePodInitializedCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, co
 }
 
 func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, oldPodStatus *v1.PodStatus, podStatus *kubecontainer.PodStatus) v1.PodCondition {
-	newSandboxNeeded, _, _ := runtimeutil.PodSandboxChanged(pod, podStatus)
+	newSandboxNeeded, _, _, reason := runtimeutil.PodSandboxChanged(pod, podStatus)
 	// if a new sandbox does not need to be created for a pod, it indicates that
 	// a sandbox for the pod with networking configured already exists.
 	// Otherwise, the kubelet needs to invoke the container runtime to create a
@@ -284,6 +285,8 @@ func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, oldPodStatus *v1.Po
 		Type:               v1.PodReadyToStartContainers,
 		ObservedGeneration: podutil.CalculatePodConditionObservedGeneration(oldPodStatus, pod.Generation, v1.PodReadyToStartContainers),
 		Status:             v1.ConditionFalse,
+		Reason:             kubetypes.PodSandboxNotReadyReason,
+		Message:            reason,
 	}
 }
 

--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -38,3 +38,16 @@ const (
 	LimitedSwap SwapBehavior = "LimitedSwap"
 	NoSwap      SwapBehavior = "NoSwap"
 )
+
+// Pod status condition reasons and messages
+const (
+	// PodReadyToStartContainers condition reason
+	PodSandboxNotReadyReason = "PodSandboxNotReady"
+
+	// PodReadyToStartContainers condition messages
+	PodSandboxNotReadyMsgNoPodSandbox         = "no pod sandbox exists"
+	PodSandboxNotReadyMsgMultipleSandboxes    = "multiple pod sandboxes are ready and need to be reconciled"
+	PodSandboxNotReadyMsgSandboxNotReady      = "pod sandbox is not ready"
+	PodSandboxNotReadyMsgNetworkNamespaceMode = "network namespace mode changed and sandbox needs to be recreated"
+	PodSandboxNotReadyMsgNoIPAddress          = "pod sandbox has no IP address"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
PodReadyToStartContainers condition lacks diagnostic message when pods stuck in ContainerCreating

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes : https://github.com/kubernetes/kubernetes/issues/135299


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `PodReadyToStartContainers` condition now includes a diagnostic message when `Status` is `False`, explaining why the pod sandbox is not ready (e.g., "pod sandbox has no IP address", "no pod sandbox exists"). This improves debuggability for pods stuck in `ContainerCreating` state without requiring access to node logs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
