### PR TITLE
Preempt pods in prebind phase without delete calls.

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -477,6 +477,7 @@ func TestPostFilter(t *testing.T) {
 					frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(tt.pods, tt.nodes)),
 					frameworkruntime.WithLogger(logger),
 					frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+					frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -2247,6 +2248,7 @@ func TestPreempt(t *testing.T) {
 						frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(testPods, nodes)),
 						frameworkruntime.WithInformerFactory(informerFactory),
 						frameworkruntime.WithWaitingPods(waitingPods),
+						frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 						frameworkruntime.WithLogger(logger),
 						frameworkruntime.WithPodActivator(&fakePodActivator{}),
 					)

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -58,6 +58,7 @@ type frameworkImpl struct {
 	registry             Registry
 	snapshotSharedLister fwk.SharedLister
 	waitingPods          *waitingPodsMap
+	podsInPreBind        *podsInPreBindMap
 	scorePluginWeight    map[string]int
 	preEnqueuePlugins    []fwk.PreEnqueuePlugin
 	enqueueExtensions    []fwk.EnqueueExtensions
@@ -153,6 +154,7 @@ type frameworkOptions struct {
 	captureProfile         CaptureProfile
 	parallelizer           parallelize.Parallelizer
 	waitingPods            *waitingPodsMap
+	podsInPreBind          *podsInPreBindMap
 	apiDispatcher          *apidispatcher.APIDispatcher
 	workloadManager        fwk.WorkloadManager
 	logger                 *klog.Logger
@@ -285,6 +287,13 @@ func WithWaitingPods(wp *waitingPodsMap) Option {
 	}
 }
 
+// WithPodsInPreBind sets podsInPreBind for the scheduling frameworkImpl.
+func WithPodsInPreBind(bp *podsInPreBindMap) Option {
+	return func(o *frameworkOptions) {
+		o.podsInPreBind = bp
+	}
+}
+
 // WithLogger overrides the default logger from k8s.io/klog.
 func WithLogger(logger klog.Logger) Option {
 	return func(o *frameworkOptions) {
@@ -323,6 +332,7 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 		sharedCSIManager:     options.sharedCSIManager,
 		scorePluginWeight:    make(map[string]int),
 		waitingPods:          options.waitingPods,
+		podsInPreBind:        options.podsInPreBind,
 		clientSet:            options.clientSet,
 		kubeConfig:           options.kubeConfig,
 		eventRecorder:        options.eventRecorder,
@@ -1456,6 +1466,10 @@ func (f *frameworkImpl) RunPreBindPlugins(ctx context.Context, state fwk.CycleSt
 				return plStatus
 			}
 			err := plStatus.AsError()
+			if errors.Is(err, context.Canceled) {
+				err = context.Cause(ctx)
+			}
+
 			logger.Error(err, "Plugin failed", "plugin", pl.Name(), "pod", klog.KObj(pod), "node", nodeName)
 			return fwk.AsStatus(fmt.Errorf("running PreBind plugin %q: %w", pl.Name(), err))
 		}
@@ -1892,6 +1906,24 @@ func (f *frameworkImpl) RejectWaitingPod(uid types.UID) bool {
 		return waitingPod.Reject("", "removed")
 	}
 	return false
+}
+
+// AddPodInPreBind adds a pod to the pods in preBind list.
+func (f *frameworkImpl) AddPodInPreBind(uid types.UID, cancel context.CancelCauseFunc) {
+	f.podsInPreBind.add(uid, cancel)
+}
+
+// GetPodInPreBind returns a pod that is in the binding cycle but before it is bound given its UID.
+func (f *frameworkImpl) GetPodInPreBind(uid types.UID) fwk.PodInPreBind {
+	if bp := f.podsInPreBind.get(uid); bp != nil {
+		return bp
+	}
+	return nil
+}
+
+// RemovePodInPreBind removes a pod from the pods in preBind list.
+func (f *frameworkImpl) RemovePodInPreBind(uid types.UID) {
+	f.podsInPreBind.remove(uid)
 }
 
 // HasFilterPlugins returns true if at least one filter plugin is defined.

--- a/pkg/scheduler/framework/runtime/pods_in_prebind_map.go
+++ b/pkg/scheduler/framework/runtime/pods_in_prebind_map.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+	fwk "k8s.io/kube-scheduler/framework"
+)
+
+// podsInPreBindMap is a thread-safe map of pods currently in the preBind phase.
+type podsInPreBindMap struct {
+	pods map[types.UID]*podInPreBind
+	mu   sync.RWMutex
+}
+
+// NewPodsInPreBindMap creates an empty podsInPreBindMap.
+func NewPodsInPreBindMap() *podsInPreBindMap {
+	return &podsInPreBindMap{
+		pods: make(map[types.UID]*podInPreBind),
+	}
+}
+
+// get returns a pod from the map if it exists.
+func (pbm *podsInPreBindMap) get(uid types.UID) *podInPreBind {
+	pbm.mu.RLock()
+	defer pbm.mu.RUnlock()
+	return pbm.pods[uid]
+}
+
+// add adds a pod to map, overwriting existing one.
+func (pbm *podsInPreBindMap) add(uid types.UID, cancel context.CancelCauseFunc) {
+	pbm.mu.Lock()
+	defer pbm.mu.Unlock()
+	pbm.pods[uid] = &podInPreBind{cancel: cancel}
+}
+
+// remove removes a pod from the map.
+func (pbm *podsInPreBindMap) remove(uid types.UID) {
+	pbm.mu.Lock()
+	defer pbm.mu.Unlock()
+	delete(pbm.pods, uid)
+}
+
+var _ fwk.PodInPreBind = &podInPreBind{}
+
+// podInPreBind describes a pod in the preBind phase, before the bind was called for a pod.
+type podInPreBind struct {
+	finished bool
+	canceled bool
+	cancel   context.CancelCauseFunc
+	mu       sync.Mutex
+}
+
+// CancelPod cancels the context running the preBind phase
+// for a given pod.
+func (bp *podInPreBind) CancelPod(message string) bool {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	if bp.finished {
+		return false
+	}
+	if !bp.canceled {
+		bp.cancel(errors.New(message))
+	}
+	bp.canceled = true
+	return true
+}
+
+// MarkPrebound marks the pod as finished with preBind phase
+// of binding cycle, making it impossible to cancel
+// the binding cycle for it.
+func (bp *podInPreBind) MarkPrebound() bool {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	if bp.canceled {
+		return false
+	}
+	bp.finished = true
+	return true
+}

