### PR TITLE
feat(storage): enable validation-gen + DV wiring for storage.k8s.io

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1829,7 +1829,7 @@ func ValidateCSIDriverName(driverName string, fldPath *field.Path, opts ...Valid
 	if len(driverName) > 63 {
 		err := field.TooLong(fldPath, "" /*unused*/, 63)
 		if slices.Contains(opts, SizeCovered) {
-			err = err.MarkCoveredByDeclarative()
+			err = err.WithOrigin("maxLength").MarkCoveredByDeclarative()
 		}
 		allErrs = append(allErrs, err)
 	}

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
@@ -43,6 +44,14 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		switch op.Request.SubresourcePath() {
 		case "/":
 			return Validate_StorageClass(ctx, op, nil /* fldPath */, obj.(*storagev1.StorageClass), safe.Cast[*storagev1.StorageClass](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type VolumeAttachment
+	scheme.AddValidationFunc((*storagev1.VolumeAttachment)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/", "/status":
+			return Validate_VolumeAttachment(ctx, op, nil /* fldPath */, obj.(*storagev1.VolumeAttachment), safe.Cast[*storagev1.VolumeAttachment](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
@@ -80,5 +89,65 @@ func Validate_StorageClass(ctx context.Context, op operation.Operation, fldPath 
 	// field storagev1.StorageClass.AllowVolumeExpansion has no validation
 	// field storagev1.StorageClass.VolumeBindingMode has no validation
 	// field storagev1.StorageClass.AllowedTopologies has no validation
+	return errs
+}
+
+// Validate_VolumeAttachment validates an instance of VolumeAttachment according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachment) (errs field.ErrorList) {
+	// field storagev1.VolumeAttachment.TypeMeta has no validation
+	// field storagev1.VolumeAttachment.ObjectMeta has no validation
+
+	// field storagev1.VolumeAttachment.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachmentSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_VolumeAttachmentSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachment) *storagev1.VolumeAttachmentSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	// field storagev1.VolumeAttachment.Status has no validation
+	return errs
+}
+
+// Validate_VolumeAttachmentSpec validates an instance of VolumeAttachmentSpec according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1.VolumeAttachmentSpec) (errs field.ErrorList) {
+	// field storagev1.VolumeAttachmentSpec.Attacher
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			return
+		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
+
+	// field storagev1.VolumeAttachmentSpec.Source has no validation
+	// field storagev1.VolumeAttachmentSpec.NodeName has no validation
 	return errs
 }

--- a/pkg/apis/storage/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.validations.go
@@ -22,7 +22,16 @@ limitations under the License.
 package v1alpha1
 
 import (
+	context "context"
+	fmt "fmt"
+
+	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	equality "k8s.io/apimachinery/pkg/api/equality"
+	operation "k8s.io/apimachinery/pkg/api/operation"
+	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	field "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
@@ -30,5 +39,75 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type VolumeAttachment
+	scheme.AddValidationFunc((*storagev1alpha1.VolumeAttachment)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/", "/status":
+			return Validate_VolumeAttachment(ctx, op, nil /* fldPath */, obj.(*storagev1alpha1.VolumeAttachment), safe.Cast[*storagev1alpha1.VolumeAttachment](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	return nil
+}
+
+// Validate_VolumeAttachment validates an instance of VolumeAttachment according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachment(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachment) (errs field.ErrorList) {
+	// field storagev1alpha1.VolumeAttachment.TypeMeta has no validation
+	// field storagev1alpha1.VolumeAttachment.ObjectMeta has no validation
+
+	// field storagev1alpha1.VolumeAttachment.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachmentSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_VolumeAttachmentSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *storagev1alpha1.VolumeAttachment) *storagev1alpha1.VolumeAttachmentSpec {
+			return &oldObj.Spec
+		}), oldObj != nil)...)
+
+	// field storagev1alpha1.VolumeAttachment.Status has no validation
+	return errs
+}
+
+// Validate_VolumeAttachmentSpec validates an instance of VolumeAttachmentSpec according
+// to declarative validation rules in the API schema.
+func Validate_VolumeAttachmentSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *storagev1alpha1.VolumeAttachmentSpec) (errs field.ErrorList) {
+	// field storagev1alpha1.VolumeAttachmentSpec.Attacher
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			errs = append(errs, validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63)...)
+			return
+		}(fldPath.Child("attacher"), &obj.Attacher, safe.Field(oldObj, func(oldObj *storagev1alpha1.VolumeAttachmentSpec) *string { return &oldObj.Attacher }), oldObj != nil)...)
+
+	// field storagev1alpha1.VolumeAttachmentSpec.Source has no validation
+	// field storagev1alpha1.VolumeAttachmentSpec.NodeName has no validation
+	return errs
 }

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -136,14 +136,6 @@ func ValidateVolumeAttachment(volumeAttachment *storage.VolumeAttachment) field.
 	allErrs := apivalidation.ValidateObjectMeta(&volumeAttachment.ObjectMeta, false, apivalidation.ValidateClassName, field.NewPath("metadata"))
 	allErrs = append(allErrs, validateVolumeAttachmentSpec(&volumeAttachment.Spec, field.NewPath("spec"))...)
 	allErrs = append(allErrs, validateVolumeAttachmentStatus(&volumeAttachment.Status, field.NewPath("status"))...)
