### PR TITLE
Remove SeparateCacheWatchRPC feature deprecated in 1.33

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -2074,11 +2074,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
 	},
 
-	genericfeatures.SeparateCacheWatchRPC: {
-		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
-	},
-
 	genericfeatures.SizeBasedListCostEstimate: {
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 	},
@@ -2545,8 +2540,6 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	genericfeatures.ResilientWatchCacheInitialization: {},
 
 	genericfeatures.RetryGenerateName: {},
-
-	genericfeatures.SeparateCacheWatchRPC: {},
 
 	genericfeatures.SizeBasedListCostEstimate: {},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -193,12 +193,6 @@ const (
 	// if the generated name conflicts with an existing resource name, up to a maximum number of 7 retries.
 	RetryGenerateName featuregate.Feature = "RetryGenerateName"
 
-	// owner: @cici37
-	//
-	// Allow watch cache to create a watch on a dedicated RPC.
-	// This prevents watch cache from being starved by other watches.
-	SeparateCacheWatchRPC featuregate.Feature = "SeparateCacheWatchRPC"
-
 	// owner: @serathius
 	//
 	// Enables APF to use size of objects for estimating request cost.
@@ -428,11 +422,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
-	},
-
-	SeparateCacheWatchRPC: {
-		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
-		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 
 	SizeBasedListCostEstimate: {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -420,12 +420,6 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 		<-cacher.timer.C
 	}
 	var contextMetadata metadata.MD
-	if utilfeature.DefaultFeatureGate.Enabled(features.SeparateCacheWatchRPC) {
-		// Add grpc context metadata to watch and progress notify requests done by cacher to:
-		// * Prevent starvation of watch opened by cacher, by moving it to separate Watch RPC than watch request that bypass cacher.
-		// * Ensure that progress notification requests are executed on the same Watch RPC as their watch, which is required for it to work.
-		contextMetadata = metadata.New(map[string]string{"source": "cache"})
-	}
 
 	eventFreshDuration := config.EventsHistoryWindow
 	if eventFreshDuration < DefaultEventFreshDuration {


### PR DESCRIPTION
/kind cleanup

```release-note
Remove SeparateCacheWatchRPC  feature
```

Fixes https://github.com/kubernetes/kubernetes/issues/133273

/assign @liggitt 
Can we finally remove the feature after deprecating and waiting 3 releases ?