### PR TITLE
pkg/apis/admissionregistration/validation: use HandleErrorWithContext in createCompiler

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -1313,14 +1313,14 @@ func getStrictStatelessCELCompiler() plugincel.Compiler {
 	return lazyStrictStatelessCELCompiler
 }
 
-func createCompiler(allowComposition bool) plugincel.Compiler {
+func createCompiler(ctx context.Context, allowComposition bool) plugincel.Compiler {
 	if !allowComposition {
 		return getStrictStatelessCELCompiler()
 	}
 	compiler, err := plugincel.NewCompositedCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion()))
 	if err != nil {
 		// should never happen, but cannot panic either.
-		utilruntime.HandleError(err)
+		utilruntime.HandleErrorWithContext(ctx, err, "failed creating composited CEL comiler")
 		return plugincel.NewCompiler(environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion()))
 	}
 	return compiler


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR updates `createCompiler` in `pkg/apis/admissionregistration/validation` to use **contextual logging**.
- It adds a `context.Context` parameter to the `createCompiler` function.
- It replaces `utilruntime.HandleError(err)` with the context-aware `utilruntime.HandleErrorWithContext(ctx, err, "failed creating composited CEL compiler")`.

#### Which issue(s) this PR is related to:
Contributes to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:
```
NONE
```
#### Does this PR introduce a user-facing change?
```
NONE
```