### PR TITLE
Enable Declarative Validation for LimitRange

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -40,6 +40,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type LimitRange
+	scheme.AddValidationFunc((*corev1.LimitRange)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_LimitRange(ctx, op, nil /* fldPath */, obj.(*corev1.LimitRange), safe.Cast[*corev1.LimitRange](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
+	// type LimitRangeList
+	scheme.AddValidationFunc((*corev1.LimitRangeList)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_LimitRangeList(ctx, op, nil /* fldPath */, obj.(*corev1.LimitRangeList), safe.Cast[*corev1.LimitRangeList](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type ReplicationController
 	scheme.AddValidationFunc((*corev1.ReplicationController)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -57,6 +73,57 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_LimitRange validates an instance of LimitRange according
+// to declarative validation rules in the API schema.
+func Validate_LimitRange(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *corev1.LimitRange) (errs field.ErrorList) {
+	// field corev1.LimitRange.TypeMeta has no validation
+
+	// field corev1.LimitRange.ObjectMeta
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *metav1.ObjectMeta, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call field-attached validations
+			func() { // cohort name
+				earlyReturn := false
+				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue); len(e) != 0 {
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "name", func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.LongName)...)
+			}()
+			return
+		}(fldPath.Child("metadata"), &obj.ObjectMeta, safe.Field(oldObj, func(oldObj *corev1.LimitRange) *metav1.ObjectMeta { return &oldObj.ObjectMeta }), oldObj != nil)...)
+
+	// field corev1.LimitRange.Spec has no validation
+	return errs
+}
+
+// Validate_LimitRangeList validates an instance of LimitRangeList according
+// to declarative validation rules in the API schema.
+func Validate_LimitRangeList(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *corev1.LimitRangeList) (errs field.ErrorList) {
+	// field corev1.LimitRangeList.TypeMeta has no validation
+	// field corev1.LimitRangeList.ListMeta has no validation
+
+	// field corev1.LimitRangeList.Items
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []corev1.LimitRange, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// iterate the list and call the type's validation function
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_LimitRange)...)
+			return
+		}(fldPath.Child("items"), obj.Items, safe.Field(oldObj, func(oldObj *corev1.LimitRangeList) []corev1.LimitRange { return oldObj.Items }), oldObj != nil)...)
+
+	return errs
 }
 
 // Validate_ReplicationController validates an instance of ReplicationController according

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -299,11 +299,6 @@ var ValidateNodeName = apimachineryvalidation.NameIsDNSSubdomain
 // trailing dashes are allowed.
 var ValidateNamespaceName = apimachineryvalidation.ValidateNamespaceName
 
-// ValidateLimitRangeName can be used to check whether the given limit range name is valid.
-// Prefix indicates this name will be used as part of generation, in which case
-// trailing dashes are allowed.
-var ValidateLimitRangeName = apimachineryvalidation.NameIsDNSSubdomain
-
 // ValidateResourceQuotaName can be used to check whether the given
 // resource quota name is valid.
 // Prefix indicates this name will be used as part of generation, in which case
