### PR TITLE
api: add +required markers to scheduling API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19030,9 +19030,6 @@
           "type": "integer"
         }
       },
-      "required": [
-        "value"
-      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
@@ -40,9 +40,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "value"
-        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -177,7 +177,7 @@ linters:
       # The following exceptions are for fields in stable or deprecated APIs that cannot be
       # changed due to backward compatibility constraints. Each rule is scoped to the
       # specific field to avoid hiding new violations.
-
+      
       ## For the "Extra" field, which is common across several auth-related APIs.
       - text: "field UserInfo.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/authentication/(v1|v1beta1)/types.go"
@@ -185,7 +185,7 @@ linters:
         path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types.go"
       - text: "field CertificateSigningRequestSpec.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/certificates/(v1|v1beta1)/types.go"
-
+      
       ## For ResourceList fields in the core API.
       - text: "field (PersistentVolumeSpec.Capacity|ContainerStatus.AllocatedResources|PodSpec.Overhead|ResourceQuotaSpec.Hard) type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
@@ -197,11 +197,11 @@ linters:
         path: "staging/src/k8s.io/api/core/v1/types.go"
       - text: "type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-
+      
       ## For the Secret.Data and ConfigMap.BinaryData fields in the core API.
       - text: "field (Secret.Data|ConfigMap.BinaryData) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-
+      
       ## For map fields in the resource API (across all versions).
       - text: "field (CounterSet|DeviceCounterConsumption).Counters should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
@@ -211,11 +211,11 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta2)/types.go"
       - text: "field (CapacityRequirements.Requests|DeviceRequestAllocationResult.ConsumedCapacity) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
-
+      
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
         path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|storage|storagemigration)"
-
+      
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
         path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -177,7 +177,7 @@ linters:
       # The following exceptions are for fields in stable or deprecated APIs that cannot be
       # changed due to backward compatibility constraints. Each rule is scoped to the
       # specific field to avoid hiding new violations.
-      
+
       ## For the "Extra" field, which is common across several auth-related APIs.
       - text: "field UserInfo.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/authentication/(v1|v1beta1)/types.go"
@@ -185,7 +185,7 @@ linters:
         path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types.go"
       - text: "field CertificateSigningRequestSpec.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/certificates/(v1|v1beta1)/types.go"
-      
+
       ## For ResourceList fields in the core API.
       - text: "field (PersistentVolumeSpec.Capacity|ContainerStatus.AllocatedResources|PodSpec.Overhead|ResourceQuotaSpec.Hard) type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
@@ -197,11 +197,11 @@ linters:
         path: "staging/src/k8s.io/api/core/v1/types.go"
       - text: "type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-      
+
       ## For the Secret.Data and ConfigMap.BinaryData fields in the core API.
       - text: "field (Secret.Data|ConfigMap.BinaryData) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-      
+
       ## For map fields in the resource API (across all versions).
       - text: "field (CounterSet|DeviceCounterConsumption).Counters should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
@@ -211,6 +211,14 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta2)/types.go"
       - text: "field (CapacityRequirements.Requests|DeviceRequestAllocationResult.ConsumedCapacity) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+
+      # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
+      - text: "must be marked as optional or required"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|storage|storagemigration)"
+
+      # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
+      - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
+        path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
 
   default: standard
   enable: # please keep this alphabetized
@@ -372,7 +380,7 @@ linters:
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
               # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
-              # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+              - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -188,7 +188,7 @@ linters:
       # The following exceptions are for fields in stable or deprecated APIs that cannot be
       # changed due to backward compatibility constraints. Each rule is scoped to the
       # specific field to avoid hiding new violations.
-      
+
       ## For the "Extra" field, which is common across several auth-related APIs.
       - text: "field UserInfo.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/authentication/(v1|v1beta1)/types.go"
@@ -196,7 +196,7 @@ linters:
         path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types.go"
       - text: "field CertificateSigningRequestSpec.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/certificates/(v1|v1beta1)/types.go"
-      
+
       ## For ResourceList fields in the core API.
       - text: "field (PersistentVolumeSpec.Capacity|ContainerStatus.AllocatedResources|PodSpec.Overhead|ResourceQuotaSpec.Hard) type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
