### PR TITLE
client-go/reflector: Improve WatchListClient disabled log message for clarity

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -302,8 +302,7 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store R
 		// Using klog.TODO() here because switching to a caller-provided contextual logger
 		// would require an API change and updating all existing call sites.
 		klog.TODO().V(2).Info(
-			"The provided ListWatcher doesn't support WatchList semantics. The feature will be disabled. If you are using a custom client, check the documentation of watchlist.DoesClientNotSupportWatchListSemantics() method",
-			"listWatcherType", fmt.Sprintf("%T", lw),
+			"The client used to build this informer/reflector doesn't support WatchList semantics. The feature will be disabled. This is expected in unit tests but not in production. For details, see the documentation of watchlist.DoesClientNotSupportWatchListSemantics().",
 			"feature", clientfeatures.WatchListClient,
 		)
 		r.useWatchList = false

--- a/staging/src/k8s.io/client-go/util/watchlist/watch_list.go
+++ b/staging/src/k8s.io/client-go/util/watchlist/watch_list.go
@@ -90,6 +90,9 @@ type unSupportedWatchListSemantics interface {
 //
 // A client does NOT support WatchList only if
 // it implements `IsWatchListSemanticsUnSupported` and that returns true.
+//
+// For an explanation of how WatchList works, see:
+// https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
 func DoesClientNotSupportWatchListSemantics(client any) bool {
 	lw, ok := client.(unSupportedWatchListSemantics)
 	if !ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Updates the log message emitted by the reflector when the WatchListClient feature is disabled due to a client that doesn’t support WatchList semantics.

@pohly pointed out the following issues with the previous msg:

```
- It's unclear if some action needs to be taken. I bet we will get questions about this.
- It doesn't tell me which client doesn't support the semantic. It mentions "cache.listWatcherWithWatchListSemanticsWrapper" (does it always do that?) but not the fake client.
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
