### PR TITLE
kubectl: fix autoscale example to match between 2 and 8 pods

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -66,7 +66,7 @@ var (
 		kubectl autoscale deployment bar --min=3 --max=6 --cpu=500m --memory=200Mi
 		
 		# Auto scale a deployment "bar", with the number of pods between 2 and 8, target CPU utilization 60% and memory utilization 70%
-        kubectl autoscale deployment bar --min=3 --max=6 --cpu=60% --memory=70%`))
+        kubectl autoscale deployment bar --min=2 --max=8 --cpu=60% --memory=70%`))
 )
 
 // AutoscaleOptions declares the arguments accepted by the Autoscale command


### PR DESCRIPTION
### What type of PR is this?

/kind documentation
/sig cli
/area kubectl

**What this PR does / why we need it:**

This PR fixes a small inconsistency in the kubectl autoscale help text example.
The comment mentioned scaling “between 2 and 8” pods, but the actual command used --min=3 --max=6.

The fix aligns both the descriptive comment and the command flags for consistency.

**Before:**
```
# Auto scale a deployment "bar", with the number of pods between 2 and 8, target CPU utilization 60% and memory utilization 70%
kubectl autoscale deployment bar --min=3 --max=6 --cpu=60% --memory=70%
```

**After:**
```
# Auto scale a deployment "bar", with the number of pods between 2 and 8, target CPU utilization 60% and memory utilization 70%
kubectl autoscale deployment bar --min=2 --max=8 --cpu=60% --memory=70%
```

This improves the accuracy and clarity of the example output for end users referencing the kubectl autoscale command.

### Which issue(s) this PR is related to:

N/A — discovered during local verification of help text output.

**Special notes for your reviewer:**

Local build and verification performed successfully on macOS (Darwin/arm64):
```
bharathkumardasaraju@kubernetes$ make kubectl
+++ [1123 12:40:51] Building go targets for darwin/arm64
    k8s.io/kubernetes/cmd/kubectl (non-static)

bharathkumardasaraju@kubernetes$ ./_output/bin/kubectl autoscale --help | grep -A1 "2 and 8"
  # Auto scale a deployment "bar", with the number of pods between 2 and 8, target CPU utilization 60% and memory utilization 70%
  kubectl autoscale deployment bar --min=2 --max=8 --cpu=60% --memory=70%
```

This confirms the updated example is correctly reflected in the built kubectl binary.

### Does this PR introduce a user-facing change?
`Fix inconsistent example in "kubectl autoscale --help" output by aligning the min/max pod values in the example.`

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
N/A – The `kubectl autoscale` documentation is generated automatically from the Go command definitions in:
staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