--- a/pkg/scheduler/framework/runtime/pods_in_prebind_map_test.go
+++ b/pkg/scheduler/framework/runtime/pods_in_prebind_map_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/ktesting"
+)
+
+const (
+	testPodUID = types.UID("pod-1")
+)
+
+func TestPodsInBindingMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		scenario func(t *testing.T, ctx context.Context, cancel context.CancelCauseFunc, m *podsInPreBindMap)
+	}{
+		{
+			name: "add and get",
+			scenario: func(t *testing.T, ctx context.Context, cancel context.CancelCauseFunc, m *podsInPreBindMap) {
+				m.add(testPodUID, cancel)
+				pod := m.get(testPodUID)
+				if pod == nil {
+					t.Fatalf("expected pod to be in map")
+				}
+			},
+		},
+		{
+			name: "add, remove and get",
+			scenario: func(t *testing.T, ctx context.Context, cancel context.CancelCauseFunc, m *podsInPreBindMap) {
+				m.add(testPodUID, cancel)
+				m.remove(testPodUID)
+				if m.get(testPodUID) != nil {
+					t.Errorf("expected pod to be removed from map")
+				}
+			},
+		},
+		{
+			name: "Verify CancelPod logic",
+			scenario: func(t *testing.T, ctx context.Context, cancel context.CancelCauseFunc, m *podsInPreBindMap) {
+				m.add(testPodUID, cancel)
+				pod := m.get(testPodUID)
+
+				// First cancel should succeed
+				if !pod.CancelPod("test cancel") {
+					t.Errorf("First CancelPod should return true")
+				}
+				if ctx.Err() == nil {
+					t.Errorf("Context should be cancelled")
+				}
+
+				// Second cancel should also return true
+				if !pod.CancelPod("test cancel") {
+					t.Errorf("Second CancelPod should return true")
+				}
+			},
+		},
+		{
+			name: "Verify MarkBound logic",
+			scenario: func(t *testing.T, ctx context.Context, cancel context.CancelCauseFunc, m *podsInPreBindMap) {
+				m.add(testPodUID, cancel)
+				pod := m.get(testPodUID)
+
+				if !pod.MarkPrebound() {
+					t.Errorf("MarkBound should return true for fresh pod")
+				}
+				if !pod.finished {
+					t.Errorf("finished should be true")
+				}
+
+				// Try to cancel after binding
+				if pod.CancelPod("test cancel") {
+					t.Errorf("CancelPod should return false after MarkBound")
+				}
+				if ctx.Err() != nil {
+					t.Errorf("Context should NOT be cancelled if MarkBound succeeded first")
+				}
+			},
+		},
+		{
+			name: "Verify MarkBound fails on cancelled pod",
+			scenario: func(t *testing.T, ctx context.Context, cancel context.CancelCauseFunc, m *podsInPreBindMap) {
+				m.add(testPodUID, cancel)
+				pod := m.get(testPodUID)
+
+				pod.CancelPod("test cancel")
+				if pod.MarkPrebound() {
+					t.Errorf("MarkBound should return false on cancelled pod")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewPodsInPreBindMap()
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancelCause(ctx)
+			defer cancel(nil)
+			tt.scenario(t, ctx, cancel, m)
+		})
+	}
+}

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -399,8 +399,9 @@ func (sched *Scheduler) bindingCycle(
 
 	assumedPod := assumedPodInfo.Pod
 
+	var preFlightStatus *fwk.Status
 	if sched.nominatedNodeNameForExpectationEnabled {
-		preFlightStatus := schedFramework.RunPreBindPreFlights(ctx, state, assumedPod, scheduleResult.SuggestedHost)
+		preFlightStatus = schedFramework.RunPreBindPreFlights(ctx, state, assumedPod, scheduleResult.SuggestedHost)
 		if preFlightStatus.Code() == fwk.Error ||
 			// Unschedulable status is not supported in PreBindPreFlight and hence we regard it as an error.
 			preFlightStatus.IsRejected() {
@@ -444,9 +445,24 @@ func (sched *Scheduler) bindingCycle(
 	// we can free the cluster events stored in the scheduling queue sooner, which is worth for busy clusters memory consumption wise.
 	sched.SchedulingQueue.Done(assumedPod.UID)
 
+	// If we are going to run prebind plugins we put the pod in binding map to optimize preemption.
+	if preFlightStatus.IsSuccess() {
+		var podInPreBindCancel context.CancelCauseFunc
+		ctx, podInPreBindCancel = context.WithCancelCause(ctx)
+		defer podInPreBindCancel(nil)
+		defer schedFramework.RemovePodInPreBind(assumedPod.UID)
+		schedFramework.AddPodInPreBind(assumedPod.UID, podInPreBindCancel)
+	}
 	// Run "prebind" plugins.
 	if status := schedFramework.RunPreBindPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost); !status.IsSuccess() {
 		return status
+	}
+
+	// Verify that pod was not preempted during prebinding.
+	bindingPod := schedFramework.GetPodInPreBind(assumedPod.UID)
+	if bindingPod != nil && !bindingPod.MarkPrebound() {
+		err := context.Cause(ctx)
+		return fwk.AsStatus(err)
 	}
 
 	// Run "bind" plugins.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -1038,10 +1038,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				},
 			}
 			waitingPods := frameworkruntime.NewWaitingPodsMap()
+			podInPreBind := frameworkruntime.NewPodsInPreBindMap()
 			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 				frameworkruntime.WithClientSet(client),
 				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
 				frameworkruntime.WithWaitingPods(waitingPods),
+				frameworkruntime.WithPodsInPreBind(podInPreBind),
 			)
 			if err != nil {
 				t.Fatalf("Failed to create new framework: %v", err)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -368,6 +368,30 @@ func newFakeNodeSelectorDependOnPodAnnotation(_ context.Context, _ runtime.Objec
 	return &fakeNodeSelectorDependOnPodAnnotation{}, nil
 }
 
+var blockingPreBindStartCh = make(chan struct{}, 1)
+
+var _ fwk.PreBindPlugin = &BlockingPreBindPlugin{}
+
+type BlockingPreBindPlugin struct {
+	handle fwk.Handle
+}
+
+func (p *BlockingPreBindPlugin) Name() string { return "BlockingPreBindPlugin" }
+
+func (p *BlockingPreBindPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	go func() { blockingPreBindStartCh <- struct{}{} }()
+	<-ctx.Done()
+	return fwk.AsStatus(ctx.Err())
+}
+
+func (p *BlockingPreBindPlugin) PreBindPreFlight(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.PreBindPreFlightResult, *fwk.Status) {
+	return &fwk.PreBindPreFlightResult{}, nil
+}
+
+func NewBlockingPreBindPlugin(_ context.Context, _ runtime.Object, h fwk.Handle) (fwk.Plugin, error) {
+	return &BlockingPreBindPlugin{handle: h}, nil
+}
+
 type TestPlugin struct {
 	name string
 }
@@ -718,6 +742,10 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		asyncAPICallsEnabled *bool
 		// If nil, the test case is run with both true and false
 		scheduleAsPodGroup *bool
+		// postSchedulingCycle is run after ScheduleOne function returns
+		// (synchronous part of scheduling is done and binding goroutine is launched)
+		// and before blocking execution on waiting for event with eventReason
+		postSchedulingCycle func(context.Context, *Scheduler)
 	}
 	table := []testItem{
 		{
@@ -899,6 +927,29 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			eventReason:             "FailedScheduling",
 		},
 		{
+			name:    "prebind pod cancelled during prebind (external preemption)",
+			sendPod: testPod,
+			registerPluginFuncs: []tf.RegisterPluginFunc{
+				tf.RegisterPreBindPlugin("BlockingPreBindPlugin", NewBlockingPreBindPlugin),
+			},
+			mockScheduleResult: scheduleResultOk,
+			postSchedulingCycle: func(ctx context.Context, sched *Scheduler) {
+				<-blockingPreBindStartCh // Wait for plugin to start
+				// Trigger preemption from "outside"
+				if bp := sched.Profiles[testSchedulerName].GetPodInPreBind(testPod.UID); bp != nil {
+					bp.CancelPod("context cancelled externally")
+				}
+			},
+			nominatedNodeNameForExpectationEnabled: ptr.To(true),
+			expectAssumedPod:                       assignedTestPod,
+			expectErrorPod:                         assignedTestPod,
+			expectForgetPod:                        assignedTestPod,
+			expectNominatedNodeName:                testNode.Name,
+			expectPodInBackoffQ:                    testPod,
+			expectError:                            fmt.Errorf(`running PreBind plugin "BlockingPreBindPlugin": context cancelled externally`),
+			eventReason:                            "FailedScheduling",
+		},
+		{
 			name:                "binding failed",
 			sendPod:             testPod,
 			injectBindError:     bindingErr,
@@ -1064,6 +1115,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			frameworkruntime.WithAPIDispatcher(apiDispatcher),
 			frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, testSchedulerName)),
 			frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+			frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 			frameworkruntime.WithInformerFactory(informerFactory),
 			frameworkruntime.WithWorkloadManager(wm),
 		)
