### PR TITLE
Fix alpha API warnings for patch version differences

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement_test.go
@@ -17,11 +17,19 @@ limitations under the License.
 package options
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/version"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/apiserver/pkg/server"
+	serverstore "k8s.io/apiserver/pkg/server/storage"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/compatibility"
+	"k8s.io/klog/v2"
 )
 
 type fakeGroupRegistry struct{}
@@ -73,6 +81,295 @@ func TestAPIEnablementOptionsValidate(t *testing.T) {
 
 			if len(testcase.expectErr) == 0 && len(errs) != 0 {
 				t.Errorf("got err: %s, expected err nil", errs)
+			}
+		})
+	}
+}
+
+type fakeGroupVersionRegistry struct {
+	versions []schema.GroupVersion
+}
+
+func (f fakeGroupVersionRegistry) PrioritizedVersionsAllGroups() []schema.GroupVersion {
+	return f.versions
+}
+
+func (f fakeGroupVersionRegistry) PrioritizedVersionsForGroup(group string) []schema.GroupVersion {
+	var result []schema.GroupVersion
+	for _, gv := range f.versions {
+		if gv.Group == group {
+			result = append(result, gv)
+		}
+	}
+	return result
+}
+
+func (f fakeGroupVersionRegistry) IsGroupRegistered(group string) bool {
+	for _, gv := range f.versions {
+		if gv.Group == group {
+			return true
+		}
+	}
+	return false
+}
+
+func (f fakeGroupVersionRegistry) IsVersionRegistered(gv schema.GroupVersion) bool {
+	for _, version := range f.versions {
+		if version == gv {
+			return true
+		}
+	}
+	return false
+}
+
+func (f fakeGroupVersionRegistry) GroupVersions() []schema.GroupVersion {
+	return f.versions
+}
+
+type fakeEffectiveVersion struct {
+	binaryVersion    *version.Version
+	emulationVersion *version.Version
+}
+
+func (f fakeEffectiveVersion) BinaryVersion() *version.Version {
+	return f.binaryVersion
+}
+
+func (f fakeEffectiveVersion) EmulationVersion() *version.Version {
+	return f.emulationVersion
+}
+
+func (f fakeEffectiveVersion) MinCompatibilityVersion() *version.Version {
+	return nil
+}
+
+func (f fakeEffectiveVersion) EqualTo(other compatibility.EffectiveVersion) bool {
+	return f.binaryVersion.EqualTo(other.BinaryVersion()) && f.emulationVersion.EqualTo(other.EmulationVersion())
+}
+
+func (f fakeEffectiveVersion) String() string {
+	return "fake"
+}
+
+func (f fakeEffectiveVersion) Info() *apimachineryversion.Info {
+	return nil
+}
+
+func (f fakeEffectiveVersion) AllowedEmulationVersionRange() string {
+	return "fake range"
+}
+
+func (f fakeEffectiveVersion) AllowedMinCompatibilityVersionRange() string {
+	return "fake range"
+}
+
+func (f fakeEffectiveVersion) Validate() []error {
+	return nil
+}
+
+func TestAPIEnablementOptionsApplyToVersionComparison(t *testing.T) {
+	// Helper function to capture klog output
+	captureKlogOutput := func(fn func()) string {
+		var buf bytes.Buffer
+		klog.SetOutput(&buf)
+		klog.LogToStderr(false)
+		defer func() {
+			klog.SetOutput(nil)
+			klog.LogToStderr(true)
+		}()
+
+		fn()
+		klog.Flush()
+		return buf.String()
+	}
+
+	testCases := []struct {
+		name                 string
+		binaryVersion        string
+		emulationVersion     string
+		alphaAPIsPresent     bool
+		versionEnabled       bool
+		expectWarning        bool
+		expectWarningContent string
+	}{
+		{
+			name:             "same major.minor versions, different patch - no warning",
+			binaryVersion:    "1.34.1",
+			emulationVersion: "1.34.0",
+			alphaAPIsPresent: true,
+			versionEnabled:   true,
+			expectWarning:    false,
+		},
+		{
+			name:             "same major.minor versions, no patch in emulation - no warning",
+			binaryVersion:    "1.34.1",
+			emulationVersion: "1.34",
+			alphaAPIsPresent: true,
+			versionEnabled:   true,
+			expectWarning:    false,
+		},
+		{
+			name:             "identical versions - no warning",
+			binaryVersion:    "1.34.1",
+			emulationVersion: "1.34.1",
+			alphaAPIsPresent: true,
+			versionEnabled:   true,
+			expectWarning:    false,
+		},
+		{
+			name:             "different major versions but not enabled - should not warn",
+			binaryVersion:    "1.34.1",
+			emulationVersion: "1.33.0",
+			alphaAPIsPresent: true,
+			expectWarning:    false,
+		},
+		{
+			name:                 "different major versions - should warn",
+			binaryVersion:        "1.34.1",
+			emulationVersion:     "1.33.0",
+			alphaAPIsPresent:     true,
+			expectWarning:        true,
+			versionEnabled:       true,
+			expectWarningContent: "alpha api enabled with emulated version",
+		},
+		{
+			name:                 "different minor versions - should warn",
+			binaryVersion:        "1.34.1",
+			emulationVersion:     "1.33.5",
+			alphaAPIsPresent:     true,
+			expectWarning:        true,
+			versionEnabled:       true,
+			expectWarningContent: "alpha api enabled with emulated version",
+		},
+		{
+			name:             "different major.minor but no alpha APIs - no warning",
+			binaryVersion:    "1.34.1",
+			emulationVersion: "1.33.0",
+			alphaAPIsPresent: false,
+			expectWarning:    false,
+			versionEnabled:   true,
+		},
+		{
+			name:             "same major.minor with alpha APIs - no warning",
+			binaryVersion:    "1.34.5",
+			emulationVersion: "1.34.0",
+			alphaAPIsPresent: true,
+			expectWarning:    false,
+			versionEnabled:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			binaryVer := version.MustParse(tc.binaryVersion)
+			emulationVer := version.MustParse(tc.emulationVersion)
+
+			effectiveVersion := fakeEffectiveVersion{
+				binaryVersion:    binaryVer,
+				emulationVersion: emulationVer,
+			}
+
+			var versions []schema.GroupVersion
+			if tc.alphaAPIsPresent {
+				versions = []schema.GroupVersion{
+					{Group: "rbac.authorization.k8s.io", Version: "v1alpha1"},
+					{Group: "storage.k8s.io", Version: "v1alpha1"},
+				}
+			} else {
+				versions = []schema.GroupVersion{
+					{Group: "rbac.authorization.k8s.io", Version: "v1"},
+					{Group: "storage.k8s.io", Version: "v1beta1"},
+				}
+			}
+
+			registry := fakeGroupVersionRegistry{versions: versions}
+			config := &server.Config{EffectiveVersion: effectiveVersion}
+			options := &APIEnablementOptions{RuntimeConfig: make(cliflag.ConfigurationMap)}
+
+			// Enable the API
+			resourceConfig := serverstore.NewResourceConfig()
+			if tc.versionEnabled {
+				resourceConfig.ExplicitGroupVersionConfigs[schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1alpha1"}] = true
+			}
+
+			// Capture log output during ApplyTo execution
+			logOutput := captureKlogOutput(func() {
+				err := options.ApplyTo(config, resourceConfig, registry)
+				if err != nil {
+					t.Errorf("ApplyTo failed: %v", err)
+				}
+			})
+
+			// Verify warning expectations
+			if tc.expectWarning {
+				if !strings.Contains(logOutput, tc.expectWarningContent) {
+					t.Errorf("Expected warning containing '%s', but got log output: %s", tc.expectWarningContent, logOutput)
+				}
+				if !strings.Contains(logOutput, "W") { // klog warning prefix
+					t.Errorf("Expected warning log level, but got log output: %s", logOutput)
+				}
+			} else if strings.Contains(logOutput, "alpha api enabled") {
+				t.Errorf("Expected no warning, but got log output: %s", logOutput)
+			}
+		})
+	}
+}
+
+func TestAPIEnablementOptionsApplyToErrorCases(t *testing.T) {
+	// Create a default effective version for test configs
+	defaultEffectiveVersion := fakeEffectiveVersion{
+		binaryVersion:    version.MustParse("1.34.0"),
+		emulationVersion: version.MustParse("1.34.0"),
+	}
+
+	testCases := []struct {
+		name          string
+		options       *APIEnablementOptions
+		config        *server.Config
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:    "nil options should not error",
+			options: nil,
+			config: &server.Config{
+				EffectiveVersion: defaultEffectiveVersion,
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid runtime config value should error",
+			options: &APIEnablementOptions{
+				RuntimeConfig: cliflag.ConfigurationMap{
+					"api/all": "invalid-value", // Must be "true" or "false"
+				},
+			},
+			config: &server.Config{
+				EffectiveVersion: defaultEffectiveVersion,
+			},
+			expectError:   true,
+			errorContains: "invalid value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := fakeGroupVersionRegistry{versions: []schema.GroupVersion{
+				{Group: "rbac.authorization.k8s.io", Version: "v1"},
+			}}
+
+			err := tc.options.ApplyTo(tc.config, serverstore.NewResourceConfig(), registry)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if tc.errorContains != "" && !strings.Contains(err.Error(), tc.errorContains) {
+					t.Errorf("Expected error containing '%s', but got: %v", tc.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Follow up to #134035

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes issue https://github.com/kubernetes/kubernetes/issues/134023 where alpha API warnings were being logged when binary version (1.34.1) and emulation version (1.34) differed only in patch version.

The issue was in api_enablement.go where the version comparison was using EqualTo() which compares all version components including patch versions. The fix changes the comparison to only check major.minor versions using version.MajorMinor().

#### Which issue(s) this PR is related to:
Fixes #134023
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:

<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: Fixes spurious warning log messages about enabled alpha APIs while starting API server
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
