### PR TITLE
Fix queue hint for inter-pod anti-affinity

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -220,15 +220,27 @@ func (pl *InterPodAffinity) isSchedulableAfterPodChange(logger klog.Logger, pod 
 		return fwk.QueueSkip, nil
 	}
 
-	// Pod is deleted. Return Queue when the deleted pod matching the target pod's anti-affinity.
-	if !podMatchesAllAffinityTerms(antiTerms, originalPod) {
-		logger.V(5).Info("a scheduled pod was deleted but it doesn't match the target pod's anti-affinity",
-			"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-		return fwk.QueueSkip, nil
+	// Pod is deleted. Return Queue when the deleted pod matches the target pod's anti-affinity or vice versa.
+
+	if podMatchesAllAffinityTerms(antiTerms, originalPod) {
+		logger.V(5).Info("a scheduled pod was deleted and it matches the target pod's anti-affinity. The pod may be schedulable now",
+			"pod", klog.KObj(pod), "originalPod", klog.KObj(originalPod))
+		return fwk.Queue, nil
 	}
-	logger.V(5).Info("a scheduled pod was deleted and it matches the target pod's anti-affinity. The pod may be schedulable now",
-		"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
-	return fwk.Queue, nil
+
+	originalPodAntiTerms, err := fwk.GetAffinityTerms(originalPod, fwk.GetPodAntiAffinityTerms(originalPod.Spec.Affinity))
+	if err != nil {
+		return fwk.Queue, err
+	}
+	if podMatchesAllAffinityTerms(originalPodAntiTerms, pod) {
+		logger.V(5).Info("a scheduled pod was deleted and the target pod matches the deleted pod's anti-affinity. The pod may be schedulable now",
+			"pod", klog.KObj(pod), "originalPod", klog.KObj(originalPod))
+		return fwk.Queue, nil
+	}
+
+	logger.V(5).Info("a scheduled pod was deleted but it doesn't match the target pod's anti-affinity, nor vice versa",
+		"pod", klog.KObj(pod), "originalPod", klog.KObj(originalPod))
+	return fwk.QueueSkip, nil
 }
 
 func (pl *InterPodAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
@@ -129,6 +129,24 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			oldPod:       st.MakePod().Node("fake-node").Label("service", "securityscan").Obj(),
 			expectedHint: fwk.Queue,
 		},
+		{
+			name:         "delete a pod with anti-affinity that matches pending pod",
+			pod:          st.MakePod().Name("p").Label("service", "securityscan").Obj(),
+			oldPod:       st.MakePod().Node("fake-node").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "delete a pod with anti-affinity that doesn't match pending pod",
+			pod:          st.MakePod().Name("p").Label("service", "foo").Obj(),
+			oldPod:       st.MakePod().Node("fake-node").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "delete a pod which doesn't match pending pod's anti-affinity and has anti-affinity that doesn't match pending pod",
+			pod:          st.MakePod().Name("p").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Label("service", "foo").Obj(),
+			oldPod:       st.MakePod().Node("fake-node").PodAntiAffinityIn("service", "region", []string{"securityscan", "value2"}, st.PodAntiAffinityWithRequiredReq).Label("service", "foo").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

An existing pod with anti-affinity might prevent another pod from scheduling.
In case such pod is deleted, the pending pod should be requeued because the two pods no longer repel each other.

The reverse case is already handled, i.e. pending pod anti-affinity matches existing pod and that pod is deleted.

If the queue hint incorrectly skips the queue for some pod, the pod will eventually get queued anyway, but this can incur unnecessary delays.

#### Which issue(s) this PR is related to:

Fixes #134393

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed queue hint for inter-pod anti-affinity in case deleted pod's anti-affinity matched the pending pod, which might have caused delays in scheduling.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
