### PR TITLE
Ensure that `--service-cluster-ip-range`  is configured as a unicast address range.

### DIFF
--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -48,6 +48,10 @@ func validateClusterIPFlags(options Extra) []error {
 		errs = append(errs, errors.New("--service-cluster-ip-range must not contain more than two entries"))
 	}
 
+	if !options.PrimaryServiceClusterIPRange.IP.IsGlobalUnicast() {
+		errs = append(errs, errors.New("--service-cluster-ip-range[0] must be unicast cidr"))
+	}
+
 	// Complete() expected to have set Primary* and Secondary
 	if !utilfeature.DefaultFeatureGate.Enabled(features.MultiCIDRServiceAllocator) ||
 		!utilfeature.DefaultFeatureGate.Enabled(features.DisableAllocatorDualWrite) {
@@ -77,6 +81,9 @@ func validateClusterIPFlags(options Extra) []error {
 			if err := validateMaxCIDRRange(options.SecondaryServiceClusterIPRange, maxCIDRBits, "--service-cluster-ip-range[1]"); err != nil {
 				errs = append(errs, err)
 			}
+		}
+		if !options.SecondaryServiceClusterIPRange.IP.IsGlobalUnicast() {
+			errs = append(errs, errors.New("--service-cluster-ip-range[1] must be unicast cidr"))
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Ensure that `--service-cluster-ip-range`  is configured as a unicast address range.
 Add validation for `--service-cluster-ip-range`.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
When configuring `--service-cluster-ip-range`, if unfamiliar with networking,  might configure it to a special address range such as multicast or broadcast, causing the service to become inaccessible.
such as:
```
root@kind-1:/etc/kubernetes/manifests# kubectl  get svc kubernetes
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   226.0.0.1    <none>        443/TCP   6h48m
root@kind-1:/etc/kubernetes/manifests# curl -k https://226.0.0.1:443
curl: (7) Failed to connect to 226.0.0.1 port 443 after 0 ms: Couldn't connect to server
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
An error occurs when `--service-cluster-ip-range` is configured with a non-unicast address range. This is to prevent incorrect configuration from causing service access failures.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
