### PR TITLE
Fix volume expansion e2e tests to use actual allocated size

### DIFF
--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -185,8 +185,16 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			gomega.Expect(l.resource.Sc.AllowVolumeExpansion).NotTo(gomega.BeNil())
 			allowVolumeExpansion := *l.resource.Sc.AllowVolumeExpansion
 			gomega.Expect(allowVolumeExpansion).To(gomega.BeFalseBecause("expected AllowVolumeExpansion value to be false"))
+
+			// Re-fetch PVC to get the latest status with updated capacity
+			ginkgo.By("Re-fetching PVC to get latest status")
+			l.resource.Pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(l.resource.Pvc.Namespace).Get(ctx, l.resource.Pvc.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "While re-fetching PVC before expansion")
+
 			ginkgo.By("Expanding non-expandable pvc")
-			currentPvcSize := l.resource.Pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			// Use Status.Capacity instead of Spec.Resources.Requests to get the actual allocated size.
+			// CSI drivers may allocate larger volumes than requested (e.g., due to minimum size constraints).
+			currentPvcSize := l.resource.Pvc.Status.Capacity[v1.ResourceStorage]
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(expandSize)
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
@@ -219,9 +227,16 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			err = e2epod.DeletePodWithWait(ctx, f.ClientSet, l.pod)
 			framework.ExpectNoError(err, "while deleting pod for resizing")
 
+			// Re-fetch PVC to get the latest status with updated capacity
+			ginkgo.By("Re-fetching PVC to get latest status")
+			l.resource.Pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(l.resource.Pvc.Namespace).Get(ctx, l.resource.Pvc.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "While re-fetching PVC before expansion")
+
 			// We expand the PVC while no pod is using it to ensure offline expansion
 			ginkgo.By("Expanding current pvc")
-			currentPvcSize := l.resource.Pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			// Use Status.Capacity instead of Spec.Resources.Requests to get the actual allocated size.
+			// CSI drivers may allocate larger volumes than requested (e.g., due to minimum size constraints).
+			currentPvcSize := l.resource.Pvc.Status.Capacity[v1.ResourceStorage]
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(expandSize)
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
@@ -291,9 +306,16 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, l.pod)
 			framework.ExpectNoError(err, "While creating pods for resizing")
 
+			// Re-fetch PVC to get the latest status with updated capacity
+			ginkgo.By("Re-fetching PVC to get latest status")
+			l.resource.Pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(l.resource.Pvc.Namespace).Get(ctx, l.resource.Pvc.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "While re-fetching PVC before expansion")
+
 			// We expand the PVC while l.pod is using it for online expansion.
 			ginkgo.By("Expanding current pvc")
-			currentPvcSize := l.resource.Pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			// Use Status.Capacity instead of Spec.Resources.Requests to get the actual allocated size.
+			// CSI drivers may allocate larger volumes than requested (e.g., due to minimum size constraints).
+			currentPvcSize := l.resource.Pvc.Status.Capacity[v1.ResourceStorage]
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(expandSize)
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
@@ -343,9 +365,16 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			ginkgo.DeferCleanup(e2epod.DeletePodWithWait, f.ClientSet, l.pod)
 			framework.ExpectNoError(err, "While creating pods for resizing")
 
+			// Re-fetch PVC to get the latest status with updated capacity
+			ginkgo.By("Re-fetching PVC to get latest status")
+			l.resource.Pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(l.resource.Pvc.Namespace).Get(ctx, l.resource.Pvc.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "While re-fetching PVC before expansion")
+
 			// We expand the PVC while l.pod is using it for online expansion.
 			ginkgo.By("Expanding current pvc")
-			currentPvcSize := l.resource.Pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			// Use Status.Capacity instead of Spec.Resources.Requests to get the actual allocated size.
+			// CSI drivers may allocate larger volumes than requested (e.g., due to minimum size constraints).
+			currentPvcSize := l.resource.Pvc.Status.Capacity[v1.ResourceStorage]
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(expandSize)
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Volume expansion e2e tests were using pvc.spec.resources.requests.storage (user-requested size) to calculate the new expanded size. This caused test failures when CSI drivers allocate larger volumes than requested due to minimum size constraints.

For example, if a user requests 5Gi but the CSI driver allocates 100Gi (due to a 100Gi minimum), the test would calculate newSize = 5Gi + 1Gi = 6Gi, which fails because 6Gi < 100Gi (current actual size).

Changed to use pvc.status.capacity.storage (actual allocated size) instead, which correctly handles cases where the allocated size differs from the requested size.

#### Which issue(s) this PR is related to:
#135456

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
