### PR TITLE
apimachinery + client-go + device taint eviction unit test: context-aware Start/WaitFor, waiting through channels

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -29,6 +30,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -29,6 +30,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 )
 
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic/controller.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,10 +47,7 @@ type controller[T runtime.Object] struct {
 
 	options ControllerOptions
 
-	// must hold a func() bool or nil
-	notificationsDelivered atomic.Value
-
-	hasProcessed synctrack.AsyncTracker[string]
+	hasProcessed *synctrack.AsyncTracker[string]
 }
 
 type ControllerOptions struct {
@@ -77,17 +73,11 @@ func NewController[T runtime.Object](
 	}
 
 	c := &controller[T]{
-		options:    options,
-		informer:   informer,
-		reconciler: reconciler,
-		queue:      nil,
-	}
-	c.hasProcessed.UpstreamHasSynced = func() bool {
-		f := c.notificationsDelivered.Load()
-		if f == nil {
-			return false
-		}
-		return f.(func() bool)()
+		options:      options,
+		informer:     informer,
+		reconciler:   reconciler,
+		queue:        nil,
+		hasProcessed: synctrack.NewAsyncTracker[string](options.Name),
 	}
 	return c
 }
@@ -159,12 +149,9 @@ func (c *controller[T]) Run(ctx context.Context) error {
 		return err
 	}
 
