### PR TITLE
Sort runtime handlers list coming from the CRI runtime

### DIFF
--- a/pkg/kubelet/runtime_test.go
+++ b/pkg/kubelet/runtime_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"reflect"
+	"testing"
+
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+func TestRuntimeStateSetRuntimeHandlersSortsAndCopies(t *testing.T) {
+	testCases := []struct {
+		name     string
+		handlers []kubecontainer.RuntimeHandler
+		expected []string
+	}{
+		{
+			name: "unsortedWithDefault",
+			handlers: []kubecontainer.RuntimeHandler{
+				{Name: "runc"},
+				{Name: ""},
+				{Name: "crun"},
+			},
+			expected: []string{"", "crun", "runc"},
+		},
+		{
+			name: "alreadySorted",
+			handlers: []kubecontainer.RuntimeHandler{
+				{Name: ""},
+				{Name: "crun"},
+				{Name: "runc"},
+			},
+			expected: []string{"", "crun", "runc"},
+		},
+		{
+			name:     "emptyHandlers",
+			handlers: nil,
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &runtimeState{}
+			input := append([]kubecontainer.RuntimeHandler(nil), tt.handlers...)
+			original := append([]kubecontainer.RuntimeHandler(nil), input...)
+
+			state.setRuntimeHandlers(input)
+
+			if !reflect.DeepEqual(input, original) {
+				t.Fatalf("setRuntimeHandlers mutated input slice: got %#v, want %#v", input, original)
+			}
+
+			got := state.runtimeHandlers()
+			if len(got) != len(tt.expected) {
+				t.Fatalf("unexpected handler count: got %d, want %d", len(got), len(tt.expected))
+			}
+			for i, name := range tt.expected {
+				if got[i].Name != name {
+					t.Errorf("unexpected handler order at %d: got %q, want %q", i, got[i].Name, name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When you have multiple runtime OCI runtime handlers configured, the list returned by the CRI runtime may not always be in same order, because they might be interesting over a map internally. If the returned order changes, then this causes unnecessary update to the node object even though actual list of runtime handlers is same as earlier (but with different order). 

This PR ensures the runtime handlers are sorted by the kubelet before processing further. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes : https://github.com/kubernetes/kubernetes/issues/135357 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Sort runtime handlers list coming from the CRI runtime
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
