### PR TITLE
Scheduler: Fix GatedPods metric desync in unschedulable queue

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -655,11 +655,11 @@ func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, pInfo *framework.Queue
 			if p.backoffQ.has(pInfo) {
 				return
 			}
-			if p.unschedulablePods.get(pInfo.Pod) != nil {
-				return
+
+			if p.unschedulablePods.get(pInfo.Pod) == nil {
+				logger.V(5).Info("Pod moved to an internal scheduling queue, because the pod is gated", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", unschedulableQ)
 			}
-			p.unschedulablePods.addOrUpdate(pInfo, event)
-			logger.V(5).Info("Pod moved to an internal scheduling queue, because the pod is gated", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", unschedulableQ)
+			p.unschedulablePods.addOrUpdate(pInfo, gatedBefore, event)
 			return
 		}
 		if pInfo.InitialAttemptTimestamp == nil {
@@ -690,9 +690,9 @@ func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, pInfo *framework.Queu
 		p.runPreEnqueuePlugins(context.Background(), pInfo)
 		if pInfo.Gated() {
 			if p.unschedulablePods.get(pInfo.Pod) == nil {
-				p.unschedulablePods.addOrUpdate(pInfo, event)
 				logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", unschedulableQ)
 			}
+			p.unschedulablePods.addOrUpdate(pInfo, gatedBefore, event)
 			return false
 		}
 	}
@@ -850,7 +850,7 @@ func (p *PriorityQueue) addUnschedulableWithoutQueueingHint(logger klog.Logger, 
 			}
 		}
 	} else {
-		p.unschedulablePods.addOrUpdate(pInfo, framework.ScheduleAttemptFailure)
+		p.unschedulablePods.addOrUpdate(pInfo, false /* the Pod was absent from all queues */, framework.ScheduleAttemptFailure)
 		logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", framework.ScheduleAttemptFailure, "queue", unschedulableQ)
 	}
 
@@ -1100,7 +1100,8 @@ func (p *PriorityQueue) Update(logger klog.Logger, oldPod, newPod *v1.Pod) {
 		}
 
 		// Pod update didn't make it schedulable, keep it in the unschedulable queue.
-		p.unschedulablePods.addOrUpdate(pInfo, framework.EventUnscheduledPodUpdate.Label())
+		// Use pInfo.Gated() to avoid double-counting "Gated" metrics during an in-place update.
+		p.unschedulablePods.addOrUpdate(pInfo, pInfo.Gated(), framework.EventUnscheduledPodUpdate.Label())
 		return
 	}
 	// If pod is not in any of the queues, we put it in the active queue.
@@ -1192,7 +1193,8 @@ func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 // NOTE: this function assumes lock has been acquired in caller
 func (p *PriorityQueue) requeuePodWithQueueingStrategy(logger klog.Logger, pInfo *framework.QueuedPodInfo, strategy queueingStrategy, event string) string {
 	if strategy == queueSkip {
-		p.unschedulablePods.addOrUpdate(pInfo, event)
+		// Current Gate status is required for already exisiting pods. For new pods, this parameter is ignored/unused by addOrUpdate.
+		p.unschedulablePods.addOrUpdate(pInfo, pInfo.Gated(), event)
 		return unschedulableQ
 	}
 

--- a/pkg/scheduler/backend/queue/unschedulable_pods_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_pods_test.go
@@ -109,7 +109,7 @@ func TestUnschedulablePods(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			upm := newUnschedulablePods(nil, nil)
 			for _, p := range test.podsToAdd {
-				upm.addOrUpdate(newQueuedPodInfoForLookup(p), framework.EventUnscheduledPodAdd.Label())
+				upm.addOrUpdate(newQueuedPodInfoForLookup(p), false, framework.EventUnscheduledPodAdd.Label())
 			}
 			if diff := cmp.Diff(test.expectedMapAfterAdd, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
 				t.Errorf("Unexpected map after adding pods(-want, +got):\n%s", diff)
@@ -117,7 +117,7 @@ func TestUnschedulablePods(t *testing.T) {
 
 			if len(test.podsToUpdate) > 0 {
 				for _, p := range test.podsToUpdate {
-					upm.addOrUpdate(newQueuedPodInfoForLookup(p), framework.EventUnscheduledPodUpdate.Label())
+					upm.addOrUpdate(newQueuedPodInfoForLookup(p), false, framework.EventUnscheduledPodUpdate.Label())
 				}
 				if diff := cmp.Diff(test.expectedMapAfterUpdate, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
 					t.Errorf("Unexpected map after updating pods (-want, +got):\n%s", diff)


### PR DESCRIPTION
Previously, when a Pod residing in the 'unschedulablePods' queue was updated and subsequently rejected by PreEnqueue plugins (returning 'Wait'), the logic in 'moveToActiveQ' would return early because the Pod was already present in the queue.

This caused the 'scheduler_gated_pods_total' metric to fail to increment, leading to metric inconsistencies (and potentially negative values upon Pod deletion).

This change adds a check to detect the transition from Ungated to Gated. If detected, the Pod is removed and re-added to the queue to ensure metrics are correctly swapped (Unschedulable-- and Gated++).

Added regression test 'TestSchedulingQueueMetrics_UngatedToGated' to verify the fix.

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes a logic error where the Gated pods metric failed to increment when a Pod transitioned from Ungated to Gated while residing in the unschedulablePods queue.

Previously, the moveToActiveQ function would return early if the pod was already present in unschedulablePods. This optimization incorrectly assumed that the pod's state had not changed. However, if an Update() event causes PreEnqueue plugins to reject the pod (returning Wait), the pod logically transitions from "Unschedulable" to "Gated." The early return caused the scheduler to skip the necessary metric swap (decrementing unschedulable metric and incrementing gated metric), leading to metric inconsistencies.

This change explicitly handles the Ungated -> Gated transition by re-adding the pod to the queue to update the metrics correctly.

#### Which issue(s) this PR is related to:
Fixes #133464

#### Special notes for your reviewer:
Added a reproduction test case TestSchedulingQueueMetrics_UngatedToGated which manually injects a pod into the unschedulable queue to simulate the specific state transition where the bug manifests.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where the Gated pods metric was not updated when a Pod transitioned from Unschedulable to Gated during an update.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

