### PR TITLE
fix(SchedulerPreemption/Async): schedule all medium priority pods first so all low priority pods can be preempted

### DIFF
--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -375,7 +375,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		highPriorityPods := make([]*v1.Pod, 0, 5*nodeListLen)
 		mediumPriorityPods := make([]*v1.Pod, 0, 10*nodeListLen)
 
-		ginkgo.By("Run high/medium priority pods that have same requirements as that of lower priority pod")
+		ginkgo.By("Run medium priority pods that have same requirements as that of lower priority pod")
 		for i := range nodeList.Items {
 			// Create medium priority pods first
 			// to confirm the scheduler finally prioritize the high priority pods, ignoring the medium priority pods.
@@ -393,19 +393,6 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 				})
 				mediumPriorityPods = append(mediumPriorityPods, p)
 			}
-
-			for j := 0; j < 5; j++ {
-				p := createPausePod(ctx, f, pausePodConfig{
-					Name:              fmt.Sprintf("pod%d-%d-%v", i, j, highPriorityClassName),
-					PriorityClassName: highPriorityClassName,
-					Resources: &v1.ResourceRequirements{
-						// Set the pod request to the low priority pod's resources
-						Requests: lowPriorityPods[0].Spec.Containers[0].Resources.Requests,
-						Limits:   lowPriorityPods[0].Spec.Containers[0].Resources.Requests,
-					},
-				})
-				highPriorityPods = append(highPriorityPods, p)
-			}
 		}
 
 		// All low priority Pods should be the target of preemption.
@@ -419,6 +406,22 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 				}
 				return preemptedPod.DeletionTimestamp != nil, nil
 			}))
+		}
+
+		ginkgo.By("Run high priority pods that have same requirements as that of lower priority pod")
+		for i := range nodeList.Items {
+			for j := 0; j < 5; j++ {
+				p := createPausePod(ctx, f, pausePodConfig{
+					Name:              fmt.Sprintf("pod%d-%d-%v", i, j, highPriorityClassName),
+					PriorityClassName: highPriorityClassName,
+					Resources: &v1.ResourceRequirements{
+						// Set the pod request to the low priority pod's resources
+						Requests: lowPriorityPods[0].Spec.Containers[0].Resources.Requests,
+						Limits:   lowPriorityPods[0].Spec.Containers[0].Resources.Requests,
+					},
+				})
+				highPriorityPods = append(highPriorityPods, p)
+			}
 		}
 
 		// All high priority Pods should be schedulable by removing the low priority Pods.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

If not all medium priority pods are allowed to preempt low priority pods first the high priority pods may occupy the low priority spot and disallow medium priority pods to preempt all low priority pods. Thus leaving some low priority pods without a DeletionTimestamp field set and failing the "Check all low priority pods to be about to preempted." check.

#### Which issue(s) this PR is related to:

Fixes: #135370

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
