### PR TITLE
update publishing rules

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.31
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.34
       dirs:
@@ -42,7 +42,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -51,7 +51,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -60,7 +60,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -95,7 +95,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -166,7 +166,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -175,7 +175,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -184,7 +184,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -193,7 +193,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -216,7 +216,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -229,7 +229,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -242,7 +242,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -255,7 +255,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -283,7 +283,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -296,7 +296,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -309,7 +309,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -322,7 +322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -346,7 +346,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -355,7 +355,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -364,7 +364,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -373,7 +373,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -401,7 +401,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -418,7 +418,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -435,7 +435,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -452,7 +452,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -492,7 +492,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -513,7 +513,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -534,7 +534,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -555,7 +555,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -603,7 +603,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -629,7 +629,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -655,7 +655,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -681,7 +681,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -728,7 +728,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -748,7 +748,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -768,7 +768,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -788,7 +788,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -832,7 +832,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -855,7 +855,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -878,7 +878,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -901,7 +901,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -940,7 +940,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -955,7 +955,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -970,7 +970,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -985,7 +985,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1015,7 +1015,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1028,7 +1028,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1041,7 +1041,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1054,7 +1054,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1084,7 +1084,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1099,7 +1099,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1114,7 +1114,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1160,7 +1160,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1175,7 +1175,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1190,7 +1190,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1205,7 +1205,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1228,25 +1228,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.31
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.34
       dirs:
@@ -1271,7 +1271,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1288,7 +1288,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1305,7 +1305,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1322,7 +1322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1362,7 +1362,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1383,7 +1383,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1404,7 +1404,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1425,7 +1425,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1467,7 +1467,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1486,7 +1486,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1505,7 +1505,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1524,7 +1524,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1568,7 +1568,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1591,7 +1591,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1614,7 +1614,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1637,7 +1637,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1687,7 +1687,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1712,7 +1712,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1737,7 +1737,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1762,7 +1762,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1800,7 +1800,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1811,7 +1811,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -1822,7 +1822,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -1833,7 +1833,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -1857,7 +1857,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1868,7 +1868,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -1879,7 +1879,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -1890,7 +1890,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -1909,25 +1909,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.31
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.34
       dirs:
@@ -1958,7 +1958,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1981,7 +1981,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -2004,7 +2004,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2027,7 +2027,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2071,7 +2071,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2090,7 +2090,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -2109,7 +2109,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2128,7 +2128,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2174,7 +2174,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2199,7 +2199,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.32
@@ -2224,7 +2224,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.33
@@ -2249,7 +2249,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -2355,7 +2355,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: apimachinery
       branch: release-1.34
@@ -2387,7 +2387,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.31
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2402,7 +2402,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.32
@@ -2417,7 +2417,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.33
@@ -2432,7 +2432,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     dependencies:
     - repository: api
       branch: release-1.34
@@ -2454,19 +2454,19 @@ rules:
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.32
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.32
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.33
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.33
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.34
-    go: 1.24.9
+    go: 1.24.10
     source:
       branch: release-1.34
       dirs:

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,12 +6,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/apimachinery
-  - name: release-1.31
-    go: 1.24.10
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/apimachinery
   - name: release-1.32
     go: 1.24.10
     source:
@@ -39,15 +33,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/api
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.32
@@ -88,21 +73,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/client-go
     smoke-test: |
@@ -165,15 +135,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/code-generator
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/code-generator
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -213,19 +174,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/component-base
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.32
@@ -282,19 +230,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/component-helpers
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/component-helpers
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -345,15 +280,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kms
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/kms
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -398,23 +324,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiserver
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.32
@@ -489,27 +398,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kube-aggregator
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    - repository: code-generator
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.32
@@ -595,32 +483,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: code-generator
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/sample-apiserver
     required-packages:
@@ -727,26 +589,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: code-generator
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -827,29 +669,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: code-generator
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
@@ -939,21 +758,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/metrics
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: code-generator
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/metrics
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -1014,19 +818,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cli-runtime
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/cli-runtime
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -1081,21 +872,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: cli-runtime
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.32
@@ -1159,21 +935,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-proxy
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/kube-proxy
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -1227,12 +988,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cri-api
-  - name: release-1.31
-    go: 1.24.10
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/cri-api
   - name: release-1.32
     go: 1.24.10
     source:
@@ -1268,23 +1023,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cri-client
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: cri-api
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.32
@@ -1359,27 +1097,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kubelet
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: cri-api
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.32
@@ -1466,25 +1183,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/controller-manager
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/controller-manager
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -1565,29 +1263,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cloud-provider
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: controller-manager
-      branch: release-1.31
-    - repository: component-helpers
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.32
@@ -1686,31 +1361,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-controller-manager
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: controller-manager
-      branch: release-1.31
-    - repository: cloud-provider
-      branch: release-1.31
-    - repository: component-helpers
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -1799,17 +1449,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -1856,17 +1495,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/csi-translation-lib
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -1906,12 +1534,6 @@ rules:
   - name: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/mount-utils
-  - name: release-1.31
-    go: 1.24.10
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.32
@@ -1955,29 +1577,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kubectl
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: cli-runtime
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: code-generator
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: component-helpers
-      branch: release-1.31
-    - repository: metrics
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.32
@@ -2070,25 +1669,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/pod-security-admission
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/pod-security-admission
   - name: release-1.32
     go: 1.24.10
     dependencies:
@@ -2171,31 +1751,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/dynamic-resource-allocation
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: apiserver
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: cri-api
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: component-helpers
-      branch: release-1.31
-    - repository: kms
-      branch: release-1.31
-    - repository: kubelet
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.32
@@ -2299,21 +1854,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-scheduler
-  - name: release-1.31
-    go: 1.23.11
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    - repository: api
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    source:
-      branch: release-1.31
-      dirs:
-      - staging/src/k8s.io/kube-scheduler
   - name: release-1.32
     go: 1.23.11
     dependencies:
@@ -2384,21 +1924,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/endpointslice
-  - name: release-1.31
-    go: 1.24.10
-    dependencies:
-    - repository: api
-      branch: release-1.31
-    - repository: apimachinery
-      branch: release-1.31
-    - repository: client-go
-      branch: release-1.31
-    - repository: component-base
-      branch: release-1.31
-    source:
-      branch: release-1.31
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.32


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- update publishing rules 
- drop rules for release-1.31 as it is EOL 


/assign @saschagrunert @dims @Verolop 
cc @kubernetes/release-managers 

#### Which issue(s) this PR is related to:

xref: https://github.com/kubernetes/release/issues/4187

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
