### PR TITLE
[Feature Cleanup] APIServerIdentity to Node Conformance

### DIFF
--- a/test/e2e/apimachinery/apiserver_identity.go
+++ b/test/e2e/apimachinery/apiserver_identity.go
@@ -32,7 +32,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -80,7 +79,7 @@ func restartAPIServer(ctx context.Context, node *v1.Node) error {
 }
 
 // This test requires that --feature-gates=APIServerIdentity=true be set on the apiserver
-var _ = SIGDescribe("kube-apiserver identity", feature.APIServerIdentity, func() {
+var _ = SIGDescribe("kube-apiserver identity", framework.WithNodeConformance(), func() {
 	f := framework.NewDefaultFramework("kube-apiserver-identity")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 

--- a/test/e2e/apimachinery/apiserver_identity.go
+++ b/test/e2e/apimachinery/apiserver_identity.go
@@ -79,7 +79,7 @@ func restartAPIServer(ctx context.Context, node *v1.Node) error {
 }
 
 // This test requires that --feature-gates=APIServerIdentity=true be set on the apiserver
-var _ = SIGDescribe("kube-apiserver identity", framework.WithNodeConformance(), func() {
+var _ = SIGDescribe("kube-apiserver identity", func() {
 	f := framework.NewDefaultFramework("kube-apiserver-identity")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -25,9 +25,6 @@ import (
 // Please keep the list in alphabetical, case-sensitive
 // (upper before any lower case character) order.
 var (
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	APIServerIdentity = framework.WithFeature(framework.ValidFeatures.Add("APIServerIdentity"))
-
 	// Owner: sig-lifecycle
 	// This label is used for tests which need the following controllers to be enabled:
 	// - bootstrap-signer-controller


### PR DESCRIPTION


#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it: 
The APIServerIdentity feature is Beta since v1.26 and is enabled by default on clusters. Verified by creating a new kind cluster with default node image v1.34.0 and ran: 

` $~ kubectl get --raw /metrics | grep APIServerIdentity  kubernetes_feature_enabled{name="APIServerIdentity",stage="BETA"} 1`

#### Which issue(s) this PR is related to:
Partial fix for https://github.com/kubernetes/kubernetes/issues/134172

#### Special notes for your reviewer:
FeatureGates is a separate cleanup
corresponding changes will be made in k/test-infra

#### Does this PR introduce a user-facing change?
no

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign @SergeyKanzhelev @roycaihw 