### PR TITLE
kubectl: Fix flaky TestEvictDuringNamespaceTerminating by relaxing timeout constraints

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -535,8 +535,8 @@ func TestEvictDuringNamespaceTerminating(t *testing.T) {
 	testPodName := "test-pod"
 	testNamespace := "default"
 
-	retryDelay := 5 * time.Millisecond
-	globalTimeout := 2 * retryDelay
+	retryDelay := 1 * time.Millisecond
+	globalTimeout := 100 * time.Millisecond
 
 	tests := []struct {
 		description string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
This PR fixes a timing-based flake in `TestEvictDuringNamespaceTerminating` within `staging/src/k8s.io/kubectl/pkg/drain/drain_test.go`.

The test previously defined the global timeout as exactly 2x the retry delay (`10ms` timeout vs `5ms` retry). This tight coupling assumed that execution overhead (error creation, logging, context switching) was negligible.

In practice—specifically in CI environments under load or when running with `-race`—the overhead combined with the 5ms sleep often exceeds the 10ms total budget, causing the test to fail with: `global timeout reached: 10ms`.

This change relaxes the timing constraints to make the test deterministic:
- Reduces `retryDelay` to 1ms to keep the test loop fast.
- Increases `globalTimeout` to 100ms to provide a sufficient safety buffer for execution overhead.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer: 
I verified this locally using `go test -race -count=20` on the package.
- Before: Failed consistently due to the race detector overhead pushing execution time > 10ms.
- After: Passed 20/20 runs successfully.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
