### PR TITLE
Fix context deadline exceeded in PodCertificate test

### DIFF
--- a/pkg/kubelet/podcertificate/podcertificatemanager_test.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager_test.go
@@ -21,7 +21,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"math/rand"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,12 +32,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	certlistersv1beta1 "k8s.io/client-go/listers/certificates/v1beta1"
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/test/utils/hermeticpodcertificatesigner"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -182,9 +187,51 @@ func TestFullFlow(t *testing.T) {
 	ctx, cancel := context.WithCancel(ktesting.Init(t))
 	defer cancel()
 
-	kc := fake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(kc, 0)
 	clock := testclock.NewFakeClock(mustRFC3339(t, "2010-01-01T00:00:00Z"))
+	kc := fake.NewSimpleClientset()
+
+	// Assign PCR name and creationTimeStamp
+	kc.Fake.PrependReactor("create", "podcertificaterequests",
+		func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			obj := action.(k8stesting.CreateAction).GetObject().(*certsv1beta1.PodCertificateRequest)
+			// Simulate server-side GenerateName behavior
+			if obj.Name == "" {
+				obj.Name = fmt.Sprintf("%s-pcr-%d", obj.Spec.PodName, rand.Int63n(1_000_000))
+			}
+			obj.CreationTimestamp = metav1.NewTime(clock.Now())
+
+			return false, obj, nil // allow normal processing
+		})
+
+	// fake.Clientset suffers from a race condition related to informers:
+	// it does not implement resource version support in its Watch
+	// implementation and instead assumes that watches are set up
+	// before further changes are made.
+	//
+	// If a test waits for caches to be synced and then immediately
+	// adds an object, that new object will never be seen by event handlers
+	// if the race goes wrong and the Watch call hadn't completed yet
+	//
+	// To work around this, we count all watches and only proceed when all of them are in place
+	var numWatches atomic.Int32
+	kc.Fake.PrependWatchReactor("*", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
+		// Recreate the default fake-client watch behaviour, but count watches
+		var opts metav1.ListOptions
+		if wa, ok := action.(k8stesting.WatchActionImpl); ok {
+			opts = wa.ListOptions
+		}
+
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		w, err := kc.Tracker().Watch(gvr, ns, opts)
+		if err != nil {
+			return false, nil, err
+		}
+
+		numWatches.Add(1)
+		return true, w, nil
+	})
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(kc, 0)
 
 	//
 	// Configure and boot up a fake podcertificaterequest signing controller.
@@ -198,7 +245,6 @@ func TestFullFlow(t *testing.T) {
 	}
 	pcrSigner := hermeticpodcertificatesigner.New(clock, signerName, caKeys, caCerts, kc)
 	go pcrSigner.Run(ctx)
-
 	//
 	// Configure and boot up enough Kubelet subsystems to run an IssuingManager.
 	//
@@ -225,8 +271,25 @@ func TestFullFlow(t *testing.T) {
 		types.NodeName(node1.ObjectMeta.Name),
 		clock,
 	)
-
+	// Start informers
 	informerFactory.Start(ctx.Done())
+
+	// wait until the informers' watches are actually registered,
+	const expectedWatches = 3 // Pods, Nodes, PodCertificateRequests
+	if err := wait.PollUntilContextTimeout(
+		ctx,
+		100*time.Millisecond,
+		5*time.Second,
+		true,
+		func(ctx context.Context) (bool, error) {
+			return numWatches.Load() >= expectedWatches, nil
+		},
+	); err != nil {
+		t.Fatalf("timed out waiting for informer watches, got %d (want >= %d): %v",
+			numWatches.Load(), expectedWatches, err)
+	}
+
+	// Now it's safe to run the manager – informers are watching.
 	go node1PodCertificateManager.Run(ctx)
 
 	//
@@ -256,6 +319,7 @@ func TestFullFlow(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: workloadNS.ObjectMeta.Name,
 			Name:      "workload",
+			UID:       "test-workload-uid",
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: workloadSA.ObjectMeta.Name,
@@ -297,7 +361,6 @@ func TestFullFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error creating workload pod: %v", err)
 	}
-
 	// Because our fake podManager is based on an informer, we need to poll
 	// until workloadPod is reflected in the informer.
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We we seeing `Error while waiting for node1 podManager to know about workloadPod: Context deadline exceeded` as fake.Clientset suffers from a race condition related to informers:
it does not implement resource version support in its Watch
implementation and instead assumes that watches are set up
before further changes are made.

If a test waits for caches to be synced and then immediately
adds an object, that new object will never be seen by event handlers
if the race goes wrong and the Watch call hadn't completed yet.

To work around this, we count all watches and only proceed when
all of them are in place. This replaces the normal watch reactor

For more info please refer this PR as it is the similar issue- https://github.com/kubernetes/kubernetes/pull/131344

. Additionally I have also added `PrependReactor` logic to make should the pcr has a name and creationTimeStamp which makes the test more robust. 
I have stress tested the case multiple times and have observed no flakes.
#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/133247
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