@@ -1114,6 +1166,10 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		informerFactory.WaitForCacheSync(ctx.Done())
 		sched.nodeInfoSnapshot = internalcache.NewEmptySnapshot()
 		sched.ScheduleOne(ctx)
+
+		if item.postSchedulingCycle != nil {
+			item.postSchedulingCycle(ctx, sched)
+		}
 
 		if item.podToAdmit != nil {
 			for {
@@ -1684,6 +1740,7 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 						frameworkruntime.WithAPIDispatcher(apiDispatcher),
 						frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, testSchedulerName)),
 						frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+						frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 					)
 					if err != nil {
 						t.Fatal(err)
@@ -4562,6 +4619,7 @@ func setupTestScheduler(ctx context.Context, t *testing.T, client clientset.Inte
 		frameworkruntime.WithInformerFactory(informerFactory),
 		frameworkruntime.WithPodNominator(schedulingQueue),
 		frameworkruntime.WithWaitingPods(waitingPods),
+		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 		frameworkruntime.WithSnapshotSharedLister(snapshot),
 	)
 	if apiDispatcher != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -318,6 +318,9 @@ func New(ctx context.Context,
 	// waitingPods holds all the pods that are in the scheduler and waiting in the permit stage
 	waitingPods := frameworkruntime.NewWaitingPodsMap()
 
+	// podsInPreBind holds all the pods that are in the scheduler in the preBind phase
+	podsInPreBind := frameworkruntime.NewPodsInPreBindMap()
+
 	var resourceClaimCache *assumecache.AssumeCache
 	var resourceSliceTracker *resourceslicetracker.Tracker
 	var draManager fwk.SharedDRAManager
@@ -365,6 +368,7 @@ func New(ctx context.Context,
 		frameworkruntime.WithExtenders(extenders),
 		frameworkruntime.WithMetricsRecorder(metricsRecorder),
 		frameworkruntime.WithWaitingPods(waitingPods),
+		frameworkruntime.WithPodsInPreBind(podsInPreBind),
 		frameworkruntime.WithAPIDispatcher(apiDispatcher),
 		frameworkruntime.WithSharedCSIManager(sharedCSIManager),
 		frameworkruntime.WithWorkloadManager(workloadManager),

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -332,6 +332,19 @@ type WaitingPod interface {
 	Preempt(pluginName, msg string) bool
 }
 
+// PodInPreBind represents a pod currently in preBind phase.
+type PodInPreBind interface {
+	// CancelPod cancels the context attached to a goroutine running binding cycle of this pod
+	// if the pod is not marked as prebound.
+	// Returns true if the cancel was successfully run.
+	CancelPod(reason string) bool
+
+	// MarkPrebound marks the pod as prebound, making it impossible to cancel the context of binding cycle
+	// via PodInPreBind
+	// Returns false if the context was already canceled.
+	MarkPrebound() bool
+}
+
 // PreFilterResult wraps needed info for scheduler framework to act upon PreFilter phase.
 type PreFilterResult struct {
 	// The set of nodes that should be considered downstream; if nil then
@@ -738,6 +751,15 @@ type Handle interface {
 	// RejectWaitingPod rejects a waiting pod given its UID.
 	// The return value indicates if the pod is waiting or not.
 	RejectWaitingPod(uid types.UID) bool
+
+	// AddPodInPreBind adds a pod to the pods in preBind list.
+	AddPodInPreBind(uid types.UID, cancel context.CancelCauseFunc)
+
+	// GetPodInPreBind returns a pod that is in the binding cycle but before it is bound given its UID.
+	GetPodInPreBind(uid types.UID) PodInPreBind
+
+	// RemovePodInPreBind removes a pod from the pods in preBind list.
+	RemovePodInPreBind(uid types.UID)
 
 	// ClientSet returns a kubernetes clientSet.
 	ClientSet() clientset.Interface


### PR DESCRIPTION
/sig scheduling

#### What type of PR is this?

/kind feature
/hold 

#### What this PR does / why we need it:

This change allows the preemption to preempt a pod that is in prebind phase without issuing a delete call to the apiserver.

Pods are added to a special map of pods currently in prebind phase  and preemption can cancel the context that is used for given pod prebind phase, allowing it to gracefully handle error in the same manner as errors coming out from prebind plugins.


#### Which issue(s) this PR is related to:

Fixes #132332

#### Special notes for your reviewer:

This change will introduce a small difference in behavior as now, the pods that are preempted when they are in the PreBind phase, will be put back in the queue, instead of being completely deleted from the cluster storage.

#### Does this PR introduce a user-facing change?
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Pods that are preempted when in PreBind phase will go back to backoff queue instead of being completely deleted from apisever.
```

