### PR TITLE
cbor: bump limits as the defaults are not large enough

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
@@ -58,12 +58,18 @@ var decode cbor.DecMode = func() cbor.DecMode {
 		// with or without tagging. If a tag number is present, it must be valid.
 		TimeTag: cbor.DecTagOptional,
 
-		// Observed depth up to 16 in fuzzed batch/v1 CronJobList. JSON implementation limit
-		// is 10000.
-		MaxNestedLevels: 64,
+		// MaxNestedLevels is set to the same value used in the JSON implementation.
+		MaxNestedLevels: 10000,
 
-		MaxArrayElements: 1024,
-		MaxMapPairs:      1024,
+		// MaxArrayElements is set to the maximum allowed by the cbor library. We rely on
+		// the library initial wellformedness scan and on the api max request limit to
+		// prevent preallocating very large slices during decoding.
+		MaxArrayElements: 2147483647,
+
+		// MaxMapPairs specifies the maximum number of key-value pairs allowed in a map.
+		// We selected this value as it is large enough so that in practice the API server
+		// decoder will always hit the request body limit before the limit here is reached.
+		MaxMapPairs: 2097152,
 
 		// Indefinite-length sequences aren't produced by this serializer, but other
 		// implementations can.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

With the current established limits we can see the following error in one of our controllers:

```
failed to list <object>: unable to determine group/version/kind: cbor: exceeded max number of elements 1024 for CBOR array.
```

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug causing clients to error out when decoding large CBOR encoded lists.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/4222
```
