### PR TITLE
Improve RemoveStatusCondition by performing the operation in-place

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
@@ -69,22 +69,20 @@ func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Cond
 
 // RemoveStatusCondition removes the corresponding conditionType from conditions if present. Returns
 // true if it was present and got removed.
-// conditions must be non-nil.
+// return false if conditions is nil or an empty slice
 func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string) (removed bool) {
 	if conditions == nil || len(*conditions) == 0 {
 		return false
 	}
-	newConditions := make([]metav1.Condition, 0, len(*conditions)-1)
-	for _, condition := range *conditions {
-		if condition.Type != conditionType {
-			newConditions = append(newConditions, condition)
+
+	for i, condition := range *conditions {
+		if condition.Type == conditionType {
+			(*conditions) = append((*conditions)[:i], (*conditions)[i+1:]...)
+			return true
 		}
 	}
 
-	removed = len(*conditions) != len(newConditions)
-	*conditions = newConditions
-
-	return removed
+	return false
 }
 
 // FindStatusCondition finds the conditionType in conditions.

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go
@@ -75,14 +75,18 @@ func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string)
 		return false
 	}
 
-	for i, condition := range *conditions {
-		if condition.Type == conditionType {
-			(*conditions) = append((*conditions)[:i], (*conditions)[i+1:]...)
-			return true
+	var i, j int
+	for i = 0; i < len(*conditions); i++ {
+		if (*conditions)[i].Type == conditionType {
+			continue
 		}
+
+		(*conditions)[j] = (*conditions)[i]
+		j++
 	}
 
-	return false
+	*conditions = (*conditions)[:j]
+	return i != j
 }
 
 // FindStatusCondition finds the conditionType in conditions.

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions_test.go
@@ -117,17 +117,47 @@ func TestRemoveStatusCondition(t *testing.T) {
 		expected      []metav1.Condition
 	}{
 		{
-			name: "present",
+			name: "present-first",
 			conditions: []metav1.Condition{
 				{Type: "first"},
 				{Type: "second"},
 				{Type: "third"},
+			},
+			conditionType: "first",
+			expectRemoval: true,
+			expected: []metav1.Condition{
+				{Type: "second"},
+				{Type: "third"},
+			},
+		},
+		{
+			name: "present-last",
+			conditions: []metav1.Condition{
+				{Type: "first"},
+				{Type: "second"},
+				{Type: "third"},
+			},
+			conditionType: "third",
+			expectRemoval: true,
+			expected: []metav1.Condition{
+				{Type: "first"},
+				{Type: "second"},
+			},
+		},
+		{
+			name: "preserve-order",
+			conditions: []metav1.Condition{
+				{Type: "first"},
+				{Type: "second"},
+				{Type: "third"},
+				{Type: "fourth"},
 			},
 			conditionType: "second",
 			expectRemoval: true,
 			expected: []metav1.Condition{
 				{Type: "first"},
 				{Type: "third"},
+				{Type: "fourth"},
 			},
 		},
 		{
@@ -145,10 +175,25 @@ func TestRemoveStatusCondition(t *testing.T) {
 			},
 		},
 		{
-			name:          "empty_conditions",
+			name:          "single-condition",
+			expectRemoval: true,
+			conditions: []metav1.Condition{
+				{Type: "first"},
+			},
+			conditionType: "first",
+			expected:      []metav1.Condition{},
+		},
+		{
+			name:          "empty-conditions",
 			conditions:    []metav1.Condition{},
 			conditionType: "Foo",
 			expected:      []metav1.Condition{},
+		},
+		{
+			name:          "nil-conditions",
+			conditions:    nil,
+			conditionType: "Foo",
+			expected:      nil,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

This PR improves `RemoveStatusCondition` by performing this operation in-place instead of relocating conditions slice.
Current implementation re-allocates the full slice even when no condition has to be removed.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

Seeing the implementation of `SetStatusCondition` and the test cases for `RemoveStatusCondition` I assumed than no more than 1 conditions should have the specified `conditionType`, however I must precise that this new implementation compared to current one doesn't remove more than 1 condition from the conditions slice.
If this new behavior is not expected I can come up with a new implementation that remove all the conditions with the specific type AND update comments accordingly. If not, I can add a comment to specify this new behavior.

I added some extra test cases that I found useful, but new implementation passed all previous tests successfully

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
