### PR TITLE
Emit an event when the result of a probe for a container changes

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -1,4 +1,4 @@
-c/*
+/*
 Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,8 +94,8 @@ const (
 
 // Probe event reason list
 const (
-	ContainerUnhealthy    = "Unhealthy"
-	ContainerProbeWarning = "ProbeWarning"
+	ContainerUnhealthy          = "Unhealthy"
+	ContainerProbeWarning       = "ProbeWarning"
 	ContainerProbeResultFailure = "ContainerProbeResultFailure"
 	ContainerProbeResultSuccess = "ContainerProbeResultSuccess"
 )

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -1,4 +1,4 @@
-/*
+c/*
 Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,8 @@ const (
 const (
 	ContainerUnhealthy    = "Unhealthy"
 	ContainerProbeWarning = "ProbeWarning"
+	ContainerProbeResultFailure = "ContainerProbeResultFailure"
+	ContainerProbeResultSuccess = "ContainerProbeResultSuccess"
 )
 
 // Pod worker event reason list

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -1,4 +1,4 @@
-/*
+c/*
 Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,6 +97,8 @@ const (
 const (
 	ContainerUnhealthy    = "Unhealthy"
 	ContainerProbeWarning = "ProbeWarning"
+	ContainerProbeResultFailure = "ContainerProbeResultFailure"
+	ContainerProbeResultSuccess = "ContainerProbeResultSuccess"
 )
 
 // Pod worker event reason list

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -1,4 +1,4 @@
-c/*
+/*
 Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,8 +95,8 @@ const (
 
 // Probe event reason list
 const (
-	ContainerUnhealthy    = "Unhealthy"
-	ContainerProbeWarning = "ProbeWarning"
+	ContainerUnhealthy          = "Unhealthy"
+	ContainerProbeWarning       = "ProbeWarning"
 	ContainerProbeResultFailure = "ContainerProbeResultFailure"
 	ContainerProbeResultSuccess = "ContainerProbeResultSuccess"
 )

--- a/pkg/kubelet/prober/events.go
+++ b/pkg/kubelet/prober/events.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+// RecordContainerEvent should be used by the prober for all container related events.
+func RecordContainerEvent(recorder record.EventRecorder, ctx context.Context, pod *v1.Pod, container *v1.Container, eventType, reason, message string, args ...interface{}) {
+	logger := klog.FromContext(ctx)
+	ref, err := kubecontainer.GenerateContainerRef(pod, container)
+	if err != nil {
+		logger.Error(err, "Can't make a ref to pod and container", "pod", klog.KObj(pod), "containerName", container.Name)
+		return
+	}
+	recorder.Eventf(ref, eventType, reason, message, args...)
+}

--- a/pkg/kubelet/prober/events.go
+++ b/pkg/kubelet/prober/events.go
@@ -1,12 +1,9 @@
-/*
+﻿/*
 Copyright 2025 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -79,8 +79,10 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 	pb.recorder.WithLogger(logger).Eventf(ref, eventType, reason, message, args...)
 }
 
-// probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+// probe probes the container and emits values on the container for probe failure or errors
+// returns a results.Result which gives the underlying result of the probe, a string containing the output from the probe
+// and an error. An error is only returned if the probe itself errors (not every results.Failure leads to an error).
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, string, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -90,13 +92,13 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	case startup:
 		probeSpec = container.StartupProbe
 	default:
-		return results.Failure, fmt.Errorf("unknown probe type: %q", probeType)
+		return results.Failure, "", fmt.Errorf("unknown probe type: %q", probeType)
 	}
 
 	logger := klog.FromContext(ctx)
 	if probeSpec == nil {
 		logger.Info("Probe is nil", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, "", nil
 	}
 
 	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
@@ -104,32 +106,32 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	if err != nil {
 		// Handle probe error
 		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
-		return results.Failure, err
+		RecordContainerEvent(pb.recorder, ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
+		return results.Failure, output, err
 	}
 
 	switch result {
 	case probe.Success:
 		logger.V(3).Info("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Warning:
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
+		RecordContainerEvent(pb.recorder, ctx, pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
 		logger.V(3).Info("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Failure:
 		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
-		return results.Failure, nil
+		RecordContainerEvent(pb.recorder, ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+		return results.Failure, output, nil
 
 	case probe.Unknown:
 		logger.V(1).Info("Probe unknown without error", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, "", nil
 
 	default:
 		logger.V(1).Info("Unsupported probe result", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, "", nil
 	}
 }
 

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -114,6 +114,9 @@ type manager struct {
 	// prober executes the probe actions.
 	prober *prober
 
+	// recorder records events associated with the probe
+	recorder record.EventRecorder
+
 	start time.Time
 }
 
@@ -130,6 +133,7 @@ func NewManager(
 	return &manager{
 		statusManager:    statusManager,
 		prober:           prober,
+		recorder:         recorder,
 		readinessManager: readinessManager,
 		livenessManager:  livenessManager,
 		startupManager:   startupManager,
@@ -198,7 +202,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, startup, pod, c)
+			w := newWorker(m, m.recorder, startup, pod, c)
 			m.workers[key] = w
 			go w.run(ctx)
 		}
@@ -210,7 +214,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, readiness, pod, c)
+			w := newWorker(m, m.recorder, readiness, pod, c)
 			m.workers[key] = w
 			go w.run(ctx)
 		}
@@ -222,7 +226,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, liveness, pod, c)
+			w := newWorker(m, m.recorder, liveness, pod, c)
 			m.workers[key] = w
 			go w.run(ctx)
 		}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -24,11 +24,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 )
 
@@ -61,6 +63,9 @@ type worker struct {
 	// Where to store this workers results.
 	resultsManager results.Manager
 	probeManager   *manager
+
+	// The event recorder to use for this worker
+	recorder record.EventRecorder
 
 	// The last known container ID for this worker.
 	containerID kubecontainer.ContainerID
@@ -96,6 +101,7 @@ func (w *worker) isInitContainer() bool {
 // Creates and starts a new probe worker.
 func newWorker(
 	m *manager,
+	recorder record.EventRecorder,
 	probeType probeType,
 	pod *v1.Pod,
 	container v1.Container) *worker {
@@ -107,6 +113,7 @@ func newWorker(
 		container:       container,
 		probeType:       probeType,
 		probeManager:    m,
+		recorder:        recorder,
 	}
 
 	switch probeType {
@@ -346,7 +353,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, output, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true
@@ -362,7 +369,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		ProberResults.With(w.proberResultsUnknownMetricLabels).Inc()
 		ProberDuration.With(w.proberDurationUnknownMetricLabels).Observe(time.Since(startTime).Seconds())
 	}
-
+	resultChanged := w.lastResult != result
 	if w.lastResult == result {
 		w.resultRun++
 	} else {
@@ -374,6 +381,30 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		(result == results.Success && w.resultRun < int(w.spec.SuccessThreshold)) {
 		// Success or failure is below threshold - leave the probe state unchanged.
 		return true
+	}
+
+	if resultChanged {
+		var eventType string
+		var eventReason string
+		if result == results.Success {
+			eventType = v1.EventTypeNormal
+			eventReason = events.ContainerProbeResultSuccess
+		} else {
+			eventType = v1.EventTypeWarning
+			eventReason = events.ContainerProbeResultFailure
+		}
+		RecordContainerEvent(
+			w.recorder,
+			ctx,
+			w.pod,
+			&w.container,
+			eventType,
+			eventReason,
+			"%s probe result changed to %s%s",
+			w.probeType,
+			result,
+			getPrefixedOutputEventString(result, output),
+		)
 	}
 
 	w.resultsManager.Set(w.containerID, result, w.pod)
@@ -399,4 +430,14 @@ func deepCopyPrometheusLabels(m metrics.Labels) metrics.Labels {
 		ret[k] = v
 	}
 	return ret
+}
+
+func getPrefixedOutputEventString(result results.Result, output string) string {
+	if result == results.Success {
+		return ""
+	} else if output == "" {
+		return ""
+	} else {
+		return ": " + output
+	}
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -21,11 +21,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -455,7 +457,7 @@ func TestFailureThreshold(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		// First probe should succeed.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 		for j := 0; j < 3; j++ {
 			msg := fmt.Sprintf("%d success (%d)", j+1, i)
@@ -464,7 +466,7 @@ func TestFailureThreshold(t *testing.T) {
 		}
 
 		// Prober starts failing :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 		// Next 2 probes should still be "success".
 		for j := 0; j < 2; j++ {
@@ -507,13 +509,13 @@ func TestSuccessThreshold(t *testing.T) {
 		}
 
 		// Prober flakes :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := fmt.Sprintf("1 failure (%d)", i)
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
 
 		// Back to success.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	}
 }
 
@@ -524,7 +526,7 @@ func TestStartupProbeSuccessThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 	for i := 0; i < successThreshold+1; i++ {
 		if i < successThreshold {
@@ -557,7 +559,7 @@ func TestStartupProbeFailureThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 	for i := 0; i < failureThreshold+1; i++ {
 		if i < failureThreshold {
@@ -678,7 +680,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		m.statusManager.SetPodStatus(logger, w.pod, status)
 
 		// First probe should fail.
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := "first probe"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -687,7 +689,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		}
 		// Set fakeExecProber to return success. However, the result will remain
 		// failure because the worker is on hold and won't probe.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 		msg = "while on hold"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -715,7 +717,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
 
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg := "initial probe success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -723,7 +725,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -731,7 +733,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -742,7 +744,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -760,7 +762,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 
 	// Below FailureThreshold leaves probe state unchanged
 	// which is failed for startup at first.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -768,7 +770,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -779,7 +781,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -860,14 +862,14 @@ func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// livenessProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// livenessProbe fails
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -880,19 +882,19 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: 1, FailureThreshold: 2})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// startupProbe fails < FailureThreshold, stays unknown
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
 	// startupProbe succeeds
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg = "Started, probe success, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// startupProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -1033,4 +1035,87 @@ func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChangeInResultToErrorIsReportedByWorker(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Failure, "oh no!", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Warning ContainerProbeResultFailure Liveness probe result changed to Failure: oh no!", <-recorder.Events)
+}
+
+func TestLackOfOutputIsHandledProperly(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Warning ContainerProbeResultFailure Liveness probe result changed to Failure", <-recorder.Events)
+}
+
+func TestOutputIgnoredForChangeToSuccess(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Success, "foobar", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Failure
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Normal ContainerProbeResultSuccess Liveness probe result changed to Success", <-recorder.Events)
+}
+
+func TestNoEventIfResultDoesNotChange(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Success, "foobar", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 0)
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -59,7 +59,7 @@ func newTestWorkerWithRestartableInitContainer(m *manager, probeType probeType) 
 		Name: "main-container",
 	}}
 
-	return newWorker(m, probeType, pod, initContainer)
+	return newWorker(m, m.recorder, probeType, pod, initContainer)
 }
 
 func TestDoProbe(t *testing.T) {
@@ -290,7 +290,7 @@ func TestDoProbeWithContainerRestartRules(t *testing.T) {
 			c.RestartPolicy = tc.container.RestartPolicy
 			c.RestartPolicyRules = tc.container.RestartPolicyRules
 			pod.Spec.Containers[0] = c
-			w := newWorker(m, probeType, pod, pod.Spec.Containers[0])
+			w := newWorker(m, m.recorder, probeType, pod, pod.Spec.Containers[0])
 
 			m.statusManager.SetPodStatus(logger, w.pod, tc.podStatus)
 
@@ -405,7 +405,7 @@ func TestDoProbeWithContainerRestartAllContainers(t *testing.T) {
 		for _, tc := range testcases {
 			pod := tc.pod()
 			podStatus := tc.podStatus()
-			w := newWorker(m, probeType, &pod, pod.Spec.Containers[0])
+			w := newWorker(m, m.recorder, probeType, &pod, pod.Spec.Containers[0])
 
 			m.statusManager.SetPodStatus(logger, w.pod, podStatus)
 

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -21,11 +21,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -455,7 +457,7 @@ func TestFailureThreshold(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		// First probe should succeed.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 		for j := 0; j < 3; j++ {
 			msg := fmt.Sprintf("%d success (%d)", j+1, i)
@@ -464,7 +466,7 @@ func TestFailureThreshold(t *testing.T) {
 		}
 
 		// Prober starts failing :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 		// Next 2 probes should still be "success".
 		for j := 0; j < 2; j++ {
@@ -507,13 +509,13 @@ func TestSuccessThreshold(t *testing.T) {
 		}
 
 		// Prober flakes :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := fmt.Sprintf("1 failure (%d)", i)
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
 
 		// Back to success.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	}
 }
 
@@ -524,7 +526,7 @@ func TestStartupProbeSuccessThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 	for i := 0; i < successThreshold+1; i++ {
 		if i < successThreshold {
@@ -557,7 +559,7 @@ func TestStartupProbeFailureThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 	for i := 0; i < failureThreshold+1; i++ {
 		if i < failureThreshold {
@@ -678,7 +680,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		m.statusManager.SetPodStatus(logger, w.pod, status)
 
 		// First probe should fail.
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := "first probe"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -687,7 +689,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		}
 		// Set fakeExecProber to return success. However, the result will remain
 		// failure because the worker is on hold and won't probe.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 		msg = "while on hold"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -715,7 +717,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
 
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg := "initial probe success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -723,7 +725,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -731,7 +733,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -742,7 +744,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -760,7 +762,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 
 	// Below FailureThreshold leaves probe state unchanged
 	// which is failed for startup at first.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -768,7 +770,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -779,7 +781,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -860,14 +862,14 @@ func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// livenessProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// livenessProbe fails
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -880,19 +882,19 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: 1, FailureThreshold: 2})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// startupProbe fails < FailureThreshold, stays unknown
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
 	// startupProbe succeeds
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg = "Started, probe success, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// startupProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -1106,4 +1108,87 @@ func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChangeInResultToErrorIsReportedByWorker(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Failure, "oh no!", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Warning ContainerProbeResultFailure Liveness probe result changed to Failure: oh no!", <-recorder.Events)
+}
+
+func TestLackOfOutputIsHandledProperly(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Warning ContainerProbeResultFailure Liveness probe result changed to Failure", <-recorder.Events)
+}
+
+func TestOutputIgnoredForChangeToSuccess(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Success, "foobar", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Failure
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Normal ContainerProbeResultSuccess Liveness probe result changed to Success", <-recorder.Events)
+}
+
+func TestNoEventIfResultDoesNotChange(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Success, "foobar", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 0)
 }


### PR DESCRIPTION
/sig node

#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR introduces a new event that is emitted by the probe worker when the result of the probe changes. End-users can watch this new event to learn when their probes entered the Sucess or Failure state and in the case of Failure they gain some contextual information in the form of the output from the last probe.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/115823 by dealing with the lack of information on when a probe fails (as users can now just look at this event)

#### Special notes for your reviewer:

This is revival of https://github.com/kubernetes/kubernetes/pull/115963 as requested in https://github.com/kubernetes/kubernetes/issues/115823#issuecomment-3554994710
The original PR passed most of the review process but wasn't kept updated enough to merge in the end.
This PR is a faithful copy of the original one on top of the latest master branch (the original PR being 2 years old).

#### Does this PR introduce a user-facing change?

Yes
```release-note
A new event is emitted on containers when their readiness, liveness or startup probes change result from Success to Failure or vice-versa. In the case of Failure information on why the probe failed may be included.
```
