### PR TITLE
Enable declarative validation for LimitRange

### DIFF
--- a/pkg/apis/core/v1/doc.go
+++ b/pkg/apis/core/v1/doc.go
@@ -20,6 +20,7 @@ limitations under the License.
 // +k8s:defaulter-gen-input=k8s.io/api/core/v1
 // +k8s:validation-gen=TypeMeta
 // +k8s:validation-gen-input=k8s.io/api/core/v1
+// +k8s:validation-gen=true
 
 // Package v1 is the v1 version of the API.
 package v1

--- a/pkg/registry/core/limitrange/strategy_test.go
+++ b/pkg/registry/core/limitrange/strategy_test.go
@@ -1,0 +1,70 @@
+package limitrange
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+func TestStrategyValidate(t *testing.T) {
+	lr := &api.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default", // Add this!
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{},
+		},
+	}
+
+	errs := Strategy.Validate(context.Background(), lr)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors from Validate: %v", errs)
+	}
+}
+
+func TestStrategyValidateUpdate(t *testing.T) {
+	oldLR := &api.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default", // Add this!
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{},
+		},
+	}
+
+	newLR := &api.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default", // Add this!
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{},
+		},
+	}
+
+	errs := Strategy.ValidateUpdate(context.Background(), newLR, oldLR)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors from ValidateUpdate: %v", errs)
+	}
+}
+
+func TestStrategyInvalid(t *testing.T) {
+	lr := &api.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "",        // Empty name should fail
+			Namespace: "default", // Add this!
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{},
+		},
+	}
+
+	errs := Strategy.Validate(context.Background(), lr)
+	if len(errs) == 0 {
+		t.Fatalf("expected validation errors but got none")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: ... (keep the template header) -->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Enables declarative validation for the LimitRange resource as part of the declarative validation migration initiative.

Changes:
1. Added +k8s:validation-gen=true to pkg/apis/core/v1/doc.go to enable validation generation
2. Updated pkg/registry/core/limitrange/strategy.go to use ValidateDeclarativelyWithMigrationChecks
3. Added basic test coverage in pkg/registry/core/limitrange/strategy_test.go

#### Which issue(s) this PR is related to:
part of #134280

#### Special notes for your reviewer:
This PR only enables the declarative validation framework. Migration of existing validation rules will be handled in separate, subsequent PRs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
