### PR TITLE
Docs: Document missing x-kubernetes extensions

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -58,3 +58,25 @@ For example:
 
 Some of the definitions may have these extensions. For more information about PatchStrategy and PatchMergeKey see
 [strategic-merge-patch](https://git.k8s.io/community/contributors/devel/sig-api-machinery/strategic-merge-patch.md).
+
+### `x-kubernetes-list-type`
+
+Operations and Definitions may have `x-kubernetes-list-type` if they
+are associated with a [kubernetes resource](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources).
+This extension is used to specify the type of the list. It can be one of `atomic`, `set`, or `map`.
+
+* `atomic`: The list is treated as a single entity.
+* `set`: The list is treated as a set.
+* `map`: The list is treated as a map.
+
+### `x-kubernetes-list-map-keys`
+
+Operations and Definitions may have `x-kubernetes-list-map-keys` if they
+are associated with a [kubernetes resource](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources).
+This extension is used to specify the keys of the map when `x-kubernetes-list-type` is set to `map`.
+
+### `x-kubernetes-unions`
+
+Operations and Definitions may have `x-kubernetes-unions` if they
+are associated with a [kubernetes resource](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources).
+This extension is used to specify the unions in the resource.


### PR DESCRIPTION
This pull request adds missing documentation for the Kubernetes-specific OpenAPI extensions `x-kubernetes-list-type`, `x-kubernetes-list-map-keys`, and `x-kubernetes-unions` in `api/openapi-spec/README.md`.

These extensions are widely used across Kubernetes API definitions, but were not previously explained in this document.  
This update provides clear, centralized reference material for contributors, API reviewers, and tooling authors on how these extensions behave and when they should be used.

## What this PR adds
- Documentation for **`x-kubernetes-list-type`**  
  - Describes valid values (`atomic`, `set`, `map`)  
  - Explains how list semantics influence patching and comparison  
- Documentation for **`x-kubernetes-list-map-keys`**  
  - Explains usage when `x-kubernetes-list-type: map` is set  
  - Describes expectations for unique key behavior  
- Documentation for **`x-kubernetes-unions`**  
  - Clarifies how unions are represented in OpenAPI  
  - Links back to API conventions  

## Why this change is needed
- These extensions play a key role in the structural schema of Kubernetes APIs.  
- Without proper documentation, contributors cannot reliably understand or validate API changes.  
- Improves consistency and reduces ambiguity when authoring or reviewing API definitions.  
- Aligns this repository’s documentation with how these extensions are actually used throughout the project.

## Related issue
Related to: #131724

```release-note
NONE
```