### PR TITLE
logging the key logs instead of fmt.print when cgroup has missing c…

### DIFF
--- a/pkg/kubelet/cm/cgroup_v2_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_v2_manager_linux.go
@@ -63,11 +63,15 @@ func (c *cgroupV2impl) Validate(name CgroupName) error {
 	neededControllers := getSupportedUnifiedControllers()
 	enabledControllers, err := readUnifiedControllers(cgroupPath)
 	if err != nil {
-		return fmt.Errorf("could not read controllers for cgroup %q: %w", name, err)
+		klog.ErrorS(err, "could not read controllers for cgroup", "cgroup", name)
+		return err
 	}
 	difference := neededControllers.Difference(enabledControllers)
 	if difference.Len() > 0 {
-		return fmt.Errorf("cgroup %q has some missing controllers: %v", name, strings.Join(sets.List(difference), ", "))
+		missing := strings.Join(sets.List(difference), ", ")
+		err := fmt.Errorf("cgroup %q has some missing controllers: %v", name, missing)
+		klog.ErrorS(err, "cgroup has some missing controllers", "cgroup", name, "missingControllers", missing)
+		return err
 	}
 	return nil
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2062,7 +2062,9 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		podKilled := false
 		if !pcm.Exists(pod) && !firstSync {
 			p := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
+			klog.V(3).InfoS("Attempting to kill pod to recreate cgroups", "pod", klog.KObj(pod), "podUID", pod.UID)
 			if err := kl.killPod(ctx, pod, p, nil); err == nil {
+				klog.V(3).InfoS("Killed pod to allow cgroup recreation", "pod", klog.KObj(pod), "podUID", pod.UID)
 				podKilled = true
 			} else {
 				if wait.Interrupted(err) {


### PR DESCRIPTION
…ntrollers

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
It's an enhancement for #131567. we had the same issue(cpuset controller was missing) recently and spent some days on it. 
it's not easy to investigate it since the key error log was not logged in kubelet. 
<!--
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
To decrease the time of troubleshooting it in the future, it's not easy to trace the kubelet if there is no error log. 
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#131567
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
