### PR TITLE
Enhance content negotiation for zpages

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/statusz/statusz_test.go
@@ -27,7 +27,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	cbor "k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1alpha1 "k8s.io/apiserver/pkg/server/statusz/api/v1alpha1"
@@ -58,6 +63,9 @@ Paths: /livez /readyz
 `
 
 func TestHandleStatusz(t *testing.T) {
+	// Enable CBOR feature gate for CBOR test case
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, true)
+
 	delimiters = []string{":"}
 	fakeStartTime := time.Now()
 	fakeUptime := uptime(fakeStartTime)
@@ -68,14 +76,14 @@ func TestHandleStatusz(t *testing.T) {
 	fakeEmulationVersion := parseVersion(t, fakeEvStr)
 	fakeListedPaths := []string{"/livez/poststarthook/peer-discovery-cache-sync", "/livez/post", "/readyz/informer-sync", "/readyz/log", "/readyz/ping"}
 	tests := []struct {
-		name           string
-		acceptHeader   string
-		componentName  string
-		registry       fakeRegistry
-		wantStatusCode int
-		wantBody       string
-		wantJSONBody   *v1alpha1.Statusz
-		wantWarning    bool
+		name               string
+		acceptHeader       string
+		componentName      string
+		registry           fakeRegistry
+		wantStatusCode     int
+		wantBody           string
+		wantStructuredBody *v1alpha1.Statusz
+		wantWarning        bool
 	}{
 		{
 			name:          "valid request for text/plain",
@@ -100,7 +108,7 @@ func TestHandleStatusz(t *testing.T) {
 			),
 		},
 		{
-			name:          "valid request for v1alpha1",
+			name:          "valid request for application/json",
 			acceptHeader:  "application/json;v=v1alpha1;g=config.k8s.io;as=Statusz",
 			componentName: "test-server",
 			registry: fakeRegistry{
@@ -112,7 +120,7 @@ func TestHandleStatusz(t *testing.T) {
 				deprecated:   map[string]bool{},
 			},
 			wantStatusCode: http.StatusOK,
-			wantJSONBody: &v1alpha1.Statusz{
+			wantStructuredBody: &v1alpha1.Statusz{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       Kind,
 					APIVersion: fmt.Sprintf("%s/%s", GroupName, Version),
@@ -248,7 +256,7 @@ func TestHandleStatusz(t *testing.T) {
 				},
 			},
 			wantStatusCode: http.StatusOK,
-			wantJSONBody: &v1alpha1.Statusz{
+			wantStructuredBody: &v1alpha1.Statusz{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       Kind,
 					APIVersion: fmt.Sprintf("%s/%s", GroupName, Version),
@@ -264,6 +272,64 @@ func TestHandleStatusz(t *testing.T) {
 				Paths:            []string{"/livez", "/readyz"},
 			},
 			wantWarning: true,
+		},
+		{
+			name:          "valid request for application/yaml",
+			acceptHeader:  "application/yaml;v=v1alpha1;g=config.k8s.io;as=Statusz",
+			componentName: "test-server",
+			registry: fakeRegistry{
+				startTime:    fakeStartTime,
+				goVer:        fakeGoVersion,
+				binaryVer:    fakeBinaryVersion,
+				emulationVer: fakeEmulationVersion,
+				listedPaths:  fakeListedPaths,
+				deprecated:   map[string]bool{},
+			},
+			wantStatusCode: http.StatusOK,
+			wantStructuredBody: &v1alpha1.Statusz{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       Kind,
+					APIVersion: fmt.Sprintf("%s/%s", GroupName, Version),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-server",
+				},
+				StartTime:        metav1.Time{Time: fakeStartTime},
+				UptimeSeconds:    int64(time.Since(fakeStartTime).Seconds()),
+				GoVersion:        fakeGoVersion,
+				BinaryVersion:    fakeBvStr,
+				EmulationVersion: fakeEvStr,
+				Paths:            []string{"/livez", "/readyz"},
+			},
+		},
+		{
+			name:          "valid request for application/cbor",
+			acceptHeader:  "application/cbor;v=v1alpha1;g=config.k8s.io;as=Statusz",
+			componentName: "test-server",
+			registry: fakeRegistry{
+				startTime:    fakeStartTime,
+				goVer:        fakeGoVersion,
+				binaryVer:    fakeBinaryVersion,
+				emulationVer: fakeEmulationVersion,
+				listedPaths:  fakeListedPaths,
+				deprecated:   map[string]bool{},
+			},
+			wantStatusCode: http.StatusOK,
+			wantStructuredBody: &v1alpha1.Statusz{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       Kind,
+					APIVersion: fmt.Sprintf("%s/%s", GroupName, Version),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-server",
+				},
+				StartTime:        metav1.Time{Time: fakeStartTime},
+				UptimeSeconds:    int64(time.Since(fakeStartTime).Seconds()),
+				GoVersion:        fakeGoVersion,
+				BinaryVersion:    fakeBvStr,
+				EmulationVersion: fakeEvStr,
+				Paths:            []string{"/livez", "/readyz"},
+			},
 		},
 	}
 
@@ -289,12 +355,10 @@ func TestHandleStatusz(t *testing.T) {
 			}
 
 			if tt.wantStatusCode == http.StatusOK {
-				if tt.wantJSONBody != nil {
+				if tt.wantStructuredBody != nil {
 					var got v1alpha1.Statusz
-					if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
-						t.Fatalf("unexpected error while unmarshalling response: %v", err)
-					}
-					if diff := cmp.Diff(*tt.wantJSONBody, got, timeEqual()); diff != "" {
+					unmarshalResponse(t, w.Header().Get("Content-Type"), w.Body.Bytes(), &got)
+					if diff := cmp.Diff(*tt.wantStructuredBody, got, timeEqual()); diff != "" {
 						t.Errorf("Unexpected diff on response (-want,+got):\n%s", diff)
 					}
 					if tt.wantWarning {
@@ -303,12 +367,32 @@ func TestHandleStatusz(t *testing.T) {
 						}
 					}
 				} else {
-					if diff := cmp.Diff(tt.wantBody, string(w.Body.String())); diff != "" {
-						t.Errorf("Unexpected diff on response (-want,+got):\n%s", diff)
+					if !strings.Contains(string(w.Body.String()), tt.wantBody) {
+						t.Errorf("Unexpected response body:\n- want to contain: %s\n- got:  %s", tt.wantBody, string(w.Body.String()))
 					}
 				}
 			}
 		})
+	}
+}
+
+func unmarshalResponse(t *testing.T, contentType string, body []byte, got *v1alpha1.Statusz) {
+	t.Helper()
+	switch {
+	case strings.Contains(contentType, "application/json"):
+		if err := json.Unmarshal(body, got); err != nil {
+			t.Fatalf("unexpected error while unmarshalling JSON response: %v", err)
+		}
+	case strings.Contains(contentType, "application/cbor"):
+		if err := cbor.Unmarshal(body, got); err != nil {
+			t.Fatalf("unexpected error while unmarshalling CBOR response: %v", err)
+		}
+	case strings.Contains(contentType, "application/yaml"):
+		if err := yaml.Unmarshal(body, got); err != nil {
+			t.Fatalf("unexpected error while unmarshalling YAML response: %v", err)
+		}
+	default:
+		t.Fatalf("unexpected content type: %s", contentType)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR:
- Adds YAML and CBOR(gated by CBORServingAndStorage feature gate) serialization support for /flagz and /statusz endpoints
- Add flagzCodecFactory and statuszCodecFactory wrapper types to filter out unsupported media types (e.g., protobuf) from the codec factory's supported media types list. This ensures that 406 Not Acceptable error messages only show media types that are actually supported by these endpoints
- Add CBOR and YAML test cases to unit and integration tests
  


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/enhancements/issues/4827
https://github.com/kubernetes/enhancements/issues/4828

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Enables YAML support for statusz and flagz.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
