### PR TITLE
Optimize image size: skip docs/weak deps and remove /var/cache/dnf

### DIFF
--- a/test/images/volume/iscsi/Dockerfile
+++ b/test/images/volume/iscsi/Dockerfile
@@ -17,7 +17,10 @@ FROM $BASEIMAGE
 
 CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
-RUN yum install -y targetcli && yum clean all
+RUN yum install -y targetcli && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
 ADD run_iscsi_target.sh /usr/local/bin/
 ADD block.tar.gz /
 

--- a/test/images/volume/nfs/Dockerfile
+++ b/test/images/volume/nfs/Dockerfile
@@ -16,8 +16,11 @@ ARG BASEIMAGE
 FROM $BASEIMAGE
 
 CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-RUN dnf -y install procps-ng nfs-utils && dnf clean all
-RUN mkdir -p /exports
+
+RUN dnf -y install --setopt=install_weak_deps=False --setopt=tsflags=nodocs procps-ng nfs-utils \
+    && rm -rf /var/cache/dnf \
+    && mkdir -p /exports
+
 ADD run_nfs.sh /usr/local/bin/
 ADD index.html /tmp/index.html
 RUN chmod 644 /tmp/index.html


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:
This PR optimizes the container image build process by:
	•	Skipping installation of weak dependencies (--setopt=install_weak_deps=False)
	•	Skipping documentation files (--setopt=tsflags=nodocs)
	•	Removing /var/cache/dnf after package installation

These changes reduce image size and improve build efficiency without affecting functionality.

### Which issue(s) this PR is related to:
N/A

### Special notes for your reviewer:
These changes are non-functional and only impact build efficiency and image size.

### Does this PR introduce a user-facing change?
N/A

### Release Note
```release-note
NONE

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