-	return allErrs
-}
-
-// ValidateVolumeAttachmentV1 validates a v1/VolumeAttachment. It contains only extra checks missing in
-// ValidateVolumeAttachment.
-func ValidateVolumeAttachmentV1(volumeAttachment *storage.VolumeAttachment) field.ErrorList {
-	allErrs := apivalidation.ValidateCSIDriverName(volumeAttachment.Spec.Attacher, field.NewPath("spec.attacher"))
-
 	if volumeAttachment.Spec.Source.PersistentVolumeName != nil {
 		pvName := *volumeAttachment.Spec.Source.PersistentVolumeName
 		for _, msg := range apivalidation.ValidatePersistentVolumeName(pvName, false) {
@@ -157,19 +149,9 @@ func ValidateVolumeAttachmentV1(volumeAttachment *storage.VolumeAttachment) fiel
 // has valid data.
 func validateVolumeAttachmentSpec(
 	spec *storage.VolumeAttachmentSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateAttacher(spec.Attacher, fldPath.Child("attacher"))...)
+	allErrs := apivalidation.ValidateCSIDriverName(spec.Attacher, fldPath.Child("attacher"), apivalidation.RequiredCovered, apivalidation.FormatCovered, apivalidation.SizeCovered)
 	allErrs = append(allErrs, validateVolumeAttachmentSource(&spec.Source, fldPath.Child("source"))...)
 	allErrs = append(allErrs, validateNodeName(spec.NodeName, fldPath.Child("nodeName"))...)
-	return allErrs
-}
-
-// validateAttacher tests if attacher is a valid qualified name.
-func validateAttacher(attacher string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	if len(attacher) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath, attacher))
-	}
 	return allErrs
 }
 
@@ -246,12 +228,17 @@ func validateVolumeError(e *storage.VolumeError, fldPath *field.Path) field.Erro
 // ValidateVolumeAttachmentUpdate validates a VolumeAttachment.
 func ValidateVolumeAttachmentUpdate(new, old *storage.VolumeAttachment) field.ErrorList {
 	allErrs := ValidateVolumeAttachment(new)
-
 	// Spec is read-only
 	// If this ever relaxes in the future, make sure to increment the Generation number in PrepareForUpdate
 	if !apiequality.Semantic.DeepEqual(old.Spec, new.Spec) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), new.Spec, "field is immutable"))
+		err := field.Invalid(
+			field.NewPath("spec"),
+			new.Spec,
+			"field is immutable",
+		).MarkCoveredByDeclarative().WithOrigin("immutable")
+		allErrs = append(allErrs, err)
 	}
+
 	return allErrs
 }
 

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -228,17 +228,7 @@ func validateVolumeError(e *storage.VolumeError, fldPath *field.Path) field.Erro
 // ValidateVolumeAttachmentUpdate validates a VolumeAttachment.
 func ValidateVolumeAttachmentUpdate(new, old *storage.VolumeAttachment) field.ErrorList {
 	allErrs := ValidateVolumeAttachment(new)
-	// Spec is read-only
-	// If this ever relaxes in the future, make sure to increment the Generation number in PrepareForUpdate
-	if !apiequality.Semantic.DeepEqual(old.Spec, new.Spec) {
-		err := field.Invalid(
-			field.NewPath("spec"),
-			new.Spec,
-			"field is immutable",
-		).MarkCoveredByDeclarative().WithOrigin("immutable")
-		allErrs = append(allErrs, err)
-	}
-
+	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec, old.Spec, field.NewPath("spec")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	return allErrs
 }
 

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -569,7 +569,7 @@ func TestVolumeAttachmentValidationV1(t *testing.T) {
 	}}
 
 	for _, volumeAttachment := range successCases {
-		if errs := ValidateVolumeAttachmentV1(&volumeAttachment); len(errs) != 0 {
+		if errs := ValidateVolumeAttachment(&volumeAttachment); len(errs) != 0 {
 			t.Errorf("expected success: %+v", errs)
 		}
 	}
@@ -597,7 +597,7 @@ func TestVolumeAttachmentValidationV1(t *testing.T) {
 	}}
 
 	for _, volumeAttachment := range errorCases {
-		if errs := ValidateVolumeAttachmentV1(&volumeAttachment); len(errs) == 0 {
+		if errs := ValidateVolumeAttachment(&volumeAttachment); len(errs) == 0 {
 			t.Errorf("Expected failure for test: %+v", volumeAttachment)
 		}
 	}

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/kubernetes/pkg/apis/storage"
 )
 
