### PR TITLE
Filter out the nodes created by other tests

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2138,7 +2138,9 @@ metadata:
 		})
 		ginkgo.It("GET on status subresource of built-in type (node) returns identical info as GET on the built-in type", func(ctx context.Context) {
 			ginkgo.By("first listing nodes in the cluster, and using first node of the list")
-			nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+				FieldSelector: "spec.unschedulable=false",
+			})
 			framework.ExpectNoError(err)
 			gomega.Expect(nodes.Items).ToNot(gomega.BeEmpty())
 			node := nodes.Items[0]


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
[Node Lifecycle](https://github.com/kubernetes/kubernetes/blob/4bed36e03e7bd699b089d33da6f7d7c9ef9eb661/test/e2e/node/node_lifecycle.go#L61-L79) test creates unschedulable fake node for its tests. In the meantime, `kubectl subresource flag` test lists all the nodes and perform actions against [the first node](https://github.com/kubernetes/kubernetes/blob/4bed36e03e7bd699b089d33da6f7d7c9ef9eb661/test/e2e/kubectl/kubectl.go#L2140-L2144). 

In rare cases, `kubectl subresource flag` test picks the fake node created by `Node Lifecycle` as first node and it fails. 

This PR filters out the nodes that are not schedulable from `kubectl subresource flag` tests to deflake it.

Note: Although this is a clear race condition, I couldn't see the flake in kubernetes. I saw it in OpenShift https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.21-e2e-aws-ovn-upgrade-fips/1991735014332567552

#### Does this PR introduce a user-facing change?
```release-note
None
```