### PR TITLE
PV Controller: add configurable concurrent syncs for PersistentVolume controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -332,6 +332,7 @@ func newPersistentVolumeBinderController(ctx context.Context, controllerContext 
 	params := persistentvolumecontroller.ControllerParameters{
 		KubeClient:                client,
 		SyncPeriod:                controllerContext.ComponentConfig.PersistentVolumeBinderController.PVClaimBinderSyncPeriod.Duration,
+		ConcurrentSyncs:           int(controllerContext.ComponentConfig.PersistentVolumeBinderController.PVClaimBinderConcurrentSyncs),
 		VolumePlugins:             plugins,
 		VolumeInformer:            controllerContext.InformerFactory.Core().V1().PersistentVolumes(),
 		ClaimInformer:             controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -161,6 +161,7 @@ var args = []string{
 	"--pv-recycler-minimum-timeout-nfs=200",
 	"--pv-recycler-timeout-increment-hostpath=45",
 	"--pvclaimbinder-sync-period=30s",
+	"--pvclaimbinder-concurrent-syncs=5",
 	"--resource-quota-sync-period=10m",
 	"--route-reconciliation-period=30s",
 	"--secondary-node-eviction-rate=0.05",
@@ -365,7 +366,8 @@ func TestAddFlags(t *testing.T) {
 		},
 		PersistentVolumeBinderController: &PersistentVolumeBinderControllerOptions{
 			&persistentvolumeconfig.PersistentVolumeBinderControllerConfiguration{
-				PVClaimBinderSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
+				PVClaimBinderSyncPeriod:      metav1.Duration{Duration: 30 * time.Second},
+				PVClaimBinderConcurrentSyncs: 5,
 				VolumeConfiguration: persistentvolumeconfig.VolumeConfiguration{
 					EnableDynamicProvisioning:  false,
 					EnableHostPathProvisioning: true,
@@ -531,6 +533,13 @@ func TestValidateFlags(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "concurrent pvclaimbinder syncs set to 0",
+			flags: []string{
+				"--pvclaimbinder-concurrent-syncs=0",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -692,7 +701,8 @@ func TestApplyTo(t *testing.T) {
 				UnhealthyZoneThreshold:    0.6,
 			},
 			PersistentVolumeBinderController: persistentvolumeconfig.PersistentVolumeBinderControllerConfiguration{
-				PVClaimBinderSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
+				PVClaimBinderSyncPeriod:      metav1.Duration{Duration: 30 * time.Second},
+				PVClaimBinderConcurrentSyncs: 5,
 				VolumeConfiguration: persistentvolumeconfig.VolumeConfiguration{
 					EnableDynamicProvisioning:  false,
 					EnableHostPathProvisioning: true,

--- a/pkg/controller/volume/persistentvolume/config/types.go
+++ b/pkg/controller/volume/persistentvolume/config/types.go
@@ -26,6 +26,10 @@ type PersistentVolumeBinderControllerConfiguration struct {
 	// pvClaimBinderSyncPeriod is the period for syncing persistent volumes
 	// and persistent volume claims.
 	PVClaimBinderSyncPeriod metav1.Duration
+	// PVClaimBinderConcurrentSyncs is the number of PVCs that are
+	// allowed to sync concurrently. Larger number = more responsive PVC binding,
+	// but more CPU (and network) load.
+	PVClaimBinderConcurrentSyncs int32
 	// volumeConfiguration holds configuration for volume related features.
 	VolumeConfiguration VolumeConfiguration
 }

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
@@ -38,7 +38,9 @@ func RecommendedDefaultPersistentVolumeBinderControllerConfiguration(obj *kubect
 	if obj.PVClaimBinderSyncPeriod == zero {
 		obj.PVClaimBinderSyncPeriod = metav1.Duration{Duration: 15 * time.Second}
 	}
-
+	if obj.PVClaimBinderConcurrentSyncs == 0 {
+		obj.PVClaimBinderConcurrentSyncs = 5
+	}
 	// Use the default VolumeConfiguration options.
 	RecommendedDefaultVolumeConfiguration(&obj.VolumeConfiguration)
 }

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
@@ -103,6 +103,7 @@ func Convert_v1_GroupResource_To_v1alpha1_GroupResource(in *v1.GroupResource, ou
 
 func autoConvert_v1alpha1_PersistentVolumeBinderControllerConfiguration_To_config_PersistentVolumeBinderControllerConfiguration(in *configv1alpha1.PersistentVolumeBinderControllerConfiguration, out *config.PersistentVolumeBinderControllerConfiguration, s conversion.Scope) error {
 	out.PVClaimBinderSyncPeriod = in.PVClaimBinderSyncPeriod
+	out.PVClaimBinderConcurrentSyncs = in.PVClaimBinderConcurrentSyncs
 	if err := Convert_v1alpha1_VolumeConfiguration_To_config_VolumeConfiguration(&in.VolumeConfiguration, &out.VolumeConfiguration, s); err != nil {
 		return err
 	}
@@ -111,6 +112,7 @@ func autoConvert_v1alpha1_PersistentVolumeBinderControllerConfiguration_To_confi
 
 func autoConvert_config_PersistentVolumeBinderControllerConfiguration_To_v1alpha1_PersistentVolumeBinderControllerConfiguration(in *config.PersistentVolumeBinderControllerConfiguration, out *configv1alpha1.PersistentVolumeBinderControllerConfiguration, s conversion.Scope) error {
 	out.PVClaimBinderSyncPeriod = in.PVClaimBinderSyncPeriod
+	out.PVClaimBinderConcurrentSyncs = in.PVClaimBinderConcurrentSyncs
 	if err := Convert_config_VolumeConfiguration_To_v1alpha1_VolumeConfiguration(&in.VolumeConfiguration, &out.VolumeConfiguration, s); err != nil {
 		return err
 	}

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -226,6 +226,7 @@ func newTestController(ctx context.Context, kubeClient clientset.Interface, info
 	params := ControllerParameters{
 		KubeClient:                kubeClient,
 		SyncPeriod:                5 * time.Second,
+		ConcurrentSyncs:           1, // Use single worker for tests to avoid race conditions
 		VolumePlugins:             []volume.VolumePlugin{},
 		VolumeInformer:            informerFactory.Core().V1().PersistentVolumes(),
 		ClaimInformer:             informerFactory.Core().V1().PersistentVolumeClaims(),

--- a/pkg/controller/volume/persistentvolume/keymutex.go
+++ b/pkg/controller/volume/persistentvolume/keymutex.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolume
+
+import "sync"
+
+// keyMutex provides per-key mutual exclusion so work on the same object
+// does not run concurrently while allowing different keys to proceed in
+// parallel.
+type keyMutex struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+// Lock returns a function that must be called to unlock the mutex for the given key.
+func (km *keyMutex) Lock(key string) func() {
+	km.mu.Lock()
+	if km.locks == nil {
+		km.locks = make(map[string]*sync.Mutex)
+	}
+	m, ok := km.locks[key]
+	if !ok {
+		m = &sync.Mutex{}
+		km.locks[key] = m
+	}
+	km.mu.Unlock()
+
+	m.Lock()
+	return m.Unlock
+}

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -159,6 +159,7 @@ type PersistentVolumeController struct {
 	volumePluginMgr           vol.VolumePluginMgr
 	enableDynamicProvisioning bool
 	resyncPeriod              time.Duration
+	workers                   int
 
 	// Cache of the last known version of volumes and claims. This cache is
 	// thread safe as long as the volumes/claims there are not modified, they

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -183,15 +183,18 @@ type PersistentVolumeController struct {
 	volumes persistentVolumeOrderedIndex
 	claims  cache.Store
 
-	// Work queues of claims and volumes to process. Every queue should have
-	// exactly one worker thread, especially syncClaim() is not reentrant.
-	// Two syncClaims could bind two different claims to the same volume or one
-	// claim to two volumes. The controller would recover from this (due to
-	// version errors in API server and other checks in this controller),
-	// however overall speed of multi-worker controller would be lower than if
-	// it runs single thread only.
+	// Work queues of claims and volumes to process. Multiple workers can process
+	// different items concurrently, but each volume/claim key is protected by
+	// keyMutex to ensure syncVolume/syncClaim are not called concurrently for
+	// the same object.
 	claimQueue  *workqueue.Typed[string]
 	volumeQueue *workqueue.Typed[string]
+
+	// Mutexes to ensure only one worker processes the same volume/claim at a time.
+	// This allows multiple workers to process different volumes/claims concurrently
+	// while preventing concurrent processing of the same object.
+	volumeMutex keyMutex
+	claimMutex  keyMutex
 
 	// Map of scheduled/running operations.
 	runningOperations goroutinemap.GoRoutineMap
@@ -1092,10 +1095,37 @@ func (ctrl *PersistentVolumeController) bindClaimToVolume(ctx context.Context, c
 // both objects as Bound. Volume is saved first.
 // It returns on first error, it's up to the caller to implement some retry
 // mechanism.
+// This function acquires locks for both volume and claim in lexicographic order
+// to prevent deadlock. Callers MUST release any held locks before calling this.
 func (ctrl *PersistentVolumeController) bind(ctx context.Context, volume *v1.PersistentVolume, claim *v1.PersistentVolumeClaim) error {
-	var err error
-	// use updateClaim/updatedVolume to keep the original claim/volume for
-	// logging in error cases.
+	volumeKey := volume.Name
+	claimKey := claimToClaimKey(claim)
+
+	// Acquire locks in lexicographic order to avoid deadlock
+	var unlockVolume, unlockClaim func()
+	if volumeKey < claimKey {
+		unlockVolume = ctrl.volumeMutex.Lock(volumeKey)
+		unlockClaim = ctrl.claimMutex.Lock(claimKey)
+	} else {
+		unlockClaim = ctrl.claimMutex.Lock(claimKey)
+		unlockVolume = ctrl.volumeMutex.Lock(volumeKey)
+	}
+	defer unlockVolume()
+	defer unlockClaim()
+
+	// Re-fetch latest versions after acquiring locks to ensure we have the latest state
+	volumeObj, found, err := ctrl.volumes.store.GetByKey(volumeKey)
+	if err != nil || !found {
+		return fmt.Errorf("volume %s not found in cache: %w", volumeKey, err)
+	}
+	volume = volumeObj.(*v1.PersistentVolume)
+
+	claimObj, found, err := ctrl.claims.GetByKey(claimKey)
+	if err != nil || !found {
+		return fmt.Errorf("claim %s not found in cache: %w", claimKey, err)
+	}
+	claim = claimObj.(*v1.PersistentVolumeClaim)
+
 	var updatedClaim *v1.PersistentVolumeClaim
 	var updatedVolume *v1.PersistentVolume
 

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -423,6 +423,10 @@ type PersistentVolumeBinderControllerConfiguration struct {
 	// pvClaimBinderSyncPeriod is the period for syncing persistent volumes
 	// and persistent volume claims.
 	PVClaimBinderSyncPeriod metav1.Duration
+	// PVClaimBinderConcurrentSyncs is the number of PVCs that are
+	// allowed to sync concurrently. Larger number = more responsive PVC binding,
+	// but more CPU (and network) load.
+	PVClaimBinderConcurrentSyncs int32
 	// volumeConfiguration holds configuration for volume related features.
 	VolumeConfiguration VolumeConfiguration
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Previously, the PV controller ran with a fixed number of workers (one volume worker and one claim worker). This change makes the worker count configurable so that operators can increase concurrency, improving controller responsiveness and reducing PVC binding latency introduced by the periodic (15s by default) resync of the volume and claim workqueues.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --pvclaimbinder-concurrent-syncs flag to configure PV controller workers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
