### PR TITLE
Fix: Creating a Service without Name creates an invalid IPAddress

### DIFF
--- a/pkg/registry/core/service/storage/alloc_test.go
+++ b/pkg/registry/core/service/storage/alloc_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+func TestPreAllocIPs(t *testing.T) {
+	testCases := []struct {
+		name            string
+		meta            metav1.ObjectMeta
+		featureDisabled bool
+		wantErr         error
+	}{
+		{
+			name: "missing name",
+			meta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "default",
+			},
+			wantErr: errors.NewInvalid(api.Kind("Service"), "", field.ErrorList{field.Required(field.NewPath("metadata", "name"), "name or generateName is required")}),
+		},
+		{
+			name: "FG enabled, name is relaxed",
+			meta: metav1.ObjectMeta{
+				Name:      "1-test",
+				Namespace: "default",
+			},
+		},
+		{
+			name: "FG disabled, name is invalid",
+			meta: metav1.ObjectMeta{
+				Name:      "1-test",
+				Namespace: "default",
+			},
+			featureDisabled: true,
+			wantErr:         errors.NewInvalid(api.Kind("Service"), "1-test", field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), "1-test", "a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')")}),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RelaxedServiceNameValidation, !tc.featureDisabled)
+
+			err := preAllocIPs(&api.Service{ObjectMeta: tc.meta})
+			if !reflect.DeepEqual(err, tc.wantErr) {
+				t.Fatalf("expected error: %v, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Create a service without a name, and we will get an inconsistent error type in the following cases:

1. Got an Internal Server Error when we don't specify a specific IP address
2. Got an Invalid error when we specify a specific IP address

For the first case, it might cause a performance issue when a bad man creates a lot of invalid services in a very short period of time because the allocator always tries to allocate an IP address from a range of IPs, even if the service is invalid.

This PR fixes the above issues by checking the generated service reference before sending a request to create the IPAddress object.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #135333

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Fix inconsistent error type between no specific IP address and specific IP address when creating a service without a name.
- If the service name is not provided, the IP allocator will return an error before sending a request to create the IPAddress object.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