-	c.notificationsDelivered.Store(registration.HasSynced)
-
 	// Make sure event handler is removed from informer in case return early from
 	// an error
 	defer func() {
-		c.notificationsDelivered.Store(func() bool { return false })
 		// Remove event handler and Handle Error here. Error should only be raised
 		// for improper usage of event handler API.
 		if err := c.informer.RemoveEventHandler(registration); err != nil {
@@ -174,7 +161,12 @@ func (c *controller[T]) Run(ctx context.Context) error {
 
 	// Wait for initial cache list to complete before beginning to reconcile
 	// objects.
-	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.informer.HasSynced) {
+	if !cache.WaitFor(ctx, "caches", c.informer.HasSyncedChecker(), registration.HasSyncedChecker()) {
+		// TODO: should cache.WaitFor return an error?
+		// ctx.Err() or context.Cause(ctx)?
+		// Either of them would make dead code like the "if err == nil"
+		// below more obvious.
+
 		// ctx cancelled during cache sync. return early
 		err := ctx.Err()
 		if err == nil {
@@ -183,6 +175,10 @@ func (c *controller[T]) Run(ctx context.Context) error {
 		}
 		return err
 	}
+
+	// c.informer *and* our handler have synced, which implies that our AddFunc(= enqueue)
+	// and thus c.hasProcessed.Start have been called for the initial list => upstream is done.
+	c.hasProcessed.UpstreamHasSynced()
 
 	waitGroup := sync.WaitGroup{}
 

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package informers
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	admissionregistration "k8s.io/client-go/informers/admissionregistration"
 	apiserverinternal "k8s.io/client-go/informers/apiserverinternal"
 	apps "k8s.io/client-go/informers/apps"
@@ -158,6 +160,10 @@ func NewSharedInformerFactoryWithOptions(client kubernetes.Interface, defaultRes
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -167,15 +173,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -192,6 +192,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -205,10 +210,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -247,26 +273,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -282,7 +327,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -142,6 +142,11 @@ type Controller interface {
 	// HasSynced delegates to the Config's Queue
 	HasSynced() bool
 
+	// HasSyncedChecker enables waiting for syncing without polling.
+	// The returned DoneChecker can be passed to WaitFor.
+	// It delegates to the Config's Queue.
+	HasSyncedChecker() DoneChecker
+
 	// LastSyncResourceVersion delegates to the Reflector when there
 	// is one, otherwise returns the empty string
 	LastSyncResourceVersion() string
@@ -168,11 +173,13 @@ func (c *controller) RunWithContext(ctx context.Context) {
 		<-ctx.Done()
 		c.config.Queue.Close()
 	}()
+	logger := klog.FromContext(ctx)
 	r := NewReflectorWithOptions(
 		c.config.ListerWatcher,
 		c.config.ObjectType,
 		c.config.Queue,
 		ReflectorOptions{
+			Logger:          &logger,
 			ResyncPeriod:    c.config.FullResyncPeriod,
 			MinWatchTimeout: c.config.MinWatchTimeout,
 			TypeDescription: c.config.ObjectDescription,
@@ -204,6 +211,13 @@ func (c *controller) RunWithContext(ctx context.Context) {
 // Returns true once this controller has completed an initial resource listing
 func (c *controller) HasSynced() bool {
 	return c.config.Queue.HasSynced()
+}
+
+// HasSyncedChecker enables waiting for syncing without polling.
+// The returned DoneChecker can be passed to [WaitFor].
+// It delegates to the Config's Queue.
+func (c *controller) HasSyncedChecker() DoneChecker {
+	return c.config.Queue.HasSyncedChecker()
 }
 
 func (c *controller) LastSyncResourceVersion() string {
@@ -591,6 +605,7 @@ func NewTransformingIndexerInformer(
 // Multiplexes updates in the form of a list of Deltas into a Store, and informs
 // a given handler of events OnUpdate, OnAdd, OnDelete
 func processDeltas(
+	logger klog.Logger,
 	// Object which receives event notifications from the given deltas
 	handler ResourceEventHandler,
 	clientState Store,
@@ -608,7 +623,7 @@ func processDeltas(
 			if !ok {
 				return fmt.Errorf("ReplacedAll did not contain ReplacedAllInfo: %T", obj)
 			}
-			if err := processReplacedAllInfo(handler, info, clientState, isInInitialList, keyFunc); err != nil {
+			if err := processReplacedAllInfo(logger, handler, info, clientState, isInInitialList, keyFunc); err != nil {
 				return err
 			}
 		case SyncAll:
@@ -653,6 +668,7 @@ func processDeltas(
 // Returns an error if any Delta or transaction fails. For TransactionError,
 // only successful operations trigger callbacks.
 func processDeltasInBatch(
+	logger klog.Logger,
 	handler ResourceEventHandler,
 	clientState Store,
 	deltas []Delta,
@@ -666,7 +682,7 @@ func processDeltasInBatch(
 	if !txnSupported {
 		var errs []error
 		for _, delta := range deltas {
-			if err := processDeltas(handler, clientState, Deltas{delta}, isInInitialList, keyFunc); err != nil {
+			if err := processDeltas(logger, handler, clientState, Deltas{delta}, isInInitialList, keyFunc); err != nil {
 				errs = append(errs, err)
 			}
 		}
@@ -731,7 +747,7 @@ func processDeltasInBatch(
 	return nil
 }
 
-func processReplacedAllInfo(handler ResourceEventHandler, info ReplacedAllInfo, clientState Store, isInInitialList bool, keyFunc KeyFunc) error {
+func processReplacedAllInfo(logger klog.Logger, handler ResourceEventHandler, info ReplacedAllInfo, clientState Store, isInInitialList bool, keyFunc KeyFunc) error {
 	var deletions []DeletedFinalStateUnknown
 	type replacement struct {
 		oldObj interface{}
@@ -739,7 +755,7 @@ func processReplacedAllInfo(handler ResourceEventHandler, info ReplacedAllInfo, 
 	}
 	replacements := make([]replacement, 0, len(info.Objects))
 
-	err := reconcileReplacement(nil, clientState, info.Objects, keyFunc,
+	err := reconcileReplacement(logger, nil, clientState, info.Objects, keyFunc,
 		func(obj DeletedFinalStateUnknown) error {
 			deletions = append(deletions, obj)
 			return nil
@@ -792,7 +808,7 @@ func newInformer(clientState Store, options InformerOptions, keyFunc KeyFunc) Co
 	if options.Logger != nil {
 		logger = *options.Logger
 	}
-	fifo := newQueueFIFO(logger, clientState, options.Transform, options.Identifier, options.FIFOMetricsProvider)
+	logger, fifo := newQueueFIFO(logger, options.ObjectType, clientState, options.Transform, options.Identifier, options.FIFOMetricsProvider)
 
 	cfg := &Config{
 		Queue:            fifo,
@@ -803,21 +819,30 @@ func newInformer(clientState Store, options InformerOptions, keyFunc KeyFunc) Co
 
 		Process: func(obj interface{}, isInInitialList bool) error {
 			if deltas, ok := obj.(Deltas); ok {
-				return processDeltas(options.Handler, clientState, deltas, isInInitialList, keyFunc)
+				// This must be the logger *of the fifo*.
+				return processDeltas(logger, options.Handler, clientState, deltas, isInInitialList, keyFunc)
 			}
 			return errors.New("object given as Process argument is not Deltas")
 		},
 		ProcessBatch: func(deltaList []Delta, isInInitialList bool) error {
-			return processDeltasInBatch(options.Handler, clientState, deltaList, isInInitialList, keyFunc)
+			// Same here.
+			return processDeltasInBatch(logger, options.Handler, clientState, deltaList, isInInitialList, keyFunc)
 		},
 	}
 	return New(cfg)
 }
 
-func newQueueFIFO(logger klog.Logger, clientState Store, transform TransformFunc, identifier InformerNameAndResource, metricsProvider FIFOMetricsProvider) Queue {
+// newQueueFIFO constructs a new FIFO, choosing between real and delta FIFO
+// depending on the InOrderInformers feature gate.
+//
+// It returns the FIFO and the logger used by the FIFO.
+// That logger includes the name used for the FIFO,
+// in contrast to the logger which was passed in.
+func newQueueFIFO(logger klog.Logger, objectType any, clientState Store, transform TransformFunc, identifier InformerNameAndResource, metricsProvider FIFOMetricsProvider) (klog.Logger, Queue) {
 	if clientgofeaturegate.FeatureGates().Enabled(clientgofeaturegate.InOrderInformers) {
 		options := RealFIFOOptions{
 			Logger:          &logger,
+			Name:            fmt.Sprintf("RealFIFO %T", objectType),
 			KeyFunction:     MetaNamespaceKeyFunc,
 			Transformer:     transform,
 			Identifier:      identifier,
@@ -830,13 +855,16 @@ func newQueueFIFO(logger klog.Logger, clientState Store, transform TransformFunc
 		} else {
 			options.KnownObjects = clientState
 		}
-		return NewRealFIFOWithOptions(options)
+		f := NewRealFIFOWithOptions(options)
+		return f.logger, f
 	} else {
-		return NewDeltaFIFOWithOptions(DeltaFIFOOptions{
+		f := NewDeltaFIFOWithOptions(DeltaFIFOOptions{
 			Logger:                &logger,
+			Name:                  fmt.Sprintf("DeltaFIFO %T", objectType),
 			KnownObjects:          clientState,
 			EmitDeltaTypeReplaced: true,
 			Transformer:           transform,
 		})
+		return f.logger, f
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -834,6 +834,7 @@ func TestProcessDeltasInBatch(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
 			mockStore := &mockTxnStore{
 				Store:       NewStore(MetaNamespaceKeyFunc),
 				failingObjs: tc.failingObjects,
@@ -851,6 +852,7 @@ func TestProcessDeltasInBatch(t *testing.T) {
 				},
 			}
 			err := processDeltasInBatch(
+				logger,
 				dummyListener,
 				mockStore,
 				tc.deltaList,
@@ -929,12 +931,12 @@ func TestReplaceEvents(t *testing.T) {
 
 			Process: func(obj interface{}, isInInitialList bool) error {
 				if deltas, ok := obj.(Deltas); ok {
-					return processDeltas(recorder, store, deltas, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
+					return processDeltas(fifo.logger, recorder, store, deltas, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
 				}
 				return errors.New("object given as Process argument is not Deltas")
 			},
 			ProcessBatch: func(deltaList []Delta, isInInitialList bool) error {
-				return processDeltasInBatch(recorder, store, deltaList, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
+				return processDeltasInBatch(fifo.logger, recorder, store, deltaList, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
 			},
 		}
 		c := New(cfg)
@@ -1066,12 +1068,12 @@ func TestResetWatch(t *testing.T) {
 
 				Process: func(obj interface{}, isInInitialList bool) error {
 					if deltas, ok := obj.(Deltas); ok {
-						return processDeltas(recorder, store, deltas, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
+						return processDeltas(fifo.logger, recorder, store, deltas, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
 					}
 					return errors.New("object given as Process argument is not Deltas")
 				},
 				ProcessBatch: func(deltaList []Delta, isInInitialList bool) error {
-					return processDeltasInBatch(recorder, store, deltaList, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
+					return processDeltasInBatch(fifo.logger, recorder, store, deltaList, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
 				},
 			}
 			c := New(cfg)

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/klog/v2"
@@ -31,6 +32,12 @@ import (
 // DeltaFIFOOptions is the configuration parameters for DeltaFIFO. All are
 // optional.
 type DeltaFIFOOptions struct {
+	// If set, log output will go to this logger instead of klog.Background().
+	// The name of the fifo gets added automatically.
+	Logger *klog.Logger
+
+	// Name can be used to override the default "DeltaFIFO" name for the new instance.
+	Name string
 
 	// KeyFunction is used to figure out what key an object should have. (It's
 	// exposed in the returned DeltaFIFO's KeyOf() method, with additional
@@ -55,9 +62,6 @@ type DeltaFIFOOptions struct {
 	// If set, will be called for objects before enqueueing them. Please
 	// see the comment on TransformFunc for details.
 	Transformer TransformFunc
-
-	// If set, log output will go to this logger instead of klog.Background().
-	Logger *klog.Logger
 }
 
 // DeltaFIFO is like FIFO, but differs in two ways.  One is that the
@@ -102,6 +106,13 @@ type DeltaFIFOOptions struct {
 // threads, you could end up with multiple threads processing slightly
 // different versions of the same object.
 type DeltaFIFO struct {
+	// logger is a per-instance logger. This gets chosen when constructing
+	// the instance, with klog.Background() as default.
+	logger klog.Logger
+
+	// name is the name of the fifo. It is included in the logger.
+	name string
+
 	// lock/cond protects access to 'items' and 'queue'.
 	lock sync.RWMutex
 	cond sync.Cond
@@ -139,10 +150,6 @@ type DeltaFIFO struct {
 
 	// Called with every object if non-nil.
 	transformer TransformFunc
-
-	// logger is a per-instance logger. This gets chosen when constructing
-	// the instance, with klog.Background() as default.
-	logger klog.Logger
 }
 
 // TransformFunc allows for transforming an object before it will be processed.
@@ -263,6 +270,8 @@ func NewDeltaFIFOWithOptions(opts DeltaFIFOOptions) *DeltaFIFO {
 	}
 
 	f := &DeltaFIFO{
+		logger:       klog.Background(),
+		name:         "DeltaFIFO",
 		items:        map[string]Deltas{},
 		queue:        []string{},
 		keyFunc:      opts.KeyFunction,
@@ -270,11 +279,14 @@ func NewDeltaFIFOWithOptions(opts DeltaFIFOOptions) *DeltaFIFO {
 
 		emitDeltaTypeReplaced: opts.EmitDeltaTypeReplaced,
 		transformer:           opts.Transformer,
-		logger:                klog.Background(),
 	}
 	if opts.Logger != nil {
 		f.logger = *opts.Logger
 	}
+	if opts.Name != "" {
+		f.name = opts.Name
+	}
+	f.logger = klog.LoggerWithName(f.logger, f.name)
 	f.cond.L = &f.lock
 	return f
 }
@@ -477,10 +489,10 @@ func (f *DeltaFIFO) queueActionInternalLocked(actionType, internalActionType Del
 		// when given a non-empty list (as it is here).
 		// If somehow it happens anyway, deal with it but complain.
 		if oldDeltas == nil {
-			f.logger.Error(nil, "Impossible dedupDeltas, ignoring", "id", id, "oldDeltas", oldDeltas, "obj", obj)
+			utilruntime.HandleErrorWithLogger(f.logger, nil, "Impossible dedupDeltas, ignoring", "id", id, "oldDeltas", oldDeltas, "obj", obj)
 			return nil
 		}
-		f.logger.Error(nil, "Impossible dedupDeltas, breaking invariant by storing empty Deltas", "id", id, "oldDeltas", oldDeltas, "obj", obj)
+		utilruntime.HandleErrorWithLogger(f.logger, nil, "Impossible dedupDeltas, breaking invariant by storing empty Deltas", "id", id, "oldDeltas", oldDeltas, "obj", obj)
 		f.items[id] = newDeltas
 		return fmt.Errorf("Impossible dedupDeltas for id=%q: oldDeltas=%#+v, obj=%#+v; broke DeltaFIFO invariant by storing empty Deltas", id, oldDeltas, obj)
 	}
@@ -530,7 +542,7 @@ func (f *DeltaFIFO) Pop(process PopProcessFunc) (interface{}, error) {
 		item, ok := f.items[id]
 		if !ok {
 			// This should never happen
-			f.logger.Error(nil, "Inconceivable! Item was in f.queue but not f.items; ignoring", "id", id)
+			utilruntime.HandleErrorWithLogger(f.logger, nil, "Inconceivable! Item was in f.queue but not f.items; ignoring", "id", id)
 			continue
 		}
 		delete(f.items, id)
@@ -623,7 +635,7 @@ func (f *DeltaFIFO) Replace(list []interface{}, _ string) error {
 			deletedObj, exists, err := f.knownObjects.GetByKey(k)
 			if err != nil {
 				deletedObj = nil
-				f.logger.Error(err, "Unexpected error during lookup, placing DeleteFinalStateUnknown marker without object", "key", k)
+				utilruntime.HandleErrorWithLogger(f.logger, err, "Unexpected error during lookup, placing DeleteFinalStateUnknown marker without object", "key", k)
 			} else if !exists {
 				deletedObj = nil
 				f.logger.Info("Key does not exist in known objects store, placing DeleteFinalStateUnknown marker without object", "key", k)
@@ -666,7 +678,7 @@ func (f *DeltaFIFO) Resync() error {
 func (f *DeltaFIFO) syncKeyLocked(key string) error {
 	obj, exists, err := f.knownObjects.GetByKey(key)
 	if err != nil {
-		f.logger.Error(err, "Unexpected error during lookup, unable to queue object for sync", "key", key)
+		utilruntime.HandleErrorWithLogger(f.logger, err, "Unexpected error during lookup, unable to queue object for sync", "key", key)
 		return nil
 	} else if !exists {
 		f.logger.Info("Key does not exist in known objects store, unable to queue object for sync", "key", key)

--- a/staging/src/k8s.io/client-go/tools/cache/event_handler_name.go
+++ b/staging/src/k8s.io/client-go/tools/cache/event_handler_name.go
@@ -50,7 +50,9 @@ func nameForHandler(handler ResourceEventHandler) (name string) {
 			value = value.Elem()
 		}
 		if value.Type().Kind() == reflect.Pointer {
-			value = value.Elem()
+			if !value.IsNil() {
+				value = value.Elem()
+			}
 		}
 		name := value.Type().PkgPath()
 		if name != "" {

--- a/staging/src/k8s.io/client-go/tools/cache/event_handler_name.go
+++ b/staging/src/k8s.io/client-go/tools/cache/event_handler_name.go
@@ -1,0 +1,119 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+func nameForHandler(handler ResourceEventHandler) (name string) {
+	defer func() {
+		// Last resort: let Sprintf handle it.
+		if name == "" {
+			name = fmt.Sprintf("%T", handler)
+		}
+	}()
+
+	if handler == nil {
+		return ""
+	}
+	switch handler := handler.(type) {
+	case *ResourceEventHandlerFuncs:
+		return nameForHandlerFuncs(*handler)
+	case ResourceEventHandlerFuncs:
+		return nameForHandlerFuncs(handler)
+	default:
+		// We can use the fully qualified name of whatever
+		// provides the interface. We don't care whether
+		// it contains fields or methods which provide
+		// the interface methods.
+		value := reflect.ValueOf(handler)
+		if value.Type().Kind() == reflect.Interface {
+			// Probably not needed, but let's play it safe.
+			value = value.Elem()
+		}
+		if value.Type().Kind() == reflect.Pointer {
+			value = value.Elem()
+		}
+		name := value.Type().PkgPath()
+		if name != "" {
+			name += "."
+		}
+		if typeName := value.Type().Name(); typeName != "" {
+			name += typeName
+		}
+		return name
+	}
+}
+
+func nameForHandlerFuncs(funcs ResourceEventHandlerFuncs) string {
+	return nameForFunctions(funcs.AddFunc, funcs.UpdateFunc, funcs.DeleteFunc)
+}
+
+func nameForFunctions(fs ...any) string {
+	// If all functions are defined in the same place, then we
+	// don't care about the actual function name in
+	// e.g. "main.FuncName" or "main.(*Foo).FuncName-fm", instead
+	// we use the common qualifier.
+	//
+	// But we don't know that yet, so we also collect all names.
+	var qualifier string
+	singleQualifier := true
+	var names []string
+	for _, f := range fs {
+		if f == nil {
+			continue
+		}
+		name := nameForFunction(f)
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+
+		newQualifier := name
+		index := strings.LastIndexByte(newQualifier, '.')
+		if index > 0 {
+			newQualifier = newQualifier[:index]
+		}
+		switch qualifier {
+		case "":
+			qualifier = newQualifier
+		case newQualifier:
+			// So far, so good...
+		default:
+			// Nope, different.
+			singleQualifier = false
+		}
+	}
+
+	if singleQualifier {
+		return qualifier
+	}
+
+	return strings.Join(names, "+")
+}
+
+func nameForFunction(f any) string {
+	fn := runtime.FuncForPC(reflect.ValueOf(f).Pointer())
+	if fn == nil {
+		return ""
+	}
+	return fn.Name()
+}

--- a/staging/src/k8s.io/client-go/tools/cache/event_handler_name_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/event_handler_name_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+)
+
+type mockHandler struct{}
+
+func (m mockHandler) OnAdd(any, bool)   {}
+func (m mockHandler) OnUpdate(any, any) {}
+func (m mockHandler) OnDelete(any)      {}
+
+func TestNameForHandler(t *testing.T) {
+	emptyHandler := ResourceEventHandlerFuncs{}
+
+	for name, tc := range map[string]struct {
+		handler  ResourceEventHandler
+		wantName string
+	}{
+		"mixture": {
+			handler: ResourceEventHandlerFuncs{
+				UpdateFunc: emptyHandler.OnUpdate,
+				DeleteFunc: func(any) {},
+			},
+			wantName: "k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate-fm+k8s.io/client-go/tools/cache.TestNameForHandler.func1", // Testcase must come first to get func1.
+		},
+		"add": {
+			handler:  ResourceEventHandlerFuncs{AddFunc: func(any) {}},
+			wantName: "k8s.io/client-go/tools/cache.TestNameForHandler",
+		},
+		"update": {
+			handler:  ResourceEventHandlerFuncs{UpdateFunc: func(any, any) {}},
+			wantName: "k8s.io/client-go/tools/cache.TestNameForHandler",
+		},
+		"delete": {
+			handler:  ResourceEventHandlerFuncs{DeleteFunc: func(any) {}},
+			wantName: "k8s.io/client-go/tools/cache.TestNameForHandler",
+		},
+		"all": {
+			handler: ResourceEventHandlerFuncs{
+				AddFunc:    func(any) {},
+				UpdateFunc: func(any, any) {},
+				DeleteFunc: func(any) {},
+			},
+			wantName: "k8s.io/client-go/tools/cache.TestNameForHandler",
+		},
+		"ptrToFuncs": {
+			handler:  &ResourceEventHandlerFuncs{AddFunc: func(any) {}},
+			wantName: "k8s.io/client-go/tools/cache.TestNameForHandler",
+		},
+		"struct": {
+			handler:  mockHandler{},
+			wantName: "k8s.io/client-go/tools/cache.mockHandler",
+		},
+		"ptrToStruct": {
+			handler:  &mockHandler{},
+			wantName: "k8s.io/client-go/tools/cache.mockHandler",
+		},
+		"nil": {
+			handler:  nil,
+			wantName: "<nil>",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotName := nameForHandler(tc.handler)
+			if gotName != tc.wantName {
+				t.Errorf("Got name:\n    %s\nWanted name:\n    %s", gotName, tc.wantName)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/event_handler_name_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/event_handler_name_test.go
@@ -76,6 +76,12 @@ func TestNameForHandler(t *testing.T) {
 			handler:  nil,
 			wantName: "<nil>",
 		},
+		"stored-nil": {
+			// This is a bit odd, but one unit test actually registered
+			// such an event handler and it somehow worked.
+			handler:  (*mockHandler)(nil),
+			wantName: "*cache.mockHandler",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			gotName := nameForHandler(tc.handler)

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
@@ -73,7 +73,7 @@ func runTestReflectorDataConsistencyDetector(t *testing.T, transformer Transform
 	defer cancel()
 
 	store := NewStore(MetaNamespaceKeyFunc)
-	fifo := newQueueFIFO(logger, store, transformer, InformerNameAndResource{}, nil)
+	_, fifo := newQueueFIFO(logger, nil, store, transformer, InformerNameAndResource{}, nil)
 
 	lw := &ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
@@ -68,12 +68,12 @@ func TestReflectorDataConsistencyDetector(t *testing.T) {
 }
 
 func runTestReflectorDataConsistencyDetector(t *testing.T, transformer TransformFunc) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	store := NewStore(MetaNamespaceKeyFunc)
-	fifo := newQueueFIFO(store, transformer, InformerNameAndResource{}, nil)
+	fifo := newQueueFIFO(logger, store, transformer, InformerNameAndResource{}, nil)
 
 	lw := &ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -563,7 +563,7 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 		s.startedLock.Lock()
 		defer s.startedLock.Unlock()
 
-		fifo := newQueueFIFO(s.indexer, s.transform, s.identifier, s.fifoMetricsProvider)
+		fifo := newQueueFIFO(logger, s.indexer, s.transform, s.identifier, s.fifoMetricsProvider)
 
 		cfg := &Config{
 			Queue:             fifo,

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -1134,8 +1134,13 @@ func TestAddWhileActive(t *testing.T) {
 		return
 	}
 
-	if !handle1.HasSynced() {
-		t.Error("Not synced after Run??")
+	select {
+	case <-handle1.HasSyncedChecker().Done():
+		if !handle1.HasSynced() {
+			t.Error("Not synced after channel said we are synced??")
+		}
+	case <-time.After(10 * time.Second):
+		t.Error("Not synced 10 seconds after Run??")
 	}
 
 	listener2.lock.Lock() // ensure we observe it before it has synced

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
@@ -34,6 +34,7 @@ type RealFIFOOptions struct {
 	Logger *klog.Logger
 
 	// Name can be used to override the default "RealFIFO" name for the new instance.
+	// Optional. Used only if Identifier.Name returns an empty string.
 	Name string
 
 	// KeyFunction is used to figure out what key an object should have. (It's
@@ -98,6 +99,11 @@ type RealFIFO struct {
 
 	items []Delta
 
+	// synced is initially an open channel. It gets closed (once!) by checkSynced_locked
+	// as soon as the initial sync is considered complete.
+	synced       chan struct{}
+	syncedClosed bool
+
 	// populated is true if the first batch of items inserted by Replace() has been populated
 	// or Delete/Add/Update was called first.
 	populated bool
@@ -160,6 +166,7 @@ type SyncAllInfo struct{}
 var (
 	_ = Queue(&RealFIFO{})             // RealFIFO is a Queue
 	_ = TransformingStore(&RealFIFO{}) // RealFIFO implements TransformingStore to allow memory optimizations
+	_ = DoneChecker(&RealFIFO{})       // RealFIFO and implements DoneChecker.
 )
 
 // Close the queue.
@@ -196,11 +203,37 @@ func (f *RealFIFO) HasSynced() bool {
 	return f.hasSynced_locked()
 }
 
-// ignoring lint to reduce delta to the original for review.  It's ok adjust later.
-//
-//lint:file-ignore ST1003: should not use underscores in Go names
+// HasSyncedChecker is done if an Add/Update/Delete/AddIfNotPresent are called first,
+// or the first batch of items inserted by Replace() has been popped.
+func (f *RealFIFO) HasSyncedChecker() DoneChecker {
+	return f
+}
+
+// Name implements [DoneChecker.Name]
+func (f *RealFIFO) Name() string {
+	return f.name
+}
+
+// Done implements [DoneChecker.Done]
+func (f *RealFIFO) Done() <-chan struct{} {
+	return f.synced
+}
+
+// hasSynced_locked returns the result of a prior checkSynced_locked call.
 func (f *RealFIFO) hasSynced_locked() bool {
-	return f.populated && f.initialPopulationCount == 0
+	return f.syncedClosed
+}
+
+// checkSynced_locked checks whether the initial batch of items (set via Replace) has been delivered
+// and closes the synced channel as needed. It must be called after changing f.populated and/or
+// f.initialPopulationCount while the mutex is still locked.
+func (f *RealFIFO) checkSynced_locked() {
+	synced := f.populated && f.initialPopulationCount == 0
+	if synced && !f.syncedClosed {
+		// Initial sync is complete.
+		f.syncedClosed = true
+		close(f.synced)
+	}
 }
 
 // addToItems_locked appends to the delta list.
@@ -291,6 +324,7 @@ func (f *RealFIFO) Add(obj interface{}) error {
 	defer f.lock.Unlock()
 
 	f.populated = true
+	f.checkSynced_locked()
 	retErr := f.addToItems_locked(Added, false, obj)
 
 	return retErr
@@ -302,6 +336,7 @@ func (f *RealFIFO) Update(obj interface{}) error {
 	defer f.lock.Unlock()
 
 	f.populated = true
+	f.checkSynced_locked()
 	retErr := f.addToItems_locked(Updated, false, obj)
 
 	return retErr
@@ -315,6 +350,7 @@ func (f *RealFIFO) Delete(obj interface{}) error {
 	defer f.lock.Unlock()
 
 	f.populated = true
+	f.checkSynced_locked()
 	retErr := f.addToItems_locked(Deleted, false, obj)
 
 	return retErr
@@ -362,6 +398,7 @@ func (f *RealFIFO) Pop(process PopProcessFunc) (interface{}, error) {
 	defer func() {
 		if f.initialPopulationCount > 0 {
 			f.initialPopulationCount--
+			f.checkSynced_locked()
 		}
 	}()
 
@@ -482,7 +519,6 @@ func (f *RealFIFO) PopBatch(processBatch ProcessBatchFunc, processSingle PopProc
 		unique.Insert(id)
 		moveDeltaToProcessList(i)
 	}
-
 	f.items = f.items[len(deltas):]
 	// Decrement initialPopulationCount if needed.
 	// This is done in a defer so we only do this *after* processing is complete,
@@ -490,6 +526,7 @@ func (f *RealFIFO) PopBatch(processBatch ProcessBatchFunc, processSingle PopProc
 	defer func() {
 		if f.initialPopulationCount > 0 {
 			f.initialPopulationCount -= len(deltas)
+			f.checkSynced_locked()
 		}
 	}()
 
@@ -539,7 +576,7 @@ func (f *RealFIFO) Replace(newItems []interface{}, resourceVersion string) error
 	if f.emitAtomicEvents {
 		err = f.addReplaceToItemsLocked(newItems, resourceVersion)
 	} else {
-		err = reconcileReplacement(f.items, f.knownObjects, newItems, f.keyOf,
+		err = reconcileReplacement(f.logger, f.items, f.knownObjects, newItems, f.keyOf,
 			func(obj DeletedFinalStateUnknown) error {
 				return f.addToItems_locked(Deleted, true, obj)
 			},
@@ -554,6 +591,7 @@ func (f *RealFIFO) Replace(newItems []interface{}, resourceVersion string) error
 	if !f.populated {
 		f.populated = true
 		f.initialPopulationCount = len(f.items)
+		f.checkSynced_locked()
 	}
 
 	return nil
@@ -563,6 +601,7 @@ func (f *RealFIFO) Replace(newItems []interface{}, resourceVersion string) error
 // and based upon the state of the items in the queue and known objects will call onDelete and onReplace
 // depending upon whether the item is being deleted or replaced/added.
 func reconcileReplacement(
+	logger klog.Logger,
 	queuedItems []Delta,
 	knownObjects KeyListerGetter,
 	newItems []interface{},
@@ -638,10 +677,10 @@ func reconcileReplacement(
 		deletedObj, exists, err := knownObjects.GetByKey(knownKey)
 		if err != nil {
 			deletedObj = nil
-			utilruntime.HandleErrorWithLogger(klog.TODO(), err, "Error during lookup, placing DeleteFinalStateUnknown marker without object", "key", knownKey)
+			utilruntime.HandleErrorWithLogger(logger, err, "Error during lookup, placing DeleteFinalStateUnknown marker without object", "key", knownKey)
 		} else if !exists {
 			deletedObj = nil
-			utilruntime.HandleErrorWithLogger(klog.TODO(), nil, "Key does not exist in known objects store, placing DeleteFinalStateUnknown marker without object", "key", knownKey)
+			utilruntime.HandleErrorWithLogger(logger, nil, "Key does not exist in known objects store, placing DeleteFinalStateUnknown marker without object", "key", knownKey)
 		}
 		retErr := onDelete(DeletedFinalStateUnknown{
 			Key: knownKey,
@@ -757,6 +796,7 @@ func NewRealFIFOWithOptions(opts RealFIFOOptions) *RealFIFO {
 		logger:                klog.Background(),
 		name:                  "RealFIFO",
 		items:                 make([]Delta, 0, 10),
+		synced:                make(chan struct{}),
 		keyFunc:               opts.KeyFunction,
 		knownObjects:          opts.KnownObjects,
 		transformer:           opts.Transformer,
@@ -769,8 +809,11 @@ func NewRealFIFOWithOptions(opts RealFIFOOptions) *RealFIFO {
 	if opts.Logger != nil {
 		f.logger = *opts.Logger
 	}
-	if opts.Name != "" {
-		f.name = opts.Name
+	if name := opts.Name; name != "" {
+		f.name = name
+	}
+	if name := opts.Identifier.Name(); name != "" {
+		f.name = name
 	}
 	f.logger = klog.LoggerWithName(f.logger, f.name)
 	f.cond.L = &f.lock

--- a/staging/src/k8s.io/client-go/tools/cache/wait_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/wait_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
+)
+
+func init() {
+	// The test below is sensitive to the time zone, log output uses time.Local.
+	time.Local = time.UTC
+}
+
+func TestWaitFor(t *testing.T) {
+	for name, tc := range map[string]struct {
+		what          string
+		checkers      []DoneChecker
+		timeout       time.Duration
+		timeoutReason string
+
+		expectDone bool
+
+		// Time is predictable and starts at the synctest epoch.
+		// %[1]d is the pid, %[2]d the line number of the WaitFor call.
+		expectOutput string
+	}{
+		"empty": {
+			expectDone: true,
+		},
+		"no-caches": {
+			what:       "my-caches",
+			expectDone: true,
+			expectOutput: `I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Waiting" for="my-caches"
+`,
+		},
+		"no-logging": {
+			checkers:   []DoneChecker{newMockChecker("first", 10*time.Second), newMockChecker("second", 5*time.Second), newMockChecker("last", 0*time.Second)},
+			expectDone: true,
+		},
+		"with-logging": {
+			what:       "my-caches",
+			checkers:   []DoneChecker{newMockChecker("first", 10*time.Second), newMockChecker("second", 5*time.Second), newMockChecker("last", 0*time.Second)},
+			expectDone: true,
+			expectOutput: `I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Waiting" for="my-caches"
+I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Done waiting" for="my-caches" instance="last"
+I0101 00:00:05.000000 %7[1]d wait_test.go:%[2]d] "Done waiting" for="my-caches" instance="second"
+I0101 00:00:10.000000 %7[1]d wait_test.go:%[2]d] "Done waiting" for="my-caches" instance="first"
+`,
+		},
+		"some-timeout": {
+			timeout:    time.Minute,
+			what:       "my-caches",
+			checkers:   []DoneChecker{newMockChecker("first", 10*time.Second), newMockChecker("second", -1), newMockChecker("last", 0*time.Second)},
+			expectDone: false,
+			expectOutput: `I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Waiting" for="my-caches"
+I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Done waiting" for="my-caches" instance="last"
+I0101 00:00:10.000000 %7[1]d wait_test.go:%[2]d] "Done waiting" for="my-caches" instance="first"
+I0101 00:01:00.000000 %7[1]d wait_test.go:%[2]d] "Timed out waiting" for="my-caches" cause="context deadline exceeded" instances=["second"]
+`,
+		},
+		"some-canceled": {
+			timeout:    -1,
+			what:       "my-caches",
+			checkers:   []DoneChecker{newMockChecker("first", 10*time.Second), newMockChecker("second", -1), newMockChecker("last", 0*time.Second)},
+			expectDone: false,
+			expectOutput: `I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Waiting" for="my-caches"
+I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Done waiting" for="my-caches" instance="last"
+I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Timed out waiting" for="my-caches" cause="context canceled" instances=["first","second"]
+`,
+		},
+		"more": {
+			timeoutReason: "go fish",
+			timeout:       5 * time.Second,
+			what:          "my-caches",
+			checkers:      []DoneChecker{newMockChecker("first", 10*time.Second), newMockChecker("second", -1), newMockChecker("last", 0*time.Second)},
+			expectDone:    false,
+			expectOutput: `I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Waiting" for="my-caches"
+I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Done waiting" for="my-caches" instance="last"
+I0101 00:00:05.000000 %7[1]d wait_test.go:%[2]d] "Timed out waiting" for="my-caches" cause="go fish" instances=["first","second"]
+`,
+		},
+		"all": {
+			timeout:    time.Minute,
+			what:       "my-caches",
+			checkers:   []DoneChecker{newMockChecker("first", -1), newMockChecker("second", -1), newMockChecker("last", -1)},
+			expectDone: false,
+			expectOutput: `I0101 00:00:00.000000 %7[1]d wait_test.go:%[2]d] "Waiting" for="my-caches"
+I0101 00:01:00.000000 %7[1]d wait_test.go:%[2]d] "Timed out waiting" for="my-caches" cause="context deadline exceeded" instances=["first","last","second"]
+`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				var buffer bytes.Buffer
+				logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(&buffer)))
+				ctx := klog.NewContext(context.Background(), logger)
+				var wg sync.WaitGroup
+				defer wg.Wait()
+				if tc.timeout != 0 {
+					switch tc.timeoutReason {
+					case "":
+						if tc.timeout > 0 {
+							c, cancel := context.WithTimeout(ctx, tc.timeout)
+							defer cancel()
+							ctx = c
+						} else {
+							c, cancel := context.WithCancel(ctx)
+							cancel()
+							ctx = c
+						}
+					default:
+						c, cancel := context.WithCancelCause(ctx)
+						wg.Go(func() {
+							time.Sleep(tc.timeout)
+							cancel(errors.New(tc.timeoutReason))
+						})
+						ctx = c
+					}
+				}
+				_, _, line, _ := runtime.Caller(0)
+				done := WaitFor(ctx, tc.what, tc.checkers...)
+				expectOutput := tc.expectOutput
+				if expectOutput != "" {
+					expectOutput = fmt.Sprintf(expectOutput, os.Getpid(), line+1)
+				}
+				assert.Equal(t, tc.expectDone, done, "done")
+				assert.Equal(t, expectOutput, buffer.String(), "output")
+			})
+		})
+	}
+}
+
+// newMockChecker can be created outside of a synctest bubble.
+// It constructs the channel inside when Done is first called.
+func newMockChecker(name string, delay time.Duration) DoneChecker {
+	return &mockChecker{
+		name:  name,
+		delay: delay,
+	}
+}
+
+type mockChecker struct {
+	name        string
+	delay       time.Duration
+	initialized bool
+	done        <-chan struct{}
+}
+
+func (m *mockChecker) Name() string { return m.name }
+func (m *mockChecker) Done() <-chan struct{} {
+	if !m.initialized {
+		switch {
+		case m.delay > 0:
+			// In the future.
+			ctx := context.Background()
+			// This leaks a cancel, but is hard to avoid (cannot use the parent t.Cleanup, no other way to delay calling it). Doesn't matter in a unit test.
+			//nolint:govet
+			ctx, _ = context.WithTimeout(ctx, m.delay)
+			m.done = ctx.Done()
+		case m.delay == 0:
+			// Immediately.
+			c := make(chan struct{})
+			close(c)
+			m.done = c
+		default:
+			// Never.
+			c := make(chan struct{})
+			m.done = c
+		}
+		m.initialized = true
+	}
+	return m.done
+}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
@@ -20,6 +20,7 @@ import "k8s.io/gengo/v2/types"
 
 var (
 	apiScheme                                    = types.Name{Package: "k8s.io/kubernetes/pkg/api/legacyscheme", Name: "Scheme"}
+	cacheDoneChecker                             = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "DoneChecker"}
 	cacheGenericLister                           = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "GenericLister"}
 	cacheIndexers                                = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "Indexers"}
 	cacheInformerName                            = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "InformerName"}
@@ -31,9 +32,12 @@ var (
 	cacheNewSharedIndexInformerWithOptions       = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformerWithOptions"}
 	cacheSharedIndexInformer                     = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformer"}
 	cacheSharedIndexInformerOptions              = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformerOptions"}
+	cacheSyncResult                              = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SyncResult"}
 	cacheTransformFunc                           = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "TransformFunc"}
 	cacheToListWatcherWithWatchListSemanticsFunc = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "ToListWatcherWithWatchListSemantics"}
+	cacheWaitForFunc                             = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "WaitFor"}
 	contextBackgroundFunc                        = types.Name{Package: "context", Name: "Background"}
+	contextCauseFunc                             = types.Name{Package: "context", Name: "Cause"}
 	contextContext                               = types.Name{Package: "context", Name: "Context"}
 	fmtErrorfFunc                                = types.Name{Package: "fmt", Name: "Errorf"}
 	listOptions                                  = types.Name{Package: "k8s.io/kubernetes/pkg/apis/core", Name: "ListOptions"}
@@ -41,10 +45,12 @@ var (
 	runtimeObject                                = types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "Object"}
 	schemaGroupResource                          = types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupResource"}
 	schemaGroupVersionResource                   = types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupVersionResource"}
+	stringsBuilder                               = types.Name{Package: "strings", Name: "Builder"}
 	syncMutex                                    = types.Name{Package: "sync", Name: "Mutex"}
 	timeDuration                                 = types.Name{Package: "time", Name: "Duration"}
 	v1ListOptions                                = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ListOptions"}
 	metav1NamespaceAll                           = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "NamespaceAll"}
 	metav1Object                                 = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "Object"}
+	waitContextForChannelFunc                    = types.Name{Package: "k8s.io/apimachinery/pkg/util/wait", Name: "ContextForChannel"}
 	watchInterface                               = types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "Interface"}
 )

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 	versioned "k8s.io/code-generator/examples/HyphenGroup/clientset/versioned"
 	example "k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example"
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 	versioned "k8s.io/code-generator/examples/MixedCase/clientset/versioned"
 	example "k8s.io/code-generator/examples/MixedCase/informers/externalversions/example"
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 	versioned "k8s.io/code-generator/examples/apiserver/clientset/versioned"
 	core "k8s.io/code-generator/examples/apiserver/informers/externalversions/core"
@@ -142,6 +144,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -151,15 +157,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -176,6 +176,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -189,10 +194,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -231,26 +257,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -266,7 +311,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 	versioned "k8s.io/code-generator/examples/single/clientset/versioned"
 	api "k8s.io/code-generator/examples/single/informers/externalversions/api"
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 	clientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	apiregistration "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration"
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client clientset.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 	versioned "k8s.io/sample-apiserver/pkg/generated/clientset/versioned"
 	internalinterfaces "k8s.io/sample-apiserver/pkg/generated/informers/externalversions/internalinterfaces"
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	context "context"
 	reflect "reflect"
 	sync "sync"
 	time "time"
@@ -26,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	wait "k8s.io/apimachinery/pkg/util/wait"
 	cache "k8s.io/client-go/tools/cache"
 	versioned "k8s.io/sample-controller/pkg/generated/clientset/versioned"
 	internalinterfaces "k8s.io/sample-controller/pkg/generated/informers/externalversions/internalinterfaces"
@@ -139,6 +141,10 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (f *sharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -148,15 +154,9 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			f.wg.Add(1)
-			// We need a new variable in each loop iteration,
-			// otherwise the goroutine would use the loop variable
-			// and that keeps changing.
-			informer := informer
-			go func() {
-				defer f.wg.Done()
-				informer.Run(stopCh)
-			}()
+			f.wg.Go(func() {
+				informer.RunWithContext(ctx)
+			})
 			f.startedInformers[informerType] = true
 		}
 	}
@@ -173,6 +173,11 @@ func (f *sharedInformerFactory) Shutdown() {
 }
 
 func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	result := f.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+	return result.Synced
+}
+
+func (f *sharedInformerFactory) WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult {
 	informers := func() map[reflect.Type]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -186,10 +191,31 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 		return informers
 	}()
 
-	res := map[reflect.Type]bool{}
-	for informType, informer := range informers {
-		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	// Wait for informers to sync, without polling.
+	cacheSyncs := make([]cache.DoneChecker, 0, len(informers))
+	for _, informer := range informers {
+		cacheSyncs = append(cacheSyncs, informer.HasSyncedChecker())
 	}
+	cache.WaitFor(ctx, "" /* no logging */, cacheSyncs...)
+
+	res := cache.SyncResult{
+		Synced: make(map[reflect.Type]bool, len(informers)),
+	}
+	failed := false
+	for informType, informer := range informers {
+		hasSynced := informer.HasSynced()
+		if !hasSynced {
+			failed = true
+		}
+		res.Synced[informType] = hasSynced
+	}
+	if failed {
+		// context.Cause is more informative than ctx.Err().
+		// This must be non-nil, otherwise WaitFor wouldn't have stopped
+		// prematurely.
+		res.Err = context.Cause(ctx)
+	}
+
 	return res
 }
 
@@ -228,26 +254,45 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.WaitForStop()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	factory.Start(ctx.Done())          // Start processing these informers.
-//	synced := factory.WaitForCacheSync(ctx.Done())
-//	for v, ok := range synced {
-//	    if !ok {
-//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
-//	        return
-//	    }
+//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	if err != nil {
+//	    return fmt.Errorf("register event handler: %v", err)
+//	}
+//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	factory.StartWithContext(ctx)                            // Start processing these informers.
+//	synced := factory.WaitForCacheSyncWithContext(ctx)
+//	if err := synced.AsError(); err != nil {
+//	    return err
+//	}
+//	for v := range synced {
+//	    // Only if desired log some information similar to this.
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	}
+//
+//	// Also make sure that all of the initial cache events have been delivered.
+//	if !WaitFor(ctx, "event handler sync", handle.HasSyncedChecker()) {
+//	    // Must have failed because of context.
+//	    return fmt.Errorf("sync event handler: %w", context.Cause(ctx))
 //	}
 //
 //	// Creating informers can also be created after Start, but then
 //	// Start must be called again:
 //	anotherGenericInformer := factory.ForResource(resource)
-//	factory.Start(ctx.Done())
+//	factory.StartWithContext(ctx)
 type SharedInformerFactory interface {
 	internalinterfaces.SharedInformerFactory
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	// Warning: StartWithContext does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
+	StartWithContext(ctx context.Context)
 
 	// Shutdown marks a factory as shutting down. At that point no new
 	// informers can be started anymore and Start will return without
@@ -263,7 +308,13 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
+	//
+	// Contextual logging: WaitForCacheSync should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced
+	// or the context gets canceled.
+	WaitForCacheSyncWithContext(ctx context.Context) cache.SyncResult
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)

--- a/test/e2e/apps/util.go
+++ b/test/e2e/apps/util.go
@@ -56,7 +56,9 @@ func NewIndexedPodAnnotationTracker(ownerName, ownerNs, labelSelector, podIndexA
 
 func (t *IndexedPodAnnotationTracker) Start(ctx context.Context, c clientset.Interface) context.CancelFunc {
 	trackerCtx, trackerCancel := context.WithCancel(ctx)
+	logger := klog.LoggerWithName(klog.FromContext(ctx), "IndexedPodAnnotationTracker")
 	_, podTracker := cache.NewInformerWithOptions(cache.InformerOptions{
+		Logger: &logger,
 		ListerWatcher: &cache.ListWatch{
 			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = t.labelSelector


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Context-aware SharedInformerFactory.Start is best explained by looking at the output of the `pkg/controller/devicetainteviction` unit test when a single unit test is intentionally broken - yes, it's long, I dare you to look at the attached file...
[before.txt](https://github.com/user-attachments/files/23681951/before.txt)

With this PR, it becomes much shorter because global log spam on stderr is avoided through (more or less) consistent usage of per-test output:

```
I1121 18:50:28.112284  396950 feature_gate.go:466] feature gates: {map[DRADeviceTaintRules:true DRADeviceTaints:true]}
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:10:00.020000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.010000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:30.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:30.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:30.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:30.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:30.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I0101 01:00:00.000000  396950 watch.go:218] "Stopping fake watcher"
I1121 18:50:29.704907  396950 feature_gate.go:466] feature gates: {map[DRADeviceTaintRules:false DRADeviceTaints:false]}
--- FAIL: TestAll (1.58s)
    --- FAIL: TestAll/Eviction (0.02s)
        --- FAIL: TestAll/Eviction/initial (0.00s)
            device_taint_eviction_test.go:2132: I0101 01:00:00.000000] starting to wait for watches
            reflector.go:314: I0101 01:00:00.000000] k8s.io/client-go/informers/factory.go:163: The provided ListWatcher doesn't support WatchList semantics. The feature will be disabled. If you are using a custom client, check the documentation of watchlist.DoesClientNotSupportWatchListSemantics() method listWatcherType="*cache.listWatcherWithWatchListSemanticsWrapper" feature=<features.Feature>: WatchListClient
            reflector.go:314: I0101 01:00:00.000000] k8s.io/client-go/informers/factory.go:163: The provided ListWatcher doesn't support WatchList semantics. The feature will be disabled. If you are using a custom client, check the documentation of watchlist.DoesClientNotSupportWatchListSemantics() method listWatcherType="*cache.listWatcherWithWatchListSemanticsWrapper" feature=<features.Feature>: WatchListClient
            reflector.go:314: I0101 01:00:00.000000] k8s.io/client-go/informers/factory.go:163: The provided ListWatcher doesn't support WatchList semantics. The feature will be disabled. If you are using a custom client, check the documentation of watchlist.DoesClientNotSupportWatchListSemantics() method listWatcherType="*cache.listWatcherWithWatchListSemanticsWrapper" feature=<features.Feature>: WatchListClient
            reflector.go:377: I0101 01:00:00.000000] Starting reflector type="*v1.ResourceSlice" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:421: I0101 01:00:00.000000] Listing and watching type="*v1.ResourceSlice" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:453: I0101 01:00:00.000000] Caches populated type="*v1.ResourceSlice" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:377: I0101 01:00:00.000000] Starting reflector type="*v1.DeviceClass" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:377: I0101 01:00:00.000000] Starting reflector type="*v1alpha3.DeviceTaintRule" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:421: I0101 01:00:00.000000] Listing and watching type="*v1alpha3.DeviceTaintRule" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:453: I0101 01:00:00.000000] Caches populated type="*v1alpha3.DeviceTaintRule" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:314: I0101 01:00:00.000000] k8s.io/client-go/informers/factory.go:163: The provided ListWatcher doesn't support WatchList semantics. The feature will be disabled. If you are using a custom client, check the documentation of watchlist.DoesClientNotSupportWatchListSemantics() method listWatcherType="*cache.listWatcherWithWatchListSemanticsWrapper" feature=<features.Feature>: WatchListClient
            reflector.go:377: I0101 01:00:00.000000] Starting reflector type="*v1.ResourceClaim" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:421: I0101 01:00:00.000000] Listing and watching type="*v1.ResourceClaim" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:421: I0101 01:00:00.000000] Listing and watching type="*v1.DeviceClass" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:453: I0101 01:00:00.000000] Caches populated type="*v1.ResourceClaim" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:453: I0101 01:00:00.000000] Caches populated type="*v1.DeviceClass" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:314: I0101 01:00:00.000000] k8s.io/client-go/informers/factory.go:163: The provided ListWatcher doesn't support WatchList semantics. The feature will be disabled. If you are using a custom client, check the documentation of watchlist.DoesClientNotSupportWatchListSemantics() method listWatcherType="*cache.listWatcherWithWatchListSemanticsWrapper" feature=<features.Feature>: WatchListClient
            reflector.go:377: I0101 01:00:00.000000] Starting reflector type="*v1.Pod" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:421: I0101 01:00:00.000000] Listing and watching type="*v1.Pod" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:453: I0101 01:00:00.000000] Caches populated type="*v1.Pod" reflector="k8s.io/client-go/informers/factory.go:163"
            device_taint_eviction_test.go:2135: I0101 01:00:00.000000] done waiting for watches
            device_taint_eviction.go:761: I0101 01:00:00.000000] Starting controller="device-taint-eviction" numWorkers=10
            device_taint_eviction.go:801: I0101 01:00:00.000000] Sending events to api server
            shared_informer.go:438: I0101 01:00:00.000000] Waiting for="cache and event handler sync"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.Pod"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.ResourceClaim"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.ResourceSlice"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.DeviceClass"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1alpha3.DeviceTaintRule"
            device_taint_eviction.go:1089: I0101 01:00:00.000000] ResourceClaim changed claimObject="default/my-pod-my-resource" oldClaim=<
                	null
                 > newClaim=<
                	{
                	  "metadata": {
                	    "name": "my-pod-my-resource",
                	    "namespace": "default",
                	    "ownerReferences": [
                	      {
                	        "apiVersion": "v1",
                	        "kind": "Pod",
                	        "name": "my-pod",
                	        "uid": "1234",
                	        "controller": true
                	      }
                	    ],
                	    "finalizers": [
                	      "resource.kubernetes.io/delete-protection"
                	    ]
                	  },
                	  "spec": {
                	    "devices": {
                	      "requests": [
                	        {
                	          "name": "req-1",
                	          "exactly": {
                	            "deviceClassName": "my-resource-class",
                	            "allocationMode": "ExactCount",
                	            "count": 1
                	          }
                	        }
                	      ]
                	    }
                	  },
                	  "status": {
                	    "allocation": {
                	      "devices": {
                	        "results": [
                	          {
                	            "request": "req-1",
                	            "driver": "some-driver",
                	            "pool": "worker",
                	            "device": "instance"
                	          }
                	        ]
                	      }
                	    },
                	    "reservedFor": [
                	      {
                	        "resource": "pods",
                	        "name": "my-pod",
                	        "uid": "1234"
                	      }
                	    ]
                	  }
                	}
                 > diff=<
                	@@ -1 +1,53 @@
                	-null
                	+{
                	+ "metadata": {
                	+  "name": "my-pod-my-resource",
                	+  "namespace": "default",
                	+  "ownerReferences": [
                	+   {
                	+    "apiVersion": "v1",
                	+    "kind": "Pod",
                	+    "name": "my-pod",
                	+    "uid": "1234",
                	+    "controller": true
                	+   }
                	+  ],
                	+  "finalizers": [
                	+   "resource.kubernetes.io/delete-protection"
                	+  ]
                	+ },
                	+ "spec": {
                	+  "devices": {
                	+   "requests": [
                	+    {
                	+     "name": "req-1",
                	+     "exactly": {
                	+      "deviceClassName": "my-resource-class",
                	+      "allocationMode": "ExactCount",
                	+      "count": 1
                	+     }
                	+    }
                	+   ]
                	+  }
                	+ },
                	+ "status": {
                	+  "allocation": {
                	+   "devices": {
                	+    "results": [
                	+     {
                	+      "request": "req-1",
                	+      "driver": "some-driver",
                	+      "pool": "worker",
                	+      "device": "instance"
                	+     }
                	+    ]
                	+   }
                	+  },
                	+  "reservedFor": [
                	+   {
                	+    "resource": "pods",
                	+    "name": "my-pod",
                	+    "uid": "1234"
                	+   }
                	+  ]
                	+ }
                	+}
                 >
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.ResourceClaim + event handler k8s.io/kubernetes/pkg/controller/devicetainteviction.(*Controller).Run"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.Pod + event handler k8s.io/kubernetes/pkg/controller/devicetainteviction.(*Controller).Run"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1alpha3.DeviceTaintRule + event handler k8s.io/kubernetes/pkg/controller/devicetainteviction.(*Controller).Run"
            device_taint_eviction.go:1328: I0101 01:00:00.000000] ResourceSlice changed pool=<devicetainteviction.poolID>: {
                        driverName: "some-driver",
                        poolName: "worker",
                    } oldSlice=<
                	null
                 > newSlice=<
                	{
                	  "metadata": {
                	    "name": "worker-some-driver"
                	  },
                	  "spec": {
                	    "driver": "some-driver",
                	    "pool": {
                	      "name": "worker",
                	      "generation": 0,
                	      "resourceSliceCount": 1
                	    },
                	    "nodeName": "worker",
                	    "devices": [
                	      {
                	        "name": "instance",
                	        "taints": [
                	          {
                	            "key": "example.com/taint",
                	            "value": "something",
                	            "effect": "NoExecute",
                	            "timeAdded": "2000-01-01T00:00:00Z"
                	          }
                	        ]
                	      },
                	      {
                	        "name": "instance-no-schedule",
                	        "taints": [
                	          {
                	            "key": "example.com/taint",
                	            "effect": "NoSchedule"
                	          }
                	        ]
                	      },
                	      {
                	        "name": "instance-no-execute",
                	        "taints": [
                	          {
                	            "key": "example.com/taint",
                	            "effect": "None",
                	            "timeAdded": "2000-01-01T00:00:00Z"
                	          },
                	          {
                	            "key": "example.com/taint",
                	            "effect": "NoExecute",
                	            "timeAdded": "2000-01-01T00:00:00Z"
                	          }
                	        ]
                	      }
                	    ]
                	  }
                	}
                 > diff=<
                	@@ -1 +1,51 @@
                	-null
                	+{
                	+ "metadata": {
                	+  "name": "worker-some-driver"
                	+ },
                	+ "spec": {
                	+  "driver": "some-driver",
                	+  "pool": {
                	+   "name": "worker",
                	+   "generation": 0,
                	+   "resourceSliceCount": 1
                	+  },
                	+  "nodeName": "worker",
                	+  "devices": [
                	+   {
                	+    "name": "instance",
                	+    "taints": [
                	+     {
                	+      "key": "example.com/taint",
                	+      "value": "something",
                	+      "effect": "NoExecute",
                	+      "timeAdded": "2000-01-01T00:00:00Z"
                	+     }
                	+    ]
                	+   },
                	+   {
                	+    "name": "instance-no-schedule",
                	+    "taints": [
                	+     {
                	+      "key": "example.com/taint",
                	+      "effect": "NoSchedule"
                	+     }
                	+    ]
                	+   },
                	+   {
                	+    "name": "instance-no-execute",
                	+    "taints": [
                	+     {
                	+      "key": "example.com/taint",
                	+      "effect": "None",
                	+      "timeAdded": "2000-01-01T00:00:00Z"
                	+     },
                	+     {
                	+      "key": "example.com/taint",
                	+      "effect": "NoExecute",
                	+      "timeAdded": "2000-01-01T00:00:00Z"
                	+     }
                	+    ]
                	+   }
                	+  ]
                	+ }
                	+}
                 >
            device_taint_eviction.go:1205: I0101 01:00:00.000000] Claim is affected by device taint claim="default/my-pod-my-resource" device=<v1.DeviceRequestAllocationResult>: 
                        device: instance
                        driver: some-driver
                        pool: worker
                        request: req-1 taint="ResourceSlice /worker-some-driver some-driver/worker/instance taint #0" evictionTime="2000-01-01 00:00:00 +0000 UTC"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.ResourceSlice + event handler k8s.io/kubernetes/pkg/controller/devicetainteviction.(*Controller).Run"
            device_taint_eviction.go:1001: I0101 01:00:00.000000] Underlying informers have synced
            device_taint_eviction_test.go:2333: I0101 01:00:00.000000] ERROR: 
                	Error Trace:	/nvme/gopath/src/k8s.io/kubernetes/pkg/controller/devicetainteviction/device_taint_eviction_test.go:2333
                	            				/nvme/gopath/src/k8s.io/kubernetes/test/utils/ktesting/tcontext.go:416
                	Error:      	Not equal: 
                	            	expected: 1
                	            	actual  : 0
                	Test:       	TestAll/Eviction/initial
                	Messages:   	get pod once
            device_taint_eviction_test.go:2334: I0101 01:00:00.000000] ERROR: 
                	Error Trace:	/nvme/gopath/src/k8s.io/kubernetes/pkg/controller/devicetainteviction/device_taint_eviction_test.go:2334
                	            				/nvme/gopath/src/k8s.io/kubernetes/test/utils/ktesting/tcontext.go:416
                	Error:      	Not equal: 
                	            	expected: 1
                	            	actual  : 0
                	Test:       	TestAll/Eviction/initial
                	Messages:   	update pod once
            device_taint_eviction_test.go:2335: I0101 01:00:00.000000] ERROR: 
                	Error Trace:	/nvme/gopath/src/k8s.io/kubernetes/pkg/controller/devicetainteviction/device_taint_eviction_test.go:2335
                	            				/nvme/gopath/src/k8s.io/kubernetes/test/utils/ktesting/tcontext.go:416
                	Error:      	Not equal: 
                	            	expected: 1
                	            	actual  : 0
                	Test:       	TestAll/Eviction/initial
                	Messages:   	delete pod once
            device_taint_eviction_test.go:2355: I0101 01:00:00.000000] ERROR: unexpected modified pod (-want, +got):
                  (*v1.Pod)(
                - 	s"&Pod{ObjectMeta:{my-pod  default  1234  0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},Spec:PodSpec{Volumes:[]Volume{},Containers:[]Container{},RestartPolicy:,TerminationGracePeriodSeconds:nil,ActiveDeadlineSeconds:nil,DNSPolicy:,NodeSel"...,
                + 	nil,
                  )
            device_taint_eviction_test.go:2366: I0101 01:00:00.000000] FATAL ERROR: 
                Expected
                    <[]v1.Event | len:0, cap:0>: nil
                to consist of
                    <[]*gstruct.FieldsMatcher | len:1, cap:1>: [
                        {
                            Fields: {
                                "Source": <*matchers.HaveFieldMatcher | 0xc008f977e0>{
                                    Field: "Component",
                                    Expected: <*matchers.EqualMatcher | 0xc001a9ea80>{
                                        Expected: <string>"device-taint-eviction",
                                    },
                                },
                                "Reason": <*matchers.EqualMatcher | 0xc001a9ea90>{
                                    Expected: <string>"DeviceTaintManagerEviction",
                                },
                                "Message": <*matchers.EqualMatcher | 0xc001a9eab0>{
                                    Expected: <string>"Marking for deletion",
                                },
                                "Count": <*matchers.EqualMatcher | 0xc001a9eac0>{Expected: <int32>1},
                                "InvolvedObject": <*matchers.EqualMatcher | 0xc001a9ead0>{
                                    Expected: 
                                        apiVersion: v1
                                        kind: Pod
                                        name: my-pod
                                        namespace: default
                                        uid: "1234",
                                },
                            },
                            IgnoreExtras: true,
                            IgnoreUnexportedExtras: false,
                            IgnoreMissing: false,
                            failures: nil,
                        },
                    ]
                the missing elements were
                    <[]*gstruct.FieldsMatcher | len:1, cap:1>: [
                        {
                            Fields: {
                                "Source": <*matchers.HaveFieldMatcher | 0xc008f977e0>{
                                    Field: "Component",
                                    Expected: <*matchers.EqualMatcher | 0xc001a9ea80>{
                                        Expected: <string>"device-taint-eviction",
                                    },
                                },
                                "Reason": <*matchers.EqualMatcher | 0xc001a9ea90>{
                                    Expected: <string>"DeviceTaintManagerEviction",
                                },
                                "Message": <*matchers.EqualMatcher | 0xc001a9eab0>{
                                    Expected: <string>"Marking for deletion",
                                },
                                "Count": <*matchers.EqualMatcher | 0xc001a9eac0>{Expected: <int32>1},
                                "InvolvedObject": <*matchers.EqualMatcher | 0xc001a9ead0>{
                                    Expected: 
                                        apiVersion: v1
                                        kind: Pod
                                        name: my-pod
                                        namespace: default
                                        uid: "1234",
                                },
                            },
                            IgnoreExtras: true,
                            IgnoreUnexportedExtras: false,
                            IgnoreMissing: false,
                            failures: nil,
                        },
                    ]
            device_taint_eviction_test.go:2312: I0101 01:00:00.000000] Waiting for goroutine termination...
            device_taint_eviction.go:794: I0101 01:00:00.000000] Shutting down work queue
            device_taint_eviction.go:1012: I0101 01:00:00.000000] Shut down controller controller="device-taint-eviction" reason=<nil>: nil
            reflector.go:383: I0101 01:00:00.000000] Stopping reflector type="*v1.DeviceClass" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:383: I0101 01:00:00.000000] Stopping reflector type="*v1.ResourceClaim" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:383: I0101 01:00:00.000000] Stopping reflector type="*v1.ResourceSlice" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:383: I0101 01:00:00.000000] Stopping reflector type="*v1.Pod" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
            reflector.go:383: I0101 01:00:00.000000] Stopping reflector type="*v1alpha3.DeviceTaintRule" resyncPeriod="0s" reflector="k8s.io/client-go/informers/factory.go:163"
FAIL
FAIL	k8s.io/kubernetes/pkg/controller/devicetainteviction	1.621s
FAIL
```

Remaining culprits are `feature_gate.go` (only two lines now because the test was rewritten to set feature gates only once, but elsewhere the problem remains) and `watch.go`.

The new `cache.WaitFor` is able to describe what it is waiting for:

```
            shared_informer.go:438: I0101 01:00:00.000000] Waiting for="cache and event handler sync"
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.Pod"
...
            shared_informer.go:456: I0101 01:00:00.000000] Done waiting for="cache and event handler sync" instance="RealFIFO *v1.ResourceSlice + event handler k8s.io/kubernetes/pkg/controller/devicetainteviction.(*Controller).Run"
```

Waiting for channels to close in `WaitFor` creates a causal relationship between goroutines which is visible to synctest. When a controller in a synctest bubble does a WaitFor in a test's background goroutine for the controller, the test can use `synctest.Wait` to wait for completion of cache sync, without requiring any test specific "has controller synced" API. Without this, the test had to poll or otherwise wait for the controller.

The polling in `WaitForCacheSync` moved the virtual clock forward by a random amount, depending on how often it had to check in wait.Poll. Now tests can be written such that all events during a test happen at a predictable time. This gets demonstrated in the updated pkg/controller/devicetainteviction unit test, addressing several open TODOs there (see https://github.com/kubernetes/kubernetes/pull/136939).

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/135315

#### Special notes for your reviewer:

Review commit-by-commit might work better.

#### Does this PR introduce a user-facing change?

I'm intentionally not documenting the Go API changes here. Some changes are backward-compatible, but others like changing the AddEventHandler return type are not. In-tree some types emulated informers and had to be updated. This isn't a very common pattern, so the expectation is that most out-of-free users of informers do not need to be changed.

```release-note
NONE
```

/cc @jpbetz 