@@ -208,11 +208,11 @@ linters:
         path: "staging/src/k8s.io/api/core/v1/types.go"
       - text: "type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-      
+
       ## For the Secret.Data and ConfigMap.BinaryData fields in the core API.
       - text: "field (Secret.Data|ConfigMap.BinaryData) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-      
+
       ## For map fields in the resource API (across all versions).
       - text: "field (CounterSet|DeviceCounterConsumption).Counters should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
@@ -222,6 +222,14 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta2)/types.go"
       - text: "field (CapacityRequirements.Requests|DeviceRequestAllocationResult.ConsumedCapacity) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+
+      # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
+      - text: "must be marked as optional or required"
+        path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|storage|storagemigration)"
+
+      # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
+      - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
+        path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"
 
   default: none
   enable: # please keep this alphabetized
@@ -381,7 +389,7 @@ linters:
               # - "nophase" # Ensure field names do not have the word "phase" in them.
               - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
               # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
-              # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+              - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
               # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
               - "ssatags" # Ensure lists have a listType tag.
               # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -188,7 +188,7 @@ linters:
       # The following exceptions are for fields in stable or deprecated APIs that cannot be
       # changed due to backward compatibility constraints. Each rule is scoped to the
       # specific field to avoid hiding new violations.
-
+      
       ## For the "Extra" field, which is common across several auth-related APIs.
       - text: "field UserInfo.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/authentication/(v1|v1beta1)/types.go"
@@ -196,7 +196,7 @@ linters:
         path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types.go"
       - text: "field CertificateSigningRequestSpec.Extra should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/certificates/(v1|v1beta1)/types.go"
-
+      
       ## For ResourceList fields in the core API.
       - text: "field (PersistentVolumeSpec.Capacity|ContainerStatus.AllocatedResources|PodSpec.Overhead|ResourceQuotaSpec.Hard) type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
@@ -208,11 +208,11 @@ linters:
         path: "staging/src/k8s.io/api/core/v1/types.go"
       - text: "type ResourceList should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-
+      
       ## For the Secret.Data and ConfigMap.BinaryData fields in the core API.
       - text: "field (Secret.Data|ConfigMap.BinaryData) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/core/v1/types.go"
-
+      
       ## For map fields in the resource API (across all versions).
       - text: "field (CounterSet|DeviceCounterConsumption).Counters should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
@@ -222,11 +222,11 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta2)/types.go"
       - text: "field (CapacityRequirements.Requests|DeviceRequestAllocationResult.ConsumedCapacity) should not use a map type, use a list type with a unique name/identifier instead"
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
-
+      
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       - text: "must be marked as optional or required"
         path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|storage|storagemigration)"
-
+      
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
         path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -87,3 +87,11 @@
   path: "staging/src/k8s.io/api/resource/(v1|v1beta2)/types.go"
 - text: "field (CapacityRequirements.Requests|DeviceRequestAllocationResult.ConsumedCapacity) should not use a map type, use a list type with a unique name/identifier instead"
   path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
+
+# OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
+- text: "must be marked as optional or required"
+  path: "staging/src/k8s.io/api/(admission|apidiscovery|apiserverinternal|apps|authentication|authorization|autoscaling|batch|certificates|coordination|core|discovery|events|extensions|flowcontrol|imagepolicy|networking|node|policy|rbac|resource|storage|storagemigration)"
+
+# OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
+- text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
+  path: "staging/src/k8s.io/api/(core/v1|extensions/v1beta1|networking/(v1|v1beta1))"

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -15,7 +15,7 @@ linters:
     # - "nophase" # Ensure field names do not have the word "phase" in them.
     - "notimestamp" # Ensure fields are not named "timestamp", prefer "time".
     # - "optionalfields" # Ensure fields marked optional have omitempty and pointers.
