### PR TITLE
Relax the noise margin threshold in TestConcurrencyIsolation

### DIFF
--- a/test/integration/apiserver/flowcontrol/concurrency_util_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_util_test.go
@@ -279,10 +279,9 @@ func TestConcurrencyIsolation(t *testing.T) {
 	// There are uncontrolled overheads that introduce noise into the system. The coefficient of variation (CV), that is,
 	// standard deviation divided by mean, for a class of traffic is a characterization of all the noise that applied to
 	// that class. We found that noxu1 generally had a much bigger CV than noxu2. This makes sense, because noxu1 probes
-	// more behavior --- the waiting in queues. So we take the minimum of the two as an indicator of the relative amount
-	// of noise that comes from all the other behavior. Currently, we use 3 times the experienced coefficient of variation
-	// as the margin of error.
-	margin := 3 * math.Min(noxu1LatStats.cv, noxu2LatStats.cv)
+	// more behavior --- the waiting in queues. Both are relevant, so we mix them to get the
+	// threshold to apply in this test.
+	margin := noxu1LatStats.cv + 2*noxu2LatStats.cv
 	t.Logf("Error margin is %v", margin)
 
 	isConcurrencyExpected := func(name string, observed float64, expected float64) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->
/kind bug
/kind failing-test

#### What this PR does / why we need it:
This PR changes the formula for the allowed amount of noise in TestConcurrencyIsolation in `test/integration/apiserver/flowcontrol/concurrency_util_test.go`.

This test is flaking hard now.
It seems to me now that the CV of both classes of traffic is relevant to the noise margin to allow in the test, so this commit changes the formula to take both into account.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #133861

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
