### PR TITLE
mount-utils: Handle /proc/mounts with >6 fields

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -749,7 +749,7 @@ func parseProcMounts(content []byte) ([]MountPoint, error) {
 		// environments (e.g., WSL with Windows paths like "path=C:\Program Files\...").
 		// The standard /proc/mounts format is:
 		//   device mountpoint type options dump pass
-		// where dump and pass are always single-digit integers (0, 1, or 2).
+		// where dump and pass are integer fields (commonly 0/1 for dump and 0–2 for pass).
 		// To handle options with spaces, we parse from the end: the last two fields
 		// are always dump and pass, and everything between type and dump is options.
 		numFields := len(fields)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
On WSL2 with Docker Desktop, certain mount entries in /proc/mounts contain Windows paths with unescaped spaces in the mount options field (e.g., 'path=C:\Program Files\Docker\Docker\resources').

**Key Point:** This issue only occurs when WSL2 with Docker Desktop is used as a Kubernetes worker node joining a cluster. Running containers directly in WSL2 works fine - the issue is specific to kubelet's mounts parsing during node initialization.

When parsed by strings.Fields(), these lines produce 7+ fields instead of the expected 6, causing kubelet to fail with:
  'Failed to start ContainerManager: system validation failed -
   wrong number of fields (expected 6, got 7)'

This change modifies parseProcMounts() to:
- Accept lines with 6 or more fields (instead of exactly 6)
- Parse dump (fs_freq) and pass (fs_passno) from the end of the line
- Join any extra middle fields into the options string

This maintains backward compatibility with standard 6-field entries while properly handling edge cases with spaces in mount options.


#### Which issue(s) this PR is related to:
Fixes #135554
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- The fix parses dump (fs_freq) and pass (fs_passno) from the end of the line since they are always single integers (0, 1, or 2)
- Standard 6-field /proc/mounts entries are parsed identically to before
- Added test case for WSL mount entry with 7 fields
- All existing mount-utils tests pass

### What did you expect to happen?

Kubelet should start successfully on WSL2 with Docker Desktop installed. The /proc/mounts parser should handle mount entries where the options field contains unescaped spaces.

### How can we reproduce it (as minimally and precisely as possible)?

How can we reproduce it (as minimally and precisely as possible)?

1. Install Windows with WSL2 and Docker Desktop for Windows with WSL2 backend enabled
2. Inside WSL2 Ubuntu, install Kubernetes components (kubeadm, kubelet, kubectl v1.34.2)
3. Join the WSL2 node to an existing Kubernetes cluster running on a separate Linux control-plane using kubeadm join
4. Observe kubelet fails to start with error: "Failed to start ContainerManager: system validation failed - wrong number of fields (expected 6, got 7)"

Root Cause:

Docker Desktop mounts Windows paths in WSL2's [mounts](vscode-file://vscode-app/c:/Users/mithu/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with unescaped spaces in the options field

Example problematic entry:
C:\134Program\040Files\134Docker\134Docker\134resources /Docker/host 9p rw,noatime,aname=drvfs;path=C:\Program Files\Docker\Docker\resources;symlinkroot=/mnt/,...


The options field contains path=C:\Program Files\Docker\Docker\resources with unescaped spaces
When strings.Fields() parses this line, it splits on whitespace, creating 7-8 fields instead of the expected 6

To verify the problematic mount entry:
$ cat /proc/mounts | grep "Program Files"
 Check field count (should be 7-8 instead of 6)
$ cat /proc/mounts | grep "Program Files" | awk '{print NF}'

Key Point: This issue only occurs when WSL2 with Docker Desktop is used as a Kubernetes worker node joining a cluster. Running containers directly in WSL2 works fine - the issue is specific to kubelet's mounts parsing during node initialization.

### Anything else we need to know?

This affects WSL2 users who have Docker Desktop installed. The /proc/mounts format defines 6 fields (device, mountpoint, type, options, dump, pass), but the options field can contain unescaped spaces in 9p/drvfs filesystems used by WSL.

#### Does this PR introduce a user-facing change?
Yes - Kubelet now starts successfully on WSL2 systems with Docker Desktop installed.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubelet failing to start on WSL2 with Docker Desktop due to /proc/mounts entries containing unescaped spaces in mount options
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
