### PR TITLE
Automated cherry pick of #135359: Fallback to live ns lookup on admission if lister cannot find namespace

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_matcher.go
@@ -17,6 +17,7 @@ limitations under the License.
 package generic
 
 import (
+	"context"
 	"fmt"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -41,8 +42,8 @@ type PolicyMatcher interface {
 	BindingMatches(a admission.Attributes, o admission.ObjectInterfaces, binding BindingAccessor) (bool, error)
 
 	// GetNamespace retrieves the Namespace resource by the given name. The name may be empty, in which case
-	// GetNamespace must return nil, nil
-	GetNamespace(name string) (*corev1.Namespace, error)
+	// GetNamespace must return nil, NotFound
+	GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error)
 }
 
 type matcher struct {
@@ -82,8 +83,8 @@ func (c *matcher) BindingMatches(a admission.Attributes, o admission.ObjectInter
 	return isMatch, err
 }
 
-func (c *matcher) GetNamespace(name string) (*corev1.Namespace, error) {
-	return c.Matcher.GetNamespace(name)
+func (c *matcher) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	return c.Matcher.GetNamespace(ctx, name)
 }
 
 var _ matching.MatchCriteria = &matchCriteria{}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/matching/matching.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/matching/matching.go
@@ -17,6 +17,7 @@ limitations under the License.
 package matching
 
 import (
+	"context"
 	"fmt"
 
 	v1 "k8s.io/api/admissionregistration/v1"
@@ -44,8 +45,8 @@ type Matcher struct {
 	objectMatcher    *object.Matcher
 }
 
-func (m *Matcher) GetNamespace(name string) (*corev1.Namespace, error) {
-	return m.namespaceMatcher.GetNamespace(name)
+func (m *Matcher) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	return m.namespaceMatcher.GetNamespace(ctx, name)
 }
 
 // NewMatcher initialize the matcher with dependencies requires

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
@@ -122,8 +122,12 @@ func (d *dispatcher) dispatchInvocations(
 	// if it is cluster scoped, namespaceName will be empty
 	// Otherwise, get the Namespace resource.
 	if namespaceName != "" {
-		namespace, err = d.matcher.GetNamespace(namespaceName)
+		namespace, err = d.matcher.GetNamespace(ctx, namespaceName)
 		if err != nil {
+			var statusError *k8serrors.StatusError
+			if errors.As(err, &statusError) {
+				return nil, statusError
+			}
 			return nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "namespaces"}, namespaceName)
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -269,7 +269,7 @@ func (f *fakeMatcher) ValidateInitialization() error {
 	return nil
 }
 
-func (f *fakeMatcher) GetNamespace(name string) (*v1.Namespace, error) {
+func (f *fakeMatcher) GetNamespace(ctx context.Context, name string) (*v1.Namespace, error) {
 	return nil, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -189,7 +189,7 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 			// if it is cluster scoped, namespaceName will be empty
 			// Otherwise, get the Namespace resource.
 			if namespaceName != "" {
-				namespace, err = c.matcher.GetNamespace(namespaceName)
+				namespace, err = c.matcher.GetNamespace(ctx, namespaceName)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Cherry pick of #135359 on release-1.34.

#135359: Fallback to live ns lookup on admission if lister cannot find namespace

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a spurious "namespace not found" error possible in default configurations in 1.30+ when using ValidatingAdmissionPolicy or MutatingAdmissionPolicy to intercept namespaced objects in newly-created namespaces
```