### PR TITLE
Add pod indexer to deployment controller

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -83,6 +83,8 @@ type DeploymentController struct {
 	rsLister appslisters.ReplicaSetLister
 	// podLister can list/get pods from the shared informer's store
 	podLister corelisters.PodLister
+	// podIndexer allows looking up pods by ControllerRef UID
+	podIndexer cache.Indexer
 
 	// dListerSynced returns true if the Deployment store has been synced at least once.
 	// Added as a member to the struct to allow injection for testing.
@@ -156,6 +158,12 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 	dc.dListerSynced = dInformer.Informer().HasSynced
 	dc.rsListerSynced = rsInformer.Informer().HasSynced
 	dc.podListerSynced = podInformer.Informer().HasSynced
+
+	if err := controller.AddPodControllerIndexer(podInformer.Informer()); err != nil {
+		return nil, fmt.Errorf("adding Pod controller UID indexer: %w", err)
+	}
+	dc.podIndexer = podInformer.Informer().GetIndexer()
+
 	return dc, nil
 }
 
@@ -562,31 +570,16 @@ func (dc *DeploymentController) getReplicaSetsForDeployment(ctx context.Context,
 // NOTE: The pod pointers returned by this method point the pod objects in the cache and thus
 // shouldn't be modified in any way.
 func (dc *DeploymentController) getPodMapForDeployment(d *apps.Deployment, rsList []*apps.ReplicaSet) (map[types.UID][]*v1.Pod, error) {
-	// Get all Pods that potentially belong to this Deployment.
-	selector, err := metav1.LabelSelectorAsSelector(d.Spec.Selector)
-	if err != nil {
-		return nil, err
-	}
-	pods, err := dc.podLister.Pods(d.Namespace).List(selector)
-	if err != nil {
-		return nil, err
-	}
 	// Group Pods by their controller (if it's in rsList).
 	podMap := make(map[types.UID][]*v1.Pod, len(rsList))
+
 	for _, rs := range rsList {
-		podMap[rs.UID] = []*v1.Pod{}
-	}
-	for _, pod := range pods {
-		// Do not ignore inactive Pods because Recreate Deployments need to verify that no
-		// Pods from older versions are running before spinning up new Pods.
-		controllerRef := metav1.GetControllerOf(pod)
-		if controllerRef == nil {
-			continue
+		// list all pods managed by this ReplicaSet using the pod indexer
+		pods, err := controller.FilterPodsByOwner(dc.podIndexer, &rs.ObjectMeta, "ReplicaSet", false)
+		if err != nil {
+			return nil, err
 		}
-		// Only append if we care about this UID.
-		if _, ok := podMap[controllerRef.UID]; ok {
-			podMap[controllerRef.UID] = append(podMap[controllerRef.UID], pod)
-		}
+		podMap[rs.UID] = pods
 	}
 	return podMap, nil
 }

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -1005,49 +1005,74 @@ func TestDeleteReplicaSetOrphan(t *testing.T) {
 }
 
 func BenchmarkGetPodMapForDeployment(b *testing.B) {
-	_, ctx := ktesting.NewTestContext(b)
-
-	f := newFixture(b)
-
-	d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
-
-	rs1 := newReplicaSet(d, "rs1", 1)
-	rs2 := newReplicaSet(d, "rs2", 1)
-
-	var pods []*v1.Pod
-	var objects []runtime.Object
-	for i := 0; i < 100; i++ {
-		p1, p2 := generatePodFromRS(rs1), generatePodFromRS(rs2)
-		p1.Name, p2.Name = p1.Name+fmt.Sprintf("-%d", i), p2.Name+fmt.Sprintf("-%d", i)
-		pods = append(pods, p1, p2)
-		objects = append(objects, p1, p2)
+	cases := []struct {
+		name      string
+		numPods   int
+		extraPods int // Pods in namespace not owned by this deployment
+	}{
+		{name: "10-Pods-No-Noise", numPods: 10, extraPods: 0},
+		{name: "10-Pods-With-Noise", numPods: 10, extraPods: 100},
+		{name: "10000-Pods-No-Noise", numPods: 10000, extraPods: 0},
+		{name: "10000-Pods-With-Noise", numPods: 10000, extraPods: 100000},
 	}
 
-	f.dLister = append(f.dLister, d)
-	f.rsLister = append(f.rsLister, rs1, rs2)
-	f.podLister = append(f.podLister, pods...)
-	f.objects = append(f.objects, d, rs1, rs2)
-	f.objects = append(f.objects, objects...)
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			_, ctx := ktesting.NewTestContext(b)
 
-	// Start the fixture.
-	c, informers, err := f.newController(ctx)
-	if err != nil {
-		b.Fatalf("error creating Deployment controller: %v", err)
-	}
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	informers.Start(stopCh)
+			f := newFixture(b)
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		m, err := c.getPodMapForDeployment(d, f.rsLister)
-		if err != nil {
-			b.Fatalf("getPodMapForDeployment() error: %v", err)
-		}
-		if len(m) != 2 {
-			b.Errorf("Invalid map size, expected 2, got: %d", len(m))
-		}
+			d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
+
+			rs1 := newReplicaSet(d, "rs1", 1)
+			rs2 := newReplicaSet(d, "rs2", 1)
+
+			var pods []*v1.Pod
+			var objects []runtime.Object
+			for i := 0; i < tc.numPods; i++ {
+				p1, p2 := generatePodFromRS(rs1), generatePodFromRS(rs2)
+				p1.Name, p2.Name = p1.Name+fmt.Sprintf("-%d", i), p2.Name+fmt.Sprintf("-%d", i)
+				pods = append(pods, p1, p2)
+				objects = append(objects, p1, p2)
+			}
+
+			// Add extra pods that don't belong to the deployment
+			for i := 0; i < tc.extraPods; i++ {
+				p := generatePodFromRS(rs1)
+				p.Name = fmt.Sprintf("extra-pod-%d", i)
+				p.OwnerReferences = nil // Orphaned/unrelated
+				p.Labels = map[string]string{"foo": "notbar"}
+				pods = append(pods, p)
+				objects = append(objects, p)
+			}
+
+			f.dLister = append(f.dLister, d)
+			f.rsLister = append(f.rsLister, rs1, rs2)
+			f.podLister = append(f.podLister, pods...)
+			f.objects = append(f.objects, d, rs1, rs2)
+			f.objects = append(f.objects, objects...)
+
+			// Start the fixture.
+			c, informers, err := f.newController(ctx)
+			if err != nil {
+				b.Fatalf("error creating Deployment controller: %v", err)
+			}
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informers.Start(stopCh)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				m, err := c.getPodMapForDeployment(d, f.rsLister)
+				if err != nil {
+					b.Fatalf("getPodMapForDeployment() error: %v", err)
+				}
+				if len(m) != 2 {
+					b.Errorf("Invalid map size, expected 2, got: %d", len(m))
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Improve performance of deployment controller by using a pod indexer and owner reference to query pods rather than a full pod list

Benchmarks:

```
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/controller/deployment
cpu: AMD EPYC 7B12
                                                │   old5.txt    │              new5.txt               │
                                                │    sec/op     │    sec/op     vs base               │
GetPodMapForDeployment/10-Pods-No-Noise-24         6.334µ ±  2%   1.971µ ±  4%  -68.88% (p=0.002 n=6)
GetPodMapForDeployment/10-Pods-With-Noise-24      12.590µ ±  4%   1.942µ ±  5%  -84.58% (p=0.002 n=6)
GetPodMapForDeployment/10000-Pods-No-Noise-24     17.294m ±  4%   1.765m ±  6%  -89.79% (p=0.002 n=6)
GetPodMapForDeployment/10000-Pods-With-Noise-24   84.670m ± 12%   2.282m ± 12%  -97.30% (p=0.002 n=6)
geomean                                            584.6µ         62.67µ        -89.28%

                                                │    old5.txt    │               new5.txt               │
                                                │      B/op      │     B/op       vs base               │
GetPodMapForDeployment/10-Pods-No-Noise-24         4.009Ki ±  0%   1.312Ki ±  0%  -67.26% (p=0.002 n=6)
GetPodMapForDeployment/10-Pods-With-Noise-24       5.709Ki ±  0%   1.313Ki ±  0%  -76.99% (p=0.002 n=6)
GetPodMapForDeployment/10000-Pods-No-Noise-24      4.789Mi ±  6%   1.107Mi ±  2%  -76.87% (p=0.002 n=6)
GetPodMapForDeployment/10000-Pods-With-Noise-24   53.486Mi ± 17%   2.203Mi ± 25%  -95.88% (p=0.002 n=6)
geomean                                            280.0Ki         45.83Ki        -83.63%

                                                │    old5.txt    │              new5.txt               │
                                                │   allocs/op    │  allocs/op    vs base               │
GetPodMapForDeployment/10-Pods-No-Noise-24           73.00 ±  0%    16.00 ±  0%  -78.08% (p=0.002 n=6)
GetPodMapForDeployment/10-Pods-With-Noise-24         73.00 ±  0%    16.00 ±  0%  -78.08% (p=0.002 n=6)
GetPodMapForDeployment/10000-Pods-No-Noise-24      44195.0 ±  2%    780.5 ± 12%  -98.23% (p=0.002 n=6)
GetPodMapForDeployment/10000-Pods-With-Noise-24   151.703k ± 14%   3.588k ± 41%  -97.63% (p=0.002 n=6)
geomean                                             2.445k          163.6        -93.31%
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @serathius 
/triage accepted
