### PR TITLE
test: verify flake in TestWebhookConverterWithWatchCache using sleep

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -319,7 +319,12 @@ func testWebhookConverter(t *testing.T, watchCache bool) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer tearDown()
+			// VERIFICATION: Force the race condition
+			defer func() {
+				tearDown() // Stop the webhook
+				t.Log("Webhook stopped. Sleeping 30s to force race condition with API Server...")
+				time.Sleep(30 * time.Second) // Force API server (still running) to hit the dead webhook
+			}()
 
 			ctc.setConversionWebhook(t, webhookClientConfig, test.reviewVersions)
 			defer ctc.removeConversionWebhook(t)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
test: verify flake in TestWebhookConverterWithWatchCache using sleep

Inject a 30s sleep immediately after the webhook server stops, but
before the API server stops, in TestWebhookConverterWithWatchCache.

This artificially widens the race window, forcing the API server (which
is still active) to attempt to contact the stopped webhook. This
consistently reproduces the `EOF` and connection errors observed in
flaky test issue #132953.

This verification confirms that the root cause is the non-deterministic
shutdown order between the API server and its dependent webhook.

**Which issue(s) this PR fixes**:
Contributes to #132624

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```