### PR TITLE
Enable declarative validation for Event

### DIFF
--- a/pkg/apis/core/v1/validation/validation_test.go
+++ b/pkg/apis/core/v1/validation/validation_test.go
@@ -479,3 +479,35 @@ func TestEventDeclarativeValidation_ReportingControllerRequired(t *testing.T) {
 		t.Fatalf("expected Required error, got %v", found.Type)
 	}
 }
+
+func TestEventDeclarativeValidation_ReportingController_Format(t *testing.T) {
+	event := &core.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-event",
+			Namespace: "default",
+		},
+		InvolvedObject: core.ObjectReference{
+			Kind:      "Pod",
+			Namespace: "default",
+			Name:      "test-pod",
+		},
+		EventTime:           metav1.MicroTime{Time: time.Now()},
+		ReportingController: "my-contr@ller",
+	}
+
+	errs := corevalidation.ValidateEventCreate(event, core.SchemeGroupVersion)
+	if len(errs) == 0 {
+		t.Fatalf("expected validation error for reportingController, got none")
+	}
+
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "reportingController") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected reportingController format error, got: %v", errs)
+	}
+}

--- a/pkg/registry/core/event/strategy.go
+++ b/pkg/registry/core/event/strategy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,7 +62,8 @@ func (eventStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 func (eventStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	groupVersion := requestGroupVersion(ctx)
 	event := obj.(*api.Event)
-	return validation.ValidateEventCreate(event, groupVersion)
+	allErrs := validation.ValidateEventCreate(event, groupVersion)
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, event, nil, allErrs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1769,6 +1769,7 @@ message Event {
 
   // Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
   // +optional
+  // +k8s:validation:Format=qualified-name
   optional string reportingComponent = 14;
 
   // ID of the controller instance, e.g. `kubelet-xyzf`.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7572,6 +7572,7 @@ type Event struct {
 
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
 	// +optional
+	// +k8s:validation:Format=qualified-name
 	ReportingController string `json:"reportingComponent" protobuf:"bytes,14,opt,name=reportingComponent"`
 
 	// ID of the controller instance, e.g. `kubelet-xyzf`.


### PR DESCRIPTION
Enable declarative validation for Event

This PR enables declarative validation for the Event resource as part of the declarative validation migration initiative.

Changes:
1. Already enabled validation generation in pkg/apis/core/v1/doc.go (from previous work)
2. Updated pkg/registry/core/event/strategy.go to use ValidateDeclarativelyWithMigrationChecks
3. Added test coverage in pkg/registry/core/event/strategy_test.go

Which issue(s) this PR is related to:
part of #134280

Special notes for your reviewer:
This PR only enables the declarative validation framework. Migration of existing validation rules will be handled in separate, subsequent PRs.

Does this PR introduce a user-facing change?
```release-note
NONE
```