### PR TITLE
Automated cherry pick of #133721: fix panic for the crd with subresource but lose openAPIV3Schema

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
@@ -105,7 +105,9 @@ func (a statusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Obj
 	var correlatedObject *common.CorrelatedObject
 	if utilfeature.DefaultFeatureGate.Enabled(apiextensionsfeatures.CRDValidationRatcheting) {
 		correlatedObject = common.NewCorrelatedObject(uNew.Object, uOld.Object, &model.Structural{Structural: a.structuralSchema})
-		options = append(options, validation.WithRatcheting(correlatedObject.Key("status")))
+		if a.structuralSchema != nil {
+			options = append(options, validation.WithRatcheting(correlatedObject.Key("status")))
+		}
 		celOptions = append(celOptions, cel.WithRatcheting(correlatedObject))
 	}
 


### PR DESCRIPTION
Cherry pick of #133721 on release-1.33.

#133721: fix panic for the crd with subresource but lose openAPIV3Schema

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kube-apiserver: fix a possible panic validating a custom resource whose CustomResourceDefinition indicates a status subresource exists, but which does not define a `status` property in the `openAPIV3Schema`
```