### PR TITLE
Replace non-contextual API `utilruntime.HandleError` within the new context-aware version when possible

### DIFF
--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -156,7 +156,7 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 
 // Run runs controller loops and returns when they are done
 func (e *Signer) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Starting")

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -111,7 +111,7 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 
 // Run runs controller loops and returns when they are done
 func (tc *TokenCleaner) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting token cleaner controller")

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -77,7 +77,7 @@ func NewCSRCleanerController(
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (ccc *CSRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting CSR cleaner controller")

--- a/pkg/controller/certificates/cleaner/pcrcleaner.go
+++ b/pkg/controller/certificates/cleaner/pcrcleaner.go
@@ -63,7 +63,7 @@ func NewPCRCleanerController(
 }
 
 func (c *PCRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PodCertificateRequest cleaner controller")

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
@@ -272,7 +272,7 @@ func (p *ClusterTrustBundlePublisher[T]) caContentChangedListener() dynamiccerti
 }
 
 func (p *ClusterTrustBundlePublisher[T]) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ClusterTrustBundle CA cert publisher controller")

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -101,7 +101,7 @@ type Publisher struct {
 
 // Run starts process
 func (c *Publisher) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting root CA cert publisher controller")

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -188,7 +188,7 @@ func ruleExists(haystack []rbacv1.PolicyRule, needle rbacv1.PolicyRule) bool {
 
 // Run starts the controller and blocks until stopCh is closed.
 func (c *ClusterRoleAggregationController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ClusterRoleAggregator controller")

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -132,7 +132,7 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 
 // Run starts the main goroutine responsible for watching and syncing jobs.
 func (jm *ControllerV2) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start event processing pipeline.
 	jm.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -299,7 +299,7 @@ func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interfa
 
 // Run begins watching and syncing daemon sets.
 func (dsc *DaemonSetsController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	dsc.eventBroadcaster.StartStructuredLogging(3)
 	dsc.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: dsc.kubeClient.CoreV1().Events("")})

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -161,7 +161,7 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 
 // Run begins watching and syncing.
 func (dc *DeploymentController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	dc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -756,7 +756,7 @@ func New(c clientset.Interface, podInformer coreinformers.PodInformer, claimInfo
 // Run starts the controller which will run until the context is done.
 // An error is returned for startup problems.
 func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name, "numWorkers", numWorkers)
 	defer logger.Info("Shut down controller", "controller", tc.name, "reason", context.Cause(ctx))

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -450,7 +450,7 @@ func verifyGroupKind(controllerRef *metav1.OwnerReference, expectedKind string, 
 }
 
 func (dc *DisruptionController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	// Start events processing pipeline.

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -182,7 +182,7 @@ type Controller struct {
 // Run will not return until stopCh is closed. workers determines how many
 // endpoints will be handled in parallel.
 func (e *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	e.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -272,7 +272,7 @@ type Controller struct {
 
 // Run will not return until stopCh is closed.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	c.eventBroadcaster.StartLogging(klog.Infof)

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -215,7 +215,7 @@ type Controller struct {
 
 // Run will not return until stopCh is closed.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	c.eventBroadcaster.StartLogging(klog.Infof)

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -130,7 +130,7 @@ func (gc *GarbageCollector) resyncMonitors(logger klog.Logger, deletableResource
 
 // Run starts garbage collector workers.
 func (gc *GarbageCollector) Run(ctx context.Context, workers int, initialSyncTimeout time.Duration) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	gc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -243,7 +243,7 @@ func newControllerWithClock(ctx context.Context, podInformer coreinformers.PodIn
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (jm *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	jm.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -198,7 +198,7 @@ func NewHorizontalController(
 
 // Run begins watching and syncing.
 func (a *HorizontalController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting HPA controller")

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -229,7 +229,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 
 // Run begins watching and syncing.
 func (rsc *ReplicaSetController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	rsc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -93,7 +93,7 @@ func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, le
 
 // Run starts one worker.
 func (c *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting storage version garbage collector")

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -123,7 +123,7 @@ func (rv *ResourceVersionController) enqueue(svm *svmv1beta1.StorageVersionMigra
 }
 
 func (rv *ResourceVersionController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", ResourceVersionControllerName)

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -136,7 +136,7 @@ func (svmc *SVMController) enqueue(svm *svmv1beta1.StorageVersionMigration) {
 }
 
 func (svmc *SVMController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", svmc.controllerName)

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -277,7 +277,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 
 // Run starts the controller which will run in loop until `stopCh` is closed.
 func (tc *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name)

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -121,7 +121,7 @@ var (
 
 // Run begins watching and syncing.
 func (ttlc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting TTL controller")

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -106,7 +106,7 @@ func New(ctx context.Context, jobInformer batchinformers.JobInformer, client cli
 
 // Run starts the workers to clean up Jobs.
 func (tc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting TTL after finished controller")

--- a/pkg/controller/validatingadmissionpolicystatus/controller.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -53,7 +53,7 @@ type Controller struct {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	var wg sync.WaitGroup
 	defer func() {

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -324,7 +324,7 @@ type attachDetachController struct {
 }
 
 func (adc *attachDetachController) Run(ctx context.Context) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	adc.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -168,7 +168,7 @@ func (ec *ephemeralController) onPVCDelete(obj interface{}) {
 }
 
 func (ec *ephemeralController) Run(ctx context.Context, workers int) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ephemeral volume controller")

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -322,7 +322,7 @@ func (expc *expandController) expand(logger klog.Logger, pvc *v1.PersistentVolum
 
 // TODO make concurrency configurable (workers argument). previously, nestedpendingoperations spawned unlimited goroutines
 func (expc *expandController) Run(ctx context.Context) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting expand controller")

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -296,7 +296,7 @@ func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *
 
 // Run starts all of this controller's control loops
 func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	ctrl.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -160,7 +160,7 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PVC protection controller")

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -75,7 +75,7 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PV protection controller")

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -343,7 +343,7 @@ func (c *Controller) enqueueAllPodsForCSIDriver(csiDriverName string) {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting SELinux warning controller")

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -200,7 +200,7 @@ func NewVACProtectionController(logger klog.Logger,
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting VAC protection controller")

--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
@@ -452,7 +452,7 @@ func (c *Controller) Enqueue() {
 
 // Run the controller until stopped.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	// make sure the work queue is shutdown which will trigger workers to end
 	defer c.queue.ShutDown()
 

--- a/pkg/controlplane/controller/defaultservicecidr/default_servicecidr_controller.go
+++ b/pkg/controlplane/controller/defaultservicecidr/default_servicecidr_controller.go
@@ -99,7 +99,7 @@ type Controller struct {
 
 // Start will not return until the default ServiceCIDR exists or stopCh is closed.
 func (c *Controller) Start(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	stopCh := ctx.Done()
 
 	c.eventBroadcaster = record.NewBroadcaster(record.WithContext(ctx))

--- a/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leaderelection_controller.go
@@ -75,7 +75,7 @@ type Controller struct {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 	defer func() {
 		err := c.leaseInformer.Informer().RemoveEventHandler(c.leaseRegistration)

--- a/pkg/controlplane/controller/leaderelection/leasecandidategc_controller.go
+++ b/pkg/controlplane/controller/leaderelection/leasecandidategc_controller.go
@@ -61,7 +61,7 @@ func NewLeaseCandidateGC(clientset kubernetes.Interface, gcCheckPeriod time.Dura
 
 // Run starts one worker.
 func (c *LeaseCandidateGCController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer klog.Infof("Shutting down apiserver leasecandidate garbage collector")
 
 	klog.Infof("Starting apiserver leasecandidate garbage collector")

--- a/pkg/controlplane/controller/legacytokentracking/controller.go
+++ b/pkg/controlplane/controller/legacytokentracking/controller.go
@@ -119,7 +119,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 
 // RunWithContext starts the controller sync loop with a context.
 func (c *Controller) RunWithContext(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -767,7 +767,7 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		if _, err := m.runner.Run(ctx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop); err != nil {
 			logger.Error(err, "PreStop hook failed", "pod", klog.KObj(pod), "podUID", pod.UID,
 				"containerName", containerSpec.Name, "containerID", containerID.String())
@@ -923,7 +923,7 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 	}
 	for _, container := range runningPod.Containers {
 		go func(container *kubecontainer.Container) {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithContext(ctx)
 			defer wg.Done()
 
 			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, container.Name)

--- a/pkg/kubelet/oom/oom_watcher_linux.go
+++ b/pkg/kubelet/oom/oom_watcher_linux.go
@@ -78,7 +78,7 @@ func (ow *realWatcher) Start(ctx context.Context, ref *v1.ObjectReference) error
 
 	go func() {
 		logger := klog.FromContext(ctx)
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithContext(ctx)
 
 		for event := range outStream {
 			if event.VictimContainerName == recordEventContainerName {

--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -107,7 +107,7 @@ type pluginManager struct {
 var _ PluginManager = &pluginManager{}
 
 func (pm *pluginManager) Run(ctx context.Context, sourcesReady config.SourcesReady, stopCh <-chan struct{}) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -214,7 +214,7 @@ func (w *worker) stop() {
 // Returns whether the worker should continue.
 func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	defer func() { recover() }() // Actually eat panics (HandleCrash takes care of logging)
-	defer runtime.HandleCrash(func(_ interface{}) { keepGoing = true })
+	defer runtime.HandleCrashWithContext(ctx, func(ctx context.Context, _ interface{}) { keepGoing = true })
 
 	logger := klog.FromContext(ctx)
 	startTime := time.Now()

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -298,7 +298,7 @@ func (e *VolumeAttachLimitExceededError) Error() string {
 
 func (vm *volumeManager) Run(ctx context.Context, sourcesReady config.SourcesReady) {
 	logger := klog.FromContext(ctx)
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	if vm.kubeClient != nil {
 		// start informer for CSIDriver

--- a/pkg/scheduler/util/assumecache/assume_cache.go
+++ b/pkg/scheduler/util/assumecache/assume_cache.go
@@ -519,7 +519,7 @@ func (c *AssumeCache) emitEvents() {
 			return
 		}
 		func() {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithLogger(c.logger)
 			deliver()
 		}()
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/apiapproval/apiapproval_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/apiapproval/apiapproval_controller.go
@@ -190,7 +190,7 @@ func (c *KubernetesAPIApprovalPolicyConformantConditionController) Run(workers i
 //
 //logcheck:context // RunWithContext should be used instead of Run in code which supports contextual logging.
 func (c *KubernetesAPIApprovalPolicyConformantConditionController) RunWithContext(workers int, ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.Infof("Starting KubernetesAPIApprovalPolicyConformantConditionController")

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
@@ -75,7 +75,7 @@ func (ec *EstablishingController) QueueCRD(key string, timeout time.Duration) {
 
 // RunWithContext starts the EstablishingController.
 func (ec *EstablishingController) RunWithContext(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer ec.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -196,7 +196,7 @@ func (c *ConditionController) Run(workers int, stopCh <-chan struct{}) {
 
 // RunWithContext is a context-aware version of Run.
 func (c *ConditionController) RunWithContext(workers int, ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.Infof("Starting NonStructuralSchemaConditionController")

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -299,7 +299,7 @@ func (c *NamingConditionController) Run(stopCh <-chan struct{}) {
 
 // RunWithContext is a context-aware version of Run.
 func (c *NamingConditionController) RunWithContext(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.Info("Starting NamingConditionController")

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn.go
@@ -127,7 +127,7 @@ func IsWebSocketRequestWithTunnelingProtocol(req *http.Request) bool {
 // IgnoreReceives reads from a WebSocket until it is closed, then returns. If timeout is set, the
 // read and write deadlines are pushed every time a new message is received.
 func IgnoreReceives(ws *websocket.Conn, timeout time.Duration) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ws.Request().Context())
 	var data []byte
 	for {
 		resetTimeout(ws, timeout)

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/stream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/stream.go
@@ -122,7 +122,7 @@ func (r *Reader) handle(ws *websocket.Conn) {
 	defer closeConn()
 
 	go func() {
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithContext(ws.Request().Context())
 		// This blocks until the connection is closed.
 		// Client should not send anything.
 		IgnoreReceives(ws, r.timeout)

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/stream_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/stream_test.go
@@ -167,7 +167,7 @@ func TestStreamSurvivesPanic(t *testing.T) {
 	}
 	r := NewReader(errs, false, NewDefaultReaderProtocols())
 
-	// do not call runtime.HandleCrash() in handler. Otherwise, the tests are interrupted.
+	// do not call runtime.HandleCrashWithContext(ctx) in handler. Otherwise, the tests are interrupted.
 	r.handleCrash = func(additionalHandlers ...func(interface{})) { recover() }
 
 	data, err := readWebSocket(r, t, nil)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -140,8 +140,8 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 				// This failure mode for the handler functions properly using the channel below.
 				recover()
 			}()
-			defer utilruntime.HandleCrash(
-				func(r interface{}) {
+			defer utilruntime.HandleCrashWithContext(ctx,
+				func(ctx context.Context, r interface{}) {
 					if r == nil {
 						return
 					}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
@@ -174,7 +174,7 @@ func (c *RequestHeaderAuthRequestController) AllowedClientNames() []string {
 
 // Run starts RequestHeaderAuthRequestController controller and blocks until stopCh is closed.
 func (c *RequestHeaderAuthRequestController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.Infof("Starting %s", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -297,7 +297,7 @@ func (s *WatchServer) HandleWS(ws *websocket.Conn) {
 	defer cleanup()
 
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ws.Request().Context())
 		// This blocks until the connection is closed.
 		// Client should not send anything.
 		wsstream.IgnoreReceives(ws, 0)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1263,7 +1263,7 @@ func (e *Store) DeleteCollection(ctx context.Context, deleteValidation rest.Vali
 	for i := 0; i < workersNumber; i++ {
 		go func() {
 			// panics don't cross goroutine boundaries
-			defer utilruntime.HandleCrash(func(panicReason interface{}) {
+			defer utilruntime.HandleCrashWithContext(ctx, func(ctx context.Context, panicReason interface{}) {
 				errs <- fmt.Errorf("DeleteCollection goroutine panicked: %v", panicReason)
 			})
 			defer wg.Done()
@@ -1288,7 +1288,7 @@ func (e *Store) DeleteCollection(ctx context.Context, deleteValidation rest.Vali
 	}
 	// In case of all workers exit, notify distributor.
 	go func() {
-		defer utilruntime.HandleCrash(func(panicReason interface{}) {
+		defer utilruntime.HandleCrashWithContext(ctx, func(ctx context.Context, panicReason interface{}) {
 			errs <- fmt.Errorf("DeleteCollection workers closer panicked: %v", panicReason)
 		})
 		wg.Wait()

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
@@ -199,7 +199,7 @@ func (c *ConfigMapCAController) RunOnce(ctx context.Context) error {
 
 // Run starts the kube-apiserver and blocks until stopCh is closed.
 func (c *ConfigMapCAController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.InfoS("Starting controller", "name", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go
@@ -155,7 +155,7 @@ func (c *DynamicFileCAContent) RunOnce(ctx context.Context) error {
 
 // Run starts the controller and blocks until stopCh is closed.
 func (c *DynamicFileCAContent) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.InfoS("Starting controller", "name", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_serving_content.go
@@ -129,7 +129,7 @@ func (c *DynamicCertKeyPairContent) RunOnce(ctx context.Context) error {
 
 // Run starts the controller and blocks until context is killed.
 func (c *DynamicCertKeyPairContent) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.queue.ShutDown()
 
 	klog.InfoS("Starting controller", "name", c.name)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filters
 
 import (
+	"context"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -65,7 +66,7 @@ func WithHTTPLogging(handler http.Handler) http.Handler {
 
 func withPanicRecovery(handler http.Handler, crashHandler func(http.ResponseWriter, *http.Request, interface{})) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		defer runtime.HandleCrash(func(err interface{}) {
+		defer runtime.HandleCrashWithContext(req.Context(), func(ctx context.Context, err interface{}) {
 			crashHandler(w, req, err)
 		})
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -533,7 +533,7 @@ func (s preparedGenericAPIServer) RunWithContext(ctx context.Context) error {
 	// If UDS profiling is enabled, start a local http server listening on that socket
 	if s.UnprotectedDebugSocket != nil {
 		go func() {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithContext(ctx)
 			klog.Error(s.UnprotectedDebugSocket.RunWithContext(ctx))
 		}()
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -196,7 +196,7 @@ func runPostStartHook(name string, entry postStartHookEntry, context PostStartHo
 	var err error
 	func() {
 		// don't let the hook *accidentally* panic and kill the server
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(context.Context)
 		err = entry.hook(context)
 	}()
 	// if the hook intentionally wants to kill server, let it.

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
@@ -92,7 +92,7 @@ func NewDynamicEncryptionConfiguration(
 
 // Run starts the controller and blocks until ctx is canceled.
 func (d *DynamicEncryptionConfigContent) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	klog.InfoS("Starting controller", "name", d.name)
 	defer klog.InfoS("Shutting down controller", "name", d.name)
@@ -101,7 +101,7 @@ func (d *DynamicEncryptionConfigContent) Run(ctx context.Context) {
 
 	wg.Add(1)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		defer wg.Done()
 		defer d.queue.ShutDown()
 		<-ctx.Done()
@@ -109,7 +109,7 @@ func (d *DynamicEncryptionConfigContent) Run(ctx context.Context) {
 
 	wg.Add(1)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		defer wg.Done()
 		d.runWorker(ctx)
 	}()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -434,7 +434,7 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
 }
 
 func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watchCacheInterval, resourceVersion uint64) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer close(c.result)
 	defer c.Stop()
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go
@@ -71,7 +71,7 @@ func (pr *ConditionalProgressRequester) Run(stopCh <-chan struct{}) {
 		ctx = metadata.NewOutgoingContext(ctx, pr.contextMetadata)
 	}
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 		<-stopCh
 		pr.mux.Lock()
 		defer pr.mux.Unlock()

--- a/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
@@ -109,7 +109,7 @@ func (f *defaultFeatureSupportChecker) checkClient(ctx context.Context, c client
 		}
 		f.checkingEndpoint[ep] = struct{}{}
 		go func(ep string) {
-			defer runtime.HandleCrash()
+			defer runtime.HandleCrashWithContext(ctx)
 			err := delayFunc.Until(ctx, true, true, func(ctx context.Context) (done bool, err error) {
 				internalErr := f.clientSupportsRequestWatchProgress(ctx, c, ep)
 				return internalErr == nil, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service.go
@@ -86,7 +86,7 @@ func NewGRPCService(ctx context.Context, endpoint string, callTimeout time.Durat
 	s.kmsClient = kmsapi.NewKeyManagementServiceClient(s.connection)
 
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 
 		<-ctx.Done()
 		_ = s.connection.Close()

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service.go
@@ -83,7 +83,7 @@ func NewGRPCService(ctx context.Context, endpoint, providerName string, callTime
 	s.kmsClient = kmsapi.NewKeyManagementServiceClient(s.connection)
 
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 
 		<-ctx.Done()
 		_ = s.connection.Close()

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peer_discovery.go
@@ -51,7 +51,7 @@ const (
 )
 
 func (h *peerProxyHandler) RunPeerDiscoveryCacheSync(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer h.peerLeaseQueue.ShutDown()
 	defer func() {
 		err := h.apiserverIdentityInformer.Informer().RemoveEventHandler(h.leaseRegistration)

--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -83,7 +83,7 @@ func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Objec
 	}
 	event := recorder.makeEvent(refRegarding, refRelated, timestamp, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithLogger(logger)
 		recorder.Action(watch.Added, event)
 	}()
 }

--- a/staging/src/k8s.io/client-go/tools/pager/pager.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager.go
@@ -219,7 +219,7 @@ func (p *ListPager) eachListChunkBuffered(ctx context.Context, options metav1.Li
 	chunkC := make(chan runtime.Object, p.PageBufferSize)
 	bgResultC := make(chan error, 1)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 
 		var err error
 		defer func() {

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -402,7 +402,7 @@ func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(*v1.Event)) w
 		return watch.NewEmptyWatch()
 	}
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(e.cancelationCtx)
 		for {
 			select {
 			case <-e.cancelationCtx.Done():

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -169,7 +169,7 @@ func (cnc *CloudNodeController) RunWithContext(ctx context.Context, controllerMa
 	cnc.recorder = cnc.broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"})
 	stopCh := ctx.Done()
 
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer cnc.workqueue.ShutDown()
 
 	// Start event processing pipeline.

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -104,7 +104,7 @@ func (c *CloudNodeLifecycleController) Run(ctx context.Context, controllerManage
 	c.broadcaster = record.NewBroadcaster(record.WithContext(ctx))
 	c.recorder = c.broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-lifecycle-controller"})
 
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	controllerManagerMetrics.ControllerStarted("cloud-node-lifecycle")
 	defer controllerManagerMetrics.ControllerStopped("cloud-node-lifecycle")
 

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -159,7 +159,7 @@ func (rc *RouteController) handleNodeUpdate(oldObj, newObj interface{}) {
 }
 
 func (rc *RouteController) Run(ctx context.Context, syncPeriod time.Duration, controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CloudControllerManagerWatchBasedRoutesReconciliation) && rc.workqueue != nil {
 		defer rc.workqueue.ShutDown()

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -223,7 +223,7 @@ func (c *Controller) Run(ctx context.Context, workers int, controllerManagerMetr
 	c.eventBroadcaster = record.NewBroadcaster(record.WithContext(ctx))
 	c.eventRecorder = c.eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "service-controller"})
 
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 	defer c.serviceQueue.ShutDown()
 	defer c.nodeQueue.ShutDown()
 

--- a/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents_windows.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/term/resizeevents_windows.go
@@ -27,7 +27,7 @@ import (
 // is closed.
 func monitorResizeEvents(fd uintptr, resizeEvents chan<- TerminalSize, stop chan struct{}) {
 	go func() {
-		defer runtime.HandleCrash()
+		defer runtime.HandleCrashWithContext(ctx)
 
 		size := GetSize(fd)
 		if size == nil {

--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/remotecommand/httpstream.go
@@ -411,7 +411,7 @@ WaitForStreams:
 func (*v1ProtocolHandler) supportsTerminalResizing() bool { return false }
 
 func handleResizeEvents(reqctx context.Context, stream io.Reader, channel chan<- remotecommand.TerminalSize) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(reqctx)
 	defer close(channel)
 
 	decoder := json.NewDecoder(stream)

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -152,7 +152,7 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
-	defer utilruntime.HandleCrash(func(_ interface{}) {
+	defer utilruntime.HandleCrashWithContext(r.Context(), func(ctx context.Context, _ interface{}) {
 		// Assume the crash happened before the response was written.
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 	})

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -160,7 +160,7 @@ func NewController(
 // is closed, at which point it will shutdown the workqueue and wait for
 // workers to finish processing their current work items.
 func (c *Controller) Run(ctx context.Context, workers int) error {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.workqueue.ShutDown()
 	logger := klog.FromContext(ctx)
 

--- a/test/e2e/framework/debug/resource_usage_gatherer.go
+++ b/test/e2e/framework/debug/resource_usage_gatherer.go
@@ -315,7 +315,7 @@ func getStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alp
 }
 
 func (w *resourceGatherWorker) gather(ctx context.Context, initialSleep time.Duration) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer w.wg.Done()
 	defer framework.Logf("Closing worker for %v", w.nodeName)
 	defer func() { w.finished = true }()


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
When possible, updates existing calls to the non-contextual API `utilruntime.HandleError` within the new context-aware version `utilruntime.HandleErrorWithContext` or `utilruntime.HandleErrorWithLogger`.

This is required as part of the Kubernetes structured logging initiative to ensure that log output from this component is structured, carries contextual fields, and correctly respects context cancellation signals.

#### Which issue(s) this PR is related to:
Related to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:
Context Prioritization: 

The inherited `context.Context` from the parent function was consistently reused and passed to the updated `HandleErrorWithContext` calls.

Where a context was absent but a logger was available, the call was updated to HandleErrorWithLogger.

Available context or logger instances stored as attributes of the implementing struct were used for the contextual calls (WithContext or WithLogger).

The context was extracted from any passed-in HTTP request or WebSocket object and used to complete the call to `HandleErrorWithContext`.

/wg structured-logging

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

- [Tracking Issue]: [https://github.com/kubernetes/kubernetes/issues/126379](https://github.com/kubernetes/kubernetes/issues/126379)

