### PR TITLE
kubectl top: add --utilization flag to show resource usage vs requests/limits

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -376,7 +376,7 @@ test-1   400m         5120Mi
 
 			top := NewTopCmdPrinter(out, false)
 			err := top.PrintPodMetrics(test.podMetric, test.printContainers,
-				test.withNamespace, test.noHeader, test.sortBy, test.sum)
+				test.withNamespace, test.noHeader, test.sortBy, test.sum, false, nil)
 			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedOutput, out.String())
 		})

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/utilization.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/utilization.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+)
+
+// UtilizationStatus represents the resource utilization state of a pod
+type UtilizationStatus string
+
+const (
+	StatusOK              UtilizationStatus = "OK"
+	StatusOverProvisioned UtilizationStatus = "OVER-PROVISIONED"
+	StatusNearLimit       UtilizationStatus = "NEAR-LIMIT"
+	StatusNoLimit         UtilizationStatus = "NO-LIMIT"
+	StatusNoRequest       UtilizationStatus = "NO-REQUEST"
+)
+
+// Thresholds for status determination
+const (
+	OverProvisionedThreshold = 25 // Below 25% of request = over-provisioned
+	NearLimitThreshold       = 90 // Above 90% of limit = near limit
+)
+
+// PodUtilization holds computed utilization data for a single pod
+type PodUtilization struct {
+	// Pod identification
+	Name      string
+	Namespace string
+
+	// Raw metrics (from Metrics API)
+	CPUUsage    resource.Quantity
+	MemoryUsage resource.Quantity
+
+	// Resource specs (from Pod API)
+	CPURequest    resource.Quantity
+	CPULimit      resource.Quantity
+	MemoryRequest resource.Quantity
+	MemoryLimit   resource.Quantity
+
+	// Computed percentages (-1 means not applicable/no request or limit set)
+	CPURequestPercent    int64
+	CPULimitPercent      int64
+	MemoryRequestPercent int64
+	MemoryLimitPercent   int64
+
+	// Computed status
+	Status UtilizationStatus
+
+	// Flags for missing data
+	HasCPURequest    bool
+	HasCPULimit      bool
+	HasMemoryRequest bool
+	HasMemoryLimit   bool
+}
+
+// CalculatePodUtilization computes utilization metrics for a pod
+func CalculatePodUtilization(
+	podMetrics *metricsapi.PodMetrics,
+	podSpec *corev1.Pod,
+	measuredResources []corev1.ResourceName,
+) *PodUtilization {
+	util := &PodUtilization{
+		Name:      podMetrics.Name,
+		Namespace: podMetrics.Namespace,
+	}
+
+	// Aggregate container metrics
+	podUsage := getPodMetrics(podMetrics, measuredResources)
+	util.CPUUsage = podUsage[corev1.ResourceCPU]
+	util.MemoryUsage = podUsage[corev1.ResourceMemory]
+
+	// Get pod requests and limits
+	if podSpec != nil {
+		reqs, limits := podRequestsAndLimitsFromSpec(podSpec)
+
+		// CPU
+		if req, ok := reqs[corev1.ResourceCPU]; ok && !req.IsZero() {
+			util.CPURequest = req
+			util.HasCPURequest = true
+			util.CPURequestPercent = calculatePercent(util.CPUUsage.MilliValue(), req.MilliValue())
+		} else {
+			util.CPURequestPercent = -1
+		}
+
+		if lim, ok := limits[corev1.ResourceCPU]; ok && !lim.IsZero() {
+			util.CPULimit = lim
+			util.HasCPULimit = true
+			util.CPULimitPercent = calculatePercent(util.CPUUsage.MilliValue(), lim.MilliValue())
+		} else {
+			util.CPULimitPercent = -1
+		}
+
+		// Memory
+		if req, ok := reqs[corev1.ResourceMemory]; ok && !req.IsZero() {
+			util.MemoryRequest = req
+			util.HasMemoryRequest = true
+			util.MemoryRequestPercent = calculatePercent(util.MemoryUsage.Value(), req.Value())
+		} else {
+			util.MemoryRequestPercent = -1
+		}
+
+		if lim, ok := limits[corev1.ResourceMemory]; ok && !lim.IsZero() {
+			util.MemoryLimit = lim
+			util.HasMemoryLimit = true
+			util.MemoryLimitPercent = calculatePercent(util.MemoryUsage.Value(), lim.Value())
+		} else {
+			util.MemoryLimitPercent = -1
+		}
+	} else {
+		// No pod spec available
+		util.CPURequestPercent = -1
+		util.CPULimitPercent = -1
+		util.MemoryRequestPercent = -1
+		util.MemoryLimitPercent = -1
+	}
+
+	// Determine status
+	util.Status = determineStatus(util)
+
+	return util
+}
+
+// calculatePercent calculates percentage, returning -1 if denominator is 0
+func calculatePercent(numerator, denominator int64) int64 {
+	if denominator == 0 {
+		return -1
+	}
+	return (numerator * 100) / denominator
+}
+
+// determineStatus determines the utilization status based on thresholds
+func determineStatus(util *PodUtilization) UtilizationStatus {
+	// Check for missing limits (highest priority concern)
+	if !util.HasCPULimit && !util.HasMemoryLimit {
+		return StatusNoLimit
+	}
+
+	// Check for missing requests
+	if !util.HasCPURequest && !util.HasMemoryRequest {
+		return StatusNoRequest
+	}
+
+	// Check for near-limit conditions (risk)
+	if (util.HasCPULimit && util.CPULimitPercent >= NearLimitThreshold) ||
+		(util.HasMemoryLimit && util.MemoryLimitPercent >= NearLimitThreshold) {
+		return StatusNearLimit
+	}
+
+	// Check for over-provisioning (waste)
+	cpuOverProvisioned := util.HasCPURequest && util.CPURequestPercent >= 0 &&
+		util.CPURequestPercent < OverProvisionedThreshold
+	memOverProvisioned := util.HasMemoryRequest && util.MemoryRequestPercent >= 0 &&
+		util.MemoryRequestPercent < OverProvisionedThreshold
+
+	if cpuOverProvisioned || memOverProvisioned {
+		return StatusOverProvisioned
+	}
+
+	return StatusOK
+}
+
+// podRequestsAndLimitsFromSpec extracts requests and limits from pod spec
+func podRequestsAndLimitsFromSpec(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
+	reqs = make(corev1.ResourceList)
+	limits = make(corev1.ResourceList)
+
+	for _, container := range pod.Spec.Containers {
+		addResourceList(reqs, container.Resources.Requests)
+		addResourceList(limits, container.Resources.Limits)
+	}
+
+	// Also consider init containers (take max)
+	for _, container := range pod.Spec.InitContainers {
+		maxResourceList(reqs, container.Resources.Requests)
+		maxResourceList(limits, container.Resources.Limits)
+	}
+
+	return reqs, limits
+}
+
+// addResourceList adds the resources in newList to list
+func addResourceList(list, newList corev1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; ok {
+			value.Add(quantity)
+			list[name] = value
+		} else {
+			list[name] = quantity.DeepCopy()
+		}
+	}
+}
+
+// maxResourceList sets list[name] = max(list[name], newList[name]) for each name
+func maxResourceList(list, newList corev1.ResourceList) {
+	for name, quantity := range newList {
+		if value, ok := list[name]; ok {
+			if quantity.Cmp(value) > 0 {
+				list[name] = quantity.DeepCopy()
+			}
+		} else {
+			list[name] = quantity.DeepCopy()
+		}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/utilization_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/utilization_test.go
@@ -1,0 +1,560 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+)
+
+func TestCalculatePercent(t *testing.T) {
+	tests := []struct {
+		name        string
+		numerator   int64
+		denominator int64
+		expected    int64
+	}{
+		{"50%", 50, 100, 50},
+		{"100%", 100, 100, 100},
+		{"0%", 0, 100, 0},
+		{"200%", 200, 100, 200},
+		{"zero denominator", 50, 0, -1},
+		{"both zero", 0, 0, -1},
+		{"25%", 25, 100, 25},
+		{"10%", 100, 1000, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculatePercent(tt.numerator, tt.denominator)
+			if result != tt.expected {
+				t.Errorf("calculatePercent(%d, %d) = %d, expected %d",
+					tt.numerator, tt.denominator, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDetermineStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		util     *PodUtilization
+		expected UtilizationStatus
+	}{
+		{
+			name: "OK status",
+			util: &PodUtilization{
+				HasCPURequest:        true,
+				HasCPULimit:          true,
+				HasMemoryRequest:     true,
+				HasMemoryLimit:       true,
+				CPURequestPercent:    50,
+				CPULimitPercent:      25,
+				MemoryRequestPercent: 50,
+				MemoryLimitPercent:   25,
+			},
+			expected: StatusOK,
+		},
+		{
+			name: "Near limit - CPU",
+			util: &PodUtilization{
+				HasCPURequest:        true,
+				HasCPULimit:          true,
+				HasMemoryRequest:     true,
+				HasMemoryLimit:       true,
+				CPURequestPercent:    95,
+				CPULimitPercent:      95,
+				MemoryRequestPercent: 50,
+				MemoryLimitPercent:   25,
+			},
+			expected: StatusNearLimit,
+		},
+		{
+			name: "Near limit - Memory",
+			util: &PodUtilization{
+				HasCPURequest:        true,
+				HasCPULimit:          true,
+				HasMemoryRequest:     true,
+				HasMemoryLimit:       true,
+				CPURequestPercent:    50,
+				CPULimitPercent:      25,
+				MemoryRequestPercent: 95,
+				MemoryLimitPercent:   95,
+			},
+			expected: StatusNearLimit,
+		},
+		{
+			name: "Over-provisioned - CPU",
+			util: &PodUtilization{
+				HasCPURequest:        true,
+				HasCPULimit:          true,
+				HasMemoryRequest:     true,
+				HasMemoryLimit:       true,
+				CPURequestPercent:    10,
+				CPULimitPercent:      5,
+				MemoryRequestPercent: 50,
+				MemoryLimitPercent:   25,
+			},
+			expected: StatusOverProvisioned,
+		},
+		{
+			name: "Over-provisioned - Memory",
+			util: &PodUtilization{
+				HasCPURequest:        true,
+				HasCPULimit:          true,
+				HasMemoryRequest:     true,
+				HasMemoryLimit:       true,
+				CPURequestPercent:    50,
+				CPULimitPercent:      25,
+				MemoryRequestPercent: 10,
+				MemoryLimitPercent:   5,
+			},
+			expected: StatusOverProvisioned,
+		},
+		{
+			name: "No limit",
+			util: &PodUtilization{
+				HasCPURequest:        true,
+				HasCPULimit:          false,
+				HasMemoryRequest:     true,
+				HasMemoryLimit:       false,
+				CPURequestPercent:    50,
+				CPULimitPercent:      -1,
+				MemoryRequestPercent: 50,
+				MemoryLimitPercent:   -1,
+			},
+			expected: StatusNoLimit,
+		},
+		{
+			name: "No request",
+			util: &PodUtilization{
+				HasCPURequest:        false,
+				HasCPULimit:          true,
+				HasMemoryRequest:     false,
+				HasMemoryLimit:       true,
+				CPURequestPercent:    -1,
+				CPULimitPercent:      50,
+				MemoryRequestPercent: -1,
+				MemoryLimitPercent:   50,
+			},
+			expected: StatusNoRequest,
+		},
+		{
+			name: "No limits takes precedence over no requests",
+			util: &PodUtilization{
+				HasCPURequest:        false,
+				HasCPULimit:          false,
+				HasMemoryRequest:     false,
+				HasMemoryLimit:       false,
+				CPURequestPercent:    -1,
+				CPULimitPercent:      -1,
+				MemoryRequestPercent: -1,
+				MemoryLimitPercent:   -1,
+			},
+			expected: StatusNoLimit,
+		},
+		{
+			name: "Near limit takes precedence over over-provisioned",
+			util: &PodUtilization{
+				HasCPURequest:        true,
+				HasCPULimit:          true,
+				HasMemoryRequest:     true,
+				HasMemoryLimit:       true,
+				CPURequestPercent:    10, // Over-provisioned
+				CPULimitPercent:      5,
+				MemoryRequestPercent: 95, // Near limit
+				MemoryLimitPercent:   95,
+			},
+			expected: StatusNearLimit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determineStatus(tt.util)
+			if result != tt.expected {
+				t.Errorf("determineStatus() = %s, expected %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCalculatePodUtilization(t *testing.T) {
+	measuredResources := []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
+
+	tests := []struct {
+		name                  string
+		metrics               *metricsapi.PodMetrics
+		podSpec               *corev1.Pod
+		expectedCPUReqPercent int64
+		expectedMemReqPercent int64
+		expectedStatus        UtilizationStatus
+	}{
+		{
+			name: "pod with requests and limits - 50% usage",
+			metrics: &metricsapi.PodMetrics{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Containers: []metricsapi.ContainerMetrics{
+					{
+						Name: "container1",
+						Usage: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+			podSpec: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCPUReqPercent: 50,
+			expectedMemReqPercent: 50,
+			expectedStatus:        StatusOK,
+		},
+		{
+			name: "pod with low utilization - over-provisioned",
+			metrics: &metricsapi.PodMetrics{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Containers: []metricsapi.ContainerMetrics{
+					{
+						Name: "container1",
+						Usage: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("25Mi"),
+						},
+					},
+				},
+			},
+			podSpec: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1000m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2000m"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCPUReqPercent: 1,
+			expectedMemReqPercent: 2,
+			expectedStatus:        StatusOverProvisioned,
+		},
+		{
+			name: "pod without requests",
+			metrics: &metricsapi.PodMetrics{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Containers: []metricsapi.ContainerMetrics{
+					{
+						Name: "container1",
+						Usage: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+			podSpec: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:      "container1",
+							Resources: corev1.ResourceRequirements{},
+						},
+					},
+				},
+			},
+			expectedCPUReqPercent: -1,
+			expectedMemReqPercent: -1,
+			expectedStatus:        StatusNoLimit, // Both no limits and no requests
+		},
+		{
+			name: "nil pod spec",
+			metrics: &metricsapi.PodMetrics{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Containers: []metricsapi.ContainerMetrics{
+					{
+						Name: "container1",
+						Usage: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+			podSpec:               nil,
+			expectedCPUReqPercent: -1,
+			expectedMemReqPercent: -1,
+			expectedStatus:        StatusNoLimit,
+		},
+		{
+			name: "pod with multiple containers",
+			metrics: &metricsapi.PodMetrics{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Containers: []metricsapi.ContainerMetrics{
+					{
+						Name: "container1",
+						Usage: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+					{
+						Name: "container2",
+						Usage: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+			podSpec: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "container1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("400m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+						{
+							Name: "container2",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("400m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			// Total usage: 200m CPU, 256Mi memory
+			// Total request: 400m CPU, 512Mi memory
+			// Percentage: 50% for both
+			expectedCPUReqPercent: 50,
+			expectedMemReqPercent: 50,
+			expectedStatus:        StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculatePodUtilization(tt.metrics, tt.podSpec, measuredResources)
+
+			if result.CPURequestPercent != tt.expectedCPUReqPercent {
+				t.Errorf("CPURequestPercent = %d, expected %d",
+					result.CPURequestPercent, tt.expectedCPUReqPercent)
+			}
+			if result.MemoryRequestPercent != tt.expectedMemReqPercent {
+				t.Errorf("MemoryRequestPercent = %d, expected %d",
+					result.MemoryRequestPercent, tt.expectedMemReqPercent)
+			}
+			if result.Status != tt.expectedStatus {
+				t.Errorf("Status = %s, expected %s", result.Status, tt.expectedStatus)
+			}
+		})
+	}
+}
+
+func TestAddResourceList(t *testing.T) {
+	tests := []struct {
+		name     string
+		list     corev1.ResourceList
+		newList  corev1.ResourceList
+		expected corev1.ResourceList
+	}{
+		{
+			name:     "add to empty list",
+			list:     corev1.ResourceList{},
+			newList:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			expected: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+		},
+		{
+			name:     "add to existing resource",
+			list:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			newList:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			expected: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")},
+		},
+		{
+			name:     "add new resource type",
+			list:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			newList:  corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+			expected: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addResourceList(tt.list, tt.newList)
+			for name, expected := range tt.expected {
+				if got, ok := tt.list[name]; !ok || got.Cmp(expected) != 0 {
+					t.Errorf("resource %s = %v, expected %v", name, got, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestMaxResourceList(t *testing.T) {
+	tests := []struct {
+		name     string
+		list     corev1.ResourceList
+		newList  corev1.ResourceList
+		expected corev1.ResourceList
+	}{
+		{
+			name:     "max to empty list",
+			list:     corev1.ResourceList{},
+			newList:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			expected: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+		},
+		{
+			name:     "max when new is larger",
+			list:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			newList:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			expected: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+		},
+		{
+			name:     "max when existing is larger",
+			list:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")},
+			newList:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			expected: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			maxResourceList(tt.list, tt.newList)
+			for name, expected := range tt.expected {
+				if got, ok := tt.list[name]; !ok || got.Cmp(expected) != 0 {
+					t.Errorf("resource %s = %v, expected %v", name, got, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestPodUtilizationSorter(t *testing.T) {
+	utilizations := []*PodUtilization{
+		{Name: "pod1", Namespace: "default", CPUUsage: resource.MustParse("100m"), MemoryUsage: resource.MustParse("128Mi"), CPURequestPercent: 50, MemoryRequestPercent: 50},
+		{Name: "pod2", Namespace: "default", CPUUsage: resource.MustParse("200m"), MemoryUsage: resource.MustParse("256Mi"), CPURequestPercent: 80, MemoryRequestPercent: 80},
+		{Name: "pod3", Namespace: "default", CPUUsage: resource.MustParse("50m"), MemoryUsage: resource.MustParse("64Mi"), CPURequestPercent: 20, MemoryRequestPercent: 20},
+		{Name: "pod4", Namespace: "default", CPUUsage: resource.MustParse("150m"), MemoryUsage: resource.MustParse("192Mi"), CPURequestPercent: -1, MemoryRequestPercent: -1}, // No requests
+	}
+
+	tests := []struct {
+		name          string
+		sortBy        string
+		expectedOrder []string
+	}{
+		{
+			name:          "sort by cpu-util descending",
+			sortBy:        "cpu-util",
+			expectedOrder: []string{"pod2", "pod1", "pod3", "pod4"}, // pod4 goes last due to no request
+		},
+		{
+			name:          "sort by mem-util descending",
+			sortBy:        "mem-util",
+			expectedOrder: []string{"pod2", "pod1", "pod3", "pod4"},
+		},
+		{
+			name:          "sort by cpu descending",
+			sortBy:        "cpu",
+			expectedOrder: []string{"pod2", "pod4", "pod1", "pod3"},
+		},
+		{
+			name:          "sort by memory descending",
+			sortBy:        "memory",
+			expectedOrder: []string{"pod2", "pod4", "pod1", "pod3"},
+		},
+		{
+			name:          "default sort by name",
+			sortBy:        "",
+			expectedOrder: []string{"pod1", "pod2", "pod3", "pod4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Copy utilizations to avoid mutating between tests
+			copyUtils := make([]*PodUtilization, len(utilizations))
+			for i, u := range utilizations {
+				copyU := *u
+				copyUtils[i] = &copyU
+			}
+
+			sorter := NewPodUtilizationSorter(copyUtils, false, tt.sortBy)
+			for i := 0; i < len(copyUtils)-1; i++ {
+				for j := i + 1; j < len(copyUtils); j++ {
+					if sorter.Less(j, i) {
+						sorter.Swap(i, j)
+					}
+				}
+			}
+
+			for i, expected := range tt.expectedOrder {
+				if copyUtils[i].Name != expected {
+					t.Errorf("position %d: got %s, expected %s", i, copyUtils[i].Name, expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig cli
/area kubectl

#### What this PR does / why we need it:

Adds a `--utilization` flag to `kubectl top pods` that displays resource usage as a percentage of configured requests and limits. This helps cluster administrators quickly identify:

- **Over-provisioned pods** - using <25% of requested resources (wasting capacity)
- **At-risk pods** - using >90% of limits (risk of throttling/OOM)
- **Unconfigured pods** - missing requests or limits

Fixes https://github.com/kubernetes/kubectl/issues/1214

#### Which issue(s) this PR fixes:

Fixes kubernetes/kubectl#1214

#### Special notes for your reviewer:

This is a continuation of the work started in #112080, which was closed due to inactivity. Key differences from that approach:

1. Uses `--utilization` flag instead of `--enumerate` (clearer intent)
2. Shows **percentages** rather than raw request/limit values (more actionable)
3. Adds a **STATUS** column for quick visual triage
4. Supports sorting by utilization (`--sort-by=cpu-util` and `--sort-by=mem-util`)

#### Does this PR introduce a user-facing change?

```release-note
Add `--utilization` flag to `kubectl top pods` to display CPU and memory usage as percentages of requests and limits, with STATUS indicator for identifying over-provisioned or at-risk workloads.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

**New columns with `--utilization`:**

| Column | Description |
|--------|-------------|
| CPU:REQ | CPU usage as % of CPU request |
| CPU:LIM | CPU usage as % of CPU limit |
| MEM:REQ | Memory usage as % of memory request |
| MEM:LIM | Memory usage as % of memory limit |
| STATUS | Health indicator (OK, OVER-PROVISIONED, NEAR-LIMIT, NO-LIMIT, NO-REQUEST) |

**New sort options (when `--utilization` is enabled):**
- `--sort-by=cpu-util` - Sort by CPU request utilization
- `--sort-by=mem-util` - Sort by memory request utilization

#### Demo

**Standard output (unchanged):**
```
$ kubectl top pods
NAME                       CPU(cores)   MEMORY(bytes)
pod-no-resources           0m           8Mi
pod-with-limits-only       0m           8Mi
pod-with-requests-limits   0m           8Mi
pod-with-requests-only     0m           8Mi
```

**With `--utilization` flag:**
```
$ kubectl top pods --utilization
NAME                       CPU(cores)   CPU:REQ   CPU:LIM   MEMORY(bytes)   MEM:REQ   MEM:LIM   STATUS
pod-no-resources           0m           -         -         8Mi             -         -         NO-LIMIT
pod-with-limits-only       0m           0%        0%        8Mi             13%       13%       OVER-PROVISIONED
pod-with-requests-limits   0m           0%        0%        8Mi             13%       6%        OVER-PROVISIONED
pod-with-requests-only     0m           0%        -         8Mi             26%       -         NO-LIMIT
```

**All namespaces with utilization:**
```
$ kubectl top pods --utilization -A
NAMESPACE     NAME                               CPU(cores)   CPU:REQ   CPU:LIM   MEMORY(bytes)   MEM:REQ   MEM:LIM   STATUS
default       pod-with-requests-limits           0m           0%        0%        8Mi             13%       6%        OVER-PROVISIONED
kube-system   coredns-66bc5c9577-fh5ks           3m           3%        -         19Mi            28%       11%       OVER-PROVISIONED
kube-system   etcd-minikube                      23m          23%       -         96Mi            96%       -         NO-LIMIT
kube-system   kube-apiserver-minikube            53m          21%       -         218Mi           -         -         NO-LIMIT
```

**Sort by memory utilization:**
```
$ kubectl top pods --utilization --sort-by=mem-util
NAME                       CPU(cores)   CPU:REQ   CPU:LIM   MEMORY(bytes)   MEM:REQ   MEM:LIM   STATUS
pod-with-requests-only     0m           0%        -         8Mi             26%       -         NO-LIMIT
pod-with-limits-only       0m           0%        0%        8Mi             13%       13%       OVER-PROVISIONED
pod-with-requests-limits   0m           0%        0%        8Mi             13%       6%        OVER-PROVISIONED
pod-no-resources           0m           -         -         8Mi             -         -         NO-LIMIT
```

#### Test Plan

**Unit Tests Added:**
- `TestCalculatePercent` - percentage calculation edge cases
- `TestDetermineStatus` - status determination logic for all status values
- `TestCalculatePodUtilization` - full utilization calculation with various pod configurations
- `TestAddResourceList` / `TestMaxResourceList` - resource aggregation helpers
- `TestPodUtilizationSorter` - sorting by cpu-util, mem-util, cpu, memory, and default

**Manual Testing Performed:**
- [x] `kubectl top pods` - unchanged behavior (no regression)
- [x] `kubectl top pods --utilization` - shows extended columns
- [x] Pods with requests/limits show valid percentages
- [x] Pods without requests show `-` for those columns
- [x] STATUS column shows correct values
- [x] `--sort-by=cpu-util` sorts correctly
- [x] `--sort-by=mem-util` sorts correctly  
- [x] `--sort-by=cpu-util` without `--utilization` gives appropriate error
- [x] `kubectl top pods --utilization -A` shows NAMESPACE column
- [x] `kubectl top pods <pod-name> --utilization` works for single pod
- [x] Help text includes new flag and examples

**Verification:**
```bash
make WHAT=cmd/kubectl
go test ./staging/src/k8s.io/kubectl/pkg/cmd/top/...
go test ./staging/src/k8s.io/kubectl/pkg/metricsutil/...
go vet ./staging/src/k8s.io/kubectl/pkg/cmd/top/... ./staging/src/k8s.io/kubectl/pkg/metricsutil/...
```