### PR TITLE
Fix device plugin admission failure after container restart

### DIFF
--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -64,9 +64,20 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 
 	var pods []*v1.Pod
 	if p.useActivePods {
+		// GetActivePods already filters out terminal pods, so no need for additional filtering.
 		pods = p.podsProvider.GetActivePods()
 	} else {
-		pods = p.podsProvider.GetPods()
+		// GetPods may include terminal pods, so we filter them out ourselves.
+		allPods := p.podsProvider.GetPods()
+		pods = make([]*v1.Pod, 0, len(allPods))
+		for _, pod := range allPods {
+			// Skip terminal pods (Failed or Succeeded).
+			// Terminal pods should not appear in podresources as they no longer consume resources.
+			if podutil.IsPodTerminal(pod) {
+				continue
+			}
+			pods = append(pods, pod)
+		}
 	}
 
 	podResources := make([]*podresourcesv1.PodResources, len(pods))

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1203,21 +1203,36 @@ func (m *ManagerImpl) ShouldResetExtendedResourceCapacity() bool {
 }
 
 func (m *ManagerImpl) isContainerAlreadyRunning(logger klog.Logger, podUID, cntName string) bool {
-	cntID, err := m.containerMap.GetContainerID(podUID, cntName)
-	if err != nil {
-		logger.Error(err, "Container not found in the initial map, assumed NOT running", "podUID", podUID, "containerName", cntName)
-		return false
-	}
-
-	// note that if container runtime is down when kubelet restarts, this set will be empty,
-	// so on kubelet restart containers will again fail admission, hitting https://github.com/kubernetes/kubernetes/issues/118559 again.
+	// Check if ANY container for this pod/container name is running.
+	// This handles the case where a container restarted before kubelet restart,
+	// so the containerMap might have multiple entries (old exited + new running).
+	// We need to check all of them to see if any are running.
+	//
+	// Note: if container runtime is down when kubelet restarts, containerRunningSet will be empty,
+	// so containers will fail admission, hitting https://github.com/kubernetes/kubernetes/issues/118559.
 	// This scenario should however be rare enough.
-	if !m.containerRunningSet.Has(cntID) {
-		logger.V(4).Info("Container not present in the initial running set", "podUID", podUID, "containerName", cntName, "containerID", cntID)
+	foundAnyContainer := false
+	foundRunningContainer := false
+
+	m.containerMap.Visit(func(visitPodUID, visitContainerName, visitContainerID string) {
+		if visitPodUID == podUID && visitContainerName == cntName {
+			foundAnyContainer = true
+			if m.containerRunningSet.Has(visitContainerID) {
+				foundRunningContainer = true
+				logger.V(4).Info("Container found in the initial running set", "podUID", podUID, "containerName", cntName, "containerID", visitContainerID)
+			}
+		}
+	})
+
+	if !foundAnyContainer {
+		logger.V(4).Info("Container not found in the initial map, assumed NOT running", "podUID", podUID, "containerName", cntName)
 		return false
 	}
 
-	// Once we make it here we know we have a running container.
-	logger.V(4).Info("Container found in the initial set, assumed running", "podUID", podUID, "containerName", cntName, "containerID", cntID)
+	if !foundRunningContainer {
+		logger.V(4).Info("Container found in map but not in running set", "podUID", podUID, "containerName", cntName)
+		return false
+	}
+
 	return true
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes device plugin test failures after kubelet restart.

**Fix 1 - isContainerAlreadyRunning():**
When a container restarts before kubelet restarts, containerMap has multiple entries (old exited + new running). `GetContainerID()` may return the exited container, causing the running check to fail. Fix by checking if ANY container for the pod/name is running.

**Fix 2 - Filter terminal pods from podresources:**
Failed/Succeeded pods should not appear in podresources as they no longer consume resources. The filtering is only applied when using `GetPods()` since `GetActivePods()` already filters them out.

**Fix 3 - Test error handling:**
When `getV1NodeDevices` returns an error, we should not return the error to Eventually as that would cause it to exit immediately. Instead, log the error and return true to continue polling until the condition is met or timeout occurs.

#### Does this PR introduce a user-facing change?

```release-note
Fixed device plugin test failures after kubelet restart.
```