### PR TITLE
Add k8s:optional on Device.Basic

### DIFF
--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -351,6 +351,14 @@ func Validate_Device(ctx context.Context, op operation.Operation, fldPath *field
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil
 			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_BasicDevice(ctx, op, fldPath, obj, oldObj)...)
 			return

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -474,6 +474,7 @@ message Device {
   //
   // +optional
   // +oneOf=deviceType
+  // +k8s:optional
   optional BasicDevice basic = 2;
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -304,6 +304,7 @@ type Device struct {
 	//
 	// +optional
 	// +oneOf=deviceType
+	// +k8s:optional
 	Basic *BasicDevice `json:"basic,omitempty" protobuf:"bytes,2,opt,name=basic"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR makes the `basic` field in the `Device` struct optional by adding the `// +k8s:optional` tag. This prevents potential nil pointer issues in generated code when the `Basic` device field is not present. The generated validation and protobuf files have been updated accordingly.

#### Which issue(s) this PR is related to:

Fixes #135354

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


