### PR TITLE
lint: Expand sorted linter to allow checking for sorted struct members

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -295,6 +295,7 @@ linters:
         settings:
           files:
             - cmd/kubeadm/app/features/features.go
+            - pkg/controller/apis/config/types.go
             - pkg/features/kube_features.go
             - staging/src/k8s.io/apiserver/pkg/features/kube_features.go
             - staging/src/k8s.io/client-go/features/known_features.go

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -304,6 +304,7 @@ linters:
         settings:
           files:
             - cmd/kubeadm/app/features/features.go
+            - pkg/controller/apis/config/types.go
             - pkg/features/kube_features.go
             - staging/src/k8s.io/apiserver/pkg/features/kube_features.go
             - staging/src/k8s.io/client-go/features/known_features.go

--- a/hack/tools/golangci-lint/sorted/README.md
+++ b/hack/tools/golangci-lint/sorted/README.md
@@ -120,6 +120,7 @@ linters:
 When no `files` configuration is provided, the linter checks these Kubernetes files:
 
 - `cmd/kubeadm/app/features/features.go`
+- `pkg/controller/apis/config/types.go`
 - `pkg/features/kube_features.go`
 - `staging/src/k8s.io/apiserver/pkg/features/kube_features.go`
 - `staging/src/k8s.io/client-go/features/known_features.go`
@@ -200,18 +201,6 @@ not sorted alphabetically:
 +	FeatureC = value
  )
 ```
-
-## Files Checked
-
-By default, this linter checks the following files in the Kubernetes codebase:
-
-- `pkg/features/kube_features.go`
-- `staging/src/k8s.io/apiserver/pkg/features/kube_features.go`
-- `staging/src/k8s.io/client-go/features/known_features.go`
-- `staging/src/k8s.io/controller-manager/pkg/features/kube_features.go`
-- `staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go`
-- `test/e2e/feature/feature.go`
-- `test/e2e/environment/environment.go`
 
 ## Integration with CI
 

--- a/hack/tools/golangci-lint/sorted/config.yaml
+++ b/hack/tools/golangci-lint/sorted/config.yaml
@@ -1,5 +1,6 @@
 files:
   - cmd/kubeadm/app/features/features.go
+  - pkg/controller/apis/config/types.go
   - pkg/features/kube_features.go
   - staging/src/k8s.io/apiserver/pkg/features/kube_features.go
   - staging/src/k8s.io/client-go/features/known_features.go

--- a/hack/tools/golangci-lint/sorted/example.golangci.yml
+++ b/hack/tools/golangci-lint/sorted/example.golangci.yml
@@ -6,7 +6,7 @@ linters:
         description: Checks if feature gates are sorted alphabetically
         original-url: k8s.io/kubernetes/hack/tools/golangci-lint/sorted
         settings:
-          debug: false
+          debug: true
           # Specify files to check (will ignore default files)
           files:
             - path/to/feature_gates.go
@@ -17,6 +17,7 @@ run:
   # This is separate from the sorted plugin's files setting
   paths:
     - staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+    - pkg/controller/apis/config/types.go
     - pkg/features/kube_features.go
     - staging/src/k8s.io/client-go/features/known_features.go
     - staging/src/k8s.io/controller-manager/pkg/features/kube_features.go

--- a/pkg/controller/apis/config/types.go
+++ b/pkg/controller/apis/config/types.go
@@ -54,32 +54,26 @@ import (
 type KubeControllerManagerConfiguration struct {
 	metav1.TypeMeta
 
-	// Generic holds configuration for a generic controller-manager
-	Generic cmconfig.GenericControllerManagerConfiguration
-	// KubeCloudSharedConfiguration holds configuration for shared related features
-	// both in cloud controller manager and kube-controller manager.
-	KubeCloudShared cpconfig.KubeCloudSharedConfiguration
-
 	// AttachDetachControllerConfiguration holds configuration for
 	// AttachDetachController related features.
 	AttachDetachController attachdetachconfig.AttachDetachControllerConfiguration
-	// CronJobControllerConfiguration holds configuration for CronJobController
-	// related features.
-	CronJobController cronjobconfig.CronJobControllerConfiguration
 	// CSRSigningControllerConfiguration holds configuration for
 	// CSRSigningController related features.
 	CSRSigningController csrsigningconfig.CSRSigningControllerConfiguration
+	// CronJobControllerConfiguration holds configuration for CronJobController
+	// related features.
+	CronJobController cronjobconfig.CronJobControllerConfiguration
 	// DaemonSetControllerConfiguration holds configuration for DaemonSetController
 	// related features.
 	DaemonSetController daemonconfig.DaemonSetControllerConfiguration
 	// DeploymentControllerConfiguration holds configuration for
 	// DeploymentController related features.
 	DeploymentController deploymentconfig.DeploymentControllerConfiguration
-	// DeviceTaintEvictionControllerConfiguration contains elements configuring the device taint eviction controller.
-	DeviceTaintEvictionController devicetaintevictionconfig.DeviceTaintEvictionControllerConfiguration
 	// DeprecatedControllerConfiguration holds configuration for some deprecated
 	// features.
 	DeprecatedController DeprecatedControllerConfiguration
+	// DeviceTaintEvictionControllerConfiguration contains elements configuring the device taint eviction controller.
+	DeviceTaintEvictionController devicetaintevictionconfig.DeviceTaintEvictionControllerConfiguration
 	// EndpointControllerConfiguration holds configuration for EndpointController
 	// related features.
 	EndpointController endpointconfig.EndpointControllerConfiguration
@@ -95,10 +89,15 @@ type KubeControllerManagerConfiguration struct {
 	// GarbageCollectorControllerConfiguration holds configuration for
 	// GarbageCollectorController related features.
 	GarbageCollectorController garbagecollectorconfig.GarbageCollectorControllerConfiguration
+	// Generic holds configuration for a generic controller-manager
+	Generic cmconfig.GenericControllerManagerConfiguration
 	// HPAControllerConfiguration holds configuration for HPAController related features.
 	HPAController poautosclerconfig.HPAControllerConfiguration
 	// JobControllerConfiguration holds configuration for JobController related features.
 	JobController jobconfig.JobControllerConfiguration
+	// KubeCloudSharedConfiguration holds configuration for shared related features
+	// both in cloud controller manager and kube-controller manager.
+	KubeCloudShared cpconfig.KubeCloudSharedConfiguration
 	// LegacySATokenCleanerConfiguration holds configuration for LegacySATokenCleaner related features.
 	LegacySATokenCleaner serviceaccountconfig.LegacySATokenCleanerConfiguration
 	// NamespaceControllerConfiguration holds configuration for NamespaceController


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This was brought up in https://github.com/kubernetes/kubernetes/pull/134152#discussion_r2490077678 and recently I reminded of it when reviewing https://github.com/kubernetes/kubernetes/pull/134701. 

This expands the sorted linter from https://github.com/kubernetes/kubernetes/pull/132668 with the ability to look into structures, like the ones from the above PRs and ensuring that members are sorted alphabetically. 

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:
/assign @dims @pohly 
since you were either authors or reviewers on this topic

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
