### PR TITLE
chore: Removed currentRV defaulting to 0

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -787,10 +787,9 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 		})
 		if err != nil {
 			if errors.Is(err, etcdrpc.ErrFutureRev) {
-				currentRV, getRVErr := s.GetCurrentResourceVersion(ctx)
-				if getRVErr != nil {
-					// If we can't get the current RV, use 0 as a fallback.
-					currentRV = 0
+				currentRV, err := s.GetCurrentResourceVersion(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get the current Resource Version: %w", err)
 				}
 				return storage.NewTooLargeResourceVersionError(uint64(withRev), currentRV, 0)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR tries to close the followup issue #132526 based of the already merged PR #132374

#### Which issue(s) this PR is related to:
Fixes #132526

#### Special notes for your reviewer:
When the current Revision is returned as 0, we now let `GetCurrentResourceVersion` handle these situations.
Since we want to return the error message early, when the revision is 0, we do not want to set it to 0.

```
	if currentResourceVersion == 0 {
		return 0, fmt.Errorf("the current resource version must be greater than 0")
	}
```

And last, but not least, a test after the changes:
```
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "Timeout: Too large resource version: 45749857498574, current: 439",
  "reason": "Timeout",
  "details": {
    "causes": [
      {
        "reason": "ResourceVersionTooLarge",
        "message": "Too large resource version"
      }
    ],
    "retryAfterSeconds": 1
  },
  "code": 504
```

#### Does this PR introduce a user-facing change?
```release-note
Returning Information if the current Resource Version is 0, instead of returning a "Too large resource version" message.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
