### PR TITLE
test: Fix image credential pulls test node scheduling

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -70,7 +70,7 @@ func (m *kubeGenericRuntimeManager) PullImage(ctx context.Context, image kubecon
 	return "", nil, utilerrors.NewAggregate(pullErrs)
 }
 
-// GetImageRef gets the ID of the image which has already been in
+// GetImageRef gets the reference (digest or ID) of the image which has already been in
 // the local storage. It returns ("", nil) if the image isn't in the local storage.
 func (m *kubeGenericRuntimeManager) GetImageRef(ctx context.Context, image kubecontainer.ImageSpec) (string, error) {
 	logger := klog.FromContext(ctx)
@@ -81,6 +81,10 @@ func (m *kubeGenericRuntimeManager) GetImageRef(ctx context.Context, image kubec
 	}
 	if resp.Image == nil {
 		return "", nil
+	}
+	// Prefer returning a digest reference over an image ID to ensure pull record lookups work correctly.
+	if len(resp.Image.RepoDigests) > 0 {
+		return resp.Image.RepoDigests[0], nil
 	}
 	return resp.Image.Id, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Fixes a node scheduling bug in the image credential pulls test that was causing test timeouts in the serial CRI-O node e2e suite.

The registry and test pods were being scheduled on different nodes. When the test pod tried to pull images from `localhost:5000`, it couldn't reach the registry running on a different node, causing test failures.

The fix ensures both the registry and test pods run on the same node by using the registry node for scheduling the test pod. In node e2e tests, this is the single test node, so proper affinity is established.

#### Which issue(s) this PR is related to:

Fixes #135375

#### Special notes for your reviewer:

- Related PR: #135244 (identical node scheduling fix for a different test)
- Test-infra fixes: kubernetes/test-infra#35946 (CRI-O insecure registry config), kubernetes/test-infra#35969 (CRI-O upgrade including cri-o/cri-o#9615)

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation:

```docs
None
```