### PR TITLE
test/e2e_node: Update procMount test to use Restricted PSA level

### DIFF
--- a/test/e2e_node/proc_mount_test.go
+++ b/test/e2e_node/proc_mount_test.go
@@ -46,10 +46,10 @@ var _ = SIGDescribe("DefaultProcMount [LinuxOnly]", framework.WithNodeConformanc
 })
 
 var _ = SIGDescribe("ProcMount [LinuxOnly]", feature.ProcMountType, feature.UserNamespacesSupport, func() {
-	f := framework.NewDefaultFramework("proc-mount-baseline-test")
-	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	f := framework.NewDefaultFramework("proc-mount-restricted-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelRestricted
 
-	f.It("will fail to unmask proc mounts if not privileged", func(ctx context.Context) {
+	f.It("will fail to unmask proc mounts at restricted level", func(ctx context.Context) {
 		if !supportsUserNS(ctx, f) {
 			e2eskipper.Skipf("runtime does not support user namespaces")
 		}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates the procMount test to use PSA Restricted level instead of Baseline, matching the intentional policy relaxation introduced in commit e8bd3f629d4.

As of Kubernetes 1.35+, Pod Security Admission Baseline policy allows `UnmaskedProcMount` for pods with user namespaces (`hostUsers: false`). This was an intentional change (from commit e8bd3f629d4 "drop UserNamespacesPodSecurityStandards feature gate") to support nested container use cases while maintaining security through user namespace isolation.

The test "will fail to unmask proc mounts if not privileged" was written in February 2024, before this PSA relaxation, and expected Baseline level to reject `UnmaskedProcMount`. Since Baseline now allows it (for user namespace pods), the test needs to use Restricted level instead, which unconditionally blocks `UnmaskedProcMount` regardless of user namespace settings.

**Why this only affected CRI-O tests:**
- CRI-O with crun correctly reports user namespace support via RuntimeHandlers
- containerd (especially with runc) doesn't report user namespace support in most CI configurations
- When user namespace support isn't reported, the test is skipped, hiding the issue

#### Which issue(s) this PR is related to:

Fixes the ci-crio-userns-e2e-serial test failure.

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP-4265: ProcMount](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4265-proc-mount)
- [KEP-127: User Namespaces](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/127-user-namespaces)
```
