### PR TITLE
Fix RBAC authorization bypass for namespace deletion via namespace-scoped Role

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -193,14 +193,12 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 	// URL forms: /namespaces/{namespace}/{kind}/*, where parts are adjusted to be relative to kind
 	if currentParts[0] == "namespaces" {
 		if len(currentParts) > 1 {
-			// requestInfo.Namespace = currentParts[1]
 			potentialNamespace := currentParts[1]
 
 			// Check if the namespace is cluster-scoped
 			if len(currentParts) == 2 {
 				// Request like: /namespaces/{namespace} is a request for the namespace resource itself
 				requestInfo.Namespace = ""
-				// requestInfo.Resource = "namespaces"
 				requestInfo.Name = potentialNamespace
 			} else {
 				requestInfo.Namespace = potentialNamespace

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -193,12 +193,22 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 	// URL forms: /namespaces/{namespace}/{kind}/*, where parts are adjusted to be relative to kind
 	if currentParts[0] == "namespaces" {
 		if len(currentParts) > 1 {
-			requestInfo.Namespace = currentParts[1]
+			// requestInfo.Namespace = currentParts[1]
+			potentialNamespace := currentParts[1]
 
-			// if there is another step after the namespace name and it is not a known namespace subresource
-			// move currentParts to include it as a resource in its own right
-			if len(currentParts) > 2 && !namespaceSubresources.Has(currentParts[2]) {
-				currentParts = currentParts[2:]
+			// Check if the namespace is cluster-scoped
+			if len(currentParts) == 2 {
+				// Request like: /namespaces/{namespace} is a request for the namespace resource itself
+				requestInfo.Namespace = ""
+				// requestInfo.Resource = "namespaces"
+				requestInfo.Name = potentialNamespace
+			} else {
+				requestInfo.Namespace = potentialNamespace
+				// if there is another step after the namespace name and it is not a known namespace subresource
+				// move currentParts to include it as a resource in its own right
+				if len(currentParts) > 2 && !namespaceSubresources.Has(currentParts[2]) {
+					currentParts = currentParts[2:]
+				}
 			}
 		}
 	} else {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -45,8 +45,6 @@ func TestGetAPIRequestInfo(t *testing.T) {
 
 		// resource paths
 		{MethodGet, "/api/v1/namespaces", "list", "api", "", "v1", "", "namespaces", "", "", []string{"namespaces"}},
-		{MethodGet, "/api/v1/namespaces/other", "get", "api", "", "v1", "other", "namespaces", "", "other", []string{"namespaces", "other"}},
-
 		{MethodGet, "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{MethodGet, "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{MethodHead, "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
@@ -54,6 +52,13 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{MethodHead, "/api/v1/pods", "list", "api", "", "v1", namespaceAll, "pods", "", "", []string{"pods"}},
 		{MethodGet, "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{MethodGet, "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
+
+		// namespace resource itself (cluster-scoped, not namespaced)
+		{MethodGet, "/api/v1/namespaces/other", "get", "api", "", "v1", "", "namespaces", "", "other", []string{"namespaces", "other"}},
+		{MethodHead, "/api/v1/namespaces/other", "get", "api", "", "v1", "", "namespaces", "", "other", []string{"namespaces", "other"}},
+		{MethodPut, "/api/v1/namespaces/other", "update", "api", "", "v1", "", "namespaces", "", "other", []string{"namespaces", "other"}},
+		{MethodPatch, "/api/v1/namespaces/other", "patch", "api", "", "v1", "", "namespaces", "", "other", []string{"namespaces", "other"}},
+		{MethodDelete, "/api/v1/namespaces/other", "delete", "api", "", "v1", "", "namespaces", "", "other", []string{"namespaces", "other"}},
 
 		// special verbs
 		{MethodGet, "/api/v1/proxy/namespaces/other/pods/foo", "proxy", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/sig auth
-->

#### What this PR does / why we need it:
This PR fixs the auth issue in RBAC authorization where a ServiceAccount with only `namespace-scoped` permissions (via `Role/RoleBinding`) could delete its own namespace, even though namespace resources are cluster-scoped.

**The root cause:**
When parsing a Delete request for `/api/v1/namespaces/ta-test`, the `NewRequestInfo` function incorrectly sets `requestInfo.Namespace = "ta-test"` instead of leaving it empty for cluster-scoped resources.
This causes the RBAC authorizer to check namespace-scoped Role/RoleBinding instead of requiring cluster-scoped ClusterRole/ClusterRoleBinding.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #134929

#### Special notes for your reviewer:
**Before the fix:**
```
DELETE /api/v1/namespaces/ta-test
→ requestInfo.Namespace = "ta-test" 
→ RBAC checks ta-test namespace's Role/RoleBinding
→ ServiceAccount with namespace admin role can delete the namespace
```

> Test with same steps provided in issue
<img width="3509" height="1139" alt="image" src="https://github.com/user-attachments/assets/2ec76ed5-b1a5-406a-b417-36f5b8d57f54" />



**After the fix:**
```
DELETE /api/v1/namespaces/ta-test
→ requestInfo.Namespace = ""  
→ RBAC checks cluster-scoped ClusterRole/ClusterRoleBinding
→ ServiceAccount needs cluster-scoped permissions
```

> Test with same steps provided in issue.
<img width="3854" height="1037" alt="image" src="https://github.com/user-attachments/assets/eb43472c-ff80-4035-9c0a-405a16712724" />


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
