### PR TITLE
Fix MAP failure on objects with duplicate list items

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd.go
@@ -138,7 +138,7 @@ func ApplyStructuredMergeDiff(
 		return nil, fmt.Errorf("invalid ApplyConfiguration: %w", err)
 	}
 
-	liveObjTyped, err := typeConverter.ObjectToTyped(originalObject)
+	liveObjTyped, err := typeConverter.ObjectToTyped(originalObject, typed.AllowDuplicates)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert original object to typed object: %w", err)
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a Mutating Admission Policy (MAP) using ApplyConfiguration was applied to an existing object containing duplicate items in a list (e.g., duplicate environment variables), the operation would fail with a conversion error from Structured Merge Diff.

This change updates the `ApplyStructuredMergeDiff` function to use `typed.AllowDuplicates` when converting the `originalObject`. This allows MAP to process existing objects that may have technically invalid (duplicate) entries but are permitted by legacy validation.

New patches generated by the policy are still strictly enforced my SMD constructs. 

Tests have been added to verify:
1. MAP can process an object with duplicate env vars.
2. MAP can modify an existing env var in an object with duplicates (which has the side effect of deduplicating the entry).

#### Which issue(s) this PR is related to:

Fixes #134167

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?
```release-note
Fixes a bug where MutatingAdmissionPolicy would fail to apply to objects with duplicate list items (like env vars).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