+var apiVersions = []string{"v1beta1", "v1"} // StorageClass.Provisioner not in v1alpha1
+
 func TestDeclarativeValidate(t *testing.T) {
-	apiVersions := []string{"v1beta1", "v1"} // StorageClass.Provisioner not in v1alpha1
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			testDeclarativeValidate(t, apiVersion)
@@ -70,7 +71,6 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
-	apiVersions := []string{"v1beta1", "v1"} // StorageClass.Provisioner not in v1alpha1
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			testDeclarativeValidateUpdate(t, apiVersion)

--- a/pkg/registry/storage/volumeattachment/declarative_validation_test.go
+++ b/pkg/registry/storage/volumeattachment/declarative_validation_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeattachment
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	storage "k8s.io/kubernetes/pkg/apis/storage"
+)
+
+var apiVersions = []string{"v1", "v1alpha1", "v1beta1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "volumeattachments",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	testCases := map[string]struct {
+		input        storage.VolumeAttachment
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidVolumeAttachment(),
+		},
+		"attacher with upper characters": {
+			input: mkValidVolumeAttachment(TweakAttacher("AAAAAAAA")),
+		},
+		"attacher with 63 characters": {
+			input: mkValidVolumeAttachment(TweakAttacher(strings.Repeat("a", 63))),
+		},
+		"invalid attacher (required)": {
+			input: mkValidVolumeAttachment(TweakAttacher("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "attacher"), ""),
+			},
+		},
+		"attacher with special characters": {
+			input: mkValidVolumeAttachment(TweakAttacher("asdadasd&@!")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "attacher"), "", "").WithOrigin("format=k8s-long-name-caseless"),
+			},
+		},
+		"attacher with number of characters exceeds 63": {
+			input: mkValidVolumeAttachment(TweakAttacher(strings.Repeat("a", 64))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "attacher"), strings.Repeat("a", 64), 63).WithOrigin("maxLength"),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:          "storage.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "volumeattachments",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	testCases := map[string]struct {
+		oldInput     storage.VolumeAttachment
+		newInput     storage.VolumeAttachment
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			oldInput: mkValidVolumeAttachment(),
+			newInput: mkValidVolumeAttachment(),
+		},
+		"immutable spec.attacher": {
+			oldInput: mkValidVolumeAttachment(),
+			newInput: mkValidVolumeAttachment(TweakAttacher("different.com")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec"), nil, "field is immutable").WithOrigin("immutable"),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.newInput, &tc.oldInput, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+func TweakAttacher(attacher string) func(obj *storage.VolumeAttachment) {
+	return func(obj *storage.VolumeAttachment) {
+		obj.Spec.Attacher = attacher
+	}
+}
+
+func mkValidVolumeAttachment(tweaks ...func(obj *storage.VolumeAttachment)) storage.VolumeAttachment {
+	pvName := "pv-001"
+	obj := storage.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-volume-attachment",
+		},
+		Spec: storage.VolumeAttachmentSpec{
+			Attacher: "example.com",
+			Source: storage.VolumeAttachmentSource{
+				PersistentVolumeName: &pvName,
+			},
+			NodeName: "node-1",
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -509,6 +509,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
+  // +k8s:immutable
   optional VolumeAttachmentSpec spec = 2;
 
   // status represents status of the VolumeAttachment request.
@@ -552,6 +553,10 @@ message VolumeAttachmentSource {
 message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
+  // +required
+  // +k8s:required
+  // +k8s:format="k8s-long-name-caseless"
+  // +k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -117,6 +117,7 @@ const (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.13
+// +k8s:supportsSubresource=/status
 
 // VolumeAttachment captures the intent to attach or detach the specified volume
 // to/from the specified node.
@@ -132,6 +133,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
+	// +k8s:immutable
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status represents status of the VolumeAttachment request.
@@ -161,6 +163,10 @@ type VolumeAttachmentList struct {
 type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
+	// +required
+	// +k8s:required
+	// +k8s:format="k8s-long-name-caseless"
+	// +k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -134,6 +134,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
+  // +k8s:immutable
   optional VolumeAttachmentSpec spec = 2;
 
   // status represents status of the VolumeAttachment request.
@@ -177,6 +178,10 @@ message VolumeAttachmentSource {
 message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
+  // +required
+  // +k8s:required
+  // +k8s:format="k8s-long-name-caseless"
+  // +k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -28,6 +28,7 @@ import (
 // +k8s:prerelease-lifecycle-gen:introduced=1.9
 // +k8s:prerelease-lifecycle-gen:deprecated=1.21
 // +k8s:prerelease-lifecycle-gen:replacement=storage.k8s.io,v1,VolumeAttachment
+// +k8s:supportsSubresource=/status
 
 // VolumeAttachment captures the intent to attach or detach the specified volume
 // to/from the specified node.
@@ -43,6 +44,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
+	// +k8s:immutable
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status represents status of the VolumeAttachment request.
@@ -74,6 +76,10 @@ type VolumeAttachmentList struct {
 type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
+	// +required
+	// +k8s:required
+	// +k8s:format="k8s-long-name-caseless"
+	// +k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -511,6 +511,7 @@ message VolumeAttachment {
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
+  // +k8s:immutable
   optional VolumeAttachmentSpec spec = 2;
 
   // status represents status of the VolumeAttachment request.
@@ -554,6 +555,10 @@ message VolumeAttachmentSource {
 message VolumeAttachmentSpec {
   // attacher indicates the name of the volume driver that MUST handle this
   // request. This is the name returned by GetPluginName().
+  // +required
+  // +k8s:required
+  // +k8s:format="k8s-long-name-caseless"
+  // +k8s:maxLength=63
   optional string attacher = 1;
 
   // source represents the volume that should be attached.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -122,6 +122,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:introduced=1.10
 // +k8s:prerelease-lifecycle-gen:deprecated=1.19
 // +k8s:prerelease-lifecycle-gen:replacement=storage.k8s.io,v1,VolumeAttachment
+// +k8s:supportsSubresource=/status
 
 // VolumeAttachment captures the intent to attach or detach the specified volume
 // to/from the specified node.
@@ -137,6 +138,7 @@ type VolumeAttachment struct {
 
 	// spec represents specification of the desired attach/detach volume behavior.
 	// Populated by the Kubernetes system.
+	// +k8s:immutable
 	Spec VolumeAttachmentSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status represents status of the VolumeAttachment request.
@@ -168,6 +170,10 @@ type VolumeAttachmentList struct {
 type VolumeAttachmentSpec struct {
 	// attacher indicates the name of the volume driver that MUST handle this
 	// request. This is the name returned by GetPluginName().
+	// +required
+	// +k8s:required
+	// +k8s:format="k8s-long-name-caseless"
+	// +k8s:maxLength=63
 	Attacher string `json:"attacher" protobuf:"bytes,1,opt,name=attacher"`
 
 	// source represents the volume that should be attached.


### PR DESCRIPTION
/kind feature
/sig api-machinery
/sig storage

What this PR does / why we need it
Enables Declarative Validation coverage for the VolumeAttachmentSpec.Attacher field in the storage API. Specifically, this PR:

Adds/updates validation-gen + DV wiring for the storage.k8s.io VolumeAttachment types as needed.

Ensures the attacher field is validated declaratively (matching existing hand-written strategy behavior).

Marks the legacy validation logic for attacher as .MarkCoveredByDeclarative() to avoid duplicate/partial coverage confusion during the migration.

Adds/updates equivalence tests to verify create/update parity between declarative and hand-written validation paths.

Which issue(s) this PR is related to
Part of [Umbrella][Declarative Validation] Enable Declarative Validation for APIs #134280

Special notes for your reviewer

Scope is limited to DV coverage for the attacher field; no behavior change intended.

This continues the incremental migration approach with parity checks and explicit coverage markers.

Follow-ups can extend DV coverage to other VolumeAttachmentSpec fields and related storage types.

Test plan

Unit tests covering create/update validation for VolumeAttachment with DV enabled.

Parity checks using VerifyValidationEquivalence and VerifyUpdateValidationEquivalence.

Existing storage validation tests continue to pass.

Does this PR introduce a user-facing change?
NONE