### PR TITLE
Enable declarative validation for Namespace

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -101,7 +101,7 @@ func Validate_Namespace(ctx context.Context, op operation.Operation, fldPath *fi
 				if earlyReturn {
 					return // do not proceed
 				}
-				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName)...)
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.ShortName)...)
 			}()
 			return
 		}(fldPath.Child("metadata"), &obj.ObjectMeta, safe.Field(oldObj, func(oldObj *corev1.Namespace) *metav1.ObjectMeta { return &oldObj.ObjectMeta }), oldObj != nil)...)

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -43,7 +43,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type Namespace
 	scheme.AddValidationFunc((*corev1.Namespace)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/finalize", "/status":
 			return Validate_Namespace(ctx, op, nil /* fldPath */, obj.(*corev1.Namespace), safe.Cast[*corev1.Namespace](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8167,6 +8167,18 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.
 // ValidateNamespace tests if required fields are set.
 func ValidateNamespace(namespace *core.Namespace) field.ErrorList {
 	allErrs := ValidateObjectMeta(&namespace.ObjectMeta, false, ValidateNamespaceName, field.NewPath("metadata"))
+
+	// TODO: update this block when increasing declarative validation coverage
+	matcher := field.ErrorMatcher{}.ByType().ByField()
+	for _, err := range allErrs {
+		switch {
+		case matcher.Matches(&field.Error{Type: field.ErrorTypeRequired, Field: "metadata.name"}, err):
+			err.MarkCoveredByDeclarative()
+		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
+			err.MarkCoveredByDeclarative().WithOrigin("format=k8s-long-name")
+		}
+	}
+
 	for i := range namespace.Spec.Finalizers {
 		allErrs = append(allErrs, validateFinalizerName(string(namespace.Spec.Finalizers[i]), field.NewPath("spec", "finalizers"))...)
 	}
@@ -8195,12 +8207,31 @@ func validateKubeFinalizerName(stringValue string, fldPath *field.Path) field.Er
 // ValidateNamespaceUpdate tests to make sure a namespace update can be applied.
 func ValidateNamespaceUpdate(newNamespace *core.Namespace, oldNamespace *core.Namespace) field.ErrorList {
 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+
+	// TODO: update this block when increasing declarative validation coverage
+	matcher := field.ErrorMatcher{}.ByType().ByField()
+	for _, err := range allErrs {
+		switch {
+		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
+			err.MarkCoveredByDeclarative().WithOrigin("immutable")
+		}
+	}
 	return allErrs
 }
 
 // ValidateNamespaceStatusUpdate tests to see if the update is legal for an end user to make.
 func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+
+	// TODO: update this block when increasing declarative validation coverage
+	matcher := field.ErrorMatcher{}.ByType().ByField()
+	for _, err := range allErrs {
+		switch {
+		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
+			err.MarkCoveredByDeclarative().WithOrigin("immutable")
+		}
+	}
+
 	if newNamespace.DeletionTimestamp.IsZero() {
 		if newNamespace.Status.Phase != core.NamespaceActive {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("status", "Phase"), newNamespace.Status.Phase, "may only be 'Active' if `deletionTimestamp` is empty"))
@@ -8216,6 +8247,15 @@ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) f
 // ValidateNamespaceFinalizeUpdate tests to see if the update is legal for an end user to make.
 func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace) field.ErrorList {
 	allErrs := ValidateObjectMetaUpdate(&newNamespace.ObjectMeta, &oldNamespace.ObjectMeta, field.NewPath("metadata"))
+
+	// TODO: update this block when increasing declarative validation coverage
+	matcher := field.ErrorMatcher{}.ByType().ByField()
+	for _, err := range allErrs {
+		switch {
+		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
+			err.MarkCoveredByDeclarative().WithOrigin("immutable")
+		}
+	}
 
 	fldPath := field.NewPath("spec", "finalizers")
 	for i := range newNamespace.Spec.Finalizers {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8166,16 +8166,18 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *core.
 
 // ValidateNamespace tests if required fields are set.
 func ValidateNamespace(namespace *core.Namespace) field.ErrorList {
-	allErrs := ValidateObjectMeta(&namespace.ObjectMeta, false, ValidateNamespaceName, field.NewPath("metadata"))
+
+	validateName := func(fldPath *field.Path, name string) field.ErrorList {
+		return validate.ShortName(context.Background(), operation.Operation{}, fldPath, &name, nil).MarkCoveredByDeclarative()
+	}
+
+	allErrs := ValidateObjectMetaWithOpts(&namespace.ObjectMeta, false, validateName, field.NewPath("metadata"))
 
 	// TODO: update this block when increasing declarative validation coverage
 	matcher := field.ErrorMatcher{}.ByType().ByField()
-	for _, err := range allErrs {
-		switch {
-		case matcher.Matches(&field.Error{Type: field.ErrorTypeRequired, Field: "metadata.name"}, err):
-			err.MarkCoveredByDeclarative()
-		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
-			err.MarkCoveredByDeclarative().WithOrigin("format=k8s-long-name")
+	for i, err := range allErrs {
+		if matcher.Matches(&field.Error{Type: field.ErrorTypeRequired, Field: "metadata.name"}, err) {
+			allErrs[i] = err.MarkCoveredByDeclarative()
 		}
 	}
 
@@ -8210,10 +8212,9 @@ func ValidateNamespaceUpdate(newNamespace *core.Namespace, oldNamespace *core.Na
 
 	// TODO: update this block when increasing declarative validation coverage
 	matcher := field.ErrorMatcher{}.ByType().ByField()
-	for _, err := range allErrs {
-		switch {
-		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
-			err.MarkCoveredByDeclarative().WithOrigin("immutable")
+	for i, err := range allErrs {
+		if matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err) {
+			allErrs[i] = err.MarkCoveredByDeclarative().WithOrigin("immutable")
 		}
 	}
 	return allErrs
@@ -8225,10 +8226,9 @@ func ValidateNamespaceStatusUpdate(newNamespace, oldNamespace *core.Namespace) f
 
 	// TODO: update this block when increasing declarative validation coverage
 	matcher := field.ErrorMatcher{}.ByType().ByField()
-	for _, err := range allErrs {
-		switch {
-		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
-			err.MarkCoveredByDeclarative().WithOrigin("immutable")
+	for i, err := range allErrs {
+		if matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err) {
+			allErrs[i] = err.MarkCoveredByDeclarative().WithOrigin("immutable")
 		}
 	}
 
@@ -8250,10 +8250,9 @@ func ValidateNamespaceFinalizeUpdate(newNamespace, oldNamespace *core.Namespace)
 
 	// TODO: update this block when increasing declarative validation coverage
 	matcher := field.ErrorMatcher{}.ByType().ByField()
-	for _, err := range allErrs {
-		switch {
-		case matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err):
-			err.MarkCoveredByDeclarative().WithOrigin("immutable")
+	for i, err := range allErrs {
+		if matcher.Matches(&field.Error{Type: field.ErrorTypeInvalid, Field: "metadata.name"}, err) {
+			allErrs[i] = err.MarkCoveredByDeclarative().WithOrigin("immutable")
 		}
 	}
 

--- a/pkg/registry/core/namespace/declarative_validation_test.go
+++ b/pkg/registry/core/namespace/declarative_validation_test.go
@@ -56,7 +56,7 @@ func TestDeclarativeValidateForNamespaceCreate(t *testing.T) {
 			expectedErrs: field.ErrorList{{
 				Type:   field.ErrorTypeInvalid,
 				Field:  "metadata.name",
-				Origin: "format=k8s-long-name",
+				Origin: "format=k8s-short-name",
 			}},
 		},
 		"invalid: non-rfc1123 name: too long": {
@@ -66,7 +66,7 @@ func TestDeclarativeValidateForNamespaceCreate(t *testing.T) {
 			expectedErrs: field.ErrorList{{
 				Type:   field.ErrorTypeInvalid,
 				Field:  "metadata.name",
-				Origin: "format=k8s-long-name",
+				Origin: "format=k8s-short-name",
 			}},
 		},
 		// TODO: add more test cases when increasing declarative validation coverage

--- a/pkg/registry/core/namespace/declarative_validation_test.go
+++ b/pkg/registry/core/namespace/declarative_validation_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestDeclarativeValidateForNamespaceCreate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		input        core.Namespace
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			expectedErrs: field.ErrorList{},
+		},
+		"invalid: empty name and generateName": {
+			input: core.Namespace{},
+			expectedErrs: field.ErrorList{{
+				Type:  field.ErrorTypeRequired,
+				Field: "metadata.name",
+			}},
+		},
+		"invalid: non-rfc1123 name: at sign": {
+			input: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "@test"},
+			},
+			expectedErrs: field.ErrorList{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "metadata.name",
+				Origin: "format=k8s-long-name",
+			}},
+		},
+		"invalid: non-rfc1123 name: too long": {
+			input: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 254)},
+			},
+			expectedErrs: field.ErrorList{{
+				Type:   field.ErrorTypeInvalid,
+				Field:  "metadata.name",
+				Origin: "format=k8s-long-name",
+			}},
+		},
+		// TODO: add more test cases when increasing declarative validation coverage
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateForNamespaceUpdate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		old          core.Namespace
+		update       core.Namespace
+		expectedErrs field.ErrorList
+	}{
+		"invalid: changing name": {
+			old: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test1",
+					ResourceVersion: "1",
+				},
+			},
+			update: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test2",
+					ResourceVersion: "2",
+				},
+			},
+			expectedErrs: field.ErrorList{
+				{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "metadata.name",
+					Origin: "immutable",
+				}},
+		},
+		// TODO: add more test cases when increasing declarative validation coverage
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateForNamespaceStatusUpdate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		old          core.Namespace
+		update       core.Namespace
+		expectedErrs field.ErrorList
+	}{
+		"invalid: changing name": {
+			old: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test1",
+					ResourceVersion: "1",
+				},
+				Status: core.NamespaceStatus{
+					Phase: core.NamespaceActive,
+				},
+			},
+			update: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test2",
+					ResourceVersion: "2",
+				},
+				Status: core.NamespaceStatus{
+					Phase: core.NamespaceActive,
+				},
+			},
+			expectedErrs: field.ErrorList{
+				{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "metadata.name",
+					Origin: "immutable",
+				}},
+		},
+		// TODO: add more test cases when increasing declarative validation coverage
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, StatusStrategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateForNamespaceFinalizeUpdate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	testCases := map[string]struct {
+		old          core.Namespace
+		update       core.Namespace
+		expectedErrs field.ErrorList
+	}{
+		"invalid: changing name": {
+			old: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test1",
+					ResourceVersion: "1",
+				},
+			},
+			update: core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test2",
+					ResourceVersion: "2",
+				},
+			},
+			expectedErrs: field.ErrorList{
+				{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "metadata.name",
+					Origin: "immutable",
+				}},
+		},
+		// TODO: add more test cases when increasing declarative validation coverage
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, FinalizeStrategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -143,8 +143,8 @@ func (namespaceStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Ob
 	newNamespace := obj.(*api.Namespace)
 	oldNamespace := old.(*api.Namespace)
 
-	errorList := validation.ValidateNamespace(newNamespace)
-	allErrs := append(errorList, validation.ValidateNamespaceUpdate(newNamespace, oldNamespace)...)
+	allErrs := validation.ValidateNamespace(newNamespace)
+	allErrs = append(allErrs, validation.ValidateNamespaceUpdate(newNamespace, oldNamespace)...)
 	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newNamespace, oldNamespace, allErrs, operation.Update)
 }
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2552,6 +2552,9 @@ message Namespace {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
+  // +k8s:subfield(name)=+k8s:required
+  // +k8s:subfield(name)=+k8s:immutable
+  // +k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the behavior of the Namespace.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2554,7 +2554,7 @@ message Namespace {
   // +optional
   // +k8s:subfield(name)=+k8s:required
   // +k8s:subfield(name)=+k8s:immutable
-  // +k8s:subfield(name)=+k8s:format=k8s-long-name
+  // +k8s:subfield(name)=+k8s:format=k8s-short-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the behavior of the Namespace.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7092,6 +7092,8 @@ type NamespaceCondition struct {
 // +genclient:skipVerbs=deleteCollection
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.0
+// +k8s:supportsSubresource=/finalize
+// +k8s:supportsSubresource=/status
 
 // Namespace provides a scope for Names.
 // Use of multiple namespaces is optional.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7102,7 +7102,7 @@ type Namespace struct {
 	// +optional
 	// +k8s:subfield(name)=+k8s:required
 	// +k8s:subfield(name)=+k8s:immutable
-	// +k8s:subfield(name)=+k8s:format=k8s-long-name
+	// +k8s:subfield(name)=+k8s:format=k8s-short-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines the behavior of the Namespace.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7100,6 +7100,9 @@ type Namespace struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
+	// +k8s:subfield(name)=+k8s:required
+	// +k8s:subfield(name)=+k8s:immutable
+	// +k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines the behavior of the Namespace.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The PR enables declarative validation for namespaces

#### Which issue(s) this PR is related to:
Part of [#134280](https://github.com/kubernetes/kubernetes/issues/134280)

#### Special notes for your reviewer:
As stated by [this comment](https://github.com/kubernetes/kubernetes/pull/134603#issuecomment-3458222741), pull requests wiring up new types require adding at least a single rule each. Since namespaces lack "easy" fields (read: not shared with other types and required), this PR focuses on `metadata.name`. Due to `ObjectMeta` being a shared type, the `validations.ValidateNamespace*` functions require some extra error matching logic in order to mark the errors covered by declarative validation (we cannot apply this logic in the functions that perform imperative validation, since they are shared by multiple types). This way of wiring up such resources is just a suggestion on how such changes can be handled, and I'd be glad to write a better implementation if anyone has other ideas (the switch blocks are indeed quite weird).



#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
```
