### PR TITLE
kubeadm: do not sort extraArgs alpha-numerically

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -167,6 +167,7 @@ type ControlPlaneComponent struct {
 	// An argument name in this list is the flag name as it appears on the
 	// command line except without leading dash(es). Extra arguments will override existing
 	// default arguments. Duplicate extra arguments are allowed.
+	// The default arguments are sorted alpha-numerically but the extra arguments are not.
 	ExtraArgs []Arg
 
 	// ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
@@ -249,6 +250,7 @@ type NodeRegistrationOptions struct {
 	// Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
 	// An argument name in this list is the flag name as it appears on the command line except without leading dash(es).
 	// Extra arguments will override existing default arguments. Duplicate extra arguments are allowed.
+	// The default arguments are sorted alpha-numerically but the extra arguments are not.
 	KubeletExtraArgs []Arg
 
 	// IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
@@ -301,6 +303,7 @@ type LocalEtcd struct {
 	// An argument name in this list is the flag name as it appears on the
 	// command line except without leading dash(es). Extra arguments will override existing
 	// default arguments. Duplicate extra arguments are allowed.
+	// The default arguments are sorted alpha-numerically but the extra arguments are not.
 	ExtraArgs []Arg
 
 	// ExtraEnvs is an extra set of environment variables to pass to the control plane component.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
@@ -172,6 +172,7 @@ type ControlPlaneComponent struct {
 	// An argument name in this list is the flag name as it appears on the
 	// command line except without leading dash(es). Extra arguments will override existing
 	// default arguments. Duplicate extra arguments are allowed.
+	// The default arguments are sorted alpha-numerically but the extra arguments are not.
 	// +optional
 	ExtraArgs []Arg `json:"extraArgs,omitempty"`
 
@@ -262,6 +263,7 @@ type NodeRegistrationOptions struct {
 	// Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
 	// An argument name in this list is the flag name as it appears on the command line except without leading dash(es).
 	// Extra arguments will override existing default arguments. Duplicate extra arguments are allowed.
+	// The default arguments are sorted alpha-numerically but the extra arguments are not.
 	// +optional
 	KubeletExtraArgs []Arg `json:"kubeletExtraArgs,omitempty"`
 
@@ -324,6 +326,7 @@ type LocalEtcd struct {
 	// An argument name in this list is the flag name as it appears on the
 	// command line except without leading dash(es). Extra arguments will override existing
 	// default arguments. Duplicate extra arguments are allowed.
+	// The default arguments are sorted alpha-numerically but the extra arguments are not.
 	// +optional
 	ExtraArgs []Arg `json:"extraArgs,omitempty"`
 

--- a/cmd/kubeadm/app/util/arguments_test.go
+++ b/cmd/kubeadm/app/util/arguments_test.go
@@ -41,8 +41,8 @@ func TestArgumentsToCommand(t *testing.T) {
 				{Name: "admission-control", Value: "NamespaceLifecycle,LimitRanger"},
 			},
 			expected: []string{
-				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
 			},
 		},
 		{
@@ -56,9 +56,9 @@ func TestArgumentsToCommand(t *testing.T) {
 				{Name: "tls-sni-cert-key", Value: "/some/new/path/subpath"},
 			},
 			expected: []string{
+				"--token-auth-file=/token",
 				"--tls-sni-cert-key=/some/new/path",
 				"--tls-sni-cert-key=/some/new/path/subpath",
-				"--token-auth-file=/token",
 			},
 		},
 		{
@@ -72,8 +72,8 @@ func TestArgumentsToCommand(t *testing.T) {
 				{Name: "tls-sni-cert-key", Value: "/some/new/path"},
 			},
 			expected: []string{
-				"--tls-sni-cert-key=/some/new/path",
 				"--token-auth-file=/token",
+				"--tls-sni-cert-key=/some/new/path",
 			},
 		},
 		{
@@ -85,8 +85,8 @@ func TestArgumentsToCommand(t *testing.T) {
 				{Name: "admission-control", Value: "NamespaceLifecycle,LimitRanger"},
 			},
 			expected: []string{
-				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
 			},
 		},
 		{
@@ -99,9 +99,9 @@ func TestArgumentsToCommand(t *testing.T) {
 				{Name: "admission-control", Value: "NamespaceLifecycle,LimitRanger"},
 			},
 			expected: []string{
-				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
 				"--something-that-allows-empty-string=",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
 			},
 		},
 		{
@@ -115,9 +115,29 @@ func TestArgumentsToCommand(t *testing.T) {
 				{Name: "something-that-allows-empty-string", Value: ""},
 			},
 			expected: []string{
-				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--allow-privileged=true",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
 				"--something-that-allows-empty-string=",
+			},
+		},
+		{
+			name: "base are sorted and overrides are not",
+			base: []kubeadmapi.Arg{
+				{Name: "b", Value: "true"},
+				{Name: "c", Value: "true"},
+				{Name: "a", Value: "true"},
+			},
+			overrides: []kubeadmapi.Arg{
+				{Name: "e", Value: "true"},
+				{Name: "b", Value: "true"},
+				{Name: "d", Value: "true"},
+			},
+			expected: []string{
+				"--a=true",
+				"--c=true",
+				"--e=true",
+				"--b=true",
+				"--d=true",
 			},
 		},
 	}
@@ -187,6 +207,21 @@ func TestArgumentsFromCommand(t *testing.T) {
 				{Name: "admission-control", Value: "NamespaceLifecycle,LimitRanger"},
 				{Name: "tls-sni-cert-key", Value: "/some/path"},
 				{Name: "tls-sni-cert-key", Value: "/some/path/subpath"},
+			},
+		},
+		{
+			name: "args are sorted",
+			args: []string{
+				"--c=foo",
+				"--a=foo",
+				"--b=foo",
+				"--b=bar",
+			},
+			expected: []kubeadmapi.Arg{
+				{Name: "a", Value: "foo"},
+				{Name: "b", Value: "bar"},
+				{Name: "b", Value: "foo"},
+				{Name: "c", Value: "foo"},
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If the user has provided extraArgs with an order that has significance (e.g. --service-account-issuer for kube-apiserver), kubeadm will correctly override any base args, but will end up sorting the entire resulting list, which is not desired.

Instead, only sort the base arguments and preserve the order of overrides provided by the user.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

fixes https://github.com/kubernetes/kubeadm/issues/3261

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: when applying the overrides provided by the user using "extraArgs", do not sort the resulted list of arguments alpha-numerically. Instead, only sort the list of default arguments and keep the list of overrides unsorted. This allows finer control for flags which have an order that matters, such as, "--service-account-issuer" for kube-apiserver.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
