### PR TITLE
Fix mounter issue with latest ubuntu 24.04 (nfs tests)

### DIFF
--- a/cluster/gce/gci/mounter/mounter.go
+++ b/cluster/gce/gci/mounter/mounter.go
@@ -28,6 +28,7 @@ const (
 	// Location of the mount file to use
 	chrootCmd        = "chroot"
 	mountCmd         = "mount"
+	mountBin         = "/bin/mount"
 	rootfs           = "rootfs"
 	nfsRPCBindErrMsg = "mount.nfs: rpc.statd is not running but is required for remote locking.\nmount.nfs: Either use '-o nolock' to keep locks local, or start statd.\nmount.nfs: an incorrect mount option was specified\n"
 	rpcBindCmd       = "/sbin/rpcbind"
@@ -60,12 +61,12 @@ func main() {
 	}
 }
 
-// MountInChroot is to run mount within chroot with the passing root directory
+// mountInChroot runs mount within chroot with the passing root directory
 func mountInChroot(rootfsPath string, args []string) error {
 	if _, err := os.Stat(rootfsPath); os.IsNotExist(err) {
 		return fmt.Errorf("path <%s> does not exist", rootfsPath)
 	}
-	args = append([]string{rootfsPath, mountCmd}, args...)
+	args = append([]string{rootfsPath, mountBin}, args...)
 	output, err := exec.Command(chrootCmd, args...).CombinedOutput()
 	if err == nil {
 		return nil


### PR DESCRIPTION
NFS tests are failing, see details in:
https://github.com/kubernetes/kubernetes/issues/135523

When we updated to Ubuntu 22.04 to 24.04, a whole bunch started failing, current situation is:
https://storage.googleapis.com/k8s-triage/index.html?test=nfs%7CNFS

When i started, timeline:
https://storage.googleapis.com/k8s-triage/index.html?date=2025-10-25&job=ubuntu&test=nfs%7CNFS

The fix was to use the full path `"/bin/mount"` inside chroot as the binary look up was failing.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
