### PR TITLE
chore: Denying deprecated pointer package in golangci-linters config

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -378,6 +378,12 @@ linters:
             #         - fruit
     depguard:
       rules:
+        utils:
+          files:
+            - $all
+          deny:
+            - pkg: "k8s.io/utils/pointer"
+              desc: "k8s.io/utils/pointer shall no longer be used, please use k8s.io/utils/ptr."
         go-cmp:
           files:
             - $all

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -387,6 +387,12 @@ linters:
             #         - fruit
     depguard:
       rules:
+        utils:
+          files:
+            - $all
+          deny:
+            - pkg: "k8s.io/utils/pointer"
+              desc: "k8s.io/utils/pointer shall no longer be used, please use k8s.io/utils/ptr."
         go-cmp:
           files:
             - $all

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -199,6 +199,12 @@ linters:
           {{include "hack/kube-api-linter/kube-api-linter.yaml" | indent 10 | trim}}
     depguard:
       rules:
+        utils:
+          files:
+            - $all
+          deny:
+            - pkg: "k8s.io/utils/pointer"
+              desc: "k8s.io/utils/pointer shall no longer be used, please use k8s.io/utils/ptr."
         go-cmp:
           files:
             - $all


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR continuous the effort (from #132414) to edit the golangci config, to deny the package import of the deprecated pointer package `k8s.io/utils/pointer`

#### Which issue(s) this PR is related to:
Related to: #132086

#### Special notes for your reviewer:
The golangci configuration has been added in the .in template, and generate through `hack/update-golangci-lint-config.sh`.

I did some manual tests, to ensure the changes take action. For the tests, I manually added the depr. package back, updated the vendored packages, and ran `./hack/verify-golangci-lint.sh`.

```
ERROR: pkg/controller/endpoint/endpoints_controller_test.go:50:2: import 'k8s.io/utils/pointer' is not allowed from list 'utils': k8s.io/utils/pointer shall no longer be used, please use k8s.io/utils/ptr. (depguard)
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
