### PR TITLE
workqueue: add delayed metric

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -7366,6 +7366,26 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
+- name: delayed_items
+  subsystem: workqueue
+  help: Current number of delayed items in workqueue
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - name
+  componentEndpoints:
+  - component: cloud-controller-manager
+    endpoint: /metrics
+  - component: kube-apiserver
+    endpoint: /metrics
+  - component: kube-controller-manager
+    endpoint: /metrics
+  - component: kube-proxy
+    endpoint: /metrics
+  - component: kube-scheduler
+    endpoint: /metrics
+  - component: kubelet
+    endpoint: /metrics
 - name: automatic_reload_last_timestamp_seconds
   subsystem: authentication_config_controller
   namespace: apiserver

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -316,6 +316,7 @@ func (q *delayingType[T]) waitingLoop(logger klog.Logger) {
 			nextReadyAtTimer = q.clock.NewTimer(entry.readyAt.Sub(now))
 			nextReadyAt = nextReadyAtTimer.C()
 		}
+		q.metrics.delayedCount(len(waitingEntryByData))
 
 		select {
 		case <-q.stopCh:

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -71,7 +71,12 @@ func TestSimpleQueue(t *testing.T) {
 
 func TestDeduping(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	mp := testMetricsProvider{}
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{
+		Name:            "test-delay",
+		Clock:           fakeClock,
+		MetricsProvider: &mp,
+	})
 
 	first := "foo"
 
@@ -79,6 +84,13 @@ func TestDeduping(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	if mp.delayed.gaugeValue() != 1 {
+		t.Errorf("expected 1 delayed, got %v", mp.delayed.gaugeValue())
+	}
+	if mp.retries.gaugeValue() != 1 {
+		t.Errorf("expected 1 retry, got %v", mp.retries.gaugeValue())
+	}
+
 	q.AddAfter(first, 70*time.Millisecond)
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -86,11 +98,20 @@ func TestDeduping(t *testing.T) {
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
+	if mp.delayed.gaugeValue() != 1 {
+		t.Errorf("expected 1 delayed, got %v", mp.delayed.gaugeValue())
+	}
+	if mp.retries.gaugeValue() != 2 {
+		t.Errorf("expected 2 retries, got %v", mp.retries.gaugeValue())
+	}
 
 	// step past the first block, we should receive now
 	fakeClock.Step(60 * time.Millisecond)
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
+	}
+	if mp.delayed.gaugeValue() != 0 {
+		t.Errorf("expected 0 delayed, got %v", mp.delayed.gaugeValue())
 	}
 	item, _ := q.Get()
 	q.Done(item)
@@ -110,10 +131,19 @@ func TestDeduping(t *testing.T) {
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
+	if mp.delayed.gaugeValue() != 1 {
+		t.Errorf("expected 1 delayed, got %v", mp.delayed.gaugeValue())
+	}
+	if mp.retries.gaugeValue() != 4 {
+		t.Errorf("expected 4 retries, got %v", mp.retries.gaugeValue())
+	}
 
 	fakeClock.Step(40 * time.Millisecond)
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
+	}
+	if mp.delayed.gaugeValue() != 0 {
+		t.Errorf("expected 0 delayed, got %v", mp.delayed.gaugeValue())
 	}
 	item, _ = q.Get()
 	q.Done(item)

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -193,35 +193,35 @@ type MetricsProvider interface {
 
 type noopMetricsProvider struct{}
 
-func (_ noopMetricsProvider) NewDepthMetric(name string) GaugeMetric {
+func (noopMetricsProvider) NewDepthMetric(name string) GaugeMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewAddsMetric(name string) CounterMetric {
+func (noopMetricsProvider) NewAddsMetric(name string) CounterMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewLatencyMetric(name string) HistogramMetric {
+func (noopMetricsProvider) NewLatencyMetric(name string) HistogramMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewWorkDurationMetric(name string) HistogramMetric {
+func (noopMetricsProvider) NewWorkDurationMetric(name string) HistogramMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
+func (noopMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric {
+func (noopMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+func (noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewDelayedMetrics(name string) SettableGaugeMetric {
+func (noopMetricsProvider) NewDelayedMetrics(name string) SettableGaugeMetric {
 	return noopMetric{}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -155,10 +155,12 @@ func (m *defaultQueueMetrics[T]) sinceInSeconds(start time.Time) float64 {
 
 type retryMetrics interface {
 	retry()
+	delayedCount(count int)
 }
 
 type defaultRetryMetrics struct {
 	retries CounterMetric
+	delayed SettableGaugeMetric
 }
 
 func (m *defaultRetryMetrics) retry() {
@@ -167,6 +169,14 @@ func (m *defaultRetryMetrics) retry() {
 	}
 
 	m.retries.Inc()
+}
+
+func (m *defaultRetryMetrics) delayedCount(count int) {
+	if m == nil {
+		return
+	}
+
+	m.delayed.Set(float64(count))
 }
 
 // MetricsProvider generates various metrics used by the queue.
@@ -178,6 +188,7 @@ type MetricsProvider interface {
 	NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric
 	NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric
 	NewRetriesMetric(name string) CounterMetric
+	NewDelayedMetrics(name string) SettableGaugeMetric
 }
 
 type noopMetricsProvider struct{}
@@ -207,6 +218,10 @@ func (_ noopMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string
 }
 
 func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+	return noopMetric{}
+}
+
+func (_ noopMetricsProvider) NewDelayedMetrics(name string) SettableGaugeMetric {
 	return noopMetric{}
 }
 
@@ -243,6 +258,7 @@ func newRetryMetrics(name string, provider MetricsProvider) retryMetrics {
 
 	return &defaultRetryMetrics{
 		retries: provider.NewRetriesMetric(name),
+		delayed: provider.NewDelayedMetrics(name),
 	}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -137,6 +137,7 @@ type testMetricsProvider struct {
 	unfinished testMetric
 	longest    testMetric
 	retries    testMetric
+	delayed    testMetric
 }
 
 func (m *testMetricsProvider) NewDepthMetric(name string) GaugeMetric {
@@ -165,6 +166,10 @@ func (m *testMetricsProvider) NewLongestRunningProcessorSecondsMetric(name strin
 
 func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return &m.retries
+}
+
+func (m *testMetricsProvider) NewDelayedMetrics(name string) SettableGaugeMetric {
+	return &m.delayed
 }
 
 func TestMetrics(t *testing.T) {

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -37,6 +37,7 @@ const (
 	UnfinishedWorkKey          = "unfinished_work_seconds"
 	LongestRunningProcessorKey = "longest_running_processor_seconds"
 	RetriesKey                 = "retries_total"
+	DelayedKey                 = "delayed_items"
 )
 
 var (
@@ -95,8 +96,15 @@ var (
 		Help:           "Total number of retries handled by workqueue",
 	}, []string{"name"})
 
+	delayed = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
+		Subsystem:      WorkQueueSubsystem,
+		Name:           DelayedKey,
+		StabilityLevel: k8smetrics.ALPHA,
+		Help:           "Current number of delayed items in workqueue",
+	}, []string{"name"})
+
 	metrics = []k8smetrics.Registerable{
-		depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries,
+		depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries, delayed,
 	}
 
 	registerOnce sync.Once
@@ -158,4 +166,9 @@ func (prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name st
 func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	register()
 	return retries.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewDelayedMetrics(name string) workqueue.SettableGaugeMetric {
+	register()
+	return delayed.WithLabelValues(name)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Use synctest and get rid of wait loop.

Reporting the number of items currently waiting for retry. This metric is suitable for an alert if it is above 0 for a long time.

Previous retry metrics is not suitable for alerting because it is hard to distinguish a random transient error from a backoff repeating error.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Workqueue gains a new "delayed_items" metric, reporting the number of items waiting for retry.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