@@ -7512,7 +7507,10 @@ func validateLimitRangeResourceName(limitType core.LimitType, value core.Resourc
 
 // ValidateLimitRange tests if required fields in the LimitRange are set.
 func ValidateLimitRange(limitRange *core.LimitRange) field.ErrorList {
-	allErrs := ValidateObjectMeta(&limitRange.ObjectMeta, true, ValidateLimitRangeName, field.NewPath("metadata"))
+	validateLongName := func(fldPath *field.Path, name string) field.ErrorList {
+		return validate.LongName(context.Background(), operation.Operation{}, fldPath, &name, nil).MarkCoveredByDeclarative()
+	}
+	allErrs := ValidateObjectMetaWithOpts(&limitRange.ObjectMeta, true, validateLongName, field.NewPath("metadata"))
 
 	// ensure resource names are properly qualified per docs/design/resources.md
 	limitTypeSet := map[core.LimitType]bool{}

--- a/pkg/registry/core/limitrange/declarative_validation_test.go
+++ b/pkg/registry/core/limitrange/declarative_validation_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitrange
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestDeclarativeValidate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:          "",
+		APIVersion:        "v1",
+		Resource:          "limitranges",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	testCases := map[string]struct {
+		input        api.LimitRange
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidLimitRange(),
+		},
+		"name: empty": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = ""
+			}),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("metadata.name"), ""),
+			},
+		},
+		"name: invalid characters": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = "^Invalid"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		"name: label format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = "this-is-a-label"
+			}),
+		},
+		"name: subdomain format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = "this.is.a.subdomain"
+			}),
+		},
+		"name: invalid label format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = "-this-is-not-a-label"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		"name: invalid subdomain format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = ".this.is.not.a.subdomain"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		"name: label format with trailing dash": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = "this-is-a-label-"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		"name: subdomain format with trailing dash": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = "this.is.a.subdomain-"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		"name: long label format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = strings.Repeat("x", 253)
+			}),
+		},
+		"name: long subdomain format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = strings.Repeat("x.", 126) + "x"
+			}),
+		},
+		"name: too long label format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = strings.Repeat("x", 254)
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		"name: too long subdomain format": {
+			input: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = strings.Repeat("x.", 126) + "xx"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		// TODO: Add more test cases as validation tags are migrated
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:          "",
+		APIVersion:        "v1",
+		Resource:          "limitranges",
+		Name:              "valid-limit-range",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
+
+	testCases := map[string]struct {
+		oldObj       api.LimitRange
+		updateObj    api.LimitRange
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			oldObj:    mkValidLimitRange(func(obj *api.LimitRange) { obj.ResourceVersion = "1" }),
+			updateObj: mkValidLimitRange(func(obj *api.LimitRange) { obj.ResourceVersion = "1" }),
+		},
+		// Note: LimitRange's ValidateUpdate doesn't call ValidateObjectMetaUpdate, so
+		// name immutability isn't explicitly checked - it just re-validates the format.
+		// This test exists to verify the DV framework is correctly wired up on
+		// the update path and produces the same error as the hand-written validation.
+		"name: invalid format on update": {
+			oldObj: mkValidLimitRange(func(obj *api.LimitRange) { obj.ResourceVersion = "1" }),
+			updateObj: mkValidLimitRange(func(obj *api.LimitRange) {
+				obj.Name = "-invalid-name"
+				obj.ResourceVersion = "1"
+			}),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("metadata.name"), nil, "").WithOrigin("format=k8s-long-name"),
+			},
+		},
+		// TODO: Add more test cases as validation tags are migrated
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+func mkValidLimitRange(tweaks ...func(obj *api.LimitRange)) api.LimitRange {
+	obj := api.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-limit-range",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{},
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}

--- a/pkg/registry/core/limitrange/strategy.go
+++ b/pkg/registry/core/limitrange/strategy.go
@@ -19,9 +19,11 @@ package limitrange
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -53,7 +55,8 @@ func (limitrangeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime
 
 func (limitrangeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	limitRange := obj.(*api.LimitRange)
-	return validation.ValidateLimitRange(limitRange)
+	allErrs := validation.ValidateLimitRange(limitRange)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -71,7 +74,8 @@ func (limitrangeStrategy) AllowCreateOnUpdate() bool {
 
 func (limitrangeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	limitRange := obj.(*api.LimitRange)
-	return validation.ValidateLimitRange(limitRange)
+	allErrs := validation.ValidateLimitRange(limitRange)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2353,6 +2353,8 @@ message LimitRange {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
+  // +k8s:subfield(name)=+k8s:optional
+  // +k8s:subfield(name)=+k8s:format=k8s-long-name
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the limits enforced.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7662,6 +7662,8 @@ type LimitRange struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
+	// +k8s:subfield(name)=+k8s:optional
+	// +k8s:subfield(name)=+k8s:format=k8s-long-name
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec defines the limits enforced.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enables the declarative validation framework for `LimitRange` in the core/v1 API group and migrates the `metadata.name` validation.

- Updates `LimitRange` strategy to call `ValidateDeclarativelyWithMigrationChecks`
- Adds `+k8s:subfield(name)` tags to migrate `metadata.name` validation (k8s-long-name format)
- Marks hand-written name validation as covered by declarative validation
- Adds comprehensive declarative validation tests for create and update operations

#### Which issue(s) this PR is related to:

Part of #134280

#### Special notes for your reviewer:

The core/v1 `doc.go` already has validation-gen enabled from PR #130724. This PR migrates the `metadata.name` validation using the same pattern as ReplicationController (PR #134347) to prove the DV framework is wired up correctly.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation:

- [KEP-5073](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen)