### PR TITLE
Fix: Check `defaultBackend` in `allowRelaxedServiceNameValidation`

### DIFF
--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -1663,6 +1663,23 @@ func TestValidateIngressUpdate(t *testing.T) {
 			},
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec").Child("rules").Index(0).Child("http").Child("paths").Index(0).Child("backend").Child("service").Child("name"), "1-test-service", `a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')`)},
 		},
+		"update defaultBackend service to conform to relaxed service name - RelaxedServiceNameValidation disabled": {
+			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
+				oldIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
+				newIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "1-test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
+			},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec").Child("defaultBackend").Child("service").Child("name"), "1-test-service", `a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')`)},
+		},
 		"update service to conform to relaxed service name - RelaxedServiceNameValidation enabled": {
 			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
 				oldIngress.Spec.Rules = []networking.IngressRule{{
@@ -1699,6 +1716,23 @@ func TestValidateIngressUpdate(t *testing.T) {
 						},
 					},
 				}}
+			},
+			relaxedServiceName: true,
+		},
+		"update defaultBackend service to conform to relaxed service name - RelaxedServiceNameValidation enabled": {
+			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
+				oldIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
+				newIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "1-test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
 			},
 			relaxedServiceName: true,
 		},
@@ -1740,6 +1774,22 @@ func TestValidateIngressUpdate(t *testing.T) {
 				}}
 			},
 		},
+		"updating an already existing relaxed validation defaultBackend service name with RelaxedServiceNameValidation disabled": {
+			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
+				oldIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "1-test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
+				newIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "2-test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
+			},
+		},
 		"updating an already existing relaxed validation service name to a non-relaxed name with RelaxedServiceNameValidation disabled": {
 			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
 				oldIngress.Spec.Rules = []networking.IngressRule{{
@@ -1776,6 +1826,22 @@ func TestValidateIngressUpdate(t *testing.T) {
 						},
 					},
 				}}
+			},
+		},
+		"updating an already existing relaxed validation defaultBackend service name to a non-relaxed name with RelaxedServiceNameValidation disabled": {
+			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
+				oldIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "1-test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
+				newIngress.Spec.DefaultBackend = &networking.IngressBackend{
+					Service: &networking.IngressServiceBackend{
+						Name: "test-service",
+						Port: networking.ServiceBackendPort{Number: 80},
+					},
+				}
 			},
 		},
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1707,7 +1707,6 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	RelaxedServiceNameValidation: {
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	ReloadKubeletServerCertificateFile: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1475,10 +1475,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.34"
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "1.35"
 - name: ReloadKubeletServerCertificateFile
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `RelaxedServiceNameValidation` feature gate implementation in `allowRelaxedServiceNameValidation()` seems to be incomplete. It checks service names in `spec.rules` but does not check `spec.defaultBackend.service.name`.

This creates inconsistent behavior where Ingresses with relaxed service names (RFC 1123-compliant but RFC 1035-noncompliant, e.g., starting with digits) in rules can be updated, but those with such names only in defaultBackend cannot.

This PR completes the feature gate implementation by adding validation for `spec.defaultBackend.service.name` to maintain backward compatibility for existing Ingresses.

Changes:
- Add check for `spec.defaultBackend.service.name` in `allowRelaxedServiceNameValidation()`
- Add test cases covering defaultBackend scenarios
- Fix typo in comment: 'Ingresss' -> 'Ingress'

#### Which issue(s) this PR is related to:

Fixes #135425

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```