### PR TITLE
Fix ResourceQuota Terminating scope and add ActiveDeadline scope

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7740,9 +7740,13 @@ const (
 type ResourceQuotaScope string
 
 const (
-	// Match all pod objects where spec.activeDeadlineSeconds >=0
+	// Match all pod objects where metadata.deletionTimestamp is set
+	// Fixed: Previously incorrectly documented as checking spec.activeDeadlineSeconds
+	// See: https://github.com/kubernetes/kubernetes/issues/135411
 	ResourceQuotaScopeTerminating ResourceQuotaScope = "Terminating"
-	// Match all pod objects where spec.activeDeadlineSeconds is nil
+	// Match all pod objects where metadata.deletionTimestamp is nil
+	// Fixed: Previously incorrectly documented as checking spec.activeDeadlineSeconds
+	// See: https://github.com/kubernetes/kubernetes/issues/135411
 	ResourceQuotaScopeNotTerminating ResourceQuotaScope = "NotTerminating"
 	// Match all pod objects that have best effort quality of service
 	ResourceQuotaScopeBestEffort ResourceQuotaScope = "BestEffort"
@@ -7752,6 +7756,16 @@ const (
 	ResourceQuotaScopePriorityClass ResourceQuotaScope = "PriorityClass"
 	// Match all pod objects that have cross-namespace pod (anti)affinity mentioned.
 	ResourceQuotaScopeCrossNamespacePodAffinity ResourceQuotaScope = "CrossNamespacePodAffinity"
+	// NEW: Match all pod objects where spec.activeDeadlineSeconds >= 0
+	// This is a NEW scope added to separate time-constrained pods from terminating pods.
+	// Use this for batch jobs and other pods with time limits.
+	// See: https://github.com/kubernetes/kubernetes/issues/135411
+	ResourceQuotaScopeActiveDeadline ResourceQuotaScope = "ActiveDeadline"
+	// NEW: Match all pod objects where spec.activeDeadlineSeconds is nil
+	// This is a NEW scope added to separate time-constrained pods from terminating pods.
+	// Use this for long-running pods without time limits.
+	// See: https://github.com/kubernetes/kubernetes/issues/135411
+	ResourceQuotaScopeNotActiveDeadline ResourceQuotaScope = "NotActiveDeadline"
 
 	// Match all pvc objects that have volume attributes class mentioned.
 	ResourceQuotaScopeVolumeAttributesClass ResourceQuotaScope = "VolumeAttributesClass"


### PR DESCRIPTION
# Pull Request Description

## What type of PR is this?

/kind bug
/kind feature

## What this PR does / why we need it

This PR fixes a semantic issue in ResourceQuota scope checking and adds a new scope for better pod lifecycle management.

**Background:**

The [original design proposal](https://github.com/kubernetes/design-proposals-archive/blob/main/resource-management/resource-quota-scoping.md) defined the `Terminating` scope as matching pods where `spec.activeDeadlineSeconds >= 0`. However, this creates a semantic mismatch:

- The scope is named **"Terminating"** (suggests pods being deleted)
- But it actually matches pods with **time limits** (batch jobs, regardless of deletion status)

**The Problem:**

This ambiguity causes confusion because `activeDeadlineSeconds` and actual termination are different concepts:

1. **`activeDeadlineSeconds`**: Maximum duration before pod is killed (set at creation, never changes)
   - Batch jobs, CI/CD tasks - these are *time-limited*, not necessarily *terminating*
   
2. **`deletionTimestamp`**: Pod is being deleted RIGHT NOW (set when deletion starts)
   - Pods in graceful shutdown - these are actually *terminating*

**Impact of Current Behavior:**
- Batch jobs are counted as "Terminating" from creation (even when running normally)
- Users expecting "Terminating" to mean "being deleted" get incorrect quota tracking
- No way to separately track time-limited vs long-running workloads

**The Solution:**

Split into two semantically clear scopes:

- **`Terminating`** (FIXED) - Now checks `pod.DeletionTimestamp` 
  - Matches pods actively being deleted
  - Semantic meaning matches scope name

- **`ActiveDeadline`** (NEW) - Checks `pod.Spec.ActiveDeadlineSeconds`
  - Matches time-limited pods (batch jobs, etc.)
  - Preserves original functionality under correct name

This gives users precise control based on actual pod lifecycle states.

## Which issue(s) this PR fixes

Fixes #135411

## Notes for reviewer

**Design Decision Rationale:**

While the original design used `activeDeadlineSeconds` for the `Terminating` scope, issue #135411 correctly points out this is semantically incorrect. The scope name strongly implies it should match pods being deleted, not pods with time constraints.

By creating a separate `ActiveDeadline` scope, we:
1. Fix the semantic meaning of `Terminating` to match user expectations
2. Preserve the ability to quota time-limited pods (under the correct name)
3. Enable users to distinguish between different workload types

**Files changed:**
- `pods.go` - Split `IsTerminating()` to check only deletionTimestamp, added `HasActiveDeadline()`
- `types.go` - Added new scope constants with clear documentation  
- `pods_test.go` - Updated existing tests + new test coverage for both scopes

All changes include detailed comments explaining the fix and referencing issue #135411.

**Backward Compatibility Note:**

This changes the behavior of the `Terminating` scope. Users relying on the old behavior (matching pods with activeDeadlineSeconds) should migrate to the new `ActiveDeadline` scope.

## Release note

```release-note
Fix ResourceQuota Terminating scope to correctly check deletionTimestamp instead of activeDeadlineSeconds. Add new ActiveDeadline/NotActiveDeadline scopes for tracking time-limited pods. Users relying on old Terminating behavior should migrate to ActiveDeadline scope.
```
