### PR TITLE
ipallocator: handle errors correctly

### DIFF
--- a/pkg/registry/core/service/ipallocator/cidrallocator.go
+++ b/pkg/registry/core/service/ipallocator/cidrallocator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ipallocator
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -391,6 +392,10 @@ func (c *MetaAllocator) AllocateNextService(service *api.Service) (net.IP, error
 		ip, err := item.allocator.AllocateNextService(service)
 		if err == nil {
 			return ip, nil
+		}
+		// only keep trying if the allocator is full or not ready
+		if !errors.Is(err, ErrFull) && !errors.Is(err, ErrNotReady) {
+			return nil, err
 		}
 	}
 	return nil, ErrFull


### PR DESCRIPTION
The ipallocator was blindly assuming that all errors are retryable, that causes that the allocator tries to exhaust all the possibilities to allocate an IP address.

If the error is not retryable this means the allocator will generate as many API calls as existing available IPs are in the allocator, causing CPU exhaustion since this requests are coming from inside the apiserver.

In addition to handle the error correctly, this patch also interpret the error to return the right status code depending on the error type.

/kind bug
/kind regression

```release-note
fix a bug in the kube-apiserver where a malformed Service without name can cause high CPU usage. The bug is present on the new Cluster IP allocators enabled with the feature MultiCIDRServiceAllocator (enabled by default since 1.33)
```

/assign @thockin @liggitt @carlory @danwinship 

Fixes: #135333 

/sig network

missing unit tests, just running it through CI and for early review
