### PR TITLE
fix(e2e): Fix HPA CPU test flake by using dynamic stability check range

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -223,7 +223,7 @@ func (st *HPAScaleTest) run(ctx context.Context, name string, kind schema.GroupV
 
 	rc.WaitForReplicas(ctx, st.firstScale, timeToWait)
 	if st.firstScaleStasis > 0 {
-		rc.EnsureDesiredReplicasInRange(ctx, st.firstScale, st.firstScale+1, st.firstScaleStasis, hpa.Name)
+		rc.EnsureDesiredReplicasInRange(ctx, st.firstScale, int(st.maxPods)-1, st.firstScaleStasis, hpa.Name)
 	}
 	if st.resourceType == cpuResource && st.cpuBurst > 0 && st.secondScale > 0 {
 		rc.ConsumeCPU(st.cpuBurst)
@@ -246,20 +246,20 @@ func scaleUp(ctx context.Context, name string, kind schema.GroupVersionKind, res
 		perPodMemRequest: 500,
 		targetValue:      getTargetValueByType(100, 20, metricTargetType),
 		minPods:          1,
-		maxPods:          4,
+		maxPods:          5,
 		firstScale:       3,
 		firstScaleStasis: stasis,
-		secondScale:      4,
+		secondScale:      5,
 		resourceType:     resourceType,
 		metricTargetType: metricTargetType,
 	}
 	if resourceType == cpuResource {
 		st.initCPUTotal = 250
-		st.cpuBurst = 500
+		st.cpuBurst = 700
 	}
 	if resourceType == memResource {
 		st.initMemTotal = 250
-		st.memBurst = 500
+		st.memBurst = 700
 	}
 	st.run(ctx, name, kind, f)
 }

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -246,20 +246,20 @@ func scaleUp(ctx context.Context, name string, kind schema.GroupVersionKind, res
 		perPodMemRequest: 500,
 		targetValue:      getTargetValueByType(100, 20, metricTargetType),
 		minPods:          1,
-		maxPods:          5,
+		maxPods:          4,
 		firstScale:       3,
 		firstScaleStasis: stasis,
-		secondScale:      5,
+		secondScale:      4,
 		resourceType:     resourceType,
 		metricTargetType: metricTargetType,
 	}
 	if resourceType == cpuResource {
 		st.initCPUTotal = 250
-		st.cpuBurst = 700
+		st.cpuBurst = 500
 	}
 	if resourceType == memResource {
 		st.initMemTotal = 250
-		st.memBurst = 700
+		st.memBurst = 500
 	}
 	st.run(ctx, name, kind, f)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR fixes a flaking HPA CPU test by making the stability check range dynamic based on `maxPods`.

**Changes:**
```go
// Before (flaky)
rc.EnsureDesiredReplicasInRange(ctx, st.firstScale, st.firstScale+1, ...)

// After (fixed)
rc.EnsureDesiredReplicasInRange(ctx, st.firstScale, int(st.maxPods)-1, ...)
```

#### Which issue(s) this PR is related to:

#134171

#### Special notes for your reviewer:

The root cause was a configuration mismatch not a bug in HPA logic.

#### Does this PR introduce a user-facing change?

```release-note
NONE
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A