### PR TITLE
Remove TestWatchStreamSeparation from storage/cacher related tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -3164,111 +3163,6 @@ func TestGetBookmarkAfterResourceVersionLockedFunc(t *testing.T) {
 	}
 }
 
-func TestWatchStreamSeparation(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SizeBasedListCostEstimate, false)
-	server, etcdStorage := newEtcdTestStorage(t, etcd3testing.PathPrefix())
-	t.Cleanup(func() {
-		server.Terminate(t)
-	})
-	setupOpts := &setupOptions{}
-	withDefaults(setupOpts)
-	config := Config{
-		Storage:             etcdStorage,
-		Versioner:           storage.APIObjectVersioner{},
-		GroupResource:       schema.GroupResource{Resource: "pods"},
-		EventsHistoryWindow: DefaultEventFreshDuration,
-		ResourcePrefix:      setupOpts.resourcePrefix,
-		KeyFunc:             setupOpts.keyFunc,
-		GetAttrsFunc:        GetPodAttrs,
-		NewFunc:             newPod,
-		NewListFunc:         newPodList,
-		IndexerFuncs:        setupOpts.indexerFuncs,
-		Codec:               codecs.LegacyCodec(examplev1.SchemeGroupVersion),
-		Clock:               setupOpts.clock,
-	}
-	tcs := []struct {
-		name                         string
-		separateCacheWatchRPC        bool
-		useWatchCacheContextMetadata bool
-		expectBookmarkOnWatchCache   bool
-		expectBookmarkOnEtcd         bool
-	}{
-		{
-			name:                       "common RPC > both get bookmarks",
-			separateCacheWatchRPC:      false,
-			expectBookmarkOnEtcd:       true,
-			expectBookmarkOnWatchCache: true,
-		},
-		{
-			name:                       "separate RPC > only etcd gets bookmarks",
-			separateCacheWatchRPC:      true,
-			expectBookmarkOnEtcd:       true,
-			expectBookmarkOnWatchCache: false,
-		},
-		{
-			name:                         "separate RPC & watch cache context > only watch cache gets bookmarks",
-			separateCacheWatchRPC:        true,
-			useWatchCacheContextMetadata: true,
-			expectBookmarkOnEtcd:         false,
-			expectBookmarkOnWatchCache:   true,
-		},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SeparateCacheWatchRPC, tc.separateCacheWatchRPC)
-			cacher, err := NewCacherFromConfig(config)
-			if err != nil {
-				t.Fatalf("Failed to initialize cacher: %v", err)
-			}
-			defer cacher.Stop()
-
-			if !utilfeature.DefaultFeatureGate.Enabled(features.ResilientWatchCacheInitialization) {
-				if err := cacher.ready.wait(context.TODO()); err != nil {
-					t.Fatalf("unexpected error waiting for the cache to be ready")
-				}
-			}
-
-			getCacherRV := func() uint64 {
-				cacher.watchCache.RLock()
-				defer cacher.watchCache.RUnlock()
-				return cacher.watchCache.resourceVersion
-			}
-			waitContext, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			waitForEtcdBookmark := watchAndWaitForBookmark(t, waitContext, cacher.storage)
-
-			increaseRV := increaseRVFunc(server.V3Client.Client)
-			increaseRV(context.Background(), t)
-			lastResourceVersion := uint64(increaseRV(context.Background(), t))
-
-			var contextMetadata metadata.MD
-			if tc.useWatchCacheContextMetadata {
-				contextMetadata = metadata.New(map[string]string{"source": "cache"})
-			}
-			// For the first 100ms from watch creation, watch progress requests are ignored.
-			time.Sleep(200 * time.Millisecond)
-			err = cacher.storage.RequestWatchProgress(metadata.NewOutgoingContext(context.Background(), contextMetadata))
-			if err != nil {
-				t.Fatal(err)
-			}
-			// Give time for bookmark to arrive
-			time.Sleep(time.Second)
-
-			etcdWatchResourceVersion := waitForEtcdBookmark()
-			gotEtcdWatchBookmark := etcdWatchResourceVersion == lastResourceVersion
-			if gotEtcdWatchBookmark != tc.expectBookmarkOnEtcd {
-				t.Errorf("Unexpected etcd bookmark check result, rv: %d, lastRV: %d, wantMatching: %v", etcdWatchResourceVersion, lastResourceVersion, tc.expectBookmarkOnEtcd)
-			}
-
-			watchCacheResourceVersion := getCacherRV()
-			cacherGotBookmark := watchCacheResourceVersion == lastResourceVersion
-			if cacherGotBookmark != tc.expectBookmarkOnWatchCache {
-				t.Errorf("Unexpected watch cache bookmark check result, rv: %d, lastRV: %d, wantMatching: %v", watchCacheResourceVersion, lastResourceVersion, tc.expectBookmarkOnWatchCache)
-			}
-		})
-	}
-}
-
 func TestComputeListLimit(t *testing.T) {
 	scenarios := []struct {
 		name          string
@@ -3323,37 +3217,6 @@ func TestComputeListLimit(t *testing.T) {
 				t.Errorf("computeListLimit returned = %v, expected %v", actualLimit, scenario.expectedLimit)
 			}
 		})
-	}
-}
-
-func watchAndWaitForBookmark(t *testing.T, ctx context.Context, etcdStorage storage.Interface) func() (resourceVersion uint64) {
-	opts := storage.ListOptions{ResourceVersion: "", Predicate: storage.Everything, Recursive: true}
-	opts.Predicate.AllowWatchBookmarks = true
-	w, err := etcdStorage.Watch(ctx, "/pods/", opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	versioner := storage.APIObjectVersioner{}
-	var rv uint64
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for event := range w.ResultChan() {
-			if event.Type == watch.Bookmark {
-				rv, err = versioner.ObjectResourceVersion(event.Object)
-				break
-			}
-		}
-	}()
-	return func() (resourceVersion uint64) {
-		defer w.Stop()
-		wg.Wait()
-		if err != nil {
-			t.Fatal(err)
-		}
-		return rv
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR deals with removing the tests around WatchStreamSeparation, which has been flaking. A couple of discussions are around the fact that the feature has been deprecated. This should help having the boards back to green while assuming it's reasonably safe to remove the test based on the discussions in the below issues. 
xref: 
  https://kubernetes.slack.com/archives/C0EG7JC6T/p1763968600923379
  https://github.com/kubernetes/kubernetes/issues/134771#issuecomment-3466875356 
  https://github.com/kubernetes/kubernetes/issues/133273#issuecomment-3139486118
  

#### Which issue(s) this PR is related to: 
#134771
#133273

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
