### PR TITLE
Document x-kubernetes list and union OpenAPI extensions

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -58,3 +58,60 @@ For example:
 
 Some of the definitions may have these extensions. For more information about PatchStrategy and PatchMergeKey see
 [strategic-merge-patch](https://git.k8s.io/community/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
+
+### `x-kubernetes-list-type`
+
+Some definitions may have `x-kubernetes-list-type`.  
+This extension describes how Kubernetes treats list (array) fields when merging objects.
+
+Valid values are:
+
+- `"atomic"` – the entire list is treated as a single value; updates replace the whole list.
+- `"set"` – the list behaves like a set; items are merged based on equality.
+- `"map"` – the list behaves like a map; uniqueness is determined by keys defined in `x-kubernetes-list-map-keys`.
+
+For example:
+
+```json
+{
+  "x-kubernetes-list-type": "map",
+  "x-kubernetes-list-map-keys": ["name"]
+}
+```
+
+### `x-kubernetes-list-map-keys`
+
+Some definitions may have `x-kubernetes-list-map-keys`.  
+This extension identifies which field(s) inside list items act as keys when `x-kubernetes-list-type` is `"map"`.
+
+Each key must refer to a field within the list element.  
+Items with matching key values are merged; items with different keys are appended.
+
+For example:
+
+```json
+{
+  "x-kubernetes-list-type": "map",
+  "x-kubernetes-list-map-keys": ["name"]
+}
+```
+
+### `x-kubernetes-unions`
+
+Some definitions may have `x-kubernetes-unions`.  
+This extension describes union-like structures where only one of several fields may be set.  
+A discriminator field determines which field is valid.
+
+For example:
+
+```yaml
+x-kubernetes-unions:
+  - discriminator: type
+    fields-to-discriminateBy:
+      httpGet: HTTPGet
+      tcpSocket: TCPSocket
+```
+
+In this example, when `type` is `"HTTPGet"`, only the `httpGet` field may appear;  
+when `type` is `"TCPSocket"`, only the `tcpSocket` field may appear.
+


### PR DESCRIPTION
This PR adds missing documentation for the following OpenAPI vendor extensions:

- `x-kubernetes-list-type`
- `x-kubernetes-list-map-keys`
- `x-kubernetes-unions`

These extensions are already supported in Kubernetes OpenAPI schemas but were not documented in `api/openapi-spec/README.md`. The update matches the format and style of existing vendor extension entries.

Fixes #131724

```release-note
NONE
```
