### PR TITLE
Fix ConvertToVersion to prefer object's GVK field over first registered kind

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/operation"
@@ -516,6 +517,35 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 		return nil, NewNotRegisteredErrForType(s.schemeName, t)
 	}
 
+	// If the object has a GVK set and multiple kinds are registered for the same Go type,
+	// reorder kinds so the object's group/kind is preferred. This ensures KindForGroupVersionKinds
+	// still receives the full list for priority decisions, but "first match" tie-breaking favors
+	// the object's actual kind.
+	originalKinds := kinds
+	objGVK := in.GetObjectKind().GroupVersionKind()
+	if len(objGVK.Kind) > 0 && len(objGVK.Version) > 0 && len(kinds) > 1 {
+		reordered := make([]schema.GroupVersionKind, 0, len(kinds))
+		var exactMatch []schema.GroupVersionKind
+		var groupKindMatch []schema.GroupVersionKind
+		var rest []schema.GroupVersionKind
+		for _, k := range kinds {
+			switch {
+			case k == objGVK:
+				exactMatch = append(exactMatch, k)
+			case k.Group == objGVK.Group && k.Kind == objGVK.Kind:
+				groupKindMatch = append(groupKindMatch, k)
+			default:
+				rest = append(rest, k)
+			}
+		}
+		if len(exactMatch) > 0 || len(groupKindMatch) > 0 {
+			reordered = append(reordered, exactMatch...)
+			reordered = append(reordered, groupKindMatch...)
+			reordered = append(reordered, rest...)
+			kinds = reordered
+		}
+	}
+
 	gvk, ok := target.KindForGroupVersionKinds(kinds)
 	if !ok {
 		// try to see if this type is listed as unversioned (for legacy support)
@@ -533,6 +563,19 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 	for _, kind := range kinds {
 		if gvk == kind {
 			return copyAndSetTargetKind(copy, in, gvk)
+		}
+	}
+
+	// If we reordered kinds and gvk was not found in the list, the target may have
+	// constructed a fallback GVK from the first element (e.g., InternalGroupVersioner).
+	// Reordering can change which element is first, producing an incorrect GVK.
+	// Retry with the original order to get the correct fallback.
+	if &kinds[0] != &originalKinds[0] {
+		if gvk2, ok := target.KindForGroupVersionKinds(originalKinds); ok {
+			if slices.Contains(originalKinds, gvk2) {
+				return copyAndSetTargetKind(copy, in, gvk2)
+			}
+			gvk = gvk2
 		}
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -520,29 +520,33 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 	// If the object has a GVK set and multiple kinds are registered for the same Go type,
 	// reorder kinds so the object's group/kind is preferred. This ensures KindForGroupVersionKinds
 	// still receives the full list for priority decisions, but "first match" tie-breaking favors
-	// the object's actual kind.
+	// the object's actual kind. The stable sort keeps registration order within each bucket.
 	originalKinds := kinds
-	objGVK := in.GetObjectKind().GroupVersionKind()
-	if len(objGVK.Kind) > 0 && len(objGVK.Version) > 0 && len(kinds) > 1 {
-		reordered := make([]schema.GroupVersionKind, 0, len(kinds))
-		var exactMatch []schema.GroupVersionKind
-		var groupKindMatch []schema.GroupVersionKind
-		var rest []schema.GroupVersionKind
-		for _, k := range kinds {
-			switch {
-			case k == objGVK:
-				exactMatch = append(exactMatch, k)
-			case k.Group == objGVK.Group && k.Kind == objGVK.Kind:
-				groupKindMatch = append(groupKindMatch, k)
-			default:
-				rest = append(rest, k)
+	reordered := false
+	if len(kinds) > 1 {
+		objGVK := in.GetObjectKind().GroupVersionKind()
+		if len(objGVK.Version) > 0 && len(objGVK.Kind) > 0 {
+			rank := func(k schema.GroupVersionKind) int {
+				switch {
+				case k == objGVK:
+					return 0
+				case k.Group == objGVK.Group && k.Kind == objGVK.Kind:
+					return 1
+				default:
+					return 2
+				}
 			}
-		}
-		if len(exactMatch) > 0 || len(groupKindMatch) > 0 {
-			reordered = append(reordered, exactMatch...)
-			reordered = append(reordered, groupKindMatch...)
-			reordered = append(reordered, rest...)
-			kinds = reordered
+			for _, k := range kinds {
+				if rank(k) < 2 {
+					sorted := slices.Clone(kinds)
+					slices.SortStableFunc(sorted, func(a, b schema.GroupVersionKind) int {
+						return rank(a) - rank(b)
+					})
+					kinds = sorted
+					reordered = true
+					break
+				}
+			}
 		}
 	}
 
@@ -570,7 +574,7 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 	// constructed a fallback GVK from the first element (e.g., InternalGroupVersioner).
 	// Reordering can change which element is first, producing an incorrect GVK.
 	// Retry with the original order to get the correct fallback.
-	if &kinds[0] != &originalKinds[0] {
+	if reordered {
 		if gvk2, ok := target.KindForGroupVersionKinds(originalKinds); ok {
 			if slices.Contains(originalKinds, gvk2) {
 				return copyAndSetTargetKind(copy, in, gvk2)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -1177,3 +1177,300 @@ func TestToOpenAPIDefinitionName(t *testing.T) {
 		})
 	}
 }
+
+// testApplication is a simple typed object for testing
+type testApplication struct {
+	runtime.TypeMeta `json:",inline"`
+	Data             string `json:"data,omitempty"`
+}
+
+func (t *testApplication) DeepCopyObject() runtime.Object {
+	return &testApplication{
+		TypeMeta: t.TypeMeta,
+		Data:     t.Data,
+	}
+}
+
+// testApplicationList is a simple typed list object for testing
+type testApplicationList struct {
+	runtime.TypeMeta `json:",inline"`
+	Items            []testApplication `json:"items"`
+}
+
+func (t *testApplicationList) DeepCopyObject() runtime.Object {
+	items := make([]testApplication, len(t.Items))
+	for i := range t.Items {
+		items[i] = *t.Items[i].DeepCopyObject().(*testApplication)
+	}
+	return &testApplicationList{
+		TypeMeta: t.TypeMeta,
+		Items:    items,
+	}
+}
+
+// TestConvertToVersionTypedObjectGVKFromField verifies that when multiple kinds are registered
+// with the same Go type, ConvertToVersion uses the GVK from the object's field instead of
+// selecting the first registered kind from typeToGVK.
+func TestConvertToVersionTypedObjectGVKFromField(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gv := schema.GroupVersion{Group: "test.cozystack.io", Version: "v1alpha1"}
+
+	// Register the same Go type with different kinds
+	kind1 := "BootBox"
+	kind2 := "Tenant"
+	kind3 := "Postgres"
+
+	gvk1 := gv.WithKind(kind1)
+	gvk2 := gv.WithKind(kind2)
+	gvk3 := gv.WithKind(kind3)
+
+	scheme.AddKnownTypeWithName(gvk1, &testApplication{})
+	scheme.AddKnownTypeWithName(gvk2, &testApplication{})
+	scheme.AddKnownTypeWithName(gvk3, &testApplication{})
+
+	// Create objects with different kinds set in their fields
+	obj1 := &testApplication{Data: "bootbox-data"}
+	obj1.SetGroupVersionKind(gvk1)
+
+	obj2 := &testApplication{Data: "tenant-data"}
+	obj2.SetGroupVersionKind(gvk2)
+
+	obj3 := &testApplication{Data: "postgres-data"}
+	obj3.SetGroupVersionKind(gvk3)
+
+	tests := []struct {
+		name        string
+		obj         *testApplication
+		expectedGVK schema.GroupVersionKind
+	}{
+		{
+			name:        "BootBox should return BootBox GVK (not first registered)",
+			obj:         obj1,
+			expectedGVK: gvk1,
+		},
+		{
+			name:        "Tenant should return Tenant GVK (not first registered)",
+			obj:         obj2,
+			expectedGVK: gvk2,
+		},
+		{
+			name:        "Postgres should return Postgres GVK (not first registered)",
+			obj:         obj3,
+			expectedGVK: gvk3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to the same version - should preserve the GVK from the field
+			result, err := scheme.ConvertToVersion(tt.obj, gv)
+			if err != nil {
+				t.Fatalf("ConvertToVersion failed: %v", err)
+			}
+
+			resultGVK := result.GetObjectKind().GroupVersionKind()
+			if resultGVK != tt.expectedGVK {
+				t.Errorf("Expected GVK %v (from object field), got %v. This indicates ConvertToVersion is using GVK from field, not from typeToGVK.", tt.expectedGVK, resultGVK)
+			}
+
+			// Verify the data is preserved
+			if typedResult, ok := result.(*testApplication); ok {
+				if typedResult.Data != tt.obj.Data {
+					t.Errorf("Expected data %q, got %q", tt.obj.Data, typedResult.Data)
+				}
+			} else {
+				t.Errorf("Expected *testApplication, got %T", result)
+			}
+		})
+	}
+
+	// Verify that all three kinds return different GVKs (not all returning the first registered)
+	allGvks := make(map[schema.GroupVersionKind]bool)
+	for _, tt := range tests {
+		result, err := scheme.ConvertToVersion(tt.obj, gv)
+		if err != nil {
+			t.Fatalf("ConvertToVersion failed: %v", err)
+		}
+		allGvks[result.GetObjectKind().GroupVersionKind()] = true
+	}
+	if len(allGvks) != 3 {
+		t.Errorf("Expected 3 different GVKs after conversion (using field GVK), got %d: %v", len(allGvks), allGvks)
+	}
+}
+
+// TestConvertToVersionTypedListGVKFromField verifies that when multiple list kinds are registered
+// with the same Go type, ConvertToVersion uses the GVK from the object's field instead of
+// selecting the first registered kind from typeToGVK.
+func TestConvertToVersionTypedListGVKFromField(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gv := schema.GroupVersion{Group: "test.cozystack.io", Version: "v1alpha1"}
+
+	// Register the same Go type with different list kinds
+	kind1 := "BootBoxList"
+	kind2 := "TenantList"
+	kind3 := "PostgresList"
+
+	gvk1 := gv.WithKind(kind1)
+	gvk2 := gv.WithKind(kind2)
+	gvk3 := gv.WithKind(kind3)
+
+	scheme.AddKnownTypeWithName(gvk1, &testApplicationList{})
+	scheme.AddKnownTypeWithName(gvk2, &testApplicationList{})
+	scheme.AddKnownTypeWithName(gvk3, &testApplicationList{})
+
+	// Create list objects with different kinds set in their fields
+	list1 := &testApplicationList{
+		Items: []testApplication{{Data: "bootbox1"}, {Data: "bootbox2"}},
+	}
+	list1.SetGroupVersionKind(gvk1)
+
+	list2 := &testApplicationList{
+		Items: []testApplication{{Data: "tenant1"}, {Data: "tenant2"}},
+	}
+	list2.SetGroupVersionKind(gvk2)
+
+	list3 := &testApplicationList{
+		Items: []testApplication{{Data: "postgres1"}, {Data: "postgres2"}},
+	}
+	list3.SetGroupVersionKind(gvk3)
+
+	tests := []struct {
+		name        string
+		obj         *testApplicationList
+		expectedGVK schema.GroupVersionKind
+	}{
+		{
+			name:        "BootBoxList should return BootBoxList GVK (not first registered)",
+			obj:         list1,
+			expectedGVK: gvk1,
+		},
+		{
+			name:        "TenantList should return TenantList GVK (not first registered)",
+			obj:         list2,
+			expectedGVK: gvk2,
+		},
+		{
+			name:        "PostgresList should return PostgresList GVK (not first registered)",
+			obj:         list3,
+			expectedGVK: gvk3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to the same version - should preserve the GVK from the field
+			result, err := scheme.ConvertToVersion(tt.obj, gv)
+			if err != nil {
+				t.Fatalf("ConvertToVersion failed: %v", err)
+			}
+
+			resultGVK := result.GetObjectKind().GroupVersionKind()
+			if resultGVK != tt.expectedGVK {
+				t.Errorf("Expected GVK %v (from object field), got %v. This indicates ConvertToVersion is using GVK from field, not from typeToGVK.", tt.expectedGVK, resultGVK)
+			}
+
+			// Verify the items are preserved
+			if typedResult, ok := result.(*testApplicationList); ok {
+				if len(typedResult.Items) != len(tt.obj.Items) {
+					t.Errorf("Expected %d items, got %d", len(tt.obj.Items), len(typedResult.Items))
+				}
+			} else {
+				t.Errorf("Expected *testApplicationList, got %T", result)
+			}
+		})
+	}
+
+	// Verify that all three list kinds return different GVKs (not all returning the first registered)
+	allGvks := make(map[schema.GroupVersionKind]bool)
+	for _, tt := range tests {
+		result, err := scheme.ConvertToVersion(tt.obj, gv)
+		if err != nil {
+			t.Fatalf("ConvertToVersion failed: %v", err)
+		}
+		allGvks[result.GetObjectKind().GroupVersionKind()] = true
+	}
+	if len(allGvks) != 3 {
+		t.Errorf("Expected 3 different GVKs after conversion (using field GVK), got %d: %v", len(allGvks), allGvks)
+	}
+}
+
+// TestConvertToVersionReorderingPreservesTargetPriority verifies that reordering kinds
+// to prefer the object's GVK still allows the target GroupVersioner to apply its own
+// priority decisions (e.g., preferring a different version for conversion).
+func TestConvertToVersionReorderingPreservesTargetPriority(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	g1v1 := schema.GroupVersion{Group: "g1", Version: "v1"}
+	g1v2 := schema.GroupVersion{Group: "g1", Version: "v2"}
+
+	// Register same type with multiple group/version/kind combinations
+	scheme.AddKnownTypeWithName(g1v1.WithKind("k1"), &testApplication{})
+	scheme.AddKnownTypeWithName(g1v1.WithKind("k2"), &testApplication{})
+	scheme.AddKnownTypeWithName(g1v2.WithKind("k1"), &testApplication{})
+	scheme.AddKnownTypeWithName(g1v2.WithKind("k2"), &testApplication{})
+
+	// Object has g1/v1/k1 set
+	obj := &testApplication{Data: "test"}
+	obj.SetGroupVersionKind(g1v1.WithKind("k1"))
+
+	// Target specifically wants g1/v2 - should convert to g1/v2/k1 (respecting target's
+	// version preference while using the object's kind)
+	result, err := scheme.ConvertToVersion(obj, g1v2)
+	if err != nil {
+		t.Fatalf("ConvertToVersion failed: %v", err)
+	}
+
+	resultGVK := result.GetObjectKind().GroupVersionKind()
+	expectedGVK := g1v2.WithKind("k1")
+	if resultGVK != expectedGVK {
+		t.Errorf("Expected GVK %v (target version with object's kind), got %v", expectedGVK, resultGVK)
+	}
+}
+
+// TestConvertToVersionCrossGroupLegacyAlias verifies that ConvertToVersion works correctly
+// when the same Go type is registered under different groups with a legacy alias
+// (like EncryptionConfig in group "" vs EncryptionConfiguration in "apiserver.config.k8s.io").
+// The reordering must not break InternalGroupVersioner's fallback which derives the internal
+// GVK from the first element in the kinds list.
+func TestConvertToVersionCrossGroupLegacyAlias(t *testing.T) {
+	internalGV := schema.GroupVersion{Group: "mygroup.example.com", Version: runtime.APIVersionInternal}
+	externalGV := schema.GroupVersion{Group: "mygroup.example.com", Version: "v1"}
+	legacyGV := schema.GroupVersion{Group: "", Version: "v1"}
+
+	scheme := runtime.NewScheme()
+
+	// Register a separate Go type as the internal version of MyConfig.
+	// Use testApplicationList here just as a distinct registered type — the real
+	// EncryptionConfiguration scenario has separate internal and versioned Go types
+	// with auto-generated conversions. We don't need actual conversion to trigger the
+	// bug; we only need s.New(gvk) to succeed for the fallback GVK.
+	scheme.AddKnownTypeWithName(internalGV.WithKind("MyConfig"), &testApplicationList{})
+
+	// Register a trivial conversion so ConvertToVersion can succeed
+	if err := scheme.AddConversionFunc((*testApplication)(nil), (*testApplicationList)(nil),
+		func(a, b interface{}, scope conversion.Scope) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	// External type
+	scheme.AddKnownTypeWithName(externalGV.WithKind("MyConfig"), &testApplication{})
+	// Legacy alias in a different group
+	scheme.AddKnownTypeWithName(legacyGV.WithKind("LegacyConfig"), &testApplication{})
+
+	// Object decoded from legacy YAML (group="", kind="LegacyConfig")
+	obj := &testApplication{Data: "legacy-data"}
+	obj.SetGroupVersionKind(legacyGV.WithKind("LegacyConfig"))
+
+	// Convert to internal version - should use the standard group's internal version,
+	// not construct a non-existent internal version from the legacy alias
+	result, err := scheme.UnsafeConvertToVersion(obj, runtime.InternalGroupVersioner)
+	if err != nil {
+		t.Fatalf("UnsafeConvertToVersion to internal failed: %v", err)
+	}
+
+	// The result should be the internal type (GVK is cleared for internal versions)
+	resultGVK := result.GetObjectKind().GroupVersionKind()
+	if resultGVK != (schema.GroupVersionKind{}) {
+		t.Errorf("Expected empty GVK for internal version, got %v", resultGVK)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Fixes `ConvertToVersion()` to prefer the object's GVK field over the first registered kind when multiple kinds are registered with the same Go type.

When multiple kinds are registered with the same Go type using `scheme.AddKnownTypeWithName()`, `ConvertToVersion()` was always selecting the first registered kind from `typeToGVK` instead of using the actual GVK from the object's field. This causes incorrect behavior in dynamic API servers where the same Go type (e.g., `Application{}`) is registered multiple times with different kinds (e.g., `BootBox`, `Tenant`, `Postgres`) at runtime.

**Use case:**
In the cozystack.io project, we use a dynamic API-server where types are registered dynamically at runtime using `gvk.GroupVersion().WithKind(kind)` multiple times for the same Go type `Application{}`. When `ConvertToVersion()` is called, it incorrectly returns the first registered type instead of the actual type from the object's field. For more details on how this dynamic API server works, see the [blog post](https://kubernetes.io/blog/2024/11/21/dynamic-kubernetes-api-server-for-cozystack/).

**Workaround limitations:**
- For regular objects, a workaround exists using `unstructured.Unstructured{}`, which reads the type from the field via a fast path in `apimachinery/pkg/runtime/serializer/versioning/versioning.go`, avoiding `ConvertToVersion()`.
- However, this workaround does not work for List types, making this fix necessary.

This PR ensures that when an object has a valid GVK in its field that matches one of the registered kinds, that GVK is used instead of always defaulting to the first registered kind.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

This change modifies the `convertToVersion` function in `staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go` to:
1. First check if the object's GVK field is set and matches one of the registered kinds
2. If found and acceptable for the target version, use that GVK
3. Otherwise, fall back to the existing logic of selecting from registered kinds

The fix includes comprehensive tests for both typed objects and typed lists to verify that:
- Objects with different GVKs in their fields return the correct GVK after conversion
- The fix works for both regular objects and List types
- All registered kinds return different GVKs (not all returning the first registered)

**Example usage context:**
In cozystack.io, types are registered like this:
```go
scheme.AddKnownTypeWithName(gv.WithKind("BootBox"), &Application{})
scheme.AddKnownTypeWithName(gv.WithKind("Tenant"), &Application{})
scheme.AddKnownTypeWithName(gv.WithKind("Postgres"), &Application{})
```

Before this fix, all three would return the GVK of "BootBox" (first registered) after `ConvertToVersion()`. After this fix, each object returns its actual GVK from the field.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed `ConvertToVersion()` to correctly use the object's GVK field when multiple kinds are registered with the same Go type. Previously, it would always return the first registered kind, causing incorrect behavior in dynamic API servers where the same Go type is registered multiple times with different kinds.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Blog post: Dynamic Kubernetes API Server for Cozystack]: https://kubernetes.io/blog/2024/11/21/dynamic-kubernetes-api-server-for-cozystack/
- [Usage example]: https://github.com/cozystack/cozystack/blob/8bc62d4c715f624da930d06404b8048001f8fa1d/pkg/apis/apps/v1alpha1/register.go#L58-L73
```


#### AI Disclosure

AI tooling (Claude) was used to assist in preparing this PR. All changes have been reviewed and verified by the author. This fix has been running in production (cozystack) for a long time from a forked apimachinery.