-    # - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
+    - "optionalorrequired" # Every field should be marked as `+optional` xor `+required`.
     # - "requiredfields" # Required fields should only be pointers when required based on the validity of the zero value, they should always have `omitempty`.
     - "ssatags" # Ensure lists have a listType tag.
     # - "uniquemarkers" # Ensure markers are not duplicated across field and type definitions.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -53205,7 +53205,6 @@ func schema_k8sio_api_scheduling_v1_PriorityClass(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"value"},
 			},
 		},
 		Dependencies: []string{
@@ -53414,7 +53413,6 @@ func schema_k8sio_api_scheduling_v1alpha1_PriorityClass(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"value"},
 			},
 		},
 		Dependencies: []string{
@@ -53708,7 +53706,6 @@ func schema_k8sio_api_scheduling_v1beta1_PriorityClass(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"value"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -39,7 +39,7 @@ message PriorityClass {
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
-  // +required
+  // +optional
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as
@@ -70,7 +70,6 @@ message PriorityClassList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
-  // +required
   repeated PriorityClass items = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -39,6 +39,7 @@ message PriorityClass {
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
+  // +required
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as
@@ -69,6 +70,7 @@ message PriorityClassList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
+  // +required
   repeated PriorityClass items = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -37,6 +37,7 @@ type PriorityClass struct {
 
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
+	// +required
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
@@ -71,5 +72,6 @@ type PriorityClassList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of PriorityClasses
+	// +required
 	Items []PriorityClass `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -37,7 +37,7 @@ type PriorityClass struct {
 
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
-	// +required
+	// +optional
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
@@ -72,6 +72,5 @@ type PriorityClassList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of PriorityClasses
-	// +required
 	Items []PriorityClass `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -86,6 +86,7 @@ message PriorityClass {
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
+  // +required
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as
@@ -116,6 +117,7 @@ message PriorityClassList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
+  // +required
   repeated PriorityClass items = 2;
 }
 
@@ -166,6 +168,7 @@ message WorkloadList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Workloads.
+  // +required
   repeated Workload items = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -86,7 +86,7 @@ message PriorityClass {
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
-  // +required
+  // +optional
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as
@@ -117,7 +117,6 @@ message PriorityClassList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
-  // +required
   repeated PriorityClass items = 2;
 }
 
@@ -168,7 +167,6 @@ message WorkloadList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Workloads.
-  // +required
   repeated Workload items = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -37,6 +37,7 @@ type PriorityClass struct {
 
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
+	// +required
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
@@ -70,6 +71,7 @@ type PriorityClassList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of PriorityClasses
+	// +required
 	Items []PriorityClass `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -104,6 +106,7 @@ type WorkloadList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Items is the list of Workloads.
+	// +required
 	Items []Workload `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -37,7 +37,7 @@ type PriorityClass struct {
 
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
-	// +required
+	// +optional
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
@@ -71,7 +71,6 @@ type PriorityClassList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of PriorityClasses
-	// +required
 	Items []PriorityClass `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -106,7 +105,6 @@ type WorkloadList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Items is the list of Workloads.
-	// +required
 	Items []Workload `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -40,6 +40,7 @@ message PriorityClass {
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
+  // +required
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as
@@ -70,6 +71,7 @@ message PriorityClassList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
+  // +required
   repeated PriorityClass items = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -40,7 +40,7 @@ message PriorityClass {
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
-  // +required
+  // +optional
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as
@@ -71,7 +71,6 @@ message PriorityClassList {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
-  // +required
   repeated PriorityClass items = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -41,7 +41,7 @@ type PriorityClass struct {
 
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
-	// +required
+	// +optional
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
@@ -79,6 +79,5 @@ type PriorityClassList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of PriorityClasses
-	// +required
 	Items []PriorityClass `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -41,6 +41,7 @@ type PriorityClass struct {
 
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
+	// +required
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
@@ -78,5 +79,6 @@ type PriorityClassList struct {
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// items is the list of PriorityClasses
+	// +required
 	Items []PriorityClass `json:"items" protobuf:"bytes,2,rep,name=items"`
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing `+required` markers to fields in the scheduling API group to satisfy the `optionalorrequired` linter rule.

#### Which issue(s) this PR fixes:

Part of #134671

#### Special notes for your reviewer:

This adds `// +required` markers to:
- `PriorityClass.Value` in v1, v1alpha1, v1beta1
- `PriorityClassList.Items` in v1, v1alpha1, v1beta1
- `WorkloadList.Items` in v1alpha1

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```release-note

```