### PR TITLE
lint: detect incorrect deprecation comments + extra links

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7757,7 +7757,7 @@
       "type": "object"
     },
     "io.k8s.api.core.v1.GitRepoVolumeSource": {
-      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
       "properties": {
         "directory": {
           "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -2812,7 +2812,7 @@
         "type": "object"
       },
       "io.k8s.api.core.v1.GitRepoVolumeSource": {
-        "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+        "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "properties": {
           "directory": {
             "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2710,7 +2710,7 @@
         "type": "object"
       },
       "io.k8s.api.core.v1.GitRepoVolumeSource": {
-        "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+        "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "properties": {
           "directory": {
             "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -2048,7 +2048,7 @@
         "type": "object"
       },
       "io.k8s.api.core.v1.GitRepoVolumeSource": {
-        "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+        "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
         "properties": {
           "directory": {
             "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/doc.go
@@ -22,7 +22,7 @@ limitations under the License.
 // Package v1beta3 defines the v1beta3 version of the kubeadm configuration file format.
 // This version improves on the v1beta2 format by fixing some minor issues and adding a few new fields.
 //
-// DEPRECATED: v1beta3 is deprecated in favor of v1beta4 and will be removed in a future release, 1.34 or later.
+// v1beta3 is deprecated in favor of v1beta4 and will be removed in a future release, 1.34 or later.
 // Please migrate.
 //
 // A list of changes since v1beta2:
@@ -282,4 +282,6 @@ limitations under the License.
 // node only (e.g. the node ip).
 //
 // - APIEndpoint, that represents the endpoint of the instance of the API server to be eventually deployed on this node.
+//
+// Deprecated: v1beta3 is deprecated in favor of v1beta4 and will be removed in a future release, 1.34 or later.
 package v1beta3

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -169,6 +169,7 @@ linters:
     - forbidigo
     - ginkgolinter
     - gocritic
+    - godoclint
     - govet
     - errorlint
     - ineffassign
@@ -411,6 +412,11 @@ linters:
         - pattern: ^gomega\.BeFalse$
           pkg: ^github.com/onsi/gomega$
           msg: "it does not produce a good failure message - use BeFalseBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
+    godoclint:
+      default: none
+      enable:
+        - deprecated
+        - no-unused-link
     revive:
       # Only these rules are enabled.
       rules:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -180,6 +180,7 @@ linters:
     - forbidigo
     - ginkgolinter
     - gocritic
+    - godoclint
     - govet
     - ineffassign
     - kubeapilinter
@@ -433,6 +434,11 @@ linters:
         - underef
         - unslice
         - valSwap
+    godoclint:
+      default: none
+      enable:
+        - deprecated
+        - no-unused-link
     revive:
       # Only these rules are enabled.
       rules:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -158,6 +158,7 @@ linters:
     - forbidigo
     - ginkgolinter
     - gocritic
+    - godoclint
     - govet
     {{- if .Hints}}
     - errorlint
@@ -234,7 +235,7 @@ linters:
           pkg: ^github.com/onsi/gomega$
           msg: "it does not produce a good failure message - use BeFalseBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"        
       {{- end}}
-      {{- if .Base }}
+    {{- if .Base }}
     gocritic:
       enabled-checks: # These are in addition to the default checks - see https://golangci-lint.run/docs/linters/configuration/#gocritic
         - boolExprSimplify
@@ -255,6 +256,11 @@ linters:
         - unslice
         - valSwap
     {{- end}}
+    godoclint:
+      default: none
+      enable:
+        - deprecated
+        - no-unused-link
     revive:
       # Only these rules are enabled.
       rules:

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -1134,7 +1134,7 @@ type AWSElasticBlockStoreVolumeSource struct {
 // Git repo volumes do not support ownership management.
 // Git repo volumes support SELinux relabeling.
 //
-// DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+// Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
 // EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
 // into the Pod's container.
 type GitRepoVolumeSource struct {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -24983,7 +24983,7 @@ func schema_k8sio_api_core_v1_GitRepoVolumeSource(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+				Description: "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"repository": {
@@ -36019,7 +36019,7 @@ func schema_k8sio_api_extensions_v1beta1_DaemonSet(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+				Description: "DaemonSet represents the configuration of a daemon set.\n\nDeprecated: This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2008,7 +2008,7 @@ message GRPCAction {
 // Git repo volumes do not support ownership management.
 // Git repo volumes support SELinux relabeling.
 //
-// DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+// Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
 // EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
 // into the Pod's container.
 message GitRepoVolumeSource {

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1397,7 +1397,7 @@ type AWSElasticBlockStoreVolumeSource struct {
 // Git repo volumes do not support ownership management.
 // Git repo volumes support SELinux relabeling.
 //
-// DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+// Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
 // EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
 // into the Pod's container.
 type GitRepoVolumeSource struct {

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -859,7 +859,7 @@ func (GRPCAction) SwaggerDoc() map[string]string {
 }
 
 var map_GitRepoVolumeSource = map[string]string{
-	"":           "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+	"":           "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
 	"repository": "repository is the URL",
 	"revision":   "revision is the commit hash for the specified revision.",
 	"directory":  "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -30,9 +30,10 @@ import "k8s.io/apimachinery/pkg/util/intstr/generated.proto";
 // Package-wide variables from generator "generated".
 option go_package = "k8s.io/api/extensions/v1beta1";
 
-// DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
-// more information.
 // DaemonSet represents the configuration of a daemon set.
+//
+// Deprecated: This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
+// more information.
 message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -536,9 +536,10 @@ type DaemonSetCondition struct {
 // +k8s:prerelease-lifecycle-gen:removed=1.16
 // +k8s:prerelease-lifecycle-gen:replacement=apps,v1,DaemonSet
 
-// DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
-// more information.
 // DaemonSet represents the configuration of a daemon set.
+//
+// Deprecated: This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
+// more information.
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -561,10 +562,11 @@ type DaemonSet struct {
 }
 
 const (
-	// DEPRECATED: DefaultDaemonSetUniqueLabelKey is used instead.
 	// DaemonSetTemplateGenerationKey is the key of the labels that is added
 	// to daemon set pods to distinguish between old and new pod templates
 	// during DaemonSet template update.
+	//
+	// Deprecated: DefaultDaemonSetUniqueLabelKey is used instead.
 	DaemonSetTemplateGenerationKey string = "pod-template-generation"
 
 	// DefaultDaemonSetUniqueLabelKey is the default label key that is added

--- a/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
@@ -28,7 +28,7 @@ package v1beta1
 
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_DaemonSet = map[string]string{
-	"":         "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+	"":         "DaemonSet represents the configuration of a daemon set.\n\nDeprecated: This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"spec":     "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 	"status":   "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/gitrepovolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/gitrepovolumesource.go
@@ -25,7 +25,7 @@ package v1
 // Git repo volumes do not support ownership management.
 // Git repo volumes support SELinux relabeling.
 //
-// DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+// Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
 // EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
 // into the Pod's container.
 type GitRepoVolumeSourceApplyConfiguration struct {

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
@@ -30,9 +30,10 @@ import (
 // DaemonSetApplyConfiguration represents a declarative configuration of the DaemonSet type for use
 // with apply.
 //
-// DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
-// more information.
 // DaemonSet represents the configuration of a daemon set.
+//
+// Deprecated: This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
+// more information.
 type DaemonSetApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:",inline"`
 	// Standard object's metadata.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

godoclint can (among other things) warn about incorrectly formatted deprecation notices. We don't want the other functionality (enforcing full documentation) but warning about deprecation notices and extra links seems useful.

https://github.com/kubernetes/kubernetes/pull/133571 already turned on a similar check in gocritic, but that missed a few instances.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/133566

#### Special notes for your reviewer:

Kudos to @babakks for suggesting godoclint.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/cc @BenTheElder @babakks