### PR TITLE
Fix goroutine leak in plugin manager test

### DIFF
--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_executor_test.go
@@ -178,7 +178,10 @@ loop:
 
 func setup(t *testing.T) (context.Context, chan interface{}, chan interface{}, OperationExecutor) {
 	tCtx := ktesting.Init(t)
-	ch, quit := make(chan interface{}), make(chan interface{})
+	// Use buffered channel to prevent goroutine leak.
+	// If time.After fires before ch receive, the goroutine sending to ch would block forever.
+	// Buffer size accommodates maximum concurrent operations.
+	ch, quit := make(chan interface{}, numPluginsToRegister*2), make(chan interface{})
 	return tCtx, ch, quit, NewOperationExecutor(newFakeOperationGenerator(ch, quit))
 }
 


### PR DESCRIPTION
# Fix Goroutine Leak in Plugin Manager Test

## What type of PR is this?

/kind bug
/area test

## What this PR does / why we need it

Fixes a goroutine leak in the plugin manager operation executor test.

The test creates goroutines that send to an unbuffered channel. If the test's timeout fires before receiving from the channel, those goroutines block forever on the send operation.

## Which issue(s) this PR fixes

Fixes #134939

## notes for reviewer

**Problem:** 
The `setup()` function creates an unbuffered channel that goroutines use to signal they've started. The test uses a `select` with `time.After` timeout. If the timeout case is selected first, no one reads from the channel, causing goroutines to block on `ch <- nil`.

**Solution:**
Changed the channel from unbuffered to buffered with capacity `numPluginsToRegister*2` (4). This allows all operation goroutines to send without blocking, even if the timeout fires first.

**Why this buffer size:**
- Tests can spawn up to 2 concurrent operations
- Buffer of 4 handles worst case where all operations start before any receives
- Small enough to catch logic errors if we somehow create too many operations

The fix  only affects the test helper function.


