### PR TITLE
Promote workqueue metrics from ALPHA to BETA

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -41,21 +41,21 @@ var (
 	depth = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
 		Subsystem:      WorkQueueSubsystem,
 		Name:           DepthKey,
-		StabilityLevel: k8smetrics.ALPHA,
+		StabilityLevel: k8smetrics.BETA,
 		Help:           "Current depth of workqueue",
 	}, []string{"name"})
 
 	adds = k8smetrics.NewCounterVec(&k8smetrics.CounterOpts{
 		Subsystem:      WorkQueueSubsystem,
 		Name:           AddsKey,
-		StabilityLevel: k8smetrics.ALPHA,
+		StabilityLevel: k8smetrics.BETA,
 		Help:           "Total number of adds handled by workqueue",
 	}, []string{"name"})
 
 	latency = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
 		Subsystem:      WorkQueueSubsystem,
 		Name:           QueueLatencyKey,
-		StabilityLevel: k8smetrics.ALPHA,
+		StabilityLevel: k8smetrics.BETA,
 		Help:           "How long in seconds an item stays in workqueue before being requested.",
 		Buckets:        k8smetrics.ExponentialBuckets(10e-9, 10, 10),
 	}, []string{"name"})
@@ -63,7 +63,7 @@ var (
 	workDuration = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
 		Subsystem:      WorkQueueSubsystem,
 		Name:           WorkDurationKey,
-		StabilityLevel: k8smetrics.ALPHA,
+		StabilityLevel: k8smetrics.BETA,
 		Help:           "How long in seconds processing an item from workqueue takes.",
 		Buckets:        k8smetrics.ExponentialBuckets(10e-9, 10, 10),
 	}, []string{"name"})
@@ -71,7 +71,7 @@ var (
 	unfinished = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
 		Subsystem:      WorkQueueSubsystem,
 		Name:           UnfinishedWorkKey,
-		StabilityLevel: k8smetrics.ALPHA,
+		StabilityLevel: k8smetrics.BETA,
 		Help: "How many seconds of work has done that " +
 			"is in progress and hasn't been observed by work_duration. Large " +
 			"values indicate stuck threads. One can deduce the number of stuck " +
@@ -81,7 +81,7 @@ var (
 	longestRunningProcessor = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
 		Subsystem:      WorkQueueSubsystem,
 		Name:           LongestRunningProcessorKey,
-		StabilityLevel: k8smetrics.ALPHA,
+		StabilityLevel: k8smetrics.BETA,
 		Help: "How many seconds has the longest running " +
 			"processor for workqueue been running.",
 	}, []string{"name"})
@@ -89,7 +89,7 @@ var (
 	retries = k8smetrics.NewCounterVec(&k8smetrics.CounterOpts{
 		Subsystem:      WorkQueueSubsystem,
 		Name:           RetriesKey,
-		StabilityLevel: k8smetrics.ALPHA,
+		StabilityLevel: k8smetrics.BETA,
 		Help:           "Total number of retries handled by workqueue",
 	}, []string{"name"})
 

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -5486,28 +5486,28 @@
   subsystem: workqueue
   help: Total number of adds handled by workqueue
   type: Counter
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - name
 - name: depth
   subsystem: workqueue
   help: Current depth of workqueue
   type: Gauge
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - name
 - name: longest_running_processor_seconds
   subsystem: workqueue
   help: How many seconds has the longest running processor for workqueue been running.
   type: Gauge
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - name
 - name: queue_duration_seconds
   subsystem: workqueue
   help: How long in seconds an item stays in workqueue before being requested.
   type: Histogram
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - name
   buckets:
@@ -5525,7 +5525,7 @@
   subsystem: workqueue
   help: Total number of retries handled by workqueue
   type: Counter
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - name
 - name: unfinished_work_seconds
@@ -5534,14 +5534,14 @@
     by work_duration. Large values indicate stuck threads. One can deduce the number
     of stuck threads by observing the rate at which this increases.
   type: Gauge
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - name
 - name: work_duration_seconds
   subsystem: workqueue
   help: How long in seconds processing an item from workqueue takes.
   type: Histogram
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - name
   buckets:

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -3552,53 +3552,53 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_adds_total</div>
 	<div class="metric_help">Total number of adds handled by workqueue</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_depth</div>
 	<div class="metric_help">Current depth of workqueue</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_longest_running_processor_seconds</div>
 	<div class="metric_help">How many seconds has the longest running processor for workqueue been running.</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_queue_duration_seconds</div>
 	<div class="metric_help">How long in seconds an item stays in workqueue before being requested.</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_retries_total</div>
 	<div class="metric_help">Total number of retries handled by workqueue</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_unfinished_work_seconds</div>
 	<div class="metric_help">How many seconds of work has done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="gauge"><label class="metric_detail">Type:</label> <span class="metric_type">Gauge</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
+	</div><div class="metric" data-stability="beta">
 	<div class="metric_name">workqueue_work_duration_seconds</div>
 	<div class="metric_help">How long in seconds processing an item from workqueue takes.</div>
 	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">BETA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">name</span></li></ul>
 	</div>

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -256,6 +256,79 @@
   - 1310.72
   - 2621.44
   - 5242.88
+- name: adds_total
+  subsystem: workqueue
+  help: Total number of adds handled by workqueue
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+- name: depth
+  subsystem: workqueue
+  help: Current depth of workqueue
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - name
+- name: longest_running_processor_seconds
+  subsystem: workqueue
+  help: How many seconds has the longest running processor for workqueue been running.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - name
+- name: queue_duration_seconds
+  subsystem: workqueue
+  help: How long in seconds an item stays in workqueue before being requested.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - name
+  buckets:
+  - 1e-08
+  - 1e-07
+  - 1e-06
+  - 9.999999999999999e-06
+  - 9.999999999999999e-05
+  - 0.001
+  - 0.01
+  - 0.1
+  - 1
+  - 10
+- name: retries_total
+  subsystem: workqueue
+  help: Total number of retries handled by workqueue
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - name
+- name: unfinished_work_seconds
+  subsystem: workqueue
+  help: How many seconds of work has done that is in progress and hasn't been observed
+    by work_duration. Large values indicate stuck threads. One can deduce the number
+    of stuck threads by observing the rate at which this increases.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - name
+- name: work_duration_seconds
+  subsystem: workqueue
+  help: How long in seconds processing an item from workqueue takes.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - name
+  buckets:
+  - 1e-08
+  - 1e-07
+  - 1e-06
+  - 9.999999999999999e-06
+  - 9.999999999999999e-05
+  - 0.001
+  - 0.01
+  - 0.1
+  - 1
+  - 10
 - name: controller_admission_duration_seconds
   subsystem: admission
   namespace: apiserver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change


#### What this PR does / why we need it:

Promote the workqueue metrics from alpha to beta as agreed upon in the issue. Note the most recent user-facing change I could find was in 2018: https://github.com/kubernetes/kubernetes/pull/71300

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #135463
KEP: https://github.com/kubernetes/enhancements/issues/1206

#### Special notes for your reviewer:

I'm fairly new to this metric promotion process. Please let me know if I need to change which KEP I'm referencing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote workqueue metrics from ALPHA to BETA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/6c67c31ebeaf71083e22d7e5a8a66bc6587085df/keps/sig-instrumentation/1206-metrics-overhaul
```

/sig instrumentation