### PR TITLE
featuregate: contextual logging

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -223,6 +223,7 @@ linters:
             contextual k8s.io/client-go/tools/cache/.*
             contextual k8s.io/client-go/tools/events/.*
             contextual k8s.io/client-go/tools/record/.*
+            contextual k8s.io/component-base/featuregate/*
             contextual k8s.io/component-helpers/.*
             contextual k8s.io/cri-api/.*
             contextual k8s.io/cri-client/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -232,6 +232,7 @@ linters:
             contextual k8s.io/client-go/tools/cache/.*
             contextual k8s.io/client-go/tools/events/.*
             contextual k8s.io/client-go/tools/record/.*
+            contextual k8s.io/component-base/featuregate/*
             contextual k8s.io/component-helpers/.*
             contextual k8s.io/cri-api/.*
             contextual k8s.io/cri-client/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -31,6 +31,7 @@ contextual k8s.io/client-go/rest/.*
 contextual k8s.io/client-go/tools/cache/.*
 contextual k8s.io/client-go/tools/events/.*
 contextual k8s.io/client-go/tools/record/.*
+contextual k8s.io/component-base/featuregate/*
 contextual k8s.io/component-helpers/.*
 contextual k8s.io/cri-api/.*
 contextual k8s.io/cri-client/.*


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is primarily useful in unit tests and therefore supported by featuregate/testing. Without this, all warnings are emitted to stderr, with no connection to the test which caused the warning to be emitted.

When a single test failed, `go test` started by showing all warnings triggered by any test, not just the failed test:

    I1121 18:50:28.112284  396950 feature_gate.go:466] feature gates: {map[DRADeviceTaintRules:true DRADeviceTaints:true]}
    ...
    I1121 18:50:29.704907  396950 feature_gate.go:466] feature gates: {map[DRADeviceTaintRules:false DRADeviceTaints:false]}
    --- FAIL: TestAll (1.58s)
        --- FAIL: TestAll/Eviction (0.02s)
    ...

This warning was actually slightly broken: it passed an atomic.Value to Infof, not the map. This violates the "must not be copied after first use" rule for atomic.Value (thus wasn't thread-safe) and printed the value in an awkward way (extra {}).

Now it shows that the feature gates are modified inside TestAll (in this example):

    --- FAIL: TestAll (1.56s)
        feature_gate.go:170: I1124 17:31:27.245108] Updated featureGates={"DRADeviceTaintRules":true,"DRADeviceTaints":true}
        --- FAIL: TestAll/Eviction (0.02s)
            --- FAIL: TestAll/Eviction/initial (0.00s)
        ...

        feature_gate.go:170: I1124 17:31:28.821975] Updated featureGates={"DRADeviceTaintRules":false,"DRADeviceTaints":false}
    FAIL
    FAIL	k8s.io/kubernetes/pkg/controller/devicetainteviction	1.602s

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @siyuanfoundation @tallclair @jpbetz 