### PR TITLE
Automated cherry pick of #132061: fix: datarace in ResolverTypeProvider

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider.go
@@ -105,23 +105,13 @@ func (p *ResolverTypeProvider) FindIdent(identName string) (ref.Val, bool) {
 	return p.underlyingTypeProvider.FindIdent(identName)
 }
 
-// ResolverEnvOption creates the ResolverTypeProvider with a given DynamicTypeResolver,
-// and also returns the CEL ResolverEnvOption to apply it to the env.
+// ResolverEnvOption creates the ResolverTypeProvider with a given DynamicTypeResolver
+// and returns the CEL ResolverEnvOption to apply it to the env.
 func ResolverEnvOption(resolver TypeResolver) cel.EnvOption {
-	_, envOpt := NewResolverTypeProviderAndEnvOption(resolver)
-	return envOpt
-}
-
-// NewResolverTypeProviderAndEnvOption creates the ResolverTypeProvider with a given DynamicTypeResolver,
-// and also returns the CEL ResolverEnvOption to apply it to the env.
-func NewResolverTypeProviderAndEnvOption(resolver TypeResolver) (*ResolverTypeProvider, cel.EnvOption) {
-	tp := &ResolverTypeProvider{typeResolver: resolver}
-	var envOption cel.EnvOption = func(e *cel.Env) (*cel.Env, error) {
-		// wrap the existing type provider (acquired from the env)
-		// and set new type provider for the env.
-		tp.underlyingTypeProvider = e.CELTypeProvider()
+	return func(e *cel.Env) (*cel.Env, error) {
+		tp := &ResolverTypeProvider{typeResolver: resolver, underlyingTypeProvider: e.CELTypeProvider()}
+		// set new type provider for the env.
 		typeProviderOption := cel.CustomTypeProvider(tp)
 		return typeProviderOption(e)
 	}
-	return tp, envOption
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/typeprovider_test.go
@@ -58,7 +58,7 @@ func TestTypeProvider(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, option := NewResolverTypeProviderAndEnvOption(&mockTypeResolver{})
+			option := ResolverEnvOption(&mockTypeResolver{})
 			env := mustCreateEnv(t, option)
 			ast, issues := env.Compile(tc.expression)
 			if len(tc.expectCompileError) > 0 {

--- a/staging/src/k8s.io/apiserver/pkg/cel/mutation/typeresolver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/mutation/typeresolver_test.go
@@ -212,7 +212,7 @@ func TestTypeResolver(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, option := common.NewResolverTypeProviderAndEnvOption(&DynamicTypeResolver{})
+			option := common.ResolverEnvOption(&DynamicTypeResolver{})
 			env := mustCreateEnv(t, option)
 			ast, issues := env.Compile(tc.expression)
 			if len(tc.expectCompileError) > 0 {
@@ -307,7 +307,7 @@ func TestCELOptional(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, option := common.NewResolverTypeProviderAndEnvOption(&DynamicTypeResolver{})
+			option := common.ResolverEnvOption(&DynamicTypeResolver{})
 			env := mustCreateEnvWithOptional(t, option)
 			ast, issues := env.Compile(tc.expression)
 			if len(tc.expectedCompileError) > 0 {


### PR DESCRIPTION
Cherry pick of #132061 on release-1.33.

 This results in underterminstics behaviour of VAP and MAP. 

Fixes: #134808

#132061: fix: datarace in ResolverTypeProvider 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
 Fixed a data race in the ResolverTypeProvider that caused indeterministic behavior in ValidatingAdmissionPolicy (VAP) and MutatingAdmissionPolicy (MAP).
```