### PR TITLE
pkg/controller/controller_utils.go : replace HandleError with HandleE…

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -1166,7 +1166,7 @@ func AddPodControllerIndexer(podInformer cache.SharedIndexInformer) error {
 }
 
 // FilterPodsByOwner gets the Pods managed by an owner or orphan Pods in the owner's namespace
-func FilterPodsByOwner(podIndexer cache.Indexer, owner *metav1.ObjectMeta, ownerKind string, includeOrphanedPods bool) ([]*v1.Pod, error) {
+func FilterPodsByOwner(ctx context.Context, podIndexer cache.Indexer, owner *metav1.ObjectMeta, ownerKind string, includeOrphanedPods bool) ([]*v1.Pod, error) {
 	result := []*v1.Pod{}
 
 	if len(owner.Namespace) == 0 {
@@ -1195,7 +1195,7 @@ func FilterPodsByOwner(podIndexer cache.Indexer, owner *metav1.ObjectMeta, owner
 		for _, obj := range pods {
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
-				utilruntime.HandleError(fmt.Errorf("unexpected object type in pod indexer: %v", obj))
+				utilruntime.HandleErrorWithContext(ctx, nil, "unexpected object type in pod indexer")
 				continue
 			}
 			result = append(result, pod)

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -709,7 +709,7 @@ func (dsc *DaemonSetsController) getDaemonPods(ctx context.Context, ds *apps.Dae
 		return nil, err
 	}
 	// List all pods indexed to DS UID and Orphan pods
-	pods, err := controller.FilterPodsByOwner(dsc.podIndexer, &ds.ObjectMeta, "DaemonSet", true)
+	pods, err := controller.FilterPodsByOwner(ctx, dsc.podIndexer, &ds.ObjectMeta, "DaemonSet", true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -776,7 +776,7 @@ func (jm *Controller) getPodsForJob(ctx context.Context, j *batch.Job) ([]*v1.Po
 	}
 
 	// list all pods managed by this Job using the pod indexer
-	pods, err := controller.FilterPodsByOwner(jm.podIndexer, &j.ObjectMeta, "Job", true)
+	pods, err := controller.FilterPodsByOwner(ctx, jm.podIndexer, &j.ObjectMeta, "Job", true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -733,7 +733,7 @@ func (rsc *ReplicaSetController) syncReplicaSet(ctx context.Context, key string)
 	}
 
 	// List all pods indexed to RS UID and Orphan pods
-	allRSPods, err := controller.FilterPodsByOwner(rsc.podIndexer, &rs.ObjectMeta, rsc.Kind, true)
+	allRSPods, err := controller.FilterPodsByOwner(ctx, rsc.podIndexer, &rs.ObjectMeta, rsc.Kind, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -326,7 +326,7 @@ func (ssc *StatefulSetController) deletePod(logger klog.Logger, obj interface{})
 // NOTE: Returned Pods are pointers to objects from the cache.
 // If you need to modify one, you need to copy it first.
 func (ssc *StatefulSetController) getPodsForStatefulSet(ctx context.Context, set *apps.StatefulSet, selector labels.Selector) ([]*v1.Pod, error) {
-	podsForSts, err := controller.FilterPodsByOwner(ssc.podIndexer, &set.ObjectMeta, "StatefulSet", true)
+	podsForSts, err := controller.FilterPodsByOwner(ctx, ssc.podIndexer, &set.ObjectMeta, "StatefulSet", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Replace utilruntime.HandleError with utilruntime.HandleErrorWithContext in FilterPodsByOwner to align with Kubernetes contextual logging. Also update all call sites to pass ctx to FilterPodsByOwner.

#### Which issue(s) this PR is related to:
Contributes to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:
Successfully built locally

#### Does this PR introduce a user-facing change?
```
NONE
```



